### PR TITLE
ice40: use 2 bits for READ/WRITE MODE for SB_RAM map

### DIFF
--- a/techlibs/ice40/brams_map.v
+++ b/techlibs/ice40/brams_map.v
@@ -7,8 +7,8 @@ module \$__ICE40_RAM4K (
 	input  [10:0] WADDR,
 	input  [15:0] MASK, WDATA
 );
-	parameter integer READ_MODE = 0;
-	parameter integer WRITE_MODE = 0;
+	parameter [1:0] READ_MODE = 0;
+	parameter [1:0] WRITE_MODE = 0;
 	parameter [0:0] NEGCLK_R = 0;
 	parameter [0:0] NEGCLK_W = 0;
 


### PR DESCRIPTION
This was leading to some issues in mapping in symbiflow. I could address with another tech mapping, but I think this is more precise, since is should only take on 4 values.