### PR TITLE
proc_prune: Promote partially redundant assignments.

### DIFF
--- a/passes/proc/proc_prune.cc
+++ b/passes/proc/proc_prune.cc
@@ -82,14 +82,23 @@ struct PruneWorker
 				if (root) {
 					bool promotable = true;
 					for (auto &bit : lhs) {
-						if (bit.wire && affected[bit]) {
+						if (bit.wire && affected[bit] && !assigned[bit]) {
 							promotable = false;
 							break;
 						}
 					}
 					if (promotable) {
+						RTLIL::SigSpec rhs = sigmap(it->second);
+						RTLIL::SigSig conn;
+						for (int i = 0; i < GetSize(lhs); i++) {
+							RTLIL::SigBit lhs_bit = lhs[i];
+							if (lhs_bit.wire && !assigned[lhs_bit]) {
+								conn.first.append_bit(lhs_bit);
+								conn.second.append(rhs.extract(i));
+							}
+						}
 						promoted_count++;
-						module->connect(*it);
+						module->connect(conn);
 						remove.insert(*it);
 					}
 				}


### PR DESCRIPTION
Before this commit, proc_prune would ignore partially redundant assignments.
eg.
```
module \top
  wire width 2 \s
  process $group_0
    assign \s 2'00 
    assign \s [0] 1'1
  end
end
```
would be transformed into:
```
module \top
  wire width 2 \s
  process $group_0
    assign \s 2'00
  end
  connect \s [0] 1'1
end
```
This is wrong because `\s [0]` is now assigned concurrently twice. 

After this commit, proc_prune promotes the first assignment too:
```
module \top
  wire width 2 \s
  process $group_0
  end
  connect \s [0] 1'1
  connect \s [1] 1'0
end
```