### PR TITLE
memory_dff: Fix checking of feedback mux input when more than one mux

### DIFF
--- a/tests/memories/read_two_mux.v
+++ b/tests/memories/read_two_mux.v
@@ -1,0 +1,16 @@
+// expect-wr-ports 1
+// expect-rd-ports 1
+// expect-no-rd-clk
+
+module top(input clk, input we, re, reset, input [7:0] addr, wdata, output reg [7:0] rdata);
+
+reg [7:0] bram[0:255];
+(* keep *) reg dummy;
+
+always @(posedge clk) begin
+	rdata <= re ? (reset ? 8'b0 : bram[addr]) : rdata;
+	if (we)
+		bram[addr] <= wdata;
+end
+
+endmodule

--- a/tests/memories/run-test.sh
+++ b/tests/memories/run-test.sh
@@ -31,6 +31,10 @@ for f in `egrep -l 'expect-(wr-ports|rd-ports|rd-clk)' *.v`; do
 		grep -q "connect \\\\RD_CLK \\$(gawk '/expect-rd-clk/ { print $3; }' $f)\$" ${f%.v}.dmp ||
 				{ echo " ERROR: Unexpected read clock."; false; }
 	fi
+	if grep -q expect-no-rd-clk $f; then
+		grep -q "connect \\\\RD_CLK 1'x\$" ${f%.v}.dmp ||
+				{ echo " ERROR: Expected no read clock."; false; }
+	fi
 	echo " ok."
 done
 


### PR DESCRIPTION
Fixes a regression from #1130

cc @gsomlo, this was found in https://github.com/gsomlo/yoloRISC