### PR TITLE
 opt_lut: leave intact LUTs with cascade feeding module outputs

### DIFF
--- a/passes/opt/opt_lut.cc
+++ b/passes/opt/opt_lut.cc
@@ -225,6 +225,12 @@ struct OptLutWorker
 
 					log("Found %s.%s (cell A) feeding %s.%s (cell B).\n", log_id(module), log_id(lutA), log_id(module), log_id(lutB));
 
+					if (index.query_is_output(lutA->getPort("\\Y")))
+					{
+						log("  Not combining LUTs (cascade connection feeds module output).\n");
+						continue;
+					}
+
 					pool<SigBit> lutA_inputs;
 					pool<SigBit> lutB_inputs;
 					for (auto &bit : lutA_input)

--- a/passes/opt/opt_lut.cc
+++ b/passes/opt/opt_lut.cc
@@ -388,8 +388,9 @@ struct OptLutWorker
 						lutM_new_table[eval] = (RTLIL::State) evaluate_lut(lutB, eval_inputs);
 					}
 
-					log("  Old truth table: %s.\n", lutM->getParam("\\LUT").as_string().c_str());
-					log("  New truth table: %s.\n", lutM_new_table.as_string().c_str());
+					log("  Cell A truth table: %s.\n", lutA->getParam("\\LUT").as_string().c_str());
+					log("  Cell B truth table: %s.\n", lutB->getParam("\\LUT").as_string().c_str());
+					log("  Merged truth table: %s.\n", lutM_new_table.as_string().c_str());
 
 					lutM->setParam("\\LUT", lutM_new_table);
 					lutM->setPort("\\A", lutM_new_inputs);

--- a/tests/opt/opt_lut_port.il
+++ b/tests/opt/opt_lut_port.il
@@ -1,0 +1,18 @@
+module $1
+  wire width 4 input 2 \_0_
+  wire output 4 \_1_
+  wire input 3 \_2_
+  wire output 1 \o
+  cell $lut \_3_
+    parameter \LUT 16'0011000000000011
+    parameter \WIDTH 4
+    connect \A { \_0_ [3] \o 2'00 }
+    connect \Y \_1_
+  end
+  cell $lut \_4_
+    parameter \LUT 4'0001
+    parameter \WIDTH 4
+    connect \A { 3'000 \_2_ }
+    connect \Y \o
+  end
+end

--- a/tests/opt/opt_lut_port.ys
+++ b/tests/opt/opt_lut_port.ys
@@ -1,0 +1,2 @@
+read_ilang opt_lut_port.il
+select -assert-count 2 t:$lut


### PR DESCRIPTION
Causes misoptimization.