### PR TITLE
Add final loop variable assignment when unrolling for-loops

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1172,6 +1172,13 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 			varbuf->children[0] = buf;
 		}
 
+		if (type == AST_FOR) {
+			AstNode *buf = next_ast->clone();
+			delete buf->children[1];
+			buf->children[1] = varbuf->children[0]->clone();
+			current_block->children.insert(current_block->children.begin() + current_block_idx++, buf);
+		}
+
 		current_scope[varbuf->str] = backup_scope_varbuf;
 		delete varbuf;
 		delete_children();


### PR DESCRIPTION
Fixes this test case (per #968):

```
module test(i_value, o_value);
	input	wire	[4:0]	i_value;
	output	reg	[7:0]	o_value;

	integer k;
	always @(*)
	begin
		for(k=0; k<4; k=k+1)
			o_value[k] = i_value[k];
		o_value[4] = i_value[k];
		o_value[5] = i_value[k];
		o_value[6] = i_value[k];
		o_value[7] = i_value[k];
	end
endmodule
```