### PR TITLE
coolrunner2: Improve optimization for TFF/counters

### DIFF
--- a/techlibs/coolrunner2/Makefile.inc
+++ b/techlibs/coolrunner2/Makefile.inc
@@ -4,4 +4,5 @@ OBJS += techlibs/coolrunner2/coolrunner2_sop.o
 
 $(eval $(call add_share_file,share/coolrunner2,techlibs/coolrunner2/cells_latch.v))
 $(eval $(call add_share_file,share/coolrunner2,techlibs/coolrunner2/cells_sim.v))
+$(eval $(call add_share_file,share/coolrunner2,techlibs/coolrunner2/tff_extract.v))
 $(eval $(call add_share_file,share/coolrunner2,techlibs/coolrunner2/xc2_dff.lib))

--- a/techlibs/coolrunner2/synth_coolrunner2.cc
+++ b/techlibs/coolrunner2/synth_coolrunner2.cc
@@ -178,6 +178,7 @@ struct SynthCoolrunner2Pass : public ScriptPass
 			run("iopadmap -bits -inpad IBUF O:I -outpad IOBUFE I:IO -inoutpad IOBUFE O:IO -toutpad IOBUFE E:I:IO -tinoutpad IOBUFE E:O:I:IO");
 			run("attrmvcp -attr src -attr LOC t:IOBUFE n:*");
 			run("attrmvcp -attr src -attr LOC -driven t:IBUF n:*");
+			run("splitnets");
 			run("clean");
 		}
 

--- a/techlibs/coolrunner2/synth_coolrunner2.cc
+++ b/techlibs/coolrunner2/synth_coolrunner2.cc
@@ -149,6 +149,16 @@ struct SynthCoolrunner2Pass : public ScriptPass
 			run("dfflibmap -prepare -liberty +/coolrunner2/xc2_dff.lib");
 		}
 
+		if (check_label("map_tff"))
+		{
+			// This is quite hacky. By telling abc that it can only use AND and XOR gates, abc will try and use XOR
+			// gates "whenever possible." This will hopefully cause toggle flip-flop structures to turn into an XOR
+			// connected to a D flip-flop. We then match on these and convert them into XC2 TFF cells.
+			run("abc -g AND,XOR");
+			run("clean");
+			run("extract -map +/coolrunner2/tff_extract.v");
+		}
+
 		if (check_label("map_pla"))
 		{
 			run("abc -sop -I 40 -P 56");
@@ -160,6 +170,8 @@ struct SynthCoolrunner2Pass : public ScriptPass
 			run("dfflibmap -liberty +/coolrunner2/xc2_dff.lib");
 			run("dffinit -ff FDCP Q INIT");
 			run("dffinit -ff FDCP_N Q INIT");
+			run("dffinit -ff FTCP Q INIT");
+			run("dffinit -ff FTCP_N Q INIT");
 			run("dffinit -ff LDCP Q INIT");
 			run("dffinit -ff LDCP_N Q INIT");
 			run("coolrunner2_sop");

--- a/techlibs/coolrunner2/tff_extract.v
+++ b/techlibs/coolrunner2/tff_extract.v
@@ -1,0 +1,41 @@
+module FTCP (C, PRE, CLR, T, Q);
+	input C, PRE, CLR, T;
+	output wire Q;
+
+	wire xorout;
+
+	$_XOR_ xorgate (
+		.A(T),
+		.B(Q),
+		.Y(xorout),
+	);
+
+	$_DFFSR_PPP_ dff (
+		.C(C),
+		.D(xorout),
+		.Q(Q),
+		.S(PRE),
+		.R(CLR),
+	);
+endmodule
+
+module FTCP_N (C, PRE, CLR, T, Q);
+	input C, PRE, CLR, T;
+	output wire Q;
+
+	wire xorout;
+
+	$_XOR_ xorgate (
+		.A(T),
+		.B(Q),
+		.Y(xorout),
+	);
+
+	$_DFFSR_NPP_ dff (
+		.C(C),
+		.D(xorout),
+		.Q(Q),
+		.S(PRE),
+		.R(CLR),
+	);
+endmodule


### PR DESCRIPTION
Rather than "properly" teaching  yosys and/or ABC to understand how to generate "XOR of SOP with a p-term" we use the hack from #398 to get simple counters "working for now." This time the hack is confined to the `techlibs/coolrunner2` directory. We may or may not want to still consider what to do with the general case (#378).

Before adding this hack, counters tended to generate a ridiculous number of product terms that would quickly overfill the CPLD. Now it only generates ~1 product term per bit.