### PR TITLE
tests: Check that Icarus can parse arch sim models

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -681,6 +681,7 @@ test: $(TARGETS) $(EXTRA_TARGETS)
 	+cd tests/svinterfaces && bash run-test.sh $(SEEDOPT)
 	+cd tests/opt && bash run-test.sh
 	+cd tests/aiger && bash run-test.sh
+	+cd tests/arch && bash run-test.sh
 	@echo ""
 	@echo "  Passed \"make test\"."
 	@echo ""

--- a/tests/arch/run-test.sh
+++ b/tests/arch/run-test.sh
@@ -4,5 +4,15 @@ set -e
 
 echo "Running syntax check on arch sim models"
 for arch in ../../techlibs/*; do
-	find $arch -name cells_sim.v -print0 | xargs -0 -n1 -r iverilog -t null -I$arch
+	find $arch -name cells_sim.v | while read path; do
+		echo -n "Test $path ->"
+		iverilog -t null -I$arch $path
+		echo " ok"
+	done
+done
+
+for path in "../../techlibs/common/simcells.v"  "../../techlibs/common/simlib.v"; do
+	echo -n "Test $path ->"
+	iverilog -t null $path
+	echo " ok"
 done

--- a/tests/arch/run-test.sh
+++ b/tests/arch/run-test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+echo "Running syntax check on arch sim models"
+for arch in ../../techlibs/*; do
+	find $arch -name cells_sim.v -print0 | xargs -0 -n1 -r iverilog -t null -I$arch
+done


### PR DESCRIPTION
Should avoid problems like those fixed in #1137 in the future.