### PR TITLE
Convert more log_error() to log_file_error() where possible.

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -171,8 +171,8 @@ bool AstNode::get_bool_attribute(RTLIL::IdString id)
 
 	AstNode *attr = attributes.at(id);
 	if (attr->type != AST_CONSTANT)
-		log_error("Attribute `%s' with non-constant value at %s:%d!\n",
-				id.c_str(), attr->filename.c_str(), attr->linenum);
+		log_file_error(attr->filename, attr->linenum, "Attribute `%s' with non-constant value!\n",
+			       id.c_str());
 
 	return attr->integer != 0;
 }
@@ -955,8 +955,8 @@ static AstModule* process_module(AstNode *ast, bool defer)
 
 		for (auto &attr : ast->attributes) {
 			if (attr.second->type != AST_CONSTANT)
-				log_error("Attribute `%s' with non-constant value at %s:%d!\n",
-						attr.first.c_str(), ast->filename.c_str(), ast->linenum);
+				log_file_error(ast->filename, ast->linenum, "Attribute `%s' with non-constant value!\n",
+					       attr.first.c_str());
 			current_module->attributes[attr.first] = attr.second->asAttrConst();
 		}
 		for (size_t i = 0; i < ast->children.size(); i++) {
@@ -1044,8 +1044,8 @@ void AST::process(RTLIL::Design *design, AstNode *ast, bool dump_ast1, bool dump
 			if (design->has((*it)->str)) {
 				RTLIL::Module *existing_mod = design->module((*it)->str);
 				if (!nooverwrite && !overwrite && !existing_mod->get_bool_attribute("\\blackbox")) {
-					log_error("Re-definition of module `%s' at %s:%d!\n",
-							(*it)->str.c_str(), (*it)->filename.c_str(), (*it)->linenum);
+					log_file_error((*it)->filename, (*it)->linenum, "Re-definition of module `%s'!\n",
+						       (*it)->str.c_str());
 				} else if (nooverwrite) {
 					log("Ignoring re-definition of module `%s' at %s:%d.\n",
 							(*it)->str.c_str(), (*it)->filename.c_str(), (*it)->linenum);
@@ -1197,4 +1197,3 @@ void AST::use_internal_line_num()
 }
 
 YOSYS_NAMESPACE_END
-

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -55,8 +55,8 @@ static RTLIL::SigSpec uniop2rtlil(AstNode *that, std::string type, int result_wi
 	if (gen_attributes)
 		for (auto &attr : that->attributes) {
 			if (attr.second->type != AST_CONSTANT)
-				log_error("Attribute `%s' with non-constant value at %s:%d!\n",
-						attr.first.c_str(), that->filename.c_str(), that->linenum);
+				log_file_error(that->filename, that->linenum, "Attribute `%s' with non-constant value!\n",
+					       attr.first.c_str());
 			cell->attributes[attr.first] = attr.second->asAttrConst();
 		}
 
@@ -89,8 +89,8 @@ static void widthExtend(AstNode *that, RTLIL::SigSpec &sig, int width, bool is_s
 	if (that != NULL)
 		for (auto &attr : that->attributes) {
 			if (attr.second->type != AST_CONSTANT)
-				log_error("Attribute `%s' with non-constant value at %s:%d!\n",
-						attr.first.c_str(), that->filename.c_str(), that->linenum);
+				log_file_error(that->filename, that->linenum, "Attribute `%s' with non-constant value!\n",
+					       attr.first.c_str());
 			cell->attributes[attr.first] = attr.second->asAttrConst();
 		}
 
@@ -117,8 +117,8 @@ static RTLIL::SigSpec binop2rtlil(AstNode *that, std::string type, int result_wi
 
 	for (auto &attr : that->attributes) {
 		if (attr.second->type != AST_CONSTANT)
-			log_error("Attribute `%s' with non-constant value at %s:%d!\n",
-					attr.first.c_str(), that->filename.c_str(), that->linenum);
+			log_file_error(that->filename, that->linenum, "Attribute `%s' with non-constant value!\n",
+				       attr.first.c_str());
 		cell->attributes[attr.first] = attr.second->asAttrConst();
 	}
 
@@ -152,8 +152,8 @@ static RTLIL::SigSpec mux2rtlil(AstNode *that, const RTLIL::SigSpec &cond, const
 
 	for (auto &attr : that->attributes) {
 		if (attr.second->type != AST_CONSTANT)
-			log_error("Attribute `%s' with non-constant value at %s:%d!\n",
-					attr.first.c_str(), that->filename.c_str(), that->linenum);
+			log_file_error(that->filename, that->linenum, "Attribute `%s' with non-constant value!\n",
+				       attr.first.c_str());
 		cell->attributes[attr.first] = attr.second->asAttrConst();
 	}
 
@@ -207,8 +207,8 @@ struct AST_INTERNAL::ProcessGenerator
 		proc->name = stringf("$proc$%s:%d$%d", always->filename.c_str(), always->linenum, autoidx++);
 		for (auto &attr : always->attributes) {
 			if (attr.second->type != AST_CONSTANT)
-				log_error("Attribute `%s' with non-constant value at %s:%d!\n",
-						attr.first.c_str(), always->filename.c_str(), always->linenum);
+				log_file_error(always->filename, always->linenum, "Attribute `%s' with non-constant value!\n",
+						attr.first.c_str());
 			proc->attributes[attr.first] = attr.second->asAttrConst();
 		}
 		current_module->processes[proc->name] = proc;
@@ -480,8 +480,8 @@ struct AST_INTERNAL::ProcessGenerator
 
 				for (auto &attr : ast->attributes) {
 					if (attr.second->type != AST_CONSTANT)
-						log_error("Attribute `%s' with non-constant value at %s:%d!\n",
-								attr.first.c_str(), ast->filename.c_str(), ast->linenum);
+						log_file_error(ast->filename, ast->linenum, "Attribute `%s' with non-constant value!\n",
+							       attr.first.c_str());
 					sw->attributes[attr.first] = attr.second->asAttrConst();
 				}
 
@@ -648,8 +648,8 @@ void AstNode::detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *foun
 				while (left_at_zero_ast->simplify(true, true, false, 1, -1, false, false)) { }
 				while (right_at_zero_ast->simplify(true, true, false, 1, -1, false, false)) { }
 				if (left_at_zero_ast->type != AST_CONSTANT || right_at_zero_ast->type != AST_CONSTANT)
-					log_error("Unsupported expression on dynamic range select on signal `%s' at %s:%d!\n",
-							str.c_str(), filename.c_str(), linenum);
+					log_file_error(filename, linenum, "Unsupported expression on dynamic range select on signal `%s'!\n",
+						       str.c_str());
 				this_width = left_at_zero_ast->integer - right_at_zero_ast->integer + 1;
 				delete left_at_zero_ast;
 				delete right_at_zero_ast;
@@ -777,8 +777,8 @@ void AstNode::detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *foun
 			if (GetSize(children) == 1) {
 				while (children[0]->simplify(true, false, false, 1, -1, false, true) == true) { }
 				if (children[0]->type != AST_CONSTANT)
-					log_error("System function %s called with non-const argument at %s:%d!\n",
-							RTLIL::unescape_id(str).c_str(), filename.c_str(), linenum);
+					log_file_error(filename, linenum, "System function %s called with non-const argument!\n",
+						       RTLIL::unescape_id(str).c_str());
 				width_hint = max(width_hint, int(children[0]->asInt(true)));
 			}
 			break;
@@ -799,8 +799,8 @@ void AstNode::detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *foun
 	default:
 		for (auto f : log_files)
 			current_ast->dumpAst(f, "verilog-ast> ");
-		log_error("Don't know how to detect sign and width for %s node at %s:%d!\n",
-				type2str(type).c_str(), filename.c_str(), linenum);
+		log_file_error(filename, linenum, "Don't know how to detect sign and width for %s node!\n",
+			       type2str(type).c_str());
 	}
 
 	if (*found_real)
@@ -863,11 +863,11 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 	// create an RTLIL::Wire for an AST_WIRE node
 	case AST_WIRE: {
 			if (current_module->wires_.count(str) != 0)
-				log_error("Re-definition of signal `%s' at %s:%d!\n",
-						str.c_str(), filename.c_str(), linenum);
+				log_file_error(filename, linenum, "Re-definition of signal `%s'!\n",
+					       str.c_str());
 			if (!range_valid)
-				log_error("Signal `%s' with non-constant width at %s:%d!\n",
-						str.c_str(), filename.c_str(), linenum);
+				log_file_error(filename, linenum, "Signal `%s' with non-constant width!\n",
+					       str.c_str());
 
 			log_assert(range_left >= range_right || (range_left == -1 && range_right == 0));
 
@@ -881,8 +881,8 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 
 			for (auto &attr : attributes) {
 				if (attr.second->type != AST_CONSTANT)
-					log_error("Attribute `%s' with non-constant value at %s:%d!\n",
-							attr.first.c_str(), filename.c_str(), linenum);
+					log_file_error(filename, linenum, "Attribute `%s' with non-constant value!\n",
+						       attr.first.c_str());
 				wire->attributes[attr.first] = attr.second->asAttrConst();
 			}
 		}
@@ -891,16 +891,16 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 	// create an RTLIL::Memory for an AST_MEMORY node
 	case AST_MEMORY: {
 			if (current_module->memories.count(str) != 0)
-				log_error("Re-definition of memory `%s' at %s:%d!\n",
-						str.c_str(), filename.c_str(), linenum);
+				log_file_error(filename, linenum, "Re-definition of memory `%s'!\n",
+					       str.c_str());
 
 			log_assert(children.size() >= 2);
 			log_assert(children[0]->type == AST_RANGE);
 			log_assert(children[1]->type == AST_RANGE);
 
 			if (!children[0]->range_valid || !children[1]->range_valid)
-				log_error("Memory `%s' with non-constant width or size at %s:%d!\n",
-						str.c_str(), filename.c_str(), linenum);
+				log_file_error(filename, linenum, "Memory `%s' with non-constant width or size!\n",
+					       str.c_str());
 
 			RTLIL::Memory *memory = new RTLIL::Memory;
 			memory->attributes["\\src"] = stringf("%s:%d", filename.c_str(), linenum);
@@ -917,8 +917,8 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 
 			for (auto &attr : attributes) {
 				if (attr.second->type != AST_CONSTANT)
-					log_error("Attribute `%s' with non-constant value at %s:%d!\n",
-							attr.first.c_str(), filename.c_str(), linenum);
+					log_file_error(filename, linenum, "Attribute `%s' with non-constant value!\n",
+						       attr.first.c_str());
 				memory->attributes[attr.first] = attr.second->asAttrConst();
 			}
 		}
@@ -937,8 +937,8 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 	case AST_REALVALUE:
 		{
 			RTLIL::SigSpec sig = realAsConst(width_hint);
-			log_warning("converting real value %e to binary %s at %s:%d.\n",
-					realvalue, log_signal(sig), filename.c_str(), linenum);
+			log_file_warning(filename, linenum, "converting real value %e to binary %s.\n",
+					 realvalue, log_signal(sig));
 			return sig;
 		}
 
@@ -964,19 +964,19 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 			}
 			else if (id2ast->type == AST_PARAMETER || id2ast->type == AST_LOCALPARAM) {
 				if (id2ast->children[0]->type != AST_CONSTANT)
-					log_error("Parameter %s does not evaluate to constant value at %s:%d!\n",
-							str.c_str(), filename.c_str(), linenum);
+					log_file_error(filename, linenum, "Parameter %s does not evaluate to constant value!\n",
+						       str.c_str());
 				chunk = RTLIL::Const(id2ast->children[0]->bits);
 				goto use_const_chunk;
 			}
 			else if (!id2ast || (id2ast->type != AST_WIRE && id2ast->type != AST_AUTOWIRE &&
 					id2ast->type != AST_MEMORY) || current_module->wires_.count(str) == 0)
-				log_error("Identifier `%s' doesn't map to any signal at %s:%d!\n",
-						str.c_str(), filename.c_str(), linenum);
+				log_file_error(filename, linenum, "Identifier `%s' doesn't map to any signal!\n",
+						str.c_str());
 
 			if (id2ast->type == AST_MEMORY)
-				log_error("Identifier `%s' does map to an unexpanded memory at %s:%d!\n",
-						str.c_str(), filename.c_str(), linenum);
+				log_file_error(filename, linenum, "Identifier `%s' does map to an unexpanded memory!\n",
+					       str.c_str());
 
 			wire = current_module->wires_[str];
 			chunk.wire = wire;
@@ -994,8 +994,8 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 					while (left_at_zero_ast->simplify(true, true, false, 1, -1, false, false)) { }
 					while (right_at_zero_ast->simplify(true, true, false, 1, -1, false, false)) { }
 					if (left_at_zero_ast->type != AST_CONSTANT || right_at_zero_ast->type != AST_CONSTANT)
-						log_error("Unsupported expression on dynamic range select on signal `%s' at %s:%d!\n",
-								str.c_str(), filename.c_str(), linenum);
+						log_file_error(filename, linenum, "Unsupported expression on dynamic range select on signal `%s'!\n",
+							       str.c_str());
 					int width = left_at_zero_ast->integer - right_at_zero_ast->integer + 1;
 					AstNode *fake_ast = new AstNode(AST_NONE, clone(), children[0]->children.size() >= 2 ?
 							children[0]->children[1]->clone() : children[0]->children[0]->clone());
@@ -1023,11 +1023,11 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 						chunk.offset = (id2ast->range_left - id2ast->range_right + 1) - (chunk.offset + chunk.width);
 					if (chunk.offset >= source_width || chunk.offset + chunk.width < 0) {
 						if (chunk.width == 1)
-							log_warning("Range select out of bounds on signal `%s' at %s:%d: Setting result bit to undef.\n",
-									str.c_str(), filename.c_str(), linenum);
+							log_file_warning(filename, linenum, "Range select out of bounds on signal `%s': Setting result bit to undef.\n",
+									 str.c_str());
 						else
-							log_warning("Range select out of bounds on signal `%s' at %s:%d: Setting all %d result bits to undef.\n",
-									str.c_str(), filename.c_str(), linenum, chunk.width);
+							log_file_warning(filename, linenum, "Range select out of bounds on signal `%s': Setting all %d result bits to undef.\n",
+									str.c_str(), chunk.width);
 						chunk = RTLIL::SigChunk(RTLIL::State::Sx, chunk.width);
 					} else {
 						if (chunk.width + chunk.offset > source_width) {
@@ -1040,11 +1040,11 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 							chunk.offset += add_undef_bits_lsb;
 						}
 						if (add_undef_bits_lsb)
-							log_warning("Range select out of bounds on signal `%s' at %s:%d: Setting %d LSB bits to undef.\n",
-									str.c_str(), filename.c_str(), linenum, add_undef_bits_lsb);
+							log_file_warning(filename, linenum, "Range select out of bounds on signal `%s': Setting %d LSB bits to undef.\n",
+									 str.c_str(), add_undef_bits_lsb);
 						if (add_undef_bits_msb)
-							log_warning("Range select out of bounds on signal `%s' at %s:%d: Setting %d MSB bits to undef.\n",
-									str.c_str(), filename.c_str(), linenum, add_undef_bits_msb);
+							log_file_warning(filename, linenum, "Range select out of bounds on signal `%s': Setting %d MSB bits to undef.\n",
+									 str.c_str(), add_undef_bits_msb);
 					}
 				}
 			}
@@ -1379,8 +1379,8 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 
 			for (auto &attr : attributes) {
 				if (attr.second->type != AST_CONSTANT)
-					log_error("Attribute `%s' with non-constant value at %s:%d!\n",
-							attr.first.c_str(), filename.c_str(), linenum);
+					log_file_error(filename, linenum, "Attribute `%s' with non-constant value!\n",
+						       attr.first.c_str());
 				cell->attributes[attr.first] = attr.second->asAttrConst();
 			}
 
@@ -1401,10 +1401,10 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 						new_left.append(left[i]);
 						new_right.append(right[i]);
 					}
-				log_warning("Ignoring assignment to constant bits at %s:%d:\n"
-						"    old assignment: %s = %s\n    new assignment: %s = %s.\n",
-						filename.c_str(), linenum, log_signal(left), log_signal(right),
-						log_signal(new_left), log_signal(new_right));
+				log_file_warning(filename, linenum, "Ignoring assignment to constant bits:\n"
+						 "    old assignment: %s = %s\n    new assignment: %s = %s.\n",
+						 log_signal(left), log_signal(right),
+						 log_signal(new_left), log_signal(new_right));
 				left = new_left;
 				right = new_right;
 			}
@@ -1418,8 +1418,7 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 			int port_counter = 0, para_counter = 0;
 
 			if (current_module->count_id(str) != 0)
-				log_error("Re-definition of cell `%s' at %s:%d!\n",
-						str.c_str(), filename.c_str(), linenum);
+				log_file_error(filename, linenum, "Re-definition of cell `%s'!\n", str.c_str());
 
 			RTLIL::Cell *cell = current_module->addCell(str, "");
 			cell->attributes["\\src"] = stringf("%s:%d", filename.c_str(), linenum);
@@ -1435,16 +1434,15 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 				if (child->type == AST_PARASET) {
 					IdString paraname = child->str.empty() ? stringf("$%d", ++para_counter) : child->str;
 					if (child->children[0]->type == AST_REALVALUE) {
-						log_warning("Replacing floating point parameter %s.%s = %f with string at %s:%d.\n",
-							log_id(cell), log_id(paraname), child->children[0]->realvalue,
-							filename.c_str(), linenum);
+						log_file_warning(filename, linenum, "Replacing floating point parameter %s.%s = %f with string.\n",
+								 log_id(cell), log_id(paraname), child->children[0]->realvalue);
 						auto strnode = AstNode::mkconst_str(stringf("%f", child->children[0]->realvalue));
 						strnode->cloneInto(child->children[0]);
 						delete strnode;
 					}
 					if (child->children[0]->type != AST_CONSTANT)
-						log_error("Parameter %s.%s with non-constant value at %s:%d!\n",
-								log_id(cell), log_id(paraname), filename.c_str(), linenum);
+						log_file_error(filename, linenum, "Parameter %s.%s with non-constant value!\n",
+							       log_id(cell), log_id(paraname));
 					cell->parameters[paraname] = child->children[0]->asParaConst();
 					continue;
 				}
@@ -1465,8 +1463,8 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 			}
 			for (auto &attr : attributes) {
 				if (attr.second->type != AST_CONSTANT)
-					log_error("Attribute `%s' with non-constant value at %s:%d!\n",
-							attr.first.c_str(), filename.c_str(), linenum);
+					log_file_error(filename, linenum, "Attribute `%s' with non-constant value!\n",
+						       attr.first.c_str());
 				cell->attributes[attr.first] = attr.second->asAttrConst();
 			}
 		}
