### PR TITLE
Add note about test requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,14 @@ Makefile.
 To build Yosys simply type 'make' in this directory.
 
 	$ make
-	$ make test
 	$ sudo make install
 
 Note that this also downloads, builds and installs ABC (using yosys-abc
 as executable name).
+
+Tests are located in the tests subdirectory and can be executed using the test target. Note that you need gawk as well as a recent version of iverilog (i.e. build from git). Then, execute tests via:
+
+	$ make test
 
 Getting Started
 ===============


### PR DESCRIPTION
As discussed on Reddit, test execution fails with iverilog version 10.1 (which is the current Ubuntu 18.04 default). With version 10.1, make test fails at svinterface1 with a seg fault, providing no useful information on how to resolve this.

This note should prompt people running into this issue to build a recent iverilog version to resolve the svinterface tests to pass.