### PR TITLE
synth_xilinx: Add -nocarry and -nowidelut options

### DIFF
--- a/techlibs/ecp5/synth_ecp5.cc
+++ b/techlibs/ecp5/synth_ecp5.cc
@@ -76,7 +76,7 @@ struct SynthEcp5Pass : public ScriptPass
 		log("    -nodram\n");
 		log("        do not use distributed RAM cells in output netlist\n");
 		log("\n");
-		log("    -nomux\n");
+		log("    -nowidelut\n");
 		log("        do not use PFU muxes to implement LUTs larger than LUT4s\n");
 		log("\n");
 		log("    -abc2\n");
@@ -93,7 +93,7 @@ struct SynthEcp5Pass : public ScriptPass
 	}
 
 	string top_opt, blif_file, edif_file, json_file;
-	bool noccu2, nodffe, nobram, nodram, nomux, flatten, retime, abc2, vpr;
+	bool noccu2, nodffe, nobram, nodram, nowidelut, flatten, retime, abc2, vpr;
 
 	void clear_flags() YS_OVERRIDE
 	{
@@ -105,7 +105,7 @@ struct SynthEcp5Pass : public ScriptPass
 		nodffe = false;
 		nobram = false;
 		nodram = false;
-		nomux = false;
+		nowidelut = false;
 		flatten = true;
 		retime = false;
 		abc2 = false;
@@ -172,8 +172,8 @@ struct SynthEcp5Pass : public ScriptPass
 				nodram = true;
 				continue;
 			}
-			if (args[argidx] == "-nomux") {
-				nomux = true;
+			if (args[argidx] == "-nowidelut" || args[argidx] == "-nomux") {
+				nowidelut = true;
 				continue;
 			}
 			if (args[argidx] == "-abc2") {
@@ -264,7 +264,7 @@ struct SynthEcp5Pass : public ScriptPass
 				run("abc", "      (only if -abc2)");
 			}
 			run("techmap -map +/ecp5/latches_map.v");
-			if (nomux)
+			if (nowidelut)
 				run("abc -lut 4 -dress");
 			else
 				run("abc -lut 4:7 -dress");

--- a/tests/memories/issue00335.v
+++ b/tests/memories/issue00335.v
@@ -1,0 +1,28 @@
+// expect-wr-ports 1
+// expect-rd-ports 1
+// expect-rd-clk \clk
+
+module ram2 (input clk,
+             input             sel,
+             input             we, 
+             input [SIZE-1:0]  adr, 
+             input [63:0]      dat_i, 
+             output reg [63:0] dat_o);
+   parameter  SIZE = 5; // Address size
+
+   reg [63:0] mem [0:(1 << SIZE)-1];
+   integer    i;
+
+   initial begin
+      for (i = 0; i < (1<<SIZE) - 1; i = i + 1)
+        mem[i] <= 0;
+   end
+   
+   always @(posedge clk)
+     if (sel) begin
+       if (~we)
+         dat_o <= mem[adr];
+       else
+         mem[adr] <= dat_i;
+     end
+endmodule


### PR DESCRIPTION
Based on and superseding #971 by @koriakin.

Instead of `-nomux` for `synth_xilinx`, it is now `-nowidelut`.
On `synth_ecp5` I've also renamed the flag and the doc, but it still accepts the old `-nomux`.