### PR TITLE
memory: Add memory_dff -zeroinit and use in Xilinx and ECP5 flows

### DIFF
--- a/passes/memory/memory.cc
+++ b/passes/memory/memory.cc
@@ -31,11 +31,11 @@ struct MemoryPass : public Pass {
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
-		log("    memory [-nomap] [-nordff] [-memx] [-bram <bram_rules>] [selection]\n");
+		log("    memory [-nomap] [-nordff] [-zeroinit] [-memx] [-bram <bram_rules>] [selection]\n");
 		log("\n");
 		log("This pass calls all the other memory_* passes in a useful order:\n");
 		log("\n");
-		log("    memory_dff [-nordff]                (-memx implies -nordff)\n");
+		log("    memory_dff  [-nordff] [-zeroinit]  (-memx implies -nordff)\n");
 		log("    opt_clean\n");
 		log("    memory_share\n");
 		log("    opt_clean\n");
@@ -53,6 +53,7 @@ struct MemoryPass : public Pass {
 		bool flag_nomap = false;
 		bool flag_nordff = false;
 		bool flag_memx = false;
+		bool flag_zeroinit = false;
 		string memory_bram_opts;
 
 		log_header(design, "Executing MEMORY pass.\n");
@@ -68,6 +69,10 @@ struct MemoryPass : public Pass {
 				flag_nordff = true;
 				continue;
 			}
+			if (args[argidx] == "-zeroinit") {
+				flag_zeroinit = true;
+				continue;
+			}
 			if (args[argidx] == "-memx") {
 				flag_nordff = true;
 				flag_memx = true;
@@ -81,7 +86,7 @@ struct MemoryPass : public Pass {
 		}
 		extra_args(args, argidx, design);
 
-		Pass::call(design, flag_nordff ? "memory_dff -nordff" : "memory_dff");
+		Pass::call(design, stringf("memory_dff%s%s", flag_nordff ? " -nordff" : "", flag_zeroinit ? " -zeroinit" : ""));
 		Pass::call(design, "opt_clean");
 		Pass::call(design, "memory_share");
 		if (flag_memx)

--- a/techlibs/common/synth.cc
+++ b/techlibs/common/synth.cc
@@ -67,6 +67,9 @@ struct SynthPass : public ScriptPass
 		log("    -nordff\n");
 		log("        passed to 'memory'. prohibits merging of FFs into memory read ports\n");
 		log("\n");
+		log("    -memory-zeroinit\n");
+		log("        passes -zeroinit to 'memory'. assumes that memory read FFs are zero-initialized\n");
+		log("\n");
 		log("    -noshare\n");
 		log("        do not run SAT-based resource sharing\n");
 		log("\n");
@@ -157,6 +160,10 @@ struct SynthPass : public ScriptPass
 			}
 			if (args[argidx] == "-nordff") {
 				memory_opts += " -nordff";
+				continue;
+			}
+			if (args[argidx] == "-memory-zeroinit") {
+				memory_opts += " -zeroinit";
 				continue;
 			}
 			if (args[argidx] == "-noshare") {

--- a/techlibs/ecp5/synth_ecp5.cc
+++ b/techlibs/ecp5/synth_ecp5.cc
@@ -225,7 +225,7 @@ struct SynthEcp5Pass : public ScriptPass
 
 		if (check_label("coarse"))
 		{
-			run("synth -run coarse");
+			run("synth -run coarse -memory-zeroinit");
 		}
 
 		if (!nobram && check_label("bram", "(skip if -nobram)"))

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -232,7 +232,7 @@ struct SynthXilinxPass : public ScriptPass
 		}
 
 		if (check_label("coarse")) {
-			run("synth -run coarse");
+			run("synth -run coarse -memory-zeroinit");
 
 			// shregmap -tech xilinx can cope with $shiftx and $mux
 			//   cells for identifying variable-length shift registers,

--- a/tests/memories/read_init.v
+++ b/tests/memories/read_init.v
@@ -1,0 +1,17 @@
+// expect-wr-ports 1
+// expect-rd-ports 1
+// expect-rd-clk \clk
+// extra-memory-args -zeroinit
+
+module top(input clk, input we, re, reset, input [7:0] addr, wdata, output reg [7:0] rdata);
+
+reg [7:0] bram[0:255];
+initial rdata = 0;
+
+always @(posedge clk) begin
+	rdata <= bram[addr];
+	if (we)
+		bram[addr] <= wdata;
+end
+
+endmodule

--- a/tests/memories/run-test.sh
+++ b/tests/memories/run-test.sh
@@ -18,7 +18,7 @@ bash ../tools/autotest.sh $abcopt $seed -G *.v
 
 for f in `egrep -l 'expect-(wr-ports|rd-ports|rd-clk)' *.v`; do
 	echo -n "Testing expectations for $f .."
-	../../yosys -qp "proc; opt; memory -nomap;; dump -outfile ${f%.v}.dmp t:\$mem" $f
+	../../yosys -qp "proc; opt; memory -nomap $(gawk '/extra-memory-args/ { print $3; }' $f);; dump -outfile ${f%.v}.dmp t:\$mem" $f
 	if grep -q expect-wr-ports $f; then
 		grep -q "parameter \\\\WR_PORTS $(gawk '/expect-wr-ports/ { print $3; }' $f)\$" ${f%.v}.dmp ||
 				{ echo " ERROR: Unexpected number of write ports."; false; }


### PR DESCRIPTION
This allows mapping of memories with zero-initialised read data registers.

Ultimately for Xilinx flows we want to support configurable initialization too, but this would require more work on the `$mem` cell.