### PR TITLE
Add full_pmux feature to pmux2shiftx

### DIFF
--- a/tests/various/pmux2shiftx.ys
+++ b/tests/various/pmux2shiftx.ys
@@ -9,8 +9,8 @@ opt
 stat
 # show -width
 select -assert-count 1 t:$sub
-select -assert-count 2 t:$mux
-select -assert-count 2 t:$shift
+select -assert-count 1 t:$mux
+select -assert-count 1 t:$shift
 select -assert-count 3 t:$shiftx
 
 design -stash gate


### PR DESCRIPTION
Consider this example:

```
module test (
	input [1:0] S,
	input [5:0] A, B, C, D,
	output reg [5:0] Y
);
	always @* begin
		Y = A;
		case (S)
			1: Y = B;
			2: Y = C;
			3: Y = D;
		endcase
	end
endmodule
```

With this change, `yosys -p 'prep; pmux2shiftx; opt; stat; show' test.v` will synthesize this to a single `$shiftx` cell, including handling of the default `A` input:

![image](https://user-images.githubusercontent.com/619764/56502636-55379200-6513-11e9-9079-07b5f9ca46d0.png)
