### PR TITLE
Add support for processes in bugpoint

### DIFF
--- a/passes/cmds/bugpoint.cc
+++ b/passes/cmds/bugpoint.cc
@@ -51,14 +51,14 @@ struct BugpointPass : public Pass {
 		log("        only consider crashes that place this string in the log file.\n");
 		log("\n");
 		log("    -fast\n");
-		log("        run `clean -purge` after each minimization step. converges faster, but\n");
-		log("        produces larger testcases, and may fail to produce any testcase at all if\n");
-		log("        the crash is related to dangling wires.\n");
+		log("        run `proc_clean; clean -purge` after each minimization step. converges\n");
+		log("        faster, but produces larger testcases, and may fail to produce any\n");
+		log("        testcase at all if the crash is related to dangling wires.\n");
 		log("\n");
 		log("    -clean\n");
-		log("        run `clean -purge` before checking testcase and after finishing. produces\n");
-		log("        smaller and more useful testcases, but may fail to produce any testcase\n");
-		log("        at all if the crash is related to dangling wires.\n");
+		log("        run `proc_clean; clean -purge` before checking testcase and after\n");
+		log("        finishing. produces smaller and more useful testcases, but may fail to\n");
+		log("        produce any testcase at all if the crash is related to dangling wires.\n");
 		log("\n");
 		log("    -modules\n");
 		log("        try to remove modules.\n");
@@ -71,6 +71,12 @@ struct BugpointPass : public Pass {
 		log("\n");
 		log("    -connections\n");
 		log("        try to reconnect ports to 'x.\n");
+		log("\n");
+		log("    -assigns\n");
+		log("        try to remove process assigns from cases.\n");
+		log("\n");
+		log("    -updates\n");
+		log("        try to remove process updates from syncs.\n");
 		log("\n");
 	}
 
@@ -110,6 +116,7 @@ struct BugpointPass : public Pass {
 		RTLIL::Design *design_copy = new RTLIL::Design;
 		for (auto &it : design->modules_)
 			design_copy->add(it.second->clone());
+		Pass::call(design_copy, "proc_clean -quiet");
 		Pass::call(design_copy, "clean -purge");
 
 		if (do_delete)
@@ -117,7 +124,7 @@ struct BugpointPass : public Pass {
 		return design_copy;
 	}
 
-	RTLIL::Design *simplify_something(RTLIL::Design *design, int &seed, bool stage2, bool modules, bool ports, bool cells, bool connections)
+	RTLIL::Design *simplify_something(RTLIL::Design *design, int &seed, bool stage2, bool modules, bool ports, bool cells, bool connections, bool assigns, bool updates)
 	{
 		RTLIL::Design *design_copy = new RTLIL::Design;
 		for (auto &it : design->modules_)
@@ -225,6 +232,59 @@ struct BugpointPass : public Pass {
 				}
 			}
 		}
+		if (assigns)
+		{
+			for (auto mod : design_copy->modules())
+			{
+				if (mod->get_blackbox_attribute())
+					continue;
+
+				for (auto &pr : mod->processes)
+				{
+					vector<RTLIL::CaseRule*> cases = {&pr.second->root_case};
+					while (!cases.empty())
+					{
+						RTLIL::CaseRule *cs = cases[0];
+						cases.erase(cases.begin());
+						for (auto it = cs->actions.begin(); it != cs->actions.end(); ++it)
+						{
+							if (index++ == seed)
+							{
+								log("Trying to remove assign %s %s in %s.%s.\n", log_signal((*it).first), log_signal((*it).second), mod->name.c_str(), pr.first.c_str());
+								cs->actions.erase(it);
+								return design_copy;
+							}
+						}
+						for (auto &sw : cs->switches)
+							cases.insert(cases.end(), sw->cases.begin(), sw->cases.end());
+					}
+				}
+			}
+		}
+		if (updates)
+		{
+			for (auto mod : design_copy->modules())
+			{
+				if (mod->get_blackbox_attribute())
+					continue;
+
+				for (auto &pr : mod->processes)
+				{
+					for (auto &sy : pr.second->syncs)
+					{
+						for (auto it = sy->actions.begin(); it != sy->actions.end(); ++it)
+						{
+							if (index++ == seed)
+							{
+								log("Trying to remove sync %s update %s %s in %s.%s.\n", log_signal(sy->signal), log_signal((*it).first), log_signal((*it).second), mod->name.c_str(), pr.first.c_str());
+								sy->actions.erase(it);
+								return design_copy;
+							}
+						}
+					}
+				}
+			}
+		}
 		return NULL;
 	}
 
