### PR TITLE
Throw runtime exception when trying to convert inexistend C++ object to Python

### DIFF
--- a/misc/py_wrap_generator.py
+++ b/misc/py_wrap_generator.py
@@ -779,6 +779,9 @@ class WClass:
 
 			#if self.link_type != link_types.pointer:
 			text += "\n\t\tstatic " + self.name + "* get_py_obj(" + long_name + "* ref)\n\t\t{"
+			text += "\n\t\t\tif(ref == nullptr){"
+			text += "\n\t\t\t\tthrow std::runtime_error(\"" + self.name + " does not exist.\");"
+			text += "\n\t\t\t}"
 			text += "\n\t\t\t" + self.name + "* ret = (" + self.name + "*)malloc(sizeof(" + self.name + "));"
 			if self.link_type == link_types.pointer:
 				text += "\n\t\t\tret->ref_obj = ref;"


### PR DESCRIPTION
Throw runtime exception when trying to convert a c++-pointer to a python-object in case the pointer is a nullptr to avoid a segfault.

Fixes #1090