### PR TITLE
fix python prefix in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ PYTHON_VERSION_TESTCODE := "import sys;t='{v[0]}.{v[1]}'.format(v=list(sys.versi
 PYTHON_EXECUTABLE := $(shell if python3 -c ""; then echo "python3"; else echo "python"; fi)
 PYTHON_VERSION := $(shell $(PYTHON_EXECUTABLE) -c ""$(PYTHON_VERSION_TESTCODE)"")
 PYTHON_MAJOR_VERSION := $(shell echo $(PYTHON_VERSION) | cut -f1 -d.)
-PYTHON_PREFIX := `$(PYTHON_EXECUTABLE)-config --prefix`
+PYTHON_PREFIX := $(shell $(PYTHON_EXECUTABLE)-config --prefix)
 PYTHON_DESTDIR := $(PYTHON_PREFIX)/lib/python$(PYTHON_VERSION)/site-packages
 
 # other configuration flags


### PR DESCRIPTION
I tried to recreate the passes described in the pyosys paper [0] and saw that it was not copying properly into my python installation when executing `sudo make install` because the command in backticks did not evaluate. It might be related to my build environment (ubuntu 19.04 and ubuntu in windows subsystem for linux) but I think the proper way in GNU Make is without backticks and `$(shell ..)` instead.

```
distro: ubuntu 19.04 Linux ubuntu-disco 5.0.0-15-generic #16-Ubuntu SMP Mon May 6 17:41:33 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
make: GNU Make 4.2.1
term: xterm-256color
shell: /bin/bash
```

also I noticed that the default location for the python module will be `/usr/lib/python3/site-packages` but on ubuntu I get the following output:

```
vagrant@ubuntu-disco:~/yosys$ python3 -c "import sys;[print(p) for p in sys.path]"

/usr/lib/python37.zip
/usr/lib/python3.7
/usr/lib/python3.7/lib-dynload
/usr/local/lib/python3.7/dist-packages
/usr/lib/python3/dist-packages
```

I read that this is due to ubuntu defaults but since it is such a popular distro it might be beneficial to include an additional check into the makefile which will put the python module into the `dist-packages` on ubuntu. If you think this is useful, I can extend this PR or create a new one.

Another remark: Listing 4 Line 5 in the paper [0] should read like this:
```
--- ys.design = Design
+++ design = ys.Design
```
[0] https://osda.gitlab.io/19/3.3.pdf

EDIT: I just found the file `yosys/examples/python-api/script.py` and saw that the typo is fixed there :) so please disregard my comment about that