### PR TITLE
Zinit option '-singleton' -> '-all'

### DIFF
--- a/passes/techmap/zinit.cc
+++ b/passes/techmap/zinit.cc
@@ -46,7 +46,7 @@ struct ZinitPass : public Pass {
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
 		{
-			if (args[argidx] == "-singleton") {
+			if (args[argidx] == "-all") {
 				all_mode = true;
 				continue;
 			}


### PR DESCRIPTION
In the help message for `zinit`, the option for setting all uninitialized FFs to zero in the initial state is called `-all`, but the code uses `-singleton`. This just updates the option handling to match the help message.