### PR TITLE
ABC name recovery fixes

### DIFF
--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -330,18 +330,31 @@ void extract_cell(RTLIL::Cell *cell, bool keepff)
 std::string remap_name(RTLIL::IdString abc_name, RTLIL::Wire **orig_wire = nullptr)
 {
 	std::string abc_sname = abc_name.substr(1);
-	if (abc_sname.substr(0, 5) == "ys__n") {
+	bool isnew = false;
+	if (abc_sname.substr(0, 4) == "new_")
+	{
+		abc_sname.erase(0, 4);
+		isnew = true;
+	}
+	if (abc_sname.substr(0, 5) == "ys__n")
+	{
 		bool inv = abc_sname.back() == 'v';
 		if (inv) abc_sname.pop_back();
 		abc_sname.erase(0, 5);
-		if (abc_sname.find_last_not_of("012345689") == std::string::npos) {
+		if (std::isdigit(abc_sname.at(0)))
+		{
 			int sid = std::stoi(abc_sname);
-			for (auto sig : signal_list) {
-				if (sig.id == sid && sig.bit.wire != nullptr) {
+			if (sid < GetSize(signal_list))
+			{
+				auto sig = signal_list.at(sid);
+				if (sig.bit.wire != nullptr)
+				{
 					std::stringstream sstr;
 					sstr << "$abc$" << map_autoidx << "$" << sig.bit.wire->name.substr(1);
 					if (sig.bit.wire->width != 1)
 						sstr << "[" << sig.bit.offset << "]";
+					if (isnew)
+						sstr << "_new";
 					if (inv)
 						sstr << "_inv";
 					if (orig_wire != nullptr)

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -338,12 +338,13 @@ std::string remap_name(RTLIL::IdString abc_name, RTLIL::Wire **orig_wire = nullp
 	}
 	if (abc_sname.substr(0, 5) == "ys__n")
 	{
-		bool inv = abc_sname.back() == 'v';
-		if (inv) abc_sname.pop_back();
 		abc_sname.erase(0, 5);
 		if (std::isdigit(abc_sname.at(0)))
 		{
 			int sid = std::stoi(abc_sname);
+			size_t postfix_start = abc_sname.find_first_not_of("0123456789");
+			std::string postfix = postfix_start != std::string::npos ? abc_sname.substr(postfix_start) : "";
+
 			if (sid < GetSize(signal_list))
 			{
 				auto sig = signal_list.at(sid);
@@ -355,8 +356,7 @@ std::string remap_name(RTLIL::IdString abc_name, RTLIL::Wire **orig_wire = nullp
 						sstr << "[" << sig.bit.offset << "]";
 					if (isnew)
 						sstr << "_new";
-					if (inv)
-						sstr << "_inv";
+					sstr << postfix;
 					if (orig_wire != nullptr)
 						*orig_wire = sig.bit.wire;
 					return sstr.str();


### PR DESCRIPTION
 - Fix accidental n² bug when finding original name
 - Add handling for `new_` prefix and postfixes other than `inv`

Marking [WIP] because it could do with a bit of testing with things like retiming and other odd modes to make sure there aren't any issues like duplicate names.

Also to consider: should we be copying recovered netnames onto the driving cell too with a post/prefix like `driver_` (instead of using an arbitrary name) - this would result in a nicer critical path report.