### PR TITLE
Unpacked array declaration using size

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -1385,7 +1385,13 @@ wire_name:
 				node->children.push_back(rng);
 			}
 			node->type = AST_MEMORY;
-			node->children.push_back($2);
+			auto *rangeNode = $2;
+			if (rangeNode->type == AST_RANGE && rangeNode->children.size() == 1) {
+				// SV array size [n], rewrite as [n-1:0]
+				rangeNode->children[0] = new AstNode(AST_SUB, rangeNode->children[0], AstNode::mkconst_int(1, true));
+				rangeNode->children.push_back(AstNode::mkconst_int(0, false));
+			}
+			node->children.push_back(rangeNode);
 		}
 		if (current_function_or_task == NULL) {
 			if (do_not_require_port_stubs && (node->is_input || node->is_output) && port_stubs.count(*$1) == 0) {

--- a/tests/various/unpacked_arrays.sv
+++ b/tests/various/unpacked_arrays.sv
@@ -1,0 +1,4 @@
+module unpacked_arrays;
+  reg array_range [0:7];
+  reg array_size [8];
+endmodule

--- a/tests/various/unpacked_arrays.ys
+++ b/tests/various/unpacked_arrays.ys
@@ -1,0 +1,2 @@
+read_verilog -sv unpacked_arrays.sv
+stat


### PR DESCRIPTION
The test needs checks.
Manually I was able to see the output of `stat` to see that there are 2 memories and 16 memory bits as opposed to 9 memory bits in the same test without the changes to `verilog_parser.y` but I did not find a way to check for this.
I would be happy to extend this checks if I could get a pointer of how to do it.
