### PR TITLE
[WIP/RFC] ecp5: 'Fix' transparent DRAMs by putting register on address

### DIFF
--- a/techlibs/ecp5/dram.txt
+++ b/techlibs/ecp5/dram.txt
@@ -1,3 +1,20 @@
+bram $__TRELLIS_DPR16X4_REG
+  init 1
+  abits 4
+  dbits 4
+  groups 2
+  ports  1 1
+  wrmode 0 1
+  enable 1 1
+  transp 2 0
+  clocks 2 1
+  clkpol 3 2
+endbram
+
+match $__TRELLIS_DPR16X4_REG
+  min wports 1
+endmatch
+
 bram $__TRELLIS_DPR16X4
   init 1
   abits 4
@@ -12,6 +29,5 @@ bram $__TRELLIS_DPR16X4
 endbram
 
 match $__TRELLIS_DPR16X4
-  make_outreg
   min wports 1
 endmatch

--- a/techlibs/ecp5/drams_map.v
+++ b/techlibs/ecp5/drams_map.v
@@ -26,3 +26,61 @@ module \$__TRELLIS_DPR16X4 (CLK1, A1ADDR, A1DATA, B1ADDR, B1DATA, B1EN);
 		.WRE(B1EN)
 	);
 endmodule
+
+module \$__TRELLIS_DPR16X4_REG (CLK1, CLK2, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
+	parameter [63:0] INIT = 64'bx;
+	parameter CLKPOL2 = 1;
+	parameter CLKPOL3 = 1;
+	parameter TRANSP2 = 0;
+
+	input CLK1, CLK2;
+
+	input [3:0] A1ADDR;
+	output [3:0] A1DATA;
+	input A1EN;
+
+	input [3:0] B1ADDR;
+	input [3:0] B1DATA;
+	input B1EN;
+
+	localparam WCKMUX = CLKPOL2 ? "WCK" : "INV";
+
+	wire [3:0] raddr, rdata;
+	wire [1023:0] _TECHMAP_DO_PROC = "proc";
+
+	TRELLIS_DPR16X4 #(
+		.INITVAL(INIT),
+		.WCKMUX(WCKMUX),
+		.WREMUX("WRE")
+	) _TECHMAP_REPLACE_ (
+		.RAD(raddr),
+		.DO(rdata),
+
+		.WAD(B1ADDR),
+		.DI(B1DATA),
+		.WCK(CLK1),
+		.WRE(B1EN)
+	);
+
+	generate
+		if (TRANSP2) begin
+			reg [3:0] raddr_reg;
+			if (CLKPOL2) begin
+				always @(posedge CLK2) if(A1EN) raddr_reg <= A1ADDR;
+			end else begin
+				always @(negedge CLK2) if(A1EN) raddr_reg <= A1ADDR;
+			end
+			assign A1DATA = rdata;
+			assign raddr = raddr_reg;
+		end else begin
+			reg [3:0] rdata_reg;
+			if (CLKPOL2) begin
+				always @(posedge CLK2) if(A1EN) rdata_reg <= rdata;
+			end else begin
+				always @(negedge CLK2) if(A1EN) rdata_reg <= rdata;
+			end
+			assign A1DATA = rdata_reg;
+			assign raddr = A1ADDR;
+		end
+	endgenerate
+endmodule


### PR DESCRIPTION
I'm not convinced that this is the best way to solve the problem, but I'm working on getting liteeth working with Yosys on the ECP5.

Migen generates a lot of "write through" memories thus:

```verilog
reg [41:0] storage_4[0:63];
reg [5:0] memadr_5;
reg [5:0] memadr_6;
always @(posedge eth_rx_clk) begin
	if (ethmac_rx_cdc_wrport_we)
		storage_4[ethmac_rx_cdc_wrport_adr] <= ethmac_rx_cdc_wrport_dat_w;
	memadr_5 <= ethmac_rx_cdc_wrport_adr;
end

always @(posedge sys_clk) begin
	memadr_6 <= ethmac_rx_cdc_rdport_adr;
end

assign ethmac_rx_cdc_wrport_dat_r = storage_4[memadr_5];
assign ethmac_rx_cdc_rdport_dat_r = storage_4[memadr_6];
```

This is mapped to DRAM because it is too shallow/wide to be economically mapped to BRAM. 

The liteeth core fails to work with Yosys unless one of the following is carried out
 - The threshold is changed such BRAM is used instead
 - DRAM is disabled altogether and logic is used instead
 - memory_bram.cc is patched to not generate the transparent "bypass" logic even if a port is supposed to be transparent

Indeed this small case 
[outreg_transp.zip](https://github.com/YosysHQ/yosys/files/2922317/outreg_transp.zip) shows some synthesis/simulation mismatches without this patch.

master:
![screenshot from 2019-03-02 16-58-07](https://user-images.githubusercontent.com/5521177/53684977-62eb4b00-3d0c-11e9-893c-3636bfe85bec.png)

patched:
![screenshot from 2019-03-02 16-59-22](https://user-images.githubusercontent.com/5521177/53684992-929a5300-3d0c-11e9-9cc5-011b6e98066a.png)

This patch creates a new bram type and techmap to deal with this specifically for the ECP5. I'm not sure if this should really be looked at in a more generic way, or whether I'm barking up the wrong tree altogether here. 

Incidentally, this patch gives significantly improved Fmax - from 95MHz to 108MHz.


