### PR TITLE
Make the generated *.tab.hh include all the headers needed

### DIFF
--- a/frontends/ilang/ilang_parser.y
+++ b/frontends/ilang/ilang_parser.y
@@ -47,6 +47,15 @@ USING_YOSYS_NAMESPACE
 
 %define api.prefix {rtlil_frontend_ilang_yy}
 
+/* The union is defined in the header, so we need to provide all the
+ * includes it requires
+ */
+%code requires {
+#include <string>
+#include <vector>
+#include "frontends/ilang/ilang_frontend.h"
+}
+
 %union {
 	char *string;
 	int integer;
@@ -451,4 +460,3 @@ conn_stmt:
 		delete $2;
 		delete $3;
 	};
-

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -112,6 +112,15 @@ struct specify_rise_fall {
 
 %define api.prefix {frontend_verilog_yy}
 
+/* The union is defined in the header, so we need to provide all the
+ * includes it requires
+ */
+%code requires {
+#include <map>
+#include <string>
+#include "frontends/verilog/verilog_frontend.h"
+}
+
 %union {
 	std::string *string;
 	struct YOSYS_NAMESPACE_PREFIX AST::AstNode *ast;
@@ -2418,4 +2427,3 @@ concat_list:
 		$$ = $3;
 		$$->children.push_back($1);
 	};
-


### PR DESCRIPTION
Cleanup.

The %union refers to types such as string or vector as well as e.g. Ast; the generated *.tab.hh did not include the needed includes for that; the code happened to compile because the *.tab.hh were always included after the other headers.

This makes sure that the generated headers contain the necessary includes, so that the declared union refers to known types.