### PR TITLE
Improve shregmap to handle case where first flop is common to two chains

### DIFF
--- a/passes/techmap/shregmap.cc
+++ b/passes/techmap/shregmap.cc
@@ -295,7 +295,18 @@ struct ShregmapWorker
 				{
 					auto r = sigbit_chain_next.insert(std::make_pair(d_bit, cell));
 					if (!r.second) {
+						// Insertion not successful means that d_bit is already
+						// connected to another register, thus mark it as a
+						// non chain user ...
 						sigbit_with_non_chain_users.insert(d_bit);
+						// ... and clone d_bit into another wire, and use that
+						// wire as a different key in the d_bit-to-cell dictionary
+						// so that it can be identified as another chain
+						// (omitting this common flop)
+						// Link: https://github.com/YosysHQ/yosys/pull/1085
+						// NB: This relies on us not updating sigmap with this
+						//     alias otherwise it would think they are the same
+						//     wire
 						Wire *wire = module->addWire(NEW_ID);
 						module->connect(wire, d_bit);
 						sigbit_chain_next.insert(std::make_pair(wire, cell));

--- a/passes/techmap/shregmap.cc
+++ b/passes/techmap/shregmap.cc
@@ -304,11 +304,9 @@ struct ShregmapWorker
 						// so that it can be identified as another chain
 						// (omitting this common flop)
 						// Link: https://github.com/YosysHQ/yosys/pull/1085
-						// NB: This relies on us not updating sigmap with this
-						//     alias otherwise it would think they are the same
-						//     wire
 						Wire *wire = module->addWire(NEW_ID);
 						module->connect(wire, d_bit);
+						sigmap.add(wire, d_bit);
 						sigbit_chain_next.insert(std::make_pair(wire, cell));
 					}
 

--- a/passes/techmap/shregmap.cc
+++ b/passes/techmap/shregmap.cc
@@ -293,10 +293,13 @@ struct ShregmapWorker
 
 				if (opts.init || sigbit_init.count(q_bit) == 0)
 				{
-					if (sigbit_chain_next.count(d_bit)) {
+					auto r = sigbit_chain_next.insert(std::make_pair(d_bit, cell));
+					if (!r.second) {
 						sigbit_with_non_chain_users.insert(d_bit);
-					} else
-						sigbit_chain_next[d_bit] = cell;
+						Wire *wire = module->addWire(NEW_ID);
+						module->connect(wire, d_bit);
+						sigbit_chain_next.insert(std::make_pair(wire, cell));
+					}
 
 					sigbit_chain_prev[q_bit] = cell;
 					continue;

--- a/passes/techmap/shregmap.cc
+++ b/passes/techmap/shregmap.cc
@@ -294,12 +294,8 @@ struct ShregmapWorker
 				if (opts.init || sigbit_init.count(q_bit) == 0)
 				{
 					auto r = sigbit_chain_next.insert(std::make_pair(d_bit, cell));
-					if (!r.second) {
+					if (!r.second)
 						sigbit_with_non_chain_users.insert(d_bit);
-						Wire *wire = module->addWire(NEW_ID);
-						module->connect(wire, d_bit);
-						sigbit_chain_next.insert(std::make_pair(wire, cell));
-					}
 
 					sigbit_chain_prev[q_bit] = cell;
 					continue;
@@ -319,14 +315,14 @@ struct ShregmapWorker
 	{
 		for (auto it : sigbit_chain_next)
 		{
+			Cell *c1, *c2 = it.second;
+
 			if (opts.tech == nullptr && sigbit_with_non_chain_users.count(it.first))
 				goto start_cell;
 
-			if (sigbit_chain_prev.count(it.first) != 0)
+			c1 = sigbit_chain_prev.at(it.first, nullptr);
+			if (c1 != nullptr)
 			{
-				Cell *c1 = sigbit_chain_prev.at(it.first);
-				Cell *c2 = it.second;
-
 				if (c1->type != c2->type)
 					goto start_cell;
 
@@ -335,6 +331,15 @@ struct ShregmapWorker
 
 				IdString d_port = opts.ffcells.at(c1->type).first;
 				IdString q_port = opts.ffcells.at(c1->type).second;
+
+				// If the previous cell's D has other non chain users,
+				// then it is possible that this previous cell could
+				// be a start of the chain
+				SigBit d_bit = sigmap(c1->getPort(d_port).as_bit());
+				if (sigbit_with_non_chain_users.count(d_bit)) {
+					c2 = c1;
+					goto start_cell;
+				}
 
 				auto c1_conn = c1->connections();
 				auto c2_conn = c1->connections();
@@ -352,7 +357,7 @@ struct ShregmapWorker
 			}
 
 		start_cell:
-			chain_start_cells.insert(it.second);
+			chain_start_cells.insert(c2);
 		}
 	}
 

--- a/tests/various/shregmap.v
+++ b/tests/various/shregmap.v
@@ -1,4 +1,4 @@
-module shregmap_test(input i, clk, output [1:0] q);
+module shregmap_static_test(input i, clk, output [1:0] q);
 reg head = 1'b0;
 reg [3:0] shift1 = 4'b0000;
 reg [3:0] shift2 = 4'b0000;
@@ -19,4 +19,30 @@ reg [DEPTH-1:0] r = INIT;
 always @(posedge C) 
     r <= { r[DEPTH-2:0], D };
 assign Q = r[DEPTH-1];
+endmodule
+
+module shregmap_variable_test(input i, clk, input [1:0] l1, l2, output [1:0] q);
+reg head = 1'b0;
+reg [3:0] shift1 = 4'b0000;
+reg [3:0] shift2 = 4'b0000;
+
+always @(posedge clk) begin
+    head <= i;
+    shift1 <= {shift1[2:0], head};
+    shift2 <= {shift2[2:0], head};
+end
+
+assign q = {shift2[l2], shift1[l1]};
+endmodule
+
+module $__XILINX_SHREG_(input C, D, input [1:0] L, output Q);
+parameter CLKPOL = 1;
+parameter ENPOL = 1;
+parameter DEPTH = 1;
+parameter [DEPTH-1:0] INIT = {DEPTH{1'b0}};
+reg [DEPTH-1:0] r = INIT;
+wire clk = C ^ CLKPOL;
+always @(posedge C)
+    r <= { r[DEPTH-2:0], D };
+assign Q = r[L];
 endmodule

--- a/tests/various/shregmap.v
+++ b/tests/various/shregmap.v
@@ -1,0 +1,22 @@
+module shregmap_test(input i, clk, output [1:0] q);
+reg head = 1'b0;
+reg [3:0] shift1 = 4'b0000;
+reg [3:0] shift2 = 4'b0000;
+
+always @(posedge clk) begin
+    head <= i;
+    shift1 <= {shift1[2:0], head};
+    shift2 <= {shift2[2:0], head};
+end
+
+assign q = {shift2[3], shift1[3]};
+endmodule
+
+module $__SHREG_DFF_P_(input C, D, output Q);
+parameter DEPTH = 1;
+parameter [DEPTH-1:0] INIT = {DEPTH{1'b0}};
+reg [DEPTH-1:0] r = INIT;
+always @(posedge C) 
+    r <= { r[DEPTH-2:0], D };
+assign Q = r[DEPTH-1];
+endmodule

--- a/tests/various/shregmap.ys
+++ b/tests/various/shregmap.ys
@@ -1,0 +1,31 @@
+read_verilog shregmap.v
+design -copy-to model $__SHREG_DFF_P_
+hierarchy -top shregmap_test
+prep
+design -save gold
+
+techmap
+shregmap -init
+
+opt
+
+stat
+# show -width
+select -assert-count 1 t:$_DFF_P_
+select -assert-count 2 t:$__SHREG_DFF_P_
+
+design -stash gate
+
+design -import gold -as gold
+design -import gate -as gate
+design -copy-from model -as $__SHREG_DFF_P_ \$__SHREG_DFF_P_
+prep
+
+miter -equiv -flatten -make_assert -make_outputs gold gate miter
+sat -verify -prove-asserts -show-ports -seq 5 miter
+
+design -load gold
+stat
+
+design -load gate
+stat

--- a/tests/various/shregmap.ys
+++ b/tests/various/shregmap.ys
@@ -1,6 +1,8 @@
 read_verilog shregmap.v
+design -save read
+
 design -copy-to model $__SHREG_DFF_P_
-hierarchy -top shregmap_test
+hierarchy -top shregmap_static_test
 prep
 design -save gold
 
@@ -19,6 +21,39 @@ design -stash gate
 design -import gold -as gold
 design -import gate -as gate
 design -copy-from model -as $__SHREG_DFF_P_ \$__SHREG_DFF_P_
+prep
+
+miter -equiv -flatten -make_assert -make_outputs gold gate miter
+sat -verify -prove-asserts -show-ports -seq 5 miter
+
+design -load gold
+stat
+
+design -load gate
+stat
+
+##########
+
+design -load read
+design -copy-to model $__XILINX_SHREG_
+hierarchy -top shregmap_variable_test
+prep
+design -save gold
+
+simplemap t:$dff t:$dffe
+shregmap -tech xilinx
+
+stat
+# show -width
+write_verilog -noexpr -norename
+select -assert-count 1 t:$_DFF_P_
+select -assert-count 2 t:$__XILINX_SHREG_
+
+design -stash gate
+
+design -import gold -as gold
+design -import gate -as gate
+design -copy-from model -as $__XILINX_SHREG_ \$__XILINX_SHREG_
 prep
 
 miter -equiv -flatten -make_assert -make_outputs gold gate miter


### PR DESCRIPTION
e.g.
```
module shregmap_test(input i, clk, output [1:0] q);
reg head = 1'b0;
reg [3:0] shift1 = 4'b0000;
reg [3:0] shift2 = 4'b0000;

always @(posedge clk) begin
    head <= i;
    shift1 <= {shift1[2:0], head};
    shift2 <= {shift2[2:0], head};
end

assign q = {shift2[3], shift1[3]};
endmodule
```

Previously, `shregmap` would create one `SHREG` only since the key for `sigbit_chain_next` would be clobbered; now I create a new temporary wire (which isn't updated by `SigMap`) to circumvent this clobbering.... a bit hacky -- is there a better way to do this?

EDIT: The alternative would be to change the data structure (multimap) or a new one (vector) capable of containing duplicates, because I really don't like the fact it could break on a sigmap update...