### PR TITLE
ice40 cells_sim.v: update clock enable behaviour based on hardware experiments

### DIFF
--- a/techlibs/ice40/cells_sim.v
+++ b/techlibs/ice40/cells_sim.v
@@ -27,18 +27,27 @@ module SB_IO (
 	reg dout_q_0, dout_q_1;
 	reg outena_q;
 
+	// IO tile generates a constant 1'b1 internally if global_cen is not connected
+	wire clken_pulled = CLOCK_ENABLE || CLOCK_ENABLE === 1'bz;
+	reg  clken_pulled_ri;
+	reg  clken_pulled_ro;
+
 	generate if (!NEG_TRIGGER) begin
-		always @(posedge INPUT_CLK)  if (CLOCK_ENABLE) din_q_0  <= PACKAGE_PIN;
-		always @(negedge INPUT_CLK)  if (CLOCK_ENABLE) din_q_1  <= PACKAGE_PIN;
-		always @(posedge OUTPUT_CLK) if (CLOCK_ENABLE) dout_q_0 <= D_OUT_0;
-		always @(negedge OUTPUT_CLK) if (CLOCK_ENABLE) dout_q_1 <= D_OUT_1;
-		always @(posedge OUTPUT_CLK) if (CLOCK_ENABLE) outena_q <= OUTPUT_ENABLE;
+		always @(posedge INPUT_CLK)                       clken_pulled_ri <= clken_pulled;
+		always @(posedge INPUT_CLK)  if (clken_pulled)    din_q_0         <= PACKAGE_PIN;
+		always @(negedge INPUT_CLK)  if (clken_pulled_ri) din_q_1         <= PACKAGE_PIN;
+		always @(posedge OUTPUT_CLK)                      clken_pulled_ro <= clken_pulled;
+		always @(posedge OUTPUT_CLK) if (clken_pulled)    dout_q_0        <= D_OUT_0;
+		always @(negedge OUTPUT_CLK) if (clken_pulled_ro) dout_q_1        <= D_OUT_1;
+		always @(posedge OUTPUT_CLK) if (clken_pulled)    outena_q        <= OUTPUT_ENABLE;
 	end else begin
-		always @(negedge INPUT_CLK)  if (CLOCK_ENABLE) din_q_0  <= PACKAGE_PIN;
-		always @(posedge INPUT_CLK)  if (CLOCK_ENABLE) din_q_1  <= PACKAGE_PIN;
-		always @(negedge OUTPUT_CLK) if (CLOCK_ENABLE) dout_q_0 <= D_OUT_0;
-		always @(posedge OUTPUT_CLK) if (CLOCK_ENABLE) dout_q_1 <= D_OUT_1;
-		always @(negedge OUTPUT_CLK) if (CLOCK_ENABLE) outena_q <= OUTPUT_ENABLE;
+		always @(negedge INPUT_CLK)                       clken_pulled_ri <= clken_pulled;
+		always @(negedge INPUT_CLK)  if (clken_pulled)    din_q_0         <= PACKAGE_PIN;
+		always @(posedge INPUT_CLK)  if (clken_pulled_ri) din_q_1         <= PACKAGE_PIN;
+		always @(negedge OUTPUT_CLK)                      clken_pulled_ro <= clken_pulled;
+		always @(negedge OUTPUT_CLK) if (clken_pulled)    dout_q_0        <= D_OUT_0;
+		always @(posedge OUTPUT_CLK) if (clken_pulled_ro) dout_q_1        <= D_OUT_1;
+		always @(negedge OUTPUT_CLK) if (clken_pulled)    outena_q        <= OUTPUT_ENABLE;
 	end endgenerate
 
 	always @* begin


### PR DESCRIPTION
This is as a result of @whitequark and I abusing some iCE40s for a while. [Useful part of thread starts here](https://twitter.com/whitequark/status/1117916172442316800). Here is a testbench containing the 5th and 6th test from that thread:

```
module tb;

reg e, clk;
wire q;

SB_IO #(
	.PIN_TYPE (6'b01_00_00)
	//            |  |
	//            |  \-------- DDR output
	//            \----------- Permanent output enable
) inst_SB_IO (
	.CLOCK_ENABLE      (e),
	.OUTPUT_CLK        (clk),
	.D_OUT_0           (1'b0),
	.D_OUT_1           (1'b1),
	.PACKAGE_PIN       (q)
);

localparam DELAY = 1000;

initial begin: stimulus
	integer i;
	{e, clk} = 2'b00;
	for (i = 0; i < 5; i = i + 1) begin
		#DELAY; {e, clk} = 2'b00;
		#DELAY; {e, clk} = 2'b01;
		#DELAY; {e, clk} = 2'b11;
		#DELAY; {e, clk} = 2'b10;
	end
	#DELAY;
	{e, clk} = 2'b00;
	#(4 * DELAY);
	for (i = 0; i < 5; i = i + 1) begin
		#DELAY; {e, clk} = 2'b00;
		#DELAY; {e, clk} = 2'b10;
		#DELAY; {e, clk} = 2'b11;
		#DELAY; {e, clk} = 2'b01;
	end
	$finish;
end

endmodule
```

The behaviour of the actual hardware is to generate no transitions (constant 0) for the first of these, and a full DDR set of transitions for the second. Using the patched simlib from this branch:

![image](https://user-images.githubusercontent.com/1298595/56324088-c8cd4e00-6165-11e9-945a-ea441c60f391.png)

Using the current simlib:
![image](https://user-images.githubusercontent.com/1298595/56324159-07630880-6166-11e9-8381-553a24c94227.png)

(the hardware seems like it might clear the DOUT0/DOUT1 flops during power-on-reset, although I'm not sure how to positively check this)

The patched simlib contains our best guess as to the actual circuit, which is (ignoring effects of `NEG_TRIGGER`):
- DOUT0 is registered with a posedge DFFE, enabled by CLOCK_ENABLE
- CLOCK_ENABLE is also reregistered with a posedge DFF
- DOUT1 is registered with a negedge DFFE, enabled by reregistered version of CLOCK_ENABLE

We didn't find any tests that disproved this model. There is one other change in this patch, which is to add a behavioural pullup to CLOCK_ENABLE, since the IO tile seems to generate a constant 1 internally if the bitstream does not connect an external net.

To be more certain, I added a different test which dynamically changes the DOUT0 and DOUT1 inputs to ensure both flops are genuinely enabled.

Old simlib:
![image](https://user-images.githubusercontent.com/1298595/56328333-62046080-6176-11e9-8277-103cb1802ab0.png)
(We think the Xs will be 0s in real life)

New simlib:
![image](https://user-images.githubusercontent.com/1298595/56328363-83fde300-6176-11e9-8583-0b2ec8c66c96.png)

Capture from logic analyser:
![image](https://user-images.githubusercontent.com/1298595/56328382-a98aec80-6176-11e9-8128-44e1aea476e5.png)
