### PR TITLE
extract_fa to return nothing more gracefully

### DIFF
--- a/passes/techmap/extract_fa.cc
+++ b/passes/techmap/extract_fa.cc
@@ -174,8 +174,10 @@ struct ExtractFaWorker
 
 				SigSpec sig = root;
 
-				if (!ce.eval(sig))
-					log_abort();
+				if (ce.eval(sig)) {
+					ce.pop();
+					return;
+				}
 
 				if (sig == State::S1)
 					func |= 1 << i;
@@ -214,8 +216,10 @@ struct ExtractFaWorker
 
 				SigSpec sig = root;
 
-				if (!ce.eval(sig))
-					log_abort();
+				if (ce.eval(sig)) {
+					ce.pop();
+					return;
+				}
 
 				if (sig == State::S1)
 					func |= 1 << i;


### PR DESCRIPTION
`extract_fa` uses `ConstEval` internally to "simulate" the output of cells. If `ConstEval::eval` fails to simulate a cell, fail more gracefully than a `log_abort`.

Fixes #1099 