### PR TITLE
Support SV implicit named ports and C-type array sizes.

### DIFF
--- a/tests/simple/run-test.sh
+++ b/tests/simple/run-test.sh
@@ -17,4 +17,4 @@ if ! which iverilog > /dev/null ; then
   exit 1
 fi
 
-exec ${MAKE:-make} -f ../tools/autotest.mk $seed *.v
+exec ${MAKE:-make} -f ../tools/autotest.mk $seed *.sv *.v

--- a/tests/simple/syntax.sv
+++ b/tests/simple/syntax.sv
@@ -1,0 +1,28 @@
+// Implied name ports
+module alu (
+	// from SV2012 spec
+	output reg [7:0] alu_out,
+	output reg zero,
+	input [7:0] ain, bin,
+	input [2:0] opcode
+	);
+endmodule
+
+module named_port;
+	wire [7:0] alu_out;
+	wire [7:0] ain, bin;
+	wire [2:0] opcode;
+
+	alu alu (
+		.alu_out(alu_out),
+		.zero(),	// zero output is unconnected
+		.ain,		// implicit named port connected to alu.ain
+		.bin(bin),
+		.opcode
+	);
+endmodule
+
+module array_sizes;
+	reg [31:0] old_way[0:15];
+	reg [31:0] new_way[16];
+endmodule


### PR DESCRIPTION
Two trivial SystemVerilog syntax enhancements

* implicit named port connections in a module instantiation where the names are the same.
* C-style array sizes e.g. `reg [7:0] mem_array[1024]`

There is a simple test but this required changes to `autotest.sh` to support SV files with names ending in `.sv`.