### PR TITLE
Fixed broken Quartus backend on dffeas init value, and other updates.

### DIFF
--- a/techlibs/achronix/Makefile.inc
+++ b/techlibs/achronix/Makefile.inc
@@ -1,5 +1,5 @@
 
-OBJS += techlibs/achronix/synth_speedster.o
+OBJS += techlibs/achronix/synth_achronix.o
 
 $(eval $(call add_share_file,share/achronix/speedster22i/,techlibs/achronix/speedster22i/cells_sim.v))
 $(eval $(call add_share_file,share/achronix/speedster22i/,techlibs/achronix/speedster22i/cells_map.v))

--- a/techlibs/achronix/speedster22i/cells_sim.v
+++ b/techlibs/achronix/speedster22i/cells_sim.v
@@ -16,50 +16,31 @@
  *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  */
+// > c60k28 (Viacheslav, VT) [at] yandex [dot] com
+// > Achronix eFPGA technology sim models. User must first simulate the generated \
+// > netlist before going to test it on board/custom chip.
+// > Changelog: 1) Removed unused VCC/GND modules
+// >            2) Altera comments here (?). Removed.
+// >            3) Reusing LUT sim model, removed wrong wires and parameters.
 
-module VCC (output V);
-   assign V = 1'b1;
-endmodule // VCC
-
-module GND (output G);
-   assign G = 1'b0;
-endmodule // GND
-
-/* Altera MAX10 devices Input Buffer Primitive */
 module PADIN (output padout, input padin);
    assign padout = padin;
-endmodule // fiftyfivenm_io_ibuf
+endmodule
 
-/* Altera MAX10 devices Output Buffer Primitive */
 module PADOUT (output padout, input padin, input oe);
    assign padout  = padin;
    assign oe = oe;
-endmodule // fiftyfivenm_io_obuf
+endmodule 
 
-/* Altera MAX10 4-input non-fracturable LUT Primitive */
 module LUT4 (output dout,
              input  din0, din1, din2, din3);
 
-/* Internal parameters which define the behaviour
-   of the LUT primitive.
-   lut_mask define the lut function, can be expressed in 16-digit bin or hex.
-   sum_lutc_input define the type of LUT (combinational | arithmetic).
-   dont_touch for retiming || carry options.
-   lpm_type for WYSIWYG */
-
-parameter lut_function = 16'hFFFF;
-//parameter dont_touch = "off";
-//parameter lpm_type = "fiftyfivenm_lcell_comb";
-//parameter sum_lutc_input = "datac";
-
-reg [1:0] lut_type;
-reg cout_rt;
+parameter [15:0] lut_function = 16'hFFFF;
 reg combout_rt;
 wire dataa_w;
 wire datab_w;
 wire datac_w;
 wire datad_w;
-wire cin_w;
 
 assign dataa_w = din0;
 assign datab_w = din1;
@@ -78,49 +59,21 @@ reg [1:0]   s1;
        s1 = datab ?   s2[3:2]  :   s2[1:0];
        lut_data = dataa ? s1[1] : s1[0];
   end
-
 endfunction
 
-initial begin
-    /*if (sum_lutc_input == "datac")*/ lut_type = 0;
-    /*else
-    if (sum_lutc_input == "cin")   lut_type = 1;
-    else begin
-      $error("Error in sum_lutc_input. Parameter %s is not a valid value.\n", sum_lutc_input);
-      $finish();
-    end*/
-end
-
 always @(dataa_w or datab_w or datac_w or datad_w or cin_w) begin
