### PR TITLE
fail svinterfaces testcases on yosys error exit

### DIFF
--- a/tests/svinterfaces/runone.sh
+++ b/tests/svinterfaces/runone.sh
@@ -11,12 +11,12 @@ echo "" > $STDERRFILE
 
 echo -n "Test: ${TESTNAME} -> "
 
+set -e
+
 $PWD/../../yosys -p "read_verilog -sv ${TESTNAME}.sv ; hierarchy -check -top TopModule ; synth ; write_verilog ${TESTNAME}_syn.v" >> $STDOUTFILE >> $STDERRFILE
 $PWD/../../yosys -p "read_verilog -sv ${TESTNAME}_ref.v ; hierarchy -check -top TopModule ; synth ; write_verilog ${TESTNAME}_ref_syn.v" >> $STDOUTFILE >> $STDERRFILE
 
 rm -f a.out reference_result.txt dut_result.txt
-
-set -e
 
 iverilog -g2012 ${TESTNAME}_syn.v
 iverilog -g2012 ${TESTNAME}_ref_syn.v


### PR DESCRIPTION
Hi!

The svinterfaces testcases did not fail when yosys exited with a nonzero exit code. Instead, they continued and compared possibly out-of-date outputs.

Regards,
Jakob