### PR TITLE
DFFLIBMAP: changed 'missing pin' error into a warning.

### DIFF
--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -101,7 +101,16 @@ static bool parse_pin(LibertyAst *cell, LibertyAst *attr, std::string &pin_name,
 		if (child->id == "pin" && child->args.size() == 1 && child->args[0] == pin_name)
 			return true;
 
-	log_error("Malformed liberty file - cannot find pin '%s' in cell '%s'.\n", pin_name.c_str(), cell->args[0].c_str());
+	/* If we end up here, the pin specified in the attribute does not exist, which is an error,
+	   or, the attribute contains an expression which we do not yet support.
+       For now, we'll simply produce a warning to let the user know something is up.
+	*/
+	if (pin_name.find_first_of("^*|&") == std::string::npos) {
+		log_warning("Malformed liberty file - cannot find pin '%s' in cell '%s' - skipping.\n", pin_name.c_str(), cell->args[0].c_str());
+	}
+	else {
+		log_warning("Found unsupported expression '%s' in pin attribute of cell '%s' - skipping.\n", pin_name.c_str(), cell->args[0].c_str());
+	}
 
 	return false;
 }


### PR DESCRIPTION
Changed 'missing pin' error into a warning.  The corresponding cell is then ignored in the DFF map pass.
This allows Yosys to continue instead of aborting.

An attempt is made to tell the user whether the problem is caused by an expression in the Liberty FF attributes, or if the referenced pin is actually not defined in the cell.

This fix was successfully tested with 'tsl18fs120' .lib file.