### PR TITLE
Added support for parsing attributes on port connections.

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -1535,11 +1535,13 @@ cell_port:
 	attr {
 		AstNode *node = new AstNode(AST_ARGUMENT);
 		astbuf2->children.push_back(node);
+		free_attr($1);
 	} |
 	attr expr {
 		AstNode *node = new AstNode(AST_ARGUMENT);
 		astbuf2->children.push_back(node);
 		node->children.push_back($2);
+		free_attr($1);
 	} |
 	attr '.' TOK_ID '(' expr ')' {
 		AstNode *node = new AstNode(AST_ARGUMENT);
@@ -1547,12 +1549,14 @@ cell_port:
 		astbuf2->children.push_back(node);
 		node->children.push_back($5);
 		delete $3;
+		free_attr($1);
 	} |
 	attr '.' TOK_ID '(' ')' {
 		AstNode *node = new AstNode(AST_ARGUMENT);
 		node->str = *$3;
 		astbuf2->children.push_back(node);
 		delete $3;
+		free_attr($1);
 	};
 
 always_stmt:

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -1532,27 +1532,27 @@ cell_port_list_rules:
 	cell_port | cell_port_list_rules ',' cell_port;
 
 cell_port:
-	/* empty */ {
+	attr {
 		AstNode *node = new AstNode(AST_ARGUMENT);
 		astbuf2->children.push_back(node);
 	} |
-	expr {
+	attr expr {
 		AstNode *node = new AstNode(AST_ARGUMENT);
 		astbuf2->children.push_back(node);
-		node->children.push_back($1);
+		node->children.push_back($2);
 	} |
-	'.' TOK_ID '(' expr ')' {
+	attr '.' TOK_ID '(' expr ')' {
 		AstNode *node = new AstNode(AST_ARGUMENT);
-		node->str = *$2;
+		node->str = *$3;
 		astbuf2->children.push_back(node);
-		node->children.push_back($4);
-		delete $2;
+		node->children.push_back($5);
+		delete $3;
 	} |
-	'.' TOK_ID '(' ')' {
+	attr '.' TOK_ID '(' ')' {
 		AstNode *node = new AstNode(AST_ARGUMENT);
-		node->str = *$2;
+		node->str = *$3;
 		astbuf2->children.push_back(node);
-		delete $2;
+		delete $3;
 	};
 
 always_stmt:

--- a/tests/simple/attrib01_module.v
+++ b/tests/simple/attrib01_module.v
@@ -1,0 +1,21 @@
+module bar(clk, rst, inp, out);
+  input  wire clk;
+  input  wire rst;
+  input  wire inp;
+  output reg  out;
+
+  always @(posedge clk)
+    if (rst) out <= 1'd0;
+    else     out <= ~inp;
+
+endmodule
+
+module foo(clk, rst, inp, out);
+  input  wire clk;
+  input  wire rst;
+  input  wire inp;
+  output wire out;
+
+  bar bar_instance (clk, rst, inp, out);
+endmodule
+

--- a/tests/simple/attrib02_port_decl.v
+++ b/tests/simple/attrib02_port_decl.v
@@ -1,0 +1,25 @@
+module bar(clk, rst, inp, out);
+  (* this_is_clock = 1 *)
+  input  wire clk;
+  (* this_is_reset = 1 *)
+  input  wire rst;
+  input  wire inp;
+  (* an_output_register = 1*)
+  output reg  out;
+
+  always @(posedge clk)
+    if (rst) out <= 1'd0;
+    else     out <= ~inp;
+
+endmodule
+
+module foo(clk, rst, inp, out);
+  (* this_is_the_master_clock *)
+  input  wire clk;
+  input  wire rst;
+  input  wire inp;
+  output wire out;
+
+  bar bar_instance (clk, rst, inp, out);
+endmodule
+

--- a/tests/simple/attrib03_parameter.v
+++ b/tests/simple/attrib03_parameter.v
@@ -1,0 +1,28 @@
+module bar(clk, rst, inp, out);
+
+  (* bus_width *)
+  parameter WIDTH = 2;
+
+  (* an_attribute_on_localparam = 55 *)
+  localparam INCREMENT = 5;
+
+  input  wire clk;
+  input  wire rst;
+  input  wire [WIDTH-1:0] inp;
+  output reg  [WIDTH-1:0] out;
+
+  always @(posedge clk)
+    if (rst) out <= 0;
+    else     out <= inp + INCREMENT;
+
+endmodule
+
+module foo(clk, rst, inp, out);
+  input  wire clk;
+  input  wire rst;
+  input  wire [7:0] inp;
+  output wire [7:0] out;
+
+  bar # (.WIDTH(8)) bar_instance (clk, rst, inp, out);
+endmodule
+

--- a/tests/simple/attrib04_net_var.v
+++ b/tests/simple/attrib04_net_var.v
@@ -1,0 +1,32 @@
+module bar(clk, rst, inp, out);
+  input  wire clk;
+  input  wire rst;
+  input  wire inp;
+  output reg  out;
+
+  (* this_is_a_prescaler *)
+  reg [7:0] counter;
+
+  (* temp_wire *)
+  wire out_val;
+
+  always @(posedge clk)
+    counter <= counter + 1;
+
+  assign out_val = inp ^ counter[4];
+
+  always @(posedge clk)
+    if (rst) out <= 1'd0;
+    else     out <= out_val;
+
+endmodule
+
+module foo(clk, rst, inp, out);
+  input  wire clk;
+  input  wire rst;
+  input  wire inp;
+  output wire out;
+
+  bar bar_instance (clk, rst, inp, out);
+endmodule
+

--- a/tests/simple/attrib05_port_conn.v.DISABLED
+++ b/tests/simple/attrib05_port_conn.v.DISABLED
@@ -1,0 +1,21 @@
+module bar(clk, rst, inp, out);
+  input  wire clk;
+  input  wire rst;
+  input  wire inp;
+  output reg  out;
+
+  always @(posedge clk)
+    if (rst) out <= 1'd0;
+    else     out <= ~inp;
+
+endmodule
+
+module foo(clk, rst, inp, out);
+  input  wire clk;
+  input  wire rst;
+  input  wire inp;
+  output wire out;
+
+  bar bar_instance ( (* clock_connected *) clk, rst, (* this_is_the_input *) inp, out);
+endmodule
+

--- a/tests/simple/attrib06_operator_suffix.v
+++ b/tests/simple/attrib06_operator_suffix.v
@@ -1,0 +1,23 @@
+module bar(clk, rst, inp_a, inp_b, out);
+  input  wire clk;
+  input  wire rst;
+  input  wire [7:0] inp_a;
+  input  wire [7:0] inp_b;
+  output reg  [7:0] out;
+
+  always @(posedge clk)
+    if (rst) out <= 0;
+    else     out <= inp_a + (* ripple_adder *) inp_b;
+
+endmodule
+
+module foo(clk, rst, inp_a, inp_b, out);
+  input  wire clk;
+  input  wire rst;
+  input  wire [7:0] inp_a;
+  input  wire [7:0] inp_b;
+  output wire [7:0] out;
+
+  bar bar_instance (clk, rst, inp_a, inp_b, out);
+endmodule
+

--- a/tests/simple/attrib07_func_call.v.DISABLED
+++ b/tests/simple/attrib07_func_call.v.DISABLED
@@ -1,0 +1,21 @@
+function [7:0] do_add;
+  input [7:0] inp_a;
+  input [7:0] inp_b;
+
+  do_add = inp_a + inp_b;
+
+endfunction
+
+module foo(clk, rst, inp_a, inp_b, out);
+  input  wire clk;
+  input  wire rst;
+  input  wire [7:0] inp_a;
+  input  wire [7:0] inp_b;
+  output wire [7:0] out;
+
+  always @(posedge clk)
+    if (rst) out <= 0;
+    else     out <= do_add (* combinational_adder *) (inp_a, inp_b);
+
+endmodule
+

--- a/tests/simple/attrib08_mod_inst.v
+++ b/tests/simple/attrib08_mod_inst.v
@@ -1,0 +1,22 @@
+module bar(clk, rst, inp, out);
+  input  wire clk;
+  input  wire rst;
+  input  wire inp;
+  output reg  out;
+
+  always @(posedge clk)
+    if (rst) out <= 1'd0;
+    else     out <= ~inp;
+
+endmodule
+
+module foo(clk, rst, inp, out);
+  input  wire clk;
+  input  wire rst;
+  input  wire inp;
+  output wire out;
+
+  (* my_module_instance = 99 *)
+  bar bar_instance (clk, rst, inp, out);
+endmodule
+

--- a/tests/simple/attrib09_case.v
+++ b/tests/simple/attrib09_case.v
@@ -1,0 +1,26 @@
+module bar(clk, rst, inp, out);
+  input  wire clk;
+  input  wire rst;
+  input  wire [1:0] inp;
+  output reg  [1:0] out;
+
+  always @(inp)
+    (* full_case, parallel_case *)
+    case(inp)
+      2'd0: out <= 2'd3;
+      2'd1: out <= 2'd2;
+      2'd2: out <= 2'd1;
+      2'd3: out <= 2'd0;
+    endcase
+
+endmodule
+
+module foo(clk, rst, inp, out);
+  input  wire clk;
+  input  wire rst;
+  input  wire [1:0] inp;
+  output wire [1:0] out;
+
+  bar bar_instance (clk, rst, inp, out);
+endmodule
+

--- a/tests/various/attrib05_port_conn.v
+++ b/tests/various/attrib05_port_conn.v
@@ -1,0 +1,21 @@
+module bar(clk, rst, inp, out);
+  input  wire clk;
+  input  wire rst;
+  input  wire inp;
+  output reg  out;
+
+  always @(posedge clk)
+    if (rst) out <= 1'd0;
+    else     out <= ~inp;
+
+endmodule
+
+module foo(clk, rst, inp, out);
+  input  wire clk;
+  input  wire rst;
+  input  wire inp;
+  output wire out;
+
+  bar bar_instance ( (* clock_connected *) clk, rst, (* this_is_the_input *) inp, out);
+endmodule
+

--- a/tests/various/attrib05_port_conn.ys
+++ b/tests/various/attrib05_port_conn.ys
@@ -1,0 +1,2 @@
+# Read and parse Verilog file
+read_verilog attrib05_port_conn.v

--- a/tests/various/attrib07_func_call.v
+++ b/tests/various/attrib07_func_call.v
@@ -1,0 +1,21 @@
+function [7:0] do_add;
+  input [7:0] inp_a;
+  input [7:0] inp_b;
+
+  do_add = inp_a + inp_b;
+
+endfunction
+
+module foo(clk, rst, inp_a, inp_b, out);
+  input  wire clk;
+  input  wire rst;
+  input  wire [7:0] inp_a;
+  input  wire [7:0] inp_b;
+  output wire [7:0] out;
+
+  always @(posedge clk)
+    if (rst) out <= 0;
+    else     out <= do_add (* combinational_adder *) (inp_a, inp_b);
+
+endmodule
+

--- a/tests/various/attrib07_func_call.ys
+++ b/tests/various/attrib07_func_call.ys
@@ -1,0 +1,2 @@
+# Read and parse Verilog file
+read_verilog attrib07_func_call.v


### PR DESCRIPTION
This PR adds support for attributes on port connections to the Verilog frontend. Attributes are allowed but discarded.