### PR TITLE
Fix formatting for msys2 mingw build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -869,9 +869,11 @@ config-mxe: clean
 
 config-msys2: clean
 	echo 'CONFIG := msys2' > Makefile.conf
+	echo 'ENABLE_PLUGINS := 0' >> Makefile.conf
 
 config-msys2-64: clean
 	echo 'CONFIG := msys2-64' > Makefile.conf
+	echo 'ENABLE_PLUGINS := 0' >> Makefile.conf
 
 config-cygwin: clean
 	echo 'CONFIG := cygwin' > Makefile.conf

--- a/Makefile
+++ b/Makefile
@@ -401,7 +401,7 @@ endif
 
 ifeq ($(CONFIG),mxe)
 CXXFLAGS += -DYOSYS_ENABLE_TCL
-LDLIBS += -ltcl86 -lwsock32 -lws2_32 -lnetapi32 -lz
+LDLIBS += -ltcl86 -lwsock32 -lws2_32 -lnetapi32 -lz -luserenv
 else
 CXXFLAGS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --cflags tcl || echo -I$(TCL_INCLUDE)) -DYOSYS_ENABLE_TCL
 ifeq ($(OS), FreeBSD)

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,8 @@ CXXFLAGS := $(filter-out -fPIC,$(CXXFLAGS))
 LDFLAGS := $(filter-out -rdynamic,$(LDFLAGS)) -s
 LDLIBS := $(filter-out -lrt,$(LDLIBS))
 ABCMKARGS += ARCHFLAGS="-DWIN32_NO_DLL -DHAVE_STRUCT_TIMESPEC -fpermissive -w"
-ABCMKARGS += LIBS="lib/x86/pthreadVC2.lib -s" ABC_USE_NO_READLINE=1 CC="/usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-gcc"
+# TODO: Try to solve pthread linking issue in more appropriate way
+ABCMKARGS += LIBS="lib/x86/pthreadVC2.lib -s" LDFLAGS="-Wl,--allow-multiple-definition" ABC_USE_NO_READLINE=1 CC="/usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-gcc"
 EXE = .exe
 
 else ifeq ($(CONFIG),msys2)

--- a/backends/aiger/xaiger.cc
+++ b/backends/aiger/xaiger.cc
@@ -610,15 +610,15 @@ struct XAigerWriter
 			std::stringstream h_buffer;
 			auto write_h_buffer = std::bind(write_buffer, std::ref(h_buffer), std::placeholders::_1);
 			write_h_buffer(1);
-			log_debug("ciNum = %zu\n", input_bits.size() + ci_bits.size());
+			log_debug("ciNum = %d\n", GetSize(input_bits) + GetSize(ci_bits));
 			write_h_buffer(input_bits.size() + ci_bits.size());
-			log_debug("coNum = %zu\n", output_bits.size() + co_bits.size());
+			log_debug("coNum = %d\n", GetSize(output_bits) + GetSize(co_bits));
 			write_h_buffer(output_bits.size() + co_bits.size());
-			log_debug("piNum = %zu\n", input_bits.size());
+			log_debug("piNum = %d\n", GetSize(input_bits));
 			write_h_buffer(input_bits.size());
-			log_debug("poNum = %zu\n", output_bits.size());
+			log_debug("poNum = %d\n", GetSize(output_bits));
 			write_h_buffer(output_bits.size());
-			log_debug("boxNum = %zu\n", box_list.size());
+			log_debug("boxNum = %d\n", GetSize(box_list));
 			write_h_buffer(box_list.size());
 
 			RTLIL::Module *holes_module = nullptr;
@@ -772,7 +772,7 @@ struct XAigerWriter
 
 				if (output_bits.count(b)) {
 					int o = ordered_outputs.at(b);
-					output_lines[o] += stringf("output %lu %d %s\n", o - co_bits.size(), i, log_id(wire));
+					output_lines[o] += stringf("output %d %d %s\n", o - GetSize(co_bits), i, log_id(wire));
 					continue;
 				}
 

--- a/frontends/aiger/aigerparse.cc
+++ b/frontends/aiger/aigerparse.cc
@@ -301,7 +301,11 @@ static uint32_t parse_xaiger_literal(std::istream &f)
 	uint32_t l;
 	f.read(reinterpret_cast<char*>(&l), sizeof(l));
 	if (f.gcount() != sizeof(l))
