### PR TITLE
Create $(LIBDIR) to fix broken build in isolated environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -679,13 +679,14 @@ endif
 	$(INSTALL_SUDO) mkdir -p $(DESTDIR)$(DATDIR)
 	$(INSTALL_SUDO) cp -r share/. $(DESTDIR)$(DATDIR)/.
 ifeq ($(ENABLE_LIBYOSYS),1)
-	$(INSTALL_SUDO) cp libyosys.so $(DESTDIR)$(LIBDIR)
+	$(INSTALL_SUDO) mkdir -p $(DESTDIR)$(LIBDIR)
+	$(INSTALL_SUDO) cp libyosys.so $(DESTDIR)$(LIBDIR)/
 	$(INSTALL_SUDO) $(STRIP) -S $(DESTDIR)$(LIBDIR)/libyosys.so
 	$(INSTALL_SUDO) ldconfig
 ifeq ($(ENABLE_PYOSYS),1)
 	$(INSTALL_SUDO) mkdir -p $(PYTHON_DESTDIR)/pyosys
-	$(INSTALL_SUDO) cp libyosys.so $(PYTHON_DESTDIR)/pyosys
-	$(INSTALL_SUDO) cp misc/__init__.py $(PYTHON_DESTDIR)/pyosys
+	$(INSTALL_SUDO) cp libyosys.so $(PYTHON_DESTDIR)/pyosys/
+	$(INSTALL_SUDO) cp misc/__init__.py $(PYTHON_DESTDIR)/pyosys/
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -682,7 +682,6 @@ ifeq ($(ENABLE_LIBYOSYS),1)
 	$(INSTALL_SUDO) mkdir -p $(DESTDIR)$(LIBDIR)
 	$(INSTALL_SUDO) cp libyosys.so $(DESTDIR)$(LIBDIR)/
 	$(INSTALL_SUDO) $(STRIP) -S $(DESTDIR)$(LIBDIR)/libyosys.so
-	$(INSTALL_SUDO) ldconfig
 ifeq ($(ENABLE_PYOSYS),1)
 	$(INSTALL_SUDO) mkdir -p $(PYTHON_DESTDIR)/pyosys
 	$(INSTALL_SUDO) cp libyosys.so $(PYTHON_DESTDIR)/pyosys/

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ PYTHON_VERSION_TESTCODE := "import sys;t='{v[0]}.{v[1]}'.format(v=list(sys.versi
 PYTHON_EXECUTABLE := $(shell if python3 -c ""; then echo "python3"; else echo "python"; fi)
 PYTHON_VERSION := $(shell $(PYTHON_EXECUTABLE) -c ""$(PYTHON_VERSION_TESTCODE)"")
 PYTHON_MAJOR_VERSION := $(shell echo $(PYTHON_VERSION) | cut -f1 -d.)
-PYTHON_DESTDIR := `$(PYTHON_EXECUTABLE)-config --prefix`/lib/python$(PYTHON_VERSION)/dist-packages
+PYTHON_PREFIX := `$(PYTHON_EXECUTABLE)-config --prefix`
+PYTHON_DESTDIR := $(PYTHON_PREFIX)/lib/python$(PYTHON_VERSION)/site-packages
 
 # other configuration flags
 ENABLE_GCOV := 0


### PR DESCRIPTION
While building yosys with libyosys+pyosys enabled in an isolated build environment (for distribution packaging), the install step fails at various places. I propose some fixes in this PR:

1. Installation fails at `strip libyosys.so`. This is caused by this copy line:

```
$(INSTALL_SUDO) cp libyosys.so $(DESTDIR)$(LIBDIR)
```

While on a regular system, this folder will exist (and `cp` will copy the file into it), in an isolated environment it might not. This makes libyosys.so end up as a file called 'lib' in $(DESTDIR)/$(PREFIX), and then the 'strip' command fails.
This PR explicitly creates the directory before copying, and also appends slashes to related copy-calls, making already the copy-step fail if the directory does not exist.

2. After fixing the first issue, calling `ldconfig` without sudo (as installation happens to an isolated area) will fail, and as I'm not so sure it's a good idea to have it in the Makefile I removed this call as well. I agree it should be called, but either it has to be done manually or the Makefile would need to check if INSTALL_SUDO is actually sudo...

3. The way of installing the python package is not compatible with this approach as well:
- PREFIX is completely ignored for the Python stuff, instead it uses python-config --prefix
- It installs to `dist-packages`, which is Debian specific and also only supposed to be used for packages installed with the distribution.

 The canonical solution to these problems would be to make a proper Python package and then use setuptools to install them at the right location. I at least factored out PYTHON_PREFIX so build scripts can override this part, and used `site-packages` instead of `dist-packages`.

Let me know if you're unhappy with any of these changes, I'd be happy to work on that.