### PR TITLE
First draft of Verilog parser support for specify blocks and parameters.

### DIFF
--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -145,6 +145,9 @@ YOSYS_NAMESPACE_END
 "endfunction"  { return TOK_ENDFUNCTION; }
 "task"         { return TOK_TASK; }
 "endtask"      { return TOK_ENDTASK; }
+"specify"      { return TOK_SPECIFY; }
+"endspecify"   { return TOK_ENDSPECIFY; }
+"specparam"    { return TOK_SPECPARAM; }
 "package"      { SV_KEYWORD(TOK_PACKAGE); }
 "endpackage"   { SV_KEYWORD(TOK_ENDPACKAGE); }
 "parameter"    { return TOK_PARAMETER; }

--- a/tests/simple/specify.v
+++ b/tests/simple/specify.v
@@ -1,0 +1,31 @@
+module test_specify;
+
+specparam a=1;
+
+specify
+endspecify
+
+specify
+(A => B) = ( 1 ) ;
+(A- => B) = ( 1,2 ) ;
+(A+ => B) = ( 1,2,3 ) ;
+(A => B) = (
+ 1.1, 2, 3,
+ 4, 5.5, 6.6
+) ;
+(A => B) = (
+ 1.1, 2, 3,
+ 4, 5.5, 6.6 ,
+ 7.7, 8.8, 9,
+ 10.1, 11, 12
+) ;
+specparam a=1;
+specparam [1:2] asasa=1;
+endspecify
+
+specify
+specparam a=1:2:3;
+endspecify
+
+endmodule
+


### PR DESCRIPTION
The only functionality of this code at the moment is to accept correct specify syntax and ignore it.
No part of the specify block is added to the AST
This aims to solve Issue #506
This PR in no way claims to implement the entire specify block syntax, but it can be easily extended towards this goal as needed.
If the approach taken by this PR is taken, I will extend it further as needed.
@edcote please take note, can you please check this or submit your specparam code?

