### PR TITLE
[WIP] Add "split shiftx" to split multi-bit $shiftx cells into single-bit ones

### DIFF
--- a/passes/pmgen/.gitignore
+++ b/passes/pmgen/.gitignore
@@ -1,1 +1,1 @@
-/ice40_dsp_pm.h
+*_pm.h

--- a/passes/pmgen/Makefile.inc
+++ b/passes/pmgen/Makefile.inc
@@ -1,8 +1,11 @@
-OBJS += passes/pmgen/ice40_dsp.o
+PMG_SRC = $(wildcard passes/pmgen/*.pmg)
+PMG_OBJS += $(patsubst %.pmg, %.o, $(PMG_SRC))
+OBJS += $(PMG_OBJS)
 
-passes/pmgen/ice40_dsp.o: passes/pmgen/ice40_dsp_pm.h
-EXTRA_OBJS += passes/pmgen/ice40_dsp_pm.h
-.SECONDARY: passes/pmgen/ice40_dsp_pm.h
+$(PMG_OBJS): %.o: %_pm.h
 
-passes/pmgen/ice40_dsp_pm.h: passes/pmgen/pmgen.py passes/pmgen/ice40_dsp.pmg
+EXTRA_OBJS += $(patsubst %.pmg, %_pm.h, $(PMG_SRC))
+.SECONDARY: $(EXTRA_OBJS)
+
+%_pm.h: passes/pmgen/pmgen.py %.pmg
 	$(P) mkdir -p passes/pmgen && python3 $^ $@

--- a/passes/pmgen/split_shiftx.cc
+++ b/passes/pmgen/split_shiftx.cc
@@ -56,7 +56,8 @@ struct BitblastShiftxPass : public Pass {
 		log("    split_shiftx [selection]\n");
 		log("\n");
 		log("Split up $shiftx cells where Y_WIDTH > 1, with consideration for any $macc\n");
-		log("cells that may be driving their B inputs.\n");
+		log("cells -- configured as a constant multiplier equal to Y_WIDTH -- that may be\n");
+		log("driving their B inputs.\n");
 		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE

--- a/passes/pmgen/split_shiftx.cc
+++ b/passes/pmgen/split_shiftx.cc
@@ -30,10 +30,11 @@ void create_split_shiftx(split_shiftx_pm &pm)
 	if (pm.blacklist_cells.count(pm.st.shiftx))
 		return;
 	SigSpec A = pm.st.shiftx->getPort("\\A");
-	SigSpec B = pm.st.shiftx->getPort("\\B");
+	SigSpec B = pm.st.shiftxB;
+	log_assert(!B.empty());
 	SigSpec Y = pm.st.shiftx->getPort("\\Y");
 	const int A_WIDTH = pm.st.shiftx->getParam("\\A_WIDTH").as_int();
-	const int B_WIDTH = pm.st.shiftx->getParam("\\B_WIDTH").as_int();
+	const int B_WIDTH = GetSize(pm.st.shiftxB);
 	const int Y_WIDTH = pm.st.shiftx->getParam("\\Y_WIDTH").as_int();
 	int trailing_zeroes = 0;
 	for (; B[trailing_zeroes] == RTLIL::S0; ++trailing_zeroes) ;

--- a/passes/pmgen/split_shiftx.cc
+++ b/passes/pmgen/split_shiftx.cc
@@ -26,9 +26,9 @@ PRIVATE_NAMESPACE_BEGIN
 
 void create_split_shiftx(split_shiftx_pm &pm)
 {
-	if (pm.st.shiftxB.empty())
-		return;
 	log_assert(pm.st.shiftx);
+	if (pm.blacklist_cells.count(pm.st.shiftx))
+		return;
 	SigSpec A = pm.st.shiftx->getPort("\\A");
 	SigSpec Y = pm.st.shiftx->getPort("\\Y");
 	const int A_WIDTH = pm.st.shiftx->getParam("\\A_WIDTH").as_int();

--- a/passes/pmgen/split_shiftx.cc
+++ b/passes/pmgen/split_shiftx.cc
@@ -1,0 +1,78 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/yosys.h"
+#include "kernel/sigtools.h"
+#include "passes/pmgen/split_shiftx_pm.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+void create_split_shiftx(split_shiftx_pm &pm)
+{
+	if (pm.st.shiftxB.empty())
+		return;
+	log_assert(pm.st.shiftx);
+	SigSpec A = pm.st.shiftx->getPort("\\A");
+	SigSpec Y = pm.st.shiftx->getPort("\\Y");
+	const int A_WIDTH = pm.st.shiftx->getParam("\\A_WIDTH").as_int();
+	const int Y_WIDTH = pm.st.shiftx->getParam("\\Y_WIDTH").as_int();
+	log_assert(Y_WIDTH > 1);
+	std::vector<SigBit> bits;
+	bits.resize(A_WIDTH / Y_WIDTH);
+	for (int i = 0; i < Y_WIDTH; ++i) {
+		for (int j = 0; j < A_WIDTH/Y_WIDTH; ++j)
+			bits[j] = A[j*Y_WIDTH + i];
+		pm.module->addShiftx(NEW_ID, bits, pm.st.shiftxB, Y[i]);
+	}
+	pm.st.shiftx->unsetPort("\\Y");
+
+	pm.autoremove(pm.st.shiftx);
+	pm.autoremove(pm.st.macc);
+}
+
+struct BitblastShiftxPass : public Pass {
+	BitblastShiftxPass() : Pass("split_shiftx", "Split up multi-bit $shiftx cells") { }
+	void help() YS_OVERRIDE
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    split_shiftx [selection]\n");
+		log("\n");
+		log("Split up $shiftx cells where Y_WIDTH > 1, with consideration for any $macc\n");
+		log("cells that may be driving their B inputs.\n");
+		log("\n");
+	}
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	{
+		log_header(design, "Executing SPLIT_SHIFTX pass.\n");
+
+		size_t argidx;
+		for (argidx = 1; argidx < args.size(); argidx++)
+		{
+			break;
+		}
+		extra_args(args, argidx, design);
+
+		for (auto module : design->selected_modules())
+			split_shiftx_pm(module, module->selected_cells()).run(create_split_shiftx);
+	}
+} BitblastShiftxPass;
+
+PRIVATE_NAMESPACE_END

--- a/passes/pmgen/split_shiftx.pmg
+++ b/passes/pmgen/split_shiftx.pmg
@@ -1,0 +1,56 @@
+state <SigSpec> shiftxB
+
+match shiftx
+	select shiftx->type == $shiftx
+	select param(shiftx, \Y_WIDTH).as_int() > 1
+endmatch
+
+code shiftxB
+	shiftxB = port(shiftx, \B);
+	const int b_width = param(shiftx, \B_WIDTH).as_int();
+	if (param(shiftx, \B_SIGNED) != 0 && shiftxB[b_width-1] == RTLIL::S0)
+		shiftxB = shiftxB.extract(0, b_width-1);
+endcode
+
+match macc
+	select macc->type == $macc
+	select param(macc, \B_WIDTH).as_int() == 0
+	index <SigSpec> port(macc, \Y) === shiftxB
+	optional
+endmatch
+
+code shiftxB
+	if (macc) {
+		Const config = param(macc, \CONFIG);
+		const int config_width = param(macc, \CONFIG_WIDTH).as_int();
+		const int num_bits = config.extract(0, 4).as_int();
+		const int num_ports = (config_width - 4) / (2 + 2*num_bits);
+		if (num_ports != 1) {
+			shiftxB = nullptr;
+			reject;
+		}
+		// IS_SIGNED?
+		if (config[4] == 1) {
+			shiftxB = nullptr;
+			reject;
+		}
+		// DO_SUBTRACT?
+		if (config[5] == 1) {
+			shiftxB = nullptr;
+			reject;
+		}
+		const int port_size_A = config.extract(6, num_bits).as_int();
+		const int port_size_B = config.extract(6 + num_bits, num_bits).as_int();
+		const SigSpec port_B = port(macc, \A).extract(port_size_A, port_size_B);
+		if (!port_B.is_fully_const()) {
+			shiftxB = nullptr;
+			reject;
+		}
+		const int multiply_factor = port_B.as_int();
+		if (multiply_factor != param(shiftx, \Y_WIDTH).as_int()) {
+			shiftxB = nullptr;
+			reject;
+		}
+		shiftxB = port(macc, \A).extract(0, port_size_A);
+	}
+endcode

--- a/passes/pmgen/split_shiftx.pmg
+++ b/passes/pmgen/split_shiftx.pmg
@@ -5,50 +5,51 @@ match shiftx
 	select param(shiftx, \Y_WIDTH).as_int() > 1
 endmatch
 
-code shiftxB
-	shiftxB = port(shiftx, \B);
-	const int b_width = param(shiftx, \B_WIDTH).as_int();
-	if (param(shiftx, \B_SIGNED) != 0 && shiftxB[b_width-1] == RTLIL::S0)
-		shiftxB = shiftxB.extract(0, b_width-1);
-endcode
-
 match macc
 	select macc->type == $macc
 	select param(macc, \B_WIDTH).as_int() == 0
-	index <SigSpec> port(macc, \Y) === shiftxB
 	optional
 endmatch
 
 code shiftxB
 	if (macc) {
+		shiftxB = port(shiftx, \B);
+		const int b_width = param(shiftx, \B_WIDTH).as_int();
+		if (param(shiftx, \B_SIGNED) != 0 && shiftxB[b_width-1] == RTLIL::S0)
+			shiftxB = shiftxB.extract(0, b_width-1);
+		if (port(macc, \Y) != shiftxB) {
+			blacklist(shiftx);
+			reject;
+		}
+
 		Const config = param(macc, \CONFIG);
 		const int config_width = param(macc, \CONFIG_WIDTH).as_int();
 		const int num_bits = config.extract(0, 4).as_int();
 		const int num_ports = (config_width - 4) / (2 + 2*num_bits);
 		if (num_ports != 1) {
-			shiftxB = nullptr;
+			blacklist(shiftx);
 			reject;
 		}
 		// IS_SIGNED?
 		if (config[4] == 1) {
-			shiftxB = nullptr;
+			blacklist(shiftx);
 			reject;
 		}
 		// DO_SUBTRACT?
 		if (config[5] == 1) {
-			shiftxB = nullptr;
+			blacklist(shiftx);
 			reject;
 		}
 		const int port_size_A = config.extract(6, num_bits).as_int();
 		const int port_size_B = config.extract(6 + num_bits, num_bits).as_int();
 		const SigSpec port_B = port(macc, \A).extract(port_size_A, port_size_B);
 		if (!port_B.is_fully_const()) {
-			shiftxB = nullptr;
+			blacklist(shiftx);
 			reject;
 		}
 		const int multiply_factor = port_B.as_int();
 		if (multiply_factor != param(shiftx, \Y_WIDTH).as_int()) {
-			shiftxB = nullptr;
+			blacklist(shiftx);
 			reject;
 		}
 		shiftxB = port(macc, \A).extract(0, port_size_A);

--- a/passes/pmgen/split_shiftx.pmg
+++ b/passes/pmgen/split_shiftx.pmg
@@ -12,11 +12,13 @@ match macc
 endmatch
 
 code shiftxB
+	shiftxB = port(shiftx, \B);
+
 	if (macc) {
-		shiftxB = port(shiftx, \B);
 		const int b_width = param(shiftx, \B_WIDTH).as_int();
 		if (param(shiftx, \B_SIGNED) != 0 && shiftxB[b_width-1] == RTLIL::S0)
 			shiftxB = shiftxB.extract(0, b_width-1);
+
 		if (port(macc, \Y) != shiftxB) {
 			blacklist(shiftx);
 			reject;

--- a/tests/various/split_shiftx.v
+++ b/tests/various/split_shiftx.v
@@ -1,0 +1,118 @@
+module split_shiftx_test01(i, s, o);
+  wire [3:0] _0_;
+  input [8:0] i;
+  output [2:0] o;
+  input [1:0] s;
+  \$macc  #(
+    .A_WIDTH(32'd4),
+    .B_WIDTH(32'd0),
+    .CONFIG(10'h282),
+    .CONFIG_WIDTH(32'd10),
+    .Y_WIDTH(32'd4)
+  ) _1_ (
+    .A({ 2'h3, s }),
+    .B(),
+    .Y(_0_)
+  );
+  \$shiftx  #(
+    .A_SIGNED(32'd0),
+    .A_WIDTH(32'd9),
+    .B_SIGNED(32'd1),
+    .B_WIDTH(32'd5),
+    .Y_WIDTH(32'd3)
+  ) _2_ (
+    .A(i),
+    .B({ 1'h0, _0_ }),
+    .Y(o)
+  );
+endmodule
+
+// Sign bit is 1
+module split_shiftx_test02(i, s, o);
+  wire [3:0] _0_;
+  input [8:0] i;
+  output [2:0] o;
+  input [1:0] s;
+  \$macc  #(
+    .A_WIDTH(32'd4),
+    .B_WIDTH(32'd0),
+    .CONFIG(10'h282),
+    .CONFIG_WIDTH(32'd10),
+    .Y_WIDTH(32'd4)
+  ) _1_ (
+    .A({ 2'h3, s }),
+    .B(),
+    .Y(_0_)
+  );
+  \$shiftx  #(
+    .A_SIGNED(32'd0),
+    .A_WIDTH(32'd9),
+    .B_SIGNED(32'd1),
+    .B_WIDTH(32'd5),
+    .Y_WIDTH(32'd3)
+  ) _2_ (
+    .A(i),
+    .B({ 1'h1, _0_ }),
+    .Y(o)
+  );
+endmodule
+
+// Non constant $macc
+module split_shiftx_test03(i, s, o);
+  wire [3:0] _0_;
+  input [8:0] i;
+  output [2:0] o;
+  input [1:0] s;
+  \$macc  #(
+    .A_WIDTH(32'd4),
+    .B_WIDTH(32'd0),
+    .CONFIG(10'h282),
+    .CONFIG_WIDTH(32'd10),
+    .Y_WIDTH(32'd4)
+  ) _1_ (
+    .A({ s, s }),
+    .B(),
+    .Y(_0_)
+  );
+  \$shiftx  #(
+    .A_SIGNED(32'd0),
+    .A_WIDTH(32'd9),
+    .B_SIGNED(32'd1),
+    .B_WIDTH(32'd5),
+    .Y_WIDTH(32'd3)
+  ) _2_ (
+    .A(i),
+    .B({ 1'h0, _0_ }),
+    .Y(o)
+  );
+endmodule
+
+// Wrong constant $macc
+module split_shiftx_test04(i, s, o);
+  wire [3:0] _0_;
+  input [8:0] i;
+  output [2:0] o;
+  input [1:0] s;
+  \$macc  #(
+    .A_WIDTH(32'd4),
+    .B_WIDTH(32'd0),
+    .CONFIG(10'h282),
+    .CONFIG_WIDTH(32'd10),
+    .Y_WIDTH(32'd4)
+  ) _1_ (
+    .A({ 2'h2, s }),
+    .B(),
+    .Y(_0_)
+  );
+  \$shiftx  #(
+    .A_SIGNED(32'd0),
+    .A_WIDTH(32'd9),
+    .B_SIGNED(32'd1),
+    .B_WIDTH(32'd5),
+    .Y_WIDTH(32'd3)
+  ) _2_ (
+    .A(i),
+    .B({ 1'h0, _0_ }),
+    .Y(o)
+  );
+endmodule

--- a/tests/various/split_shiftx.ys
+++ b/tests/various/split_shiftx.ys
@@ -1,0 +1,21 @@
+read_verilog -icells split_shiftx.v
+split_shiftx
+
+cd split_shiftx_test01
+select -assert-count 3 t:$shiftx
+select -assert-count 0 t: t:$shiftx %n %i
+
+cd split_shiftx_test02
+select -assert-count 1 t:$shiftx
+select -assert-count 1 t:$macc
+select -assert-count 0 t: t:$shiftx t:$macc %u %n %i
+
+cd split_shiftx_test03
+select -assert-count 1 t:$shiftx
+select -assert-count 1 t:$macc
+select -assert-count 0 t: t:$shiftx t:$macc %u %n %i
+
+cd split_shiftx_test04
+select -assert-count 1 t:$shiftx
+select -assert-count 1 t:$macc
+select -assert-count 0 t: t:$shiftx t:$macc %u %n %i


### PR DESCRIPTION
Taking into account any `$macc` cells -- configured a constant multiplier -- that might be driving the `$shiftx`'s `B` input.