### PR TITLE
Add Protobuf backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ ENABLE_EDITLINE := 0
 ENABLE_VERIFIC := 0
 ENABLE_COVER := 1
 ENABLE_LIBYOSYS := 0
+ENABLE_PROTOBUF := 0
 
 # other configuration flags
 ENABLE_GPROF := 0
@@ -323,6 +324,10 @@ VERIFIC_DIR ?= /usr/local/src/verific_lib_eval
 VERIFIC_COMPONENTS ?= verilog vhdl database util containers sdf hier_tree
 CXXFLAGS += $(patsubst %,-I$(VERIFIC_DIR)/%,$(VERIFIC_COMPONENTS)) -DYOSYS_ENABLE_VERIFIC
 LDLIBS += $(patsubst %,$(VERIFIC_DIR)/%/*-linux.a,$(VERIFIC_COMPONENTS)) -lz
+endif
+
+ifeq ($(ENABLE_PROTOBUF),1)
+LDLIBS += $(shell pkg-config --cflags --libs protobuf)
 endif
 
 ifeq ($(ENABLE_COVER),1)

--- a/backends/protobuf/.gitignore
+++ b/backends/protobuf/.gitignore
@@ -1,0 +1,2 @@
+yosys.pb.cc
+yosys.pb.h

--- a/backends/protobuf/Makefile.inc
+++ b/backends/protobuf/Makefile.inc
@@ -1,0 +1,8 @@
+ifeq ($(ENABLE_PROTOBUF),1)
+
+backends/protobuf/yosys.pb.cc backends/protobuf/yosys.pb.h: share/yosys.proto
+	$(Q) cd misc && protoc --cpp_out "../backends/protobuf" yosys.proto
+
+OBJS += backends/protobuf/protobuf.o backends/protobuf/yosys.pb.o
+
+endif

--- a/backends/protobuf/protobuf.cc
+++ b/backends/protobuf/protobuf.cc
@@ -1,0 +1,370 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *  Copyright (C) 2018  Serge Bazanski <q3k@symbioticeda.com>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include <google/protobuf/text_format.h>
+
+#include "kernel/rtlil.h"
+#include "kernel/register.h"
+#include "kernel/sigtools.h"
+#include "kernel/celltypes.h"
+#include "kernel/cellaigs.h"
+#include "kernel/log.h"
+#include "yosys.pb.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+struct ProtobufDesignSerializer
+{
+	bool aig_mode_;
+	bool use_selection_;
+	yosys::pb::Design *pb_;
+
+	Design *design_;
+	Module *module_;
+
+	SigMap sigmap_;
+	int sigidcounter_;
+	dict<SigBit, uint64_t> sigids_;
+	pool<Aig> aig_models_;
+
+
+	ProtobufDesignSerializer(bool use_selection, bool aig_mode) :
+			aig_mode_(aig_mode), use_selection_(use_selection) { }
+	
+	string get_name(IdString name)
+	{
+		return RTLIL::unescape_id(name);
+	}
+
+
+	void serialize_parameters(google::protobuf::Map<std::string, yosys::pb::Parameter> *out,
+		const dict<IdString, Const> &parameters)
+	{
+		for (auto &param : parameters) {
+			std::string key = get_name(param.first);
+			
+
+			yosys::pb::Parameter pb_param;
+
+			if ((param.second.flags & RTLIL::ConstFlags::CONST_FLAG_STRING) != 0) {
+				pb_param.set_str(param.second.decode_string());
+			} else if (GetSize(param.second.bits) > 64) {
+				pb_param.set_str(param.second.as_string());
+			} else {
+				pb_param.set_int_(param.second.as_int());
+			}
+
+			(*out)[key] = pb_param;
+		}
+	}
+
+	void get_bits(yosys::pb::BitVector *out, SigSpec sig)
+	{
+		for (auto bit : sigmap_(sig)) {
+			auto sig = out->add_signal();
+
+			// Constant driver.
+			if (bit.wire == nullptr) {
+				if (bit == State::S0) sig->set_constant(sig->CONSTANT_DRIVER_LOW);
+				else if (bit == State::S1) sig->set_constant(sig->CONSTANT_DRIVER_HIGH);
+				else if (bit == State::Sz) sig->set_constant(sig->CONSTANT_DRIVER_Z);
+				else sig->set_constant(sig->CONSTANT_DRIVER_X);
+				continue;
+			}
+
+			// Signal - give it a unique identifier.
+			if (sigids_.count(bit) == 0) {
+				sigids_[bit] = sigidcounter_++;
+			}
+			sig->set_id(sigids_[bit]);
+		}
+	}
+
+	void serialize_module(yosys::pb::Module* out, Module *module)
+	{
+		module_ = module;
+		log_assert(module_->design == design_);
+		sigmap_.set(module_);
+		sigids_.clear();
+		sigidcounter_ = 0;
+
+		serialize_parameters(out->mutable_attribute(), module_->attributes);
+
+		for (auto n : module_->ports) {
+			Wire *w = module->wire(n);
+			if (use_selection_ && !module_->selected(w))
+				continue;
+
+			yosys::pb::Module::Port pb_port;
+			pb_port.set_direction(w->port_input ? w->port_output ?
+				yosys::pb::DIRECTION_INOUT : yosys::pb::DIRECTION_INPUT : yosys::pb::DIRECTION_OUTPUT);
+			get_bits(pb_port.mutable_bits(), w);
+			(*out->mutable_port())[get_name(n)] = pb_port;
+		}
+
+		for (auto c : module_->cells()) {
+			if (use_selection_ && !module_->selected(c))
+				continue;
+
+			yosys::pb::Module::Cell pb_cell;
+			pb_cell.set_hide_name(c->name[0] == '$');
+			pb_cell.set_type(get_name(c->type));
+
+			if (aig_mode_) {
+				Aig aig(c);
+				if (aig.name.empty())
+					continue;
+				pb_cell.set_model(aig.name);
+				aig_models_.insert(aig);
+			}
+			serialize_parameters(pb_cell.mutable_parameter(), c->parameters);
+			serialize_parameters(pb_cell.mutable_attribute(), c->attributes);
+
+			if (c->known()) {
+				for (auto &conn : c->connections()) {
+					yosys::pb::Direction direction = yosys::pb::DIRECTION_OUTPUT;
+					if (c->input(conn.first))
+						direction = c->output(conn.first) ? yosys::pb::DIRECTION_INOUT : yosys::pb::DIRECTION_INPUT;
+					(*pb_cell.mutable_port_direction())[get_name(conn.first)] = direction;
+				}
+			}
+			for (auto &conn : c->connections()) {
+				yosys::pb::BitVector vec;
+				get_bits(&vec, conn.second);
+				(*pb_cell.mutable_connection())[get_name(conn.first)] = vec;
+			}
+
+			(*out->mutable_cell())[get_name(c->name)] = pb_cell;
+		}
+
+		for (auto w : module_->wires()) {
+			if (use_selection_ && !module_->selected(w))
+				continue;
+
+			auto netname = out->add_netname();
+			netname->set_hide_name(w->name[0] == '$');
+			get_bits(netname->mutable_bits(), w);
+			serialize_parameters(netname->mutable_attributes(), w->attributes);
+		}
+	}
+
+
+	void serialize_models(google::protobuf::Map<string, yosys::pb::Model> *models)
+	{
+		for (auto &aig : aig_models_) {
+			yosys::pb::Model pb_model;
+			for (auto &node : aig.nodes) {
+				auto pb_node = pb_model.add_node();
+				if (node.portbit >= 0) {
+					if (node.inverter) {
+						pb_node->set_type(pb_node->TYPE_NPORT);
+					} else {
+						pb_node->set_type(pb_node->TYPE_PORT);
+					}
+					auto port = pb_node->mutable_port();
+					port->set_portname(log_id(node.portname));
+					port->set_bitindex(node.portbit);
+				} else if (node.left_parent < 0 && node.right_parent < 0) {
+					if (node.inverter) {
+						pb_node->set_type(pb_node->TYPE_TRUE);
+					} else {
+						pb_node->set_type(pb_node->TYPE_FALSE);
+					}
+				} else {
+					if (node.inverter) {
+						pb_node->set_type(pb_node->TYPE_NAND);
+					} else {
+						pb_node->set_type(pb_node->TYPE_AND);
+					}
+					auto gate = pb_node->mutable_gate();
+					gate->set_left(node.left_parent);
+					gate->set_right(node.right_parent);
+				}
+				for (auto &op : node.outports) {
+					auto pb_op = pb_node->add_out_port();
+					pb_op->set_name(log_id(op.first));
+					pb_op->set_bit_index(op.second);
+				}
+			}
+			(*models)[aig.name] = pb_model;
+		}
+	}
+	
+	void serialize_design(yosys::pb::Design *pb, Design *design)
+	{
+		GOOGLE_PROTOBUF_VERIFY_VERSION;
+		pb_ = pb;
+		pb_->Clear();
+		pb_->set_creator(yosys_version_str);
+
+		design_ = design;
+		design_->sort();
+
+		auto modules = use_selection_ ? design_->selected_modules() : design_->modules();
+		for (auto mod : modules) {
+			yosys::pb::Module pb_mod;
+			serialize_module(&pb_mod, mod);
+			(*pb->mutable_modules())[mod->name.str()] = pb_mod;
+		}
+
+		serialize_models(pb_->mutable_models());
+	}
+};
+
+struct ProtobufBackend : public Backend {
+	ProtobufBackend(): Backend("protobuf", "write design to a Protocol Buffer file") { }
+	virtual void help()
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    write_protobuf [options] [filename]\n");
+		log("\n");
+		log("Write a JSON netlist of the current design.\n");
+		log("\n");
+		log("    -aig\n");
+		log("        include AIG models for the different gate types\n");
+		log("\n");
+		log("    -text\n");
+		log("        output protobuf in Text/ASCII representation\n");
+		log("\n");
+		log("The schema of the output Protocol Buffer is defined in misc/yosys.pb in the\n");
+		log("Yosys source code distribution.\n");
+		log("\n");
+	}
+	virtual void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	{
+		bool aig_mode = false;
+		bool text_mode = false;
+
+		size_t argidx;
+		for (argidx = 1; argidx < args.size(); argidx++) {
+			if (args[argidx] == "-aig") {
+				aig_mode = true;
+				continue;
+			}
+			if (args[argidx] == "-text") {
+				text_mode = true;
+				continue;
+			}
+			break;
+		}
+		extra_args(f, filename, args, argidx);
+
+		log_header(design, "Executing Protobuf backend.\n");
+
+		yosys::pb::Design pb;
+		ProtobufDesignSerializer serializer(false, aig_mode);
+		serializer.serialize_design(&pb, design);
+
+		if (text_mode) {
+			string out;
+			google::protobuf::TextFormat::PrintToString(pb, &out);
+			*f << out;
+		} else {
+			pb.SerializeToOstream(f);
+		}
+	}
+} ProtobufBackend;
+
+struct ProtobufPass : public Pass {
+	ProtobufPass() : Pass("protobuf", "write design in Protobuf format") { }
+	virtual void help()
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    protobuf [options] [selection]\n");
+		log("\n");
+		log("Write a JSON netlist of all selected objects.\n");
+		log("\n");
+		log("    -o <filename>\n");
+		log("        write to the specified file.\n");
+		log("\n");
+		log("    -aig\n");
+		log("        include AIG models for the different gate types\n");
+		log("\n");
+		log("    -text\n");
+		log("        output protobuf in Text/ASCII representation\n");
+		log("\n");
+		log("The schema of the output Protocol Buffer is defined in misc/yosys.pb in the\n");
+		log("Yosys source code distribution.\n");
+		log("\n");
+	}
+	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	{
+		std::string filename;
+		bool aig_mode = false;
+		bool text_mode = false;
+
+		size_t argidx;
+		for (argidx = 1; argidx < args.size(); argidx++)
+		{
+			if (args[argidx] == "-o" && argidx+1 < args.size()) {
+				filename = args[++argidx];
+				continue;
+			}
+			if (args[argidx] == "-aig") {
+				aig_mode = true;
+				continue;
+			}
+			if (args[argidx] == "-text") {
+				text_mode = true;
+				continue;
+			}
+			break;
+		}
+		extra_args(args, argidx, design);
+
+		std::ostream *f;
+		std::stringstream buf;
+
+		if (!filename.empty()) {
+			std::ofstream *ff = new std::ofstream;
+			ff->open(filename.c_str(), std::ofstream::trunc);
+			if (ff->fail()) {
+				delete ff;
+				log_error("Can't open file `%s' for writing: %s\n", filename.c_str(), strerror(errno));
+			}
+			f = ff;
+		} else {
+			f = &buf;
+		}
+
+		yosys::pb::Design pb;
+		ProtobufDesignSerializer serializer(true, aig_mode);
+		serializer.serialize_design(&pb, design);
+
+		if (text_mode) {
+			string out;
+			google::protobuf::TextFormat::PrintToString(pb, &out);
+			*f << out;
+		} else {
+			pb.SerializeToOstream(f);
+		}
+
+		if (!filename.empty()) {
+			delete f;
+		} else {
+			log("%s", buf.str().c_str());
+		}
+	}
+} ProtobufPass;
+
+PRIVATE_NAMESPACE_END;

--- a/misc/yosys.proto
+++ b/misc/yosys.proto
@@ -1,0 +1,175 @@
+//
+// yosys -- Yosys Open SYnthesis Suite
+// 
+// Copyright (C) 2018  Serge Bazanski <q3k@symbioticeda.com>
+// 
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+
+/// Protobuf definition of Yosys RTLIL dump/restore format for RTL designs.
+
+syntax = "proto3";
+
+package yosys.pb;
+
+// Port direction.
+enum Direction {
+    DIRECTION_INVALID = 0;
+    DIRECTION_INPUT = 1;
+    DIRECTION_OUTPUT = 2;
+    DIRECTION_INOUT = 3;
+}
+
+// A freeform parameter/attribute value.
+message Parameter {
+    oneof value {
+        int64 int = 1;
+        string str = 2;
+    }
+}
+
+// A signal in the design - either a unique identifier for one, or a constant
+// driver (low or high).
+message Signal {
+    // A constant signal driver in the design.
+    enum ConstantDriver {
+        CONSTANT_DRIVER_INVALID = 0;
+        CONSTANT_DRIVER_LOW = 1;
+        CONSTANT_DRIVER_HIGH = 2;
+        CONSTANT_DRIVER_Z = 3;
+        CONSTANT_DRIVER_X = 4;
+    }
+    oneof type {
+        // Signal uniquely identified by ID number.
+        int64 id = 1;
+        // Constant driver.
+        ConstantDriver constant = 2;
+    }
+}
+
+// A vector of signals.
+message BitVector {
+    repeated Signal signal = 1;
+}
+
+// A netlist module.
+message Module {
+    // Freeform attributes.
+    map<string, Parameter> attribute = 1;
+
+    // Named ports in this module.
+    message Port {
+        Direction direction = 1;
+        BitVector bits = 2;
+    }
+    map<string, Port> port = 2;
+    
+    // Named cells in this module.
+    message Cell {
+        // Set to true when the name of this cell is automatically created and
+        // likely not of interest for a regular user.
+        bool hide_name = 1;
+        string type = 2;
+        // Set if this module has an AIG model available.
+        string model = 3;
+        // Freeform parameters.
+        map<string, Parameter> parameter = 4;
+        // Freeform attributes.
+        map<string, Parameter> attribute = 5;
+
+        /// Ports of the cell.
+        // Direction of the port, if interface is known.
+        map<string, Direction> port_direction = 6;
+        // Connection of named port to signal(s).
+        map<string, BitVector> connection = 7;
+    }
+    map<string, Cell> cell = 3;
+
+    // Nets in this module.
+    message Netname {
+        // Set to true when the name of this net is automatically created and
+        // likely not of interest for a regular user.
+        bool hide_name = 1;
+        // Signal(s) that make up this net.
+        BitVector bits = 2;
+        // Freeform attributes.
+        map<string, Parameter> attributes = 3;
+    }
+    repeated Netname netname = 4;
+}
+
+// And-Inverter-Graph model.
+message Model {
+    message Node {
+        // Type of AIG node - or, what its' value is.
+        enum Type {
+            TYPE_INVALID = 0;
+            // The node's value is the value of the specified input port bit.
+            TYPE_PORT = 1;
+            // The node's value is the inverted value of the specified input
+            // port bit.
+            TYPE_NPORT = 2;
+            // The node's value is the ANDed value of specified nodes.
+            TYPE_AND = 3;
+            // The node's value is the NANDed value of specified nodes.
+            TYPE_NAND = 4;
+            // The node's value is a constant 1.
+            TYPE_TRUE = 5;
+            // The node's value is a constant 0.
+            TYPE_FALSE = 6;
+        };
+        Type type = 1;
+    
+        message Port {
+            // Name of port.
+            string portname = 1;
+            // Bit index in port.
+            int64 bitindex = 2;
+        }
+        message Gate {
+            // Node index of left side of operation.
+            int64 left = 1;
+            // Node index of right side of operation.
+            int64 right = 2;
+        }
+        oneof node {
+            // Set for PORT, NPORT
+            Port port = 2;
+            // Set for AND, NAND.
+            Gate gate = 3;
+        }
+    
+        // Set when the node drives given output port(s).
+        message OutPort {
+            // Name of port.
+            string name = 1;
+            // Bit index in port.
+            int64 bit_index = 2;
+        }
+        repeated OutPort out_port = 4;
+    }
+
+    // List of  AIG nodes - each is explicitely numbered by its' index in this
+    // array.
+    repeated Node node = 1;
+}
+
+// A Yosys design netlist dumped from RTLIL.
+message Design {
+    // Human-readable freeform 'remark' string.
+    string creator = 1;
+    // List of named modules in design.
+    map<string, Module> modules = 2;
+    // List of named AIG models in design (if AIG export enabled).
+    map<string, Model> models = 3;
+}


### PR DESCRIPTION
This introduces a Google Protocol Buffer backend for Yosys.

The schema is kept similar to the JSON backend, but with a few important changes:

 - signal numbers now start from 0, and constant signals are typed to their value
 - AIG nodes are typed

Interestingly, these changes cause us to generate fairly large protos - larger than JSON! This is because we end up having a lot of repeated data (ie any bitvector must also specify a type for each member - whether it's a unique signal id, or a constant driver).

To test, compile Yosys with ENABLE_PROTOBUF=1 (you'll need protoc), and run:

    yosys -p 'read_verilog ./tests/simple/aes_kexp128.v; write_protobuf -text'

This will spit out a Text Format protobuf to your terminal. For binary proto (ie. the main wire format), run:

    yosys -p 'read_verilog ./tests/simple/aes_kexp128.v; write_protobuf foo.pb'

One last thing to note: I have chosen to use the singular noun form for maps/repeated fields in the Proto definition, which makes it more readable in C++ and text format (but looks slightly odd in other languages, like Python or Go). :)