### PR TITLE
Allow attributes on individual switch cases in RTLIL

### DIFF
--- a/backends/ilang/ilang_backend.cc
+++ b/backends/ilang/ilang_backend.cc
@@ -204,6 +204,11 @@ void ILANG_BACKEND::dump_proc_switch(std::ostream &f, std::string indent, const 
 
 	for (auto it = sw->cases.begin(); it != sw->cases.end(); ++it)
 	{
+		for (auto ait = (*it)->attributes.begin(); ait != (*it)->attributes.end(); ++ait) {
+			f << stringf("%s  attribute %s ", indent.c_str(), ait->first.c_str());
+			dump_const(f, ait->second);
+			f << stringf("\n");
+		}
 		f << stringf("%s  case ", indent.c_str());
 		for (size_t i = 0; i < (*it)->compare.size(); i++) {
 			if (i > 0)

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1327,7 +1327,7 @@ public:
 #endif
 };
 
-struct RTLIL::CaseRule
+struct RTLIL::CaseRule : public RTLIL::AttrObject
 {
 	std::vector<RTLIL::SigSpec> compare;
 	std::vector<RTLIL::SigSig> actions;


### PR DESCRIPTION
The parser changes are slightly awkward. Consider the following IL:

    process $0
      <point 1>
      switch \foo
        <point 2>
        case 1'1
          assign \bar \baz
          <point 3>
          ...
        case
      end
    end

Before this commit, attributes are valid in <point 1>, and <point 3>
iff it is immediately followed by a `switch`. (They are essentially
attached to the switch.) But, after this commit, and because switch
cases do not have an ending delimiter, <point 3> becomes ambiguous:
the attribute could attach to either the following `case`, or to
the following `switch`. This isn't expressible in LALR(1) and results
in a reduce/reduce conflict.

To address this, attributes inside processes are now valid anywhere
inside the process: in <point 1> and <point 3> a part of case body,
and in <point 2> as a separate rule. As a consequence, attributes
can now precede `assign`s, which is made illegal in the same way it
is illegal to attach attributes to `connect`.

Attributes are tracked separately from the parser state, so this
does not affect collection of attributes at all, other than allowing
them on `case`s. The grammar change serves purely to allow attributes
in more syntactic places.