### PR TITLE
memory_dff: Fix typo when checking init value

### DIFF
--- a/passes/memory/memory_dff.cc
+++ b/passes/memory/memory_dff.cc
@@ -41,7 +41,7 @@ struct MemoryDffWorker
 			if (wire->attributes.count("\\init") == 0)
 				continue;
 			SigSpec sig = sigmap(wire);
-			Const initval = wire->attributes.count("\\init");
+			Const initval = wire->attributes.at("\\init");
 			for (int i = 0; i < GetSize(sig) && i < GetSize(initval); i++)
 				if (initval[i] == State::S0 || initval[i] == State::S1)
 					init_bits.insert(sig[i]);


### PR DESCRIPTION
Fixes #589 

This was preventing DFFs with an init value of X being merged in memory_dff