+#if defined(_WIN32) && defined(__MINGW32__)
+		log_error("Offset %I64d: unable to read literal!\n", static_cast<int64_t>(f.tellg()));
+#else
 		log_error("Offset %" PRId64 ": unable to read literal!\n", static_cast<int64_t>(f.tellg()));
+#endif
 	return from_big_endian(l);
 }
 

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -88,6 +88,10 @@ extern int Tcl_EvalFile(Tcl_Interp *interp, const char *fileName);
 extern void Tcl_Finalize(void);
 extern int Tcl_GetCommandInfo(Tcl_Interp *interp, const char *cmdName, Tcl_CmdInfo *infoPtr);
 extern const char *Tcl_GetStringResult(Tcl_Interp *interp);
+extern Tcl_Obj *Tcl_NewStringObj(const char *bytes, int length);
+extern Tcl_Obj *Tcl_NewIntObj(int intValue);
+extern Tcl_Obj *Tcl_NewListObj(int objc, Tcl_Obj *const objv[]);
+extern Tcl_Obj *Tcl_ObjSetVar2(Tcl_Interp *interp, Tcl_Obj *part1Ptr, Tcl_Obj *part2Ptr, Tcl_Obj *newValuePtr, int flags);
 #  endif
 #endif
 

--- a/misc/launcher.c
+++ b/misc/launcher.c
@@ -61,6 +61,7 @@ SOFTWARE. */
 #include <windows.h>
 #include <tchar.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 int child_pid=0;
 
@@ -338,7 +339,7 @@ int run(int argc, char **argv, int is_gui) {
 
     if (is_gui) {
         /* Use exec, we don't need to wait for the GUI to finish */
-        execv(ptr, (const char * const *)(newargs));
+        execv(ptr, (char * const *)(newargs));
         return fail("Could not exec %s", ptr);   /* shouldn't get here! */
     }
 

--- a/passes/opt/opt_lut.cc
+++ b/passes/opt/opt_lut.cc
@@ -81,7 +81,7 @@ struct OptLutWorker
 			}
 		}
 
