### PR TITLE
Make nobram false by default for gowin

### DIFF
--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -73,7 +73,7 @@ struct SynthGowinPass : public ScriptPass
 		vout_file = "";
 		retime = false;
 		flatten = true;
-		nobram = true;
+		nobram = false;
 	}
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE


### PR DESCRIPTION
Make nobram to false, to make it same as for other architectures.
Right not it is not possible to make yosys actually use bram due to this.
Also makes testing of parts of code for bram instantiation possible.