### PR TITLE
ice40/cells_sim.v: Add support for TRIM input to SB_HFOSC

### DIFF
--- a/techlibs/ice40/cells_sim.v
+++ b/techlibs/ice40/cells_sim.v
@@ -930,10 +930,21 @@ endmodule
 
 (* blackbox *)
 module SB_HFOSC(
+	input TRIM0,
+	input TRIM1,
+	input TRIM2,
+	input TRIM3,
+	input TRIM4,
+	input TRIM5,
+	input TRIM6,
+	input TRIM7,
+	input TRIM8,
+	input TRIM9,
 	input CLKHFPU,
 	input CLKHFEN,
 	output CLKHF
 );
+parameter TRIM_EN = "0b0";
 parameter CLKHF_DIV = "0b00";
 endmodule
 


### PR DESCRIPTION
Signed-off-by: Sylvain Munaut <tnt@246tNt.com>