### PR TITLE
Make return value of $clog2 signed

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1913,7 +1913,7 @@ skip_dynamic_range_lvalue_expansion:;
 					if (arg_value.bits.at(i) == RTLIL::State::S1)
 						result = i + 1;
 
-				newNode = mkconst_int(result, false);
+				newNode = mkconst_int(result, true);
 				goto apply_newNode;
 			}
 


### PR DESCRIPTION
As per Verilog 2005 - 17.11.1.

Fixes #708

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>