### PR TITLE
intel: Make -noiopads the default

### DIFF
--- a/techlibs/intel/synth_intel.cc
+++ b/techlibs/intel/synth_intel.cc
@@ -61,8 +61,8 @@ struct SynthIntelPass : public ScriptPass {
 		log("        from label is synonymous to 'begin', and empty to label is\n");
 		log("        synonymous to the end of the command list.\n");
 		log("\n");
-		log("    -noiopads\n");
-		log("        do not use IO pad cells in output netlist\n");
+		log("    -iopads\n");
+		log("        use IO pad cells in output netlist\n");
 		log("\n");
 		log("    -nobram\n");
 		log("        do not use block RAM cells in output netlist\n");
@@ -79,7 +79,7 @@ struct SynthIntelPass : public ScriptPass {
 	}
 
 	string top_opt, family_opt, vout_file, blif_file;
-	bool retime, flatten, nobram, noiopads;
+	bool retime, flatten, nobram, iopads;
 
 	void clear_flags() YS_OVERRIDE
 	{
@@ -90,7 +90,7 @@ struct SynthIntelPass : public ScriptPass {
 		retime = false;
 		flatten = true;
 		nobram = false;
-		noiopads = false;
+		iopads = false;
 	}
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
@@ -125,8 +125,8 @@ struct SynthIntelPass : public ScriptPass {
 				run_to = args[argidx].substr(pos + 1);
 				continue;
 			}
-			if (args[argidx] == "-noiopads") {
-				noiopads = true;
+			if (args[argidx] == "-iopads") {
+				iopads = true;
 				continue;
 			}
 			if (args[argidx] == "-nobram") {
@@ -215,8 +215,8 @@ struct SynthIntelPass : public ScriptPass {
 		}
 
 		if (check_label("map_cells")) {
-			if (!noiopads)
-				run("iopadmap -bits -outpad $__outpad I:O -inpad $__inpad O:I", "(unless -noiopads)");
+			if (iopads || help_mode)
+				run("iopadmap -bits -outpad $__outpad I:O -inpad $__inpad O:I", "(if -iopads)");
                         run(stringf("techmap -map +/intel/%s/cells_map.v", family_opt.c_str()));
 
 			run("dffinit -highlow -ff dffeas q power_up");


### PR DESCRIPTION
Recent (I'm using 18.1 Lite) Quartus versions do not produce any IO pad cells in their netlists, suggesting Quartus can infer them now, or that they're unnecessary. Since Yosys doesn't care, and nextpnr (as a long shot) can infer them too, switch them off by default, while keeping the option around.