### PR TITLE
Fix all warnings that occurred when compiling with gcc9

### DIFF
--- a/backends/firrtl/firrtl.cc
+++ b/backends/firrtl/firrtl.cc
@@ -344,6 +344,7 @@ struct FirrtlWorker
 				switch (dir) {
 					case FD_INOUT:
 						log_warning("Instance port connection %s.%s is INOUT; treating as OUT\n", cell_type.c_str(), log_signal(it->second));
+						/* FALLTHRU */
 					case FD_OUT:
 						sourceExpr = firstName;
 						sinkExpr = secondExpr;
@@ -351,7 +352,7 @@ struct FirrtlWorker
 						break;
 					case FD_NODIRECTION:
 						log_warning("Instance port connection %s.%s is NODIRECTION; treating as IN\n", cell_type.c_str(), log_signal(it->second));
-						/* FALL_THROUGH */
+						/* FALLTHRU */
 					case FD_IN:
 						sourceExpr = secondExpr;
 						sinkExpr = firstName;

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -518,6 +518,7 @@ struct RTLIL::Const
 	Const(const std::vector<RTLIL::State> &bits) : bits(bits) { flags = CONST_FLAG_NONE; }
 	Const(const std::vector<bool> &bits);
 	Const(const RTLIL::Const &c);
+	RTLIL::Const &operator =(const RTLIL::Const &other) = default;
 
 	bool operator <(const RTLIL::Const &other) const;
 	bool operator ==(const RTLIL::Const &other) const;
@@ -597,6 +598,7 @@ struct RTLIL::SigChunk
 	SigChunk(RTLIL::State bit, int width = 1);
 	SigChunk(RTLIL::SigBit bit);
 	SigChunk(const RTLIL::SigChunk &sigchunk);
+	RTLIL::SigChunk &operator =(const RTLIL::SigChunk &other) = default;
 
 	RTLIL::SigChunk extract(int offset, int length) const;
 
@@ -622,6 +624,7 @@ struct RTLIL::SigBit
 	SigBit(const RTLIL::SigChunk &chunk, int index);
 	SigBit(const RTLIL::SigSpec &sig);
 	SigBit(const RTLIL::SigBit &sigbit);
+	RTLIL::SigBit &operator =(const RTLIL::SigBit &other) = default;
 
 	bool operator <(const RTLIL::SigBit &other) const;
 	bool operator ==(const RTLIL::SigBit &other) const;

--- a/libs/minisat/Vec.h
+++ b/libs/minisat/Vec.h
@@ -94,6 +94,7 @@ public:
 };
 
 
+
 template<class T, class _Size>
 void vec<T,_Size>::capacity(Size min_cap) {
     if (cap >= min_cap) return;

--- a/passes/cmds/bugpoint.cc
+++ b/passes/cmds/bugpoint.cc
@@ -298,7 +298,7 @@ struct BugpointPass : public Pass {
 		if (!check_logfile(grep))
 			log_cmd_error("The provided grep string is not found in the log file!\n");
 
-		int seed = 0, crashing_seed = seed;
+		int seed = 0;
 		bool found_something = false, stage2 = false;
 		while (true)
 		{
@@ -324,7 +324,6 @@ struct BugpointPass : public Pass {
 					if (crashing_design != design)
 						delete crashing_design;
 					crashing_design = simplified;
-					crashing_seed = seed;
 					found_something = true;
 				}
 				else

--- a/passes/techmap/flowmap.cc
+++ b/passes/techmap/flowmap.cc
@@ -397,7 +397,6 @@ struct FlowGraph
 		pool<RTLIL::SigBit> x, xi;
 
 		NodePrime source_prime = {source, true};
-		NodePrime sink_prime = {sink, false};
 		pool<NodePrime> visited;
 		vector<NodePrime> worklist = {source_prime};
 		while (!worklist.empty())
@@ -1382,7 +1381,8 @@ struct FlowmapWorker
 
 			vector<RTLIL::SigBit> input_nodes(lut_edges_bw[node].begin(), lut_edges_bw[node].end());
 			RTLIL::Const lut_table(State::Sx, max(1 << input_nodes.size(), 1 << minlut));
-			for (unsigned i = 0; i < (1 << input_nodes.size()); i++)
+			unsigned const mask = 1 << input_nodes.size();
+			for (unsigned i = 0; i < mask; i++)
 			{
 				ce.push();
 				for (size_t n = 0; n < input_nodes.size(); n++)


### PR DESCRIPTION
The most annoying warning was that the implicit copy assignment was not defined.