### PR TITLE
Make abc9 pass aware of optional ABCEXTERNAL override

### DIFF
--- a/passes/techmap/Makefile.inc
+++ b/passes/techmap/Makefile.inc
@@ -10,6 +10,7 @@ OBJS += passes/techmap/abc.o
 OBJS += passes/techmap/abc9.o
 ifneq ($(ABCEXTERNAL),)
 passes/techmap/abc.o: CXXFLAGS += -DABCEXTERNAL='"$(ABCEXTERNAL)"'
+passes/techmap/abc9.o: CXXFLAGS += -DABCEXTERNAL='"$(ABCEXTERNAL)"'
 endif
 endif
 


### PR DESCRIPTION
This is a fixup for the P.R. #1098 merge.