-    if (lut_type == 0) begin // logic function
-        combout_rt = lut_data(lut_function, dataa_w, datab_w,
-                            datac_w, datad_w);
-    end
-    else if (lut_type == 1) begin // arithmetic function
-        combout_rt = lut_data(lut_function, dataa_w, datab_w,
-                            cin_w, datad_w);
-    end
-    cout_rt = lut_data(lut_function, dataa_w, datab_w, cin_w, 'b0);
+   combout_rt = lut_data(lut_function, dataa_w, datab_w,
+                         datac_w, datad_w);
 end
-
 assign dout = combout_rt & 1'b1;
-//assign cout = cout_rt & 1'b1;
+endmodule 
 
-endmodule // fiftyfivenm_lcell_comb
-
-/* Altera MAX10 D Flip-Flop Primitive */
-// TODO: Implement advanced simulation functions
-module dffeas ( output q,
-                input d, clk, clrn, prn, ena,
-		input asdata, aload, sclr, sload );
-
-parameter power_up="dontcare";
-parameter is_wysiwyg="false";
-  reg q;
-
-  always @(posedge clk)
-    q <= d;
-
+module DFF (output q,
+            input  d, ck);
+   reg             q;
+   always @(posedge ck)
+     q <= d;
+   
 endmodule
 
 

--- a/techlibs/achronix/synth_achronix.cc
+++ b/techlibs/achronix/synth_achronix.cc
@@ -25,14 +25,14 @@
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
-struct SynthIntelPass : public ScriptPass {
-  SynthIntelPass() : ScriptPass("synth_speedster", "synthesis for Acrhonix Speedster22i FPGAs.") { }
+struct SynthAchronixPass : public ScriptPass {
+  SynthAchronixPass() : ScriptPass("synth_achronix", "synthesis for Acrhonix Speedster22i FPGAs.") { }
 
   virtual void help() YS_OVERRIDE
   {
     //   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
     log("\n");
-    log("    synth_speedster [options]\n");
+    log("    synth_achronix [options]\n");
     log("\n");
     log("This command runs synthesis for Achronix Speedster eFPGAs. This work is still experimental.\n");
     log("\n");
@@ -110,7 +110,7 @@ struct SynthIntelPass : public ScriptPass {
     if (!design->full_selection())
       log_cmd_error("This comannd only operates on fully selected designs!\n");
 
-    log_header(design, "Executing SYNTH_SPEEDSTER pass.\n");
+    log_header(design, "Executing SYNTH_ACHRONIX pass.\n");
     log_push();
 
     run_script(design, run_from, run_to);
@@ -146,9 +146,9 @@ struct SynthIntelPass : public ScriptPass {
         run("opt -undriven -fine");
         run("dffsr2dff");
         run("dff2dffe -direct-match $_DFF_*");
-        run("opt -full");
+        run("opt -fine");
         run("techmap -map +/techmap.v");
-        run("opt -fast");
+        run("opt -full");
         run("clean -purge");
         run("setundef -undriven -zero");
         if (retime || help_mode)
@@ -157,7 +157,7 @@ struct SynthIntelPass : public ScriptPass {
 
     if (check_label("map_luts"))
       {
-        run("abc -luts 2:2,3,6:5,10,20" + string(retime ? " -dff" : ""));
+        run("abc -lut 4" + string(retime ? " -dff" : ""));
         run("clean");
       }
 
@@ -165,7 +165,7 @@ struct SynthIntelPass : public ScriptPass {
       {
         run("iopadmap -bits -outpad $__outpad I:O -inpad $__inpad O:I");
         run("techmap -map +/achronix/speedster22i/cells_map.v");
-        run("dffinit -ff dffeas Q INIT");
+        // VT: not done yet run("dffinit -highlow -ff DFF q power_up");
         run("clean -purge");
       }
 
@@ -179,10 +179,10 @@ struct SynthIntelPass : public ScriptPass {
     if (check_label("vout"))
       {
         if (!vout_file.empty() || help_mode)
-          run(stringf("write_verilog -nodec -attr2comment -defparam -nohex -renameprefix yosys_ %s",
+          run(stringf("write_verilog -nodec -attr2comment -defparam -renameprefix syn_ %s",
                       help_mode ? "<file-name>" : vout_file.c_str()));
       }
   }
-} SynthIntelPass;
+} SynthAchronixPass;
 
 PRIVATE_NAMESPACE_END

--- a/techlibs/intel/cyclone10/cells_map.v
+++ b/techlibs/intel/cyclone10/cells_map.v
@@ -16,33 +16,43 @@
  *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  */
+// > c60k28 (Viacheslav, VT) [at] yandex [dot] com
+// > Intel FPGA technology mapping. User must first simulate the generated \
+// > netlist before going to test it on board.
+// > Changelog: 1) The missing power_up parameter in the techmap introduces a problem in Quartus mapper. Fixed.
+
 // Normal mode DFF negedge clk, negedge reset
 module  \$_DFF_N_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   parameter power_up=1'bx;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Normal mode DFF
 module  \$_DFF_P_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   parameter power_up=1'bx;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 // Async Active Low Reset DFF
 module  \$_DFF_PN0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   parameter power_up=1'bx;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up("power_up")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Async Active High Reset DFF
 module  \$_DFF_PP0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
+   parameter power_up=1'bx;
    wire R_i = ~ R;
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R_i), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R_i), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 module  \$__DFFE_PP0 (input D, C, E, R, output Q);
    parameter WYSIWYG="TRUE";
+   parameter power_up=1'bx;
    wire E_i = ~ E;
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(E_i), .sload(1'b0));
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(E_i), .sload(1'b0));
 endmodule
 
 // Input buffer map

--- a/techlibs/intel/cycloneiv/cells_map.v
+++ b/techlibs/intel/cycloneiv/cells_map.v
@@ -16,33 +16,43 @@
  *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  */
+// > c60k28 (Viacheslav, VT) [at] yandex [dot] com
+// > Intel FPGA technology mapping. User must first simulate the generated \
+// > netlist before going to test it on board.
+// > Changelog: 1) The missing power_up parameter in the techmap introduces a problem in Quartus mapper. Fixed.
+
 // Normal mode DFF negedge clk, negedge reset
 module  \$_DFF_N_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   parameter power_up=1'bx;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Normal mode DFF
 module  \$_DFF_P_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   parameter power_up=1'bx;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 // Async Active Low Reset DFF
 module  \$_DFF_PN0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   parameter power_up=1'bx;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up("power_up")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Async Active High Reset DFF
 module  \$_DFF_PP0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
+   parameter power_up=1'bx;
    wire R_i = ~ R;
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R_i), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R_i), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 module  \$__DFFE_PP0 (input D, C, E, R, output Q);
    parameter WYSIWYG="TRUE";
+   parameter power_up=1'bx;
    wire E_i = ~ E;
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(E_i), .sload(1'b0));
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(E_i), .sload(1'b0));
 endmodule
 
 // Input buffer map

--- a/techlibs/intel/cycloneive/arith_map.v
+++ b/techlibs/intel/cycloneive/arith_map.v
@@ -16,6 +16,48 @@
  *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  */
+/* TODO: Describe the following mode */
+module fa
+  (input  a_c,
+   input  b_c,
+   input  cin_c,
+   output cout_t,
+   output sum_x);
+
+   wire   a_c;
+   wire   b_c;
+   wire   cout_t;
+   wire   cin_c;
+   wire   sum_x;
+   wire   VCC;
+
+   assign VCC = 1'b1;
+   
+   cycloneiv_lcell_comb gen_sum_0 (.combout(sum_x),
+                                   .dataa(a_c),
+                                   .datab(b_c),
+                                   .datac(cin_c),
+                                   .datad(VCC));
+   defparam syn__05_.lut_mask = 16'b1001011010010110;
+   defparam syn__05_.sum_lutc_input = "datac";
+   
+   cycloneiv_lcell_comb gen_cout_0 (.combout(cout_t),
+                                    .dataa(cin_c),
+                                    .datab(b_c),
+                                    .datac(a_c),
+                                    .datad(VCC));
+   defparam syn__06_.lut_mask = 16'b1110000011100000;
+   defparam syn__06_.sum_lutc_input = "datac";
+   
+endmodule // fa
+
+module f_stage();
+   
+endmodule // f_stage
+
+module f_end();
+
+endmodule // f_end
 
 module _80_cycloneive_alu (A, B, CI, BI, X, Y, CO);
    parameter A_SIGNED = 0;
@@ -41,8 +83,13 @@ module _80_cycloneive_alu (A, B, CI, BI, X, Y, CO);
    wire [Y_WIDTH-1:0]   BB = BI ? ~B_buf : B_buf;
    wire [Y_WIDTH:0]     C = {CO, CI};
 
-   cycloneive_lcell_comb #(.lut_mask(16'b0110_0110_1000_1000), .sum_lutc_input("cin")) carry_start  (.cout(CO[0]), .dataa(BB[0]), .datab(1'b1), .datac(1'b1), .datad(1'b1));
-   genvar               i;
+   fa f0 (.a_c(AA[0]),
+          .b_c(BB[0]),
+          .cin_c(C[0]),
+          .cout_t(C0[1]),
+          .sum_x(Y[0]));
+   
+   genvar i;
    generate for (i = 1; i < Y_WIDTH; i = i + 1) begin:slice
       cycloneive_lcell_comb #(.lut_mask(16'b0101_1010_0101_0000), .sum_lutc_input("cin")) arith_cell (.combout(Y[i]), .cout(CO[i]), .dataa(BB[i]), .datab(1'b1), .datac(1'b1), .datad(1'b1), .cin(C[i]));
    end endgenerate

--- a/techlibs/intel/cycloneive/cells_map.v
+++ b/techlibs/intel/cycloneive/cells_map.v
@@ -16,32 +16,43 @@
  *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  */
+// > c60k28 (Viacheslav, VT) [at] yandex [dot] com
+// > Intel FPGA technology mapping. User must first simulate the generated \
+// > netlist before going to test it on board.
+// > Changelog: 1) The missing power_up parameter in the techmap introduces a problem in Quartus mapper. Fixed.
+
 // Normal mode DFF negedge clk, negedge reset
 module  \$_DFF_N_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   parameter power_up=1'bx;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Normal mode DFF
 module  \$_DFF_P_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   parameter power_up=1'bx;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
+
 // Async Active Low Reset DFF
 module  \$_DFF_PN0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   parameter power_up=1'bx;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up("power_up")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Async Active High Reset DFF
 module  \$_DFF_PP0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
+   parameter power_up=1'bx;
    wire R_i = ~ R;
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R_i), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R_i), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 module  \$__DFFE_PP0 (input D, C, E, R, output Q);
    parameter WYSIWYG="TRUE";
+   parameter power_up=1'bx;
    wire E_i = ~ E;
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(E_i), .sload(1'b0));
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(E_i), .sload(1'b0));
 endmodule
 
 // Input buffer map

--- a/techlibs/intel/cyclonev/cells_map.v
+++ b/techlibs/intel/cyclonev/cells_map.v
@@ -16,33 +16,45 @@
  *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  */
+// > c60k28 (Viacheslav, VT) [at] yandex [dot] com
+// > Intel FPGA technology mapping. User must first simulate the generated \
+// > netlist before going to test it on board.
+// > Changelog: 1) The missing power_up parameter in the techmap introduces a problem in Quartus mapper. Fixed.
+//              2) Cyclone V 7-input LUT function was wrong implemented. Removed abc option to map this function \
+//                 and added the explanation in this file instead. Such function needs to be implemented.
+
 // Normal mode DFF negedge clk, negedge reset
 module  \$_DFF_N_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   parameter power_up=1'bx;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Normal mode DFF
 module  \$_DFF_P_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   parameter power_up=1'bx;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 // Async Active Low Reset DFF
 module  \$_DFF_PN0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   parameter power_up=1'bx;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up("power_up")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Async Active High Reset DFF
 module  \$_DFF_PP0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
+   parameter power_up=1'bx;
    wire R_i = ~ R;
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R_i), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R_i), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 module  \$__DFFE_PP0 (input D, C, E, R, output Q);
    parameter WYSIWYG="TRUE";
+   parameter power_up=1'bx;
    wire E_i = ~ E;
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(E_i), .sload(1'b0));
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(E_i), .sload(1'b0));
 endmodule
 
 // Input buffer map
@@ -61,6 +73,10 @@ module \$lut (A, Y);
    parameter LUT    = 0;
    input [WIDTH-1:0] A;
    output            Y;
+   wire              VCC;
+   wire              GND;
+   assign {VCC,GND} = {1'b1,1'b0};
+   
    generate
       if (WIDTH == 1) begin
 	 assign Y = ~A[0]; // Not need to spend 1 logic cell for such an easy function
@@ -72,11 +88,11 @@ module \$lut (A, Y);
              (.combout(Y),
               .dataa(A[0]),
               .datab(A[1]),
-              .datac(1'b1),
-              .datad(1'b1),
-              .datae(1'b1),
-              .dataf(1'b1),
-              .datag(1'b1));
+              .datac(VCC),
+              .datad(VCC),
+              .datae(VCC),
+              .dataf(VCC),
+              .datag(VCC));
         end
         else
           if(WIDTH == 3) begin
@@ -86,10 +102,10 @@ module \$lut (A, Y);
                 .dataa(A[0]),
                 .datab(A[1]),
                 .datac(A[2]),
-                .datad(1'b1),
-                .datae(1'b1),
-                .dataf(1'b1),
-                .datag(1'b1));
+                .datad(VCC),
+                .datae(VCC),
+                .dataf(VCC),
+                .datag(VCC));
           end
           else
             if(WIDTH == 4) begin
@@ -100,9 +116,9 @@ module \$lut (A, Y);
                   .datab(A[1]),
                   .datac(A[2]),
                   .datad(A[3]),
-                  .datae(1'b1),
-                  .dataf(1'b1),
-                  .datag(1'b1));
+                  .datae(VCC),
+                  .dataf(VCC),
+                  .datag(VCC));
             end
             else
               if(WIDTH == 5) begin
@@ -114,8 +130,8 @@ module \$lut (A, Y);
                     .datac(A[2]),
                     .datad(A[3]),
                     .datae(A[4]),
-                    .dataf(1'b1),
-                    .datag(1'b1));
+                    .dataf(VCC),
+                    .datag(VCC));
               end
               else
                 if(WIDTH == 6) begin
@@ -128,21 +144,16 @@ module \$lut (A, Y);
                       .datad(A[3]),
                       .datae(A[4]),
                       .dataf(A[5]),
-                      .datag(1'b1));
+                      .datag(VCC));
                 end
-                else
+                /*else
                   if(WIDTH == 7) begin
-                     cyclonev_lcell_comb #(.lut_mask(LUT), .shared_arith("off"), .extended_lut("off"))
-                     _TECHMAP_REPLACE_
-                       (.combout(Y),
-                        .dataa(A[0]),
-                        .datab(A[1]),
-                        .datac(A[2]),
-                        .datad(A[3]),
-                        .datae(A[4]),
-                        .dataf(A[5]),
-                        .datag(A[6]));
-                  end
+                    TODO: There's not a just 7-input function on Cyclone V, see the following note:
+                    **Extended LUT Mode**
+                    Use extended LUT mode to implement a specific set of 7-input functions. The set must
+                    be a 2-to-1 multiplexer fed by two arbitrary 5-input functions sharing four inputs. 
+                    [source](Device Interfaces and Integration Basics for Cyclone V Devices).
+                  end*/
                   else
                      wire _TECHMAP_FAIL_ = 1;
    endgenerate

--- a/techlibs/intel/max10/cells_map.v
+++ b/techlibs/intel/max10/cells_map.v
@@ -16,43 +16,53 @@
  *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  */
+// > c60k28 (Viacheslav, VT) [at] yandex [dot] com
+// > Intel FPGA technology mapping. User must first simulate the generated \
+// > netlist before going to test it on board.
+// > Changelog: 1) The missing power_up parameter in the techmap introduces a problem in Quartus mapper. Fixed.
+
 // Normal mode DFF negedge clk, negedge reset
 module  \$_DFF_N_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   parameter power_up=1'bx;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Normal mode DFF
 module  \$_DFF_P_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   parameter power_up=1'bx;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 // Async Active Low Reset DFF
 module  \$_DFF_PN0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   parameter power_up=1'bx;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up("power_up")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Async Active High Reset DFF
 module  \$_DFF_PP0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
+   parameter power_up=1'bx;
    wire R_i = ~ R;
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R_i), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R_i), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 module  \$__DFFE_PP0 (input D, C, E, R, output Q);
    parameter WYSIWYG="TRUE";
+   parameter power_up=1'bx;
    wire E_i = ~ E;
-   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(E_i), .sload(1'b0));
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(E_i), .sload(1'b0));
 endmodule
 
 // Input buffer map
 module \$__inpad (input I, output O);
-    fiftyfivenm_io_ibuf _TECHMAP_REPLACE_ (.o(O), .i(I), .ibar(1'b0));
+   fiftyfivenm_io_ibuf _TECHMAP_REPLACE_ (.o(O), .i(I), .ibar(1'b0));
 endmodule
 
 // Output buffer map
 module \$__outpad (input I, output O);
-    fiftyfivenm_io_obuf _TECHMAP_REPLACE_ (.o(O), .i(I), .oe(1'b1));
+   fiftyfivenm_io_obuf _TECHMAP_REPLACE_ (.o(O), .i(I), .oe(1'b1));
 endmodule
 
 // LUT Map


### PR DESCRIPTION
## Why this pull request?
As per the recent changes in **__synth_intel.cc__** regarding the power up initialization of DFFEAS primitive, the missing parameter in the techlibs was making Quartus mapper fails. The generated netlist was incorrect.
I did corrected all the dffeas primitives in all the Intel families, but __tested only on Cyclone V__ since is the only hardware I have from such FPGA vendor. But also tried to compile the same working design after and before the changes and all of them are passing fine Quartus map.

## What else the commit does contain?
* Achronix Speedster organization. Should work fine now.
* VPR implementation on Intel devices. For experiments and hopefully someone else could use it as well.
* Fixed Cyclone V lut functions map. The Yosys netlist can generate a working SOF file fur such device now.

This is the first commit from myself. Please do let me know if there is anything else needed in order to add this commit to the head. Also please take into account that, without Intel changes, Yosys-Intel implementation is broken right now.

---
Signed by: Viacheslav T <c60k28 [at] yandex [dot] com