### PR TITLE
Add output_directory arg for bram_init

### DIFF
--- a/techlibs/xilinx/brams_init.py
+++ b/techlibs/xilinx/brams_init.py
@@ -1,6 +1,18 @@
 #!/usr/bin/env python3
 
-with open("techlibs/xilinx/brams_init_18.vh", "w") as f:
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import os
+
+parser = argparse.ArgumentParser(description='Generate Xilinx bram initializations')
+parser.add_argument('--output_directory', default=os.path.dirname(__file__))
+args = parser.parse_args()
+
+init_18_path = os.path.join(args.output_directory, "brams_init_18.vh")
+with open(init_18_path, "w") as f:
     for i in range(8):
         init_snippets = ["INIT[%3d*9+8]" % (k+256*i,) for k in range(255, -1, -1)]
         for k in range(4, 256, 4):
@@ -12,7 +24,8 @@ with open("techlibs/xilinx/brams_init_18.vh", "w") as f:
             init_snippets[k] = "\n          " + init_snippets[k]
         print(".INIT_%02X({%s})," % (i, ", ".join(init_snippets)), file=f)
 
-with open("techlibs/xilinx/brams_init_36.vh", "w") as f:
+init_36_path = os.path.join(args.output_directory, "brams_init_36.vh")
+with open(init_36_path, "w") as f:
     for i in range(16):
         init_snippets = ["INIT[%3d*9+8]" % (k+256*i,) for k in range(255, -1, -1)]
         for k in range(4, 256, 4):
@@ -24,11 +37,13 @@ with open("techlibs/xilinx/brams_init_36.vh", "w") as f:
             init_snippets[k] = "\n          " + init_snippets[k]
         print(".INIT_%02X({%s})," % (i, ", ".join(init_snippets)), file=f)
 
-with open("techlibs/xilinx/brams_init_16.vh", "w") as f:
+init_16_path = os.path.join(args.output_directory, "brams_init_16.vh")
+with open(init_16_path, "w") as f:
     for i in range(64):
         print(".INIT_%02X(INIT[%3d*256 +: 256])," % (i, i), file=f)
 
-with open("techlibs/xilinx/brams_init_32.vh", "w") as f:
+init_32_path = os.path.join(args.output_directory, "brams_init_32.vh")
+with open(init_32_path, "w") as f:
     for i in range(128):
         print(".INIT_%02X(INIT[%3d*256 +: 256])," % (i, i), file=f)
 


### PR DESCRIPTION
This change adds a single argument to specify the output directory for xilinx/bram_init.py, defaulting to the script directory (which was the previous behavior). This makes it easier for (non-default) build systems to perform out-of-source builds.

