### PR TITLE
Extend AST's dumpVlog to output actual verilog code

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -262,16 +262,19 @@ AstNode::~AstNode()
 
 // create a nice text representation of the node
 // (traverse tree by recursion, use 'other' pointer for diffing two AST trees)
-void AstNode::dumpAst(FILE *f, std::string indent) const
+void AstNode::dumpAst(FILE *f, std::string indent, bool dumpFileLine) const
 {
 	if (f == NULL) {
 		for (auto f : log_files)
-			dumpAst(f, indent);
+			dumpAst(f, indent, dumpFileLine);
 		return;
 	}
 
 	std::string type_name = type2str(type);
-	fprintf(f, "%s%s <%s:%d>", indent.c_str(), type_name.c_str(), filename.c_str(), linenum);
+    	fprintf(f, "%s%s", indent.c_str(), type_name.c_str());
+	if (dumpFileLine) {
+	    fprintf(f, " <%s:%d>", filename.c_str(), linenum);
+	}
 
 	if (!flag_no_dump_ptr) {
 		if (id2ast)
@@ -319,11 +322,11 @@ void AstNode::dumpAst(FILE *f, std::string indent) const
 
 	for (auto &it : attributes) {
 		fprintf(f, "%s  ATTR %s:\n", indent.c_str(), it.first.c_str());
-		it.second->dumpAst(f, indent + "    ");
+		it.second->dumpAst(f, indent + "    ", dumpFileLine);
 	}
 
 	for (size_t i = 0; i < children.size(); i++)
-		children[i]->dumpAst(f, indent + "  ");
+		children[i]->dumpAst(f, indent + "  ", dumpFileLine);
 
 	fflush(f);
 }

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -397,6 +397,14 @@ void AstNode::dumpVlog(FILE *f, std::string indent, bool inGenerate, AstNodeType
 
 	switch (type)
 	{
+
+        case AST_DESIGN:
+                for (const auto &child : children) {
+                      child->dumpVlog(f, "", false, type);
+                      fprintf(f, "\n\n");
+                }
+                break;
+
 	if (0) { case AST_INTERFACE: txt = "interface"; }
 	if (0) { case AST_MODULE: txt = "module"; }
 		{

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -1550,4 +1550,21 @@ void AST::use_internal_line_num()
 	get_line_num = &internal_get_line_num;
 }
 
+
+void AST::removeNestedBlock(AstNode*& node) {
+	if (node->type != AST_BLOCK && node->type != AST_GENBLOCK)
+		log_file_error(node->filename, node->linenum, "remove nested block called with non block");
+
+	if (node->children.size()!=1)
+		return;
+
+	AstNode * unneeded = node->children[0];
+
+	if (unneeded->type == node->type && unneeded->str.empty() ) {
+		node->children = unneeded->children;
+		unneeded->children.clear();
+		delete unneeded;
+	}
+}
+
 YOSYS_NAMESPACE_END

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -157,9 +157,15 @@ std::string AST::type2str(AstNodeType type)
 	X(AST_POSEDGE)
 	X(AST_NEGEDGE)
 	X(AST_EDGE)
+	X(AST_INTERFACE)
+	X(AST_INTERFACEPORT)
+	X(AST_INTERFACEPORTTYPE)
+	X(AST_MODPORT)
+	X(AST_MODPORTMEMBER)
 	X(AST_PACKAGE)
 #undef X
 	default:
+		log_error("Unknown node type %d", type);
 		log_abort();
 	}
 }

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -242,7 +242,7 @@ namespace AST
 		bool is_simple_const_expr();
 
 		// create a human-readable text representation of the AST (for debugging)
-		void dumpAst(FILE *f, std::string indent) const;
+		void dumpAst(FILE *f = NULL, std::string indent = "", bool dumpFileLine = true) const;
 		void dumpVlog(FILE *f, std::string indent) const;
 
 		// used by genRTLIL() for detecting expression width and sign

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -316,6 +316,8 @@ namespace AST
 	std::pair<std::string,std::string> split_modport_from_type(std::string name_type);
 	AstNode * find_modport(AstNode *intf, std::string name);
 	void explode_interface_port(AstNode *module_ast, RTLIL::Module * intfmodule, std::string intfname, AstNode *modport);
+
+    	void removeNestedBlock(AstNode*& node);
 }
 
 namespace AST_INTERNAL

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -243,7 +243,7 @@ namespace AST
 
 		// create a human-readable text representation of the AST (for debugging)
 		void dumpAst(FILE *f = NULL, std::string indent = "", bool dumpFileLine = true) const;