@@ -1493,19 +1491,19 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 				int width = width_hint;
 
 				if (GetSize(children) > 1)
-					log_error("System function %s got %d arguments, expected 1 or 0 at %s:%d.\n",
-							RTLIL::unescape_id(str).c_str(), GetSize(children), filename.c_str(), linenum);
+					log_file_error(filename, linenum, "System function %s got %d arguments, expected 1 or 0.\n",
+						       RTLIL::unescape_id(str).c_str(), GetSize(children));
 
 				if (GetSize(children) == 1) {
 					if (children[0]->type != AST_CONSTANT)
-						log_error("System function %s called with non-const argument at %s:%d!\n",
-								RTLIL::unescape_id(str).c_str(), filename.c_str(), linenum);
+						log_file_error(filename, linenum, "System function %s called with non-const argument!\n",
+							       RTLIL::unescape_id(str).c_str());
 					width = children[0]->asInt(true);
 				}
 
 				if (width <= 0)
-					log_error("Failed to detect width of %s at %s:%d!\n",
-							RTLIL::unescape_id(str).c_str(), filename.c_str(), linenum);
+					log_file_error(filename, linenum, "Failed to detect width of %s!\n",
+						       RTLIL::unescape_id(str).c_str());
 
 				Cell *cell = current_module->addCell(myid, str.substr(1));
 				cell->attributes["\\src"] = stringf("%s:%d", filename.c_str(), linenum);
