### PR TITLE
More meaningful SystemVerilog/Verilog parser error messages

### DIFF
--- a/tests/errors/syntax_err01.v
+++ b/tests/errors/syntax_err01.v
@@ -1,0 +1,4 @@
+module a;
+integer [31:0]w;
+endmodule
+

--- a/tests/errors/syntax_err02.v
+++ b/tests/errors/syntax_err02.v
@@ -1,0 +1,7 @@
+module a;
+task to (
+  input integer [3:0]x
+);
+endtask
+endmodule
+

--- a/tests/errors/syntax_err03.v
+++ b/tests/errors/syntax_err03.v
@@ -1,0 +1,7 @@
+module a;
+task to (
+  input [3]x
+);
+endtask
+endmodule
+

--- a/tests/errors/syntax_err04.v
+++ b/tests/errors/syntax_err04.v
@@ -1,0 +1,4 @@
+module a;
+wire [3]x;
+endmodule
+

--- a/tests/errors/syntax_err05.v
+++ b/tests/errors/syntax_err05.v
@@ -1,0 +1,4 @@
+module a;
+input x[2:0];
+endmodule
+

--- a/tests/errors/syntax_err06.v
+++ b/tests/errors/syntax_err06.v
@@ -1,0 +1,6 @@
+module a;
+initial
+begin : label1
+end: label2
+endmodule
+

--- a/tests/errors/syntax_err07.v
+++ b/tests/errors/syntax_err07.v
@@ -1,0 +1,6 @@
+module a;
+wire [5:0]x;
+wire [3:0]y;
+assign y = (4)55;
+endmodule
+

--- a/tests/errors/syntax_err08.v
+++ b/tests/errors/syntax_err08.v
@@ -1,0 +1,6 @@
+module a;
+wire [5:0]x;
+wire [3:0]y;
+assign y = x 55;
+endmodule
+

--- a/tests/errors/syntax_err09.v
+++ b/tests/errors/syntax_err09.v
@@ -1,0 +1,3 @@
+module a(input wire x = 1'b0);
+endmodule
+

--- a/tests/errors/syntax_err10.v
+++ b/tests/errors/syntax_err10.v
@@ -1,0 +1,3 @@
+module a;
+parameter integer [2:0]x=0;
+endmodule

--- a/tests/errors/syntax_err11.v
+++ b/tests/errors/syntax_err11.v
@@ -1,0 +1,3 @@
+module a;
+parameter integer real x=0;
+endmodule

--- a/tests/errors/syntax_err12.v
+++ b/tests/errors/syntax_err12.v
@@ -1,0 +1,7 @@
+interface iface;
+endinterface
+
+module a (
+  iface x = 1'b0
+);
+endmodule

--- a/tests/errors/syntax_err13.v
+++ b/tests/errors/syntax_err13.v
@@ -1,0 +1,4 @@
+module a #(p = 0)
+();
+endmodule
+


### PR DESCRIPTION
Currently, the Verilog/SystemVerilog parser has about 14 cryptic "Syntax error" messages.
This PR renames thosee generic "Syntax error" message from into unique, meaningful info on the error.
Also add 13 compilation examples that triggers each of these messages.
