### PR TITLE
Add "script -select [selection]" to allow commands to be taken from wires

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,18 +6,12 @@ Yosys 0.9 .. Yosys 0.9-dev
 --------------------------
 
  * Various
-    - Added "script -select"
-
-
-Yosys 0.9 .. Yosys 0.9-dev
---------------------------
-
- * Various
     - Added "write_xaiger" backend
     - Added "abc9" pass for timing-aware techmapping (experimental, FPGA only, no FFs)
     - Added "synth_xilinx -abc9" (experimental)
     - Added "synth_ice40 -abc9" (experimental)
     - Added "synth -abc9" (experimental)
+    - Added "script -select"
 
 
 Yosys 0.8 .. Yosys 0.8-dev

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,7 +12,7 @@ Yosys 0.9 .. Yosys 0.9-dev
     - Added "synth_xilinx -abc9" (experimental)
     - Added "synth_ice40 -abc9" (experimental)
     - Added "synth -abc9" (experimental)
-    - Added "script -select"
+    - Added "script -scriptwire
 
 
 Yosys 0.8 .. Yosys 0.8-dev

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 List of major changes and improvements between releases
 =======================================================
 
+
 Yosys 0.9 .. Yosys 0.9-dev
 --------------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,12 @@
 List of major changes and improvements between releases
 =======================================================
 
+Yosys 0.9 .. Yosys 0.9-dev
+--------------------------
+
+ * Various
+    - Added "script -select"
+
 
 Yosys 0.8 .. Yosys 0.8-dev
 --------------------------

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -1259,7 +1259,7 @@ struct ScriptCmdPass : public Pass {
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
 		log("    script <filename> [<from_label>:<to_label>]\n");
-		log("    script -select [selection]\n");
+		log("    script -scriptwire [selection]\n");
 		log("\n");
 		log("This command executes the yosys commands in the specified file (default\n");
 		log("behaviour), or commands embedded in the constant text value connected to the\n");
@@ -1276,17 +1276,17 @@ struct ScriptCmdPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
-		bool select_mode = false;
+		bool scriptwire = false;
 
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++) {
-			if (args[argidx] == "-select") {
-				select_mode = true;
+			if (args[argidx] == "-scriptwire") {
+				scriptwire = true;
 				continue;
 			}
 			break;
 		}
-		if (select_mode) {
+		if (scriptwire) {
 			extra_args(args, argidx, design);
 
 			for (auto mod : design->selected_modules())

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -1299,7 +1299,7 @@ struct ScriptCmdPass : public Pass {
 					if (!c.second.is_fully_const())
 						log_error("RHS of selected wire %s.%s is not constant.\n", log_id(mod), log_id(w));
 					auto v = c.second.as_const();
-					Pass::call(design, v.decode_string());
+					Pass::call_on_module(design, mod, v.decode_string());
 				}
 		}
 		else if (args.size() < 2)

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -1254,24 +1254,55 @@ struct HistoryPass : public Pass {
 #endif
 
 struct ScriptCmdPass : public Pass {
-	ScriptCmdPass() : Pass("script", "execute commands from script file") { }
+	ScriptCmdPass() : Pass("script", "execute commands from file or wire") { }
 	void help() YS_OVERRIDE {
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
 		log("    script <filename> [<from_label>:<to_label>]\n");
+		log("    script -select [selection]\n");
 		log("\n");
-		log("This command executes the yosys commands in the specified file.\n");
+		log("This command executes the yosys commands in the specified file (default\n");
+		log("behaviour), or commands embedded in the constant text value connected to the\n");
+		log("selected wires.\n");
 		log("\n");
-		log("The 2nd argument can be used to only execute the section of the\n");
-		log("file between the specified labels. An empty from label is synonymous\n");
-		log("for the beginning of the file and an empty to label is synonymous\n");
-		log("for the end of the file.\n");
+		log("In the default (file) case, the 2nd argument can be used to only execute the\n");
+		log("section of the file between the specified labels. An empty from label is\n");
+		log("synonymous with the beginning of the file and an empty to label is synonymous\n");
+		log("with the end of the file.\n");
 		log("\n");
 		log("If only one label is specified (without ':') then only the block\n");
 		log("marked with that label (until the next label) is executed.\n");
 		log("\n");
 	}
-	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE {
-		if (args.size() < 2)
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	{
+		bool select_mode = false;
+
+		size_t argidx;
+		for (argidx = 1; argidx < args.size(); argidx++) {
+			if (args[argidx] == "-select") {
+				select_mode = true;
+				continue;
+			}
+			break;
+		}
+		if (select_mode) {
+			extra_args(args, argidx, design);
+
+			for (auto mod : design->selected_modules())
+				for (auto &c : mod->connections()) {
+					if (!c.first.is_wire())
+						continue;
+					auto w = c.first.as_wire();
+					if (!mod->selected(w))
+						continue;
+					if (!c.second.is_fully_const())
+						log_error("RHS of selected wire %s.%s is not constant.\n", log_id(mod), log_id(w));
+					auto v = c.second.as_const();
+					Pass::call(design, v.decode_string());
+				}
+		}
+		else if (args.size() < 2)
 			log_cmd_error("Missing script file.\n");
 		else if (args.size() == 2)
 			run_frontend(args[1], "script", design);

--- a/tests/various/script.ys
+++ b/tests/various/script.ys
@@ -13,8 +13,8 @@ read_verilog -formal <<EOT
     endmodule
 EOT
 
-script -select w:_RUNME*
+script -scriptwire w:_RUNME*
 
 select w:_DELETE
-script -select
+script -scriptwire
 select -assert-count 1 t:foo

--- a/tests/various/script.ys
+++ b/tests/various/script.ys
@@ -1,0 +1,17 @@
+read_verilog -formal <<EOT
+    module top;
+        foo bar();
+        foo asdf();
+        winnie the_pooh();
+
+        wire [1023:0] _RUNME0 = "select -assert-count 2 t:foo";
+        wire [1023:0] _RUNME1 = "select -assert-count 1 t:winnie";
+        wire [1023:0] _DELETE = "delete c:bar";
+    endmodule
+EOT
+
+script -select w:_RUNME*
+
+select w:_DELETE
+script -select
+select -assert-count 1 t:foo

--- a/tests/various/script.ys
+++ b/tests/various/script.ys
@@ -9,7 +9,7 @@ read_verilog -formal <<EOT
     endmodule
 
     module other;
-        wire [1023:0] _DELETE = "delete c:bar";
+        wire [1023:0] _DELETE = "cd; delete c:bar";
     endmodule
 EOT
 

--- a/tests/various/script.ys
+++ b/tests/various/script.ys
@@ -6,6 +6,9 @@ read_verilog -formal <<EOT
 
         wire [1023:0] _RUNME0 = "select -assert-count 2 t:foo";
         wire [1023:0] _RUNME1 = "select -assert-count 1 t:winnie";
+    endmodule
+
+    module other;
         wire [1023:0] _DELETE = "delete c:bar";
     endmodule
 EOT


### PR DESCRIPTION
Inspired by `_TECHMAP_DO_*`, with the intention for it to be used in testing circuits procedurally generated outside of Yosys so that we don't need to generate two files -- a Verilog and a YS file (and without using less elegant solutions).