### PR TITLE
support repeat loops with constant repeat counts outside of constant functions

### DIFF
--- a/tests/sat/counters-repeat.v
+++ b/tests/sat/counters-repeat.v
@@ -1,0 +1,38 @@
+// coverage for repeat loops outside of constant functions
+
+module counter1(clk, rst, ping);
+	input clk, rst;
+	output ping;
+	reg [31:0] count;
+
+	always @(posedge clk) begin
+		if (rst)
+			count <= 0;
+		else
+			count <= count + 1;
+	end
+
+	assign ping = &count;
+endmodule
+
+module counter2(clk, rst, ping);
+	input clk, rst;
+	output ping;
+	reg [31:0] count;
+
+	integer i;
+	reg carry;
+
+	always @(posedge clk) begin
+		carry = 1;
+		i = 0;
+		repeat (32) begin
+			count[i] <= !rst & (count[i] ^ carry);
+			carry = count[i] & carry;
+			i = i+1;
+		end
+	end
+
+	assign ping = &count;
+endmodule
+

--- a/tests/sat/counters-repeat.ys
+++ b/tests/sat/counters-repeat.ys
@@ -1,0 +1,10 @@
+
+read_verilog counters-repeat.v
+proc; opt
+
+expose -shared counter1 counter2
+miter -equiv -make_assert -make_outputs counter1 counter2 miter
+
+cd miter; flatten; opt
+sat -verify -prove-asserts -tempinduct -set-at 1 in_rst 1 -seq 1 -show-inputs -show-outputs
+


### PR DESCRIPTION
I changed the `sat/counters` test to use repeat instead of for, and it seems to work. I noticed that the test ran much slower (about ~0.2s vs. ~1.3s), so I imagine I'm missing something important here.

Feedback is greatly appreciated!