### PR TITLE
FreeBSD build

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ Similarily, on Mac OS X MacPorts or Homebrew can be used to install dependencies
 	$ sudo port install bison flex readline gawk libffi \
 		git mercurial graphviz pkgconfig python36
 
+On FreeBSD use the following command to install all prerequisites:
+
+	# pkg install bison flex readline gawk libffi\
+		git mercurial graphviz pkgconfig python3 python36 tcl-wrapper
+
+On FreeBSD system use gmake instead of make. To run tests use:
+    % MAKE=gmake CC=cc gmake test
+
 There are also pre-compiled Yosys binary packages for Ubuntu and Win32 as well
 as a source distribution for Visual Studio. Visit the Yosys download page for
 more information: http://www.clifford.at/yosys/download.html

--- a/tests/tools/autotest.sh
+++ b/tests/tools/autotest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 libs=""
 genvcd=false


### PR DESCRIPTION
Changes (only for FreeBSD):
- ABC revision changed to revision from Feb 05 which supports FreeBSD
- removed <code>-ldl</code> - FreeBSD's <code>dlopen()</code> and similar functions are in libc
- paths: changed TCL include and library path
- tests: don't use <code>/bin/bash</code> directly, and use gmake for running test on FreeBSD
