### PR TITLE
ecp5: Don't map ROMs to DRAM

### DIFF
--- a/techlibs/ecp5/dram.txt
+++ b/techlibs/ecp5/dram.txt
@@ -13,4 +13,5 @@ endbram
 
 match $__TRELLIS_DPR16X4
   make_outreg
+  min wports 1
 endmatch


### PR DESCRIPTION
Previously, ROMs were being mapped to distributed RAM, which was less efficient (wasting a slice for the unused write port) than just letting them become LUTs.