### PR TITLE
Support SystemVerilog `` extension for macros

### DIFF
--- a/frontends/verilog/preproc.cc
+++ b/frontends/verilog/preproc.cc
@@ -244,6 +244,7 @@ static bool try_expand_macro(std::set<std::string> &defines_with_args,
 				args.push_back(std::string());
 				while (1)
 				{
+					skip_spaces();
 					tok = next_token(true);
 					if (tok == ")" || tok == "}" || tok == "]")
 						level--;

--- a/frontends/verilog/preproc.cc
+++ b/frontends/verilog/preproc.cc
@@ -183,8 +183,9 @@ static std::string next_token(bool pass_newline = false)
 		const char *ok = "abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ$0123456789";
 		if (ch == '`' || strchr(ok, ch) != NULL)
 		{
+			char first = ch;
 			ch = next_char();
-			if (ch == '"') {
+			if (first == '`' && (ch == '"' || ch == '`')) {
 				token += ch;
 			} else do {
 					if (strchr(ok, ch) == NULL) {
@@ -265,6 +266,9 @@ static bool try_expand_macro(std::set<std::string> &defines_with_args,
 			}
 			insert_input(defines_map[name]);
 			return true;
+	} else if (tok == "``") {
+		// Swallow `` in macro expansion
+		return true;
 	} else return false;
 }
 


### PR DESCRIPTION
These patches add support for the ``` `` ``` token-pasting operator in macros, and clean up whitespace handling (which becomes more important when using ``` `` ```).  I verified with:
```
`define ADD(a,b) a+b
`define CONCAT1(a,b) a``b
`define CONCAT2(a) test_``a
`define CONCAT3(a) a``_test
`define FOO foo
`define BAR bar
`define CONCAT4 `FOO```BAR
`define STRING(a) `"a`"

module test;
   reg r0  = `CONCAT1(foo, bar);
   reg r1  = `CONCAT2(xx);
   reg r2  = `CONCAT3(yy);
   reg r3  = `CONCAT4;
   reg r4  = `ADD(1,2);
   reg r5  = `ADD(1, 2);
   reg r6  = `ADD(1,2 );
   reg r7  = `ADD( 1,2);
   reg r8  = `ADD( 1, 2);
   reg r9  = `ADD( 1,2 );
   reg r10 = `ADD(1 ,2);
   reg r11 = `ADD(1 , 2);
   reg r12 = `ADD(1 ,2 );
   reg r13 = `STRING(hello);
endmodule
```
and compared the output of yosis, iverilog, and Verilog-Perl:
```
yosys -p 'read_verilog -ppdump test.v'
ivlpp test.v # iverilog
vppreproc test.v # Verilog-Perl
```
which all give:
```
module test;
   reg r0  = foobar;
   reg r1  = test_xx;
   reg r2  = yy_test;
   reg r3  = foobar;
   reg r4  = 1+2;
   reg r5  = 1+2;
   reg r6  = 1+2;
   reg r7  = 1+2;
   reg r8  = 1+2;
   reg r9  = 1+2;
   reg r10 = 1+2;
   reg r11 = 1+2;
   reg r12 = 1+2;
   reg r13 = "hello";
endmodule
```