-		void dumpVlog(FILE *f, std::string indent) const;
+		void dumpVlog(FILE *f = NULL, std::string indent = "", bool inGenerate = false, AstNodeType parentType = AST_NONE) const;
 
 		// used by genRTLIL() for detecting expression width and sign
 		void detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *found_real = NULL);

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -1177,7 +1177,25 @@ single_cell:
 			astbuf2->str = *$1;
 		delete $1;
 		ast_stack.back()->children.push_back(new AstNode(AST_CELLARRAY, $2, astbuf2));
-	} '(' cell_port_list ')';
+	} '(' cell_port_list ')' |
+	/* interface port instantiation */
+	TOK_ID {
+		astbuf2 = new AstNode(AST_INTERFACEPORT);
+		astbuf2->str = *$1;
+		astbuf3 = new AstNode(AST_INTERFACEPORTTYPE);
+		astbuf3->str = astbuf1->children[0]->str;
+		astbuf2->children.push_back(astbuf3);
+
+		if (port_stubs.count(*$1) != 0) {
+			astbuf2->port_id = port_stubs[*$1];
+			port_stubs.erase(*$1);
+		} else {
+			frontend_verilog_yyerror("Module port `%s' is not declared in module header.", $1->c_str());
+		}
+
+		ast_stack.back()->children.push_back(astbuf2);
+		delete $1;
+	};
 
 prim_list:
 	single_prim |

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -549,6 +549,7 @@ checker_decl:
 		ast_stack.push_back(node);
 	} module_body TOK_ENDCHECKER {
 		delete $2;
+		removeNestedBlock(ast_stack.back());
 		ast_stack.pop_back();
 	};
 
@@ -1275,6 +1276,7 @@ always_stmt:
 		ast_stack.back()->children.push_back(block);
 		ast_stack.push_back(block);
 	} behavioral_stmt {
+		removeNestedBlock(ast_stack.back());
 		ast_stack.pop_back();
 		ast_stack.pop_back();
 	} |
@@ -1287,6 +1289,7 @@ always_stmt:
 		ast_stack.back()->children.push_back(block);
 		ast_stack.push_back(block);
 	} behavioral_stmt {
+		removeNestedBlock(ast_stack.back());
 		ast_stack.pop_back();
 		ast_stack.pop_back();
 	};
@@ -1588,6 +1591,7 @@ behavioral_stmt:
 			delete $3;
 		if ($7 != NULL)
 			delete $7;
+		removeNestedBlock(ast_stack.back());
 		ast_stack.pop_back();
 	} |
 	attr TOK_FOR '(' {
@@ -1602,6 +1606,7 @@ behavioral_stmt:
 		ast_stack.back()->children.push_back(block);
 		ast_stack.push_back(block);
 	} behavioral_stmt {
+		removeNestedBlock(ast_stack.back());
 		ast_stack.pop_back();
 		ast_stack.pop_back();
 	} |
@@ -1615,6 +1620,7 @@ behavioral_stmt:
 		ast_stack.back()->children.push_back(block);
 		ast_stack.push_back(block);
 	} behavioral_stmt {
+		removeNestedBlock(ast_stack.back());
 		ast_stack.pop_back();
 		ast_stack.pop_back();
 	} |
@@ -1628,6 +1634,7 @@ behavioral_stmt:
 		ast_stack.back()->children.push_back(block);
 		ast_stack.push_back(block);
 	} behavioral_stmt {
+		removeNestedBlock(ast_stack.back());
 		ast_stack.pop_back();
 		ast_stack.pop_back();
 	} |
