### PR TITLE
Don't apply result sign attribute to operands.

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -2515,8 +2515,9 @@ replace_fcall_later:;
 		if (0) { case AST_DIV: const_func = RTLIL::const_div; }
 		if (0) { case AST_MOD: const_func = RTLIL::const_mod; }
 			if (children[0]->type == AST_CONSTANT && children[1]->type == AST_CONSTANT) {
-				RTLIL::Const y = const_func(children[0]->bitsAsConst(width_hint, sign_hint),
-						children[1]->bitsAsConst(width_hint, sign_hint), sign_hint, sign_hint, width_hint);
+				RTLIL::Const y = const_func(
+						children[0]->bitsAsConst(width_hint, children[0]->is_signed),
+						children[1]->bitsAsConst(width_hint, children[1]->is_signed), children[0]->is_signed, children[1]->is_signed, width_hint);
 				newNode = mkconst_bits(y.bits, sign_hint);
 			} else
 			if (children[0]->isConst() && children[1]->isConst()) {


### PR DESCRIPTION
This is potential fix for issue #370.

When expanding the operands of the `i = i + 1'b` addition, the code uses the sign hint of the result instead of the sign of the operand. Since `i` is a signed integer, it will expand `1'b` as a signed number as well, resulting in -1 instead of +1.

The fix uses the sign of the operands as sign hint for the bitsAsConst method. 

I also use the sign of the 2 operands as a parameters of `const_func`. So the only place were the `sign_hint` is still used, is in the final `mkconst_bits`.

Tom
