### PR TITLE
Handling ff/latch in liberty files

### DIFF
--- a/frontends/liberty/liberty.cc
+++ b/frontends/liberty/liberty.cc
@@ -634,6 +634,8 @@ struct LibertyFrontend : public Frontend {
 				}
 			}
 
+			// some liberty files do not put ff/latch at the beginning of a cell
+			// try to find "ff" or "latch" and create FF/latch before processing all other nodes 
 			for (auto node : cell->children)
 			{
 				if (!flag_lib) {
@@ -645,6 +647,21 @@ struct LibertyFrontend : public Frontend {
 							goto skip_cell;
 						}
 				}
+			}
+
+			for (auto node : cell->children)
+			{
+				/*
+				if (!flag_lib) {
+					if (node->id == "ff" && node->args.size() == 2)
+						create_ff(module, node);
+					if (node->id == "latch" && node->args.size() == 2)
+						if (!create_latch(module, node, flag_ignore_miss_data_latch)) {
+							delete module;
+							goto skip_cell;
+						}
+				}
+				*/
 
 				if (node->id == "pin" && node->args.size() == 1)
 				{


### PR DESCRIPTION
The ff/latch block may not be defined at the beginning of the cell definition. I change the flow to detect ff/latch before processing other nodes. Thanks.
