### PR TITLE
Ensure fid() calls make_id() for consistency; tests/simple/dff_init.v fails

### DIFF
--- a/backends/firrtl/firrtl.cc
+++ b/backends/firrtl/firrtl.cc
@@ -165,8 +165,7 @@ struct FirrtlWorker
 
 	std::string fid(RTLIL::IdString internal_id)
 	{
-		const char *str = internal_id.c_str();
-		return *str == '\\' ? str + 1 : str;
+		return make_id(internal_id);
 	}
 
 	std::string cellname(RTLIL::Cell *cell)

--- a/tests/simple/xfirrtl
+++ b/tests/simple/xfirrtl
@@ -1,6 +1,7 @@
 # This file contains the names of verilog files to exclude from verilog to FIRRTL regression tests due to known failures.
 arraycells.v	inst id[0] of
 dff_different_styles.v
+dff_init.v	Initial value not supported
 generate.v	combinational loop
 hierdefparam.v	inst id[0] of
 i2c_master_tests.v   $adff


### PR DESCRIPTION
This change to fid() (call make_id()) wasn't incorporated in the previous firrtlfixes. Do so now.

Mark dff_init.v as expected to fail since it uses "initial value".
