### PR TITLE
Support for attributes on parameters and localparams for Verilog frontend

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -1193,7 +1193,7 @@ param_range:
 	};
 
 param_decl:
-	TOK_PARAMETER {
+	attr TOK_PARAMETER {
 		astbuf1 = new AstNode(AST_PARAMETER);
 		astbuf1->children.push_back(AstNode::mkconst_int(0, true));
 	} param_signed param_integer param_real param_range param_decl_list ';' {
@@ -1201,7 +1201,7 @@ param_decl:
 	};
 
 localparam_decl:
-	TOK_LOCALPARAM {
+	attr TOK_LOCALPARAM {
 		astbuf1 = new AstNode(AST_LOCALPARAM);
 		astbuf1->children.push_back(AstNode::mkconst_int(0, true));
 	} param_signed param_integer param_real param_range param_decl_list ';' {

--- a/tests/simple/localparam_attr.v
+++ b/tests/simple/localparam_attr.v
@@ -1,0 +1,11 @@
+module uut_localparam_attr (I, O);
+
+(* LOCALPARAM_ATTRIBUTE = "attribute_content" *)
+localparam WIDTH = 1;
+
+input  wire [WIDTH-1:0] I;
+output wire [WIDTH-1:0] O;
+
+assign O = I;
+
+endmodule

--- a/tests/simple/param_attr.v
+++ b/tests/simple/param_attr.v
@@ -1,0 +1,11 @@
+module uut_param_attr (I, O);
+
+(* PARAMETER_ATTRIBUTE = "attribute_content" *)
+parameter WIDTH = 1;
+
+input  wire [WIDTH-1:0] I;
+output wire [WIDTH-1:0] O;
+
+assign O = I;
+
+endmodule


### PR DESCRIPTION
This PR adds to the Verilog frontend support for attributes on the "parameter" and "localparam" statements.  Attributes are just accepted by the parser and their content is ignored. There are also tests added regarding this functionality (under `tests/simple`)

Fixes #1009