### PR TITLE
manual/presentation.tex: bg option is unknown with beamer 3.3 in beamercolorbox

### DIFF
--- a/manual/presentation.tex
+++ b/manual/presentation.tex
@@ -74,7 +74,7 @@
 {\usebeamerfont{subsection name}\usebeamercolor[fg]{subsection name}of \sectionname~\insertsectionnumber}
 \vskip1em\par
 \setbeamercolor{graybox}{bg=gray}
-\begin{beamercolorbox}[sep=8pt,center,bg=gray]{graybox}
+\begin{beamercolorbox}[sep=8pt,center]{graybox}
 \usebeamerfont{subsection title}\insertsection\par
 \end{beamercolorbox}
 \end{centering}}


### PR DESCRIPTION
Permit to generate manual with beamer 3.3 deleting fg= option in beamercolorbox.
