### PR TITLE
rename: add -src, for inferring names from source locations

### DIFF
--- a/passes/cmds/rename.cc
+++ b/passes/cmds/rename.cc
@@ -52,6 +52,15 @@ static void rename_in_module(RTLIL::Module *module, std::string from_name, std::
 	log_cmd_error("Object `%s' not found!\n", from_name.c_str());
 }
 
+static std::string derive_name_from_src(const std::string &src, int counter)
+{
+	std::string src_base = src.substr(0, src.find('|'));
+	if (src_base.empty())
+		return stringf("$%d", counter);
+	else
+		return stringf("\\%s$%d", src_base.c_str(), counter);
+}
+
 struct RenamePass : public Pass {
 	RenamePass() : Pass("rename", "rename object in the design") { }
 	void help() YS_OVERRIDE
@@ -63,6 +72,10 @@ struct RenamePass : public Pass {
 		log("Rename the specified object. Note that selection patterns are not supported\n");
 		log("by this command.\n");
 		log("\n");
+		log("    rename -src [selection]\n");
+		log("\n");
+		log("Assign names auto-generated from the src attribute to all selected wires and\n");
+		log("cells with private names.\n");
 		log("\n");
 		log("    rename -enumerate [-pattern <pattern>] [selection]\n");
 		log("\n");
@@ -84,6 +97,7 @@ struct RenamePass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		std::string pattern_prefix = "_", pattern_suffix = "_";
+		bool flag_src = false;
 		bool flag_enumerate = false;
 		bool flag_hide = false;
 		bool flag_top = false;
@@ -93,6 +107,11 @@ struct RenamePass : public Pass {
 		for (argidx = 1; argidx < args.size(); argidx++)
 		{
 			std::string arg = args[argidx];
+			if (arg == "-src" && !got_mode) {
+				flag_src = true;
+				got_mode = true;
+				continue;
+			}
 			if (arg == "-enumerate" && !got_mode) {
 				flag_enumerate = true;
 				got_mode = true;
@@ -117,6 +136,37 @@ struct RenamePass : public Pass {
 			break;
 		}
 
+		if (flag_src)
+		{
+			extra_args(args, argidx, design);
+
+			for (auto &mod : design->modules_)
+			{
+				int counter = 0;
+
+				RTLIL::Module *module = mod.second;
+				if (!design->selected(module))
+					continue;
+
+				dict<RTLIL::IdString, RTLIL::Wire*> new_wires;
+				for (auto &it : module->wires_) {
+					if (it.first[0] == '$' && design->selected(module, it.second))
+						it.second->name = derive_name_from_src(it.second->get_src_attribute(), counter++);
+					new_wires[it.second->name] = it.second;
+				}
+				module->wires_.swap(new_wires);
+				module->fixup_ports();
+
+				dict<RTLIL::IdString, RTLIL::Cell*> new_cells;
+				for (auto &it : module->cells_) {
+					if (it.first[0] == '$' && design->selected(module, it.second))
+						it.second->name = derive_name_from_src(it.second->get_src_attribute(), counter++);
+					new_cells[it.second->name] = it.second;
+				}
+				module->cells_.swap(new_cells);
+			}
+		}
+		else
 		if (flag_enumerate)
 		{
 			extra_args(args, argidx, design);


### PR DESCRIPTION
Example timing report from nextpnr after `synth_ice40 -noabc -relut ; rename -src` with embedded source locations:
<details>

```
Info: Critical path report for clock 'sys_clk_$glb_clk' (posedge -> posedge):
Info: curr total
Info:  1.4  2.8  Source boneless.v:176$749_LC.O
Info:  1.8  4.5    Net $27 budget 3.704000 ns (11,14) -> (11,15)
Info:                Sink /home/whitequark/Projects/yosys/share/gate2lut.v:9$684_LC.I0
Info:  1.3  5.8  Source /home/whitequark/Projects/yosys/share/gate2lut.v:9$684_LC.O
Info:  1.8  7.6    Net state[0] budget 3.783000 ns (11,15) -> (10,16)
Info:                Sink boneless.v:176$1182_LC.I0
Info:  1.3  8.9  Source boneless.v:176$1182_LC.O
Info:  1.8 10.6    Net boneless.v:176$158[0] budget 3.783000 ns (10,16) -> (10,16)
Info:                Sink boneless.v:176$703_LC.I0
Info:  1.3 11.9  Source boneless.v:176$703_LC.O
Info:  1.8 13.7    Net $38[0] budget 3.783000 ns (10,16) -> (10,16)
Info:                Sink boneless.v:176$704_LC.I0
Info:  1.3 15.0  Source boneless.v:176$704_LC.O
Info:  3.6 18.6    Net boneless.v:176$223[0] budget 3.783000 ns (10,16) -> (13,21)
Info:                Sink boneless.v:176$893_LC.I2
Info:  1.2 19.8  Source boneless.v:176$893_LC.O
Info:  1.8 21.5    Net s_opB[0] budget 3.783000 ns (13,21) -> (12,22)
Info:                Sink boneless.v:269$1058_LC.I0
Info:  1.3 22.8  Source boneless.v:269$1058_LC.O
Info:  2.4 25.2    Net boneless.v:269$14[0] budget 3.783000 ns (12,22) -> (11,24)
Info:                Sink boneless.v:269$646$CARRY.I2
Info:  0.6 25.8  Source boneless.v:269$646$CARRY.COUT
Info:  0.0 25.8    Net boneless.v:269$15[1] budget 0.000000 ns (11,24) -> (11,24)
Info:                Sink boneless.v:269$659_LC.CIN
Info:  0.3 26.1  Source boneless.v:269$659_LC.COUT
Info:  0.0 26.1    Net boneless.v:269$15[2] budget 0.000000 ns (11,24) -> (11,24)
Info:                Sink boneless.v:269$661_LC.CIN
Info:  0.3 26.4  Source boneless.v:269$661_LC.COUT
Info:  0.0 26.4    Net boneless.v:269$15[3] budget 0.000000 ns (11,24) -> (11,24)
Info:                Sink boneless.v:269$663_LC.CIN
Info:  0.3 26.7  Source boneless.v:269$663_LC.COUT
Info:  0.0 26.7    Net boneless.v:269$15[4] budget 0.000000 ns (11,24) -> (11,24)
Info:                Sink boneless.v:269$665_LC.CIN
Info:  0.3 26.9  Source boneless.v:269$665_LC.COUT
Info:  0.0 26.9    Net boneless.v:269$15[5] budget 0.000000 ns (11,24) -> (11,24)
Info:                Sink boneless.v:269$667_LC.CIN
Info:  0.3 27.2  Source boneless.v:269$667_LC.COUT
Info:  0.0 27.2    Net boneless.v:269$15[6] budget 0.000000 ns (11,24) -> (11,24)
Info:                Sink boneless.v:269$669_LC.CIN
Info:  0.3 27.5  Source boneless.v:269$669_LC.COUT
Info:  0.0 27.5    Net boneless.v:269$15[7] budget 0.000000 ns (11,24) -> (11,24)
Info:                Sink boneless.v:269$671_LC.CIN
Info:  0.3 27.8  Source boneless.v:269$671_LC.COUT
Info:  0.6 28.3    Net boneless.v:269$15[8] budget 0.560000 ns (11,24) -> (11,25)
Info:                Sink boneless.v:269$673_LC.CIN
Info:  0.3 28.6  Source boneless.v:269$673_LC.COUT
Info:  0.0 28.6    Net boneless.v:269$15[9] budget 0.000000 ns (11,25) -> (11,25)
Info:                Sink boneless.v:269$675_LC.CIN
Info:  0.3 28.9  Source boneless.v:269$675_LC.COUT
Info:  0.0 28.9    Net boneless.v:269$15[10] budget 0.000000 ns (11,25) -> (11,25)
Info:                Sink boneless.v:269$647_LC.CIN
Info:  0.3 29.2  Source boneless.v:269$647_LC.COUT
Info:  0.0 29.2    Net boneless.v:269$15[11] budget 0.000000 ns (11,25) -> (11,25)
Info:                Sink boneless.v:269$649_LC.CIN
Info:  0.3 29.4  Source boneless.v:269$649_LC.COUT
Info:  0.0 29.4    Net boneless.v:269$15[12] budget 0.000000 ns (11,25) -> (11,25)
Info:                Sink boneless.v:269$651_LC.CIN
Info:  0.3 29.7  Source boneless.v:269$651_LC.COUT
Info:  0.0 29.7    Net boneless.v:269$15[13] budget 0.000000 ns (11,25) -> (11,25)
Info:                Sink boneless.v:269$653_LC.CIN
Info:  0.3 30.0  Source boneless.v:269$653_LC.COUT
Info:  0.0 30.0    Net boneless.v:269$15[14] budget 0.000000 ns (11,25) -> (11,25)
Info:                Sink boneless.v:269$655_LC.CIN
Info:  0.3 30.3  Source boneless.v:269$655_LC.COUT
Info:  0.7 30.9    Net boneless.v:269$15[15] budget 3.783000 ns (11,25) -> (11,25)
Info:                Sink boneless.v:269$657_LC.I3
Info:  0.9 31.8  Source boneless.v:269$657_LC.O
Info:  3.0 34.8    Net boneless.v:264$428[0] budget 3.783000 ns (11,25) -> (13,24)
Info:                Sink boneless.v:264$1289_LC.I2
Info:  1.2 36.0  Source boneless.v:264$1289_LC.O
Info:  1.8 37.7    Net boneless.v:264$302[1] budget 3.783000 ns (13,24) -> (13,23)
Info:                Sink boneless.v:264$979_LC.I1
Info:  1.2 39.0  Source boneless.v:264$979_LC.O
Info:  2.4 41.4    Net boneless.v:249$460[0] budget 3.783000 ns (13,23) -> (13,21)
Info:                Sink boneless.v:249$1306_LC.I2
Info:  1.2 42.6  Source boneless.v:249$1306_LC.O
Info:  2.4 45.0    Net boneless.v:176$477[0] budget 3.783000 ns (13,21) -> (13,18)
Info:                Sink boneless.v:176$1323_LC.I0
Info:  1.3 46.3  Source boneless.v:176$1323_LC.O
Info:  1.8 48.0    Net boneless.v:176$335[1] budget 3.783000 ns (13,18) -> (13,17)
Info:                Sink boneless.v:176$1012_LC.I1
Info:  1.2 49.3  Source boneless.v:176$1012_LC.O
Info:  1.8 51.0    Net s_res[15] budget 3.783000 ns (13,17) -> (13,17)
Info:                Sink boneless.v:427$1176_LC.I0
Info:  1.3 52.3  Source boneless.v:427$1176_LC.O
Info:  1.8 54.1    Net boneless.v:427$154[1] budget 3.783000 ns (13,17) -> (12,17)
Info:                Sink boneless.v:427$686_LC.I3
Info:  0.9 54.9  Source boneless.v:427$686_LC.O
Info:  1.8 56.7    Net boneless.v:427$217[0] budget 3.783000 ns (12,17) -> (12,17)
Info:                Sink /home/whitequark/Projects/yosys/share/gate2lut.v:26$728_LC.I2
Info:  0.1 56.8  Setup /home/whitequark/Projects/yosys/share/gate2lut.v:26$728_LC.I2
Info: 24.2 ns logic, 32.6 ns routing
```
</details>

This very clearly points to a specific subtractor in the critical path ([source](https://paste.debian.net/1054561/)), which AFAIK wasn't really possible to see before...