@@ -232,7 +292,7 @@ struct BugpointPass : public Pass {
 	{
 		string yosys_cmd = "yosys", script, grep;
 		bool fast = false, clean = false;
-		bool modules = false, ports = false, cells = false, connections = false, has_part = false;
+		bool modules = false, ports = false, cells = false, connections = false, assigns = false, updates = false, has_part = false;
 
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
@@ -277,6 +337,16 @@ struct BugpointPass : public Pass {
 				has_part = true;
 				continue;
 			}
+			if (args[argidx] == "-assigns") {
+				assigns = true;
+				has_part = true;
+				continue;
+			}
+			if (args[argidx] == "-updates") {
+				updates = true;
+				has_part = true;
+				continue;
+			}
 			break;
 		}
 		extra_args(args, argidx, design);
@@ -290,6 +360,8 @@ struct BugpointPass : public Pass {
 			ports = true;
 			cells = true;
 			connections = true;
+			assigns = true;
+			updates = true;
 		}
 
 		if (!design->full_selection())
@@ -305,7 +377,7 @@ struct BugpointPass : public Pass {
 		bool found_something = false, stage2 = false;
 		while (true)
 		{
-			if (RTLIL::Design *simplified = simplify_something(crashing_design, seed, stage2, modules, ports, cells, connections))
+			if (RTLIL::Design *simplified = simplify_something(crashing_design, seed, stage2, modules, ports, cells, connections, assigns, updates))
 			{
 				simplified = clean_design(simplified, fast, /*do_delete=*/true);
 

--- a/passes/proc/proc_clean.cc
+++ b/passes/proc/proc_clean.cc
@@ -143,7 +143,7 @@ void proc_clean_case(RTLIL::CaseRule *cs, bool &did_something, int &count, int m
 YOSYS_NAMESPACE_END
 PRIVATE_NAMESPACE_BEGIN
 
-void proc_clean(RTLIL::Module *mod, RTLIL::Process *proc, int &total_count)
+void proc_clean(RTLIL::Module *mod, RTLIL::Process *proc, int &total_count, bool quiet)
 {
 	int count = 0;
 	bool did_something = true;
@@ -160,7 +160,7 @@ void proc_clean(RTLIL::Module *mod, RTLIL::Process *proc, int &total_count)
 		did_something = false;
 		proc_clean_case(&proc->root_case, did_something, count, -1);
 	}
-	if (count > 0)
+	if (count > 0 && !quiet)
 		log("Found and cleaned up %d empty switch%s in `%s.%s'.\n", count, count == 1 ? "" : "es", mod->name.c_str(), proc->name.c_str());
 	total_count += count;
 }
@@ -171,7 +171,10 @@ struct ProcCleanPass : public Pass {
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
-		log("    proc_clean [selection]\n");
+		log("    proc_clean [options] [selection]\n");
+		log("\n");
+		log("    -quiet\n");
+		log("        do not print any messages.\n");
 		log("\n");
 		log("This pass removes empty parts of processes and ultimately removes a process\n");
 		log("if it contains only empty structures.\n");
@@ -180,9 +183,20 @@ struct ProcCleanPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		int total_count = 0;
-		log_header(design, "Executing PROC_CLEAN pass (remove empty switches from decision trees).\n");
+		bool quiet = false;
 
-		extra_args(args, 1, design);
+		if (find(args.begin(), args.end(), "-quiet") == args.end())
+			log_header(design, "Executing PROC_CLEAN pass (remove empty switches from decision trees).\n");
+
+		size_t argidx;
+		for (argidx = 1; argidx < args.size(); argidx++)
+		{
+			if (args[argidx] == "-quiet") {
+				quiet = true;
+				continue;
+			}
+		}
+		extra_args(args, argidx, design);
 
 		for (auto mod : design->modules()) {
 			std::vector<RTLIL::IdString> delme;
@@ -191,10 +205,11 @@ struct ProcCleanPass : public Pass {
 			for (auto &proc_it : mod->processes) {
 				if (!design->selected(mod, proc_it.second))
 					continue;
-				proc_clean(mod, proc_it.second, total_count);
+				proc_clean(mod, proc_it.second, total_count, quiet);
 				if (proc_it.second->syncs.size() == 0 && proc_it.second->root_case.switches.size() == 0 &&
 						proc_it.second->root_case.actions.size() == 0) {
-					log("Removing empty process `%s.%s'.\n", log_id(mod), proc_it.second->name.c_str());
+					if (!quiet)
+						log("Removing empty process `%s.%s'.\n", log_id(mod), proc_it.second->name.c_str());
 					delme.push_back(proc_it.first);
 				}
 			}
@@ -204,7 +219,8 @@ struct ProcCleanPass : public Pass {
 			}
 		}
 
-		log("Cleaned up %d empty switch%s.\n", total_count, total_count == 1 ? "" : "es");
+		if (!quiet)
+			log("Cleaned up %d empty switch%s.\n", total_count, total_count == 1 ? "" : "es");
 	}
 } ProcCleanPass;
 


### PR DESCRIPTION
I think it'd make sense to teach `opt_clean` to work on modules with processes, which I may do in the future. I also think it'd make sense to add a `-quiet` option to `opt_clean` (like I did for `proc_clean`) instead of duplicating the entire pass for the `clean` command...