### PR TITLE
ice40: Honor the "dont_touch" attribute in FFSSR pass

### DIFF
--- a/techlibs/ice40/ice40_ffssr.cc
+++ b/techlibs/ice40/ice40_ffssr.cc
@@ -81,6 +81,9 @@ struct Ice40FfssrPass : public Pass {
 
 			for (auto cell : ff_cells)
 			{
+				if (cell->get_bool_attribute("\\dont_touch"))
+					continue;
+
 				SigSpec sig_d = cell->getPort("\\D");
 
 				if (GetSize(sig_d) < 1)


### PR DESCRIPTION
This is useful if you want to place FF manually ... can't merge SR in those
because it might make the manual placement invalid

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>