### PR TITLE
proc_clean: remove any empty cases, if possible to do safely

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -3793,6 +3793,11 @@ RTLIL::CaseRule::~CaseRule()
 		delete *it;
 }
 
+bool RTLIL::CaseRule::empty() const
+{
+	return actions.empty() && switches.empty();
+}
+
 RTLIL::CaseRule *RTLIL::CaseRule::clone() const
 {
 	RTLIL::CaseRule *new_caserule = new RTLIL::CaseRule;
@@ -3807,6 +3812,11 @@ RTLIL::SwitchRule::~SwitchRule()
 {
 	for (auto it = cases.begin(); it != cases.end(); it++)
 		delete *it;
+}
+
+bool RTLIL::SwitchRule::empty() const
+{
+	return cases.empty();
 }
 
 RTLIL::SwitchRule *RTLIL::SwitchRule::clone() const

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1227,6 +1227,8 @@ struct RTLIL::CaseRule
 	~CaseRule();
 	void optimize();
 
+	bool empty() const;
+
 	template<typename T> void rewrite_sigspecs(T &functor);
 	RTLIL::CaseRule *clone() const;
 };
@@ -1237,6 +1239,8 @@ struct RTLIL::SwitchRule : public RTLIL::AttrObject
 	std::vector<RTLIL::CaseRule*> cases;
 
 	~SwitchRule();
+
+	bool empty() const;
 
 	template<typename T> void rewrite_sigspecs(T &functor);
 	RTLIL::SwitchRule *clone() const;

--- a/passes/proc/proc_clean.cc
+++ b/passes/proc/proc_clean.cc
@@ -77,18 +77,14 @@ void proc_clean_switch(RTLIL::SwitchRule *sw, RTLIL::CaseRule *parent, bool &did
 	}
 	else
 	{
-		bool all_cases_are_empty = true;
 		for (auto cs : sw->cases) {
-			if (cs->actions.size() != 0 || cs->switches.size() != 0)
-				all_cases_are_empty = false;
 			if (max_depth != 0)
 				proc_clean_case(cs, did_something, count, max_depth-1);
 		}
-		if (all_cases_are_empty) {
+		while (!sw->cases.empty() && (sw->cases.back()->actions.empty() && sw->cases.back()->switches.empty())) {
 			did_something = true;
-			for (auto cs : sw->cases)
-				delete cs;
-			sw->cases.clear();
+			delete sw->cases.back();
+			sw->cases.pop_back();
 		}
 	}
 }


### PR DESCRIPTION
Previously, only completely empty switches were removed.

This is a seemingly simple change with surprisingly far reaching consequences and motivation, so bear with me for a bit.

The immediate effect of this seemingly simple change, using Boneless CPU as a benchmark, is that the LUT count goes up: from 475 to 511 on one specific instantiation. This points to a larger inefficiency in mux tree optimization.

However! The motivation for adding this (and, later, I'd like to add further simplifications) to `proc_clean` is quite complicated, and is mostly because of the behavior of Verilog simulators. Specifically, nMigen would emit all of its logic into one giant RTLIL process, which ends up as a giant `always @*` block after `write_verilog`, plus a few `always @(posedge)` blocks that actually update the register values. This is entirely fine for synthesis, but every single Verilog simulator in existence, proprietary, FOSS, whichever, appears to choke on this pattern because of false combinatorial loops, once the Migen/nMigen design reaches a large enough size.

As such, I've changed nMigen to do the following transformation. For every signal, an RTLIL process individual for that specific process is emitted, which is essentially the same as the original RTLIL process that would be emitted, but "filtered" to only include assignments to that signal. This means that the resulting IL file (and Verilog output) will contain a very large amount of empty cases and processes, many of which are not cleaned up by the current `proc_clean` pass.

There is a worse consequence. I've mentioned that with this `proc_clean` change, LUT count goes up from 475 to 511. However, with the *nMigen* change, which is completely mechanical and produces equivalent code, the LUT count rises from 343 to 475!

My conclusions is that the current mux tree optimizations in Yosys are unable to cope with *this* `proc_clean` change, but are *also* unable to cope with other changes in input, in more severe ways. Therefore, it is my opinion that `proc_clean` should be improved to remove empty cases (such as done in this PR), and the mux optimizations should separately be improved to cope with redundant muxes.