### PR TITLE
Improve ABC netname preservation 

### DIFF
--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -329,6 +329,18 @@ void extract_cell(RTLIL::Cell *cell, bool keepff)
 
 std::string remap_name(RTLIL::IdString abc_name)
 {
+	std::string abc_sname = abc_name.substr(1);
+	if (abc_sname.substr(0, 5) == "ys__n") {
+		int sid = std::stoi(abc_sname.substr(5));
+		bool inv = abc_sname.back() == 'v';
+		for (auto sig : signal_list) {
+			if (sig.id == sid) {
+				std::stringstream sstr;
+				sstr << "$abc$" << map_autoidx << "$" << log_signal(sig.bit) << (inv ? "_inv" : "");
+				return sstr.str();
+			}
+		}
+	}
 	std::stringstream sstr;
 	sstr << "$abc$" << map_autoidx << "$" << abc_name.substr(1);
 	return sstr.str();
@@ -353,12 +365,12 @@ void dump_loop_graph(FILE *f, int &nr, std::map<int, std::set<int>> &edges, std:
 	}
 
 	for (auto n : nodes)
-		fprintf(f, "  n%d [label=\"%s\\nid=%d, count=%d\"%s];\n", n, log_signal(signal_list[n].bit),
+		fprintf(f, "  ys__n%d [label=\"%s\\nid=%d, count=%d\"%s];\n", n, log_signal(signal_list[n].bit),
 				n, in_counts[n], workpool.count(n) ? ", shape=box" : "");
 
 	for (auto &e : edges)
 	for (auto n : e.second)
-		fprintf(f, "  n%d -> n%d;\n", e.first, n);
+		fprintf(f, "  ys__n%d -> ys__n%d;\n", e.first, n);
 
 	fprintf(f, "}\n");
 }
@@ -624,7 +636,7 @@ struct abc_output_filter
 void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::string script_file, std::string exe_file,
 		std::string liberty_file, std::string constr_file, bool cleanup, vector<int> lut_costs, bool dff_mode, std::string clk_str,
 		bool keepff, std::string delay_target, std::string sop_inputs, std::string sop_products, std::string lutin_shared, bool fast_mode,
-		const std::vector<RTLIL::Cell*> &cells, bool show_tempdir, bool sop_mode)
+		const std::vector<RTLIL::Cell*> &cells, bool show_tempdir, bool sop_mode, bool abc_dress)
 {
 	module = current_module;
 	map_autoidx = autoidx++;
@@ -728,7 +740,8 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 
 	for (size_t pos = abc_script.find("{S}"); pos != std::string::npos; pos = abc_script.find("{S}", pos))
 		abc_script = abc_script.substr(0, pos) + lutin_shared + abc_script.substr(pos+3);
-
+	if (abc_dress)
+		abc_script += "; dress";
 	abc_script += stringf("; write_blif %s/output.blif", tempdir_name.c_str());
 	abc_script = add_echos_to_abc_cmd(abc_script);
 
@@ -784,7 +797,7 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 	for (auto &si : signal_list) {
 		if (!si.is_port || si.type != G(NONE))
 			continue;
-		fprintf(f, " n%d", si.id);
+		fprintf(f, " ys__n%d", si.id);
 		pi_map[count_input++] = log_signal(si.bit);
 	}
 	if (count_input == 0)
@@ -796,17 +809,17 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 	for (auto &si : signal_list) {
 		if (!si.is_port || si.type == G(NONE))
 			continue;
-		fprintf(f, " n%d", si.id);
+		fprintf(f, " ys__n%d", si.id);
 		po_map[count_output++] = log_signal(si.bit);
 	}
 	fprintf(f, "\n");
 
 	for (auto &si : signal_list)
-		fprintf(f, "# n%-5d %s\n", si.id, log_signal(si.bit));
+		fprintf(f, "# ys__n%-5d %s\n", si.id, log_signal(si.bit));
 
 	for (auto &si : signal_list) {
 		if (si.bit.wire == NULL) {
-			fprintf(f, ".names n%d\n", si.id);
+			fprintf(f, ".names ys__n%d\n", si.id);
 			if (si.bit == RTLIL::State::S1)
 				fprintf(f, "1\n");
 		}
@@ -815,68 +828,68 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 	int count_gates = 0;
 	for (auto &si : signal_list) {
 		if (si.type == G(BUF)) {
-			fprintf(f, ".names n%d n%d\n", si.in1, si.id);
+			fprintf(f, ".names ys__n%d ys__n%d\n", si.in1, si.id);
 			fprintf(f, "1 1\n");
 		} else if (si.type == G(NOT)) {
-			fprintf(f, ".names n%d n%d\n", si.in1, si.id);
+			fprintf(f, ".names ys__n%d ys__n%d\n", si.in1, si.id);
 			fprintf(f, "0 1\n");
 		} else if (si.type == G(AND)) {
-			fprintf(f, ".names n%d n%d n%d\n", si.in1, si.in2, si.id);
+			fprintf(f, ".names ys__n%d ys__n%d ys__n%d\n", si.in1, si.in2, si.id);
 			fprintf(f, "11 1\n");
 		} else if (si.type == G(NAND)) {
-			fprintf(f, ".names n%d n%d n%d\n", si.in1, si.in2, si.id);
+			fprintf(f, ".names ys__n%d ys__n%d ys__n%d\n", si.in1, si.in2, si.id);
 			fprintf(f, "0- 1\n");
 			fprintf(f, "-0 1\n");
 		} else if (si.type == G(OR)) {
-			fprintf(f, ".names n%d n%d n%d\n", si.in1, si.in2, si.id);
+			fprintf(f, ".names ys__n%d ys__n%d ys__n%d\n", si.in1, si.in2, si.id);
 			fprintf(f, "-1 1\n");
 			fprintf(f, "1- 1\n");
 		} else if (si.type == G(NOR)) {
-			fprintf(f, ".names n%d n%d n%d\n", si.in1, si.in2, si.id);
+			fprintf(f, ".names ys__n%d ys__n%d ys__n%d\n", si.in1, si.in2, si.id);
 			fprintf(f, "00 1\n");
 		} else if (si.type == G(XOR)) {
-			fprintf(f, ".names n%d n%d n%d\n", si.in1, si.in2, si.id);
+			fprintf(f, ".names ys__n%d ys__n%d ys__n%d\n", si.in1, si.in2, si.id);
 			fprintf(f, "01 1\n");
 			fprintf(f, "10 1\n");
 		} else if (si.type == G(XNOR)) {
-			fprintf(f, ".names n%d n%d n%d\n", si.in1, si.in2, si.id);
+			fprintf(f, ".names ys__n%d ys__n%d ys__n%d\n", si.in1, si.in2, si.id);
 			fprintf(f, "00 1\n");
 			fprintf(f, "11 1\n");
 		} else if (si.type == G(ANDNOT)) {
-			fprintf(f, ".names n%d n%d n%d\n", si.in1, si.in2, si.id);
+			fprintf(f, ".names ys__n%d ys__n%d ys__n%d\n", si.in1, si.in2, si.id);
 			fprintf(f, "10 1\n");
 		} else if (si.type == G(ORNOT)) {
-			fprintf(f, ".names n%d n%d n%d\n", si.in1, si.in2, si.id);
+			fprintf(f, ".names ys__n%d ys__n%d ys__n%d\n", si.in1, si.in2, si.id);
 			fprintf(f, "1- 1\n");
 			fprintf(f, "-0 1\n");
 		} else if (si.type == G(MUX)) {
-			fprintf(f, ".names n%d n%d n%d n%d\n", si.in1, si.in2, si.in3, si.id);
+			fprintf(f, ".names ys__n%d ys__n%d ys__n%d ys__n%d\n", si.in1, si.in2, si.in3, si.id);
 			fprintf(f, "1-0 1\n");
 			fprintf(f, "-11 1\n");
 		} else if (si.type == G(AOI3)) {
-			fprintf(f, ".names n%d n%d n%d n%d\n", si.in1, si.in2, si.in3, si.id);
+			fprintf(f, ".names ys__n%d ys__n%d ys__n%d ys__n%d\n", si.in1, si.in2, si.in3, si.id);
 			fprintf(f, "-00 1\n");
 			fprintf(f, "0-0 1\n");
 		} else if (si.type == G(OAI3)) {
-			fprintf(f, ".names n%d n%d n%d n%d\n", si.in1, si.in2, si.in3, si.id);
+			fprintf(f, ".names ys__n%d ys__n%d ys__n%d ys__n%d\n", si.in1, si.in2, si.in3, si.id);
 			fprintf(f, "00- 1\n");
 			fprintf(f, "--0 1\n");
 		} else if (si.type == G(AOI4)) {
-			fprintf(f, ".names n%d n%d n%d n%d n%d\n", si.in1, si.in2, si.in3, si.in4, si.id);
+			fprintf(f, ".names ys__n%d ys__n%d ys__n%d ys__n%d ys__n%d\n", si.in1, si.in2, si.in3, si.in4, si.id);
 			fprintf(f, "-0-0 1\n");
 			fprintf(f, "-00- 1\n");
 			fprintf(f, "0--0 1\n");
 			fprintf(f, "0-0- 1\n");
 		} else if (si.type == G(OAI4)) {
-			fprintf(f, ".names n%d n%d n%d n%d n%d\n", si.in1, si.in2, si.in3, si.in4, si.id);
+			fprintf(f, ".names ys__n%d ys__n%d ys__n%d ys__n%d ys__n%d\n", si.in1, si.in2, si.in3, si.in4, si.id);
 			fprintf(f, "00-- 1\n");
 			fprintf(f, "--00 1\n");
 		} else if (si.type == G(FF)) {
 			if (si.init == State::S0 || si.init == State::S1) {
-				fprintf(f, ".latch n%d n%d %d\n", si.in1, si.id, si.init == State::S1 ? 1 : 0);
+				fprintf(f, ".latch ys__n%d ys__n%d %d\n", si.in1, si.id, si.init == State::S1 ? 1 : 0);
 				recover_init = true;
 			} else
-				fprintf(f, ".latch n%d n%d 2\n", si.in1, si.id);
+				fprintf(f, ".latch ys__n%d ys__n%d 2\n", si.in1, si.id);
 		} else if (si.type != G(NONE))
 			log_abort();
 		if (si.type != G(NONE))
@@ -889,7 +902,6 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 	log("Extracted %d gates and %d wires to a netlist network with %d inputs and %d outputs.\n",
 			count_gates, GetSize(signal_list), count_input, count_output);
 	log_push();
-
 	if (count_output > 0)
 	{
 		log_header(design, "Executing ABC.\n");
@@ -1213,7 +1225,7 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 		for (auto &si : signal_list)
 			if (si.is_port) {
 				char buffer[100];
-				snprintf(buffer, 100, "\\n%d", si.id);
+				snprintf(buffer, 100, "\\ys__n%d", si.id);
 				RTLIL::SigSig conn;
 				if (si.type != G(NONE)) {
 					conn.first = si.bit;
@@ -1407,6 +1419,11 @@ struct AbcPass : public Pass {
 		log("        this attribute is a unique integer for each ABC process started. This\n");
 		log("        is useful for debugging the partitioning of clock domains.\n");
 		log("\n");
+		log("    -dress\n");
+		log("        run the 'dress' command after all other ABC commands. This aims to\n");
+		log("        preserve naming by an equivalence check between the original and post-ABC\n");
+		log("        netlists (experimental).\n");
+		log("\n");
 		log("When neither -liberty nor -lut is used, the Yosys standard cell library is\n");
 		log("loaded into ABC before the ABC script is executed.\n");
 		log("\n");
@@ -1441,6 +1458,7 @@ struct AbcPass : public Pass {
 		std::string delay_target, sop_inputs, sop_products, lutin_shared = "-S 1";
 		bool fast_mode = false, dff_mode = false, keepff = false, cleanup = true;
 		bool show_tempdir = false, sop_mode = false;
+		bool abc_dress = false;
 		vector<int> lut_costs;
 		markgroups = false;
 
@@ -1553,6 +1571,10 @@ struct AbcPass : public Pass {
 			}
 			if (arg == "-mux16") {
 				map_mux16 = true;
+				continue;
+			}
+			if (arg == "-dress") {
+				abc_dress = true;
 				continue;
 			}
 			if (arg == "-g" && argidx+1 < args.size()) {
@@ -1704,7 +1726,7 @@ struct AbcPass : public Pass {
 
 			if (!dff_mode || !clk_str.empty()) {
 				abc_module(design, mod, script_file, exe_file, liberty_file, constr_file, cleanup, lut_costs, dff_mode, clk_str, keepff,
-						delay_target, sop_inputs, sop_products, lutin_shared, fast_mode, mod->selected_cells(), show_tempdir, sop_mode);
+						delay_target, sop_inputs, sop_products, lutin_shared, fast_mode, mod->selected_cells(), show_tempdir, sop_mode, abc_dress);
 				continue;
 			}
 
@@ -1849,7 +1871,7 @@ struct AbcPass : public Pass {
 				en_polarity = std::get<2>(it.first);
 				en_sig = assign_map(std::get<3>(it.first));
 				abc_module(design, mod, script_file, exe_file, liberty_file, constr_file, cleanup, lut_costs, !clk_sig.empty(), "$",
-						keepff, delay_target, sop_inputs, sop_products, lutin_shared, fast_mode, it.second, show_tempdir, sop_mode);
+						keepff, delay_target, sop_inputs, sop_products, lutin_shared, fast_mode, it.second, show_tempdir, sop_mode, abc_dress);
 				assign_map.set(mod);
 			}
 		}

--- a/techlibs/ecp5/synth_ecp5.cc
+++ b/techlibs/ecp5/synth_ecp5.cc
@@ -268,9 +268,9 @@ struct SynthEcp5Pass : public ScriptPass
 			}
 			run("techmap -map +/ecp5/latches_map.v");
 			if (nomux)
-				run("abc -lut 4");
+				run("abc -lut 4 -dress");
 			else
-				run("abc -lut 4:7");
+				run("abc -lut 4:7 -dress");
 			run("clean");
 		}
 

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -282,7 +282,7 @@ struct SynthIce40Pass : public ScriptPass
 				run("techmap -map +/gate2lut.v -D LUT_WIDTH=4", "(only if -noabc)");
 			}
 			if (!noabc) {
-				run("abc -lut 4", "(skip if -noabc)");
+				run("abc -dress -lut 4", "(skip if -noabc)");
 			}
 			run("clean");
 			if (relut || help_mode) {


### PR DESCRIPTION
 - Better recovered netnames, don't use log_signal as this was adding spaces
 - Copy `src` attribute for use with `rename -src`
 - Use `abc -dress` by default in the basic part of `synth_ice40` (not when retiming, as this doesn't seem to work)

I'd like to test this a bit more before merging.