### PR TITLE
Consistent use of 'override' for virtual methods in derived classes.

### DIFF
--- a/CodingReadme
+++ b/CodingReadme
@@ -21,7 +21,7 @@ Here is a the C++ code for a "hello_world" Yosys command (hello.cc):
 
 	struct HelloWorldPass : public Pass {
 		HelloWorldPass() : Pass("hello_world") { }
-		virtual void execute(vector<string>, Design*) {
+		void execute(vector<string>, Design*) override {
 			log("Hello World!\n");
 		}
 	} HelloWorldPass;

--- a/backends/aiger/aiger.cc
+++ b/backends/aiger/aiger.cc
@@ -657,7 +657,7 @@ struct AigerWriter
 
 struct AigerBackend : public Backend {
 	AigerBackend() : Backend("aiger", "write design to AIGER file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -690,7 +690,7 @@ struct AigerBackend : public Backend {
 		log("        like -map, but more verbose\n");
 		log("\n");
 	}
-	virtual void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool ascii_mode = false;
 		bool zinit_mode = false;

--- a/backends/blif/blif.cc
+++ b/backends/blif/blif.cc
@@ -464,7 +464,7 @@ struct BlifDumper
 
 struct BlifBackend : public Backend {
 	BlifBackend() : Backend("blif", "write design to BLIF file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -534,7 +534,7 @@ struct BlifBackend : public Backend {
 		log("        do not write definitions for the $true, $false and $undef wires.\n");
 		log("\n");
 	}
-	virtual void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::string top_module_name;
 		std::string buf_type, buf_in, buf_out;

--- a/backends/btor/btor.cc
+++ b/backends/btor/btor.cc
@@ -1076,7 +1076,7 @@ struct BtorWorker
 
 struct BtorBackend : public Backend {
 	BtorBackend() : Backend("btor", "write design to BTOR file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -1091,7 +1091,7 @@ struct BtorBackend : public Backend {
 		log("    Output only a single bad property for all asserts\n");
 		log("\n");
 	}
-	virtual void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool verbose = false, single_bad = false;
 

--- a/backends/edif/edif.cc
+++ b/backends/edif/edif.cc
@@ -90,7 +90,7 @@ struct EdifNames
 
 struct EdifBackend : public Backend {
 	EdifBackend() : Backend("edif", "write design to EDIF netlist file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -116,7 +116,7 @@ struct EdifBackend : public Backend {
 		log("is targeted.\n");
 		log("\n");
 	}
-	virtual void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing EDIF backend.\n");
 		std::string top_module_name;

--- a/backends/firrtl/firrtl.cc
+++ b/backends/firrtl/firrtl.cc
@@ -527,7 +527,7 @@ struct FirrtlWorker
 
 struct FirrtlBackend : public Backend {
 	FirrtlBackend() : Backend("firrtl", "write design to a FIRRTL file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -536,7 +536,7 @@ struct FirrtlBackend : public Backend {
 		log("Write a FIRRTL netlist of the current design.\n");
 		log("\n");
 	}
-	virtual void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)

--- a/backends/ilang/ilang_backend.cc
+++ b/backends/ilang/ilang_backend.cc
@@ -382,7 +382,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct IlangBackend : public Backend {
 	IlangBackend() : Backend("ilang", "write design to ilang file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -395,7 +395,7 @@ struct IlangBackend : public Backend {
 		log("        only write selected parts of the design.\n");
 		log("\n");
 	}
-	virtual void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool selected = false;
 
@@ -422,7 +422,7 @@ struct IlangBackend : public Backend {
 
 struct DumpPass : public Pass {
 	DumpPass() : Pass("dump", "print parts of the design in ilang format") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -445,7 +445,7 @@ struct DumpPass : public Pass {
 		log("        like -outfile but append instead of overwrite\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::string filename;
 		bool flag_m = false, flag_n = false, append = false;

--- a/backends/intersynth/intersynth.cc
+++ b/backends/intersynth/intersynth.cc
@@ -46,7 +46,7 @@ static std::string netname(std::set<std::string> &conntypes_code, std::set<std::
 
 struct IntersynthBackend : public Backend {
 	IntersynthBackend() : Backend("intersynth", "write design to InterSynth netlist file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -71,7 +71,7 @@ struct IntersynthBackend : public Backend {
 		log("http://www.clifford.at/intersynth/\n");
 		log("\n");
 	}
-	virtual void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing INTERSYNTH backend.\n");
 		log_push();

--- a/backends/json/json.cc
+++ b/backends/json/json.cc
@@ -250,7 +250,7 @@ struct JsonWriter
 
 struct JsonBackend : public Backend {
 	JsonBackend() : Backend("json", "write design to a JSON file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -458,7 +458,7 @@ struct JsonBackend : public Backend {
 		log("format. A program processing this format must ignore all unknown fields.\n");
 		log("\n");
 	}
-	virtual void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool aig_mode = false;
 
@@ -482,7 +482,7 @@ struct JsonBackend : public Backend {
 
 struct JsonPass : public Pass {
 	JsonPass() : Pass("json", "write design in JSON format") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -499,7 +499,7 @@ struct JsonPass : public Pass {
 		log("See 'help write_json' for a description of the JSON format used.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::string filename;
 		bool aig_mode = false;

--- a/backends/protobuf/protobuf.cc
+++ b/backends/protobuf/protobuf.cc
@@ -231,7 +231,7 @@ struct ProtobufDesignSerializer
 
 struct ProtobufBackend : public Backend {
 	ProtobufBackend(): Backend("protobuf", "write design to a Protocol Buffer file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -249,7 +249,7 @@ struct ProtobufBackend : public Backend {
 		log("Yosys source code distribution.\n");
 		log("\n");
 	}
-	virtual void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool aig_mode = false;
 		bool text_mode = false;
@@ -286,7 +286,7 @@ struct ProtobufBackend : public Backend {
 
 struct ProtobufPass : public Pass {
 	ProtobufPass() : Pass("protobuf", "write design in Protobuf format") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -307,7 +307,7 @@ struct ProtobufPass : public Pass {
 		log("Yosys source code distribution.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::string filename;
 		bool aig_mode = false;

--- a/backends/simplec/simplec.cc
+++ b/backends/simplec/simplec.cc
@@ -742,7 +742,7 @@ struct SimplecWorker
 
 struct SimplecBackend : public Backend {
 	SimplecBackend() : Backend("simplec", "convert design to simple C code") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -761,7 +761,7 @@ struct SimplecBackend : public Backend {
 		log("THIS COMMAND IS UNDER CONSTRUCTION\n");
 		log("\n");
 	}
-	virtual void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		reserved_cids.clear();
 		id2cid.clear();

--- a/backends/smt2/smt2.cc
+++ b/backends/smt2/smt2.cc
@@ -1251,7 +1251,7 @@ struct Smt2Worker
 
 struct Smt2Backend : public Backend {
 	Smt2Backend() : Backend("smt2", "write design to SMT-LIBv2 file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -1407,7 +1407,7 @@ struct Smt2Backend : public Backend {
 		log("from non-zero to zero in the test design.\n");
 		log("\n");
 	}
-	virtual void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::ifstream template_f;
 		bool bvmode = true, memmode = true, wiresmode = false, verbose = false, statebv = false, statedt = false;

--- a/backends/smv/smv.cc
+++ b/backends/smv/smv.cc
@@ -675,7 +675,7 @@ struct SmvWorker
 
 struct SmvBackend : public Backend {
 	SmvBackend() : Backend("smv", "write design to SMV file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -693,7 +693,7 @@ struct SmvBackend : public Backend {
 		log("THIS COMMAND IS UNDER CONSTRUCTION\n");
 		log("\n");
 	}
-	virtual void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::ifstream template_f;
 		bool verbose = false;

--- a/backends/spice/spice.cc
+++ b/backends/spice/spice.cc
@@ -132,7 +132,7 @@ static void print_spice_module(std::ostream &f, RTLIL::Module *module, RTLIL::De
 
 struct SpiceBackend : public Backend {
 	SpiceBackend() : Backend("spice", "write design to SPICE netlist file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -161,7 +161,7 @@ struct SpiceBackend : public Backend {
 		log("        set the specified module as design top module\n");
 		log("\n");
 	}
-	virtual void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::string top_module_name;
 		RTLIL::Module *top_module = NULL;

--- a/backends/table/table.cc
+++ b/backends/table/table.cc
@@ -29,7 +29,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct TableBackend : public Backend {
 	TableBackend() : Backend("table", "write design as connectivity table") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -48,7 +48,7 @@ struct TableBackend : public Backend {
 		log("module inputs and outputs are output using cell type and port '-' and with\n");
 		log("'pi' (primary input) or 'po' (primary output) or 'pio' as direction.\n");
 	}
-	virtual void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing TABLE backend.\n");
 

--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -1482,7 +1482,7 @@ void dump_module(std::ostream &f, std::string indent, RTLIL::Module *module)
 
 struct VerilogBackend : public Backend {
 	VerilogBackend() : Backend("verilog", "write design to Verilog file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -1550,7 +1550,7 @@ struct VerilogBackend : public Backend {
 		log("this command is called on a design with RTLIL processes.\n");
 		log("\n");
 	}
-	virtual void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing Verilog backend.\n");
 

--- a/examples/cxx-api/evaldemo.cc
+++ b/examples/cxx-api/evaldemo.cc
@@ -22,7 +22,7 @@ struct EvalDemoPass : public Pass
 {
 	EvalDemoPass() : Pass("evaldemo") { }
 
-	virtual void execute(vector<string>, Design *design)
+	void execute(vector<string>, Design *design) YS_OVERRIDE
 	{
 		Module *module = design->top_module();
 

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -1,4 +1,4 @@
-/*
+/* -*- c++ -*-
  *  yosys -- Yosys Open SYnthesis Suite
  *
  *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
@@ -282,9 +282,9 @@ namespace AST
 	struct AstModule : RTLIL::Module {
 		AstNode *ast;
 		bool nolatches, nomeminit, nomem2reg, mem2reg, lib, noopt, icells, autowire;
-		virtual ~AstModule();
-		virtual RTLIL::IdString derive(RTLIL::Design *design, dict<RTLIL::IdString, RTLIL::Const> parameters, bool mayfail);
-		virtual RTLIL::Module *clone() const;
+		~AstModule() YS_OVERRIDE;
+		RTLIL::IdString derive(RTLIL::Design *design, dict<RTLIL::IdString, RTLIL::Const> parameters, bool mayfail) YS_OVERRIDE;
+		RTLIL::Module *clone() const YS_OVERRIDE;
 	};
 
 	// this must be set by the language frontend before parsing the sources

--- a/frontends/blif/blifparse.cc
+++ b/frontends/blif/blifparse.cc
@@ -550,7 +550,7 @@ error:
 
 struct BlifFrontend : public Frontend {
 	BlifFrontend() : Frontend("blif", "read BLIF file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -566,7 +566,7 @@ struct BlifFrontend : public Frontend {
 		log("        multi-bit port 'name'.\n");
 		log("\n");
 	}
-	virtual void execute(std::istream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::istream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool sop_mode = false;
 		bool wideports = false;

--- a/frontends/ilang/ilang_frontend.cc
+++ b/frontends/ilang/ilang_frontend.cc
@@ -35,7 +35,7 @@ YOSYS_NAMESPACE_BEGIN
 
 struct IlangFrontend : public Frontend {
 	IlangFrontend() : Frontend("ilang", "read modules from ilang file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -45,7 +45,7 @@ struct IlangFrontend : public Frontend {
 		log("representation of a design in yosys's internal format.)\n");
 		log("\n");
 	}
-	virtual void execute(std::istream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::istream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing ILANG frontend.\n");
 		extra_args(f, filename, args, 1);

--- a/frontends/json/jsonparse.cc
+++ b/frontends/json/jsonparse.cc
@@ -494,7 +494,7 @@ void json_import(Design *design, string &modname, JsonNode *node)
 
 struct JsonFrontend : public Frontend {
 	JsonFrontend() : Frontend("json", "read JSON file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -504,7 +504,7 @@ struct JsonFrontend : public Frontend {
 		log("for a description of the file format.\n");
 		log("\n");
 	}
-	virtual void execute(std::istream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::istream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing JSON frontend.\n");
 

--- a/frontends/liberty/liberty.cc
+++ b/frontends/liberty/liberty.cc
@@ -452,7 +452,7 @@ void parse_type_map(std::map<std::string, std::tuple<int, int, bool>> &type_map,
 
 struct LibertyFrontend : public Frontend {
 	LibertyFrontend() : Frontend("liberty", "read cells from liberty file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -485,7 +485,7 @@ struct LibertyFrontend : public Frontend {
 		log("        set the specified attribute (to the value 1) on all loaded modules\n");
 		log("\n");
 	}
-	virtual void execute(std::istream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::istream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool flag_lib = false;
 		bool flag_nooverwrite = false;

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -1685,7 +1685,7 @@ bool check_noverific_env()
 
 struct VerificPass : public Pass {
 	VerificPass() : Pass("verific", "load Verilog and VHDL designs using Verific") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -1784,7 +1784,7 @@ struct VerificPass : public Pass {
 		log("\n");
 	}
 #ifdef YOSYS_ENABLE_VERIFIC
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		if (check_noverific_env())
 			log_cmd_error("This version of Yosys is built without Verific support.\n");
@@ -2162,7 +2162,7 @@ struct VerificPass : public Pass {
 
 	}
 #else /* YOSYS_ENABLE_VERIFIC */
-	virtual void execute(std::vector<std::string>, RTLIL::Design *) {
+	void execute(std::vector<std::string>, RTLIL::Design *) YS_OVERRIDE {
 		log_cmd_error("This version of Yosys is built without Verific support.\n");
 	}
 #endif
@@ -2170,7 +2170,7 @@ struct VerificPass : public Pass {
 
 struct ReadPass : public Pass {
 	ReadPass() : Pass("read", "load HDL designs") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -2203,7 +2203,7 @@ struct ReadPass : public Pass {
 		log("Add directory to global Verilog/SystemVerilog include directories.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		if (args.size() < 2)
 			log_cmd_error("Missing mode parameter.\n");

--- a/frontends/verilog/verilog_frontend.cc
+++ b/frontends/verilog/verilog_frontend.cc
@@ -49,7 +49,7 @@ static void error_on_dpi_function(AST::AstNode *node)
 
 struct VerilogFrontend : public Frontend {
 	VerilogFrontend() : Frontend("verilog", "read modules from Verilog file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -180,7 +180,7 @@ struct VerilogFrontend : public Frontend {
 		log("supported by the Yosys Verilog front-end.\n");
 		log("\n");
 	}
-	virtual void execute(std::istream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::istream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool flag_dump_ast1 = false;
 		bool flag_dump_ast2 = false;
@@ -395,7 +395,7 @@ struct VerilogFrontend : public Frontend {
 
 struct VerilogDefaults : public Pass {
 	VerilogDefaults() : Pass("verilog_defaults", "set default options for read_verilog") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -416,7 +416,7 @@ struct VerilogDefaults : public Pass {
 		log("not imply -clear.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design*)
+	void execute(std::vector<std::string> args, RTLIL::Design*) YS_OVERRIDE
 	{
 		if (args.size() < 2)
 			cmd_error(args, 1, "Missing argument.");
@@ -453,7 +453,7 @@ struct VerilogDefaults : public Pass {
 
 struct VerilogDefines : public Pass {
 	VerilogDefines() : Pass("verilog_defines", "define and undefine verilog defines") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -469,7 +469,7 @@ struct VerilogDefines : public Pass {
 		log("        undefine the preprocessor symbol 'name'\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++) {

--- a/kernel/celledges.h
+++ b/kernel/celledges.h
@@ -1,4 +1,4 @@
-/*
+/* -*- c++ -*-
  *  yosys -- Yosys Open SYnthesis Suite
  *
  *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
@@ -38,7 +38,7 @@ struct FwdCellEdgesDatabase : AbstractCellEdgesDatabase
 	dict<SigBit, pool<SigBit>> db;
 	FwdCellEdgesDatabase(SigMap &sigmap) : sigmap(sigmap) { }
 
-	virtual void add_edge(RTLIL::Cell *cell, RTLIL::IdString from_port, int from_bit, RTLIL::IdString to_port, int to_bit, int) override {
+	void add_edge(RTLIL::Cell *cell, RTLIL::IdString from_port, int from_bit, RTLIL::IdString to_port, int to_bit, int) YS_OVERRIDE {
 		SigBit from_sigbit = sigmap(cell->getPort(from_port)[from_bit]);
 		SigBit to_sigbit = sigmap(cell->getPort(to_port)[to_bit]);
 		db[from_sigbit].insert(to_sigbit);
@@ -51,7 +51,7 @@ struct RevCellEdgesDatabase : AbstractCellEdgesDatabase
 	dict<SigBit, pool<SigBit>> db;
 	RevCellEdgesDatabase(SigMap &sigmap) : sigmap(sigmap) { }
 
-	virtual void add_edge(RTLIL::Cell *cell, RTLIL::IdString from_port, int from_bit, RTLIL::IdString to_port, int to_bit, int) override {
+	void add_edge(RTLIL::Cell *cell, RTLIL::IdString from_port, int from_bit, RTLIL::IdString to_port, int to_bit, int) YS_OVERRIDE {
 		SigBit from_sigbit = sigmap(cell->getPort(from_port)[from_bit]);
 		SigBit to_sigbit = sigmap(cell->getPort(to_port)[to_bit]);
 		db[to_sigbit].insert(from_sigbit);

--- a/kernel/modtools.h
+++ b/kernel/modtools.h
@@ -1,4 +1,4 @@
-/*
+/* -*- c++ -*-
  *  yosys -- Yosys Open SYnthesis Suite
  *
  *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
@@ -158,7 +158,7 @@ struct ModIndex : public RTLIL::Monitor
 #endif
 	}
 
-	virtual void notify_connect(RTLIL::Cell *cell, const RTLIL::IdString &port, const RTLIL::SigSpec &old_sig, RTLIL::SigSpec &sig) YS_OVERRIDE
+	void notify_connect(RTLIL::Cell *cell, const RTLIL::IdString &port, const RTLIL::SigSpec &old_sig, RTLIL::SigSpec &sig) YS_OVERRIDE
 	{
 		log_assert(module == cell->module);
 
@@ -169,7 +169,7 @@ struct ModIndex : public RTLIL::Monitor
 		port_add(cell, port, sig);
 	}
 
-	virtual void notify_connect(RTLIL::Module *mod YS_ATTRIBUTE(unused), const RTLIL::SigSig &sigsig) YS_OVERRIDE
+	void notify_connect(RTLIL::Module *mod YS_ATTRIBUTE(unused), const RTLIL::SigSig &sigsig) YS_OVERRIDE
 	{
 		log_assert(module == mod);
 
@@ -214,13 +214,13 @@ struct ModIndex : public RTLIL::Monitor
 		}
 	}
 
-	virtual void notify_connect(RTLIL::Module *mod YS_ATTRIBUTE(unused), const std::vector<RTLIL::SigSig>&) YS_OVERRIDE
+	void notify_connect(RTLIL::Module *mod YS_ATTRIBUTE(unused), const std::vector<RTLIL::SigSig>&) YS_OVERRIDE
 	{
 		log_assert(module == mod);
 		auto_reload_module = true;
 	}
 
-	virtual void notify_blackout(RTLIL::Module *mod YS_ATTRIBUTE(unused)) YS_OVERRIDE
+	void notify_blackout(RTLIL::Module *mod YS_ATTRIBUTE(unused)) YS_OVERRIDE
 	{
 		log_assert(module == mod);
 		auto_reload_module = true;

--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -615,7 +615,7 @@ static struct CellHelpMessages {
 
 struct HelpPass : public Pass {
 	HelpPass() : Pass("help", "display help messages") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		log("\n");
 		log("    help  ................  list all commands\n");
@@ -684,7 +684,7 @@ struct HelpPass : public Pass {
 
 		fclose(f);
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design*)
+	void execute(std::vector<std::string> args, RTLIL::Design*) YS_OVERRIDE
 	{
 		if (args.size() == 1) {
 			log("\n");
@@ -768,7 +768,7 @@ struct HelpPass : public Pass {
 
 struct EchoPass : public Pass {
 	EchoPass() : Pass("echo", "turning echoing back of commands on and off") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		log("\n");
 		log("    echo on\n");
@@ -781,7 +781,7 @@ struct EchoPass : public Pass {
 		log("Do not print all commands to log before executing them. (default)\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design*)
+	void execute(std::vector<std::string> args, RTLIL::Design*) YS_OVERRIDE
 	{
 		if (args.size() > 2)
 			cmd_error(args, 2, "Unexpected argument.");
@@ -806,10 +806,9 @@ struct MinisatSatSolver : public SatSolver {
 	MinisatSatSolver() : SatSolver("minisat") {
 		yosys_satsolver = this;
 	}
-	virtual ezSAT *create() YS_OVERRIDE {
+	ezSAT *create() YS_OVERRIDE {
 		return new ezMiniSAT();
 	}
 } MinisatSatSolver;
 
 YOSYS_NAMESPACE_END
-

--- a/kernel/register.h
+++ b/kernel/register.h
@@ -1,4 +1,4 @@
-/*
+/* -*- c++ -*-
  *  yosys -- Yosys Open SYnthesis Suite
  *
  *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
@@ -88,9 +88,9 @@ struct Frontend : Pass
 
 	std::string frontend_name;
 	Frontend(std::string name, std::string short_help = "** document me **");
-	virtual void run_register() YS_OVERRIDE;
-	virtual ~Frontend();
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE YS_FINAL;
+	void run_register() YS_OVERRIDE;
+	~Frontend() YS_OVERRIDE;
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE YS_FINAL;
 	virtual void execute(std::istream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) = 0;
 
 	static std::vector<std::string> next_args;
@@ -104,9 +104,9 @@ struct Backend : Pass
 {
 	std::string backend_name;
 	Backend(std::string name, std::string short_help = "** document me **");
-	virtual void run_register() YS_OVERRIDE;
-	virtual ~Backend();
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE YS_FINAL;
+	void run_register() YS_OVERRIDE;
+	~Backend() YS_OVERRIDE;
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE YS_FINAL;
 	virtual void execute(std::ostream *&f, std::string filename,  std::vector<std::string> args, RTLIL::Design *design) = 0;
 
 	void extra_args(std::ostream *&f, std::string &filename, std::vector<std::string> args, size_t argidx);

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1,4 +1,4 @@
-/*
+/* -*- c++ -*-
  *  yosys -- Yosys Open SYnthesis Suite
  *
  *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>

--- a/kernel/satgen.h
+++ b/kernel/satgen.h
@@ -1,4 +1,4 @@
-/*
+/* -*- c++ -*-
  *  yosys -- Yosys Open SYnthesis Suite
  *
  *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -636,7 +636,7 @@ extern Tcl_Interp *yosys_get_tcl_interp()
 
 struct TclPass : public Pass {
 	TclPass() : Pass("tcl", "execute a TCL script file") { }
-	virtual void help() {
+	void help() YS_OVERRIDE {
 		log("\n");
 		log("    tcl <filename>\n");
 		log("\n");
@@ -649,7 +649,7 @@ struct TclPass : public Pass {
 		log("in order to avoid a name collision with the built in commands.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) {
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE {
 		if (args.size() < 2)
 			log_cmd_error("Missing script file.\n");
 		if (args.size() > 2)
@@ -1111,7 +1111,7 @@ void shell(RTLIL::Design *design)
 
 struct ShellPass : public Pass {
 	ShellPass() : Pass("shell", "enter interactive command mode") { }
-	virtual void help() {
+	void help() YS_OVERRIDE {
 		log("\n");
 		log("    shell\n");
 		log("\n");
@@ -1143,7 +1143,7 @@ struct ShellPass : public Pass {
 		log("Press Ctrl-D or type 'exit' to leave the interactive shell.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) {
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE {
 		extra_args(args, 1, design, false);
 		shell(design);
 	}
@@ -1152,7 +1152,7 @@ struct ShellPass : public Pass {
 #if defined(YOSYS_ENABLE_READLINE) || defined(YOSYS_ENABLE_EDITLINE)
 struct HistoryPass : public Pass {
 	HistoryPass() : Pass("history", "show last interactive commands") { }
-	virtual void help() {
+	void help() YS_OVERRIDE {
 		log("\n");
 		log("    history\n");
 		log("\n");
@@ -1161,7 +1161,7 @@ struct HistoryPass : public Pass {
 		log("from executed scripts.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) {
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE {
 		extra_args(args, 1, design, false);
 #ifdef YOSYS_ENABLE_READLINE
 		for(HIST_ENTRY **list = history_list(); *list != NULL; list++)
@@ -1176,7 +1176,7 @@ struct HistoryPass : public Pass {
 
 struct ScriptCmdPass : public Pass {
 	ScriptCmdPass() : Pass("script", "execute commands from script file") { }
-	virtual void help() {
+	void help() YS_OVERRIDE {
 		log("\n");
 		log("    script <filename> [<from_label>:<to_label>]\n");
 		log("\n");
@@ -1191,7 +1191,7 @@ struct ScriptCmdPass : public Pass {
 		log("marked with that label (until the next label) is executed.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) {
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE {
 		if (args.size() < 2)
 			log_cmd_error("Missing script file.\n");
 		else if (args.size() == 2)

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -1,4 +1,4 @@
-/*
+/* -*- c++ -*-
  *  yosys -- Yosys Open SYnthesis Suite
  *
  *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>

--- a/manual/CHAPTER_Prog/stubnets.cc
+++ b/manual/CHAPTER_Prog/stubnets.cc
@@ -98,7 +98,7 @@ static void find_stub_nets(RTLIL::Design *design, RTLIL::Module *module, bool re
 // each pass contains a singleton object that is derived from Pass
 struct StubnetsPass : public Pass {
 	StubnetsPass() : Pass("stubnets") { }
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		// variables to mirror information from passed options
 		bool report_bits = 0;

--- a/manual/PRESENTATION_Prog/my_cmd.cc
+++ b/manual/PRESENTATION_Prog/my_cmd.cc
@@ -6,7 +6,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct MyPass : public Pass {
     MyPass() : Pass("my_cmd", "just a simple test") { }
-    virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+    void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
     {
         log("Arguments to my_cmd:\n");
         for (auto &arg : args)
@@ -22,7 +22,7 @@ struct MyPass : public Pass {
 
 struct Test1Pass : public Pass {
     Test1Pass() : Pass("test1", "creating the absval module") { }
-    virtual void execute(std::vector<std::string>, RTLIL::Design *design)
+    void execute(std::vector<std::string>, RTLIL::Design *design) YS_OVERRIDE
     {
         if (design->has("\\absval") != 0)
             log_error("A module with the name absval already exists!\n");
@@ -49,7 +49,7 @@ struct Test1Pass : public Pass {
 
 struct Test2Pass : public Pass {
     Test2Pass() : Pass("test2", "demonstrating sigmap on test module") { }
-    virtual void execute(std::vector<std::string>, RTLIL::Design *design)
+    void execute(std::vector<std::string>, RTLIL::Design *design) YS_OVERRIDE
     {
         if (design->selection_stack.back().empty())
             log_cmd_error("This command can't operator on an empty selection!\n");

--- a/passes/cmds/add.cc
+++ b/passes/cmds/add.cc
@@ -83,7 +83,7 @@ static void add_wire(RTLIL::Design *design, RTLIL::Module *module, std::string n
 
 struct AddPass : public Pass {
 	AddPass() : Pass("add", "add objects to the design") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -106,7 +106,7 @@ struct AddPass : public Pass {
 		log("selected modules.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::string command;
 		std::string arg_name;

--- a/passes/cmds/blackbox.cc
+++ b/passes/cmds/blackbox.cc
@@ -24,7 +24,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct BlackboxPass : public Pass {
 	BlackboxPass() : Pass("blackbox", "change type of cells in the design") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -34,7 +34,7 @@ struct BlackboxPass : public Pass {
 		log("module attribute).\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)

--- a/passes/cmds/check.cc
+++ b/passes/cmds/check.cc
@@ -27,7 +27,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct CheckPass : public Pass {
 	CheckPass() : Pass("check", "check for obvious problems in the design") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -51,7 +51,7 @@ struct CheckPass : public Pass {
 		log("problems are found in the current design.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		int counter = 0;
 		bool noinit = false;

--- a/passes/cmds/chformal.cc
+++ b/passes/cmds/chformal.cc
@@ -25,7 +25,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct ChformalPass : public Pass {
 	ChformalPass() : Pass("chformal", "change formal constraints of the design") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -62,7 +62,7 @@ struct ChformalPass : public Pass {
 		log("        change the roles of cells as indicated. this options can be combined\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool assert2assume = false;
 		bool assume2assert = false;

--- a/passes/cmds/chtype.cc
+++ b/passes/cmds/chtype.cc
@@ -24,7 +24,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct ChtypePass : public Pass {
 	ChtypePass() : Pass("chtype", "change type of cells in the design") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -40,7 +40,7 @@ struct ChtypePass : public Pass {
 		log("\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		IdString set_type;
 		dict<IdString, IdString> map_types;

--- a/passes/cmds/connect.cc
+++ b/passes/cmds/connect.cc
@@ -43,7 +43,7 @@ static void unset_drivers(RTLIL::Design *design, RTLIL::Module *module, SigMap &
 
 struct ConnectPass : public Pass {
 	ConnectPass() : Pass("connect", "create or remove connections") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -75,7 +75,7 @@ struct ConnectPass : public Pass {
 		log("This command does not operate on module with processes.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		RTLIL::Module *module = NULL;
 		for (auto &it : design->modules_) {

--- a/passes/cmds/connwrappers.cc
+++ b/passes/cmds/connwrappers.cc
@@ -150,7 +150,7 @@ struct ConnwrappersWorker
 
 struct ConnwrappersPass : public Pass {
 	ConnwrappersPass() : Pass("connwrappers", "match width of input-output port pairs") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -172,7 +172,7 @@ struct ConnwrappersPass : public Pass {
 		log("The options -signed, -unsigned, and -port can be specified multiple times.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		ConnwrappersWorker worker;
 

--- a/passes/cmds/copy.cc
+++ b/passes/cmds/copy.cc
@@ -26,7 +26,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct CopyPass : public Pass {
 	CopyPass() : Pass("copy", "copy modules in the design") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -36,7 +36,7 @@ struct CopyPass : public Pass {
 		log("by this command.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		if (args.size() != 3)
 			log_cmd_error("Invalid number of arguments!\n");

--- a/passes/cmds/cover.cc
+++ b/passes/cmds/cover.cc
@@ -35,7 +35,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct CoverPass : public Pass {
 	CoverPass() : Pass("cover", "print code coverage counters") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -83,7 +83,7 @@ struct CoverPass : public Pass {
 		log("Coverage counters are only available in Yosys for Linux.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::vector<FILE*> out_files;
 		std::vector<std::string> patterns;

--- a/passes/cmds/delete.cc
+++ b/passes/cmds/delete.cc
@@ -24,7 +24,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct DeletePass : public Pass {
 	DeletePass() : Pass("delete", "delete objects in the design") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -40,7 +40,7 @@ struct DeletePass : public Pass {
 		log("selected wires, thus 'deleting' module ports.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool flag_input = false;
 		bool flag_output = false;

--- a/passes/cmds/design.cc
+++ b/passes/cmds/design.cc
@@ -27,7 +27,7 @@ std::vector<RTLIL::Design*> pushed_designs;
 
 struct DesignPass : public Pass {
 	DesignPass() : Pass("design", "save, restore and reset current design") { }
-	virtual ~DesignPass() {
+	~DesignPass() YS_OVERRIDE {
 		for (auto &it : saved_designs)
 			delete it.second;
 		saved_designs.clear();
@@ -35,7 +35,7 @@ struct DesignPass : public Pass {
 			delete it;
 		pushed_designs.clear();
 	}
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -94,7 +94,7 @@ struct DesignPass : public Pass {
 		log("between calls to 'read_verilog'. This command resets this memory.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool got_mode = false;
 		bool reset_mode = false;

--- a/passes/cmds/edgetypes.cc
+++ b/passes/cmds/edgetypes.cc
@@ -25,7 +25,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct EdgetypePass : public Pass {
 	EdgetypePass() : Pass("edgetypes", "list all types of edges in selection") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -35,7 +35,7 @@ struct EdgetypePass : public Pass {
 		log("is a 4-tuple of source and sink cell type and port name.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++) {

--- a/passes/cmds/logcmd.cc
+++ b/passes/cmds/logcmd.cc
@@ -27,7 +27,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct LogPass : public Pass {
 	LogPass() : Pass("log", "print text and log files") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -52,7 +52,7 @@ struct LogPass : public Pass {
 		log("        do not append a newline\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design*)
+	void execute(std::vector<std::string> args, RTLIL::Design*) YS_OVERRIDE
 	{
 		size_t argidx;
 		bool to_stdout = false;

--- a/passes/cmds/ltp.cc
+++ b/passes/cmds/ltp.cc
@@ -141,7 +141,7 @@ struct LtpWorker
 
 struct LtpPass : public Pass {
 	LtpPass() : Pass("ltp", "print longest topological path") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -154,7 +154,7 @@ struct LtpPass : public Pass {
 		log("        automatically exclude FF cell types\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool noff = false;
 

--- a/passes/cmds/plugin.cc
+++ b/passes/cmds/plugin.cc
@@ -58,7 +58,7 @@ void load_plugin(std::string, std::vector<std::string>)
 
 struct PluginPass : public Pass {
 	PluginPass() : Pass("plugin", "load and list loaded plugins") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -76,7 +76,7 @@ struct PluginPass : public Pass {
 		log("        List loaded plugins\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::string plugin_filename;
 		std::vector<std::string> plugin_aliases;

--- a/passes/cmds/qwp.cc
+++ b/passes/cmds/qwp.cc
@@ -778,7 +778,7 @@ struct QwpWorker
 
 struct QwpPass : public Pass {
 	QwpPass() : Pass("qwp", "quadratic wirelength placer") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -808,7 +808,7 @@ struct QwpPass : public Pass {
 		log("dense matrix operations. It is only a toy-placer for small circuits.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		QwpConfig config;
 		xorshift32_state = 123456789;

--- a/passes/cmds/rename.cc
+++ b/passes/cmds/rename.cc
@@ -54,7 +54,7 @@ static void rename_in_module(RTLIL::Module *module, std::string from_name, std::
 
 struct RenamePass : public Pass {
 	RenamePass() : Pass("rename", "rename object in the design") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -81,7 +81,7 @@ struct RenamePass : public Pass {
 		log("Rename top module.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::string pattern_prefix = "_", pattern_suffix = "_";
 		bool flag_enumerate = false;

--- a/passes/cmds/scatter.cc
+++ b/passes/cmds/scatter.cc
@@ -27,7 +27,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct ScatterPass : public Pass {
 	ScatterPass() : Pass("scatter", "add additional intermediate nets") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -41,7 +41,7 @@ struct ScatterPass : public Pass {
 		log("Use the opt_clean command to get rid of the additional nets.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		CellTypes ct(design);
 		extra_args(args, 1, design);

--- a/passes/cmds/scc.cc
+++ b/passes/cmds/scc.cc
@@ -218,7 +218,7 @@ struct SccWorker
 
 struct SccPass : public Pass {
 	SccPass() : Pass("scc", "detect strongly connected components (logic loops)") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -255,7 +255,7 @@ struct SccPass : public Pass {
 		log("        that are part of a found logic loop\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::map<std::string, std::string> setAttr;
 		bool allCellTypes = false;

--- a/passes/cmds/select.cc
+++ b/passes/cmds/select.cc
@@ -950,7 +950,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct SelectPass : public Pass {
 	SelectPass() : Pass("select", "modify and view the list of selected objects") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -964,7 +964,7 @@ struct SelectPass : public Pass {
 		log("list of selected objects.\n");
 		log("\n");
 		log("Note that many commands support an optional [selection] argument that can be\n");
-		log("used to override the global selection for the command. The syntax of this\n");
+		log("used to YS_OVERRIDE the global selection for the command. The syntax of this\n");
 		log("optional argument is identical to the syntax of the <selection> argument\n");
 		log("described here.\n");
 		log("\n");
@@ -1167,7 +1167,7 @@ struct SelectPass : public Pass {
 		log("    select */t:SWITCH %%x:+[GATE] */t:SWITCH %%d\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool add_mode = false;
 		bool del_mode = false;
@@ -1470,7 +1470,7 @@ struct SelectPass : public Pass {
 
 struct CdPass : public Pass {
 	CdPass() : Pass("cd", "a shortcut for 'select -module <name>'") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -1496,7 +1496,7 @@ struct CdPass : public Pass {
 		log("This is just a shortcut for 'select -clear'.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		if (args.size() != 1 && args.size() != 2)
 			log_cmd_error("Invalid number of arguments.\n");
@@ -1578,7 +1578,7 @@ static void log_matches(const char *title, Module *module, T list)
 
 struct LsPass : public Pass {
 	LsPass() : Pass("ls", "list modules or objects in modules") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -1589,7 +1589,7 @@ struct LsPass : public Pass {
 		log("When an active module is selected, this prints a list of objects in the module.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		size_t argidx = 1;
 		extra_args(args, argidx, design);

--- a/passes/cmds/setattr.cc
+++ b/passes/cmds/setattr.cc
@@ -56,7 +56,7 @@ static void do_setunset(dict<RTLIL::IdString, RTLIL::Const> &attrs, const std::v
 
 struct SetattrPass : public Pass {
 	SetattrPass() : Pass("setattr", "set/unset attributes on objects") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -69,7 +69,7 @@ struct SetattrPass : public Pass {
 		log("instead of objects within modules.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::vector<setunset_t> setunset_list;
 		bool flag_mod = false;
@@ -130,7 +130,7 @@ struct SetattrPass : public Pass {
 
 struct SetparamPass : public Pass {
 	SetparamPass() : Pass("setparam", "set/unset parameters on objects") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -142,7 +142,7 @@ struct SetparamPass : public Pass {
 		log("The -type option can be used to change the cell type of the selected cells.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		vector<setunset_t> setunset_list;
 		string new_cell_type;
@@ -188,7 +188,7 @@ struct SetparamPass : public Pass {
 
 struct ChparamPass : public Pass {
 	ChparamPass() : Pass("chparam", "re-evaluate modules with new parameters") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -203,7 +203,7 @@ struct ChparamPass : public Pass {
 		log("List the available parameters of the selected modules.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::vector<setunset_t> setunset_list;
 		dict<RTLIL::IdString, RTLIL::Const> new_parameters;

--- a/passes/cmds/setundef.cc
+++ b/passes/cmds/setundef.cc
@@ -79,7 +79,7 @@ struct SetundefWorker
 
 struct SetundefPass : public Pass {
 	SetundefPass() : Pass("setundef", "replace undef values with defined constants") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -113,7 +113,7 @@ struct SetundefPass : public Pass {
 		log("        also create/update init values for flip-flops\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool got_value = false;
 		bool undriven_mode = false;

--- a/passes/cmds/show.cc
+++ b/passes/cmds/show.cc
@@ -573,7 +573,7 @@ struct ShowWorker
 
 struct ShowPass : public Pass {
 	ShowPass() : Pass("show", "generate schematics using graphviz") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -655,7 +655,7 @@ struct ShowPass : public Pass {
 		log("the 'show' command is executed.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Generating Graphviz representation of design.\n");
 		log_push();

--- a/passes/cmds/splice.cc
+++ b/passes/cmds/splice.cc
@@ -247,7 +247,7 @@ struct SpliceWorker
 
 struct SplicePass : public Pass {
 	SplicePass() : Pass("splice", "create explicit splicing cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -288,7 +288,7 @@ struct SplicePass : public Pass {
 		log("by selected wires are rewired.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool sel_by_cell = false;
 		bool sel_by_wire = false;

--- a/passes/cmds/splitnets.cc
+++ b/passes/cmds/splitnets.cc
@@ -87,7 +87,7 @@ struct SplitnetsWorker
 
 struct SplitnetsPass : public Pass {
 	SplitnetsPass() : Pass("splitnets", "split up multi-bit nets") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -109,7 +109,7 @@ struct SplitnetsPass : public Pass {
 		log("        and split nets so that no driver drives only part of a net.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool flag_ports = false;
 		bool flag_driver = false;

--- a/passes/cmds/stat.cc
+++ b/passes/cmds/stat.cc
@@ -209,7 +209,7 @@ void read_liberty_cellarea(dict<IdString, double> &cell_area, string liberty_fil
 
 struct StatPass : public Pass {
 	StatPass() : Pass("stat", "print some statistics") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -231,7 +231,7 @@ struct StatPass : public Pass {
 		log("        e.g. $add_8 for an 8 bit wide $add cell.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Printing statistics.\n");
 

--- a/passes/cmds/tee.cc
+++ b/passes/cmds/tee.cc
@@ -27,7 +27,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct TeePass : public Pass {
 	TeePass() : Pass("tee", "redirect command output to file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -49,7 +49,7 @@ struct TeePass : public Pass {
 		log("        Add/subract INT from the -v setting for this command.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::vector<FILE*> backup_log_files, files_to_close;
 		int backup_log_verbose_level = log_verbose_level;

--- a/passes/cmds/torder.cc
+++ b/passes/cmds/torder.cc
@@ -27,7 +27,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct TorderPass : public Pass {
 	TorderPass() : Pass("torder", "print cells in topological order") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -43,7 +43,7 @@ struct TorderPass : public Pass {
 		log("        are not used in topological sorting. this option deactivates that.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool noautostop = false;
 		dict<IdString, pool<IdString>> stop_db;

--- a/passes/cmds/trace.cc
+++ b/passes/cmds/trace.cc
@@ -25,34 +25,34 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct TraceMonitor : public RTLIL::Monitor
 {
-	virtual void notify_module_add(RTLIL::Module *module) YS_OVERRIDE
+	void notify_module_add(RTLIL::Module *module) YS_OVERRIDE
 	{
 		log("#TRACE# Module add: %s\n", log_id(module));
 	}
 
-	virtual void notify_module_del(RTLIL::Module *module) YS_OVERRIDE
+	void notify_module_del(RTLIL::Module *module) YS_OVERRIDE
 	{
 		log("#TRACE# Module delete: %s\n", log_id(module));
 	}
 
-	virtual void notify_connect(RTLIL::Cell *cell, const RTLIL::IdString &port, const RTLIL::SigSpec &old_sig, RTLIL::SigSpec &sig) YS_OVERRIDE
+	void notify_connect(RTLIL::Cell *cell, const RTLIL::IdString &port, const RTLIL::SigSpec &old_sig, RTLIL::SigSpec &sig) YS_OVERRIDE
 	{
 		log("#TRACE# Cell connect: %s.%s.%s = %s (was: %s)\n", log_id(cell->module), log_id(cell), log_id(port), log_signal(sig), log_signal(old_sig));
 	}
 
-	virtual void notify_connect(RTLIL::Module *module, const RTLIL::SigSig &sigsig) YS_OVERRIDE
+	void notify_connect(RTLIL::Module *module, const RTLIL::SigSig &sigsig) YS_OVERRIDE
 	{
 		log("#TRACE# Connection in module %s: %s = %s\n", log_id(module), log_signal(sigsig.first), log_signal(sigsig.second));
 	}
 
-	virtual void notify_connect(RTLIL::Module *module, const std::vector<RTLIL::SigSig> &sigsig_vec) YS_OVERRIDE
+	void notify_connect(RTLIL::Module *module, const std::vector<RTLIL::SigSig> &sigsig_vec) YS_OVERRIDE
 	{
 		log("#TRACE# New connections in module %s:\n", log_id(module));
 		for (auto &sigsig : sigsig_vec)
 			log("##    %s = %s\n", log_signal(sigsig.first), log_signal(sigsig.second));
 	}
 
-	virtual void notify_blackout(RTLIL::Module *module) YS_OVERRIDE
+	void notify_blackout(RTLIL::Module *module) YS_OVERRIDE
 	{
 		log("#TRACE# Blackout in module %s:\n", log_id(module));
 	}
@@ -60,7 +60,7 @@ struct TraceMonitor : public RTLIL::Monitor
 
 struct TracePass : public Pass {
 	TracePass() : Pass("trace", "redirect command output to file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -70,7 +70,7 @@ struct TracePass : public Pass {
 		log("the design in real time.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
@@ -95,4 +95,3 @@ struct TracePass : public Pass {
 } TracePass;
 
 PRIVATE_NAMESPACE_END
-

--- a/passes/cmds/write_file.cc
+++ b/passes/cmds/write_file.cc
@@ -25,7 +25,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct WriteFileFrontend : public Frontend {
 	WriteFileFrontend() : Frontend("=write_file", "write a text to a file") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -44,7 +44,7 @@ struct WriteFileFrontend : public Frontend {
 		log("    EOT\n");
 		log("\n");
 	}
-	virtual void execute(std::istream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design*)
+	void execute(std::istream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design*) YS_OVERRIDE
 	{
 		bool append_mode = false;
 		std::string output_filename;

--- a/passes/equiv/equiv_add.cc
+++ b/passes/equiv/equiv_add.cc
@@ -25,7 +25,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct EquivAddPass : public Pass {
 	EquivAddPass() : Pass("equiv_add", "add a $equiv cell") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -39,7 +39,7 @@ struct EquivAddPass : public Pass {
 		log("This command adds $equiv cells for the ports of the specified cells.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, Design *design)
+	void execute(std::vector<std::string> args, Design *design) YS_OVERRIDE
 	{
 		bool try_mode = false;
 

--- a/passes/equiv/equiv_induct.cc
+++ b/passes/equiv/equiv_induct.cc
@@ -162,7 +162,7 @@ struct EquivInductWorker
 
 struct EquivInductPass : public Pass {
 	EquivInductPass() : Pass("equiv_induct", "proving $equiv cells using temporal induction") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -192,7 +192,7 @@ struct EquivInductPass : public Pass {
 		log("after reset.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, Design *design)
+	void execute(std::vector<std::string> args, Design *design) YS_OVERRIDE
 	{
 		int success_counter = 0;
 		bool model_undef = false;

--- a/passes/equiv/equiv_make.cc
+++ b/passes/equiv/equiv_make.cc
@@ -390,7 +390,7 @@ struct EquivMakeWorker
 
 struct EquivMakePass : public Pass {
 	EquivMakePass() : Pass("equiv_make", "prepare a circuit for equivalence checking") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -415,7 +415,7 @@ struct EquivMakePass : public Pass {
 		log("checking problem. Use 'miter -equiv' if you want to create a miter circuit.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		EquivMakeWorker worker;
 		worker.ct.setup(design);

--- a/passes/equiv/equiv_mark.cc
+++ b/passes/equiv/equiv_mark.cc
@@ -204,7 +204,7 @@ struct EquivMarkWorker
 
 struct EquivMarkPass : public Pass {
 	EquivMarkPass() : Pass("equiv_mark", "mark equivalence checking regions") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -216,7 +216,7 @@ struct EquivMarkPass : public Pass {
 		log("wires and cells.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, Design *design)
+	void execute(std::vector<std::string> args, Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing EQUIV_MARK pass.\n");
 

--- a/passes/equiv/equiv_miter.cc
+++ b/passes/equiv/equiv_miter.cc
@@ -261,7 +261,7 @@ struct EquivMiterWorker
 
 struct EquivMiterPass : public Pass {
 	EquivMiterPass() : Pass("equiv_miter", "extract miter from equiv circuit") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -282,7 +282,7 @@ struct EquivMiterPass : public Pass {
 		log("        Create compare logic that handles undefs correctly\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		EquivMiterWorker worker;
 		worker.ct.setup(design);

--- a/passes/equiv/equiv_purge.cc
+++ b/passes/equiv/equiv_purge.cc
@@ -176,7 +176,7 @@ struct EquivPurgeWorker
 
 struct EquivPurgePass : public Pass {
 	EquivPurgePass() : Pass("equiv_purge", "purge equivalence checking module") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -187,7 +187,7 @@ struct EquivPurgePass : public Pass {
 		log("ports as needed.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, Design *design)
+	void execute(std::vector<std::string> args, Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing EQUIV_PURGE pass.\n");
 

--- a/passes/equiv/equiv_remove.cc
+++ b/passes/equiv/equiv_remove.cc
@@ -24,7 +24,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct EquivRemovePass : public Pass {
 	EquivRemovePass() : Pass("equiv_remove", "remove $equiv cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -40,7 +40,7 @@ struct EquivRemovePass : public Pass {
 		log("        keep gate circuit\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, Design *design)
+	void execute(std::vector<std::string> args, Design *design) YS_OVERRIDE
 	{
 		bool mode_gold = false;
 		bool mode_gate = false;

--- a/passes/equiv/equiv_simple.cc
+++ b/passes/equiv/equiv_simple.cc
@@ -273,7 +273,7 @@ struct EquivSimpleWorker
 
 struct EquivSimplePass : public Pass {
 	EquivSimplePass() : Pass("equiv_simple", "try proving simple $equiv instances") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -298,7 +298,7 @@ struct EquivSimplePass : public Pass {
 		log("        the max. number of time steps to be considered (default = 1)\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, Design *design)
+	void execute(std::vector<std::string> args, Design *design) YS_OVERRIDE
 	{
 		bool verbose = false, short_cones = false, model_undef = false, nogroup = false;
 		int success_counter = 0;

--- a/passes/equiv/equiv_status.cc
+++ b/passes/equiv/equiv_status.cc
@@ -24,7 +24,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct EquivStatusPass : public Pass {
 	EquivStatusPass() : Pass("equiv_status", "print status of equivalent checking module") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -36,7 +36,7 @@ struct EquivStatusPass : public Pass {
 		log("        produce an error if any unproven $equiv cell is found\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, Design *design)
+	void execute(std::vector<std::string> args, Design *design) YS_OVERRIDE
 	{
 		bool assert_mode = false;
 		int unproven_count = 0;

--- a/passes/equiv/equiv_struct.cc
+++ b/passes/equiv/equiv_struct.cc
@@ -283,7 +283,7 @@ struct EquivStructWorker
 
 struct EquivStructPass : public Pass {
 	EquivStructPass() : Pass("equiv_struct", "structural equivalence checking") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -314,7 +314,7 @@ struct EquivStructPass : public Pass {
 		log("        maximum number of iterations to run before aborting\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, Design *design)
+	void execute(std::vector<std::string> args, Design *design) YS_OVERRIDE
 	{
 		pool<IdString> fwonly_cells({ "$equiv" });
 		bool mode_icells = false;

--- a/passes/fsm/fsm.cc
+++ b/passes/fsm/fsm.cc
@@ -27,7 +27,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct FsmPass : public Pass {
 	FsmPass() : Pass("fsm", "extract and optimize finite state machines") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -68,7 +68,7 @@ struct FsmPass : public Pass {
 		log("        passed through to fsm_recode pass\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool flag_nomap = false;
 		bool flag_norecode = false;

--- a/passes/fsm/fsm_detect.cc
+++ b/passes/fsm/fsm_detect.cc
@@ -245,7 +245,7 @@ static void detect_fsm(RTLIL::Wire *wire)
 
 struct FsmDetectPass : public Pass {
 	FsmDetectPass() : Pass("fsm_detect", "finding FSMs in design") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -261,7 +261,7 @@ struct FsmDetectPass : public Pass {
 		log("'fsm_encoding' attribute to \"none\".\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing FSM_DETECT pass (finding FSMs in design).\n");
 		extra_args(args, 1, design);

--- a/passes/fsm/fsm_expand.cc
+++ b/passes/fsm/fsm_expand.cc
@@ -265,7 +265,7 @@ struct FsmExpand
 
 struct FsmExpandPass : public Pass {
 	FsmExpandPass() : Pass("fsm_expand", "expand FSM cells by merging logic into it") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -279,7 +279,7 @@ struct FsmExpandPass : public Pass {
 		log("word-wide cells. Call with -full to consider all cells for merging.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool full_mode = false;
 

--- a/passes/fsm/fsm_export.cc
+++ b/passes/fsm/fsm_export.cc
@@ -120,7 +120,7 @@ void write_kiss2(struct RTLIL::Module *module, struct RTLIL::Cell *cell, std::st
  */
 struct FsmExportPass : public Pass {
 	FsmExportPass() : Pass("fsm_export", "exporting FSMs to KISS2 files") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -143,7 +143,7 @@ struct FsmExportPass : public Pass {
 		log("        use binary state encoding as state names instead of s0, s1, ...\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		dict<RTLIL::IdString, RTLIL::Const>::iterator attr_it;
 		std::string arg;

--- a/passes/fsm/fsm_extract.cc
+++ b/passes/fsm/fsm_extract.cc
@@ -401,7 +401,7 @@ static void extract_fsm(RTLIL::Wire *wire)
 
 struct FsmExtractPass : public Pass {
 	FsmExtractPass() : Pass("fsm_extract", "extracting FSMs in design") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -417,7 +417,7 @@ struct FsmExtractPass : public Pass {
 		log("'opt_clean' pass to eliminate this signal.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing FSM_EXTRACT pass (extracting FSM from design).\n");
 		extra_args(args, 1, design);

--- a/passes/fsm/fsm_info.cc
+++ b/passes/fsm/fsm_info.cc
@@ -30,7 +30,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct FsmInfoPass : public Pass {
 	FsmInfoPass() : Pass("fsm_info", "print information on finite state machines") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -41,7 +41,7 @@ struct FsmInfoPass : public Pass {
 		log("pass so that this information is included in the synthesis log file.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing FSM_INFO pass (dumping all available information on FSM cells).\n");
 		extra_args(args, 1, design);

--- a/passes/fsm/fsm_map.cc
+++ b/passes/fsm/fsm_map.cc
@@ -322,7 +322,7 @@ static void map_fsm(RTLIL::Cell *fsm_cell, RTLIL::Module *module)
 
 struct FsmMapPass : public Pass {
 	FsmMapPass() : Pass("fsm_map", "mapping FSMs to basic logic") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -331,7 +331,7 @@ struct FsmMapPass : public Pass {
 		log("This pass translates FSM cells to flip-flops and logic.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing FSM_MAP pass (mapping FSMs to basic logic).\n");
 		extra_args(args, 1, design);

--- a/passes/fsm/fsm_opt.cc
+++ b/passes/fsm/fsm_opt.cc
@@ -323,7 +323,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct FsmOptPass : public Pass {
 	FsmOptPass() : Pass("fsm_opt", "optimize finite state machines") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -334,7 +334,7 @@ struct FsmOptPass : public Pass {
 		log("combination with the 'opt_clean' pass (see also 'help fsm').\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing FSM_OPT pass (simple optimizations of FSMs).\n");
 		extra_args(args, 1, design);

--- a/passes/fsm/fsm_recode.cc
+++ b/passes/fsm/fsm_recode.cc
@@ -126,7 +126,7 @@ static void fsm_recode(RTLIL::Cell *cell, RTLIL::Module *module, FILE *fm_set_fs
 
 struct FsmRecodePass : public Pass {
 	FsmRecodePass() : Pass("fsm_recode", "recoding finite state machines") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -151,7 +151,7 @@ struct FsmRecodePass : public Pass {
 		log("            .map <old_bitpattern> <new_bitpattern>\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		FILE *fm_set_fsm_file = NULL;
 		FILE *encfile = NULL;

--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -343,7 +343,7 @@ int find_top_mod_score(Design *design, Module *module, dict<Module*, int> &db)
 
 struct HierarchyPass : public Pass {
 	HierarchyPass() : Pass("hierarchy", "check, expand and clean up design hierarchy") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -414,7 +414,7 @@ struct HierarchyPass : public Pass {
 		log("in the current design.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing HIERARCHY pass (managing design hierarchy).\n");
 

--- a/passes/hierarchy/submod.cc
+++ b/passes/hierarchy/submod.cc
@@ -269,7 +269,7 @@ struct SubmodWorker
 
 struct SubmodPass : public Pass {
 	SubmodPass() : Pass("submod", "moving part of a module to a new submodule") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -297,7 +297,7 @@ struct SubmodPass : public Pass {
 		log("with -copy to not modify the source module.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing SUBMOD pass (moving cells to submodules as requested).\n");
 		log_push();

--- a/passes/hierarchy/uniquify.cc
+++ b/passes/hierarchy/uniquify.cc
@@ -24,7 +24,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct UniquifyPass : public Pass {
 	UniquifyPass() : Pass("uniquify", "create unique copies of modules") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -41,7 +41,7 @@ struct UniquifyPass : public Pass {
 		log("attribute set (the 'top' module is unique implicitly).\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing UNIQUIFY pass (creating unique copies of modules).\n");
 

--- a/passes/memory/memory.cc
+++ b/passes/memory/memory.cc
@@ -27,7 +27,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct MemoryPass : public Pass {
 	MemoryPass() : Pass("memory", "translate memories to basic cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -48,7 +48,7 @@ struct MemoryPass : public Pass {
 		log("or multiport memory blocks if called with the -nomap option.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool flag_nomap = false;
 		bool flag_nordff = false;

--- a/passes/memory/memory_bram.cc
+++ b/passes/memory/memory_bram.cc
@@ -1120,7 +1120,7 @@ void handle_cell(Cell *cell, const rules_t &rules)
 
 struct MemoryBramPass : public Pass {
 	MemoryBramPass() : Pass("memory_bram", "map memories to block rams") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -1210,7 +1210,7 @@ struct MemoryBramPass : public Pass {
 		log("the data bits to accommodate the enable pattern of port A.\n");
 		log("\n");
 	}
-	virtual void execute(vector<string> args, Design *design)
+	void execute(vector<string> args, Design *design) YS_OVERRIDE
 	{
 		rules_t rules;
 

--- a/passes/memory/memory_collect.cc
+++ b/passes/memory/memory_collect.cc
@@ -246,7 +246,7 @@ static void handle_module(Design *design, Module *module)
 
 struct MemoryCollectPass : public Pass {
 	MemoryCollectPass() : Pass("memory_collect", "creating multi-port memory cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -256,7 +256,7 @@ struct MemoryCollectPass : public Pass {
 		log("memory cells.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) {
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE {
 		log_header(design, "Executing MEMORY_COLLECT pass (generating $mem cells).\n");
 		extra_args(args, 1, design);
 		for (auto &mod_it : design->modules_)

--- a/passes/memory/memory_dff.cc
+++ b/passes/memory/memory_dff.cc
@@ -283,7 +283,7 @@ struct MemoryDffWorker
 
 struct MemoryDffPass : public Pass {
 	MemoryDffPass() : Pass("memory_dff", "merge input/output DFFs into memories") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -297,7 +297,7 @@ struct MemoryDffPass : public Pass {
 		log("        do not merge registers on read ports\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool flag_wr_only = false;
 

--- a/passes/memory/memory_map.cc
+++ b/passes/memory/memory_map.cc
@@ -352,7 +352,7 @@ struct MemoryMapWorker
 
 struct MemoryMapPass : public Pass {
 	MemoryMapPass() : Pass("memory_map", "translate multiport memories to basic cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -362,7 +362,7 @@ struct MemoryMapPass : public Pass {
 		log("pass to word-wide DFFs and address decoders.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) {
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE {
 		log_header(design, "Executing MEMORY_MAP pass (converting $mem cells to logic and flip-flops).\n");
 		extra_args(args, 1, design);
 		for (auto mod : design->selected_modules())

--- a/passes/memory/memory_memx.cc
+++ b/passes/memory/memory_memx.cc
@@ -28,7 +28,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct MemoryMemxPass : public Pass {
 	MemoryMemxPass() : Pass("memory_memx", "emulate vlog sim behavior for mem ports") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -38,7 +38,7 @@ struct MemoryMemxPass : public Pass {
 		log("behavior for out-of-bounds memory reads and writes.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) {
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE {
 		log_header(design, "Executing MEMORY_MEMX pass (converting $mem cells to logic and flip-flops).\n");
 		extra_args(args, 1, design);
 

--- a/passes/memory/memory_nordff.cc
+++ b/passes/memory/memory_nordff.cc
@@ -25,7 +25,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct MemoryNordffPass : public Pass {
 	MemoryNordffPass() : Pass("memory_nordff", "extract read port FFs from memories") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -35,7 +35,7 @@ struct MemoryNordffPass : public Pass {
 		log("similar to what one would get from calling memory_dff with -nordff.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing MEMORY_NORDFF pass (extracting $dff cells from $mem).\n");
 

--- a/passes/memory/memory_share.cc
+++ b/passes/memory/memory_share.cc
@@ -726,7 +726,7 @@ struct MemoryShareWorker
 
 struct MemorySharePass : public Pass {
 	MemorySharePass() : Pass("memory_share", "consolidate memory ports") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -752,7 +752,7 @@ struct MemorySharePass : public Pass {
 		log("optimizations) such as \"share\" and \"opt_merge\".\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) {
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE {
 		log_header(design, "Executing MEMORY_SHARE pass (consolidating $memrd/$memwr cells).\n");
 		extra_args(args, 1, design);
 		for (auto module : design->selected_modules())

--- a/passes/memory/memory_unpack.cc
+++ b/passes/memory/memory_unpack.cc
@@ -127,7 +127,7 @@ void handle_module(RTLIL::Design *design, RTLIL::Module *module)
 
 struct MemoryUnpackPass : public Pass {
 	MemoryUnpackPass() : Pass("memory_unpack", "unpack multi-port memory cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -137,7 +137,7 @@ struct MemoryUnpackPass : public Pass {
 		log("$memwr cells. It is the counterpart to the memory_collect pass.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) {
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE {
 		log_header(design, "Executing MEMORY_UNPACK pass (generating $memrd/$memwr cells form $mem cells).\n");
 		extra_args(args, 1, design);
 		for (auto &mod_it : design->modules_)

--- a/passes/opt/opt.cc
+++ b/passes/opt/opt.cc
@@ -27,7 +27,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct OptPass : public Pass {
 	OptPass() : Pass("opt", "perform simple optimizations") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -63,7 +63,7 @@ struct OptPass : public Pass {
 		log("\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::string opt_clean_args;
 		std::string opt_expr_args;

--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -442,7 +442,7 @@ void rmunused_module(RTLIL::Module *module, bool purge_mode, bool verbose, bool 
 
 struct OptCleanPass : public Pass {
 	OptCleanPass() : Pass("opt_clean", "remove unused cells and wires") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -459,7 +459,7 @@ struct OptCleanPass : public Pass {
 		log("        also remove internal nets if they have a public name\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool purge_mode = false;
 
@@ -505,7 +505,7 @@ struct OptCleanPass : public Pass {
 
 struct CleanPass : public Pass {
 	CleanPass() : Pass("clean", "remove unused cells and wires") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -520,7 +520,7 @@ struct CleanPass : public Pass {
 		log("in -purge mode between the commands.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool purge_mode = false;
 

--- a/passes/opt/opt_demorgan.cc
+++ b/passes/opt/opt_demorgan.cc
@@ -169,7 +169,7 @@ void demorgan_worker(
 
 struct OptDemorganPass : public Pass {
 	OptDemorganPass() : Pass("opt_demorgan", "Optimize reductions with DeMorgan equivalents") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -179,7 +179,7 @@ struct OptDemorganPass : public Pass {
 		log("overall gate count of the circuit\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing OPT_DEMORGAN pass (push inverters through $reduce_* cells).\n");
 

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -1470,7 +1470,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 struct OptExprPass : public Pass {
 	OptExprPass() : Pass("opt_expr", "perform const folding and simple expression rewriting") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -1504,7 +1504,7 @@ struct OptExprPass : public Pass {
 		log("        replaced by 'a'. the -keepdc option disables all such optimizations.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool mux_undef = false;
 		bool mux_bool = false;

--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -341,7 +341,7 @@ struct OptMergeWorker
 
 struct OptMergePass : public Pass {
 	OptMergePass() : Pass("opt_merge", "consolidate identical cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -357,7 +357,7 @@ struct OptMergePass : public Pass {
 		log("        Operate on all cell types, not just built-in types.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing OPT_MERGE pass (detect identical cells).\n");
 

--- a/passes/opt/opt_muxtree.cc
+++ b/passes/opt/opt_muxtree.cc
@@ -449,7 +449,7 @@ struct OptMuxtreeWorker
 
 struct OptMuxtreePass : public Pass {
 	OptMuxtreePass() : Pass("opt_muxtree", "eliminate dead trees in multiplexer trees") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -462,7 +462,7 @@ struct OptMuxtreePass : public Pass {
 		log("This pass only operates on completely selected modules without processes.\n");
 		log("\n");
 	}
-	virtual void execute(vector<std::string> args, RTLIL::Design *design)
+	void execute(vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing OPT_MUXTREE pass (detect dead branches in mux trees).\n");
 		extra_args(args, 1, design);

--- a/passes/opt/opt_reduce.cc
+++ b/passes/opt/opt_reduce.cc
@@ -329,7 +329,7 @@ struct OptReduceWorker
 
 struct OptReducePass : public Pass {
 	OptReducePass() : Pass("opt_reduce", "simplify large MUXes and AND/OR gates") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -350,7 +350,7 @@ struct OptReducePass : public Pass {
 		log("      alias for -fine\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool do_fine = false;
 

--- a/passes/opt/opt_rmdff.cc
+++ b/passes/opt/opt_rmdff.cc
@@ -399,7 +399,7 @@ delete_dff:
 
 struct OptRmdffPass : public Pass {
 	OptRmdffPass() : Pass("opt_rmdff", "remove DFFs with constant inputs") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -409,7 +409,7 @@ struct OptRmdffPass : public Pass {
 		log("a constant driver.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		int total_count = 0, total_initdrv = 0;
 		log_header(design, "Executing OPT_RMDFF pass (remove dff with constant values).\n");

--- a/passes/opt/rmports.cc
+++ b/passes/opt/rmports.cc
@@ -28,7 +28,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct RmportsPassPass : public Pass {
 	RmportsPassPass() : Pass("rmports", "remove module ports with no connections") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -39,7 +39,7 @@ struct RmportsPassPass : public Pass {
 		log("\n");
 	}
 
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing RMPORTS pass (remove ports with no connections).\n");
 

--- a/passes/opt/share.cc
+++ b/passes/opt/share.cc
@@ -1421,7 +1421,7 @@ struct ShareWorker
 
 struct SharePass : public Pass {
 	SharePass() : Pass("share", "perform sat-based resource sharing") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -1453,7 +1453,7 @@ struct SharePass : public Pass {
 		log("    Only perform the first N merges, then stop. This is useful for debugging.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		ShareWorkerConfig config;
 

--- a/passes/opt/wreduce.cc
+++ b/passes/opt/wreduce.cc
@@ -353,7 +353,7 @@ struct WreduceWorker
 
 struct WreducePass : public Pass {
 	WreducePass() : Pass("wreduce", "reduce the word size of operations if possible") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -373,7 +373,7 @@ struct WreducePass : public Pass {
 		log("        flows that use the 'memory_memx' pass.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, Design *design)
+	void execute(std::vector<std::string> args, Design *design) YS_OVERRIDE
 	{
 		WreduceConfig config;
 		bool opt_memx = false;

--- a/passes/proc/proc.cc
+++ b/passes/proc/proc.cc
@@ -27,7 +27,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct ProcPass : public Pass {
 	ProcPass() : Pass("proc", "translate processes to netlists") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -57,7 +57,7 @@ struct ProcPass : public Pass {
 		log("        executed in -ifx mode.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::string global_arst;
 		bool ifxmode = false;

--- a/passes/proc/proc_arst.cc
+++ b/passes/proc/proc_arst.cc
@@ -203,7 +203,7 @@ restart_proc_arst:
 
 struct ProcArstPass : public Pass {
 	ProcArstPass() : Pass("proc_arst", "detect asynchronous resets") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -221,7 +221,7 @@ struct ProcArstPass : public Pass {
 		log("        in the 'init' attribute on the net.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::string global_arst;
 		bool global_arst_neg = false;

--- a/passes/proc/proc_clean.cc
+++ b/passes/proc/proc_clean.cc
@@ -143,7 +143,7 @@ void proc_clean(RTLIL::Module *mod, RTLIL::Process *proc, int &total_count)
 
 struct ProcCleanPass : public Pass {
 	ProcCleanPass() : Pass("proc_clean", "remove empty parts of processes") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -153,7 +153,7 @@ struct ProcCleanPass : public Pass {
 		log("if it contains only empty structures.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		int total_count = 0;
 		log_header(design, "Executing PROC_CLEAN pass (remove empty switches from decision trees).\n");

--- a/passes/proc/proc_dff.cc
+++ b/passes/proc/proc_dff.cc
@@ -370,7 +370,7 @@ void proc_dff(RTLIL::Module *mod, RTLIL::Process *proc, ConstEval &ce)
 
 struct ProcDffPass : public Pass {
 	ProcDffPass() : Pass("proc_dff", "extract flip-flops from processes") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -380,7 +380,7 @@ struct ProcDffPass : public Pass {
 		log("d-type flip-flop cells.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing PROC_DFF pass (convert process syncs to FFs).\n");
 

--- a/passes/proc/proc_dlatch.cc
+++ b/passes/proc/proc_dlatch.cc
@@ -422,7 +422,7 @@ void proc_dlatch(proc_dlatch_db_t &db, RTLIL::Process *proc)
 
 struct ProcDlatchPass : public Pass {
 	ProcDlatchPass() : Pass("proc_dlatch", "extract latches from processes") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -432,7 +432,7 @@ struct ProcDlatchPass : public Pass {
 		log("d-type latches.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing PROC_DLATCH pass (convert process syncs to latches).\n");
 

--- a/passes/proc/proc_init.cc
+++ b/passes/proc/proc_init.cc
@@ -102,7 +102,7 @@ void proc_init(RTLIL::Module *mod, RTLIL::Process *proc)
 
 struct ProcInitPass : public Pass {
 	ProcInitPass() : Pass("proc_init", "convert initial block to init attributes") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -113,7 +113,7 @@ struct ProcInitPass : public Pass {
 		log("respective wire.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing PROC_INIT pass (extract init attributes).\n");
 

--- a/passes/proc/proc_mux.cc
+++ b/passes/proc/proc_mux.cc
@@ -382,7 +382,7 @@ void proc_mux(RTLIL::Module *mod, RTLIL::Process *proc, bool ifxmode)
 
 struct ProcMuxPass : public Pass {
 	ProcMuxPass() : Pass("proc_mux", "convert decision trees to multiplexers") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -396,7 +396,7 @@ struct ProcMuxPass : public Pass {
 		log("        'case' expressions and 'if' conditions.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool ifxmode = false;
 		log_header(design, "Executing PROC_MUX pass (convert decision trees to multiplexers).\n");

--- a/passes/proc/proc_rmdead.cc
+++ b/passes/proc/proc_rmdead.cc
@@ -65,7 +65,7 @@ void proc_rmdead(RTLIL::SwitchRule *sw, int &counter)
 
 struct ProcRmdeadPass : public Pass {
 	ProcRmdeadPass() : Pass("proc_rmdead", "eliminate dead trees in decision trees") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -74,7 +74,7 @@ struct ProcRmdeadPass : public Pass {
 		log("This pass identifies unreachable branches in decision trees and removes them.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing PROC_RMDEAD pass (remove dead branches from decision trees).\n");
 

--- a/passes/sat/assertpmux.cc
+++ b/passes/sat/assertpmux.cc
@@ -181,7 +181,7 @@ struct AssertpmuxWorker
 
 struct AssertpmuxPass : public Pass {
 	AssertpmuxPass() : Pass("assertpmux", "convert internal signals to module ports") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -199,7 +199,7 @@ struct AssertpmuxPass : public Pass {
 		log("        additional constrained and check the $pmux condition always.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool flag_noinit = false;
 		bool flag_always = false;

--- a/passes/sat/async2sync.cc
+++ b/passes/sat/async2sync.cc
@@ -25,7 +25,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct Async2syncPass : public Pass {
 	Async2syncPass() : Pass("async2sync", "convert async FF inputs to sync circuits") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -42,7 +42,7 @@ struct Async2syncPass : public Pass {
 		log("Currently only $adff cells are supported by this pass.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		// bool flag_noinit = false;
 

--- a/passes/sat/clk2fflogic.cc
+++ b/passes/sat/clk2fflogic.cc
@@ -25,7 +25,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct Clk2fflogicPass : public Pass {
 	Clk2fflogicPass() : Pass("clk2fflogic", "convert clocked FFs to generic $ff cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -36,7 +36,7 @@ struct Clk2fflogicPass : public Pass {
 		log("multiple clocks.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		// bool flag_noinit = false;
 

--- a/passes/sat/eval.cc
+++ b/passes/sat/eval.cc
@@ -360,7 +360,7 @@ struct VlogHammerReporter
 
 struct EvalPass : public Pass {
 	EvalPass() : Pass("eval", "evaluate the circuit given an input") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -383,7 +383,7 @@ struct EvalPass : public Pass {
 		log("        then all output ports of the current module are used.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::vector<std::pair<std::string, std::string>> sets;
 		std::vector<std::string> shows, tables;

--- a/passes/sat/expose.cc
+++ b/passes/sat/expose.cc
@@ -220,7 +220,7 @@ RTLIL::Wire *add_new_wire(RTLIL::Module *module, RTLIL::IdString name, int width
 
 struct ExposePass : public Pass {
 	ExposePass() : Pass("expose", "convert internal signals to module ports") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -257,7 +257,7 @@ struct ExposePass : public Pass {
 		log("        designator for the exposed signal.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool flag_shared = false;
 		bool flag_evert = false;

--- a/passes/sat/freduce.cc
+++ b/passes/sat/freduce.cc
@@ -760,7 +760,7 @@ struct FreduceWorker
 
 struct FreducePass : public Pass {
 	FreducePass() : Pass("freduce", "perform functional reduction") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -791,7 +791,7 @@ struct FreducePass : public Pass {
 		log("circuit that is analyzed.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		reduce_counter = 0;
 		reduce_stop_at = 0;

--- a/passes/sat/miter.cc
+++ b/passes/sat/miter.cc
@@ -358,7 +358,7 @@ void create_miter_assert(struct Pass *that, std::vector<std::string> args, RTLIL
 
 struct MiterPass : public Pass {
 	MiterPass() : Pass("miter", "automatically create a miter circuit") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -402,7 +402,7 @@ struct MiterPass : public Pass {
 		log("        call 'flatten; opt_expr -keepdc -undriven;;' on the miter circuit.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		if (args.size() > 1 && args[1] == "-equiv") {
 			create_miter_equiv(this, args, design);

--- a/passes/sat/sat.cc
+++ b/passes/sat/sat.cc
@@ -890,7 +890,7 @@ void print_qed()
 
 struct SatPass : public Pass {
 	SatPass() : Pass("sat", "solve a SAT problem in the circuit") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -1057,7 +1057,7 @@ struct SatPass : public Pass {
 		log("        Like -falsify but do not return an error for timeouts.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::vector<std::pair<std::string, std::string>> sets, sets_init, prove, prove_x;
 		std::map<int, std::vector<std::pair<std::string, std::string>>> sets_at;

--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -745,7 +745,7 @@ struct SimWorker : SimShared
 
 struct SimPass : public Pass {
 	SimPass() : Pass("sim", "simulate the circuit") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -787,7 +787,7 @@ struct SimPass : public Pass {
 		log("        enable debug output\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		SimWorker worker;
 		int numcycles = 20;

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1248,7 +1248,7 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 
 struct AbcPass : public Pass {
 	AbcPass() : Pass("abc", "use ABC for technology mapping") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -1420,7 +1420,7 @@ struct AbcPass : public Pass {
 		log("[1] http://www.eecs.berkeley.edu/~alanmi/abc/\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing ABC pass (technology mapping using ABC).\n");
 		log_push();

--- a/passes/techmap/aigmap.cc
+++ b/passes/techmap/aigmap.cc
@@ -25,7 +25,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct AigmapPass : public Pass {
 	AigmapPass() : Pass("aigmap", "map logic to and-inverter-graph circuit") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		log("\n");
 		log("    aigmap [options] [selection]\n");
@@ -37,7 +37,7 @@ struct AigmapPass : public Pass {
 		log("        Enable creation of $_NAND_ cells\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool nand_mode = false;
 

--- a/passes/techmap/alumacc.cc
+++ b/passes/techmap/alumacc.cc
@@ -539,7 +539,7 @@ struct AlumaccWorker
 
 struct AlumaccPass : public Pass {
 	AlumaccPass() : Pass("alumacc", "extract ALU and MACC cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -549,7 +549,7 @@ struct AlumaccPass : public Pass {
 		log("and $macc cells.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing ALUMACC pass (create $alu and $macc cells).\n");
 

--- a/passes/techmap/attrmap.cc
+++ b/passes/techmap/attrmap.cc
@@ -81,7 +81,7 @@ struct AttrmapAction {
 
 struct AttrmapTocase : AttrmapAction {
 	string name;
-	virtual bool apply(IdString &id, Const&) {
+	bool apply(IdString &id, Const&) YS_OVERRIDE {
 		if (match_name(name, id, true))
 			id = RTLIL::escape_id(name);
 		return true;
@@ -90,7 +90,7 @@ struct AttrmapTocase : AttrmapAction {
 
 struct AttrmapRename : AttrmapAction {
 	string old_name, new_name;
-	virtual bool apply(IdString &id, Const&) {
+	bool apply(IdString &id, Const&) YS_OVERRIDE {
 		if (match_name(old_name, id))
 			id = RTLIL::escape_id(new_name);
 		return true;
@@ -101,7 +101,7 @@ struct AttrmapMap : AttrmapAction {
 	bool imap;
 	string old_name, new_name;
 	string old_value, new_value;
-	virtual bool apply(IdString &id, Const &val) {
+	bool apply(IdString &id, Const &val) YS_OVERRIDE {
 		if (match_name(old_name, id) && match_value(old_value, val, true)) {
 			id = RTLIL::escape_id(new_name);
 			val = make_value(new_value);
@@ -112,7 +112,7 @@ struct AttrmapMap : AttrmapAction {
 
 struct AttrmapRemove : AttrmapAction {
 	string name, value;
-	virtual bool apply(IdString &id, Const &val) {
+	bool apply(IdString &id, Const &val) YS_OVERRIDE {
 		return !(match_name(name, id) && match_value(value, val));
 	}
 };
@@ -144,7 +144,7 @@ void attrmap_apply(string objname, vector<std::unique_ptr<AttrmapAction>> &actio
 
 struct AttrmapPass : public Pass {
 	AttrmapPass() : Pass("attrmap", "renaming attributes") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -179,7 +179,7 @@ struct AttrmapPass : public Pass {
 		log("            -imap keep=\"false\" keep=0 -remove keep=0\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing ATTRMAP pass (move or copy attributes).\n");
 

--- a/passes/techmap/attrmvcp.cc
+++ b/passes/techmap/attrmvcp.cc
@@ -25,7 +25,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct AttrmvcpPass : public Pass {
 	AttrmvcpPass() : Pass("attrmvcp", "move or copy attributes from wires to driving cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		log("\n");
 		log("    attrmvcp [options] [selection]\n");
@@ -53,7 +53,7 @@ struct AttrmvcpPass : public Pass {
 		log("        multiple times.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing ATTRMVCP pass (move or copy attributes).\n");
 

--- a/passes/techmap/deminout.cc
+++ b/passes/techmap/deminout.cc
@@ -25,7 +25,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct DeminoutPass : public Pass {
 	DeminoutPass() : Pass("deminout", "demote inout ports to input or output") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		log("\n");
 		log("    deminout [options] [selection]\n");
@@ -33,7 +33,7 @@ struct DeminoutPass : public Pass {
 		log("\"Demote\" inout ports to input or output ports, if possible.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing DEMINOUT pass (demote inout ports to input or output).\n");
 

--- a/passes/techmap/dff2dffe.cc
+++ b/passes/techmap/dff2dffe.cc
@@ -253,7 +253,7 @@ struct Dff2dffeWorker
 
 struct Dff2dffePass : public Pass {
 	Dff2dffePass() : Pass("dff2dffe", "transform $dff cells to $dffe cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -284,7 +284,7 @@ struct Dff2dffePass : public Pass {
 		log("        $_DFFE_[NP]_.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing DFF2DFFE pass (transform $dff to $dffe where applicable).\n");
 

--- a/passes/techmap/dff2dffs.cc
+++ b/passes/techmap/dff2dffs.cc
@@ -26,7 +26,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct Dff2dffsPass : public Pass {
 	Dff2dffsPass() : Pass("dff2dffs", "process sync set/reset with SR over CE priority") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		log("\n");
 		log("    dff2dffs [options] [selection]\n");
@@ -35,7 +35,7 @@ struct Dff2dffsPass : public Pass {
 		log("dff2dffe for SR over CE priority.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing dff2dffs pass (merge synchronous set/reset into FF cells).\n");
 

--- a/passes/techmap/dffinit.cc
+++ b/passes/techmap/dffinit.cc
@@ -25,7 +25,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct DffinitPass : public Pass {
 	DffinitPass() : Pass("dffinit", "set INIT param on FF cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -44,7 +44,7 @@ struct DffinitPass : public Pass {
 		log("        mode.)\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing DFFINIT pass (set INIT param on FF cells).\n");
 

--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -537,7 +537,7 @@ static void dfflibmap(RTLIL::Design *design, RTLIL::Module *module, bool prepare
 
 struct DfflibmapPass : public Pass {
 	DfflibmapPass() : Pass("dfflibmap", "technology mapping of flip-flops") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		log("\n");
 		log("    dfflibmap [-prepare] -liberty <file> [selection]\n");
@@ -553,7 +553,7 @@ struct DfflibmapPass : public Pass {
 		log("liberty file.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing DFFLIBMAP pass (mapping DFF cells to sequential cells from liberty file).\n");
 

--- a/passes/techmap/dffsr2dff.cc
+++ b/passes/techmap/dffsr2dff.cc
@@ -176,7 +176,7 @@ void adff_worker(SigMap &sigmap, Module *module, Cell *cell)
 
 struct Dffsr2dffPass : public Pass {
 	Dffsr2dffPass() : Pass("dffsr2dff", "convert DFFSR cells to simpler FF cell types") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -186,7 +186,7 @@ struct Dffsr2dffPass : public Pass {
 		log("$_DFF_???_) to simpler FF cell types when any of the set/reset inputs is unused.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing DFFSR2DFF pass (mapping DFFSR cells to simpler FFs).\n");
 

--- a/passes/techmap/extract.cc
+++ b/passes/techmap/extract.cc
@@ -352,7 +352,7 @@ bool compareSortNeedleList(RTLIL::Module *left, RTLIL::Module *right)
 
 struct ExtractPass : public Pass {
 	ExtractPass() : Pass("extract", "find subcircuits and replace them with cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -440,7 +440,7 @@ struct ExtractPass : public Pass {
 		log("See 'help techmap' for a pass that does the opposite thing.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing EXTRACT pass (map subcircuits to cells).\n");
 		log_push();

--- a/passes/techmap/extract_counter.cc
+++ b/passes/techmap/extract_counter.cc
@@ -559,7 +559,7 @@ void counter_worker(
 
 struct ExtractCounterPass : public Pass {
 	ExtractCounterPass() : Pass("extract_counter", "Extract GreenPak4 counter cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -578,7 +578,7 @@ struct ExtractCounterPass : public Pass {
 		log("\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing EXTRACT_COUNTER pass (find counters in netlist).\n");
 

--- a/passes/techmap/extract_fa.cc
+++ b/passes/techmap/extract_fa.cc
@@ -531,7 +531,7 @@ struct ExtractFaWorker
 
 struct ExtractFaPass : public Pass {
 	ExtractFaPass() : Pass("extract_fa", "find and extract full/half adders") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -553,7 +553,7 @@ struct ExtractFaPass : public Pass {
 		log("        Verbose output\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		ExtractFaConfig config;
 

--- a/passes/techmap/extract_reduce.cc
+++ b/passes/techmap/extract_reduce.cc
@@ -33,7 +33,7 @@ struct ExtractReducePass : public Pass
 
 	ExtractReducePass() : Pass("extract_reduce", "converts gate chains into $reduce_* cells") { }
 
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -62,7 +62,7 @@ struct ExtractReducePass : public Pass
 				(cell->type == "$_XOR_" && gt == GateType::Xor);
 	}
 
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing EXTRACT_REDUCE pass.\n");
 		log_push();

--- a/passes/techmap/hilomap.cc
+++ b/passes/techmap/hilomap.cc
@@ -55,7 +55,7 @@ void hilomap_worker(RTLIL::SigSpec &sig)
 
 struct HilomapPass : public Pass {
 	HilomapPass() : Pass("hilomap", "technology mapping of constant hi- and/or lo-drivers") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		log("\n");
 		log("    hilomap [options] [selection]\n");
@@ -74,7 +74,7 @@ struct HilomapPass : public Pass {
 		log("        each constant bit.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing HILOMAP pass (mapping to constant drivers).\n");
 

--- a/passes/techmap/insbuf.cc
+++ b/passes/techmap/insbuf.cc
@@ -25,7 +25,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct InsbufPass : public Pass {
 	InsbufPass() : Pass("insbuf", "insert buffer cells for connected wires") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		log("\n");
 		log("    insbuf [options] [selection]\n");
@@ -37,7 +37,7 @@ struct InsbufPass : public Pass {
 		log("        call to \"clean\" will remove all $_BUF_ in the design.)\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing INSBUF pass (insert buffer cells for connected wires).\n");
 

--- a/passes/techmap/iopadmap.cc
+++ b/passes/techmap/iopadmap.cc
@@ -34,7 +34,7 @@ void split_portname_pair(std::string &port1, std::string &port2)
 
 struct IopadmapPass : public Pass {
 	IopadmapPass() : Pass("iopadmap", "technology mapping of i/o pads (or buffers)") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		log("\n");
 		log("    iopadmap [options] [selection]\n");
@@ -78,7 +78,7 @@ struct IopadmapPass : public Pass {
 		log("Tristate PADS (-toutpad, -tinoutpad) always operate in -bits mode.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing IOPADMAP pass (mapping inputs/outputs to IO-PAD cells).\n");
 

--- a/passes/techmap/lut2mux.cc
+++ b/passes/techmap/lut2mux.cc
@@ -56,7 +56,7 @@ int lut2mux(Cell *cell)
 
 struct Lut2muxPass : public Pass {
 	Lut2muxPass() : Pass("lut2mux", "convert $lut to $_MUX_") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -65,7 +65,7 @@ struct Lut2muxPass : public Pass {
 		log("This pass converts $lut cells to $_MUX_ gates.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing LUT2MUX pass (convert $lut to $_MUX_).\n");
 

--- a/passes/techmap/maccmap.cc
+++ b/passes/techmap/maccmap.cc
@@ -365,7 +365,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct MaccmapPass : public Pass {
 	MaccmapPass() : Pass("maccmap", "mapping macc cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -375,7 +375,7 @@ struct MaccmapPass : public Pass {
 		log("is used then the $macc cell is mapped to $add, $sub, etc. cells instead.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool unmap_mode = false;
 

--- a/passes/techmap/muxcover.cc
+++ b/passes/techmap/muxcover.cc
@@ -561,7 +561,7 @@ struct MuxcoverWorker
 
 struct MuxcoverPass : public Pass {
 	MuxcoverPass() : Pass("muxcover", "cover trees of MUX cells with wider MUXes") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -579,7 +579,7 @@ struct MuxcoverPass : public Pass {
 		log("        less efficient than the original circuit.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing MUXCOVER pass (mapping to wider MUXes).\n");
 

--- a/passes/techmap/nlutmap.cc
+++ b/passes/techmap/nlutmap.cc
@@ -129,7 +129,7 @@ struct NlutmapWorker
 
 struct NlutmapPass : public Pass {
 	NlutmapPass() : Pass("nlutmap", "map to LUTs of different sizes") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -149,7 +149,7 @@ struct NlutmapPass : public Pass {
 		log("to generic logic gates ($_AND_, etc.).\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		NlutmapConfig config;
 

--- a/passes/techmap/pmuxtree.cc
+++ b/passes/techmap/pmuxtree.cc
@@ -67,7 +67,7 @@ static SigSpec recursive_mux_generator(Module *module, const SigSpec &sig_data, 
 
 struct PmuxtreePass : public Pass {
 	PmuxtreePass() : Pass("pmuxtree", "transform $pmux cells to trees of $mux cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -76,7 +76,7 @@ struct PmuxtreePass : public Pass {
 		log("This pass transforms $pmux cells to a trees of $mux cells.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing PMUXTREE pass.\n");
 

--- a/passes/techmap/shregmap.cc
+++ b/passes/techmap/shregmap.cc
@@ -391,7 +391,7 @@ struct ShregmapWorker
 
 struct ShregmapPass : public Pass {
 	ShregmapPass() : Pass("shregmap", "map shift registers") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -449,7 +449,7 @@ struct ShregmapPass : public Pass {
 		log("        map to greenpak4 shift registers.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		ShregmapOptions opts;
 		string clkpol, enpol;

--- a/passes/techmap/simplemap.cc
+++ b/passes/techmap/simplemap.cc
@@ -575,7 +575,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct SimplemapPass : public Pass {
 	SimplemapPass() : Pass("simplemap", "mapping simple coarse-grain cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -590,7 +590,7 @@ struct SimplemapPass : public Pass {
 		log("  $sr, $ff, $dff, $dffsr, $adff, $dlatch\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing SIMPLEMAP pass (map simple cells to gate primitives).\n");
 		extra_args(args, 1, design);

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -891,7 +891,7 @@ struct TechmapWorker
 
 struct TechmapPass : public Pass {
 	TechmapPass() : Pass("techmap", "generic technology mapper") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -1022,7 +1022,7 @@ struct TechmapPass : public Pass {
 		log("essentially techmap but using the design itself as map library).\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing TECHMAP pass (map to technology primitives).\n");
 		log_push();
@@ -1141,7 +1141,7 @@ struct TechmapPass : public Pass {
 
 struct FlattenPass : public Pass {
 	FlattenPass() : Pass("flatten", "flatten design") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -1155,7 +1155,7 @@ struct FlattenPass : public Pass {
 		log("flattened by this command.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing FLATTEN pass (flatten design).\n");
 		log_push();

--- a/passes/techmap/tribuf.cc
+++ b/passes/techmap/tribuf.cc
@@ -139,7 +139,7 @@ struct TribufWorker {
 
 struct TribufPass : public Pass {
 	TribufPass() : Pass("tribuf", "infer tri-state buffers") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -156,7 +156,7 @@ struct TribufPass : public Pass {
 		log("        to non-tristate logic. this option implies -merge.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		TribufConfig config;
 

--- a/passes/techmap/zinit.cc
+++ b/passes/techmap/zinit.cc
@@ -25,7 +25,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct ZinitPass : public Pass {
 	ZinitPass() : Pass("zinit", "add inverters so all FF are zero-initialized") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -37,7 +37,7 @@ struct ZinitPass : public Pass {
 		log("        also add zero initialization to uninitialized FFs\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		bool all_mode = false;
 

--- a/passes/tests/test_abcloop.cc
+++ b/passes/tests/test_abcloop.cc
@@ -244,7 +244,7 @@ static void test_abcloop()
 
 struct TestAbcloopPass : public Pass {
 	TestAbcloopPass() : Pass("test_abcloop", "automatically test handling of loops in abc command") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -259,7 +259,7 @@ struct TestAbcloopPass : public Pass {
 		log("        use this value as rng seed value (default = unix time).\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design*)
+	void execute(std::vector<std::string> args, RTLIL::Design*) YS_OVERRIDE
 	{
 		int num_iter = 100;
 		xorshift32_state = 0;

--- a/passes/tests/test_autotb.cc
+++ b/passes/tests/test_autotb.cc
@@ -324,7 +324,7 @@ static void autotest(std::ostream &f, RTLIL::Design *design, int num_iter, int s
 
 struct TestAutotbBackend : public Backend {
 	TestAutotbBackend() : Backend("=test_autotb", "generate simple test benches") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -349,7 +349,7 @@ struct TestAutotbBackend : public Backend {
 		log("        number of iterations the test bench should run (default = 1000)\n");
 		log("\n");
 	}
-	virtual void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		int num_iter = 1000;
 		int seed = 0;

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -652,7 +652,7 @@ static void run_eval_test(RTLIL::Design *design, bool verbose, bool nosat, std::
 
 struct TestCellPass : public Pass {
 	TestCellPass() : Pass("test_cell", "automatically test the implementation of a cell type") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -712,7 +712,7 @@ struct TestCellPass : public Pass {
 		log("        create a Verilog test bench to test simlib and write_verilog\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design*)
+	void execute(std::vector<std::string> args, RTLIL::Design*) YS_OVERRIDE
 	{
 		int num_iter = 100;
 		std::string techmap_cmd = "techmap -assert";

--- a/techlibs/achronix/synth_achronix.cc
+++ b/techlibs/achronix/synth_achronix.cc
@@ -28,7 +28,7 @@ PRIVATE_NAMESPACE_BEGIN
 struct SynthAchronixPass : public ScriptPass {
   SynthAchronixPass() : ScriptPass("synth_achronix", "synthesis for Acrhonix Speedster22i FPGAs.") { }
 
-  virtual void help() YS_OVERRIDE
+  void help() YS_OVERRIDE
   {
     //   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
     log("\n");
@@ -63,7 +63,7 @@ struct SynthAchronixPass : public ScriptPass {
   string top_opt, family_opt, vout_file;
   bool retime, flatten;
 
-  virtual void clear_flags() YS_OVERRIDE
+  void clear_flags() YS_OVERRIDE
   {
     top_opt = "-auto-top";
     vout_file = "";
@@ -71,7 +71,7 @@ struct SynthAchronixPass : public ScriptPass {
     flatten = true;
   }
 
-  virtual void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+  void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
   {
     string run_from, run_to;
     clear_flags();
@@ -118,7 +118,7 @@ struct SynthAchronixPass : public ScriptPass {
     log_pop();
   }
 
-  virtual void script() YS_OVERRIDE
+  void script() YS_OVERRIDE
   {
     if (check_label("begin"))
       {

--- a/techlibs/common/prep.cc
+++ b/techlibs/common/prep.cc
@@ -29,7 +29,7 @@ struct PrepPass : public ScriptPass
 {
 	PrepPass() : ScriptPass("prep", "generic synthesis script") { }
 
-	virtual void help() YS_OVERRIDE
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -81,7 +81,7 @@ struct PrepPass : public ScriptPass
 	string top_module, fsm_opts;
 	bool autotop, flatten, ifxmode, memxmode, nomemmode, nokeepdc, nordff;
 
-	virtual void clear_flags() YS_OVERRIDE
+	void clear_flags() YS_OVERRIDE
 	{
 		top_module.clear();
 
@@ -94,7 +94,7 @@ struct PrepPass : public ScriptPass
 		nordff = true;
 	}
 
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		string run_from, run_to;
 
@@ -163,7 +163,7 @@ struct PrepPass : public ScriptPass
 		log_pop();
 	}
 
-	virtual void script() YS_OVERRIDE
+	void script() YS_OVERRIDE
 	{
 
 		if (check_label("begin"))

--- a/techlibs/common/synth.cc
+++ b/techlibs/common/synth.cc
@@ -29,7 +29,7 @@ struct SynthPass : public ScriptPass
 {
 	SynthPass() : ScriptPass("synth", "generic synthesis script") { }
 
-	virtual void help() YS_OVERRIDE
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -81,7 +81,7 @@ struct SynthPass : public ScriptPass
 	string top_module, fsm_opts, memory_opts;
 	bool autotop, flatten, noalumacc, nofsm, noabc, noshare;
 
-	virtual void clear_flags() YS_OVERRIDE
+	void clear_flags() YS_OVERRIDE
 	{
 		top_module.clear();
 		fsm_opts.clear();
@@ -95,7 +95,7 @@ struct SynthPass : public ScriptPass
 		noshare = false;
 	}
 
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		string run_from, run_to;
 		clear_flags();
@@ -165,7 +165,7 @@ struct SynthPass : public ScriptPass
 		log_pop();
 	}
 
-	virtual void script() YS_OVERRIDE
+	void script() YS_OVERRIDE
 	{
 		if (check_label("begin"))
 		{

--- a/techlibs/coolrunner2/coolrunner2_sop.cc
+++ b/techlibs/coolrunner2/coolrunner2_sop.cc
@@ -25,7 +25,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct Coolrunner2SopPass : public Pass {
 	Coolrunner2SopPass() : Pass("coolrunner2_sop", "break $sop cells into ANDTERM/ORTERM cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		log("\n");
 		log("    coolrunner2_sop [options] [selection]\n");
@@ -33,7 +33,7 @@ struct Coolrunner2SopPass : public Pass {
 		log("Break $sop cells into ANDTERM/ORTERM cells.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing COOLRUNNER2_SOP pass (break $sop cells into ANDTERM/ORTERM cells).\n");
 		extra_args(args, 1, design);

--- a/techlibs/coolrunner2/synth_coolrunner2.cc
+++ b/techlibs/coolrunner2/synth_coolrunner2.cc
@@ -29,7 +29,7 @@ struct SynthCoolrunner2Pass : public ScriptPass
 {
 	SynthCoolrunner2Pass() : ScriptPass("synth_coolrunner2", "synthesis for Xilinx Coolrunner-II CPLDs") { }
 
-	virtual void help() YS_OVERRIDE
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -66,7 +66,7 @@ struct SynthCoolrunner2Pass : public ScriptPass
 	string top_opt, json_file;
 	bool flatten, retime;
 
-	virtual void clear_flags() YS_OVERRIDE
+	void clear_flags() YS_OVERRIDE
 	{
 		top_opt = "-auto-top";
 		json_file = "";
@@ -74,7 +74,7 @@ struct SynthCoolrunner2Pass : public ScriptPass
 		retime = false;
 	}
 
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		string run_from, run_to;
 		clear_flags();
@@ -121,7 +121,7 @@ struct SynthCoolrunner2Pass : public ScriptPass
 		log_pop();
 	}
 
-	virtual void script() YS_OVERRIDE
+	void script() YS_OVERRIDE
 	{
 		if (check_label("begin"))
 		{

--- a/techlibs/easic/synth_easic.cc
+++ b/techlibs/easic/synth_easic.cc
@@ -29,7 +29,7 @@ struct SynthEasicPass : public ScriptPass
 {
 	SynthEasicPass() : ScriptPass("synth_easic", "synthesis for eASIC platform") { }
 
-	virtual void help() YS_OVERRIDE
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -67,7 +67,7 @@ struct SynthEasicPass : public ScriptPass
 	string top_opt, vlog_file, etools_path;
 	bool flatten, retime;
 
-	virtual void clear_flags() YS_OVERRIDE
+	void clear_flags() YS_OVERRIDE
 	{
 		top_opt = "-auto-top";
 		vlog_file = "";
@@ -76,7 +76,7 @@ struct SynthEasicPass : public ScriptPass
 		retime = false;
 	}
 
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		string run_from, run_to;
 		clear_flags();
@@ -127,7 +127,7 @@ struct SynthEasicPass : public ScriptPass
 		log_pop();
 	}
 
-	virtual void script() YS_OVERRIDE
+	void script() YS_OVERRIDE
 	{
 		string phys_clk_lib = stringf("%s/data_ruby28/design_libs/logical/timing/gp/n3x_phys_clk_0v893ff125c.lib", etools_path.c_str());
 		string logic_lut_lib = stringf("%s/data_ruby28/design_libs/logical/timing/gp/n3x_logic_lut_0v893ff125c.lib", etools_path.c_str());

--- a/techlibs/ecp5/synth_ecp5.cc
+++ b/techlibs/ecp5/synth_ecp5.cc
@@ -30,7 +30,7 @@ struct SynthEcp5Pass : public ScriptPass
 {
 	SynthEcp5Pass() : ScriptPass("synth_ecp5", "synthesis for ECP5 FPGAs") { }
 
-	virtual void help() YS_OVERRIDE
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -95,7 +95,7 @@ struct SynthEcp5Pass : public ScriptPass
 	string top_opt, blif_file, edif_file, json_file;
 	bool noccu2, nodffe, nobram, nodram, nomux, flatten, retime, abc2, vpr;
 
-	virtual void clear_flags() YS_OVERRIDE
+	void clear_flags() YS_OVERRIDE
 	{
 		top_opt = "-auto-top";
 		blif_file = "";
@@ -112,7 +112,7 @@ struct SynthEcp5Pass : public ScriptPass
 		vpr = false;
 	}
 
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		string run_from, run_to;
 		clear_flags();
@@ -199,7 +199,7 @@ struct SynthEcp5Pass : public ScriptPass
 		log_pop();
 	}
 
-	virtual void script() YS_OVERRIDE
+	void script() YS_OVERRIDE
 	{
 		if (check_label("begin"))
 		{

--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -29,7 +29,7 @@ struct SynthGowinPass : public ScriptPass
 {
 	SynthGowinPass() : ScriptPass("synth_gowin", "synthesis for Gowin FPGAs") { }
 
-	virtual void help() YS_OVERRIDE
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -61,14 +61,14 @@ struct SynthGowinPass : public ScriptPass
 	string top_opt, vout_file;
 	bool retime;
 
-	virtual void clear_flags() YS_OVERRIDE
+	void clear_flags() YS_OVERRIDE
 	{
 		top_opt = "-auto-top";
 		vout_file = "";
 		retime = false;
 	}
 
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		string run_from, run_to;
 		clear_flags();
@@ -111,7 +111,7 @@ struct SynthGowinPass : public ScriptPass
 		log_pop();
 	}
 
-	virtual void script() YS_OVERRIDE
+	void script() YS_OVERRIDE
 	{
 		if (check_label("begin"))
 		{

--- a/techlibs/greenpak4/greenpak4_dffinv.cc
+++ b/techlibs/greenpak4/greenpak4_dffinv.cc
@@ -91,7 +91,7 @@ void invert_gp_dff(Cell *cell, bool invert_input)
 
 struct Greenpak4DffInvPass : public Pass {
 	Greenpak4DffInvPass() : Pass("greenpak4_dffinv", "merge greenpak4 inverters and DFF/latches") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		log("\n");
 		log("    greenpak4_dffinv [options] [selection]\n");
@@ -99,7 +99,7 @@ struct Greenpak4DffInvPass : public Pass {
 		log("Merge GP_INV cells with GP_DFF* and GP_DLATCH* cells.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing GREENPAK4_DFFINV pass (merge input/output inverters into FF/latch cells).\n");
 

--- a/techlibs/greenpak4/synth_greenpak4.cc
+++ b/techlibs/greenpak4/synth_greenpak4.cc
@@ -29,7 +29,7 @@ struct SynthGreenPAK4Pass : public ScriptPass
 {
 	SynthGreenPAK4Pass() : ScriptPass("synth_greenpak4", "synthesis for GreenPAK4 FPGAs") { }
 
-	virtual void help() YS_OVERRIDE
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -70,7 +70,7 @@ struct SynthGreenPAK4Pass : public ScriptPass
 	string top_opt, part, json_file;
 	bool flatten, retime;
 
-	virtual void clear_flags() YS_OVERRIDE
+	void clear_flags() YS_OVERRIDE
 	{
 		top_opt = "-auto-top";
 		part = "SLG46621V";
@@ -79,7 +79,7 @@ struct SynthGreenPAK4Pass : public ScriptPass
 		retime = false;
 	}
 
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		string run_from, run_to;
 		clear_flags();
@@ -133,7 +133,7 @@ struct SynthGreenPAK4Pass : public ScriptPass
 		log_pop();
 	}
 
-	virtual void script() YS_OVERRIDE
+	void script() YS_OVERRIDE
 	{
 		if (check_label("begin"))
 		{

--- a/techlibs/ice40/ice40_ffinit.cc
+++ b/techlibs/ice40/ice40_ffinit.cc
@@ -25,7 +25,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct Ice40FfinitPass : public Pass {
 	Ice40FfinitPass() : Pass("ice40_ffinit", "iCE40: handle FF init values") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -35,7 +35,7 @@ struct Ice40FfinitPass : public Pass {
 		log("nonzero init values.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing ICE40_FFINIT pass (implement FF init values).\n");
 

--- a/techlibs/ice40/ice40_ffssr.cc
+++ b/techlibs/ice40/ice40_ffssr.cc
@@ -25,7 +25,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct Ice40FfssrPass : public Pass {
 	Ice40FfssrPass() : Pass("ice40_ffssr", "iCE40: merge synchronous set/reset into FF cells") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		log("\n");
 		log("    ice40_ffssr [options] [selection]\n");
@@ -33,7 +33,7 @@ struct Ice40FfssrPass : public Pass {
 		log("Merge synchronous set/reset $_MUX_ cells into iCE40 FFs.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		log_header(design, "Executing ICE40_FFSSR pass (merge synchronous set/reset into FF cells).\n");
 

--- a/techlibs/ice40/ice40_opt.cc
+++ b/techlibs/ice40/ice40_opt.cc
@@ -136,7 +136,7 @@ static void run_ice40_opts(Module *module, bool unlut_mode)
 
 struct Ice40OptPass : public Pass {
 	Ice40OptPass() : Pass("ice40_opt", "iCE40: perform simple optimizations") { }
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -156,7 +156,7 @@ struct Ice40OptPass : public Pass {
 		log("mapped SB_LUT4 cells back to logic.\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		string opt_expr_args = "-mux_undef -undriven";
 		bool unlut_mode = false;

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -29,7 +29,7 @@ struct SynthIce40Pass : public ScriptPass
 {
 	SynthIce40Pass() : ScriptPass("synth_ice40", "synthesis for iCE40 FPGAs") { }
 
-	virtual void help() YS_OVERRIDE
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -88,7 +88,7 @@ struct SynthIce40Pass : public ScriptPass
 	string top_opt, blif_file, edif_file, json_file;
 	bool nocarry, nodffe, nobram, flatten, retime, abc2, vpr;
 
-	virtual void clear_flags() YS_OVERRIDE
+	void clear_flags() YS_OVERRIDE
 	{
 		top_opt = "-auto-top";
 		blif_file = "";
@@ -103,7 +103,7 @@ struct SynthIce40Pass : public ScriptPass
 		vpr = false;
 	}
 
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		string run_from, run_to;
 		clear_flags();
@@ -182,7 +182,7 @@ struct SynthIce40Pass : public ScriptPass
 		log_pop();
 	}
 
-	virtual void script() YS_OVERRIDE
+	void script() YS_OVERRIDE
 	{
 		if (check_label("begin"))
 		{

--- a/techlibs/intel/synth_intel.cc
+++ b/techlibs/intel/synth_intel.cc
@@ -28,7 +28,7 @@ PRIVATE_NAMESPACE_BEGIN
 struct SynthIntelPass : public ScriptPass {
   SynthIntelPass() : ScriptPass("synth_intel", "synthesis for Intel (Altera) FPGAs.") { }
 
-  virtual void help() YS_OVERRIDE
+  void help() YS_OVERRIDE
   {
     //   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
     log("\n");
@@ -79,7 +79,7 @@ struct SynthIntelPass : public ScriptPass {
   string top_opt, family_opt, vout_file, blif_file;
   bool retime, flatten, nobram, noiopads;
 
-  virtual void clear_flags() YS_OVERRIDE
+  void clear_flags() YS_OVERRIDE
   {
     top_opt = "-auto-top";
     family_opt = "max10";
@@ -91,7 +91,7 @@ struct SynthIntelPass : public ScriptPass {
     noiopads = false;
   }
 
-  virtual void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+  void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
   {
     string run_from, run_to;
     clear_flags();
@@ -156,7 +156,7 @@ struct SynthIntelPass : public ScriptPass {
     log_pop();
   }
 
-  virtual void script() YS_OVERRIDE
+  void script() YS_OVERRIDE
   {
     if (check_label("begin"))
       {
@@ -255,7 +255,7 @@ struct SynthIntelPass : public ScriptPass {
           run(stringf("write_verilog -attr2comment -defparam -nohex -decimal -renameprefix syn_ %s",
                       help_mode ? "<file-name>" : vout_file.c_str()));
       }
-    
+
     if (check_label("vpr"))
       {
         if (!blif_file.empty() || help_mode)
@@ -264,7 +264,7 @@ struct SynthIntelPass : public ScriptPass {
             run(stringf("write_blif %s", help_mode ? "<file-name>" : blif_file.c_str()));
           }
       }
-  }       
+  }
 } SynthIntelPass;
 
 PRIVATE_NAMESPACE_END

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -38,7 +38,7 @@ struct SynthXilinxPass : public Pass
 {
 	SynthXilinxPass() : Pass("synth_xilinx", "synthesis for Xilinx FPGAs") { }
 
-	virtual void help()
+	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
@@ -128,7 +128,7 @@ struct SynthXilinxPass : public Pass
 		log("        write_blif <file-name>\n");
 		log("\n");
 	}
-	virtual void execute(std::vector<std::string> args, RTLIL::Design *design)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::string top_opt = "-auto-top";
 		std::string edif_file;


### PR DESCRIPTION
 - Not all derived methods were marked 'override', but it is a great
  feature of C++11 that we should make use of.
 - While at it: touched header files got a `-*- c++ -*-` for emacs to
  provide support for that language.
 - use YS_OVERRIDE for all override keywords (though we should probably
  use the plain keyword going forward now that C++11 is established)

Mostly a suggestion, but I think it would make working with the code easier as it provides automatic typo-detection in derived classes.

Note, this does not contain any functional changes, just mechanical text changes.

I think we should use the plain `override` keyword and remove the `#define YS_OVERRIDE` (and YS_FINAL); it looks like these defines were necessary in the transition to full c++11 support in compilers, but now that these compilers are established, simplifying that would probably be good. Your call, I am happy to do a follow-up pull-request that converts all `YS_OVERRIDE` -> `override` and remove the `#define`.

This change does not touch any overrides in `libs/` as these seem to be mostly upstream-imported from somewhere.