### PR TITLE
Add "synth -keepdc" option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ Yosys 0.9 .. Yosys 0.9-dev
     - Added "synth_xilinx -abc9" (experimental)
     - Added "synth_ice40 -abc9" (experimental)
     - Added "synth -abc9" (experimental)
+    - Added "synth -keepdc"
     - Added "script -scriptwire
 
 

--- a/passes/opt/wreduce.cc
+++ b/passes/opt/wreduce.cc
@@ -497,7 +497,7 @@ struct WreducePass : public Pass {
 		log("        flows that use the 'memory_memx' pass.\n");
 		log("\n");
 		log("    -keepdc\n");
-		log("        Do not optimize explicit don't-care values.\n");
+		log("        Do not optimize explicit don't-care values on $mux cells.\n");
 		log("\n");
 	}
 	void execute(std::vector<std::string> args, Design *design) YS_OVERRIDE


### PR DESCRIPTION
Propagated through to `wreduce` call.

Also clarify doc for `wreduce -keepdc` to indicate use only for `$mux` cells.

Response to #1165 