### PR TITLE
synth_ice40: split `map_gates` off `fine`

### DIFF
--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -240,6 +240,10 @@ struct SynthIce40Pass : public ScriptPass
 			run("opt -fast -mux_undef -undriven -fine");
 			run("memory_map");
 			run("opt -undriven -fine");
+		}
+
+		if (check_label("map_gates"))
+		{
 			if (nocarry)
 				run("techmap");
 			else


### PR DESCRIPTION
I am currently looking at some optimizations to be done on iCE40 that would run on the coarse-grain cells. In this case it is very useful to me to be able to stop synthesis before all arch-dependent transformations, but after all arch-independent optimizations have already been done. I.e. see and affect the state just before techmapping, and restart afterwards.

Feel free to close this PR if this is not something desirable, or tell me to also implement this for other `synth_*` commands.