### PR TITLE
initialize more registers in setundef -init

### DIFF
--- a/passes/cmds/setundef.cc
+++ b/passes/cmds/setundef.cc
@@ -404,22 +404,29 @@ struct SetundefPass : public Pass {
 					initwires.insert(wire);
 				}
 
-				for (int wire_types = 0; wire_types < 2; wire_types++)
-					for (auto wire : module->wires())
-					{
-						if (wire->name[0] == (wire_types ? '\\' : '$'))
-					next_wire:
-							continue;
+				for (int wire_types = 0; wire_types < 2; wire_types++) {
+                                        pool<SigBit> ffbitsToErase;
+                                        for (auto wire : module->wires()) {
+                                                if (wire->name[0] == (wire_types ? '\\' : '$')) {
+                                                        next_wire:
+                                                        continue;
+                                                }
 
-						for (auto bit : sigmap(wire))
-							if (!ffbits.count(bit))
-								goto next_wire;
+                                                for (auto bit : sigmap(wire))
+                                                        if (!ffbits.count(bit)) {
+                                                                goto next_wire;
+                                                        }
 
-						for (auto bit : sigmap(wire))
-							ffbits.erase(bit);
+                                                for (auto bit : sigmap(wire)) {
+                                                        ffbitsToErase.insert(bit);
+                                                }
 
-						initwires.insert(wire);
-					}
+                                                initwires.insert(wire);
+                                        }
+                                        for (const auto &bit : ffbitsToErase) {
+                                                ffbits.erase(bit);
+                                        }
+                                }
 
 				for (auto wire : initwires)
 				{


### PR DESCRIPTION
## Steps to reproduce the issue
Currently, setundef -init misses some registers that are also assigned to something:

Running the following Verilog code:

    module register #(
    	parameter DEPTH = 10
    ) (
    	input wire clk,
    	input wire in,
    	output wire out
    );
    	reg [DEPTH-1:0] regs;
    	always @(posedge clk) regs <= { regs[DEPTH-2:0], in};
    	assign out = regs[DEPTH-1];
    endmodule

through this script:

    read_verilog register.v
    prep
    setundef -zero -init

## Expected behavior

The register `regs` should be initialized to zero (attribute init set to 0).

    attribute \src "register.v:6"
    wire output 3 \out
    attribute \init 10'0000000000
    attribute \src "register.v:8"
    wire width 10 \regs


## Actual behavior

`out` is initialized to zero.

    attribute \init 1'0
    attribute \src "register.v:6"
    wire output 3 \out
    attribute \src "register.v:8"
    wire width 10 \regs


## Fix
This PR tries to fix the issue by waiting to erase from `ffbits` until all wires have been looked at.

With this PR applied, both `regs` and `out` get the `init` attribute. I am not sure if having the attribute on `out` as well is problematic. Comments?
