### PR TITLE
Fix two instances of integer-assignment to string.

### DIFF
--- a/passes/cmds/cover.cc
+++ b/passes/cmds/cover.cc
@@ -105,7 +105,8 @@ struct CoverPass : public Pass {
 			#else
 					char filename_buffer[4096];
 					snprintf(filename_buffer, 4096, "%s/yosys_cover_%d_XXXXXX.txt", filename.c_str(), getpid());
-					filename = mkstemps(filename_buffer, 4);
+					mkstemps(filename_buffer, 4);
+					filename = filename_buffer;
 			#endif
 				}
 				FILE *f = fopen(filename.c_str(), open_mode);

--- a/passes/techmap/libparse.cc
+++ b/passes/techmap/libparse.cc
@@ -94,7 +94,7 @@ int LibertyParser::lexer(std::string &str)
 
 	// search for identifiers, numbers, plus or minus.
 	if (('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') || c == '_' || c == '-' || c == '+' || c == '.') {
-		str = c;
+		str = static_cast<char>(c);
 		while (1) {
 			c = f.get();
 			if (('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') || c == '_' || c == '-' || c == '+' || c == '.')


### PR DESCRIPTION
o In cover.cc, the int-result of mkstemps() was assigned to a string
  and silently interpreted as a single-character filename with a funny
  value. Fix with the intent: assign the filename.
o in libparse.cc, an int was assigned to a string, but depending on
  visible constructors, this is ambiguous. Explicitly cast this to
  a char.