### PR TITLE
Splits SigSpec into bits before calling check_signal_in_fanout (solves #675)

### DIFF
--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1304,10 +1304,6 @@ inline const RTLIL::SigBit &RTLIL::SigSpecConstIterator::operator*() const {
 }
 
 inline RTLIL::SigBit::SigBit(const RTLIL::SigSpec &sig) {
-	if(sig.size() != 1 || sig.chunks().size() != 1) {
-    std::cout << "rtp " << sig.size() << std::endl;
-    std::cout << "rtp " << sig.chunks().size() << std::endl;
-  }
 	log_assert(sig.size() == 1 && sig.chunks().size() == 1);
 	*this = SigBit(sig.chunks().front());
 }

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1304,6 +1304,10 @@ inline const RTLIL::SigBit &RTLIL::SigSpecConstIterator::operator*() const {
 }
 
 inline RTLIL::SigBit::SigBit(const RTLIL::SigSpec &sig) {
+	if(sig.size() != 1 || sig.chunks().size() != 1) {
+    std::cout << "rtp " << sig.size() << std::endl;
+    std::cout << "rtp " << sig.chunks().size() << std::endl;
+  }
 	log_assert(sig.size() == 1 && sig.chunks().size() == 1);
 	*this = SigBit(sig.chunks().front());
 }

--- a/passes/equiv/equiv_make.cc
+++ b/passes/equiv/equiv_make.cc
@@ -298,20 +298,21 @@ struct EquivMakeWorker
 				SigSpec new_sig = rd_signal_map(old_sig);
 
 				if(old_sig != new_sig) {
-					for (auto &old_bit : old_sig.bits()) {
-						SigBit new_bit = new_sig.bits()[old_bit.offset];
+					SigSpec tmp_sig = old_sig;
+					for (int i = 0; i < GetSize(old_sig); i++) {
+						SigBit old_bit = old_sig[i], new_bit = new_sig[i];
 
 						visited_cells.clear();
-						if (old_bit != new_bit) {
-							if (check_signal_in_fanout(visited_cells, old_bit, new_bit))
-								continue;
+						if (check_signal_in_fanout(visited_cells, old_bit, new_bit))
+							continue;
 
-							log("Changing input %s of cell %s (%s): %s -> %s\n",
-									log_id(conn.first), log_id(c), log_id(c->type),
-									log_signal(old_bit), log_signal(new_bit));
-							c->setPort(conn.first, new_bit);
-						}
+						log("Changing input %s of cell %s (%s): %s -> %s\n",
+								log_id(conn.first), log_id(c), log_id(c->type),
+								log_signal(old_bit), log_signal(new_bit));
+
+						tmp_sig[i] = new_bit;
 					}
+					c->setPort(conn.first, tmp_sig);
 				}
 			}
 

--- a/passes/equiv/equiv_make.cc
+++ b/passes/equiv/equiv_make.cc
@@ -290,7 +290,7 @@ struct EquivMakeWorker
 
 		init_bit2driven();
 
-		pool<Cell*>	visited_cells;
+		pool<Cell*> visited_cells;
 		for (auto c : cells_list)
 		for (auto &conn : c->connections())
 			if (!ct.cell_output(c->type, conn.first)) {
@@ -418,7 +418,7 @@ struct EquivMakeWorker
 		}
 	}
 
-	bool check_signal_in_fanout(pool<Cell*> & visited_cells, SigSpec source_bit, SigSpec target_bit)
+	bool check_signal_in_fanout(pool<Cell*> & visited_cells, SigBit source_bit, SigBit target_bit)
 	{
 		if (source_bit == target_bit)
 			return true;

--- a/passes/equiv/equiv_make.cc
+++ b/passes/equiv/equiv_make.cc
@@ -298,7 +298,7 @@ struct EquivMakeWorker
 				SigSpec new_sig = rd_signal_map(old_sig);
 
 				if(old_sig != new_sig) {
-					for(auto & old_bit : old_sig.bits()) {
+					for (auto &old_bit : old_sig.bits()) {
 						SigBit new_bit = new_sig.bits()[old_bit.offset];
 
 						visited_cells.clear();


### PR DESCRIPTION
Splits SigSpec into bits before calling check_signal_in_fanout in the equiv_make pass.
