### PR TITLE
abc9: push inverters driving box inputs (comb outputs) through $lut soft logic

### DIFF
--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -761,11 +761,11 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 
 			auto jt = bit2sinks.find(a_bit);
 			if (jt == bit2sinks.end())
-				goto duplicate_lut;
+				goto clone_lut;
 
 			for (auto sink_cell : jt->second)
 				if (sink_cell->type != "$lut")
-					goto duplicate_lut;
+					goto clone_lut;
 
 			// Push downstream LUTs past inverter
 			for (auto sink_cell : jt->second) {
@@ -787,7 +787,7 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 				sink_cell->setParam("\\LUT", mask);
 			}
 
-duplicate_lut:
+clone_lut:
 			driver_mask = driver_lut->getParam("\\LUT");
 			for (auto &b : driver_mask.bits) {
 				if (b == RTLIL::State::S0) b = RTLIL::State::S1;

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -30,8 +30,7 @@
 						"&st; &if -g -K 6; &synch2; &if {W} -v; &save; &load; "\
 						"&mfs; &ps -l"
 #else
-#define ABC_COMMAND_LUT "&st; &scorr; &sweep; &dc2; &st; &dch -f; &ps; &if {W} {D} -v; &mfs -b; &ps -l"
-//#define ABC_COMMAND_LUT "&st; &scorr; &sweep; &dc2; &st; &put -v; dch -f; if {W} {D} -vo; mfs2; &get -vm; &ps -l"
+#define ABC_COMMAND_LUT "&st; &scorr; &sweep; &dc2; &st; &dch -f; &ps; &if {W} {D} -v; &mfs; &ps -l"
 #endif
 
 
@@ -756,16 +755,11 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 			RTLIL::SigBit a_bit = not_cell->getPort("\\A");
 			RTLIL::SigBit y_bit = not_cell->getPort("\\Y");
 			RTLIL::Const driver_mask;
-			RTLIL::Wire *orig_a_bit_wire = a_bit.wire;
-			decltype(bit2sinks)::const_iterator jt;
 
 			a_bit.wire = module->wires_.at(remap_name(a_bit.wire->name));
 			y_bit.wire = module->wires_.at(remap_name(y_bit.wire->name));
 
-			if (orig_a_bit_wire->port_output)
-				goto duplicate_lut;
-
-			jt = bit2sinks.find(a_bit);
+			auto jt = bit2sinks.find(a_bit);
 			if (jt == bit2sinks.end())
 				goto duplicate_lut;
 

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -611,21 +611,15 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 								RTLIL::SigBit(module->wires_.at(remap_name(y_bit.wire->name)), y_bit.offset),
 								RTLIL::Const::from_string("01"));
 						bit2sinks[cell->getPort("\\A")].push_back(cell);
+						cell_stats["$lut"]++;
 					}
-					else {
+					else
 						push_inverters.emplace_back(c, driver_lut);
-						continue;
-					}
+					continue;
 				}
-				else {
-					cell = module->addCell(remap_name(c->name), "$_NOT_");
-					cell->setPort("\\A", RTLIL::SigBit(module->wires_.at(remap_name(a_bit.wire->name)), a_bit.offset));
-					cell->setPort("\\Y", RTLIL::SigBit(module->wires_.at(remap_name(y_bit.wire->name)), y_bit.offset));
-					cell_stats[RTLIL::unescape_id(c->type)]++;
+				else
 					log_abort();
-				}
 				if (cell && markgroups) cell->attributes["\\abcgroup"] = map_autoidx;
-				cell_stats[RTLIL::unescape_id(c->type)]++;
 				continue;
 			}
 			cell_stats[RTLIL::unescape_id(c->type)]++;

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -607,8 +607,8 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 						// If a driver couldn't be found (could be from PI or box CI)
 						// then implement using a LUT
 						cell = module->addLut(remap_name(stringf("%s$lut", c->name.c_str())),
-								RTLIL::SigBit(module->wires_[remap_name(a_bit.wire->name)], a_bit.offset),
-								RTLIL::SigBit(module->wires_[remap_name(y_bit.wire->name)], y_bit.offset),
+								RTLIL::SigBit(module->wires_.at(remap_name(a_bit.wire->name)), a_bit.offset),
+								RTLIL::SigBit(module->wires_.at(remap_name(y_bit.wire->name)), y_bit.offset),
 								RTLIL::Const::from_string("01"));
 						bit2sinks[cell->getPort("\\A")].push_back(cell);
 					}
@@ -619,8 +619,8 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 				}
 				else {
 					cell = module->addCell(remap_name(c->name), "$_NOT_");
-					cell->setPort("\\A", RTLIL::SigBit(module->wires_[remap_name(a_bit.wire->name)], a_bit.offset));
-					cell->setPort("\\Y", RTLIL::SigBit(module->wires_[remap_name(y_bit.wire->name)], y_bit.offset));
+					cell->setPort("\\A", RTLIL::SigBit(module->wires_.at(remap_name(a_bit.wire->name)), a_bit.offset));
+					cell->setPort("\\Y", RTLIL::SigBit(module->wires_.at(remap_name(y_bit.wire->name)), y_bit.offset));
 					cell_stats[RTLIL::unescape_id(c->type)]++;
 					log_abort();
 				}
