### PR TITLE
Use 'bvashr' SMT-LIB function instead of bvLshr.

### DIFF
--- a/backends/smt2/smt2.cc
+++ b/backends/smt2/smt2.cc
@@ -551,7 +551,7 @@ struct Smt2Worker
 			if (cell->type == "$shl") return export_bvop(cell, "(bvshl A B)", 's');
 			if (cell->type == "$shr") return export_bvop(cell, "(bvlshr A B)", 's');
 			if (cell->type == "$sshl") return export_bvop(cell, "(bvshl A B)", 's');
-			if (cell->type == "$sshr") return export_bvop(cell, "(bvLshr A B)", 's');
+			if (cell->type == "$sshr") return export_bvop(cell, "(bvashr A B)", 's');
 
 			if (cell->type.in("$shift", "$shiftx")) {
 				if (cell->getParam("\\B_SIGNED").as_bool()) {


### PR DESCRIPTION
According to http://smtlib.cs.uiowa.edu/logics-all.shtml I think this is meant to be bvashr. Without this change, the following assertion fails:

wire signed [3:0] f_tmp = 4'b1111;
assert (($signed(f_tmp) >>> 1) == 4'b1111);

I want to add a regression test for this but it would be great to get a pointer to where the tests are for smt2 related code.