### PR TITLE
Fix typographical and grammatical errors and inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ reading the design using the Verilog frontend:
 
 	yosys> read_verilog tests/simple/fiedler-cooley.v
 
-writing the design to the console in yosys's internal format:
+writing the design to the console in Yosys's internal format:
 
 	yosys> write_ilang
 
@@ -234,7 +234,7 @@ Unsupported Verilog-2005 Features
 =================================
 
 The following Verilog-2005 features are not supported by
-yosys and there are currently no plans to add support
+Yosys and there are currently no plans to add support
 for them:
 
 - Non-synthesizable language features as defined in
@@ -285,9 +285,9 @@ Verilog Attributes and non-standard features
   storage element. The register itself will always have all bits set
   to 'x' (undefined). The variable may only be used as blocking assigned
   temporary variable within an always block. This is mostly used internally
-  by yosys to synthesize Verilog functions and access arrays.
+  by Yosys to synthesize Verilog functions and access arrays.
 
-- The ``onehot`` attribute on wires mark them as onehot state register. This
+- The ``onehot`` attribute on wires mark them as one-hot state register. This
   is used for example for memory port sharing and set by the fsm_map pass.
 
 - The ``blackbox`` attribute on modules is used to mark empty stub modules
@@ -319,13 +319,13 @@ Verilog Attributes and non-standard features
   through the synthesis. When entities are combined, a new |-separated
   string is created that contains all the string from the original entities.
 
-- In addition to the ``(* ... *)`` attribute syntax, yosys supports
+- In addition to the ``(* ... *)`` attribute syntax, Yosys supports
   the non-standard ``{* ... *}`` attribute syntax to set default attributes
   for everything that comes after the ``{* ... *}`` statement. (Reset
   by adding an empty ``{* *}`` statement.)
 
 - In module parameter and port declarations, and cell port and parameter