@@ -633,8 +633,8 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 			RTLIL::Cell *existing_cell = nullptr;
 			if (c->type == "$lut") {
 				if (GetSize(c->getPort("\\A")) == 1 && c->getParam("\\LUT") == RTLIL::Const::from_string("01")) {
-					SigSpec my_a = module->wires_[remap_name(c->getPort("\\A").as_wire()->name)];
-					SigSpec my_y = module->wires_[remap_name(c->getPort("\\Y").as_wire()->name)];
+					SigSpec my_a = module->wires_.at(remap_name(c->getPort("\\A").as_wire()->name));
+					SigSpec my_y = module->wires_.at(remap_name(c->getPort("\\Y").as_wire()->name));
 					module->connect(my_y, my_a);
 					if (markgroups) c->attributes["\\abcgroup"] = map_autoidx;
 					log_abort();
@@ -664,7 +664,7 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 						continue;
 					//log_assert(c.width == 1);
 					if (c.wire)
-						c.wire = module->wires_[remap_name(c.wire->name)];
+						c.wire = module->wires_.at(remap_name(c.wire->name));
 					newsig.append(c);
 				}
 				cell->setPort(conn.first, newsig);
@@ -683,14 +683,14 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 			if (!conn.first.is_fully_const()) {
 				auto chunks = conn.first.chunks();
 				for (auto &c : chunks)
-					c.wire = module->wires_[remap_name(c.wire->name)];
+					c.wire = module->wires_.at(remap_name(c.wire->name));
 				conn.first = std::move(chunks);
 			}
 			if (!conn.second.is_fully_const()) {
 				auto chunks = conn.second.chunks();
 				for (auto &c : chunks)
 					if (c.wire)
-						c.wire = module->wires_[remap_name(c.wire->name)];
+						c.wire = module->wires_.at(remap_name(c.wire->name));
 				conn.second = std::move(chunks);
 			}
 			module->connect(conn);
@@ -777,12 +777,11 @@ duplicate_lut:
 			}
 			auto driver_a = driving_lut->getPort("\\A").chunks();
 			for (auto &chunk : driver_a)
-				chunk.wire = module->wires_[remap_name(chunk.wire->name)];
+				chunk.wire = module->wires_.at(remap_name(chunk.wire->name));
 			module->addLut(remap_name(not_cell->name),
 					driver_a,
 					y_bit,
 					driver_lut);
-			//mapped_mod->remove(not_cell);
 		}
 
 		//log("ABC RESULTS:        internal signals: %8d\n", int(signal_list.size()) - in_wires - out_wires);

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -756,7 +756,6 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 			log_assert(driving_lut);
 			RTLIL::SigBit a_bit = not_cell->getPort("\\A");
 			RTLIL::SigBit y_bit = not_cell->getPort("\\Y");
-			driving_lut = module->cell(remap_name(driving_lut->name));
 			log_assert(driving_lut);
 			RTLIL::Const driver_lut = driving_lut->getParam("\\LUT");
 			for (auto &b : driver_lut.bits) {
@@ -771,11 +770,6 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 			for (auto sink_cell : it->second)
 				if (sink_cell->type != "$lut")
 					goto duplicate_lut;
-
-			//static int count = 0;
-			//log_warning("%d\n", count);
-			//if (count++ >= 41)
-			//	goto duplicate_lut;
 
 			for (auto sink_cell : it->second) {
 				SigSpec A = sink_cell->getPort("\\A");
@@ -805,7 +799,7 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 duplicate_lut:
 			auto not_cell_name = not_cell->name;
 			module->remove(not_cell);
-#if 0
+#if 1
 			auto driver_a = driving_lut->getPort("\\A").chunks();
 			for (auto &chunk : driver_a)
 				chunk.wire = module->wires_[remap_name(chunk.wire->name)];

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -787,6 +787,11 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 				sink_cell->setParam("\\LUT", mask);
 			}
 
+			// Since we have rewritten all sinks (which we know
+			// to be only LUTs) to be after the inverter, we can
+			// go ahead and clone the LUT with the expectation
+			// that the original driving LUT will become dangling
+			// and get cleaned away
 clone_lut:
 			driver_mask = driver_lut->getParam("\\LUT");
 			for (auto &b : driver_mask.bits) {

--- a/tests/various/abc9.ys
+++ b/tests/various/abc9.ys
@@ -19,6 +19,6 @@ hierarchy -top abc9_test028
 proc
 
 abc9 -lut 4
-select -assert-count 1 t:$lut r:LUT=1 r:WIDTH=1 %i %i
+select -assert-count 1 t:$lut r:LUT=2'b01 r:WIDTH=1 %i %i
 select -assert-count 1 t:unknown
 select -assert-none t:$lut t:unknown %% t: %D


### PR DESCRIPTION
`abc9` can sometimes return a LUT mapping that has a `$_NOT_` gate left behind.
Previously, I would clone the driving flop (if one exists) but flip its mask so that we are guaranteed to never increase the logic depth.
This is sub-optimal as the `$_NOT_` gate can sometimes be absorbed into the driving LUT; doing so also requires that (a) all downstream sinks (i.e. those before the NOT gate) that driven by the same LUT must only be soft logic LUTs, and if so (b) we can then twiddle the mask of those downstream sinks to cope with the driving LUT being inverted.
This PR does (a) and (b).