### PR TITLE
Link sdf component when building Verific

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -400,7 +400,7 @@ endif
 
 ifeq ($(ENABLE_VERIFIC),1)
 VERIFIC_DIR ?= /usr/local/src/verific_lib
-VERIFIC_COMPONENTS ?= verilog vhdl database util containers hier_tree
+VERIFIC_COMPONENTS ?= verilog vhdl database util containers hier_tree sdf
 CXXFLAGS += $(patsubst %,-I$(VERIFIC_DIR)/%,$(VERIFIC_COMPONENTS)) -DYOSYS_ENABLE_VERIFIC
 ifeq ($(OS), Darwin)
 LDLIBS += $(patsubst %,$(VERIFIC_DIR)/%/*-mac.a,$(VERIFIC_COMPONENTS)) -lz


### PR DESCRIPTION
I received new eval binaries from Verific, which seem to introduce a new dependency between the verilog and sdf component. Link error here for good measure: https://gist.github.com/arjenroodselaar/aaf03d3f2577c273a91ba104a5086035