### PR TITLE
Fixed the help summary line for a few commands

### DIFF
--- a/passes/cmds/blackbox.cc
+++ b/passes/cmds/blackbox.cc
@@ -23,7 +23,7 @@ USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
 struct BlackboxPass : public Pass {
-	BlackboxPass() : Pass("blackbox", "change type of cells in the design") { }
+	BlackboxPass() : Pass("blackbox", "convert modules into blackbox modules") { }
 	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|

--- a/passes/sat/assertpmux.cc
+++ b/passes/sat/assertpmux.cc
@@ -180,7 +180,7 @@ struct AssertpmuxWorker
 };
 
 struct AssertpmuxPass : public Pass {
-	AssertpmuxPass() : Pass("assertpmux", "convert internal signals to module ports") { }
+	AssertpmuxPass() : Pass("assertpmux", "adds asserts for parallel muxes") { }
 	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
@@ -195,8 +195,8 @@ struct AssertpmuxPass : public Pass {
 		log("\n");
 		log("    -always\n");
 		log("        usually the $pmux condition is only checked when the $pmux output\n");
-		log("        is used be the mux tree it drives. this option will deactivate this\n");
-		log("        additional constrained and check the $pmux condition always.\n");
+		log("        is used by the mux tree it drives. this option will deactivate this\n");
+		log("        additional constraint and check the $pmux condition always.\n");
 		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE

--- a/passes/sat/cutpoint.cc
+++ b/passes/sat/cutpoint.cc
@@ -24,7 +24,7 @@ USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
 struct CutpointPass : public Pass {
-	CutpointPass() : Pass("cutpoint", "add hi/lo cover cells for each wire bit") { }
+	CutpointPass() : Pass("cutpoint", "adds formal cut points to the design") { }
 	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|

--- a/techlibs/ice40/ice40_unlut.cc
+++ b/techlibs/ice40/ice40_unlut.cc
@@ -74,7 +74,7 @@ static void run_ice40_unlut(Module *module)
 }
 
 struct Ice40UnlutPass : public Pass {
-	Ice40UnlutPass() : Pass("ice40_unlut", "iCE40: perform simple optimizations") { }
+	Ice40UnlutPass() : Pass("ice40_unlut", "iCE40: transform SBLUT4 cells to $lut cells") { }
 	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|

--- a/techlibs/ice40/ice40_unlut.cc
+++ b/techlibs/ice40/ice40_unlut.cc
@@ -74,7 +74,7 @@ static void run_ice40_unlut(Module *module)
 }
 
 struct Ice40UnlutPass : public Pass {
-	Ice40UnlutPass() : Pass("ice40_unlut", "iCE40: transform SBLUT4 cells to $lut cells") { }
+	Ice40UnlutPass() : Pass("ice40_unlut", "iCE40: transform SB_LUT4 cells to $lut cells") { }
 	void help() YS_OVERRIDE
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|


### PR DESCRIPTION
When you run the "help" command in Yosys without an argument, you get a list of commands and a summary of each command. I noticed a few summaries were incorrect since they described other commands. I went through and fixed all the incorrect summaries that appeared to be for other commands.