### PR TITLE
suppressing semi-colon at the end of dot files

### DIFF
--- a/manual/APPNOTE_011_Design_Investigation/cmos_00.dot
+++ b/manual/APPNOTE_011_Design_Investigation/cmos_00.dot
@@ -31,4 +31,4 @@ n5:e -> c11:p7:w [color="black", label=""];
 n6:e -> x0:s0:w [color="black", label=""];
 n6:e -> x1:s0:w [color="black", label=""];
 n6:e -> x2:s0:w [color="black", label=""];
-};
+}

--- a/manual/APPNOTE_011_Design_Investigation/cmos_01.dot
+++ b/manual/APPNOTE_011_Design_Investigation/cmos_01.dot
@@ -20,4 +20,4 @@ n5:e -> c12:p8:w [color="black", label=""];
 c15:p10:e -> n6:w [color="black", label=""];
 c14:p10:e -> n7:w [color="black", label=""];
 n7:e -> c15:p9:w [color="black", label=""];
-};
+}

--- a/manual/APPNOTE_011_Design_Investigation/example_00.dot
+++ b/manual/APPNOTE_011_Design_Investigation/example_00.dot
@@ -20,4 +20,4 @@ n7:e -> p1:w [color="black", label=""];
 p1:e -> n8:w [color="black", style="setlinewidth(3)", label=""];
 n8:e -> p1:w [color="black", style="setlinewidth(3)", label=""];
 v0:e -> c14:p9:w [color="black", style="setlinewidth(3)", label=""];
-};
+}

--- a/manual/APPNOTE_011_Design_Investigation/example_01.dot
+++ b/manual/APPNOTE_011_Design_Investigation/example_01.dot
@@ -30,4 +30,4 @@ n8:e -> c21:p19:w [color="black", label=""];
 n8:e -> x1:w:w [color="black", label=""];
 n9:e -> c18:p15:w [color="black", label=""];
 v0:e -> c21:p11:w [color="black", style="setlinewidth(3)", label=""];
-};
+}

--- a/manual/APPNOTE_011_Design_Investigation/example_02.dot
+++ b/manual/APPNOTE_011_Design_Investigation/example_02.dot
@@ -17,4 +17,4 @@ n5:e -> c17:p16:w [color="black", label=""];
 n6:e -> c15:p12:w [color="black", label=""];
 c15:p14:e -> n7:w [color="black", style="setlinewidth(3)", label=""];
 n7:e -> c17:p8:w [color="black", style="setlinewidth(3)", label=""];
-};
+}

--- a/manual/APPNOTE_011_Design_Investigation/example_03.dot
+++ b/manual/APPNOTE_011_Design_Investigation/example_03.dot
@@ -8,4 +8,4 @@ c4 [ shape=record, label="{{<p1> A|<p2> B}|$2\n$add|{<p3> Y}}" ];
 v0:e -> c4:p1:w [color="black", label=""];
 v1:e -> c4:p2:w [color="black", label=""];
 c4:p3:e -> v2:w [color="black", style="setlinewidth(3)", label=""];
-};
+}

--- a/manual/APPNOTE_011_Design_Investigation/memdemo_00.dot
+++ b/manual/APPNOTE_011_Design_Investigation/memdemo_00.dot
@@ -135,4 +135,4 @@ v6:e -> c47:p34:w [color="black", label=""];
 v7:e -> c48:p33:w [color="black", style="setlinewidth(3)", label=""];
 v8:e -> c49:p33:w [color="black", style="setlinewidth(3)", label=""];
 v9:e -> c50:p33:w [color="black", style="setlinewidth(3)", label=""];
-};
+}

--- a/manual/APPNOTE_011_Design_Investigation/memdemo_01.dot
+++ b/manual/APPNOTE_011_Design_Investigation/memdemo_01.dot
@@ -26,4 +26,4 @@ v0:e -> c13:p11:w [color="black", label=""];
 v1:e -> c14:p11:w [color="black", label=""];
 v2:e -> c15:p11:w [color="black", label=""];
 v3:e -> c19:p16:w [color="black", label=""];
-};
+}

--- a/manual/APPNOTE_011_Design_Investigation/splice.dot
+++ b/manual/APPNOTE_011_Design_Investigation/splice.dot
@@ -36,4 +36,4 @@ x1:s0:e -> n8:w [color="black", style="setlinewidth(3)", label=""];
 x3:s0:e -> n8:w [color="black", style="setlinewidth(3)", label=""];
 x3:s1:e -> n8:w [color="black", style="setlinewidth(3)", label=""];
 x6:s0:e -> n8:w [color="black", style="setlinewidth(3)", label=""];
-};
+}

--- a/manual/APPNOTE_011_Design_Investigation/submod_00.dot
+++ b/manual/APPNOTE_011_Design_Investigation/submod_00.dot
@@ -42,4 +42,4 @@ c21:p8:e -> n8:w [color="black", style="setlinewidth(3)", label=""];
 n8:e -> c20:p8:w [color="black", style="setlinewidth(3)", label=""];
 c21:p9:e -> n9:w [color="black", style="setlinewidth(3)", label=""];
 n9:e -> c20:p9:w [color="black", style="setlinewidth(3)", label=""];
-};
+}

