### PR TITLE
ice40: Adapt the relut process passes to the new $lut/SB_LUT4 port map

### DIFF
--- a/techlibs/ice40/ice40_unlut.cc
+++ b/techlibs/ice40/ice40_unlut.cc
@@ -56,10 +56,10 @@ static void run_ice40_unlut(Module *module)
 			cell->unsetParam("\\LUT_INIT");
 
 			cell->setPort("\\A", SigSpec({
-				get_bit_or_zero(cell->getPort("\\I3")),
-				get_bit_or_zero(cell->getPort("\\I2")),
+				get_bit_or_zero(cell->getPort("\\I0")),
 				get_bit_or_zero(cell->getPort("\\I1")),
-				get_bit_or_zero(cell->getPort("\\I0"))
+				get_bit_or_zero(cell->getPort("\\I2")),
+				get_bit_or_zero(cell->getPort("\\I3"))
 			}));
 			cell->setPort("\\Y", cell->getPort("\\O")[0]);
 			cell->unsetPort("\\I0");

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -345,7 +345,7 @@ struct SynthIce40Pass : public ScriptPass
 			}
 			run("clean");
 			run("ice40_unlut");
-			run("opt_lut -dlogic SB_CARRY:I0=1:I1=2:CI=3");
+			run("opt_lut -dlogic SB_CARRY:I0=2:I1=1:CI=0");
 		}
 
 		if (check_label("map_cells"))


### PR DESCRIPTION
The new mapping introduced in 437fec0d88b4a2ad172edf0d1a861a38845f3b1d
needed matching adaptation when converting and optimizing LUTs during
the relut process

Fixes #1187

(Diagnosis of the issue by @daveshah1 on IRC)

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>