### PR TITLE
Static builds and cross-compilation support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,14 @@ LD = gcc
 CXXFLAGS += -std=c++11 -Os
 ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H"
 
+else ifeq ($(CONFIG),gcc-static)
+LD = $(CXX)
+LDFLAGS := $(filter-out -rdynamic,$(LDFLAGS)) -s
+LDLIBS := -static $(filter-out -lrt,$(LDLIBS))
+CXXFLAGS += -std=c++11 -Os
+ABCMKARGS = CC="$(CC)" CXX="$(CXX)" LD="$(LD)" LIBS="-static -lm -ldl -pthread" OPTFLAGS="-O" \
+                       ARCHFLAGS="-DABC_USE_STDINT_H -DABC_NO_DYNAMIC_LINKING=1 -Wno-unused-but-set-variable" ABC_USE_NO_READLINE=1
+
 else ifeq ($(CONFIG),gcc-4.8)
 CXX = gcc-4.8
 LD = gcc-4.8
@@ -671,6 +679,12 @@ config-clang: clean
 config-gcc: clean
 	echo 'CONFIG := gcc' > Makefile.conf
 
+config-gcc-static: clean
+	echo 'CONFIG := gcc-static' > Makefile.conf
+	echo 'ENABLE_PLUGINS := 0' >> Makefile.conf
+	echo 'ENABLE_READLINE := 0' >> Makefile.conf
+	echo 'ENABLE_TCL := 0' >> Makefile.conf
+
 config-gcc-4.8: clean
 	echo 'CONFIG := gcc-4.8' > Makefile.conf
 
@@ -712,5 +726,5 @@ echo-git-rev:
 -include techlibs/*/*.d
 
 .PHONY: all top-all abc test install install-abc manual clean mrproper qtcreator
-.PHONY: config-clean config-clang config-gcc config-gcc-4.8 config-gprof config-sudo
+.PHONY: config-clean config-clang config-gcc config-gcc-static config-gcc-4.8 config-gprof config-sudo
 

--- a/Makefile
+++ b/Makefile
@@ -159,13 +159,16 @@ ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H"
 else ifeq ($(CONFIG),gcc-static)
 LD = $(CXX)
 LDFLAGS := $(filter-out -rdynamic,$(LDFLAGS)) -s
-LDLIBS := -static $(filter-out -lrt,$(LDLIBS))
+LDLIBS := -static $(filter-out -lrt,$(LDLIBS)) 
 ifeq ($(NO_FPIC),1)
 CXXFLAGS := $(filter-out -fPIC,$(CXXFLAGS))
 endif
 CXXFLAGS += -std=c++11 -Os
-ABCMKARGS = CC="$(CC)" CXX="$(CXX)" LD="$(LD)" ABC_USE_LIBSTDCXX=1 LIBS="-static -lm -lpthread" OPTFLAGS="-O" \
+ABCMKARGS = CC="$(CC)" CXX="$(CXX)" LD="$(LD)" ABC_USE_LIBSTDCXX=1 LIBS="-lm -lpthread -static" OPTFLAGS="-O" \
                        ARCHFLAGS="-DABC_USE_STDINT_H -DABC_NO_DYNAMIC_LINKING=1 -Wno-unused-but-set-variable $(ARCHFLAGS)" ABC_USE_NO_READLINE=1
+ifeq ($(DISABLE_ABC_THREADS),1)
+ABCMKARGS += "ABC_USE_NO_PTHREADS=1"
+endif
 
 else ifeq ($(CONFIG),gcc-4.8)
 CXX = gcc-4.8

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,9 @@ else ifeq ($(CONFIG),gcc-static)
 LD = $(CXX)
 LDFLAGS := $(filter-out -rdynamic,$(LDFLAGS)) -s
 LDLIBS := -static $(filter-out -lrt,$(LDLIBS))
+ifeq ($(NO_FPIC),1)
+CXXFLAGS := $(filter-out -fPIC,$(CXXFLAGS))
+endif
 CXXFLAGS += -std=c++11 -Os
 ABCMKARGS = CC="$(CC)" CXX="$(CXX)" LD="$(LD)" LIBS="-static -lm -ldl -pthread" OPTFLAGS="-O" \
                        ARCHFLAGS="-DABC_USE_STDINT_H -DABC_NO_DYNAMIC_LINKING=1 -Wno-unused-but-set-variable" ABC_USE_NO_READLINE=1

--- a/Makefile
+++ b/Makefile
@@ -159,10 +159,8 @@ ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H"
 else ifeq ($(CONFIG),gcc-static)
 LD = $(CXX)
 LDFLAGS := $(filter-out -rdynamic,$(LDFLAGS)) -s
-LDLIBS := -static $(filter-out -lrt,$(LDLIBS)) 
-ifeq ($(NO_FPIC),1)
+LDLIBS := $(filter-out -lrt,$(LDLIBS)) 
 CXXFLAGS := $(filter-out -fPIC,$(CXXFLAGS))
-endif
 CXXFLAGS += -std=c++11 -Os
 ABCMKARGS = CC="$(CC)" CXX="$(CXX)" LD="$(LD)" ABC_USE_LIBSTDCXX=1 LIBS="-lm -lpthread -static" OPTFLAGS="-O" \
                        ARCHFLAGS="-DABC_USE_STDINT_H -DABC_NO_DYNAMIC_LINKING=1 -Wno-unused-but-set-variable $(ARCHFLAGS)" ABC_USE_NO_READLINE=1

--- a/Makefile
+++ b/Makefile
@@ -164,8 +164,8 @@ ifeq ($(NO_FPIC),1)
 CXXFLAGS := $(filter-out -fPIC,$(CXXFLAGS))
 endif
 CXXFLAGS += -std=c++11 -Os
-ABCMKARGS = CC="$(CC)" CXX="$(CXX)" LD="$(LD)" LIBS="-static -lm -ldl -pthread" OPTFLAGS="-O" \
-                       ARCHFLAGS="-DABC_USE_STDINT_H -DABC_NO_DYNAMIC_LINKING=1 -Wno-unused-but-set-variable" ABC_USE_NO_READLINE=1
+ABCMKARGS = CC="$(CC)" CXX="$(CXX)" LD="$(LD)" ABC_USE_LIBSTDCXX=1 LIBS="-static -lm -lpthread" OPTFLAGS="-O" \
+                       ARCHFLAGS="-DABC_USE_STDINT_H -DABC_NO_DYNAMIC_LINKING=1 -Wno-unused-but-set-variable $(ARCHFLAGS)" ABC_USE_NO_READLINE=1
 
 else ifeq ($(CONFIG),gcc-4.8)
 CXX = gcc-4.8


### PR DESCRIPTION
Added gcc-static for easier cross compilation, builds static executable.

make config-gcc-static
for aarch64:
make CC="aarch64-linux-gnu-gcc" CXX="aarch64-linux-gnu-g++"

for arm 32bit:
make CC="arm-linux-gnueabihf-gcc" CXX="arm-linux-gnueabihf-g++" 