### PR TITLE
verilog_lexer: Increase YY_BUF_SIZE to 65536

### DIFF
--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -70,6 +70,9 @@ YOSYS_NAMESPACE_END
 #define YY_INPUT(buf,result,max_size) \
 	result = readsome(*VERILOG_FRONTEND::lexin, buf, max_size)
 
+#undef YY_BUF_SIZE
+#define YY_BUF_SIZE 65536
+
 %}
 
 %option yylineno


### PR DESCRIPTION
Otherwise "medium" Boom configuration (and possibly other FIRRTL-derived Verilog input) fail with `input buffer overflow, can't enlarge buffer because scanner uses REJECT`. 64k shouldn't make a significant difference to Yosys' memory footprint.