### PR TITLE
Added -no_dump_ptr flag for AST dump options in 'read_verilog'

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -44,7 +44,7 @@ namespace AST {
 
 // instanciate global variables (private API)
 namespace AST_INTERNAL {
-	bool flag_dump_ast1, flag_dump_ast2, flag_dump_vlog, flag_dump_rtlil, flag_nolatches, flag_nomeminit;
+	bool flag_dump_ast1, flag_dump_ast2, flag_no_dump_ptr, flag_dump_vlog, flag_dump_rtlil, flag_nolatches, flag_nomeminit;
 	bool flag_nomem2reg, flag_mem2reg, flag_lib, flag_noopt, flag_icells, flag_autowire;
 	AstNode *current_ast, *current_ast_mod;
 	std::map<std::string, AstNode*> current_scope;
@@ -267,10 +267,12 @@ void AstNode::dumpAst(FILE *f, std::string indent) const
 	std::string type_name = type2str(type);
 	fprintf(f, "%s%s <%s:%d>", indent.c_str(), type_name.c_str(), filename.c_str(), linenum);
 
-	if (id2ast)
-		fprintf(f, " [%p -> %p]", this, id2ast);
-	else
-		fprintf(f, " [%p]", this);
+	if (!flag_no_dump_ptr) {
+		if (id2ast)
+			fprintf(f, " [%p -> %p]", this, id2ast);
+		else
+			fprintf(f, " [%p]", this);
+	}
 
 	if (!str.empty())
 		fprintf(f, " str='%s'", str.c_str());
@@ -1008,12 +1010,13 @@ static AstModule* process_module(AstNode *ast, bool defer)
 }
 
 // create AstModule instances for all modules in the AST tree and add them to 'design'
-void AST::process(RTLIL::Design *design, AstNode *ast, bool dump_ast1, bool dump_ast2, bool dump_vlog, bool dump_rtlil,
+void AST::process(RTLIL::Design *design, AstNode *ast, bool dump_ast1, bool dump_ast2, bool no_dump_ptr, bool dump_vlog, bool dump_rtlil,
 		bool nolatches, bool nomeminit, bool nomem2reg, bool mem2reg, bool lib, bool noopt, bool icells, bool nooverwrite, bool overwrite, bool defer, bool autowire)
 {
 	current_ast = ast;
 	flag_dump_ast1 = dump_ast1;
 	flag_dump_ast2 = dump_ast2;
+	flag_no_dump_ptr = no_dump_ptr;
 	flag_dump_vlog = dump_vlog;
 	flag_dump_rtlil = dump_rtlil;
 	flag_nolatches = nolatches;

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -274,7 +274,7 @@ namespace AST
 	};
 
 	// process an AST tree (ast must point to an AST_DESIGN node) and generate RTLIL code
-	void process(RTLIL::Design *design, AstNode *ast, bool dump_ast1, bool dump_ast2, bool dump_vlog, bool dump_rtlil, bool nolatches, bool nomeminit,
+	void process(RTLIL::Design *design, AstNode *ast, bool dump_ast1, bool dump_ast2, bool no_dump_ptr, bool dump_vlog, bool dump_rtlil, bool nolatches, bool nomeminit,
 			bool nomem2reg, bool mem2reg, bool lib, bool noopt, bool icells, bool nooverwrite, bool overwrite, bool defer, bool autowire);
 
 	// parametric modules are supported directly by the AST library
@@ -305,7 +305,7 @@ namespace AST
 namespace AST_INTERNAL
 {
 	// internal state variables
-	extern bool flag_dump_ast1, flag_dump_ast2, flag_dump_rtlil, flag_nolatches, flag_nomeminit;
+	extern bool flag_dump_ast1, flag_dump_ast2, flag_no_dump_ptr, flag_dump_rtlil, flag_nolatches, flag_nomeminit;
 	extern bool flag_nomem2reg, flag_mem2reg, flag_lib, flag_noopt, flag_icells, flag_autowire;
 	extern AST::AstNode *current_ast, *current_ast_mod;
 	extern std::map<std::string, AST::AstNode*> current_scope;

--- a/frontends/verilog/verilog_frontend.cc
+++ b/frontends/verilog/verilog_frontend.cc
@@ -78,6 +78,9 @@ struct VerilogFrontend : public Frontend {
 		log("    -dump_ast2\n");
 		log("        dump abstract syntax tree (after simplification)\n");
 		log("\n");
+		log("    -no_dump_ptr\n");
+		log("        do not include hex memory addresses in dump (easier to diff dumps)\n");
+		log("\n");
 		log("    -dump_vlog\n");
 		log("        dump ast as Verilog code (after simplification)\n");
 		log("\n");
@@ -184,6 +187,7 @@ struct VerilogFrontend : public Frontend {
 	{
 		bool flag_dump_ast1 = false;
 		bool flag_dump_ast2 = false;
+		bool flag_no_dump_ptr = false;
 		bool flag_dump_vlog = false;
 		bool flag_dump_rtlil = false;
 		bool flag_nolatches = false;
@@ -239,6 +243,10 @@ struct VerilogFrontend : public Frontend {
 			}
 			if (arg == "-dump_ast2") {
 				flag_dump_ast2 = true;
+				continue;
+			}
+			if (arg == "-no_dump_ptr") {
+				flag_no_dump_ptr = true;
 				continue;
 			}
 			if (arg == "-dump_vlog") {
@@ -381,7 +389,7 @@ struct VerilogFrontend : public Frontend {
 		if (flag_nodpi)
 			error_on_dpi_function(current_ast);
 
-		AST::process(design, current_ast, flag_dump_ast1, flag_dump_ast2, flag_dump_vlog, flag_dump_rtlil, flag_nolatches, flag_nomeminit, flag_nomem2reg, flag_mem2reg, lib_mode, flag_noopt, flag_icells, flag_nooverwrite, flag_overwrite, flag_defer, default_nettype_wire);
+		AST::process(design, current_ast, flag_dump_ast1, flag_dump_ast2, flag_no_dump_ptr, flag_dump_vlog, flag_dump_rtlil, flag_nolatches, flag_nomeminit, flag_nomem2reg, flag_mem2reg, lib_mode, flag_noopt, flag_icells, flag_nooverwrite, flag_overwrite, flag_defer, default_nettype_wire);
 
 		if (!flag_nopp)
 			delete lexin;


### PR DESCRIPTION
This option disables the memory pointer display.
This is useful when diff'ing different dumps because otherwise the node pointers makes every diff line different when the AST content is the same.

I find this extremely useful when developing verilog frontend enhancements where I need to compare long AST dumps for subtle changes.

For example (before the PR):
```
-- Running command `read_verilog -sv -dump_ast1  tests/simple/always01.v' --

1. Executing Verilog-2005 frontend.
Parsing SystemVerilog input from `tests/simple/always01.v' to AST representation.
Generating RTLIL representation for module `\uut_always01'.
Dumping Verilog AST before simplification:
    AST_MODULE <tests/simple/always01.v:1> [0x186a740] str='\uut_always01'
      AST_WIRE <tests/simple/always01.v:3> [0x186aa50] str='\clock' input port=1
      AST_WIRE <tests/simple/always01.v:3> [0x186abd0] str='\reset' input port=2
      AST_WIRE <tests/simple/always01.v:4> [0x186b170] str='\count' output port=3
        AST_RANGE <tests/simple/always01.v:4> [0x186b2b0]
          AST_CONSTANT <tests/simple/always01.v:4> [0x186b3f0] bits='00000000000000000000000000000011'(32) signed range=[31:0] int=3
          AST_CONSTANT <tests/simple/always01.v:4> [0x186b560] bits='00000000000000000000000000000000'(32) signed range=[31:0]
      AST_WIRE <tests/simple/always01.v:5> [0x186b720] str='\count' reg
        AST_RANGE <tests/simple/always01.v:5> [0x186b860]
          AST_CONSTANT <tests/simple/always01.v:5> [0x186fbb0] bits='00000000000000000000000000000011'(32) signed range=[31:0] int=3
          AST_CONSTANT <tests/simple/always01.v:5> [0x186fcc0] bits='00000000000000000000000000000000'(32) signed range=[31:0]
      AST_ALWAYS <tests/simple/always01.v:7> [0x186a910]
        AST_POSEDGE <tests/simple/always01.v:7> [0x186aef0]
          AST_IDENTIFIER <tests/simple/always01.v:7> [0x186ad80] str='\clock'
        AST_BLOCK <tests/simple/always01.v:7> [0x186b060]
          AST_ASSIGN_LE <tests/simple/always01.v:8> [0x18706a0]
            AST_IDENTIFIER <tests/simple/always01.v:8> [0x186fdd0] str='\count'
            AST_TERNARY <tests/simple/always01.v:8> [0x1870540]
              AST_IDENTIFIER <tests/simple/always01.v:8> [0x186fee0] str='\reset'
              AST_CONSTANT <tests/simple/always01.v:8> [0x1870020] bits='00000000000000000000000000000000'(32) signed range=[31:0]
              AST_ADD <tests/simple/always01.v:8> [0x1870430]
                AST_IDENTIFIER <tests/simple/always01.v:8> [0x1870160] str='\count'
                AST_CONSTANT <tests/simple/always01.v:8> [0x18702c0] bits='00000000000000000000000000000001'(32) signed range=[31:0] int=1
--- END OF AST DUMP ---
```

After this PR:
```
-- Running command `read_verilog -sv -dump_ast1 -no_dump_ptr tests/simple/always01.v' --

1. Executing Verilog-2005 frontend.
Parsing SystemVerilog input from `tests/simple/always01.v' to AST representation.
Generating RTLIL representation for module `\uut_always01'.
Dumping Verilog AST before simplification:
    AST_MODULE <tests/simple/always01.v:1> str='\uut_always01'
      AST_WIRE <tests/simple/always01.v:3> str='\clock' input port=1
      AST_WIRE <tests/simple/always01.v:3> str='\reset' input port=2
      AST_WIRE <tests/simple/always01.v:4> str='\count' output port=3
        AST_RANGE <tests/simple/always01.v:4>
          AST_CONSTANT <tests/simple/always01.v:4> bits='00000000000000000000000000000011'(32) signed range=[31:0] int=3
          AST_CONSTANT <tests/simple/always01.v:4> bits='00000000000000000000000000000000'(32) signed range=[31:0]
      AST_WIRE <tests/simple/always01.v:5> str='\count' reg
        AST_RANGE <tests/simple/always01.v:5>
          AST_CONSTANT <tests/simple/always01.v:5> bits='00000000000000000000000000000011'(32) signed range=[31:0] int=3
          AST_CONSTANT <tests/simple/always01.v:5> bits='00000000000000000000000000000000'(32) signed range=[31:0]
      AST_ALWAYS <tests/simple/always01.v:7>
        AST_POSEDGE <tests/simple/always01.v:7>
          AST_IDENTIFIER <tests/simple/always01.v:7> str='\clock'
        AST_BLOCK <tests/simple/always01.v:7>
          AST_ASSIGN_LE <tests/simple/always01.v:8>
            AST_IDENTIFIER <tests/simple/always01.v:8> str='\count'
            AST_TERNARY <tests/simple/always01.v:8>
              AST_IDENTIFIER <tests/simple/always01.v:8> str='\reset'
              AST_CONSTANT <tests/simple/always01.v:8> bits='00000000000000000000000000000000'(32) signed range=[31:0]
              AST_ADD <tests/simple/always01.v:8>
                AST_IDENTIFIER <tests/simple/always01.v:8> str='\count'
                AST_CONSTANT <tests/simple/always01.v:8> bits='00000000000000000000000000000001'(32) signed range=[31:0] int=1
--- END OF AST DUMP ---
Successfully finished Verilog frontend.
```

