### PR TITLE
xilinx: Add keep attribute where appropriate

### DIFF
--- a/techlibs/xilinx/cells_xtra.sh
+++ b/techlibs/xilinx/cells_xtra.sh
@@ -7,6 +7,7 @@ function xtract_cell_decl()
 {
 	for dir in $libdir/xeclib $libdir/retarget; do
 		[ -f $dir/$1.v ] || continue
+		[ -z "$2" ] || echo $2
 		egrep '^\s*((end)?module|parameter|input|inout|output|(end)?function|(end)?task)' $dir/$1.v |
 			sed -re '/UNPLACED/ d; /^\s*function/,/endfunction/ d; /^\s*task/,/endtask/ d;
 			         s,//.*,,; s/#?\(.*/(...);/; s/^(input|output|parameter)/ \1/;
@@ -37,10 +38,10 @@ function xtract_cell_decl()
 	xtract_cell_decl BUFMR
 	xtract_cell_decl BUFMRCE
 	xtract_cell_decl BUFR
-	xtract_cell_decl CAPTUREE2
+	xtract_cell_decl CAPTUREE2 "(* keep *)"
 	# xtract_cell_decl CARRY4
 	xtract_cell_decl CFGLUT5
-	xtract_cell_decl DCIRESET
+	xtract_cell_decl DCIRESET "(* keep *)"
 	xtract_cell_decl DNA_PORT
 	xtract_cell_decl DSP48E1
 	xtract_cell_decl EFUSE_USR
@@ -67,10 +68,10 @@ function xtract_cell_decl()
 	xtract_cell_decl IBUFDS_GTE2
 	xtract_cell_decl IBUFDS_IBUFDISABLE
 	xtract_cell_decl IBUFDS_INTERMDISABLE
-	xtract_cell_decl ICAPE2
+	xtract_cell_decl ICAPE2 "(* keep *)"
 	xtract_cell_decl IDDR
 	xtract_cell_decl IDDR_2CLK
-	xtract_cell_decl IDELAYCTRL
+	xtract_cell_decl IDELAYCTRL "(* keep *)"
 	xtract_cell_decl IDELAYE2
 	xtract_cell_decl IN_FIFO
 	xtract_cell_decl IOBUF
@@ -112,7 +113,7 @@ function xtract_cell_decl()
 	xtract_cell_decl PHY_CONTROL
 	xtract_cell_decl PLLE2_ADV
 	xtract_cell_decl PLLE2_BASE
-	xtract_cell_decl PS7
+	xtract_cell_decl PS7 "(* keep *)"
 	xtract_cell_decl PULLDOWN
 	xtract_cell_decl PULLUP
 	xtract_cell_decl RAM128X1D
@@ -136,7 +137,7 @@ function xtract_cell_decl()
 	xtract_cell_decl ROM64X1
 	xtract_cell_decl SRL16E
 	xtract_cell_decl SRLC32E
-	xtract_cell_decl STARTUPE2
+	xtract_cell_decl STARTUPE2 "(* keep *)"
 	xtract_cell_decl USR_ACCESSE2
 	xtract_cell_decl XADC
 } > cells_xtra.new

--- a/techlibs/xilinx/cells_xtra.v
+++ b/techlibs/xilinx/cells_xtra.v
@@ -114,6 +114,7 @@ module BUFR (...);
     parameter SIM_DEVICE = "7SERIES";
 endmodule
 
+(* keep *)
 module CAPTUREE2 (...);
     parameter ONESHOT = "TRUE";
     input CAP;
@@ -130,6 +131,7 @@ module CFGLUT5 (...);
     input CDI, CE, CLK;
 endmodule
 
+(* keep *)
 module DCIRESET (...);
     output LOCKED;
     input RST;
@@ -2102,6 +2104,7 @@ module IBUFDS_INTERMDISABLE (...);
     input INTERMDISABLE;
 endmodule
 
+(* keep *)
 module ICAPE2 (...);
     parameter [31:0] DEVICE_ID = 32'h04244093;
     parameter ICAP_WIDTH = "X32";
@@ -2149,6 +2152,7 @@ module IDDR_2CLK (...);
     input S;
 endmodule
 
+(* keep *)
 module IDELAYCTRL (...);
     parameter SIM_DEVICE = "7SERIES";
     output RDY;
@@ -3057,6 +3061,7 @@ module PLLE2_BASE (...);
     input RST;
 endmodule
 
+(* keep *)
 module PS7 (...);
     output DMA0DAVALID;
     output DMA0DRREADY;
@@ -3688,30 +3693,22 @@ module PULLUP (...);
     output O;
 endmodule
 
+module RAM128X1D (...);
+    parameter [127:0] INIT = 128'h00000000000000000000000000000000;
+    parameter [0:0] IS_WCLK_INVERTED = 1'b0;
+    output DPO, SPO;
+    input [6:0] A;
+    input [6:0] DPRA;
+    input D;
+    input WCLK;
+    input WE;
+endmodule
+
 module RAM128X1S (...);
     parameter [127:0] INIT = 128'h00000000000000000000000000000000;
     parameter [0:0] IS_WCLK_INVERTED = 1'b0;
     output O;
     input A0, A1, A2, A3, A4, A5, A6, D, WCLK, WE;
-endmodule
-
-module RAM128X1D (
-  output       DPO, SPO,
-  input        D, WCLK, WE,
-  input  [6:0] A, DPRA
-);
-	parameter [127:0] INIT = 128'bx;
-	parameter IS_WCLK_INVERTED = 0;
-endmodule
-
-module RAM64X1D (
-  output DPO, SPO,
-  input  D, WCLK, WE,
-  input  A0, A1, A2, A3, A4, A5,
-  input  DPRA0, DPRA1, DPRA2, DPRA3, DPRA4, DPRA5
-);
-	parameter [63:0] INIT = 64'bx;
-	parameter IS_WCLK_INVERTED = 0;
 endmodule
 
 module RAM256X1S (...);
@@ -3797,6 +3794,13 @@ module RAM64M (...);
     input WE;
 endmodule
 
+module RAM64X1D (...);
+    parameter [63:0] INIT = 64'h0000000000000000;
+    parameter [0:0] IS_WCLK_INVERTED = 1'b0;
+    output DPO, SPO;
+    input A0, A1, A2, A3, A4, A5, D, DPRA0, DPRA1, DPRA2, DPRA3, DPRA4, DPRA5, WCLK, WE;
+endmodule
+
 module RAM64X1S (...);
     parameter [63:0] INIT = 64'h0000000000000000;
     parameter [0:0] IS_WCLK_INVERTED = 1'b0;
@@ -3859,6 +3863,7 @@ module SRLC32E (...);
     input CE, CLK, D;
 endmodule
 
+(* keep *)
 module STARTUPE2 (...);
     parameter PROG_USR = "FALSE";
     parameter real SIM_CCLK_FREQ = 0.0;


### PR DESCRIPTION
The order of a couple of RAM primitives also changed. I think that's just because of manual changes to the Verilog & the script not being re-run.