### PR TITLE
opt_lut: eliminate LUTs evaluating to constants or inputs

### DIFF
--- a/tests/opt/opt_lut_elim.il
+++ b/tests/opt/opt_lut_elim.il
@@ -1,0 +1,19 @@
+module \test
+  wire input 1 \i
+
+  wire output 2 \o1
+  cell $lut $1
+    parameter \LUT 16'0110100110010110
+    parameter \WIDTH 4
+    connect \A { \i 3'000 }
+    connect \Y \o1
+  end
+
+  wire output 2 \o2
+  cell $lut $2
+    parameter \LUT 16'0110100010010110
+    parameter \WIDTH 4
+    connect \A { \i 3'000 }
+    connect \Y \o2
+  end
+end

--- a/tests/opt/opt_lut_elim.ys
+++ b/tests/opt/opt_lut_elim.ys
@@ -1,0 +1,3 @@
+read_ilang opt_lut_elim.il
+opt_lut
+select -assert-count 0 t:$lut

--- a/tests/opt/opt_lut_port.ys
+++ b/tests/opt/opt_lut_port.ys
@@ -1,2 +1,3 @@
 read_ilang opt_lut_port.il
+opt_lut
 select -assert-count 2 t:$lut


### PR DESCRIPTION
This doesn't fire all that often, but it at least fires on every adder with carry out (even with ABC).