### PR TITLE
Anlogic: let LUT5/6 have more cost than LUT4-

### DIFF
--- a/techlibs/anlogic/synth_anlogic.cc
+++ b/techlibs/anlogic/synth_anlogic.cc
@@ -176,7 +176,7 @@ struct SynthAnlogicPass : public ScriptPass
 
 		if (check_label("map_luts"))
 		{
-			run("abc -lut 6");
+			run("abc -lut 4:6");
 			run("clean");
 		}
 


### PR DESCRIPTION
According to the datasheet of Anlogic Eagle FPGAs, The LUTs natively
in an Anlogic FPGA is LUT4 (in MSLICEs) and "Enhanced LUT5" (in
LSLICEs). An "Enhanced LUT5" can be divided into two LUT4s.

So a LUT5 will cost around 2x resource of a LUT4, and a LUT6 will cost
2x resource of a LUT5.

Change the -lut parameter passed to the abc command to pass this cost
info to the ABC process.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>