### PR TITLE
 write_xaiger to treat unknown cell connections as keep-s

### DIFF
--- a/tests/various/abc9.v
+++ b/tests/various/abc9.v
@@ -3,3 +3,7 @@ initial o = 1'b0;
 always @*
     o <= ~o;
 endmodule
+
+module abc9_test028(input i, output o);
+unknown u(~i, o);
+endmodule

--- a/tests/various/abc9.ys
+++ b/tests/various/abc9.ys
@@ -1,4 +1,6 @@
 read_verilog abc9.v
+design -save read
+hierarchy -top abc9_test027
 proc
 design -save gold
 
@@ -12,3 +14,11 @@ design -import gate -as gate
 miter -equiv -flatten -make_assert -make_outputs gold gate miter
 sat -verify -prove-asserts -show-ports miter
 
+design -load read
+hierarchy -top abc9_test028
+proc
+
+abc9 -lut 4
+select -assert-count 1 t:$lut r:LUT=1 r:WIDTH=1 %i %i
+select -assert-count 1 t:unknown
+select -assert-none t:$lut t:unknown %% t: %D


### PR DESCRIPTION
Fixes case where unknown cell is instantiated in design