### PR TITLE
smt: handle failure of setrlimit syscall

### DIFF
--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -43,7 +43,11 @@ if os.name == "posix":
         if current_rlimit_stack[1] != resource.RLIM_INFINITY:
             smtio_stacksize = min(smtio_stacksize, current_rlimit_stack[1])
         if current_rlimit_stack[0] < smtio_stacksize:
-            resource.setrlimit(resource.RLIMIT_STACK, (smtio_stacksize, current_rlimit_stack[1]))
+            try:
+                resource.setrlimit(resource.RLIMIT_STACK, (smtio_stacksize, current_rlimit_stack[1]))
+            except ValueError:
+                # couldn't get more stack, just run with what we have
+                pass
 
 
 # currently running solvers (so we can kill them)


### PR DESCRIPTION
Due to [a bug in the python resource module](https://bugs.python.org/issue36432), any call to SMT currently fails on recent macOS versions because the stack size can't be increased. There might also potentially be other reasons for the syscall to fail, and not getting a larger stack allocated shouldn't be a hard error.

This silently ignores failure from the setrlimit call, and tries to run the solver anyway with whatever stack is available.

I'm assuming that if the solver does run out of memory the error message is explicit enough, but I wasn't able to trigger that message. If it's too cryptic we could consider emitting a warning instead when stack allocation fails.