@@ -1642,6 +1649,7 @@ behavioral_stmt:
 		ast_stack.push_back(block);
 		append_attr(node, $1);
 	} behavioral_stmt optional_else {
+		removeNestedBlock(ast_stack.back());
 		ast_stack.pop_back();
 		ast_stack.pop_back();
 	} |
@@ -1702,6 +1710,7 @@ optional_else:
 	TOK_ELSE {
 		AstNode *block = new AstNode(AST_BLOCK);
 		AstNode *cond = new AstNode(AST_COND, new AstNode(AST_DEFAULT), block);
+		removeNestedBlock(ast_stack.back());
 		ast_stack.pop_back();
 		ast_stack.back()->children.push_back(cond);
 		ast_stack.push_back(block);
@@ -1726,6 +1735,7 @@ case_item:
 		case_type_stack.push_back(0);
 	} behavioral_stmt {
 		case_type_stack.pop_back();
+		removeNestedBlock(ast_stack.back());
 		ast_stack.pop_back();
 		ast_stack.pop_back();
 	};
@@ -1868,6 +1878,7 @@ gen_stmt:
 			delete $2;
 		if ($6 != NULL)
 			delete $6;
+		removeNestedBlock(ast_stack.back());
 		ast_stack.pop_back();
 	};
 
@@ -1877,6 +1888,7 @@ gen_stmt_block:
 		ast_stack.back()->children.push_back(node);
 		ast_stack.push_back(node);
 	} gen_stmt_or_module_body_stmt {
+		removeNestedBlock(ast_stack.back());
 		ast_stack.pop_back();
 	};
 

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -690,6 +690,10 @@ task_func_port:
 				astbuf2->children.push_back(AstNode::mkconst_int(astbuf1->range_right, true));
 			}
 		}
+		astbuf1->range_left = -1;
+		astbuf1->range_right = 0;
+
+
 		if (astbuf2 && astbuf2->children.size() != 2)
 			frontend_verilog_yyerror("task/function argument range must be of the form: [<expr>:<expr>], [<expr>+:<expr>], or [<expr>-:<expr>]");
 	} wire_name | wire_name;
@@ -984,6 +988,8 @@ wire_decl:
 				astbuf2->children.push_back(AstNode::mkconst_int(astbuf1->range_right, true));
 			}
 		}
+		astbuf1->range_left = -1;
+		astbuf1->range_right = 0;
 		if (astbuf2 && astbuf2->children.size() != 2)
 			frontend_verilog_yyerror("wire/reg/logic packed dimension must be of the form: [<expr>:<expr>], [<expr>+:<expr>], or [<expr>-:<expr>]");
 	} wire_name_list {

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -138,6 +138,22 @@ std::string RTLIL::Const::as_string() const
 	return ret;
 }
 
+
+std::string RTLIL::Const::as_verilog_string() const
+{
+    std::string ret;
+    for (size_t i = bits.size(); i > 0; i--)
+	    switch (bits[i-1]) {
+		    case S0: ret += "0"; break;
+		    case S1: ret += "1"; break;
+		    case Sx: ret += "x"; break;
+		    case Sz: ret += "z"; break;
+		    case Sa: ret += "?"; break;
+		    case Sm: ret += "m"; break;
+	    }
+    return ret;
+}
+
 RTLIL::Const RTLIL::Const::from_string(std::string str)
 {
 	Const c;

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -526,6 +526,7 @@ struct RTLIL::Const
 	bool as_bool() const;
 	int as_int(bool is_signed = false) const;
 	std::string as_string() const;
+	std::string as_verilog_string() const;
 	static Const from_string(std::string str);
 
 	std::string decode_string() const;


### PR DESCRIPTION
Hi!

I am planning to use Yosys for some AST level code transformations. Therefore, I need to be able to export the AST as working Verilog code.

I extended AstNode's dumpVlog function to no longer dump Verilog *Pseudo* Code, but rather working Verilog code. It can be parsed again and produce an identical AST. To that end, I made some changes in the Verilog parser, hopefully without breaking stuff.

I am not very familiar with Yosys' code base, so please have a close look at my work. :-)

Kind Regards,
Jakob