### PR TITLE
Fix #938 - Crash occurs in case when use write_firrtl command

### DIFF
--- a/tests/memories/firrtl_938.v
+++ b/tests/memories/firrtl_938.v
@@ -1,0 +1,22 @@
+module top
+(
+	input [7:0] data_a,
+	input [6:1] addr_a,
+	input we_a, clk,
+	output reg [7:0] q_a
+);
+	// Declare the RAM variable
+	reg [7:0] ram[63:0];
+
+	// Port A
+	always @ (posedge clk)
+	begin
+		if (we_a)
+		begin
+			ram[addr_a] <= data_a;
+			q_a <= data_a;
+		end
+			q_a <= ram[addr_a];
+	end
+
+endmodule

--- a/tests/simple/xfirrtl
+++ b/tests/simple/xfirrtl
@@ -16,6 +16,7 @@ operators.v	$pow
 partsel.v	drops modules
 process.v	drops modules
 realexpr.v	drops modules
+retime.v	Initial value (11110101) for (retime_test.ff) not supported
 scopes.v	original verilog issues ( -x where x isn't declared signed)
 sincos.v	$adff
 specify.v	no code (empty module generates error


### PR DESCRIPTION
Add missing memory initialization.
Sanity-check memory parameters.
Add Cell pointer to memory object (for error reporting).

This should resolve #938 