### PR TITLE
readme: Fix formatting of a keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ Verilog Attributes and non-standard features
 Non-standard or SystemVerilog features for formal verification
 ==============================================================
 
-- Support for ``assert``, ``assume``, ``restrict``, and ``cover'' is enabled
+- Support for ``assert``, ``assume``, ``restrict``, and ``cover`` is enabled
   when ``read_verilog`` is called with ``-formal``.
 
 - The system task ``$initstate`` evaluates to 1 in the initial state and


### PR DESCRIPTION
Single quotes were used instead of backticks leading to incorrect formatting.