### PR TITLE
`show` pass `-format` and `-viewer` improvements on Windows

### DIFF
--- a/passes/cmds/show.cc
+++ b/passes/cmds/show.cc
@@ -584,6 +584,7 @@ struct ShowPass : public Pass {
 		log("\n");
 		log("    -viewer <viewer>\n");
 		log("        Run the specified command with the graphics file as parameter.\n");
+		log("        On Windows, this pauses yosys until the viewer exits.\n");
 		log("\n");
 		log("    -format <format>\n");
 		log("        Generate a graphics file in the specified format. Use 'dot' to just\n");
@@ -645,7 +646,7 @@ struct ShowPass : public Pass {
 		log("        do not add the module name as graph title to the dot file\n");
 		log("\n");
 		log("When no <format> is specified, 'dot' is used. When no <format> and <viewer> is\n");
-		log("specified, 'xdot' is used to display the schematic.\n");
+		log("specified, 'xdot' is used to display the schematic (POSIX systems only).\n");
 		log("\n");
 		log("The generated output files are '~/.yosys_show.dot' and '~/.yosys_show.<format>',\n");
 		log("unless another prefix is specified using -prefix <prefix>.\n");


### PR DESCRIPTION
This should be the last quality-of-life PR I need to make on `yosys` for a while, I promise! :)

Recently, msys2 got graphviz support, so now it's easy for a Windows user to use yosys not only to generate `.dot` files, but to also convert them to one's favorite display format!

When using the `system()` `stdlib.h` function, Windows is unable to understand/strip single quotes, as demonstrated in this example program:

```
William@William-THINK MINGW64 ~/src/yosys-experiments/example-011
$ ls
 dummy.c   dummy.exe   example.v   manual.c   manual.exe   scripts   show.dot   show.png  "'show.png.new'"

William@William-THINK MINGW64 ~/src/yosys-experiments/example-011
$ cat manual.c
#include <stdlib.h>

int main()
{
    system("dot -Tpng 'show.dot' > 'show.png.new' && mv 'show.png.new' 'show.png'");

    return EXIT_SUCCESS;
}

William@William-THINK MINGW64 ~/src/yosys-experiments/example-011
$ ./manual.exe
Error: dot: can't open 'show.dot'

William@William-THINK MINGW64 ~/src/yosys-experiments/example-011
$
```

Therefore, I converted all single-quotes to double-quotes to make Windows happy (and also used the internal `move` command instead of `mv`. Even when run from a bash prompt, the Windows `system()` function will understand `move`.)

Additionally, Windows doesn't have an equivalent of background processes, so the `-viewer` option stops `yosys` while the viewer is running. This is _in addition_ to the pause that a user gets from using the `-pause` option. I updated the documentation accordingly, but perhaps the `-viewer` option should possibly be disabled on Windows?