### PR TITLE
README.md: Missing formatting for <tag>

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Verilog Attributes and non-standard features
       $ yosys -p 'plugin -a foo -i /lib/libm.so; read_verilog dpitest.v'
 
 - Sized constants (the syntax ``<size>'s?[bodh]<value>``) support constant
-  expressions as <size>. If the expression is not a simple identifier, it
+  expressions as ``<size>``. If the expression is not a simple identifier, it
   must be put in parentheses. Examples: ``WIDTH'd42``, ``(4+2)'b101010``
 
 - The system tasks ``$finish``, ``$stop`` and ``$display`` are supported in


### PR DESCRIPTION
This is a drive-by PR to fix an invisible reference to `<size>` due to missing formatting.