### PR TITLE
Optimize ceil_log2 function

### DIFF
--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -151,14 +151,16 @@ void yosys_banner()
 
 int ceil_log2(int x)
 {
+#if defined(__GNUC__)
+        return x > 1 ? (8*sizeof(int)) - __builtin_clz(x-1) : 0;
+#else
 	if (x <= 0)
 		return 0;
-
 	for (int i = 0; i < 32; i++)
 		if (((x-1) >> i) == 0)
 			return i;
-
 	log_abort();
+#endif
 }
 
 std::string stringf(const char *fmt, ...)

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -244,7 +244,7 @@ extern bool memhasher_active;
 inline void memhasher() { if (memhasher_active) memhasher_do(); }
 
 void yosys_banner();
-int ceil_log2(int x);
+int ceil_log2(int x) YS_ATTRIBUTE(const);
 std::string stringf(const char *fmt, ...) YS_ATTRIBUTE(format(printf, 1, 2));
 std::string vstringf(const char *fmt, va_list ap);
 int readsome(std::istream &f, char *s, int n);


### PR DESCRIPTION
Hey all,
Just was scrolling through `yosys` and this caught my eye. Do you have any thoughts on how to properly incorporate this compiler-specific function? Would really like to land this push, as it leads to a speedup for your `ceil_log2` function. 

Proof:
```
int ceil_log2(int x) {
  return (x > 0) * (32 - __builtin_clz(x-1) - (x == 1));
}

int ceil_orig_log2(int x) {
        if (x <= 0)
                return 0;
        for (int i = 0; i < 32; i++)
                if (((x-1) >> i) == 0)
                        return i;
}
```

compiles to:
```
ceil_log2(int):
  lea edx, [rdi-1]
  mov eax, 32
  bsr edx, edx
  xor edx, 31
  sub eax, edx
  xor edx, edx
  cmp edi, 1
  sete dl
  sub eax, edx
  xor edx, edx
  test edi, edi
  setg dl
  imul eax, edx
  ret
```
and
```
ceil_orig_log2(int):
        push    rbp
        mov     rbp, rsp
        mov     DWORD PTR [rbp-20], edi
        cmp     DWORD PTR [rbp-20], 0
        jg      .L4
        mov     eax, 0
        jmp     .L3
.L4:
        mov     DWORD PTR [rbp-4], 0
.L8:
        cmp     DWORD PTR [rbp-4], 31
        jg      .L6
        mov     eax, DWORD PTR [rbp-20]
        lea     edx, [rax-1]
        mov     eax, DWORD PTR [rbp-4]
        mov     ecx, eax
        sar     edx, cl
        mov     eax, edx
        test    eax, eax
        jne     .L7
        mov     eax, DWORD PTR [rbp-4]
        jmp     .L3
.L7:
        add     DWORD PTR [rbp-4], 1
        jmp     .L8
.L6:
.L3:
        pop     rbp
        ret
```