### PR TITLE
Revert "Recognise default entry in case even if all cases covered (fix for #931)"

### DIFF
--- a/passes/proc/proc_rmdead.cc
+++ b/passes/proc/proc_rmdead.cc
@@ -34,7 +34,7 @@ void proc_rmdead(RTLIL::SwitchRule *sw, int &counter)
 
 	for (size_t i = 0; i < sw->cases.size(); i++)
 	{
-		bool is_default = GetSize(sw->cases[i]->compare) == 0 || GetSize(sw->signal) == 0;
+		bool is_default = GetSize(sw->cases[i]->compare) == 0 && (!pool.empty() || GetSize(sw->signal) == 0);
 
 		for (size_t j = 0; j < sw->cases[i]->compare.size(); j++) {
 			RTLIL::SigSpec sig = sw->cases[i]->compare[j];

--- a/tests/various/muxcover.ys
+++ b/tests/various/muxcover.ys
@@ -8,13 +8,12 @@ read_verilog -formal <<EOT
                 3'b?1?: Y = B;
                 3'b1??: Y = C;
                 3'b000: Y = D;
-                default: Y = 'bx;
             endcase
     endmodule
 EOT
 
 
-## Example usage for "pmuxtree" and "muxcover"
+## Examle usage for "pmuxtree" and "muxcover"
 
 proc
 pmuxtree
@@ -36,7 +35,7 @@ read_verilog -formal <<EOT
                 3'b010: Y = B;
                 3'b100: Y = C;
                 3'b000: Y = D;
-                default: Y = 'bx;
+		default: Y = 'bx;
             endcase
     endmodule
 EOT


### PR DESCRIPTION
Reverts YosysHQ/yosys#932; see #935 of breakage.