### PR TITLE
Visual Studio build fix

### DIFF
--- a/backends/aiger/xaiger.cc
+++ b/backends/aiger/xaiger.cc
@@ -53,7 +53,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 inline int32_t to_big_endian(int32_t i32) {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-	return __builtin_bswap32(i32);
+	return bswap32(i32);
 #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 	return i32;
 #else

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -49,6 +49,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <cctype>
 #include <cerrno>
 #include <sstream>
 #include <climits>


### PR DESCRIPTION
bswap32 was defined for each platform but GCC specific was used at the end
including cctype needed due to usage of std::isdigit