### PR TITLE
SHA1 library: fixing incorrect buffer size allocation, and unsafe integer size type

### DIFF
--- a/libs/sha1/sha1.cpp
+++ b/libs/sha1/sha1.cpp
@@ -54,7 +54,7 @@ void SHA1::update(std::istream &is)
 
     while (is)
     {
-        uint32 block[BLOCK_INTS];
+        uint32_t block[BLOCK_INTS];
         buffer_to_block(buffer, block);
         transform(block);
         read(is, buffer, BLOCK_BYTES);
@@ -69,7 +69,7 @@ void SHA1::update(std::istream &is)
 std::string SHA1::final()
 {
     /* Total number of hashed bits */
-    uint64 total_bits = (transforms*BLOCK_BYTES + buffer.size()) * 8;
+    uint64_t total_bits = (transforms*BLOCK_BYTES + buffer.size()) * 8;
 
     /* Padding */
     buffer += 0x80;
@@ -79,7 +79,7 @@ std::string SHA1::final()
         buffer += (char)0x00;
     }
 
-    uint32 block[BLOCK_INTS];
+    uint32_t block[BLOCK_INTS];
     buffer_to_block(buffer, block);
 
     if (orig_size > BLOCK_BYTES - 8)
@@ -91,7 +91,7 @@ std::string SHA1::final()
         }
     }
 
-    /* Append total_bits, split this uint64 into two uint32 */
+    /* Append total_bits, split this uint64_t into two uint32_t */
     block[BLOCK_INTS - 1] = total_bits;
     block[BLOCK_INTS - 2] = (total_bits >> 32);
     transform(block);
@@ -139,14 +139,14 @@ void SHA1::reset()
  * Hash a single 512-bit block. This is the core of the algorithm.
  */
 
-void SHA1::transform(uint32 block[BLOCK_BYTES])
+void SHA1::transform(uint32_t block[BLOCK_BYTES])
 {
     /* Copy digest[] to working vars */
-    uint32 a = digest[0];
-    uint32 b = digest[1];
-    uint32 c = digest[2];
-    uint32 d = digest[3];
-    uint32 e = digest[4];
+    uint32_t a = digest[0];
+    uint32_t b = digest[1];
+    uint32_t c = digest[2];
+    uint32_t d = digest[3];
+    uint32_t e = digest[4];
 
 
     /* 4 rounds of 20 operations each. Loop unrolled. */
@@ -243,9 +243,9 @@ void SHA1::transform(uint32 block[BLOCK_BYTES])
 }
 
 
-void SHA1::buffer_to_block(const std::string &buffer, uint32 block[BLOCK_INTS])
+void SHA1::buffer_to_block(const std::string &buffer, uint32_t block[BLOCK_INTS])
 {
-    /* Convert the std::string (byte buffer) to a uint32 array (MSB) */
+    /* Convert the std::string (byte buffer) to a uint32_t array (MSB) */
     for (unsigned int i = 0; i < BLOCK_INTS; i++)
     {
         block[i] = (buffer[4*i+3] & 0xff)

--- a/libs/sha1/sha1.h
+++ b/libs/sha1/sha1.h
@@ -34,22 +34,19 @@ public:
     static std::string from_file(const std::string &filename);
 
 private:
-    typedef unsigned long int uint32;   /* just needs to be at least 32bit */
-    typedef unsigned long long uint64;  /* just needs to be at least 64bit */
-
     static const unsigned int DIGEST_INTS = 5;  /* number of 32bit integers per SHA1 digest */
     static const unsigned int BLOCK_INTS = 16;  /* number of 32bit integers per SHA1 block */
     static const unsigned int BLOCK_BYTES = BLOCK_INTS * 4;
 
-    uint32 digest[DIGEST_INTS];
+    uint32_t digest[DIGEST_INTS];
     std::string buffer;
-    uint64 transforms;
+    uint64_t transforms;
 
     void reset();
-    void transform(uint32 block[BLOCK_BYTES]);
+    void transform(uint32_t block[BLOCK_BYTES]);
 
     static void read(std::istream &is, std::string &s, size_t max);
-    static void buffer_to_block(const std::string &buffer, uint32 block[BLOCK_INTS]);
+    static void buffer_to_block(const std::string &buffer, uint32_t block[BLOCK_INTS]);
 };
 
 std::string sha1(const std::string &string);


### PR DESCRIPTION
This library has some bugs including an incorrectly allocated buffer, and a potential buffer overflow due to an unsafe integer size type.  This mirrors the fixes at https://github.com/slowriot/sha1 (fork of https://github.com/vag/sha1)
