### PR TITLE
tests: use optional ABCEXTERNAL when specified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -666,6 +666,12 @@ else
 SEEDOPT=""
 endif
 
+ifneq ($(ABCEXTERNAL),)
+ABCOPT="-A $(ABCEXTERNAL)"
+else
+ABCOPT=""
+endif
+
 test: $(TARGETS) $(EXTRA_TARGETS)
 	+cd tests/simple && bash run-test.sh $(SEEDOPT)
 	+cd tests/hana && bash run-test.sh $(SEEDOPT)
@@ -674,13 +680,13 @@ test: $(TARGETS) $(EXTRA_TARGETS)
 	+cd tests/share && bash run-test.sh $(SEEDOPT)
 	+cd tests/fsm && bash run-test.sh $(SEEDOPT)
 	+cd tests/techmap && bash run-test.sh
-	+cd tests/memories && bash run-test.sh $(SEEDOPT)
+	+cd tests/memories && bash run-test.sh $(ABCOPT) $(SEEDOPT)
 	+cd tests/bram && bash run-test.sh $(SEEDOPT)
 	+cd tests/various && bash run-test.sh
 	+cd tests/sat && bash run-test.sh
 	+cd tests/svinterfaces && bash run-test.sh $(SEEDOPT)
 	+cd tests/opt && bash run-test.sh
-	+cd tests/aiger && bash run-test.sh
+	+cd tests/aiger && bash run-test.sh $(ABCOPT)
 	+cd tests/arch && bash run-test.sh
 	@echo ""
 	@echo "  Passed \"make test\"."

--- a/tests/aiger/run-test.sh
+++ b/tests/aiger/run-test.sh
@@ -2,6 +2,16 @@
 
 set -e
 
+OPTIND=1
+abcprog="../../yosys-abc"    # default to built-in version of abc
+while getopts "A:" opt
+do
+    case "$opt" in
+	A) abcprog="$OPTARG" ;;
+    esac
+done
+shift "$((OPTIND-1))"
+
 # NB: *.aag and *.aig must contain a symbol table naming the primary
 #     inputs and outputs, otherwise ABC and Yosys will name them
 #     arbitrarily (and inconsistently with each other).
@@ -11,7 +21,7 @@ for aag in *.aag; do
     # (which would have been created by the reference aig2aig utility,
     #  available from http://fmv.jku.at/aiger/)
     echo "Checking $aag."
-    ../../yosys-abc -q "read -c ${aag%.*}.aig; write ${aag%.*}_ref.v"
+    $abcprog -q "read -c ${aag%.*}.aig; write ${aag%.*}_ref.v"
     ../../yosys -qp "
 read_verilog ${aag%.*}_ref.v
 prep
@@ -28,7 +38,7 @@ done
 
 for aig in *.aig; do
     echo "Checking $aig."
-    ../../yosys-abc -q "read -c $aig; write ${aig%.*}_ref.v"
+    $abcprog -q "read -c $aig; write ${aig%.*}_ref.v"
     ../../yosys -qp "
 read_verilog ${aig%.*}_ref.v
 prep

--- a/tests/memories/run-test.sh
+++ b/tests/memories/run-test.sh
@@ -4,15 +4,17 @@ set -e
 
 OPTIND=1
 seed=""    # default to no seed specified
-while getopts "S:" opt
+abcopt=""
+while getopts "A:S:" opt
 do
     case "$opt" in
+	A) abcopt="-A $OPTARG" ;;
 	S) seed="-S $OPTARG" ;;
     esac
 done
 shift "$((OPTIND-1))"
 
-bash ../tools/autotest.sh $seed -G *.v
+bash ../tools/autotest.sh $abcopt $seed -G *.v
 
 for f in `egrep -l 'expect-(wr-ports|rd-ports|rd-clk)' *.v`; do
 	echo -n "Testing expectations for $f .."

--- a/tests/tools/autotest.sh
+++ b/tests/tools/autotest.sh
@@ -23,12 +23,13 @@ warn_iverilog_git=false
 # The tests are skipped if firrtl2verilog is the empty string (the default).
 firrtl2verilog=""
 xfirrtl="../xfirrtl"
+abcprog="$toolsdir/../../yosys-abc"
 
 if [ ! -f $toolsdir/cmp_tbdata -o $toolsdir/cmp_tbdata.c -nt $toolsdir/cmp_tbdata ]; then
 	( set -ex; ${CC:-gcc} -Wall -o $toolsdir/cmp_tbdata $toolsdir/cmp_tbdata.c; ) || exit 1
 fi
 
-while getopts xmGl:wkjvref:s:p:n:S:I:-: opt; do
+while getopts xmGl:wkjvref:s:p:n:S:I:A:-: opt; do
 	case "$opt" in
 		x)
 			use_xsim=true ;;
@@ -65,6 +66,8 @@ while getopts xmGl:wkjvref:s:p:n:S:I:-: opt; do
 			include_opts="$include_opts -I $OPTARG"
 			xinclude_opts="$xinclude_opts -i $OPTARG"
 			minclude_opts="$minclude_opts +incdir+$OPTARG" ;;
+		A)
+			abcprog="$OPTARG" ;;
 		-)
 			case "${OPTARG}" in
 			    xfirrtl)
@@ -147,7 +150,7 @@ do
 		if [[ "$ext" == "v" ]]; then
 			egrep -v '^\s*`timescale' ../$fn > ${bn}_ref.${ext}
 		elif [[ "$ext" == "aig" ]] || [[ "$ext" == "aag" ]]; then
-			"$toolsdir"/../../yosys-abc -c "read_aiger ../${fn}; write ${bn}_ref.${refext}"
+			$abcprog -c "read_aiger ../${fn}; write ${bn}_ref.${refext}"
 		else
 			refext=$ext
 			cp ../${fn} ${bn}_ref.${refext}


### PR DESCRIPTION
Commits 65924fd1, abc40924, and ebe29b66 hard-code the invocation
of yosys-abc, which fails if ABCEXTERNAL was specified during the
build. Allow tests to utilize an optional, externally specified
abc binary.

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>