### PR TITLE
Fixed pyosys commands returning RTLIL::SigSig

### DIFF
--- a/misc/py_wrap_generator.py
+++ b/misc/py_wrap_generator.py
@@ -508,23 +508,17 @@ class TupleTranslator(PythonDictTranslator):
 	#Generate c++ code to translate to a boost::python::tuple
 	@classmethod
 	def translate_cpp(c, varname, types, prefix, ref):
-		text  = prefix + TupleTranslator.typename + " " + varname + "___tmp = boost::python::make_tuple(" + varname + ".first, " + varname + ".second);"
-		return text
-		tmp_name = "tmp_" + str(Translator.tmp_cntr)
-		Translator.tmp_cntr = Translator.tmp_cntr + 1
-		if ref:
-			text += prefix + "for(auto " + tmp_name + " : *" + varname + ")"
+		# if the tuple is a pair of SigSpecs (aka SigSig), then we need
+		# to call get_py_obj() on each item in the tuple
+		if types[0].name in classnames:
+			first_var = types[0].name + "::get_py_obj(" + varname + ".first)"
 		else:
-			text += prefix + "for(auto " + tmp_name + " : " + varname + ")"
-		text += prefix + "{"
-		if types[0].name.split(" ")[-1] in primitive_types or types[0].name in enum_names:
-			text += prefix + "\t" + varname + "___tmp.append(" + tmp_name + ");"
-		elif types[0].name in known_containers:
-			text += known_containers[types[0].name].translate_cpp(tmp_name, types[0].cont.args, prefix + "\t", types[1].attr_type == attr_types.star)
-			text += prefix + "\t" + varname + "___tmp.append(" + types[0].name + "::get_py_obj(" + tmp_name + "___tmp);"
-		elif types[0].name in classnames:
-			text += prefix + "\t" + varname + "___tmp.append(" + types[0].name + "::get_py_obj(" + tmp_name + "));"
-		text += prefix + "}"
+			first_var = varname + ".first"
+		if types[1].name in classnames:
+			second_var = types[1].name + "::get_py_obj(" + varname + ".second)"
+		else:
+			second_var = varname + ".second"
+		text  = prefix + TupleTranslator.typename + " " + varname + "___tmp = boost::python::make_tuple(" + first_var + ", " + second_var + ");"
 		return text
 
 #Associate the Translators with their c++ type


### PR DESCRIPTION
In the Python API for Yosys (pyosys), when I try to access `connections_` from a `Module`, I get the following error in python:
```
TypeError: No to_python (by-value) converter found for C++ type: Yosys::RTLIL::SigSpec
```

I have no previous experience with Boost Python, but it appears from looking at the rest of the C++ wrapper that the C++ code for creating a tuple is missing a call to `get_py_obj` when necessary. I looked at the code in `misc/py_wrap_generator.py` for other containers and modeled my solution after those. In addition to fixing the bug, I also removed a significant amount of dead code in the function.

A possible improvement for this function (beyond my bugfix) is to add logic for the case where the types are in `known_containers`. This case doesn't happen with the current Yosys API, but if any function is added that returns a tuple of one or more containers, then a bug will reappear. This simplest way to protect against this is to raise an exception if either type is a container.

Here's a python script to reproduce the bug I fixed:

```python
try:
    from pyosys import libyosys as ys
except:
    import sys
    sys.path.append('/usr/lib/python3.5/site-packages')
    from pyosys import libyosys as ys

with open('test.v', 'w') as f:
    f.write('''
module test_module(
        input x,
        output y
    );
    assign y = x;
endmodule''')

design = ys.Design()
ys.run_pass("read_verilog test.v", design);

module = design.selected_whole_modules_warn()[0]
connections = module.connections_
print(str(connections))
```

