### PR TITLE
opt_rmdff to work on $dffe and $_DFFE_*

### DIFF
--- a/passes/opt/opt_rmdff.cc
+++ b/passes/opt/opt_rmdff.cc
@@ -342,8 +342,8 @@ bool handle_dff(RTLIL::Module *mod, RTLIL::Cell *dff)
 		if (!sig_e.is_fully_const())
 			return false;
 		if (sig_e != val_ep) {
-            if (has_init)
-                mod->connect(sig_q, val_init);
+			if (has_init)
+				mod->connect(sig_q, val_init);
 			goto delete_dff;
 		}
 	}

--- a/passes/opt/opt_rmdff.cc
+++ b/passes/opt/opt_rmdff.cc
@@ -342,8 +342,7 @@ bool handle_dff(RTLIL::Module *mod, RTLIL::Cell *dff)
 		if (!sig_e.is_fully_const())
 			return false;
 		if (sig_e != val_ep) {
-			if (has_init)
-				mod->connect(sig_q, val_init);
+			mod->connect(sig_q, val_init);
 			goto delete_dff;
 		}
 	}

--- a/passes/opt/opt_rmdff.cc
+++ b/passes/opt/opt_rmdff.cc
@@ -385,9 +385,7 @@ bool handle_dff(RTLIL::Module *mod, RTLIL::Cell *dff)
 	//                            (ii) reset value is same as constant D
 	//                        and (a) has no initial value
 	//                            (b) initial value same as constant D
