### PR TITLE
Dockerfile for Yosys

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.editorconfig
+.gitignore
+.gitmodules
+.github
+.git
+Dockerfile
+README.md
+manual
+CodingReadme
+CodeOfConduct
+.travis
+.travis.yml
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:16.04 as builder
+LABEL author="Abdelrahman Hosny <abdelrahman.hosny@hotmail.com>"
+
+RUN apt-get update && apt-get install -y build-essential \
+    clang \
+    bison \
+    flex \
+    libreadline-dev \
+    gawk \
+    tcl-dev \
+    libffi-dev \
+    git \
+    graphviz \
+    xdot \
+    pkg-config \
+    python3
+
+COPY . /
+RUN make && \
+    make install
+
+
+FROM ubuntu:16.04
+RUN apt-get update && apt-get install -y clang \
+    bison \
+    flex \
+    libreadline-dev \
+    gawk \
+    tcl-dev \
+    libffi-dev \
+    git \
+    graphviz \
+    xdot \
+    pkg-config \
+    python3
+COPY --from=builder /yosys /build/yosys
+COPY --from=builder /yosys-abc /build/yosys-abc
+COPY --from=builder /yosys-config /build/yosys-config
+COPY --from=builder /yosys-filterlib /build/yosys-filterlib
+COPY --from=builder /yosys-smtbmc /build/yosys-smtbmc
+
+ENV PATH /build:$PATH
+
+RUN mkdir /data
+WORKDIR /data
+
+ENTRYPOINT ["yosys"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:16.04 as builder
+FROM ubuntu:18.04 as builder
 LABEL author="Abdelrahman Hosny <abdelrahman.hosny@hotmail.com>"
-
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y build-essential \
     clang \
     bison \
@@ -10,29 +10,17 @@ RUN apt-get update && apt-get install -y build-essential \
     tcl-dev \
     libffi-dev \
     git \
-    graphviz \
-    xdot \
     pkg-config \
-    python3
-
+    python3 && \
+    rm -rf /var/lib/apt/lists
 COPY . /
 RUN make && \
     make install
 
+FROM ubuntu:18.04
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y libreadline-dev tcl-dev
 
-FROM ubuntu:16.04
-RUN apt-get update && apt-get install -y clang \
-    bison \
-    flex \
-    libreadline-dev \
-    gawk \
-    tcl-dev \
-    libffi-dev \
-    git \
-    graphviz \
-    xdot \
-    pkg-config \
-    python3
 COPY --from=builder /yosys /build/yosys
 COPY --from=builder /yosys-abc /build/yosys-abc
 COPY --from=builder /yosys-config /build/yosys-config
@@ -40,8 +28,6 @@ COPY --from=builder /yosys-filterlib /build/yosys-filterlib
 COPY --from=builder /yosys-smtbmc /build/yosys-smtbmc
 
 ENV PATH /build:$PATH
-
-RUN mkdir /data
-WORKDIR /data
-
+RUN useradd -m yosys
+USER yosys
 ENTRYPOINT ["yosys"]


### PR DESCRIPTION
This pull request proposes to dockerize Yosys suite. To build the Docker image: `docker build -t yosys .`. To use the image, mount the directory where you have your RTL and library files to `/data` inside the image. There are two options to run yosys:

- Use the interactive shell: `docker run -it -v <data-directory>:/data yosys`. Read files from `/data` directory. For example: `read_verilog /data/design.v`
- Use the yosys commands from a file: `docker run -v <data-directory>:/data yosys /data/synth.ys`, where `synth.ys` should be located in the host data directory as well.

To try without building the image locally, use image name `openroad/yosys` on Docker Hub: https://hub.docker.com/r/openroad/yosys 