### PR TITLE
Add pmux2shiftx command

### DIFF
--- a/passes/opt/Makefile.inc
+++ b/passes/opt/Makefile.inc
@@ -13,5 +13,6 @@ OBJS += passes/opt/wreduce.o
 OBJS += passes/opt/opt_demorgan.o
 OBJS += passes/opt/rmports.o
 OBJS += passes/opt/opt_lut.o
+OBJS += passes/opt/pmux2shiftx.o
 endif
 

--- a/passes/opt/pmux2shiftx.cc
+++ b/passes/opt/pmux2shiftx.cc
@@ -1,0 +1,81 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/yosys.h"
+#include "kernel/sigtools.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+struct Pmux2ShiftxPass : public Pass {
+	Pmux2ShiftxPass() : Pass("pmux2shiftx", "transform $pmux cells to $shiftx cells") { }
+	void help() YS_OVERRIDE
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    pmux2shiftx [selection]\n");
+		log("\n");
+		log("This pass transforms $pmux cells to $shiftx cells.\n");
+		log("\n");
+	}
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	{
+		log_header(design, "Executing PMUX2SHIFTX pass.\n");
+
+		size_t argidx;
+		for (argidx = 1; argidx < args.size(); argidx++) {
+			break;
+		}
+		extra_args(args, argidx, design);
+
+		for (auto module : design->selected_modules())
+		for (auto cell : module->selected_cells())
+		{
+			if (cell->type != "$pmux")
+				continue;
+
+			// Create a new encoder, out of a $pmux, that takes
+			// the existing pmux's 'S' input and transforms it
+			// back into a binary value
+			RTLIL::SigSpec shiftx_a;
+			RTLIL::SigSpec pmux_s;
+
+			int s_width = cell->getParam("\\S_WIDTH").as_int();
+			if (!cell->getPort("\\A").is_fully_undef()) {
+				++s_width;
+				shiftx_a.append(cell->getPort("\\A"));
+				pmux_s.append(module->Not(NEW_ID, module->ReduceOr(NEW_ID, cell->getPort("\\S"))));
+			}
+			const int clog2width = ceil(log2(s_width));
+
+			RTLIL::SigSpec pmux_b;
+			for (int i = s_width-1; i >= 0; i--)
+				pmux_b.append(RTLIL::Const(i, clog2width));
+			shiftx_a.append(cell->getPort("\\B"));
+			pmux_s.append(cell->getPort("\\S"));
+
+			RTLIL::SigSpec pmux_y = module->addWire(NEW_ID, clog2width);
+			module->addPmux(NEW_ID, RTLIL::Const(RTLIL::Sx, clog2width), pmux_b, pmux_s, pmux_y);
+			module->addShiftx(NEW_ID, shiftx_a, pmux_y, cell->getPort("\\Y"));
+			module->remove(cell);
+		}
+	}
+} Pmux2ShiftxPass;
+
+PRIVATE_NAMESPACE_END

