### PR TITLE
Improve verific -chparam and add hierarchy -chparam

### DIFF
--- a/frontends/verific/verific.h
+++ b/frontends/verific/verific.h
@@ -26,7 +26,7 @@ YOSYS_NAMESPACE_BEGIN
 extern int verific_verbose;
 
 extern bool verific_import_pending;
-extern void verific_import(Design *design, std::string top = std::string());
+extern void verific_import(Design *design, const std::map<std::string,std::string> &parameters, std::string top = std::string());
 
 extern pool<int> verific_sva_prims;
 
@@ -93,7 +93,7 @@ struct VerificImporter
 	void merge_past_ffs_clock(pool<RTLIL::Cell*> &candidates, SigBit clock, bool clock_pol);
 	void merge_past_ffs(pool<RTLIL::Cell*> &candidates);
 
-	void import_netlist(RTLIL::Design *design, Verific::Netlist *nl, std::set<Verific::Netlist*> &nl_todo);
+	void import_netlist(RTLIL::Design *design, Verific::Netlist *nl, std::set<Verific::Netlist*> &nl_todo, bool top=false);
 };
 
 void verific_import_sva_assert(VerificImporter *importer, Verific::Instance *inst);

--- a/frontends/verific/verific.h
+++ b/frontends/verific/verific.h
@@ -93,7 +93,7 @@ struct VerificImporter
 	void merge_past_ffs_clock(pool<RTLIL::Cell*> &candidates, SigBit clock, bool clock_pol);
 	void merge_past_ffs(pool<RTLIL::Cell*> &candidates);
 
-	void import_netlist(RTLIL::Design *design, Verific::Netlist *nl, std::set<Verific::Netlist*> &nl_todo, bool top=false);
+	void import_netlist(RTLIL::Design *design, Verific::Netlist *nl, std::set<Verific::Netlist*> &nl_todo);
 };
 
 void verific_import_sva_assert(VerificImporter *importer, Verific::Instance *inst);

--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -741,7 +741,7 @@ struct HierarchyPass : public Pass {
 				const std::string &value = args[++argidx];
 				auto r = parameters.emplace(key, value);
 				if (!r.second) {
-					log_warning_noprefix("-chparam %s already specified: overwriting.\n", key.c_str());
+					log_warning("-chparam %s already specified: overwriting.\n", key.c_str());
 					r.first->second = value;
 				}
 				continue;

--- a/tests/various/chparam.sh
+++ b/tests/various/chparam.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+trap 'echo "ERROR in chparam.sh" >&2; exit 1' ERR
+
+cat > chparam1.sv << "EOT"
+module top #(
+        parameter [31:0] X = 0
+) (
+        input [31:0] din,
+        output [31:0] dout
+);
+        assign dout = X-din;
+endmodule
+
+module top_props #(
+        parameter [31:0] X = 0
+) (
+        input [31:0] dout
+);
+        always @* assert (dout != X);
+endmodule
+
+bind top top_props #(.X(123456789)) props (.*);
+EOT
+
+cat > chparam2.sv << "EOT"
+module top #(
+	parameter [31:0] X = 0
+) (
+	input [31:0] din,
+	output [31:0] dout
+);
+	assign dout = X-din;
+	always @* assert (dout != 123456789);
+endmodule
+EOT
+
+if ../../yosys -q -p 'verific -sv chparam1.sv'; then
+	../../yosys -q -p 'verific -sv chparam1.sv; hierarchy -chparam X 123123123 -top top; prep -flatten' \
+			-p 'sat -verify -prove-asserts -show-ports -set din[0] 1' \
+			-p 'sat -falsify -prove-asserts -show-ports -set din[0] 0'
+
+	../../yosys -q -p 'verific -sv chparam2.sv; hierarchy -chparam X 123123123 -top top; prep -flatten' \
+			-p 'sat -verify -prove-asserts -show-ports -set din[0] 1' \
+			-p 'sat -falsify -prove-asserts -show-ports -set din[0] 0'
+fi
+../../yosys -q -p 'read_verilog -sv chparam2.sv; hierarchy -chparam X 123123123 -top top; prep -flatten' \
+		-p 'sat -verify -prove-asserts -show-ports -set din[0] 1' \
+		-p 'sat -falsify -prove-asserts -show-ports -set din[0] 0'
+
+rm chparam1.sv
+rm chparam2.sv


### PR DESCRIPTION
* `verific -import -chparam <param> <value> <top_module(s)>` now imports top modules from Verific using their original (not parameterised) name
* `verific -import <top_module(s)>` now elaborates SV root modules in order to cope with bind statements therein
* `hierarchy -top` using Verific is now improved to not elaborate all modules (only specified module, and root modules)
* Added `hierarchy -chparam` support (only works for Verific so far)
* Also more testing in YosysHQ/yosys-tests#16

TODO:
* `hierarchy -chparam ...` support for non Verific