### PR TITLE
Include unistd.h in svgview.cpp (required for getcwd() function)

### DIFF
--- a/libs/svgviewer/svgview.cpp
+++ b/libs/svgviewer/svgview.cpp
@@ -47,6 +47,7 @@
 #include <QGraphicsWebView>
 #include <QPaintEvent>
 #include <qmath.h>
+#include <unistd.h>
 
 #ifndef QT_NO_OPENGL
 #include <QGLWidget>


### PR DESCRIPTION
This fixes compilation on Arch Linux, which otherwise fails.

Signed-off-by: Martin Schmölzer martin.schmoelzer@student.tuwien.ac.at