--- a/passes/opt/pmux2shiftx.cc
+++ b/passes/opt/pmux2shiftx.cc
@@ -33,9 +33,9 @@ struct Pmux2ShiftxPass : public Pass {
 		log("\n");
 		log("This pass transforms $pmux cells to $shiftx cells.\n");
 		log("\n");
-		log("    -min_density <non_offset_percentage> <offset_percentage>\n");
-		log("        specifies the minimum density for non_offset- and for offset-mode\n");
-		log("        default values are 30 (non-offset) and 50 (offset)\n");
+		log("    -min_density <percentage>\n");
+		log("        specifies the minimum density for the shifter\n");
+		log("        default: 50\n");
 		log("\n");
 		log("    -min_choices <int>\n");
 		log("        specified the minimum number of choices for a control signal\n");
@@ -48,8 +48,7 @@ struct Pmux2ShiftxPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
-		int min_non_offset_percentage = 30;
-		int min_offset_percentage = 50;
+		int min_density = 50;
 		int min_choices = 3;
 		bool allow_onehot = false;
 
@@ -57,9 +56,8 @@ struct Pmux2ShiftxPass : public Pass {
 
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++) {
-			if (args[argidx] == "-min_density" && argidx+2 < args.size()) {
-				min_non_offset_percentage = atoi(args[++argidx].c_str());
-				min_offset_percentage = atoi(args[++argidx].c_str());
+			if (args[argidx] == "-min_density" && argidx+1 < args.size()) {
+				min_density = atoi(args[++argidx].c_str());
 				continue;
 			}
 			if (args[argidx] == "-min_choices" && argidx+1 < args.size()) {
@@ -369,7 +367,7 @@ struct Pmux2ShiftxPass : public Pass {
 
 					// check density percentages
 					Const offset(State::S0, GetSize(sig));
-					if (absolute_density < min_non_offset_percentage && range_density >= min_offset_percentage)
+					if (absolute_density < min_density && range_density >= min_density)
 					{
 						offset = Const(min_choice, GetSize(sig));
 						log("    offset: %s\n", log_signal(offset));
@@ -382,7 +380,7 @@ struct Pmux2ShiftxPass : public Pass {
 							new_perm_choices[const_sub(it.first, offset, false, false, GetSize(sig))] = it.second;
 						perm_choices.swap(new_perm_choices);
 					} else
-					if (absolute_density < min_non_offset_percentage) {
+					if (absolute_density < min_density) {
 						log("    insufficient density.\n");
 						seldb.erase(sig);
 						continue;

--- a/passes/opt/pmux2shiftx.cc
+++ b/passes/opt/pmux2shiftx.cc
@@ -39,7 +39,7 @@ struct Pmux2ShiftxPass : public Pass {
 		log("\n");
 		log("    -min_choices <int>\n");
 		log("        specified the minimum number of choices for a control signal\n");
-		log("        defaukt: 3\n");
+		log("        default: 3\n");
 		log("\n");
 		log("    -allow_onehot\n");
 		log("        by default, pmuxes with one-hot encoded control signals are not\n");
@@ -253,7 +253,7 @@ struct Pmux2ShiftxPass : public Pass {
 							int best_maxval = 0;
 							int best_delta = 0;
 
-							// find best src colum for this dst column
+							// find best src column for this dst column
 							for (int src_col = 0; src_col < GetSize(sig); src_col++)
 							{
 								if (used_src_columns[src_col])

--- a/tests/various/pmux2shiftx.v
+++ b/tests/various/pmux2shiftx.v
@@ -1,28 +1,34 @@
 module pmux2shiftx_test (
 	input [2:0] S1,
 	input [5:0] S2,
-	input [9:0] A, B, C, D, D, E, F,
-	input [9:0] G, H, I, J, K, L, M, N,
+	input [1:0] S3,
+	input [9:0] A, B, C, D, D, E, F, G, H,
+	input [9:0] I, J, K, L, M, N, O, P, Q,
 	output reg [9:0] X
 );
 	always @* begin
 		case (S1)
-			3'd0: X = A;
-			3'd1: X = B;
-			3'd2: X = C;
-			3'd3: X = D;
-			3'd4: X = E;
-			3'd5: X = F;
-			3'd6: X = G;
-			3'd7: X = H;
+			3'd 0: X = A;
+			3'd 1: X = B;
+			3'd 2: X = C;
+			3'd 3: X = D;
+			3'd 4: X = E;
+			3'd 5: X = F;
+			3'd 6: X = G;
+			3'd 7: X = H;
 		endcase
 		case (S2)
-			6'd46: X = I;
-			6'd47: X = J;
-			6'd48: X = K;
-			6'd52: X = L;
-			6'd53: X = M;
-			6'd54: X = N;
+			6'd 45: X = I;
+			6'd 47: X = J;
+			6'd 49: X = K;
+			6'd 55: X = L;
+			6'd 57: X = M;
+			6'd 59: X = N;
+		endcase
+		case (S3)
+			2'd 1: X = O;
+			2'd 2: X = P;
+			2'd 3: X = Q;
 		endcase
 	end
 endmodule

--- a/tests/various/pmux2shiftx.v
+++ b/tests/various/pmux2shiftx.v
@@ -1,0 +1,28 @@
+module pmux2shiftx_test (
+	input [2:0] S1,
+	input [5:0] S2,
+	input [9:0] A, B, C, D, D, E, F,
+	input [9:0] G, H, I, J, K, L, M, N,
+	output reg [9:0] X
+);
+	always @* begin
+		case (S1)
+			3'd0: X = A;
+			3'd1: X = B;
+			3'd2: X = C;
+			3'd3: X = D;
+			3'd4: X = E;
+			3'd5: X = F;
+			3'd6: X = G;
+			3'd7: X = H;
+		endcase
+		case (S2)
+			6'd46: X = I;
+			6'd47: X = J;
+			6'd48: X = K;
+			6'd52: X = L;
+			6'd53: X = M;
+			6'd54: X = N;
+		endcase
+	end
+endmodule

--- a/tests/various/pmux2shiftx.ys
+++ b/tests/various/pmux2shiftx.ys
@@ -2,7 +2,7 @@ read_verilog pmux2shiftx.v
 prep
 design -save gold
 
-pmux2shiftx -min_density 70 50
+pmux2shiftx -min_density 70
 
 opt
 

--- a/tests/various/pmux2shiftx.ys
+++ b/tests/various/pmux2shiftx.ys
@@ -2,7 +2,7 @@ read_verilog pmux2shiftx.v
 prep
 design -save gold
 
-pmux2shiftx -density 70 50
+pmux2shiftx -min_density 70 50
 
 opt
 

--- a/tests/various/pmux2shiftx.ys
+++ b/tests/various/pmux2shiftx.ys
@@ -1,0 +1,24 @@
+read_verilog pmux2shiftx.v
+prep
+design -save gold
+
+pmux2shiftx
+opt
+# show -width
+select -assert-count 1 t:$mux
+select -assert-count 1 t:$shift
+select -assert-count 2 t:$shiftx
+select -assert-count 1 t:$sub
+design -stash gate
+
+design -import gold -as gold
+design -import gate -as gate
+
+miter -equiv -flatten -make_assert -make_outputs gold gate miter
+sat -verify -prove-asserts -show-ports miter
+
+design -load gold
+stat
+
+design -load gate
+stat

--- a/tests/various/pmux2shiftx.ys
+++ b/tests/various/pmux2shiftx.ys
@@ -2,13 +2,17 @@ read_verilog pmux2shiftx.v
 prep
 design -save gold
 
-pmux2shiftx
+pmux2shiftx -density 70 50
+
 opt
+
+stat
 # show -width
-select -assert-count 1 t:$mux
-select -assert-count 1 t:$shift
-select -assert-count 2 t:$shiftx
 select -assert-count 1 t:$sub
+select -assert-count 2 t:$mux
+select -assert-count 2 t:$shift
+select -assert-count 3 t:$shiftx
+
 design -stash gate
 
 design -import gold -as gold


### PR DESCRIPTION
Consider the following test design (`tests/various/pmux2shiftx.v` in this branch):

```
module pmux2shiftx_test (
	input [2:0] S1,
	input [5:0] S2,
	input [9:0] A, B, C, D, D, E, F,
	input [9:0] G, H, I, J, K, L, M, N,
	output reg [9:0] X
);
	always @* begin
		case (S1)
			3'd0: X = A;
			3'd1: X = B;
			3'd2: X = C;
			3'd3: X = D;
			3'd4: X = E;
			3'd5: X = F;
			3'd6: X = G;
			3'd7: X = H;
		endcase
		case (S2)
			6'd46: X = I;
			6'd47: X = J;
			6'd48: X = K;
			6'd52: X = L;
			6'd53: X = M;
			6'd54: X = N;
		endcase
	end
endmodule
```

The command `./yosys -p 'prep; pmux2shiftx; opt; stat' tests/various/pmux2shiftx.v` synthesizes this into a circuit with the following stats:

```
=== pmux2shiftx_test ===

   Number of wires:                 22
   Number of wire bits:            192
   Number of public wires:          17
   Number of public wire bits:     159
   Number of memories:               0
   Number of memory bits:            0
   Number of processes:              0
   Number of cells:                  6
     $mux                            1
     $shift                          1
     $shiftx                         2
     $sub                            1
     $xor                            1
```

The first case statement is straight converted into a single `$shiftx` cell.

The 2nd case statement is converted into a slightly more complex circuit consisting of a `$shiftx` cell for the data, a `$shift` cell for decoding valid entries. There's also a `$sub` cell for subtracting the offset and a `$xor` cell that flips control bits in an effort to create a denser packing of elements.

Finally, the `$mux` cell selects the output of one of the two `$shiftx`. The valid-entry decoder for the 2nd case statement drives the select input of that `$mux` cell.