### PR TITLE
fix basys3 example

### DIFF
--- a/examples/basys3/example.xdc
+++ b/examples/basys3/example.xdc
@@ -19,3 +19,6 @@ set_property -dict { IOSTANDARD LVCMOS33 PACKAGE_PIN L1  } [get_ports {LD[15]}]
 
 create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports CLK]
 
+set_property CONFIG_VOLTAGE 3.3 [current_design]
+set_property CFGBVS VCCO [current_design]
+

--- a/examples/basys3/run_prog.tcl
+++ b/examples/basys3/run_prog.tcl
@@ -1,3 +1,4 @@
+open_hw
 connect_hw_server
 open_hw_target [lindex [get_hw_targets] 0]
 set_property PROGRAM.FILE example.bit [lindex [get_hw_devices] 0]


### PR DESCRIPTION
Added `CONFIG_VOLTAGE` and `CFGBVS` to constraints file
to avoid warning `DRC 23-20`.

Added `open_hw` needed for programming.