### PR TITLE
Use appropriate static libraries when building with Verific on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,11 @@ ifeq ($(ENABLE_VERIFIC),1)
 VERIFIC_DIR ?= /usr/local/src/verific_lib_eval
 VERIFIC_COMPONENTS ?= verilog vhdl database util containers sdf hier_tree
 CXXFLAGS += $(patsubst %,-I$(VERIFIC_DIR)/%,$(VERIFIC_COMPONENTS)) -DYOSYS_ENABLE_VERIFIC
+ifeq ($(OS), Darwin)
+LDLIBS += $(patsubst %,$(VERIFIC_DIR)/%/*-mac.a,$(VERIFIC_COMPONENTS)) -lz
+else
 LDLIBS += $(patsubst %,$(VERIFIC_DIR)/%/*-linux.a,$(VERIFIC_COMPONENTS)) -lz
+endif
 endif
 
 ifeq ($(ENABLE_PROTOBUF),1)


### PR DESCRIPTION
The Makefile assumes static libraries for Linux when building with Verific.