### PR TITLE
Extract ice40_unlut pass from ice40_opt

### DIFF
--- a/techlibs/ice40/Makefile.inc
+++ b/techlibs/ice40/Makefile.inc
@@ -3,6 +3,7 @@ OBJS += techlibs/ice40/synth_ice40.o
 OBJS += techlibs/ice40/ice40_ffssr.o
 OBJS += techlibs/ice40/ice40_ffinit.o
 OBJS += techlibs/ice40/ice40_opt.o
+OBJS += techlibs/ice40/ice40_unlut.o
 
 GENFILES += techlibs/ice40/brams_init1.vh
 GENFILES += techlibs/ice40/brams_init2.vh

--- a/techlibs/ice40/ice40_opt.cc
+++ b/techlibs/ice40/ice40_opt.cc
@@ -33,7 +33,7 @@ static SigBit get_bit_or_zero(const SigSpec &sig)
 	return sig[0];
 }
 
-static void run_ice40_opts(Module *module, bool unlut_mode)
+static void run_ice40_opts(Module *module)
 {
 	pool<SigBit> optimized_co;
 	vector<Cell*> sb_lut_cells;
@@ -95,9 +95,6 @@ static void run_ice40_opts(Module *module, bool unlut_mode)
 		inbits.append(get_bit_or_zero(cell->getPort("\\I3")));
 		sigmap.apply(inbits);
 
-		if (unlut_mode)
-			goto remap_lut;
-
 		if (optimized_co.count(inbits[0])) goto remap_lut;
 		if (optimized_co.count(inbits[1])) goto remap_lut;
 		if (optimized_co.count(inbits[2])) goto remap_lut;
@@ -152,14 +149,10 @@ struct Ice40OptPass : public Pass {
 		log("        opt_clean\n");
 		log("    while <changed design>\n");
 		log("\n");
-		log("When called with the option -unlut, this command will transform all already\n");
-		log("mapped SB_LUT4 cells back to logic.\n");
-		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		string opt_expr_args = "-mux_undef -undriven";
-		bool unlut_mode = false;
 
 		log_header(design, "Executing ICE40_OPT pass (performing simple optimizations).\n");
 		log_push();
@@ -168,10 +161,6 @@ struct Ice40OptPass : public Pass {
 		for (argidx = 1; argidx < args.size(); argidx++) {
 			if (args[argidx] == "-full") {
 				opt_expr_args += " -full";
-				continue;
-			}
-			if (args[argidx] == "-unlut") {
-				unlut_mode = true;
 				continue;
 			}
 			break;
@@ -184,7 +173,7 @@ struct Ice40OptPass : public Pass {
 
 			log_header(design, "Running ICE40 specific optimizations.\n");
 			for (auto module : design->selected_modules())
-				run_ice40_opts(module, unlut_mode);
+				run_ice40_opts(module);
 
 			Pass::call(design, "opt_expr " + opt_expr_args);
 			Pass::call(design, "opt_merge");

--- a/techlibs/ice40/ice40_unlut.cc
+++ b/techlibs/ice40/ice40_unlut.cc
@@ -1,0 +1,106 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/yosys.h"
+#include "kernel/sigtools.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+static SigBit get_bit_or_zero(const SigSpec &sig)
+{
+	if (GetSize(sig) == 0)
+		return State::S0;
+	return sig[0];
+}
+
+static void run_ice40_unlut(Module *module)
+{
+	SigMap sigmap(module);
+
+	for (auto cell : module->selected_cells())
+	{
+		if (cell->type == "\\SB_LUT4")
+		{
+			SigSpec inbits;
+
+			inbits.append(get_bit_or_zero(cell->getPort("\\I0")));
+			inbits.append(get_bit_or_zero(cell->getPort("\\I1")));
+			inbits.append(get_bit_or_zero(cell->getPort("\\I2")));
+			inbits.append(get_bit_or_zero(cell->getPort("\\I3")));
+			sigmap.apply(inbits);
+
+			log("Mapping SB_LUT4 cell %s.%s to $lut.\n", log_id(module), log_id(cell));
+
+			cell->type ="$lut";
+			cell->setParam("\\WIDTH", 4);
+			cell->setParam("\\LUT", cell->getParam("\\LUT_INIT"));
+			cell->unsetParam("\\LUT_INIT");
+
+			cell->setPort("\\A", SigSpec({
+				get_bit_or_zero(cell->getPort("\\I3")),
+				get_bit_or_zero(cell->getPort("\\I2")),
+				get_bit_or_zero(cell->getPort("\\I1")),
+				get_bit_or_zero(cell->getPort("\\I0"))
+			}));
+			cell->setPort("\\Y", cell->getPort("\\O")[0]);
+			cell->unsetPort("\\I0");
+			cell->unsetPort("\\I1");
+			cell->unsetPort("\\I2");
+			cell->unsetPort("\\I3");
+			cell->unsetPort("\\O");
+
+			cell->check();
+		}
+	}
+}
+
+struct Ice40UnlutPass : public Pass {
+	Ice40UnlutPass() : Pass("ice40_unlut", "iCE40: perform simple optimizations") { }
+	void help() YS_OVERRIDE
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    ice40_unlut [options] [selection]\n");
+		log("\n");
+		log("This command transforms all SB_LUT4 cells to generic $lut cells.\n");
+		log("\n");
+	}
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	{
+		log_header(design, "Executing ICE40_UNLUT pass (convert SB_LUT4 to $lut).\n");
+		log_push();
+
+		size_t argidx;
+		for (argidx = 1; argidx < args.size(); argidx++) {
+			// if (args[argidx] == "-???") {
+			//  continue;
+			// }
+			break;
+		}
+		extra_args(args, argidx, design);
+
+		for (auto module : design->selected_modules())
+			run_ice40_unlut(module);
+	}
+} Ice40UnlutPass;
+
+PRIVATE_NAMESPACE_END


### PR DESCRIPTION
Currently, `ice40_opt -unlut` would map SB_LUT4 to $lut and convert
them back to logic immediately. This is not desirable if the goal
is to operate on $lut cells. If this is desirable, the same result
as `ice40_opt -unlut` can be achieved by running simplemap and opt
after ice40_unlut.

This is a part of my work on #715.