@@ -1532,8 +1530,8 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 		for (auto f : log_files)
 			current_ast->dumpAst(f, "verilog-ast> ");
 		type_name = type2str(type);
-		log_error("Don't know how to generate RTLIL code for %s node at %s:%d!\n",
-				type_name.c_str(), filename.c_str(), linenum);
+		log_file_error(filename, linenum, "Don't know how to generate RTLIL code for %s node!\n",
+			       type_name.c_str());
 	}
 
 	return RTLIL::SigSpec();

--- a/frontends/verilog/const2ast.cc
+++ b/frontends/verilog/const2ast.cc
@@ -49,8 +49,7 @@ static int my_decimal_div_by_two(std::vector<uint8_t> &digits)
 	int carry = 0;
 	for (size_t i = 0; i < digits.size(); i++) {
 		if (digits[i] >= 10)
-			log_error("Invalid use of [a-fxz?] in decimal constant at %s:%d.\n",
-				current_filename.c_str(), get_line_num());
+			log_file_error(current_filename, get_line_num(), "Invalid use of [a-fxz?] in decimal constant.\n");
 		digits[i] += carry * 10;
 		carry = digits[i] % 2;
 		digits[i] /= 2;
@@ -105,8 +104,8 @@ static void my_strtobin(std::vector<RTLIL::State> &data, const char *str, int le
 		int bits_per_digit = my_ilog2(base-1);
 		for (auto it = digits.rbegin(), e = digits.rend(); it != e; it++) {
 			if (*it > (base-1) && *it < 0xf0)
-				log_error("Digit larger than %d used in in base-%d constant at %s:%d.\n",
-					base-1, base, current_filename.c_str(), get_line_num());
+				log_file_error(current_filename, get_line_num(), "Digit larger than %d used in in base-%d constant.\n",
+					       base-1, base);
 			for (int i = 0; i < bits_per_digit; i++) {
 				int bitmask = 1 << i;
 				if (*it == 0xf0)
@@ -238,4 +237,3 @@ AstNode *VERILOG_FRONTEND::const2ast(std::string code, char case_type, bool warn
 }
 
 YOSYS_NAMESPACE_END
-


### PR DESCRIPTION
Mostly statements that span over multiple lines and haven't been
caught with the previous conversion.