### PR TITLE
memory_bram: Fix multiport make_transp

### DIFF
--- a/passes/memory/memory_bram.cc
+++ b/passes/memory/memory_bram.cc
@@ -744,7 +744,8 @@ grow_read_ports:;
 			if (clken) {
 				clock_domains[pi.clocks] = clkdom;
 				clock_polarities[pi.clkpol] = clkdom.second;
-				read_transp[pi.transp] = transp;
+				if (!pi.make_transp)
+					read_transp[pi.transp] = transp;
 				pi.sig_clock = clkdom.first;
 				pi.sig_en = rd_en[cell_port_i];
 				pi.effective_clkpol = clkdom.second;


### PR DESCRIPTION
This was a latent defect revealed by #903 causing things like the picorv32 register file to break, as make_transp wasn't being set on the second read port (but also wasn't being erroneously copied in the wrong place as before, either).