### PR TITLE
Provide source-location logging.

### DIFF
--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -958,9 +958,9 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 				wire->attributes["\\src"] = stringf("%s:%d", filename.c_str(), linenum);
 				wire->name = str;
 				if (flag_autowire)
-					log_warning("Identifier `%s' is implicitly declared at %s:%d.\n", str.c_str(), filename.c_str(), linenum);
+					log_file_warning(filename, linenum, "Identifier `%s' is implicitly declared.\n", str.c_str());
 				else
-					log_error("Identifier `%s' is implicitly declared at %s:%d and `default_nettype is set to none.\n", str.c_str(), filename.c_str(), linenum);
+					log_file_error(filename, linenum, "Identifier `%s' is implicitly declared and `default_nettype is set to none.\n", str.c_str());
 			}
 			else if (id2ast->type == AST_PARAMETER || id2ast->type == AST_LOCALPARAM) {
 				if (id2ast->children[0]->type != AST_CONSTANT)
@@ -1563,4 +1563,3 @@ RTLIL::SigSpec AstNode::genWidthRTLIL(int width, const dict<RTLIL::SigBit, RTLIL
 }
 
 YOSYS_NAMESPACE_END
-

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -203,7 +203,8 @@ void logv_header(RTLIL::Design *design, const char *format, va_list ap)
 		log_files.pop_back();
 }
 
-void logv_warning(const char *format, va_list ap)
+static void logv_warning_with_prefix(const char *prefix,
+                                     const char *format, va_list ap)
 {
 	std::string message = vstringf(format, ap);
 	bool suppressed = false;
@@ -214,7 +215,7 @@ void logv_warning(const char *format, va_list ap)
 
 	if (suppressed)
 	{
-		log("Suppressed warning: %s", message.c_str());
+		log("Suppressed %s%s", prefix, message.c_str());
 	}
 	else
 	{
@@ -224,7 +225,7 @@ void logv_warning(const char *format, va_list ap)
 
 		if (log_warnings.count(message))
 		{
-			log("Warning: %s", message.c_str());
+			log("%s%s", prefix, message.c_str());
 			log_flush();
 		}
 		else
@@ -232,7 +233,7 @@ void logv_warning(const char *format, va_list ap)
 			if (log_errfile != NULL && !log_quiet_warnings)
 				log_files.push_back(log_errfile);
 
-			log("Warning: %s", message.c_str());
+			log("%s%s", prefix, message.c_str());
 			log_flush();
 
 			if (log_errfile != NULL && !log_quiet_warnings)
@@ -243,51 +244,32 @@ void logv_warning(const char *format, va_list ap)
 
 		log_warnings_count++;
 	}
+}
+
+void logv_warning(const char *format, va_list ap)
+{
+	logv_warning_with_prefix("Warning: ", format, ap);
 }
 
 void logv_warning_noprefix(const char *format, va_list ap)
 {
-	std::string message = vstringf(format, ap);
-	bool suppressed = false;
-
-	for (auto &re : log_nowarn_regexes)
-		if (std::regex_search(message, re))
-			suppressed = true;
-
-	if (suppressed)
-	{
-		log("%s", message.c_str());
-	}
-	else
-	{
-		for (auto &re : log_werror_regexes)
-			if (std::regex_search(message, re))
-				log_error("%s",  message.c_str());
-
-		if (log_warnings.count(message))
-		{
-			log("%s", message.c_str());
-			log_flush();
-		}
-		else
-		{
-			if (log_errfile != NULL && !log_quiet_warnings)
-				log_files.push_back(log_errfile);
-
-			log("%s", message.c_str());
-			log_flush();
-
-			if (log_errfile != NULL && !log_quiet_warnings)
-				log_files.pop_back();
-
-			log_warnings.insert(message);
-		}
-
-		log_warnings_count++;
-	}
+	logv_warning_with_prefix("", format, ap);
 }
 
-void logv_error(const char *format, va_list ap)
+void log_file_warning(const std::string &filename, int lineno,
+                      const char *format, ...)
+{
+	va_list ap;
+	va_start(ap, format);
+	std::string prefix = stringf("%s:%d: Warning: ",
+				     filename.c_str(), lineno);
+	logv_warning_with_prefix(prefix.c_str(), format, ap);
+	va_end(ap);
+}
+
+YS_ATTRIBUTE(noreturn)
+static void logv_error_with_prefix(const char *prefix,
+                                   const char *format, va_list ap)
 {
 #ifdef EMSCRIPTEN
 	auto backup_log_files = log_files;
@@ -302,7 +284,7 @@ void logv_error(const char *format, va_list ap)
 				f = stderr;
 
 	log_last_error = vstringf(format, ap);
-	log("ERROR: %s", log_last_error.c_str());
+	log("%s%s", prefix, log_last_error.c_str());
 	log_flush();
 
 	if (log_error_atexit)
@@ -316,6 +298,21 @@ void logv_error(const char *format, va_list ap)
 #else
 	_Exit(1);
 #endif
+}
+
+void logv_error(const char *format, va_list ap)
+{
+	logv_error_with_prefix("ERROR: ", format, ap);
+}
+
+void log_file_error(const string &filename, int lineno,
+                    const char *format, ...)
+{
+	va_list ap;
+	va_start(ap, format);
+	std::string prefix = stringf("%s:%d: ERROR: ",
+				     filename.c_str(), lineno);
+	logv_error_with_prefix(prefix.c_str(), format, ap);
 }
 
 void log(const char *format, ...)
@@ -636,4 +633,3 @@ dict<std::string, std::pair<std::string, int>> get_coverage_data()
 #endif
 
 YOSYS_NAMESPACE_END
-

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -73,8 +73,13 @@ YS_NORETURN void logv_error(const char *format, va_list ap) YS_ATTRIBUTE(noretur
 void log(const char *format, ...)  YS_ATTRIBUTE(format(printf, 1, 2));
 void log_header(RTLIL::Design *design, const char *format, ...) YS_ATTRIBUTE(format(printf, 2, 3));
 void log_warning(const char *format, ...) YS_ATTRIBUTE(format(printf, 1, 2));
+
+// Log with filename to report a problem in a source file.
+void log_file_warning(const std::string &filename, int lineno, const char *format, ...) YS_ATTRIBUTE(format(printf, 3, 4));
+
 void log_warning_noprefix(const char *format, ...) YS_ATTRIBUTE(format(printf, 1, 2));
 YS_NORETURN void log_error(const char *format, ...) YS_ATTRIBUTE(format(printf, 1, 2), noreturn);
+void log_file_error(const string &filename, int lineno, const char *format, ...) YS_ATTRIBUTE(format(printf, 3, 4), noreturn);
 YS_NORETURN void log_cmd_error(const char *format, ...) YS_ATTRIBUTE(format(printf, 1, 2), noreturn);
 
 void log_spacer();


### PR DESCRIPTION
Provide a standardized warning/error logging which makes it much easier to develop verilog as it allows to step through the messages with IDEs, emacs or vi as they all know the `<filename>:<line>:<msg>` format that is also standardized in compilers such as gcc or clang.

I intend to survey all the places where we have a filename and line-number available in future pull requests, but for now just the base-work and a proof-of-concept place in genrtlil.

o Provide log_file_warning() and log_file_error() that prefix the log
  message with `<filename>:<lineno>:` to be easily picked up by IDEs that
  need to step through errors.
o Simplify some duplicate logging code in kernel/log.cc
o Use the new log functions in genrtlil.