### PR TITLE
escape spaces with backslash when writing dep file

### DIFF
--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -529,13 +529,13 @@ int main(int argc, char **argv)
 			log_error("Can't open dependencies file for writing: %s\n", strerror(errno));
 		bool first = true;
 		for (auto fn : yosys_output_files) {
-			fprintf(f, "%s%s", first ? "" : " ", escape_filename_spaces (fn).c_str());
+			fprintf(f, "%s%s", first ? "" : " ", escape_filename_spaces(fn).c_str());
 			first = false;
 		}
 		fprintf(f, ":");
 		for (auto fn : yosys_input_files) {
 			if (yosys_output_files.count(fn) == 0)
-				fprintf(f, " %s", escape_filename_spaces (fn).c_str());
+				fprintf(f, " %s", escape_filename_spaces(fn).c_str());
 		}
 		fprintf(f, "\n");
 	}

--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -529,13 +529,13 @@ int main(int argc, char **argv)
 			log_error("Can't open dependencies file for writing: %s\n", strerror(errno));
 		bool first = true;
 		for (auto fn : yosys_output_files) {
-			fprintf(f, "%s%s", first ? "" : " ", fn.c_str());
+			fprintf(f, "%s%s", first ? "" : " ", escape_filename_spaces (fn).c_str());
 			first = false;
 		}
 		fprintf(f, ":");
 		for (auto fn : yosys_input_files) {
 			if (yosys_output_files.count(fn) == 0)
-				fprintf(f, " %s", fn.c_str());
+				fprintf(f, " %s", escape_filename_spaces (fn).c_str());
 		}
 		fprintf(f, "\n");
 	}

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -482,18 +482,18 @@ void remove_directory(std::string dirname)
 #endif
 }
 
-std::string escape_filename_spaces (const std::string& filename)
+std::string escape_filename_spaces(const std::string& filename)
 {
-  std::string out;
-  out.reserve (filename.size ());
-  for (auto c : filename)
-  {
-    if (c == ' ')
-      out += "\\ ";
-    else
-      out.push_back (c);
-  }
-  return out;
+	std::string out;
+	out.reserve(filename.size());
+	for (auto c : filename)
+	{
+		if (c == ' ')
+			out += "\\ ";
+		else
+			out.push_back(c);
+	}
+	return out;
 }
 
 int GetSize(RTLIL::Wire *wire)

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -482,6 +482,20 @@ void remove_directory(std::string dirname)
 #endif
 }
 
+std::string escape_filename_spaces (const std::string& filename)
+{
+  std::string out;
+  out.reserve (filename.size ());
+  for (auto c : filename)
+  {
+    if (c == ' ')
+      out += "\\ ";
+    else
+      out.push_back (c);
+  }
+  return out;
+}
+
 int GetSize(RTLIL::Wire *wire)
 {
 	return wire->width;

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -257,7 +257,7 @@ std::string make_temp_dir(std::string template_str = "/tmp/yosys_XXXXXX");
 bool check_file_exists(std::string filename, bool is_exec = false);
 bool is_absolute_path(std::string filename);
 void remove_directory(std::string dirname);
-std::string escape_filename_spaces (const std::string& filename);
+std::string escape_filename_spaces(const std::string& filename);
 
 template<typename T> int GetSize(const T &obj) { return obj.size(); }
 int GetSize(RTLIL::Wire *wire);

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -257,6 +257,7 @@ std::string make_temp_dir(std::string template_str = "/tmp/yosys_XXXXXX");
 bool check_file_exists(std::string filename, bool is_exec = false);
 bool is_absolute_path(std::string filename);
 void remove_directory(std::string dirname);
+std::string escape_filename_spaces (const std::string& filename);
 
 template<typename T> int GetSize(const T &obj) { return obj.size(); }
 int GetSize(RTLIL::Wire *wire);


### PR DESCRIPTION
filenames are sparated by spaces in the dep file.  if a filename in the
dep file contains spaces they must be escaped, otherwise the tool that
reads the dep file will see multiple wrong filenames.