### PR TITLE
Set RAM runtime flags for Verific frontend

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -1632,6 +1632,9 @@ struct VerificPass : public Pass {
 		RuntimeFlags::SetVar("db_preserve_user_nets", 1);
 		RuntimeFlags::SetVar("db_allow_external_nets", 1);
 		RuntimeFlags::SetVar("vhdl_ignore_assertion_statements", 0);
+		RuntimeFlags::SetVar("veri_extract_dualport_rams", 0);
+		RuntimeFlags::SetVar("veri_extract_multiport_rams", 1);
+		RuntimeFlags::SetVar("db_infer_wide_operators", 1);
 		veri_file::DefineCmdLineMacro("VERIFIC");
 		veri_file::DefineCmdLineMacro("SYNTHESIS");
 


### PR DESCRIPTION
This is a follow up to https://github.com/YosysHQ/yosys/issues/516. By setting these runtime flags, users will get the expected results from the Verific frontend regardless of the flag values at compile time.

* veri_extract_multiport_rams enables RamNets so that the memories are preserved when importing to Yosys.
* veri_extract_dualport_rams needs to be disabled, because the two flags should not be used together.
* db_infer_wide_operators looks for wide operators instead of "bitblasting".

As far as I know, it makes sense to always use multiport rams. For everything I do, it also makes sense to set db_infer_wide_operators. It does disable some optimizations, but those simplifications could always be done in Yosys. Furthermore, based on the log file you provided in https://github.com/YosysHQ/yosys/issues/516, this seems like the configuration you're using.