### PR TITLE
Add "min bits" and "min wports" to xilinx dram rules

### DIFF
--- a/techlibs/xilinx/drams.txt
+++ b/techlibs/xilinx/drams.txt
@@ -26,11 +26,15 @@ bram $__XILINX_RAM128X1D
 endbram
 
 match $__XILINX_RAM64X1D
+  min bits 5
+  min wports 1
   make_outreg
   or_next_if_better
 endmatch
 
 match $__XILINX_RAM128X1D
+  min bits 9
+  min wports 1
   make_outreg
 endmatch
 


### PR DESCRIPTION
Fixes #1033.

Logic behind `min wrports` is that there is no point inferring a hard ROM when soft LUTs are the ultimate ROM anyway, and leaving them as soft LUTs means it can be optimised by ABC.