### PR TITLE
Include unistd.h in passes/hierarchy/hierarchy.cc (required for access(3))

### DIFF
--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <fnmatch.h>
 #include <set>
+#include <unistd.h>
 
 namespace {
 	struct generate_port_decl_t {


### PR DESCRIPTION
This fixes compilation errors on Arch Linux.

Signed-off-by: Martin Schmölzer martin.schmoelzer@student.tuwien.ac.at