-		log("Number of LUTs: %8zu\n", luts.size());
+		log("Number of LUTs: %8d\n", GetSize(luts));
 		for (int arity = 1; arity <= max_arity; arity++)
 		{
 			if (arity_counts[arity])
@@ -351,14 +351,14 @@ struct OptLutWorker
 
 					int lutM_arity = lutA_arity + lutB_arity - 1 - common_inputs.size();
 					if (lutA_dlogic_inputs.size())
-						log_debug("  Cell A is a %d-LUT with %zu dedicated connections. ", lutA_arity, lutA_dlogic_inputs.size());
+						log_debug("  Cell A is a %d-LUT with %d dedicated connections. ", lutA_arity, GetSize(lutA_dlogic_inputs));
 					else
 						log_debug("  Cell A is a %d-LUT. ", lutA_arity);
 					if (lutB_dlogic_inputs.size())
-						log_debug("Cell B is a %d-LUT with %zu dedicated connections.\n", lutB_arity, lutB_dlogic_inputs.size());
+						log_debug("Cell B is a %d-LUT with %d dedicated connections.\n", lutB_arity, GetSize(lutB_dlogic_inputs));
 					else
 						log_debug("Cell B is a %d-LUT.\n", lutB_arity);
-					log_debug("  Cells share %zu input(s) and can be merged into one %d-LUT.\n", common_inputs.size(), lutM_arity);
+					log_debug("  Cells share %d input(s) and can be merged into one %d-LUT.\n", GetSize(common_inputs), lutM_arity);
 
 					const int COMBINE_A = 1, COMBINE_B = 2, COMBINE_EITHER = COMBINE_A | COMBINE_B;
 					int combine_mask = 0;

--- a/passes/opt/rmports.cc
+++ b/passes/opt/rmports.cc
@@ -171,7 +171,7 @@ struct RmportsPassPass : public Pass {
 			wire->port_output = false;
 			wire->port_id = 0;
 		}
-		log("Removed %zu unused ports.\n", unused_ports.size());
+		log("Removed %d unused ports.\n", GetSize(unused_ports));
 
 		// Re-number all of the wires that DO have ports still on them
 		for(size_t i=0; i<module->ports.size(); i++)

--- a/passes/techmap/flowmap.cc
+++ b/passes/techmap/flowmap.cc
@@ -783,7 +783,7 @@ struct FlowmapWorker
 		int depth = 0;
 		for (auto label : labels)
 			depth = max(depth, label.second);
-		log("Mapped to %zu LUTs with maximum depth %d.\n", lut_nodes.size(), depth);
+		log("Mapped to %d LUTs with maximum depth %d.\n", GetSize(lut_nodes), depth);
 
 		if (debug)
 		{
@@ -1195,7 +1195,7 @@ struct FlowmapWorker
 
 	bool relax_depth_for_bound(bool first, int depth_bound, dict<RTLIL::SigBit, pool<RTLIL::SigBit>> &lut_critical_outputs)
 	{
-		size_t initial_count = lut_nodes.size();
+		int initial_count = GetSize(lut_nodes);
 
 		for (auto node : lut_nodes)
 		{
@@ -1215,7 +1215,7 @@ struct FlowmapWorker
 
 			if (potentials.empty())
 			{
-				log("  Relaxed to %zu (+%zu) LUTs.\n", lut_nodes.size(), lut_nodes.size() - initial_count);
+				log("  Relaxed to %d (+%d) LUTs.\n", GetSize(lut_nodes), GetSize(lut_nodes) - initial_count);
 				if (!first && break_num == 1)
 				{
 					log("  Design fully relaxed.\n");
@@ -1419,9 +1419,9 @@ struct FlowmapWorker
 			lut_area += lut_table.size();
 
 			if ((int)input_nodes.size() >= minlut)
-				log("  Packed into a %zu-LUT %s.%s.\n", input_nodes.size(), log_id(module), log_id(lut));
+				log("  Packed into a %d-LUT %s.%s.\n", GetSize(input_nodes), log_id(module), log_id(lut));
 			else
-				log("  Packed into a %zu-LUT %s.%s (implemented as %d-LUT).\n", input_nodes.size(), log_id(module), log_id(lut), minlut);
+				log("  Packed into a %d-LUT %s.%s (implemented as %d-LUT).\n", GetSize(input_nodes), log_id(module), log_id(lut), minlut);
 		}
 
 		for (auto node : mapped_nodes)

--- a/techlibs/anlogic/anlogic_determine_init.cc
+++ b/techlibs/anlogic/anlogic_determine_init.cc
@@ -50,7 +50,7 @@ struct AnlogicDetermineInitPass : public Pass {
 
 		extra_args(args, args.size(), design);
 
-		size_t cnt = 0;
+		int cnt = 0;
 		for (auto module : design->selected_modules())
 		{
 			for (auto cell : module->selected_cells())
@@ -65,7 +65,7 @@ struct AnlogicDetermineInitPass : public Pass {
 				}
 			}
 		}
-		log_header(design, "Updated %lu cells with determined init value.\n", cnt);
+		log_header(design, "Updated %d cells with determined init value.\n", cnt);
 	}
 } AnlogicDetermineInitPass;
 

--- a/techlibs/anlogic/anlogic_eqn.cc
+++ b/techlibs/anlogic/anlogic_eqn.cc
@@ -69,7 +69,7 @@ struct AnlogicEqnPass : public Pass {
 
 		extra_args(args, args.size(), design);
 
-		size_t cnt = 0;
+		int cnt = 0;
 		for (auto module : design->selected_modules())
 		{
 			for (auto cell : module->selected_cells())
@@ -106,7 +106,7 @@ struct AnlogicEqnPass : public Pass {
 				}
 			}
 		}
-		log_header(design, "Updated %lu of AL_MAP_LUT* elements with equation.\n", cnt);
+		log_header(design, "Updated %d of AL_MAP_LUT* elements with equation.\n", cnt);
 	}
 } AnlogicEqnPass;
 

--- a/techlibs/gowin/determine_init.cc
+++ b/techlibs/gowin/determine_init.cc
@@ -50,7 +50,7 @@ struct DetermineInitPass : public Pass {
 
 		extra_args(args, args.size(), design);
 
-		size_t cnt = 0;
+		int cnt = 0;
 		for (auto module : design->selected_modules())
 		{
 			for (auto cell : module->selected_cells())
@@ -65,7 +65,7 @@ struct DetermineInitPass : public Pass {
 				}
 			}
 		}
-		log_header(design, "Updated %lu cells with determined init value.\n", cnt);
+		log_header(design, "Updated %d cells with determined init value.\n", cnt);
 	}
 } DetermineInitPass;
 


### PR DESCRIPTION
- msys2 builds anyway can not be compiled with plugins so made config so compile work by default
- %zu is not supported in msys mingw, mxe and VisualStudio older then 2015 so made define for size_t formatting
- update places where wrong formatting have been used for size_t values
- fixed cast and not defined symbol in launcher.c

TODO: check mxe build after these changes   