### PR TITLE
Improve handling of "full_case" attributes

### DIFF
--- a/backends/ilang/ilang_backend.cc
+++ b/backends/ilang/ilang_backend.cc
@@ -204,7 +204,7 @@ void ILANG_BACKEND::dump_proc_switch(std::ostream &f, std::string indent, const 
 		f << stringf("%s  case ", indent.c_str());
 		for (size_t i = 0; i < (*it)->compare.size(); i++) {
 			if (i > 0)
-				f << stringf(", ");
+				f << stringf(" , ");
 			dump_sigspec(f, (*it)->compare[i]);
 		}
 		f << stringf("\n");

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -525,7 +525,16 @@ struct AST_INTERNAL::ProcessGenerator
 				}
 
 				if (last_generated_case != NULL && ast->get_bool_attribute("\\full_case") && default_case == NULL) {
+			#if 0
+					// this is a valid transformation, but as optimization it is premature.
+					// better: add a default case that assigns 'x' to everything, and let later
+					// optimizations take care of the rest
 					last_generated_case->compare.clear();
+			#else
+					default_case = new RTLIL::CaseRule;
+					addChunkActions(default_case->actions, this_case_eq_ltemp, SigSpec(State::Sx, GetSize(this_case_eq_rvalue)));
+					sw->cases.push_back(default_case);
+			#endif
 				} else {
 					if (default_case == NULL) {
 						default_case = new RTLIL::CaseRule;


### PR DESCRIPTION
This dramatically improves the way we handle `full_case` attributes, by not eagerly handling them right in the Verilog front-end.

This change reduces the size of PicoRV32 in it's default configuration by 6% on iCE40: 1915 LUTs vs 1802 LUTs. (Feel free to track down where that difference comes from. I'm not spoiling it here. But I'll say this much: It's a *really* stupid QoR / miscompilation bug.)