-  lists, a trailing comma is ignored. This simplifies writing verilog code
+  lists, a trailing comma is ignored. This simplifies writing Verilog code
   generators a bit in some cases.
 
 - Modules can be declared with ``module mod_name(...);`` (with three dots
@@ -410,11 +410,11 @@ Non-standard or SystemVerilog features for formal verification
 
 - The system functions ``$allconst`` and ``$allseq`` can be used to construct
   formal exist-forall problems. Assumptions only hold if the trace satisfies
-  the assumtion for all ``$allconst/$allseq`` values. For assertions and cover
+  the assumption for all ``$allconst/$allseq`` values. For assertions and cover
   statements it is sufficient if just one ``$allconst/$allseq`` value triggers
   the property (similar to ``$anyconst/$anyseq``).
 
-- Wires/registers decalred using the ``anyconst/anyseq/allconst/allseq`` attribute
+- Wires/registers declared using the ``anyconst/anyseq/allconst/allseq`` attribute
   (for example ``(* anyconst *) reg [7:0] foobar;``) will behave as if driven
   by a ``$anyconst/$anyseq/$allconst/$allseq`` function.
 
@@ -485,6 +485,6 @@ Then execute, from the root of the repository:
 
 Notes:
 
-- To run `make manual` you need to have installed yosys with `make install`,
+- To run `make manual` you need to have installed Yosys with `make install`,
   otherwise it will fail on finding `kernel/yosys.h` while building
   `PRESENTATION_Prog`.

--- a/backends/simplec/simplec.cc
+++ b/backends/simplec/simplec.cc
@@ -748,7 +748,7 @@ struct SimplecBackend : public Backend {
 		log("\n");
 		log("    write_simplec [options] [filename]\n");
 		log("\n");
-		log("Write simple C code for simulating the design. The C code writen can be used to\n");
+		log("Write simple C code for simulating the design. The C code written can be used to\n");
 		log("simulate the design in a C environment, but the purpose of this command is to\n");
 		log("generate code that works well with C-based formal verification.\n");
 		log("\n");

--- a/backends/smt2/smtbmc.py
+++ b/backends/smt2/smtbmc.py
@@ -87,7 +87,7 @@ yosys-smtbmc [options] <yosys_smt2_output>
 
     --aig <aim_filename>:<aiw_filename>
         like above, but for map files and witness files that do not
-        share a filename prefix (or use differen file extensions).
+        share a filename prefix (or use different file extensions).
 
     --aig-noheader
         the AIGER witness file does not include the status and
@@ -103,8 +103,8 @@ yosys-smtbmc [options] <yosys_smt2_output>
     --presat
         check if the design with assumptions but without assertions
         is SAT before checking if assertions are UNSAT. This will
-        detect if there are contradicting assumtions. In some cases
-        this will also help to "warmup" the solver, potentially
+        detect if there are contradicting assumptions. In some cases
+        this will also help to "warm up" the solver, potentially
         yielding a speedup.
 
     --final-only
@@ -149,7 +149,7 @@ yosys-smtbmc [options] <yosys_smt2_output>
     --append <num_steps>
         add <num_steps> time steps at the end of the trace
         when creating a counter example (this additional time
-        steps will still be constrained by assumtions)
+        steps will still be constrained by assumptions)
 """ + so.helpmsg())
     sys.exit(1)
 

--- a/backends/table/table.cc
+++ b/backends/table/table.cc
@@ -109,7 +109,7 @@ struct TableBackend : public Backend {
 				else if (cell->output(conn.first))
 					*f << "out" << "\t";
 				else
-					*f << "unkown" << "\t";
+					*f << "unknown" << "\t";
 
 				*f << log_signal(sigmap(conn.second)) << "\n";
 			}

--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -1447,7 +1447,7 @@ void dump_module(std::ostream &f, std::string indent, RTLIL::Module *module)
 		}
 
 	if (!module->processes.empty())
-		log_warning("Module %s contains unmapped RTLIL proccesses. RTLIL processes\n"
+		log_warning("Module %s contains unmapped RTLIL processes. RTLIL processes\n"
 				"can't always be mapped directly to Verilog always blocks. Unintended\n"
 				"changes in simulation behavior are possible! Use \"proc\" to convert\n"
 				"processes to logic networks and registers.\n", log_id(module));

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -36,14 +36,14 @@ YOSYS_NAMESPACE_BEGIN
 using namespace AST;
 using namespace AST_INTERNAL;
 
-// instanciate global variables (public API)
+// instantiate global variables (public API)
 namespace AST {
 	std::string current_filename;
 	void (*set_line_num)(int) = NULL;
 	int (*get_line_num)() = NULL;
 }
 
-// instanciate global variables (private API)
+// instantiate global variables (private API)
 namespace AST_INTERNAL {
 	bool flag_dump_ast1, flag_dump_ast2, flag_no_dump_ptr, flag_dump_vlog, flag_dump_rtlil, flag_nolatches, flag_nomeminit;
 	bool flag_nomem2reg, flag_mem2reg, flag_lib, flag_noopt, flag_icells, flag_autowire;

--- a/frontends/blif/blifparse.cc
+++ b/frontends/blif/blifparse.cc
@@ -276,7 +276,7 @@ void parse_blif(RTLIL::Design *design, std::istream &f, std::string dff_name, bo
 
 				if(lastcell == nullptr || module == nullptr)
 				{
-					err_reason = stringf("No primative object to attach .cname %s.", p);
+					err_reason = stringf("No primitive object to attach .cname %s.", p);
 					goto error_with_reason;
 				}
 

--- a/frontends/liberty/liberty.cc
+++ b/frontends/liberty/liberty.cc
@@ -616,7 +616,7 @@ struct LibertyFrontend : public Frontend {
 					LibertyAst *bus_type_node = node->find("bus_type");
 
 					if (!bus_type_node || !type_map.count(bus_type_node->value))
-						log_error("Unkown or unsupported type for bus interface %s on cell %s.\n",
+						log_error("Unknown or unsupported type for bus interface %s on cell %s.\n",
 								node->args.at(0).c_str(), log_id(cell_name));
 
 					int bus_type_width = std::get<0>(type_map.at(bus_type_node->value));

--- a/frontends/verific/verificsva.cc
+++ b/frontends/verific/verificsva.cc
@@ -827,9 +827,9 @@ struct SvaFsm
 
 			for (auto &it : nodes[i].edges) {
 				if (it.second != State::S1)
-					log("          egde %s -> %d\n", log_signal(it.second), it.first);
+					log("          edge %s -> %d\n", log_signal(it.second), it.first);
 				else
-					log("          egde -> %d\n", it.first);
+					log("          edge -> %d\n", it.first);
 			}
 
 			for (auto &it : nodes[i].links) {
@@ -856,9 +856,9 @@ struct SvaFsm
 
 			for (auto &it : unodes[i].edges) {
 				if (!it.second.empty())
-					log("          egde %s -> %d\n", log_signal(it.second), it.first);
+					log("          edge %s -> %d\n", log_signal(it.second), it.first);
 				else
-					log("          egde -> %d\n", it.first);
+					log("          edge -> %d\n", it.first);
 			}
 
 			for (auto &ctrl : unodes[i].accept) {

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -794,7 +794,7 @@ more_path_inputs :
 list_of_path_outputs :
 	specify_output_terminal_descriptor |
 	list_of_path_outputs ',' specify_output_terminal_descriptor ;
-	
+
 opt_polarity_operator :
 	'+'
 	| '-'
@@ -819,7 +819,7 @@ system_timing_arg :
 system_timing_args :
 	system_timing_arg |
 	system_timing_args ',' system_timing_arg ;
- 
+
 /*
 t_path_delay_expression :
 	path_delay_expression;
@@ -881,7 +881,7 @@ constant_mintypmax_expression :
 // for the time being this is OK, but we may write our own expr here.
 // as I'm not sure it is legal to use a full expr here (probably not)
 // On the other hand, other rules requiring constant expressions also use 'expr'
-// (such as param assignment), so we may leave this as-is, perhaps assing runtime checks for constant-ness
+// (such as param assignment), so we may leave this as-is, perhaps adding runtime checks for constant-ness
 constant_expression:
 	expr ;
 

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -195,7 +195,7 @@ struct PerformanceTimer
 		t += 1000000000ULL * (int64_t) rusage.ru_stime.tv_sec + (int64_t) rusage.ru_stime.tv_usec * 1000ULL;
 		return t;
 #  else
-#    error Dont know how to measure per-process CPU time. Need alternative method (times()/clocks()/gettimeofday()?).
+#    error "Don't know how to measure per-process CPU time. Need alternative method (times()/clocks()/gettimeofday()?)."
 #  endif
 	}
 

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -744,7 +744,7 @@ std::string proc_self_dirname()
 	return "/";
 }
 #else
-	#error Dont know how to determine process executable base path!
+	#error "Don't know how to determine process executable base path!"
 #endif
 
 #ifdef EMSCRIPTEN

--- a/libs/ezsat/ezminisat.h
+++ b/libs/ezsat/ezminisat.h
@@ -28,7 +28,7 @@
 #include <time.h>
 
 // minisat is using limit macros and format macros in their headers that
-// can be the source of some troubles when used from c++11. thefore we
+// can be the source of some troubles when used from c++11. therefore we
 // don't force ezSAT users to use minisat headers..
 namespace Minisat {
 	class Solver;

--- a/libs/subcircuit/README
+++ b/libs/subcircuit/README
@@ -109,7 +109,7 @@ look at the demo.cc example program in this directory.
 Setting up graphs
 -----------------
 
-Instanciate the SubCircuit::Graph class and use the methods of this class to
+Instantiate the SubCircuit::Graph class and use the methods of this class to
 set up the circuit.
 
 	SubCircuit::Graph myGraph;
@@ -152,7 +152,7 @@ rotate shift,
 
 The method createConstant() can be used to add a constant driver to a signal.
 The signal value is encoded as one char by bit, allowing for multi-valued
-logic matching. The follwoing command sets the lowest bit of cell6.A to a
+logic matching. The following command sets the lowest bit of cell6.A to a
 logic 1:
 
 	myGraph.createConnection("cell6", "A", 0, '1');
@@ -314,7 +314,7 @@ bool userCompareEdge(needleGraphId, needleFromNodeId, needleFromUserData, needle
 
 	Perform additional checks on a pair of a pair of adjacent nodes (one
 	adjacent pair from the needle and one adjacent pair from the haystack)
-	to determine wheter this edge from the needle is compatible with
+	to determine whether this edge from the needle is compatible with
 	that edge from the haystack. The default implementation always
 	returns true.
 

--- a/passes/cmds/chformal.cc
+++ b/passes/cmds/chformal.cc
@@ -32,7 +32,7 @@ struct ChformalPass : public Pass {
 		log("    chformal [types] [mode] [options] [selection]\n");
 		log("\n");
 		log("Make changes to the formal constraints of the design. The [types] options\n");
-		log("the type of constraint to operate on. If none of the folling options is given,\n");
+		log("the type of constraint to operate on. If none of the following options are given,\n");
 		log("the command will operate on all constraint types:\n");
 		log("\n");
 		log("    -assert       $assert cells, representing assert(...) constraints\n");
@@ -59,7 +59,7 @@ struct ChformalPass : public Pass {
 		log("    -assume2assert\n");
 		log("    -live2fair\n");
 		log("    -fair2live\n");
-		log("        change the roles of cells as indicated. this options can be combined\n");
+		log("        change the roles of cells as indicated. these options can be combined\n");
 		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE

--- a/passes/cmds/connect.cc
+++ b/passes/cmds/connect.cc
@@ -137,7 +137,7 @@ struct ConnectPass : public Pass {
 		if (!set_lhs.empty())
 		{
 			if (!unset_expr.empty() || !port_cell.empty())
-				log_cmd_error("Cant use -set together with -unset and/or -port.\n");
+				log_cmd_error("Can't use -set together with -unset and/or -port.\n");
 
 			RTLIL::SigSpec sig_lhs, sig_rhs;
 			if (!RTLIL::SigSpec::parse_sel(sig_lhs, design, module, set_lhs))
@@ -157,7 +157,7 @@ struct ConnectPass : public Pass {
 		if (!unset_expr.empty())
 		{
 			if (!port_cell.empty() || flag_nounset)
-				log_cmd_error("Cant use -unset together with -port and/or -nounset.\n");
+				log_cmd_error("Can't use -unset together with -port and/or -nounset.\n");
 
 			RTLIL::SigSpec sig;
 			if (!RTLIL::SigSpec::parse_sel(sig, design, module, unset_expr))
@@ -170,7 +170,7 @@ struct ConnectPass : public Pass {
 		if (!port_cell.empty())
 		{
 			if (flag_nounset)
-				log_cmd_error("Cant use -port together with -nounset.\n");
+				log_cmd_error("Can't use -port together with -nounset.\n");
 
 			if (module->cells_.count(RTLIL::escape_id(port_cell)) == 0)
 				log_cmd_error("Can't find cell %s.\n", port_cell.c_str());

--- a/passes/cmds/select.cc
+++ b/passes/cmds/select.cc
@@ -987,7 +987,7 @@ struct SelectPass : public Pass {
 		log("list of selected objects.\n");
 		log("\n");
 		log("Note that many commands support an optional [selection] argument that can be\n");
-		log("used to YS_OVERRIDE the global selection for the command. The syntax of this\n");
+		log("used to override the global selection for the command. The syntax of this\n");
 		log("optional argument is identical to the syntax of the <selection> argument\n");
 		log("described here.\n");
 		log("\n");

--- a/passes/cmds/setundef.cc
+++ b/passes/cmds/setundef.cc
@@ -137,7 +137,7 @@ struct SetundefPass : public Pass {
 		log("        replace with $anyconst drivers (for formal)\n");
 		log("\n");
 		log("    -random <seed>\n");
-		log("        replace with random bits using the specified integer als seed\n");
+		log("        replace with random bits using the specified integer as seed\n");
 		log("        value for the random number generator.\n");
 		log("\n");
 		log("    -init\n");

--- a/passes/cmds/show.cc
+++ b/passes/cmds/show.cc
@@ -623,7 +623,7 @@ struct ShowPass : public Pass {
 		log("        assigned to each unique value of this attribute.\n");
 		log("\n");
 		log("    -width\n");
-		log("        annotate busses with a label indicating the width of the bus.\n");
+		log("        annotate buses with a label indicating the width of the bus.\n");
 		log("\n");
 		log("    -signed\n");
 		log("        mark ports (A, B) that are declared as signed (using the [AB]_SIGNED\n");

--- a/passes/cmds/tee.cc
+++ b/passes/cmds/tee.cc
@@ -37,7 +37,7 @@ struct TeePass : public Pass {
 		log("specified logfile(s).\n");
 		log("\n");
 		log("    -q\n");
-		log("        Do not print output to the normal destination (console and/or log file)\n");
+		log("        Do not print output to the normal destination (console and/or log file).\n");
 		log("\n");
 		log("    -o logfile\n");
 		log("        Write output to this file, truncate if exists.\n");
@@ -46,7 +46,7 @@ struct TeePass : public Pass {
 		log("        Write output to this file, append if exists.\n");
 		log("\n");
 		log("    +INT, -INT\n");
-		log("        Add/subract INT from the -v setting for this command.\n");
+		log("        Add/subtract INT from the -v setting for this command.\n");
 		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE

--- a/passes/fsm/fsm_detect.cc
+++ b/passes/fsm/fsm_detect.cc
@@ -196,13 +196,13 @@ static void detect_fsm(RTLIL::Wire *wire)
 		vector<string> warnings;
 
 		if (is_module_port)
-			warnings.push_back("Forcing fsm recoding on module port might result in larger circuit.\n");
+			warnings.push_back("Forcing FSM recoding on module port might result in larger circuit.\n");
 
 		if (!looks_like_good_state_reg)
-			warnings.push_back("Users of state reg look like fsm recoding might result in larger circuit.\n");
+			warnings.push_back("Users of state reg look like FSM recoding might result in larger circuit.\n");
 
 		if (has_init_attr)
-			warnings.push_back("Init value on fsm state registers are ignored. Possible simulation-synthesis mismatch!");
+			warnings.push_back("Initialization value on FSM state register is ignored. Possible simulation-synthesis mismatch!\n");
 
 		if (!looks_like_state_reg)
 			warnings.push_back("Doesn't look like a proper FSM. Possible simulation-synthesis mismatch!\n");
@@ -236,7 +236,7 @@ static void detect_fsm(RTLIL::Wire *wire)
 			log("    Users of register don't seem to benefit from recoding.\n");
 
 		if (has_init_attr)
-			log("    Register has an initialization value.");
+			log("    Register has an initialization value.\n");
 
 		if (is_self_resetting)
 			log("    Circuit seems to be self-resetting.\n");

--- a/passes/fsm/fsm_extract.cc
+++ b/passes/fsm/fsm_extract.cc
@@ -178,7 +178,7 @@ undef_bit_in_next_state:
 			log_state_in = fsm_data.state_table.at(state_in);
 
 		if (states.count(ce.values_map(ce.assign_map(dff_in)).as_const()) == 0) {
-			log("  transition: %10s %s -> INVALID_STATE(%s) %s  <ignored invalid transistion!>%s\n",
+			log("  transition: %10s %s -> INVALID_STATE(%s) %s  <ignored invalid transition!>%s\n",
 					log_signal(log_state_in), log_signal(tr.ctrl_in),
 					log_signal(ce.values_map(ce.assign_map(dff_in))), log_signal(tr.ctrl_out),
 					undef_bit_in_next_state_mode ? " SHORTENED" : "");
@@ -194,7 +194,7 @@ undef_bit_in_next_state:
 					log_signal(log_state_in), log_signal(tr.ctrl_in),
 					log_signal(fsm_data.state_table[tr.state_out]), log_signal(tr.ctrl_out));
 		} else {
-			log("  transition: %10s %s -> %10s %s  <ignored undef transistion!>\n",
+			log("  transition: %10s %s -> %10s %s  <ignored undef transition!>\n",
 					log_signal(log_state_in), log_signal(tr.ctrl_in),
 					log_signal(fsm_data.state_table[tr.state_out]), log_signal(tr.ctrl_out));
 		}

--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -543,7 +543,7 @@ struct HierarchyPass : public Pass {
 		log("        an unknown module is used as cell type.\n");
 		log("\n");
 		log("    -simcheck\n");
-		log("        like -check, but also thow an error if blackbox modules are\n");
+		log("        like -check, but also throw an error if blackbox modules are\n");
 		log("        instantiated, and throw an error if the design has no top module\n");
 		log("\n");
 		log("    -purge_lib\n");

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -1477,7 +1477,7 @@ struct OptExprPass : public Pass {
 		log("    opt_expr [options] [selection]\n");
 		log("\n");
 		log("This pass performs const folding on internal cell types with constant inputs.\n");
-		log("It also performs some simple expression rewritring.\n");
+		log("It also performs some simple expression rewriting.\n");
 		log("\n");
 		log("    -mux_undef\n");
 		log("        remove 'undef' inputs from $mux, $pmux and $_MUX_ cells\n");

--- a/passes/opt/opt_lut.cc
+++ b/passes/opt/opt_lut.cc
@@ -133,7 +133,7 @@ struct OptLutWorker
 				// Second, make sure that the connection to dedicated logic is legal. If it is not legal,
 				// it means one of the two things:
 				//   * The connection is spurious. I.e. this is dedicated logic that will be packed
-				//     with some other LUT, and it just happens to be conected to this LUT as well.
+				//     with some other LUT, and it just happens to be connected to this LUT as well.
 				//   * The connection is illegal.
 				// In either of these cases, we don't need to concern ourselves with preserving the connection
 				// between this LUT and this dedicated logic cell.

--- a/techlibs/achronix/speedster22i/cells_map.v
+++ b/techlibs/achronix/speedster22i/cells_map.v
@@ -32,7 +32,7 @@ endmodule
 // > end buffers <
 
 // > Look-Up table <
-// > VT: I still think Achronix folks would have choosen a better \
+// > VT: I still think Achronix folks would have chosen a better \
 // >     logic architecture.
 // LUT Map
 module \$lut (A, Y);
@@ -43,30 +43,30 @@ module \$lut (A, Y);
    generate
       if (WIDTH == 1) begin
 	   // VT: This is not consistent and ACE will complain: assign Y = ~A[0];
-         LUT4 #(.lut_function({4{LUT}})) _TECHMAP_REPLACE_ 
+         LUT4 #(.lut_function({4{LUT}})) _TECHMAP_REPLACE_
            (.dout(Y), .din0(A[0]), .din1(1'b0), .din2(1'b0), .din3(1'b0));
       end else
       if (WIDTH == 2) begin
-              LUT4 #(.lut_function({4{LUT}})) _TECHMAP_REPLACE_ 
+              LUT4 #(.lut_function({4{LUT}})) _TECHMAP_REPLACE_
                 (.dout(Y), .din0(A[0]), .din1(A[1]), .din2(1'b0), .din3(1'b0));
       end else
       if(WIDTH == 3) begin
-	      LUT4 #(.lut_function({2{LUT}})) _TECHMAP_REPLACE_ 
+	      LUT4 #(.lut_function({2{LUT}})) _TECHMAP_REPLACE_
                 (.dout(Y), .din0(A[0]), .din1(A[1]), .din2(A[2]), .din3(1'b0));
       end else
       if(WIDTH == 4) begin
-             LUT4 #(.lut_function(LUT)) _TECHMAP_REPLACE_ 
+             LUT4 #(.lut_function(LUT)) _TECHMAP_REPLACE_
                (.dout(Y), .din0(A[0]), .din1(A[1]), .din2(A[2]), .din3(A[3]));
       end else
 	   wire _TECHMAP_FAIL_ = 1;
    endgenerate
-endmodule 
+endmodule
 // > end LUT <
 
 // > Flops <
 // DFF flop
 module  \$_DFF_P_ (input D, C, output Q);
-   DFF _TECHMAP_REPLACE_ 
+   DFF _TECHMAP_REPLACE_
      (.q(Q), .d(D), .ck(C));
-endmodule 
+endmodule
 

--- a/techlibs/achronix/synth_achronix.cc
+++ b/techlibs/achronix/synth_achronix.cc
@@ -108,7 +108,7 @@ struct SynthAchronixPass : public ScriptPass {
     extra_args(args, argidx, design);
 
     if (!design->full_selection())
-      log_cmd_error("This comannd only operates on fully selected designs!\n");
+      log_cmd_error("This command only operates on fully selected designs!\n");
 
     log_header(design, "Executing SYNTH_ACHRONIX pass.\n");
     log_push();

--- a/techlibs/anlogic/synth_anlogic.cc
+++ b/techlibs/anlogic/synth_anlogic.cc
@@ -119,7 +119,7 @@ struct SynthAnlogicPass : public ScriptPass
 		extra_args(args, argidx, design);
 
 		if (!design->full_selection())
-			log_cmd_error("This comannd only operates on fully selected designs!\n");
+			log_cmd_error("This command only operates on fully selected designs!\n");
 
 		log_header(design, "Executing SYNTH_ANLOGIC pass.\n");
 		log_push();

--- a/techlibs/common/prep.cc
+++ b/techlibs/common/prep.cc
@@ -153,7 +153,7 @@ struct PrepPass : public ScriptPass
 		extra_args(args, argidx, design);
 
 		if (!design->full_selection())
-			log_cmd_error("This comannd only operates on fully selected designs!\n");
+			log_cmd_error("This command only operates on fully selected designs!\n");
 
 		log_header(design, "Executing PREP pass.\n");
 		log_push();

--- a/techlibs/common/synth.cc
+++ b/techlibs/common/synth.cc
@@ -155,7 +155,7 @@ struct SynthPass : public ScriptPass
 		extra_args(args, argidx, design);
 
 		if (!design->full_selection())
-			log_cmd_error("This comannd only operates on fully selected designs!\n");
+			log_cmd_error("This command only operates on fully selected designs!\n");
 
 		log_header(design, "Executing SYNTH pass.\n");
 		log_push();

--- a/techlibs/coolrunner2/synth_coolrunner2.cc
+++ b/techlibs/coolrunner2/synth_coolrunner2.cc
@@ -111,7 +111,7 @@ struct SynthCoolrunner2Pass : public ScriptPass
 		extra_args(args, argidx, design);
 
 		if (!design->full_selection())
-			log_cmd_error("This comannd only operates on fully selected designs!\n");
+			log_cmd_error("This command only operates on fully selected designs!\n");
 
 		log_header(design, "Executing SYNTH_COOLRUNNER2 pass.\n");
 		log_push();

--- a/techlibs/easic/synth_easic.cc
+++ b/techlibs/easic/synth_easic.cc
@@ -117,7 +117,7 @@ struct SynthEasicPass : public ScriptPass
 		extra_args(args, argidx, design);
 
 		if (!design->full_selection())
-			log_cmd_error("This comannd only operates on fully selected designs!\n");
+			log_cmd_error("This command only operates on fully selected designs!\n");
 
 		log_header(design, "Executing SYNTH_EASIC pass.\n");
 		log_push();

--- a/techlibs/ecp5/cells_bb.v
+++ b/techlibs/ecp5/cells_bb.v
@@ -484,7 +484,7 @@ module DCUA(
 	parameter D_XGE_MODE = "0b0";
 
 // These parameters don't do anything but are
-// needed for compatability with Diamond
+// needed for compatibility with Diamond
 	parameter D_TX_MAX_RATE = "2.5";
 	parameter D_RX_MAX_RATE = "2.5";
 	parameter CH0_TXAMPLITUDE = "0d1300";

--- a/techlibs/ecp5/synth_ecp5.cc
+++ b/techlibs/ecp5/synth_ecp5.cc
@@ -189,7 +189,7 @@ struct SynthEcp5Pass : public ScriptPass
 		extra_args(args, argidx, design);
 
 		if (!design->full_selection())
-			log_cmd_error("This comannd only operates on fully selected designs!\n");
+			log_cmd_error("This command only operates on fully selected designs!\n");
 
 		log_header(design, "Executing SYNTH_ECP5 pass.\n");
 		log_push();

--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -109,7 +109,7 @@ struct SynthGowinPass : public ScriptPass
 		extra_args(args, argidx, design);
 
 		if (!design->full_selection())
-			log_cmd_error("This comannd only operates on fully selected designs!\n");
+			log_cmd_error("This command only operates on fully selected designs!\n");
 
 		log_header(design, "Executing SYNTH_GOWIN pass.\n");
 		log_push();

--- a/techlibs/greenpak4/synth_greenpak4.cc
+++ b/techlibs/greenpak4/synth_greenpak4.cc
@@ -120,7 +120,7 @@ struct SynthGreenPAK4Pass : public ScriptPass
 		extra_args(args, argidx, design);
 
 		if (!design->full_selection())
-			log_cmd_error("This comannd only operates on fully selected designs!\n");
+			log_cmd_error("This command only operates on fully selected designs!\n");
 
 		if (part != "SLG46140V" && part != "SLG46620V" && part != "SLG46621V")
 			log_cmd_error("Invalid part name: '%s'\n", part.c_str());

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -198,7 +198,7 @@ struct SynthIce40Pass : public ScriptPass
 		extra_args(args, argidx, design);
 
 		if (!design->full_selection())
-			log_cmd_error("This comannd only operates on fully selected designs!\n");
+			log_cmd_error("This command only operates on fully selected designs!\n");
 
 		log_header(design, "Executing SYNTH_ICE40 pass.\n");
 		log_push();

--- a/techlibs/intel/cyclonev/cells_sim.v
+++ b/techlibs/intel/cyclonev/cells_sim.v
@@ -54,7 +54,7 @@ module cyclonev_lcell_comb
    // Internal variables
    // Sub mask for fragmented LUTs
    wire [15:0] mask_a, mask_b, mask_c, mask_d;
-   // Independant output for fragmented LUTs
+   // Independent output for fragmented LUTs
    wire        output_0, output_1, output_2, output_3;
    // Extended mode uses mux to define the output
    wire        mux_0, mux_1;

--- a/techlibs/sf2/synth_sf2.cc
+++ b/techlibs/sf2/synth_sf2.cc
@@ -118,7 +118,7 @@ struct SynthSf2Pass : public ScriptPass
 		extra_args(args, argidx, design);
 
 		if (!design->full_selection())
-			log_cmd_error("This comannd only operates on fully selected designs!\n");
+			log_cmd_error("This command only operates on fully selected designs!\n");
 
 		log_header(design, "Executing SYNTH_SF2 pass.\n");
 		log_push();

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -178,7 +178,7 @@ struct SynthXilinxPass : public Pass
 		extra_args(args, argidx, design);
 
 		if (!design->full_selection())
-			log_cmd_error("This comannd only operates on fully selected designs!\n");
+			log_cmd_error("This command only operates on fully selected designs!\n");
 
 		bool active = run_from.empty();
 


### PR DESCRIPTION
The initial list of hits was generated with the codespell command
below, and each hit was evaluated and fixed manually while taking
context into consideration.

    DIRS="kernel/ frontends/ backends/ passes/ techlibs/""
    codespell $DIRS -S *.o -L upto,iff,thru,synopsys,uint

More hits were found by looking through comments and strings manually.