### PR TITLE
static link flag on main executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H"
 
 else ifeq ($(CONFIG),gcc-static)
 LD = $(CXX)
-LDFLAGS := $(filter-out -rdynamic,$(LDFLAGS)) -s
+LDFLAGS := $(filter-out -rdynamic,$(LDFLAGS)) -static
 LDLIBS := $(filter-out -lrt,$(LDLIBS)) 
 CXXFLAGS := $(filter-out -fPIC,$(CXXFLAGS))
 CXXFLAGS += -std=c++11 -Os


### PR DESCRIPTION
Missed this one, noticed that it is not actually static while compiling for arm