### PR TITLE
Improve debugging Yosys with pretty printers and better default settings.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,11 @@ ifeq ($(ENABLE_DEBUG),1)
 ifeq ($(CONFIG),clang)
 CXXFLAGS := -O0 -DDEBUG $(filter-out -Os,$(CXXFLAGS))
 else
+ifeq ($(CONFIG),gcc)
+CXXFLAGS := -O0 -ggdb3 -fvar-tracking -fvar-tracking-assignments -DDEBUG $(filter-out -Os -ggdb,$(CXXFLAGS))
+else
 CXXFLAGS := -Og -DDEBUG $(filter-out -Os,$(CXXFLAGS))
+endif
 endif
 endif
 

--- a/kernel/gdb.h
+++ b/kernel/gdb.h
@@ -1,9 +1,36 @@
-#ifdef DEBUG
-
-/* Autoloading of GDB Python pretty printing scripts.
- * More information at
- * https://sourceware.org/gdb/onlinedocs/gdb/dotdebug_005fgdb_005fscripts-section.html#dotdebug_005fgdb_005fscripts-section
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
  */
+#ifndef GDB_H
+#define GDB_H
+
+/* Default empty definition */
+#define DEFINE_GDB_PY_SCRIPT(script_name)
+
+/* If supported by your compiler + system, add autoloading of GDB Python pretty
+ * printing scripts.
+ * More information at
+ *  https://sourceware.org/gdb/onlinedocs/gdb/dotdebug_005fgdb_005fscripts-section.html#dotdebug_005fgdb_005fscripts-section
+ */
+#if (defined(__GNUC__) || defined(__clang__))
+#ifndef _WIN32
+
+#undef DEFINE_GDB_PY_SCRIPT
 
 /* Note: The "MS" section flags are to remove duplicates.  */
 #define _DEFINE_GDB_PY_SCRIPT(script_name) \
@@ -18,9 +45,5 @@
     _DEFINE_GDB_PY_SCRIPT(script_name) \
     _DEFINE_GDB_PY_SCRIPT("misc/gdb/" script_name) \
 
-
-#else
-
-#define DEFINE_GDB_PY_SCRIPT(script_name)
 
 #endif

--- a/kernel/gdb.h
+++ b/kernel/gdb.h
@@ -1,0 +1,26 @@
+#ifdef DEBUG
+
+/* Autoloading of GDB Python pretty printing scripts.
+ * More information at
+ * https://sourceware.org/gdb/onlinedocs/gdb/dotdebug_005fgdb_005fscripts-section.html#dotdebug_005fgdb_005fscripts-section
+ */
+
+/* Note: The "MS" section flags are to remove duplicates.  */
+#define _DEFINE_GDB_PY_SCRIPT(script_name) \
+  asm("\
+.pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\n\
+.byte 1 /* Python */\n\
+.asciz \"" script_name "\"\n\
+.popsection \n\
+");
+
+#define DEFINE_GDB_PY_SCRIPT(script_name) \
+    _DEFINE_GDB_PY_SCRIPT(script_name) \
+    _DEFINE_GDB_PY_SCRIPT("misc/gdb/" script_name) \
+
+
+#else
+
+#define DEFINE_GDB_PY_SCRIPT(script_name)
+
+#endif

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -17,10 +17,14 @@
  *
  */
 
+#include "kernel/gdb.h"
 #include "kernel/yosys.h"
 
 #ifndef RTLIL_H
 #define RTLIL_H
+
+/* GDB pretty printer to make viewing IdStrings easy */
+DEFINE_GDB_PY_SCRIPT ("yosys-gdb.py")
 
 YOSYS_NAMESPACE_BEGIN
 

--- a/misc/gdb/printers.py
+++ b/misc/gdb/printers.py
@@ -1,0 +1,57 @@
+import gdb.printing
+
+
+def std_vector_at(v, i):
+    """Get the gdb.Value object from a std::vector for a given index."""
+    # Find a pretty printer for the std::vector and then find the child
+    # which matches our index.
+    ni = '[%d]' % i
+    vprinter = gdb.default_visualizer(v)
+    value = None
+    for n, v in vprinter.children():
+        if n == ni:
+            value = v
+            break
+
+    # Return either the child object or None
+    return value
+
+
+class IdStringPrinter:
+    """Print a IdString object."""
+
+    def __init__(self, val):
+        self.val = val
+
+    def children(self):
+        return []
+
+    def type_hint(self):
+        return 'string'
+
+    @property
+    def index(self):
+        return int(self.val["index_"])
+
+    def get_value(self):
+        # Get the actual string from the global id storage which is a
+        # std::vector
+        return std_vector_at(self.val["global_id_storage_"], self.index)
+
+    def to_string(self):
+        value = self.get_value()
+        vstr = "???"
+        if value is not None:
+            vprinter = gdb.default_visualizer(value)
+            if vprinter is not None:
+                vstr = '"%s"' % vprinter.to_string()
+            else:
+                vstr = '"%s"' % value.string()
+        return '(%d)%s' % (self.index, vstr)
+
+
+def build_pretty_printer():
+    pp = gdb.printing.RegexpCollectionPrettyPrinter(
+        "yosys")
+    pp.add_printer('IdString', '^Yosys::RTLIL::IdString$', IdStringPrinter)
+    return pp

--- a/misc/gdb/yosys-gdb.py
+++ b/misc/gdb/yosys-gdb.py
@@ -1,0 +1,11 @@
+import sys
+import os.path
+sys.path.insert(0, os.path.dirname(__file__))
+
+import gdb
+import gdb.printing
+import printers
+
+gdb.printing.register_pretty_printer(
+    gdb.current_objfile(),
+    printers.build_pretty_printer())


### PR DESCRIPTION
Adding GDB pretty printer for IdString. Now when you print a structure (such as a `cell`) in gdb you get something much more readable.

 * Script to pretty print the IdString primitive, making it *much* easier to use GDB with Yosys.

 * Install the gdb scripts to the correct location so that they can be autoloaded.

 * Add script entries so the pretty printers are automatically loaded.

Example usage;
```shell
make ENABLE_DEBUG=1
gdb \
 -iex "add-auto-load-safe-path $PWD/misc/gdb" \
 --args ./yosys
```
(If Yosys is installed, the `add-auto-load-safe-path` is not needed.)