### PR TITLE
support for multiple -liberty opt in stat cmd

### DIFF
--- a/passes/cmds/stat.cc
+++ b/passes/cmds/stat.cc
@@ -253,6 +253,19 @@ struct StatPass : public Pass {
 				read_liberty_cellarea(cell_area, liberty_file);
 				continue;
 			}
+			if (args[argidx] == "-liberty2" && argidx+1 < args.size()) {
+				string liberty_file = args[++argidx];
+				rewrite_filename(liberty_file);
+				read_liberty_cellarea(cell_area, liberty_file);
+				continue;
+			}
+			if (args[argidx] == "-liberty3" && argidx+1 < args.size()) {
+				string liberty_file = args[++argidx];
+				rewrite_filename(liberty_file);
+				read_liberty_cellarea(cell_area, liberty_file);
+				continue;
+			}
+			/* ETC. */
 			if (args[argidx] == "-top" && argidx+1 < args.size()) {
 				if (design->modules_.count(RTLIL::escape_id(args[argidx+1])) == 0)
 					log_cmd_error("Can't find module %s.\n", args[argidx+1].c_str());


### PR DESCRIPTION
I don't expect this PR to be merged AS-IS, but I can help make modifications if necessary.

The stat command can only take a single .lib file for purpose of generating chip area #.

Does your API for parsing options work for varargs options?

Can you suggest a better implementation than the hack I have here?