### PR TITLE
Fix unhandled std::out_of_range in run_frontend() due to integer underflow

### DIFF
--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -821,7 +821,7 @@ void run_frontend(std::string filename, std::string command, std::string *backen
 			command = "verilog";
 		else if (filename.size() > 2 && filename.substr(filename.size()-3) == ".sv")
 			command = "verilog -sv";
-		else if (filename.size() > 2 && filename.substr(filename.size()-4) == ".vhd")
+		else if (filename.size() > 3 && filename.substr(filename.size()-4) == ".vhd")
 			command = "vhdl";
 		else if (filename.size() > 4 && filename.substr(filename.size()-5) == ".blif")
 			command = "blif";
@@ -833,7 +833,7 @@ void run_frontend(std::string filename, std::string command, std::string *backen
 			command = "ilang";
 		else if (filename.size() > 3 && filename.substr(filename.size()-3) == ".ys")
 			command = "script";
-		else if (filename.size() > 2 && filename.substr(filename.size()-4) == ".tcl")
+		else if (filename.size() > 3 && filename.substr(filename.size()-4) == ".tcl")
 			command = "tcl";
 		else if (filename == "-")
 			command = "script";


### PR DESCRIPTION
There's a bug in the logic for guessing which frontend to use based off the filename.
This leads to yosys crashing with an unhandled `std::out_of_range` when it's called with a single argument of length 3.
To reproduce, run the yosys CLI like this:
```
~>yosys abc

 /----------------------------------------------------------------------------\
 |                                                                            |
 |  yosys -- Yosys Open SYnthesis Suite                                       |
 |                                                                            |
 |  Copyright (C) 2012 - 2018  Clifford Wolf <clifford@clifford.at>           |
 |                                                                            |
 |  Permission to use, copy, modify, and/or distribute this software for any  |
 |  purpose with or without fee is hereby granted, provided that the above    |
 |  copyright notice and this permission notice appear in all copies.         |
 |                                                                            |
 |  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES  |
 |  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF          |
 |  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR   |
 |  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES    |
 |  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN     |
 |  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF   |
 |  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.            |
 |                                                                            |
 \----------------------------------------------------------------------------/

 Yosys 0.8+19 (git sha1 23b69ca3, clang 6.0.1-9.1 -fPIC -Os)

terminate called after throwing an instance of 'std::out_of_range'
  what():  basic_string::substr: __pos (which is 18446744073709551615) > this->size() (which is 3)
sh: “./yosys abc” terminated by signal SIGABRT (Abort)
```

This PR fixes that crash. See my commit comments for details.