### PR TITLE
memory_bram: Consider read enable for address expansion register

### DIFF
--- a/passes/memory/memory_bram.cc
+++ b/passes/memory/memory_bram.cc
@@ -957,6 +957,8 @@ grow_read_ports:;
 					SigSpec addr_ok_q = addr_ok;
 					if ((pi.clocks || pi.make_outreg) && !addr_ok.empty()) {
 						addr_ok_q = module->addWire(NEW_ID);
+						if (!pi.sig_en.empty())
+							addr_ok = module->Mux(NEW_ID, addr_ok_q, addr_ok, pi.sig_en);
 						module->addDff(NEW_ID, pi.sig_clock, addr_ok, addr_ok_q, pi.effective_clkpol);
 					}
 


### PR DESCRIPTION
The register for the address signals used in the expansion mux wasn't considering the read enable previously.

Thanks @smunaut for finding
