### PR TITLE
anlogic: fix dbits of Anlogic Eagle DRAM16X4

### DIFF
--- a/techlibs/anlogic/drams.txt
+++ b/techlibs/anlogic/drams.txt
@@ -1,7 +1,7 @@
 bram $__ANLOGIC_DRAM16X4
   init 0
   abits 4
-  dbits 2
+  dbits 4
   groups 2
   ports  1 1
   wrmode 0 1


### PR DESCRIPTION
The dbits of DRAM16X4 is wrong set to 2, which leads to waste of DRAM
bits.

Fix the dbits number in the RAM configuration.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>