### PR TITLE
Reduced error to warning in dfflibmap

### DIFF
--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -101,7 +101,7 @@ static bool parse_pin(LibertyAst *cell, LibertyAst *attr, std::string &pin_name,
 		if (child->id == "pin" && child->args.size() == 1 && child->args[0] == pin_name)
 			return true;
 
-	log_error("Malformed liberty file - cannot find pin '%s' in cell '%s'.\n", pin_name.c_str(), cell->args[0].c_str());
+	log_warning("Malformed liberty file - cannot find pin '%s' in cell '%s'.\n", pin_name.c_str(), cell->args[0].c_str());
 
 	return false;
 }


### PR DESCRIPTION
Reduced error to warning in dfflibmap so cells with next_state expressions are ignored, instead of yosys bailing.

Next_state expressions are used in scanable/DFT flip flops, which are present in most ASIC tech libs.
Generating an error & exiting instead of warning and ignoring the cell makes Yosys unusable on all but the most basic techlibs. 