### PR TITLE
firrtl backend demote errors cell type not supported, write port

### DIFF
--- a/backends/firrtl/firrtl.cc
+++ b/backends/firrtl/firrtl.cc
@@ -373,10 +373,10 @@ struct FirrtlWorker
 				for (int i = 0; i < wr_ports; i++)
 				{
 					if (wr_clk_enable[i] != State::S1)
-						log_error("Unclocked write port %d on memory %s.%s.\n", i, log_id(module), log_id(cell));
+						log_warning("Unclocked write port %d on memory %s.%s.\n", i, log_id(module), log_id(cell));
 
 					if (wr_clk_polarity[i] != State::S1)
-						log_error("Negedge write port %d on memory %s.%s.\n", i, log_id(module), log_id(cell));
+						log_warning("Negedge write port %d on memory %s.%s.\n", i, log_id(module), log_id(cell));
 
 					string addr_expr = make_expr(cell->getPort("\\WR_ADDR").extract(i*abits, abits));
 					string data_expr = make_expr(cell->getPort("\\WR_DATA").extract(i*width, width));
@@ -387,7 +387,7 @@ struct FirrtlWorker
 
 					for (int i = 1; i < GetSize(wen_sig); i++)
 						if (wen_sig[0] != wen_sig[i])
-							log_error("Complex write enable on port %d on memory %s.%s.\n", i, log_id(module), log_id(cell));
+							log_warning("Complex write enable on port %d on memory %s.%s.\n", i, log_id(module), log_id(cell));
 
 					cell_exprs.push_back(stringf("    %s.w%d.addr <= %s\n", mem_id.c_str(), i, addr_expr.c_str()));
 					cell_exprs.push_back(stringf("    %s.w%d.data <= %s\n", mem_id.c_str(), i, data_expr.c_str()));
@@ -418,7 +418,7 @@ struct FirrtlWorker
 				continue;
 			}
 
-			log_error("Cell type not supported: %s (%s.%s)\n", log_id(cell->type), log_id(module), log_id(cell));
+			log_warning("Cell type not supported: %s (%s.%s)\n", log_id(cell->type), log_id(module), log_id(cell));
 		}
 
 		for (auto conn : module->connections())

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -598,6 +598,8 @@ static int tcl_yosys_cmd(ClientData, Tcl_Interp *interp, int argc, const char *a
 			std::string tcl_command_name = it.first;
 			if (tcl_command_name == "proc")
 				tcl_command_name = "procs";
+			else if (tcl_command_name == "rename")
+				tcl_command_name = "renames";			
 			Tcl_CmdInfo info;
 			if (Tcl_GetCommandInfo(interp, tcl_command_name.c_str(), &info) != 0) {
 				log("[TCL: yosys -import] Command name collision: found pre-existing command `%s' -> skip.\n", it.first.c_str());
@@ -638,8 +640,9 @@ struct TclPass : public Pass {
 		log("\n");
 		log("The tcl command 'yosys -import' can be used to import all yosys\n");
 		log("commands directly as tcl commands to the tcl shell. The yosys\n");
-		log("command 'proc' is wrapped using the tcl command 'procs' in order\n");
-		log("to avoid a name collision with the tcl builtin command 'proc'.\n");
+		log("commands 'proc' and 'rename' are wrapped using tcl commands 'procs'\n");
+		log("and 'renames' in order to avoid a name collision with the tcl builtin\n");
+		log("commands 'proc' and 'rename'.\n");
 		log("\n");
 	}
 	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) {


### PR DESCRIPTION
FIRRTL backend is not fully implemented.  This PR is to throw warnings instead of errors "cell type not supported" and unsupported memory write port configurations.
