### PR TITLE
dffinit to do nothing when (* init *) value is 1'bx

### DIFF
--- a/passes/techmap/dffinit.cc
+++ b/passes/techmap/dffinit.cc
@@ -102,7 +102,8 @@ struct DffinitPass : public Pass {
 				if (wire->attributes.count("\\init")) {
 					Const value = wire->attributes.at("\\init");
 					for (int i = 0; i < min(GetSize(value), GetSize(wire)); i++)
-						init_bits[sigmap(SigBit(wire, i))] = value[i];
+						if (value[i] != State::Sx)
+							init_bits[sigmap(SigBit(wire, i))] = value[i];
 				}
 				if (wire->port_output)
 					for (auto bit : sigmap(wire))

--- a/passes/techmap/dffinit.cc
+++ b/passes/techmap/dffinit.cc
@@ -135,18 +135,10 @@ struct DffinitPass : public Pass {
 							continue;
 						while (GetSize(value.bits) <= i)
 							value.bits.push_back(State::S0);
-						if (noreinit && value.bits[i] != State::Sx && value.bits[i] != init_bits.at(sig[i])) {
-							if (init_bits.at(sig[i]) != State::Sx) {
-								log_error("Trying to assign a different init value for %s.%s.%s which technically "
-										"have a conflicted init value.\n",
-										log_id(module), log_id(cell), log_id(it.second));
-							}
-							else {
-								// Trying to overwrite an existing INIT value with 1'bx,
-								//   silently ignore?
-								continue;
-							}
-						}
+						if (noreinit && value.bits[i] != State::Sx && value.bits[i] != init_bits.at(sig[i]))
+							log_error("Trying to assign a different init value for %s.%s.%s which technically "
+									"have a conflicted init value.\n",
+									log_id(module), log_id(cell), log_id(it.second));
 						value.bits[i] = init_bits.at(sig[i]);
 						cleanup_bits.insert(sig[i]);
 					}

--- a/passes/techmap/dffinit.cc
+++ b/passes/techmap/dffinit.cc
@@ -135,10 +135,18 @@ struct DffinitPass : public Pass {
 							continue;
 						while (GetSize(value.bits) <= i)
 							value.bits.push_back(State::S0);
-						if (noreinit && value.bits[i] != State::Sx && value.bits[i] != init_bits.at(sig[i]))
-							log_error("Trying to assign a different init value for %s.%s.%s which technically "
-									"have a conflicted init value.\n",
-									log_id(module), log_id(cell), log_id(it.second));
+						if (noreinit && value.bits[i] != State::Sx && value.bits[i] != init_bits.at(sig[i])) {
+							if (init_bits.at(sig[i]) != State::Sx) {
+								log_error("Trying to assign a different init value for %s.%s.%s which technically "
+										"have a conflicted init value.\n",
+										log_id(module), log_id(cell), log_id(it.second));
+							}
+							else {
+								// Trying to overwrite an existing INIT value with 1'bx,
+								//   silently ignore?
+								continue;
+							}
+						}
 						value.bits[i] = init_bits.at(sig[i]);
 						cleanup_bits.insert(sig[i]);
 					}

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -250,7 +250,7 @@ struct SynthXilinxPass : public ScriptPass
 			if (!nosrl || help_mode)
 				run("shregmap -minlen 3 -init -params -enpol any_or_none", "(skip if '-nosrl')");
 			run("techmap -map +/xilinx/lut_map.v -map +/xilinx/ff_map.v -map +/xilinx/cells_map.v");
-			run("dffinit -ff FDRE Q INIT -ff FDCE Q INIT -ff FDPE Q INIT -ff FDSE Q INIT "
+			run("dffinit -noreinit -ff FDRE Q INIT -ff FDCE Q INIT -ff FDPE Q INIT -ff FDSE Q INIT "
 					"-ff FDRE_1 Q INIT -ff FDCE_1 Q INIT -ff FDPE_1 Q INIT -ff FDSE_1 Q INIT");
 			run("clean");
 		}

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -250,7 +250,7 @@ struct SynthXilinxPass : public ScriptPass
 			if (!nosrl || help_mode)
 				run("shregmap -minlen 3 -init -params -enpol any_or_none", "(skip if '-nosrl')");
 			run("techmap -map +/xilinx/lut_map.v -map +/xilinx/ff_map.v -map +/xilinx/cells_map.v");
-			run("dffinit -noreinit -ff FDRE Q INIT -ff FDCE Q INIT -ff FDPE Q INIT -ff FDSE Q INIT "
+			run("dffinit -ff FDRE Q INIT -ff FDCE Q INIT -ff FDPE Q INIT -ff FDSE Q INIT "
 					"-ff FDRE_1 Q INIT -ff FDCE_1 Q INIT -ff FDPE_1 Q INIT -ff FDSE_1 Q INIT");
 			run("clean");
 		}


### PR DESCRIPTION
Fix for #982 

@cliffordwolf If this approach is acceptable, perhaps we should do this even when `-noreinit` is not specified?