### PR TITLE
anlogic: fix Makefile.inc

### DIFF
--- a/techlibs/anlogic/Makefile.inc
+++ b/techlibs/anlogic/Makefile.inc
@@ -5,5 +5,6 @@ OBJS += techlibs/anlogic/anlogic_eqn.o
 $(eval $(call add_share_file,share/anlogic,techlibs/anlogic/cells_map.v))
 $(eval $(call add_share_file,share/anlogic,techlibs/anlogic/arith_map.v))
 $(eval $(call add_share_file,share/anlogic,techlibs/anlogic/cells_sim.v))
+$(eval $(call add_share_file,share/anlogic,techlibs/anlogic/eagle_bb.v))
 $(eval $(call add_share_file,share/anlogic,techlibs/anlogic/drams.txt))
 $(eval $(call add_share_file,share/anlogic,techlibs/anlogic/drams_map.v))


### PR DESCRIPTION
During the addition of DRAM inferring support, the installation of
eagle_bb.v is accidentally removed.

Fix this issue.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>