### PR TITLE
Include module name for area summary stats

### DIFF
--- a/passes/cmds/stat.cc
+++ b/passes/cmds/stat.cc
@@ -142,7 +142,7 @@ struct statdata_t
 		}
 	}
 
-	void log_data()
+	void log_data(RTLIL::IdString mod_name, bool top_mod)
 	{
 		log("   Number of wires:             %6d\n", num_wires);
 		log("   Number of wire bits:         %6d\n", num_wire_bits);
@@ -163,7 +163,7 @@ struct statdata_t
 
 		if (area != 0) {
 			log("\n");
-			log("   Chip area for this module: %f\n", area);
+			log("   Chip area for %smodule '%s': %f\n", (top_mod) ? "top " : "", mod_name.c_str(), area);
 		}
 	}
 };
@@ -275,7 +275,7 @@ struct StatPass : public Pass {
 			log("\n");
 			log("=== %s%s ===\n", RTLIL::id2cstr(mod->name), design->selected_whole_module(mod->name) ? "" : " (partially selected)");
 			log("\n");
-			data.log_data();
+			data.log_data(mod->name, false);
 		}
 
 		if (top_mod != NULL && GetSize(mod_stat) > 1)
@@ -288,7 +288,7 @@ struct StatPass : public Pass {
 			statdata_t data = hierarchy_worker(mod_stat, top_mod->name, 0);
 
 			log("\n");
-			data.log_data();
+			data.log_data(top_mod->name, true);
 		}
 
 		log("\n");


### PR DESCRIPTION
The PR prints the name of the module when displaying the final area count.

Pros:
- Easier for the user to `grep` for area information about a specific module

Cons:
- Arguably more verbose, less "pretty" than what author may desire

Verification:
~~~~
30c30
<    Chip area for this module: 20616.349000
---
>    Chip area for module '$paramod$d1738fc0bb353d517bc2caf8fef2abb20bced034\picorv32': 20616.349000
70c70
<    Chip area for this module: 88.697700
---
>    Chip area for module '\picorv32_axi_adapter': 88.697700
102c102
<    Chip area for this module: 20705.046700
---
>    Chip area for top module '\picorv32_axi': 20705.046700
~~~~