### PR TITLE
 Keep zero-width wires in opt_clean if and only if they are ports

### DIFF
--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -230,6 +230,9 @@ static void logv_warning_with_prefix(const char *prefix,
 	}
 	else
 	{
+		int bak_log_make_debug = log_make_debug;
+		log_make_debug = 0;
+
 		for (auto &re : log_werror_regexes)
 			if (std::regex_search(message, re))
 				log_error("%s",  message.c_str());
@@ -254,6 +257,7 @@ static void logv_warning_with_prefix(const char *prefix,
 		}
 
 		log_warnings_count++;
+		log_make_debug = bak_log_make_debug;
 	}
 }
 
@@ -285,6 +289,9 @@ static void logv_error_with_prefix(const char *prefix,
 #ifdef EMSCRIPTEN
 	auto backup_log_files = log_files;
 #endif
+	int bak_log_make_debug = log_make_debug;
+	log_make_debug = 0;
+	log_suppressed();
 
 	if (log_errfile != NULL)
 		log_files.push_back(log_errfile);
@@ -297,6 +304,8 @@ static void logv_error_with_prefix(const char *prefix,
 	log_last_error = vstringf(format, ap);
 	log("%s%s", prefix, log_last_error.c_str());
 	log_flush();
+
+	log_make_debug = bak_log_make_debug;
 
 	if (log_error_atexit)
 		log_error_atexit();

--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -319,8 +319,9 @@ bool rmunused_module_signals(RTLIL::Module *module, bool purge_mode, bool verbos
 			wire->attributes.erase("\\init");
 
 		if (GetSize(wire) == 0) {
-			// delete zero-width wires
-			goto delete_this_wire;
+			// delete zero-width wires, unless they are module ports
+			if (wire->port_id == 0)
+				goto delete_this_wire;
 		} else
 		if (wire->port_id != 0 || wire->get_bool_attribute("\\keep") || !initval.is_fully_undef()) {
 			// do not delete anything with "keep" or module ports or initialized wires


### PR DESCRIPTION
Also fixes the log_error issue described in #1023.

Replaces #1025. I think we should only keep zero-width wires when they are module ports. (In those cases removing the port would have unwanted consequences, such as breaking positional arguments. The other option would be to call `Module::fixup_ports()` at the end of `opt_clean`, if we really wanted to remove those ports. I see no reason to keep a zero-width wire that isn't a port, even when it has the `keep` attribute set.)