-	//                        and (1) has no enable signal
-	//                            (2) enable is always active
-	if (sig_d.is_fully_const() && (!sig_r.size() || val_rv == sig_d.as_const()) && (!has_init || val_init == sig_d.as_const()) && (!sig_e.size() || (sig_d.is_fully_undef() && !has_init))) {
+	if (sig_d.is_fully_const() && (!sig_r.size() || val_rv == sig_d.as_const()) && (!has_init || val_init == sig_d.as_const())) {
 		// Q is permanently D
 		mod->connect(sig_q, sig_d);
 		goto delete_dff;

--- a/passes/opt/opt_rmdff.cc
+++ b/passes/opt/opt_rmdff.cc
@@ -260,8 +260,8 @@ delete_dlatch:
 
 bool handle_dff(RTLIL::Module *mod, RTLIL::Cell *dff)
 {
-	RTLIL::SigSpec sig_d, sig_q, sig_c, sig_r;
-	RTLIL::Const val_cp, val_rp, val_rv;
+	RTLIL::SigSpec sig_d, sig_q, sig_c, sig_r, sig_e;
+	RTLIL::Const val_cp, val_rp, val_rv, val_ep;
 
 	if (dff->type == "$_FF_") {
 		sig_d = dff->getPort("\\D");
@@ -285,6 +285,16 @@ bool handle_dff(RTLIL::Module *mod, RTLIL::Cell *dff)
 		val_rp = RTLIL::Const(dff->type[7] == 'P', 1);
 		val_rv = RTLIL::Const(dff->type[8] == '1', 1);
 	}
+	else if (dff->type.substr(0,7) == "$_DFFE_" && dff->type.substr(9) == "_" &&
+			(dff->type[7] == 'N' || dff->type[7] == 'P') &&
+			(dff->type[8] == 'N' || dff->type[8] == 'P')) {
+		sig_d = dff->getPort("\\D");
+		sig_q = dff->getPort("\\Q");
+		sig_c = dff->getPort("\\C");
+		sig_e = dff->getPort("\\E");
+		val_cp = RTLIL::Const(dff->type[6] == 'P', 1);
+		val_ep = RTLIL::Const(dff->type[7] == 'P', 1);
+	}
 	else if (dff->type == "$ff") {
 		sig_d = dff->getPort("\\D");
 		sig_q = dff->getPort("\\Q");
@@ -294,6 +304,14 @@ bool handle_dff(RTLIL::Module *mod, RTLIL::Cell *dff)
 		sig_q = dff->getPort("\\Q");
 		sig_c = dff->getPort("\\CLK");
 		val_cp = RTLIL::Const(dff->parameters["\\CLK_POLARITY"].as_bool(), 1);
+	}
+	else if (dff->type == "$dffe") {
+		sig_e = dff->getPort("\\EN");
+		sig_d = dff->getPort("\\D");
+		sig_q = dff->getPort("\\Q");
+		sig_c = dff->getPort("\\CLK");
+		val_cp = RTLIL::Const(dff->parameters["\\CLK_POLARITY"].as_bool(), 1);
+		val_ep = RTLIL::Const(dff->parameters["\\EN_POLARITY"].as_bool(), 1);
 	}
 	else if (dff->type == "$adff") {
 		sig_d = dff->getPort("\\D");
@@ -318,6 +336,16 @@ bool handle_dff(RTLIL::Module *mod, RTLIL::Cell *dff)
 		if (bit.wire == NULL || keepdc)
 			has_init = true;
 		val_init.bits.push_back(bit.wire == NULL ? bit.data : RTLIL::State::Sx);
+	}
+
+	if (sig_e.size()) {
+		if (!sig_e.is_fully_const())
+			return false;
+		if (sig_e != val_ep) {
+            if (has_init)
+                mod->connect(sig_q, val_init);
+			goto delete_dff;
+		}
 	}
 
 	if (dff->type.in("$ff", "$dff") && mux_drivers.has(sig_d)) {
@@ -489,7 +517,8 @@ struct OptRmdffPass : public Pass {
 				if (cell->type.in("$_FF_", "$_DFF_N_", "$_DFF_P_",
 						"$_DFF_NN0_", "$_DFF_NN1_", "$_DFF_NP0_", "$_DFF_NP1_",
 						"$_DFF_PN0_", "$_DFF_PN1_", "$_DFF_PP0_", "$_DFF_PP1_",
-						"$ff", "$dff", "$adff"))
+						"$_DFFE_NN_", "$_DFFE_NP_", "$_DFFE_PN_", "$_DFFE_PP_",
+						"$ff", "$dff", "$dffe", "$adff"))
 					dff_list.push_back(cell->name);
 
 				if (cell->type.in("$dlatch", "$_DLATCH_P_", "$_DLATCH_N_"))

--- a/tests/various/opt_rmdff.v
+++ b/tests/various/opt_rmdff.v
@@ -1,50 +1,50 @@
-module opt_rmdff_test (input C, input D, input E, output reg [29:0] Q);
+module opt_rmdff_test (input C, input D, input E, output [29:0] Q);
 \$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove0 (.CLK(C), .D(D), .EN(1'b0), .Q(Q[0])); // EN is never active
-initial Q[1] = 1'b1;
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove1 (.CLK(C), .D(D), .EN(1'b0), .Q(Q[1])); // EN is never active
+(* init = "1'b1" *) wire Q1; assign Q[1] = Q1;
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove1 (.CLK(C), .D(D), .EN(1'b0), .Q(Q1)); // EN is never active
 \$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove2 (.CLK(C), .D(D), .EN(1'bx), .Q(Q[2])); // EN is don't care
 \$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) keep3 (.CLK(C), .D(D), .EN(1'b1), .Q(Q[3])); // EN is always active
-initial Q[3] = 1'b0;
-\$dffe #(.WIDTH(1), .CLK_POLARITY(0), .EN_POLARITY(1)) keep4 (.CLK(C), .D(D), .EN(1'b1), .Q(Q[4])); // EN is always active
+(* init = "1'b0" *) wire Q4; assign Q[4] = Q4;
+\$dffe #(.WIDTH(1), .CLK_POLARITY(0), .EN_POLARITY(1)) keep4 (.CLK(C), .D(D), .EN(1'b1), .Q(Q4)); // EN is always active
 \$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove5 (.CLK(C), .D(D), .EN(1'b1), .Q(Q[5])); // EN is never active
 \$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove6 (.CLK(C), .D(D), .EN(1'bx), .Q(Q[6])); // EN is don't care
-initial Q[6] = 1'b0;
-\$dffe #(.WIDTH(1), .CLK_POLARITY(0), .EN_POLARITY(0)) keep7 (.CLK(C), .D(D), .EN(E), .Q(Q[7])); // EN is non constant
+(* init = "1'b0" *) wire Q7; assign Q[7] = Q7;
+\$dffe #(.WIDTH(1), .CLK_POLARITY(0), .EN_POLARITY(0)) keep7 (.CLK(C), .D(D), .EN(E), .Q(Q7)); // EN is non constant
 
 \$_DFFE_PP_ remove8 (.C(C), .D(D), .E(1'b0), .Q(Q[8])); // EN is never active
-initial Q[9] = 1'b1;
-\$_DFFE_PP_ remove9 (.C(C), .D(D), .E(1'b0), .Q(Q[9])); // EN is never active
+(* init = "1'b1" *) wire Q9; assign Q[9] = Q9;
+\$_DFFE_PP_ remove9 (.C(C), .D(D), .E(1'b0), .Q(Q9)); // EN is never active
 \$_DFFE_PP_ remove10 (.C(C), .D(D), .E(1'bx), .Q(Q[10])); // EN is don't care
 \$_DFFE_PP_ keep11 (.C(C), .D(D), .E(1'b1), .Q(Q[11])); // EN is always active
-initial Q[12] = 1'b0;
-\$_DFFE_PP_ keep12 (.C(C), .D(D), .E(1'b1), .Q(Q[12])); // EN is always active
+(* init = "1'b0" *) wire Q12; assign Q[12] = Q12;
+\$_DFFE_PP_ keep12 (.C(C), .D(D), .E(1'b1), .Q(Q12)); // EN is always active
 
 \$_DFFE_NN_ remove13 (.C(C), .D(D), .E(1'b1), .Q(Q[13])); // EN is never active
-initial Q[14] = 1'b1;
-\$_DFFE_NN_ remove14 (.C(C), .D(D), .E(1'b1), .Q(Q[14])); // EN is never active
+(* init = "1'b1" *) wire Q14; assign Q[14] = Q14;
+\$_DFFE_NN_ remove14 (.C(C), .D(D), .E(1'b1), .Q(Q14)); // EN is never active
 \$_DFFE_NN_ remove15 (.C(C), .D(D), .E(1'bx), .Q(Q[15])); // EN is don't care
 \$_DFFE_NN_ keep16 (.C(C), .D(D), .E(1'b0), .Q(Q[16])); // EN is always active
-initial Q[17] = 1'b0;
-\$_DFFE_NN_ keep17 (.C(C), .D(D), .E(1'b0), .Q(Q[17])); // EN is always active
+(* init = "1'b0" *) wire Q17; assign Q[17] = Q17;
+\$_DFFE_NN_ keep17 (.C(C), .D(D), .E(1'b0), .Q(Q17)); // EN is always active
 
 \$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove18 (.CLK(1'b0), .D(D), .EN(E), .Q(Q[18])); // CLK is constant
-initial Q[19] = 1'b1;
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove19 (.CLK(1'b1), .D(D), .EN(E), .Q(Q[19])); // CLK is constant
+(* init = "1'b1" *) wire Q19; assign Q[19] = Q19;
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove19 (.CLK(1'b1), .D(D), .EN(E), .Q(Q19)); // CLK is constant
 \$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove20 (.CLK(C), .D(1'bx), .EN(E), .Q(Q[20])); // D is undriven, Q has no initial value
-initial Q[21] = 1'b0;
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) keep21 (.CLK(C), .D(1'bx), .EN(E), .Q(Q[21])); // D is undriven, Q has initial value
+(* init = "1'b0" *) wire Q21; assign Q[21] = Q21;
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) keep21 (.CLK(C), .D(1'bx), .EN(E), .Q(Q21)); // D is undriven, Q has initial value
 //\$dffe #(.WIDTH(1), .CLK_POLARITY(0), .EN_POLARITY(1)) remove22 (.CLK(C), .D(1'b0), .EN(1'b1), .Q(Q[22])); // D is constant, no initial Q value, EN is always active
 //                                                                                                           // (TODO, Q starts with 1'bx and becomes 1'b0)
-initial Q[23] = 1'b0;
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) noenable23 (.CLK(C), .D(1'b0), .EN(1'b1), .Q(Q[23])); // D is constant, initial Q value same as D, EN is always active
-initial Q[24] = 1'b1;
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) keep24 (.CLK(C), .D(1'b0), .EN(1'b0), .Q(Q[24])); // D is constant, initial Q value NOT same as D, EN is always active
-initial Q[25] = 1'b1;
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove25 (.CLK(C), .D(1'b0), .EN(1'b1), .Q(Q[25])); // D is constant, EN is never active
+(* init = "1'b0" *) wire Q23; assign Q[23] = Q23;
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) noenable23 (.CLK(C), .D(1'b0), .EN(1'b1), .Q(Q23)); // D is constant, initial Q value same as D, EN is always active
+(* init = "1'b1" *) wire Q24; assign Q[24] = Q24;
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) keep24 (.CLK(C), .D(1'b0), .EN(1'b0), .Q(Q24)); // D is constant, initial Q value NOT same as D, EN is always active
+(* init = "1'b1" *) wire Q25; assign Q[25] = Q25;
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove25 (.CLK(C), .D(1'b0), .EN(1'b1), .Q(Q25)); // D is constant, EN is never active
 \$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove26 (.CLK(C), .D(Q[26]), .EN(1'b1), .Q(Q[26])); // D is Q, EN is always active
 \$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove27 (.CLK(C), .D(Q[27]), .EN(1'b1), .Q(Q[27])); // D is Q, EN is never active, but no initial value
 \$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove28 (.CLK(C), .D(Q[28]), .EN(E), .Q(Q[28])); // EN is nonconst, but no initial value
-initial Q[29] = 1'b1;
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) keep29 (.CLK(C), .D(Q[29]), .EN(1'b1), .Q(Q[29])); // EN is always active, but with initial value
+(* init = "1'b1" *) wire Q29; assign Q[29] = Q29;
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) keep29 (.CLK(C), .D(Q[29]), .EN(1'b1), .Q(Q29)); // EN is always active, but with initial value
 
 endmodule

--- a/tests/various/opt_rmdff.v
+++ b/tests/various/opt_rmdff.v
@@ -3,28 +3,28 @@ module opt_rmdff_test (input C, input D, input E, output reg [16:0] Q);
 initial Q[1] = 1'b1;
 \$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove1 (.CLK(C), .D(D), .EN(1'b0), .Q(Q[1]));
 \$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove2 (.CLK(C), .D(D), .EN(1'bx), .Q(Q[2]));
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) keep2 (.CLK(C), .D(D), .EN(1'b1), .Q(Q[2]));
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) keep3 (.CLK(C), .D(D), .EN(1'b1), .Q(Q[3]));
 initial Q[3] = 1'b0;
-\$dffe #(.WIDTH(1), .CLK_POLARITY(0), .EN_POLARITY(1)) keep3 (.CLK(C), .D(D), .EN(1'b1), .Q(Q[3]));
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove4 (.CLK(C), .D(D), .EN(1'b1), .Q(Q[4]));
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove5 (.CLK(C), .D(D), .EN(1'bx), .Q(Q[5]));
+\$dffe #(.WIDTH(1), .CLK_POLARITY(0), .EN_POLARITY(1)) keep4 (.CLK(C), .D(D), .EN(1'b1), .Q(Q[4]));
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove5 (.CLK(C), .D(D), .EN(1'b1), .Q(Q[5]));
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove6 (.CLK(C), .D(D), .EN(1'bx), .Q(Q[6]));
 initial Q[6] = 1'b0;
-\$dffe #(.WIDTH(1), .CLK_POLARITY(0), .EN_POLARITY(0)) keep6 (.CLK(C), .D(D), .EN(E), .Q(Q[6]));
+\$dffe #(.WIDTH(1), .CLK_POLARITY(0), .EN_POLARITY(0)) keep7 (.CLK(C), .D(D), .EN(E), .Q(Q[7]));
 
-\$_DFFE_PP_ remove7 (.C(C), .D(D), .E(1'b0), .Q(Q[7]));
-initial Q[8] = 1'b1;
 \$_DFFE_PP_ remove8 (.C(C), .D(D), .E(1'b0), .Q(Q[8]));
-\$_DFFE_PP_ remove9 (.C(C), .D(D), .E(1'bx), .Q(Q[9]));
-\$_DFFE_PP_ keep10 (.C(C), .D(D), .E(1'b1), .Q(Q[10]));
-initial Q[11] = 1'b0;
+initial Q[8] = 1'b1;
+\$_DFFE_PP_ remove9 (.C(C), .D(D), .E(1'b0), .Q(Q[9]));
+\$_DFFE_PP_ remove10 (.C(C), .D(D), .E(1'bx), .Q(Q[10]));
 \$_DFFE_PP_ keep11 (.C(C), .D(D), .E(1'b1), .Q(Q[11]));
+initial Q[12] = 1'b0;
+\$_DFFE_PP_ keep12 (.C(C), .D(D), .E(1'b1), .Q(Q[12]));
 
-\$_DFFE_NN_ remove12 (.C(C), .D(D), .E(1'b1), .Q(Q[12]));
-initial Q[13] = 1'b1;
 \$_DFFE_NN_ remove13 (.C(C), .D(D), .E(1'b1), .Q(Q[13]));
-\$_DFFE_NN_ remove14 (.C(C), .D(D), .E(1'bx), .Q(Q[14]));
-\$_DFFE_NN_ keep15 (.C(C), .D(D), .E(1'b0), .Q(Q[15]));
-initial Q[16] = 1'b0;
+initial Q[14] = 1'b1;
+\$_DFFE_NN_ remove14 (.C(C), .D(D), .E(1'b1), .Q(Q[14]));
+\$_DFFE_NN_ remove15 (.C(C), .D(D), .E(1'bx), .Q(Q[15]));
 \$_DFFE_NN_ keep16 (.C(C), .D(D), .E(1'b0), .Q(Q[16]));
+initial Q[17] = 1'b0;
+\$_DFFE_NN_ keep17 (.C(C), .D(D), .E(1'b0), .Q(Q[17]));
 
 endmodule

--- a/tests/various/opt_rmdff.v
+++ b/tests/various/opt_rmdff.v
@@ -1,0 +1,30 @@
+module opt_rmdff_test (input C, input D, input E, output reg [16:0] Q);
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove0 (.CLK(C), .D(D), .EN(1'b0), .Q(Q[0]));
+initial Q[1] = 1'b1;
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove1 (.CLK(C), .D(D), .EN(1'b0), .Q(Q[1]));
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove2 (.CLK(C), .D(D), .EN(1'bx), .Q(Q[2]));
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) keep2 (.CLK(C), .D(D), .EN(1'b1), .Q(Q[2]));
+initial Q[3] = 1'b0;
+\$dffe #(.WIDTH(1), .CLK_POLARITY(0), .EN_POLARITY(1)) keep3 (.CLK(C), .D(D), .EN(1'b1), .Q(Q[3]));
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove4 (.CLK(C), .D(D), .EN(1'b1), .Q(Q[4]));
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove5 (.CLK(C), .D(D), .EN(1'bx), .Q(Q[5]));
+initial Q[6] = 1'b0;
+\$dffe #(.WIDTH(1), .CLK_POLARITY(0), .EN_POLARITY(0)) keep6 (.CLK(C), .D(D), .EN(E), .Q(Q[6]));
+
+\$_DFFE_PP_ remove7 (.C(C), .D(D), .E(1'b0), .Q(Q[7]));
+initial Q[8] = 1'b1;
+\$_DFFE_PP_ remove8 (.C(C), .D(D), .E(1'b0), .Q(Q[8]));
+\$_DFFE_PP_ remove9 (.C(C), .D(D), .E(1'bx), .Q(Q[9]));
+\$_DFFE_PP_ keep10 (.C(C), .D(D), .E(1'b1), .Q(Q[10]));
+initial Q[11] = 1'b0;
+\$_DFFE_PP_ keep11 (.C(C), .D(D), .E(1'b1), .Q(Q[11]));
+
+\$_DFFE_NN_ remove12 (.C(C), .D(D), .E(1'b1), .Q(Q[12]));
+initial Q[13] = 1'b1;
+\$_DFFE_NN_ remove13 (.C(C), .D(D), .E(1'b1), .Q(Q[13]));
+\$_DFFE_NN_ remove14 (.C(C), .D(D), .E(1'bx), .Q(Q[14]));
+\$_DFFE_NN_ keep15 (.C(C), .D(D), .E(1'b0), .Q(Q[15]));
+initial Q[16] = 1'b0;
+\$_DFFE_NN_ keep16 (.C(C), .D(D), .E(1'b0), .Q(Q[16]));
+
+endmodule

--- a/tests/various/opt_rmdff.v
+++ b/tests/various/opt_rmdff.v
@@ -1,5 +1,5 @@
 module opt_rmdff_test (input C, input D, input E, output reg [29:0] Q);
-//\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove0 (.CLK(C), .D(D), .EN(1'b0), .Q(Q[0])); // EN is never active
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove0 (.CLK(C), .D(D), .EN(1'b0), .Q(Q[0])); // EN is never active
 initial Q[1] = 1'b1;
 \$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove1 (.CLK(C), .D(D), .EN(1'b0), .Q(Q[1])); // EN is never active
 \$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove2 (.CLK(C), .D(D), .EN(1'bx), .Q(Q[2])); // EN is don't care
@@ -27,12 +27,12 @@ initial Q[14] = 1'b1;
 initial Q[17] = 1'b0;
 \$_DFFE_NN_ keep17 (.C(C), .D(D), .E(1'b0), .Q(Q[17])); // EN is always active
 
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove18 (.CLK(1'b0), .D(D), .EN(EN), .Q(Q[18])); // CLK is constant
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove18 (.CLK(1'b0), .D(D), .EN(E), .Q(Q[18])); // CLK is constant
 initial Q[19] = 1'b1;
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove19 (.CLK(1'b1), .D(D), .EN(EN), .Q(Q[19])); // CLK is constant
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove20 (.CLK(C), .D(1'bx), .EN(EN), .Q(Q[20])); // D is undriven, Q has no initial value
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove19 (.CLK(1'b1), .D(D), .EN(E), .Q(Q[19])); // CLK is constant
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove20 (.CLK(C), .D(1'bx), .EN(E), .Q(Q[20])); // D is undriven, Q has no initial value
 initial Q[21] = 1'b0;
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) keep21 (.CLK(C), .D(1'bx), .EN(EN), .Q(Q[21])); // D is undriven, Q has initial value
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) keep21 (.CLK(C), .D(1'bx), .EN(E), .Q(Q[21])); // D is undriven, Q has initial value
 //\$dffe #(.WIDTH(1), .CLK_POLARITY(0), .EN_POLARITY(1)) remove22 (.CLK(C), .D(1'b0), .EN(1'b1), .Q(Q[22])); // D is constant, no initial Q value, EN is always active
 //                                                                                                           // (TODO, Q starts with 1'bx and becomes 1'b0)
 initial Q[23] = 1'b0;
@@ -43,7 +43,7 @@ initial Q[25] = 1'b1;
 \$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove25 (.CLK(C), .D(1'b0), .EN(1'b1), .Q(Q[25])); // D is constant, EN is never active
 \$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove26 (.CLK(C), .D(Q[26]), .EN(1'b1), .Q(Q[26])); // D is Q, EN is always active
 \$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove27 (.CLK(C), .D(Q[27]), .EN(1'b1), .Q(Q[27])); // D is Q, EN is never active, but no initial value
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove28 (.CLK(C), .D(Q[28]), .EN(EN), .Q(Q[28])); // EN is nonconst, but no initial value
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove28 (.CLK(C), .D(Q[28]), .EN(E), .Q(Q[28])); // EN is nonconst, but no initial value
 initial Q[29] = 1'b1;
 \$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) keep29 (.CLK(C), .D(Q[29]), .EN(1'b1), .Q(Q[29])); // EN is always active, but with initial value
 

--- a/tests/various/opt_rmdff.v
+++ b/tests/various/opt_rmdff.v
@@ -1,30 +1,50 @@
-module opt_rmdff_test (input C, input D, input E, output reg [16:0] Q);
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove0 (.CLK(C), .D(D), .EN(1'b0), .Q(Q[0]));
+module opt_rmdff_test (input C, input D, input E, output reg [29:0] Q);
+//\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove0 (.CLK(C), .D(D), .EN(1'b0), .Q(Q[0])); // EN is never active
 initial Q[1] = 1'b1;
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove1 (.CLK(C), .D(D), .EN(1'b0), .Q(Q[1]));
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove2 (.CLK(C), .D(D), .EN(1'bx), .Q(Q[2]));
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) keep3 (.CLK(C), .D(D), .EN(1'b1), .Q(Q[3]));
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove1 (.CLK(C), .D(D), .EN(1'b0), .Q(Q[1])); // EN is never active
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove2 (.CLK(C), .D(D), .EN(1'bx), .Q(Q[2])); // EN is don't care
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) keep3 (.CLK(C), .D(D), .EN(1'b1), .Q(Q[3])); // EN is always active
 initial Q[3] = 1'b0;
-\$dffe #(.WIDTH(1), .CLK_POLARITY(0), .EN_POLARITY(1)) keep4 (.CLK(C), .D(D), .EN(1'b1), .Q(Q[4]));
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove5 (.CLK(C), .D(D), .EN(1'b1), .Q(Q[5]));
-\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove6 (.CLK(C), .D(D), .EN(1'bx), .Q(Q[6]));
+\$dffe #(.WIDTH(1), .CLK_POLARITY(0), .EN_POLARITY(1)) keep4 (.CLK(C), .D(D), .EN(1'b1), .Q(Q[4])); // EN is always active
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove5 (.CLK(C), .D(D), .EN(1'b1), .Q(Q[5])); // EN is never active
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove6 (.CLK(C), .D(D), .EN(1'bx), .Q(Q[6])); // EN is don't care
 initial Q[6] = 1'b0;
-\$dffe #(.WIDTH(1), .CLK_POLARITY(0), .EN_POLARITY(0)) keep7 (.CLK(C), .D(D), .EN(E), .Q(Q[7]));
+\$dffe #(.WIDTH(1), .CLK_POLARITY(0), .EN_POLARITY(0)) keep7 (.CLK(C), .D(D), .EN(E), .Q(Q[7])); // EN is non constant
 
-\$_DFFE_PP_ remove8 (.C(C), .D(D), .E(1'b0), .Q(Q[8]));
-initial Q[8] = 1'b1;
-\$_DFFE_PP_ remove9 (.C(C), .D(D), .E(1'b0), .Q(Q[9]));
-\$_DFFE_PP_ remove10 (.C(C), .D(D), .E(1'bx), .Q(Q[10]));
-\$_DFFE_PP_ keep11 (.C(C), .D(D), .E(1'b1), .Q(Q[11]));
+\$_DFFE_PP_ remove8 (.C(C), .D(D), .E(1'b0), .Q(Q[8])); // EN is never active
+initial Q[9] = 1'b1;
+\$_DFFE_PP_ remove9 (.C(C), .D(D), .E(1'b0), .Q(Q[9])); // EN is never active
+\$_DFFE_PP_ remove10 (.C(C), .D(D), .E(1'bx), .Q(Q[10])); // EN is don't care
+\$_DFFE_PP_ keep11 (.C(C), .D(D), .E(1'b1), .Q(Q[11])); // EN is always active
 initial Q[12] = 1'b0;
-\$_DFFE_PP_ keep12 (.C(C), .D(D), .E(1'b1), .Q(Q[12]));
+\$_DFFE_PP_ keep12 (.C(C), .D(D), .E(1'b1), .Q(Q[12])); // EN is always active
 
-\$_DFFE_NN_ remove13 (.C(C), .D(D), .E(1'b1), .Q(Q[13]));
+\$_DFFE_NN_ remove13 (.C(C), .D(D), .E(1'b1), .Q(Q[13])); // EN is never active
 initial Q[14] = 1'b1;
-\$_DFFE_NN_ remove14 (.C(C), .D(D), .E(1'b1), .Q(Q[14]));
-\$_DFFE_NN_ remove15 (.C(C), .D(D), .E(1'bx), .Q(Q[15]));
-\$_DFFE_NN_ keep16 (.C(C), .D(D), .E(1'b0), .Q(Q[16]));
+\$_DFFE_NN_ remove14 (.C(C), .D(D), .E(1'b1), .Q(Q[14])); // EN is never active
+\$_DFFE_NN_ remove15 (.C(C), .D(D), .E(1'bx), .Q(Q[15])); // EN is don't care
+\$_DFFE_NN_ keep16 (.C(C), .D(D), .E(1'b0), .Q(Q[16])); // EN is always active
 initial Q[17] = 1'b0;
-\$_DFFE_NN_ keep17 (.C(C), .D(D), .E(1'b0), .Q(Q[17]));
+\$_DFFE_NN_ keep17 (.C(C), .D(D), .E(1'b0), .Q(Q[17])); // EN is always active
+
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove18 (.CLK(1'b0), .D(D), .EN(EN), .Q(Q[18])); // CLK is constant
+initial Q[19] = 1'b1;
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove19 (.CLK(1'b1), .D(D), .EN(EN), .Q(Q[19])); // CLK is constant
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove20 (.CLK(C), .D(1'bx), .EN(EN), .Q(Q[20])); // D is undriven, Q has no initial value
+initial Q[21] = 1'b0;
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) keep21 (.CLK(C), .D(1'bx), .EN(EN), .Q(Q[21])); // D is undriven, Q has initial value
+//\$dffe #(.WIDTH(1), .CLK_POLARITY(0), .EN_POLARITY(1)) remove22 (.CLK(C), .D(1'b0), .EN(1'b1), .Q(Q[22])); // D is constant, no initial Q value, EN is always active
+//                                                                                                           // (TODO, Q starts with 1'bx and becomes 1'b0)
+initial Q[23] = 1'b0;
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) noenable23 (.CLK(C), .D(1'b0), .EN(1'b1), .Q(Q[23])); // D is constant, initial Q value same as D, EN is always active
+initial Q[24] = 1'b1;
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) keep24 (.CLK(C), .D(1'b0), .EN(1'b0), .Q(Q[24])); // D is constant, initial Q value NOT same as D, EN is always active
+initial Q[25] = 1'b1;
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove25 (.CLK(C), .D(1'b0), .EN(1'b1), .Q(Q[25])); // D is constant, EN is never active
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) remove26 (.CLK(C), .D(Q[26]), .EN(1'b1), .Q(Q[26])); // D is Q, EN is always active
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove27 (.CLK(C), .D(Q[27]), .EN(1'b1), .Q(Q[27])); // D is Q, EN is never active, but no initial value
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(0)) remove28 (.CLK(C), .D(Q[28]), .EN(EN), .Q(Q[28])); // EN is nonconst, but no initial value
+initial Q[29] = 1'b1;
+\$dffe #(.WIDTH(1), .CLK_POLARITY(1), .EN_POLARITY(1)) keep29 (.CLK(C), .D(Q[29]), .EN(1'b1), .Q(Q[29])); // EN is always active, but with initial value
 
 endmodule

--- a/tests/various/opt_rmdff.ys
+++ b/tests/various/opt_rmdff.ys
@@ -1,0 +1,25 @@
+read_verilog -icells opt_rmdff.v
+prep
+design -stash gold
+read_verilog -icells opt_rmdff.v
+opt_rmdff
+
+select -assert-count 0 c:remove*
+select -assert-min 7 c:keep*
+
+prep
+design -stash gate
+
+design -import gold -as gold
+design -import gate -as gate
+
+equiv_make gold gate equiv
+hierarchy -top equiv
+equiv_simple -undef
+equiv_status -assert
+
+design -load gold
+stat
+
+design -load gate
+stat

--- a/tests/various/opt_rmdff.ys
+++ b/tests/various/opt_rmdff.ys
@@ -7,6 +7,7 @@ opt_rmdff
 
 select -assert-count 0 c:remove*
 select -assert-min 7 c:keep*
+select -assert-count 0  t:$dffe 7:$_DFFE_* %u c:noenable* %i
 
 design -stash gate
 

--- a/tests/various/opt_rmdff.ys
+++ b/tests/various/opt_rmdff.ys
@@ -2,12 +2,12 @@ read_verilog -icells opt_rmdff.v
 prep
 design -stash gold
 read_verilog -icells opt_rmdff.v
+proc
 opt_rmdff
 
 select -assert-count 0 c:remove*
 select -assert-min 7 c:keep*
 
-prep
 design -stash gate
 
 design -import gold -as gold


### PR DESCRIPTION
Fixes #1034.

In particular, flops with constant enables that are never high (according to enable polarity) will get optimised away to their INIT value (or if one doesn't exist, to nothing at all).