### PR TITLE
Read bigger Verilog files.

### DIFF
--- a/frontends/verilog/Makefile.inc
+++ b/frontends/verilog/Makefile.inc
@@ -14,7 +14,7 @@ frontends/verilog/verilog_lexer.cc: frontends/verilog/verilog_lexer.l
 	$(Q) mkdir -p $(dir $@)
 	$(P) flex -o frontends/verilog/verilog_lexer.cc $<
 
-frontends/verilog/verilog_parser.tab.o: CXXFLAGS += -DYYMAXDEPTH=100000
+frontends/verilog/verilog_parser.tab.o: CXXFLAGS += -DYYMAXDEPTH=10000000
 
 OBJS += frontends/verilog/verilog_parser.tab.o
 OBJS += frontends/verilog/verilog_lexer.o


### PR DESCRIPTION
Hit parser limit with 3M gate design. This commit fix it.