### PR TITLE
Fix pyosys-build on CentOS7

### DIFF
--- a/misc/py_wrap_generator.py
+++ b/misc/py_wrap_generator.py
@@ -2026,7 +2026,6 @@ def gen_wrappers(filename, debug_level_ = 0):
 #include <boost/python/wrapper.hpp>
 #include <boost/python/call.hpp>
 #include <boost/python.hpp>
-#include <boost/log/exceptions.hpp>
 
 USING_YOSYS_NAMESPACE
 


### PR DESCRIPTION
CentOS7 provides no boost-log, which is why building yosys+pyosys fails there. But as it turns out this include is unused anyways, so removing it solves the issue.