### PR TITLE
verilog_parser: Fix Bison warning

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -96,7 +96,7 @@ static void free_attr(std::map<std::string, AstNode*> *al)
 
 %}
 
-%name-prefix "frontend_verilog_yy"
+%define api.prefix {frontend_verilog_yy}
 
 %union {
 	std::string *string;


### PR DESCRIPTION
As of Bison 2.6, name-prefix is deprecated. This fixes
frontends/verilog/verilog_parser.y:99.1-34: warning: deprecated directive, use ‘%define api.prefix {frontend_verilog_yy}’ [-Wdeprecated]
 %name-prefix "frontend_verilog_yy"

For details: https://www.gnu.org/software/bison/manual/html_node/Multiple-Parsers.html

Compile tested only.

Signed-off-by: Ben Widawsky <ben@bwidawsk.net>