### PR TITLE
Detect illegal port declaration, e.g input/output/inout keyword must …

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -376,9 +376,10 @@ wire_type:
 	};
 
 wire_type_token_list:
-	wire_type_token | wire_type_token_list wire_type_token;
+	wire_type_token | wire_type_token_list wire_type_token |
+	wire_type_token_io ;
 
-wire_type_token:
+wire_type_token_io:
 	TOK_INPUT {
 		astbuf3->is_input = true;
 	} |
@@ -388,7 +389,9 @@ wire_type_token:
 	TOK_INOUT {
 		astbuf3->is_input = true;
 		astbuf3->is_output = true;
-	} |
+	};
+
+wire_type_token:
 	TOK_WIRE {
 	} |
 	TOK_REG {


### PR DESCRIPTION
This PR is tightening the verilog parser around port definition.

Currently the following invalid code is accepted:
```
module x(wire input i);
endmodule
```
or
```
module y(i);
wire input i;
endmodule
```

These code snippets should be illegal, and in addition I hope will help future parser enhancements (e.g. for typedefs).
From my past experience any effort to touch the wire/reg declaration rules for typedefs, where the reg/wire keyword is replaced by a simple TOK_ID triggers ~15 shift/reduce or reduce/reduce conflicts.
