### PR TITLE
memory_collect: do not truncate 'x from \INIT

### DIFF
--- a/passes/memory/memory_collect.cc
+++ b/passes/memory/memory_collect.cc
@@ -184,9 +184,6 @@ Cell *handle_memory(Module *module, RTLIL::Memory *memory)
 	mem->parameters["\\OFFSET"] = Const(memory->start_offset);
 	mem->parameters["\\SIZE"] = Const(memory->size);
 	mem->parameters["\\ABITS"] = Const(addr_bits);
-
-	while (GetSize(init_data) > 1 && init_data.bits.back() == State::Sx && init_data.bits[GetSize(init_data)-2] == State::Sx)
-		init_data.bits.pop_back();
 	mem->parameters["\\INIT"] = init_data;
 
 	log_assert(sig_wr_clk.size() == wr_ports);


### PR DESCRIPTION
The semantics of an RTLIL constant that has less bits than its declared bit width is zero padding. Therefore, if the output of memory_collect will be used for simulation, truncating 'x from the end of \INIT will produce incorrect simulation results.

For example, this is the `write_verilog` output for a 16-deep memory initialized at two first locations:
```verilog
  reg [7:0] mem [15:0];
  initial begin
    mem[0] = 8'haa;
    mem[1] = 8'h55;
    mem[2] = 8'b0000000x;
    mem[3] = 8'h00;
    // [snip]
    mem[15] = 8'h00;
  end
```
And this is the `write_verilog` output after this patch:
```verilog
  initial begin
    mem[0] = 8'haa;
    mem[1] = 8'h55;
    mem[2] = 8'hxx;
    // [snip]
    mem[15] = 8'hxx;
  end
```
The former listing is clearly incorrect, and the bug is caused by, I believe, the fact that RTLIL doesn't appear to have the same x-extension rules as Verilog. One of the two needs to happen: either no `x` are removed from `\INIT` value, or no leading `x` is left in the `\INIT` value. I have chosen the former fix for this PR because it preserves what I understand the intent of the existing code.