### PR TITLE
deminout fixes

### DIFF
--- a/passes/techmap/deminout.cc
+++ b/passes/techmap/deminout.cc
@@ -113,7 +113,8 @@ struct DeminoutPass : public Pass {
 						{
 							if (bits_numports[bit] > 1 || bits_inout.count(bit))
 								new_input = true, new_output = true;
-
+							if (bit == State::S0 || bit == State::S1)
+								new_output = true;
 							if (bits_written.count(bit)) {
 								new_output = true;
 								if (bits_tribuf.count(bit))

--- a/passes/techmap/deminout.cc
+++ b/passes/techmap/deminout.cc
@@ -83,9 +83,9 @@ struct DeminoutPass : public Pass {
 						for (auto bit : sigmap(conn.second))
 							bits_used.insert(bit);
 
-					if (conn.first == "\\Y" && cell->type.in("$mux", "$pmux", "$_MUX_", "$_TBUF_"))
+					if (conn.first == "\\Y" && cell->type.in("$mux", "$pmux", "$_MUX_", "$_TBUF_", "$tribuf"))
 					{
-						bool tribuf = (cell->type == "$_TBUF_");
+						bool tribuf = (cell->type == "$_TBUF_" || cell->type == "$tribuf");
 
 						if (!tribuf) {
 							for (auto &c : cell->connections()) {


### PR DESCRIPTION
Fixes for issues raised in YosysHQ/nextpnr#176

 - Consider constant drivers in `deminout` so constant driven signals aren't demoted to inputs
 - Treat word-level `$tribuf` the same as `$_TBUF_` in `deminout`, as `synth_ice40` runs `deminout` on the word-level netlist