### PR TITLE
Changes in GoWin synth commands and ALU primitive support

### DIFF
--- a/techlibs/gowin/Makefile.inc
+++ b/techlibs/gowin/Makefile.inc
@@ -3,4 +3,5 @@ OBJS += techlibs/gowin/synth_gowin.o
 
 $(eval $(call add_share_file,share/gowin,techlibs/gowin/cells_map.v))
 $(eval $(call add_share_file,share/gowin,techlibs/gowin/cells_sim.v))
+$(eval $(call add_share_file,share/gowin,techlibs/gowin/arith_map.v))
 

--- a/techlibs/gowin/arith_map.v
+++ b/techlibs/gowin/arith_map.v
@@ -1,0 +1,59 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *  Copyright (C) 2018  David Shah <dave@ds0.me>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+(* techmap_celltype = "$alu" *)
+module _80_gw1n_alu(A, B, CI, BI, X, Y, CO);
+   parameter A_SIGNED = 0;
+   parameter B_SIGNED = 0;
+   parameter A_WIDTH = 1;
+   parameter B_WIDTH = 1;
+   parameter Y_WIDTH = 1;
+   
+   input [A_WIDTH-1:0] A;
+   input [B_WIDTH-1:0] B;
+   output [Y_WIDTH-1:0] X, Y;
+   
+   input 		CI, BI;
+   output [Y_WIDTH-1:0] CO;
+   
+   wire 		_TECHMAP_FAIL_ = Y_WIDTH <= 2;
+   
+   wire [Y_WIDTH-1:0] 	A_buf, B_buf;
+   \$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(Y_WIDTH)) A_conv (.A(A), .Y(A_buf));
+   \$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(Y_WIDTH)) B_conv (.A(B), .Y(B_buf));
+   
+   wire [Y_WIDTH-1:0] 	AA = A_buf;
+   wire [Y_WIDTH-1:0] 	BB = BI ? ~B_buf : B_buf;
+   wire [Y_WIDTH-1:0] 	C = {CO, CI};
+   
+   genvar 		i;
+   generate for (i = 0; i < Y_WIDTH; i = i + 1) begin:slice
+      ALU #(.ALU_MODE(32'b0))
+      alu(.I0(AA[i]),
+	  .I1(BB[i]),
+	  .I3(1'b0),
+	  .CIN(C[i]),
+	  .COUT(CO[i]),
+	  .SUM(Y[i])
+	  );
+   end endgenerate
+   assign X = AA ^ BB;
+endmodule
+

--- a/techlibs/gowin/cells_sim.v
+++ b/techlibs/gowin/cells_sim.v
@@ -57,3 +57,9 @@ endmodule
 module GSR (input GSRI);
 	wire GSRO = GSRI;
 endmodule
+
+module ALU (input I0, input I1, input I3, input CIN, output COUT, output SUM);
+   parameter [3:0] ALU_MODE = 0; // default 0 = ADD
+   assign  {COUT, SUM} = CIN + I1 + I0;
+endmodule // alu
+

--- a/techlibs/intel/common/brams_map.v
+++ b/techlibs/intel/common/brams_map.v
@@ -2,8 +2,8 @@ module \$__M9K_ALTSYNCRAM_SINGLEPORT_FULL (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1A
 
    parameter CFG_ABITS = 8;
    parameter CFG_DBITS = 36;
-   parameter ABITS = "1";
-   parameter DBITS = "1";
+   parameter ABITS = 1;
+   parameter DBITS = 1;
    parameter CLKPOL2 = 1;
    parameter CLKPOL3 = 1;
 
@@ -63,21 +63,21 @@ module \$__M9K_ALTSYNCRAM_SINGLEPORT_FULL (CLK2, CLK3, A1ADDR, A1DATA, A1EN, B1A
                  .width_byteena_a                (1), // Forced value
                  .numwords_b                     ( NUMWORDS     ),
                  .numwords_a                     ( NUMWORDS     ),
-                 .widthad_b                      ( CFG_ABITS    ),
-                 .width_b                        ( CFG_DBITS    ),
-                 .widthad_a                      ( CFG_ABITS    ),
-                 .width_a                        ( CFG_DBITS    )
+                 .widthad_b                      ( CFG_DBITS    ),
+                 .width_b                        ( CFG_ABITS    ),
+                 .widthad_a                      ( CFG_DBITS    ),
+                 .width_a                        ( CFG_ABITS    )
                  ) _TECHMAP_REPLACE_ (
                                       .data_a(B1DATA),
                                       .address_a(B1ADDR),
                                       .wren_a(B1EN),
                                       .rden_a(A1EN),
                                       .q_a(A1DATA),
-                                      .data_b(1'b0),
+                                      .data_b(B1DATA),
                                       .address_b(0),
                                       .wren_b(1'b0),
                                       .rden_b(1'b0),
-                                      .q_b(1'b0),
+                                      .q_b(),
                                       .clock0(CLK2),
                                       .clock1(1'b1), // Unused in single port mode
                                       .clocken0(1'b1),


### PR DESCRIPTION
I have added ALU primitive support, modify the synth_gowin command to handle the new primitive and started SP/SDP memory support as well.
Also, a minor modification on M9K.