### PR TITLE
Reversed array indexing in EDIF backend

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ Yosys 0.8 .. Yosys 0.8-dev
     - Added "gate2lut.v" techmap rule
     - Added "rename -src"
     - Added "equiv_opt" pass
+    - Reversed array inexing order in EDIF backend.
 
 
 Yosys 0.7 .. Yosys 0.8

--- a/backends/edif/edif.cc
+++ b/backends/edif/edif.cc
@@ -333,7 +333,7 @@ struct EdifBackend : public Backend {
 					*f << stringf("          (port (array %s %d) (direction %s))\n", EDIF_DEFR(wire->name, port_rename, b[0], b[1]), wire->width, dir);
 					for (int i = 0; i < wire->width; i++) {
 						RTLIL::SigSpec sig = sigmap(RTLIL::SigSpec(wire, i));
-						net_join_db[sig].insert(stringf("(portRef (member %s %d))", EDIF_REF(wire->name), GetSize(wire)-i-1));
+						net_join_db[sig].insert(stringf("(portRef (member %s %d))", EDIF_REF(wire->name), i));
 					}
 				}
 			}
@@ -385,12 +385,12 @@ struct EdifBackend : public Backend {
 						else if (sig.size() == 1)
 							net_join_db[sig[i]].insert(stringf("(portRef %s (instanceRef %s))", EDIF_REF(p.first), EDIF_REF(cell->name)));
 						else {
-							int member_idx = GetSize(sig)-i-1;
+							int member_idx = i;
 							auto m = design->module(cell->type);
 							if (m) {
 								auto w = m->wire(p.first);
 								if (w)
-									member_idx = GetSize(w)-i-1;
+									member_idx = i;
 							}
 							net_join_db[sig[i]].insert(stringf("(portRef (member %s %d) (instanceRef %s))",
 									EDIF_REF(p.first), member_idx, EDIF_REF(cell->name)));


### PR DESCRIPTION
I was trying to implement designs using Yosys and Vivado and stumbled upon a problem with signal array ordering in EDIF files. It seemed that all signal arrays were indexed in reverse order with respect to what Vivado expects.

In this PR I've simply reversed the array indexing order in EDIF backend. And now it is possible to pass EDIFs from Yosys to Vivado and everything works.