### PR TITLE
xilinx: Still map LUT7/LUT8 to Xilinx specific primitives when using `-vpr`

### DIFF
--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -235,10 +235,9 @@ struct SynthXilinxPass : public Pass
 
 		if (check_label(active, run_from, run_to, "map_cells"))
 		{
+			Pass::call(design, "techmap -map +/xilinx/cells_map.v");
 			if (vpr)
-			    Pass::call(design, "techmap -D NO_LUT -map +/xilinx/cells_map.v");
-			else
-			    Pass::call(design, "techmap -map +/xilinx/cells_map.v");
+			    Pass::call(design, "techmap -map +/xilinx/lut2lut.v");
 			Pass::call(design, "dffinit -ff FDRE Q INIT -ff FDCE Q INIT -ff FDPE Q INIT");
 			Pass::call(design, "clean");
 		}


### PR DESCRIPTION
Then if targeting vpr map all the Xilinx specific LUTs back into generic Yosys LUTs.

This makes LUT8 and LUT7 get converted to `LUT6` + `MUXF8` // `LUT6` + `MUXF7` when using vpr.