--- a/manual/APPNOTE_011_Design_Investigation/submod_01.dot
+++ b/manual/APPNOTE_011_Design_Investigation/submod_01.dot
@@ -84,4 +84,4 @@ v4:e -> c35:p24:w [color="black", style="setlinewidth(3)", label=""];
 v5:e -> c36:p24:w [color="black", style="setlinewidth(3)", label=""];
 v6:e -> c37:p24:w [color="black", style="setlinewidth(3)", label=""];
 v7:e -> c38:p24:w [color="black", style="setlinewidth(3)", label=""];
-};
+}

--- a/manual/APPNOTE_011_Design_Investigation/submod_02.dot
+++ b/manual/APPNOTE_011_Design_Investigation/submod_02.dot
@@ -30,4 +30,4 @@ n8:e -> c17:p12:w [color="black", style="setlinewidth(3)", label=""];
 n9:e -> x0:s0:w [color="black", label=""];
 n9:e -> x1:s0:w [color="black", label=""];
 n9:e -> x2:s0:w [color="black", label=""];
-};
+}

--- a/manual/APPNOTE_011_Design_Investigation/submod_03.dot
+++ b/manual/APPNOTE_011_Design_Investigation/submod_03.dot
@@ -23,4 +23,4 @@ x1:s1:e -> n5:w [color="black", style="setlinewidth(3)", label=""];
 n6:e -> x2:s1:w [color="black", style="setlinewidth(3)", label=""];
 n7:e -> x2:s0:w [color="black", style="setlinewidth(3)", label=""];
 v0:e -> c13:p8:w [color="black", style="setlinewidth(3)", label=""];
-};
+}

--- a/manual/APPNOTE_011_Design_Investigation/sumprod_00.dot
+++ b/manual/APPNOTE_011_Design_Investigation/sumprod_00.dot
@@ -15,4 +15,4 @@ c4:p3:e -> v2:w [color="black", style="setlinewidth(3)", label=""];
 v3:e -> c5:p1:w [color="black", style="setlinewidth(3)", label=""];
 v4:e -> c5:p2:w [color="black", style="setlinewidth(3)", label=""];
 c5:p3:e -> v5:w [color="black", style="setlinewidth(3)", label=""];
-};
+}

--- a/manual/APPNOTE_011_Design_Investigation/sumprod_01.dot
+++ b/manual/APPNOTE_011_Design_Investigation/sumprod_01.dot
@@ -12,4 +12,4 @@ n2:e -> c9:p6:w [color="black", style="setlinewidth(3)", label=""];
 n3:e -> c9:p7:w [color="black", style="setlinewidth(3)", label=""];
 n4:e -> c10:p7:w [color="black", style="setlinewidth(3)", label=""];
 c10:p8:e -> n5:w [color="black", style="setlinewidth(3)", label=""];
-};
+}

--- a/manual/APPNOTE_011_Design_Investigation/sumprod_02.dot
+++ b/manual/APPNOTE_011_Design_Investigation/sumprod_02.dot
@@ -2,4 +2,4 @@ digraph "sumprod" {
 rankdir="LR";
 remincross=true;
 n1 [ shape=octagon, label="prod", color="black", fontcolor="black" ];
-};
+}

--- a/manual/APPNOTE_011_Design_Investigation/sumprod_03.dot
+++ b/manual/APPNOTE_011_Design_Investigation/sumprod_03.dot
@@ -8,4 +8,4 @@ c5 [ shape=record, label="{{<p2> A|<p3> B}|$4\n$mul|{<p4> Y}}" ];
 c5:p4:e -> n1:w [color="black", style="setlinewidth(3)", label=""];
 v0:e -> c5:p2:w [color="black", style="setlinewidth(3)", label=""];
 v1:e -> c5:p3:w [color="black", style="setlinewidth(3)", label=""];
-};
+}

--- a/manual/APPNOTE_011_Design_Investigation/sumprod_04.dot
+++ b/manual/APPNOTE_011_Design_Investigation/sumprod_04.dot
@@ -8,4 +8,4 @@ n1 [ shape=diamond, label="$3_Y" ];
 n1:e -> c7:p4:w [color="black", style="setlinewidth(3)", label=""];
 n2:e -> c7:p5:w [color="black", style="setlinewidth(3)", label=""];
 c7:p6:e -> n3:w [color="black", style="setlinewidth(3)", label=""];
-};
+}

--- a/manual/APPNOTE_011_Design_Investigation/sumprod_05.dot
+++ b/manual/APPNOTE_011_Design_Investigation/sumprod_05.dot
@@ -12,4 +12,4 @@ n2:e -> c8:p5:w [color="black", style="setlinewidth(3)", label=""];
 c8:p6:e -> n3:w [color="black", style="setlinewidth(3)", label=""];
 v0:e -> c7:p4:w [color="black", style="setlinewidth(3)", label=""];
 v1:e -> c7:p5:w [color="black", style="setlinewidth(3)", label=""];
-};
+}


### PR DESCRIPTION
Hello,
When I try to generate manual on debian jessie with the shell command : 
$ make manual

It complain about last semi-colon in .dot files.

Here a patch to delete semi-colons in all .dot files.

But it's not enough, I can't make manual. I've got another tex bug : 

``` bash
[...]
) [85] [86]) (./PRESENTATION_ExAdv.tex [87] [88]

! Package keyval Error: bg undefined.

See the keyval package documentation for explanation.
Type  H <return>  for immediate help.
 ...                                              

l.25 \end{frame}

!  ==> Fatal error occurred, no output PDF file produced!
Transcript written on presentation.log.
Makefile:294: recipe for target 'manual' failed
make: *** [manual] Error 1
```

I'm searching for solution.

Regards.
