### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = tab
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
See https://editorconfig.org/ for details.

In short, `.editorconfig` is a standard way to tell a multitude of editors (at least a plugin exists for anything imaginable) what kind of indentation the project uses, to avoid repeated SNAFUs like [in the recent PR](https://github.com/YosysHQ/yosys/pull/724#pullrequestreview-185390607).

I could have configured Sublime Text locally to respect the Yosys conventions but it seems more useful to fix it for everyone, or at least everyone who configures their editor to respect `.editorconfig` once.