### PR TITLE
write_verilog: inline internal cells that are used exactly once

### DIFF
--- a/kernel/modtools.h
+++ b/kernel/modtools.h
@@ -226,6 +226,10 @@ struct ModIndex : public RTLIL::Monitor
 		auto_reload_module = true;
 	}
 
+	ModIndex() : module(NULL)
+	{
+	}
+
 	ModIndex(RTLIL::Module *_m) : sigmap(_m), module(_m)
 	{
 		auto_reload_counter = 0;
@@ -235,7 +239,8 @@ struct ModIndex : public RTLIL::Monitor
 
 	~ModIndex()
 	{
-		module->monitors.erase(this);
+		if (module)
+			module->monitors.erase(this);
 	}
 
 	SigBitInfo *query(RTLIL::SigBit bit)


### PR DESCRIPTION
This has the effect of leaving *much* nicer Verilog code, and making Yosys quite usable for converting other HDLs to human-readable Verilog (which is what I'm experimenting with).

For example, a simple ALU:

<details>
<summary>Before (or with -noinline)</summary>

```verilog
module \$1 ();
  wire [15:0] _00_;
  wire [15:0] _01_;
  wire [16:0] _02_;
  wire [16:0] _03_;
  wire [16:0] _04_;
  wire [16:0] _05_;
  wire _06_;
  wire [17:0] _07_;
  wire _08_;
  wire _09_;
  wire [15:0] _10_;
  wire [15:0] a;
  wire [15:0] \a$next ;
  wire [15:0] b;
  wire [15:0] \b$next ;
  reg co;
  wire \co$next ;
  reg [15:0] o;
  wire [15:0] \o$next ;
  wire [1:0] sel;
  wire [1:0] \sel$next ;
  assign _00_ = a & b;
  assign _01_ = a ^ b;
  assign _03_ = + a;
  assign _05_ = - b;
  assign _04_ = + $signed(_05_);
  assign _07_ = $signed(_03_) + $signed(_04_);
  assign _02_ = + $signed(_07_);
  assign _06_ = sel == 0'b0;
  assign _08_ = sel == 1'h1;
  assign _09_ = sel == 2'h2;
  assign _10_ = a | b;
  always @* begin
    o = 16'h0000;
    co = 1'h0;
    casez ({ 1'h1, _09_, _08_, _06_ })
      4'bzzz1:
          o = _10_;
      4'bzz1z:
          o = _00_;
      4'bz1zz:
          o = _01_;
      4'b1zzz:
          { co, o } = _02_;
    endcase
  end
  always @* begin
      o <= \o$next ;
      co <= \co$next ;
  end
endmodule
```
</details>

<details>
<summary>After</summary>

```verilog
module \$1 ();
  wire [15:0] a;
  wire [15:0] \a$next ;
  wire [15:0] b;
  wire [15:0] \b$next ;
  reg co;
  wire \co$next ;
  reg [15:0] o;
  wire [15:0] \o$next ;
  wire [1:0] sel;
  wire [1:0] \sel$next ;
  always @* begin
    o = 16'h0000;
    co = 1'h0;
    casez ({ 1'h1, sel == 2'h2, sel == 1'h1, sel == 0'b0 })
      4'bzzz1:
          o = a | b;
      4'bzz1z:
          o = a & b;
      4'bz1zz:
          o = a ^ b;
      4'b1zzz:
          { co, o } = + $signed($signed(+ a) + $signed(+ $signed(- b)));
    endcase
  end
  always @* begin
      o <= \o$next ;
      co <= \co$next ;
  end
endmodule
```
</details>

This is rather close to what one might write by hand.

This pass is conservative; only wires that are driven by exactly one cell and are consumed exactly once by another cell or exactly once in a process are eliminated. Everything else, including unused wires, is kept as-is. In some cases, e.g. if a wire is used exactly once but it is sliced, such a wire is also left as-is as an arbitrary expression is not legal in Verilog in such context, only an identifier.