### PR TITLE
abc9: speedup by using using "clean" more efficiently

### DIFF
--- a/frontends/aiger/aigerparse.h
+++ b/frontends/aiger/aigerparse.h
@@ -47,7 +47,7 @@ struct AigerReader
 
     AigerReader(RTLIL::Design *design, std::istream &f, RTLIL::IdString module_name, RTLIL::IdString clk_name, std::string map_filename, bool wideports);
     void parse_aiger();
-    void parse_xaiger();
+    void parse_xaiger(const dict<int,IdString> &box_lookup);
     void parse_aiger_ascii();
     void parse_aiger_binary();
     void post_process();

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -736,6 +736,8 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 			}
 		}
 
+		// TODO: Move this optimisation into parse_xaiger, so that we
+		//       can get save on the "clean" call at the end of this function
 		for (auto &it : bit_users)
 			if (bit_drivers.count(it.first))
 				for (auto driver_cell : bit_drivers.at(it.first))

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -736,8 +736,6 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 			}
 		}
 
-		// TODO: Move this optimisation into parse_xaiger, so that we
-		//       can get save on the "clean" call at the end of this function
 		for (auto &it : bit_users)
 			if (bit_drivers.count(it.first))
 				for (auto driver_cell : bit_drivers.at(it.first))

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -1263,9 +1263,10 @@ struct Abc9Pass : public Pass {
 			}
 		}
 
-		Pass::call(design, "clean");
-
 		assign_map.clear();
+
+		// The "clean" pass also contains a design->check() call
+		Pass::call(design, "clean");
 
 		log_pop();
 	}


### PR DESCRIPTION
Unfortunately, I overlooked the fact that while `clean` does operate on selected modules, it also runs `optimize()`/`sort()`/`check()` on the entire design that it gets called on:

https://github.com/YosysHQ/yosys/blob/e8a2d10982cd8f6ba3b0e66fbd922b051073f0cf/passes/opt/opt_clean.cc#L625-L627

Since `abc9` (currently, rightly or wrongly) relies on a O(N) of `clean`-s for (several for each module to be abc9-ed) in order to remove the AIG from which LUTs were generated, this ends up costing quite a bit, particularly on large designs with many modules.

This PR improves this situation by placing each of the to-be-cleaned modules into its own design. ~There's one remaining known TODO (which I will revisit next week) to get rid of one final `clean` call.~ EDIT: Don't think my TODO would have helped things since we need to run a `clean` before doing any of those optimisations anyway...

Quick experiment with soc_ethernetsoc_rocket on Xilinx. Before:
```
CPU: user 473.28s system 19.69s, MEM: 1157.45 MB total, 1119.32 MB resident
Yosys 0.8+618 (git sha1 e8a2d109, clang 7.0.0-3 -fPIC -Os)
Time spent: 27% 1x abc9 (133 sec), 24% 316x clean (120 sec), ...
```
After:
```
CPU: user 332.13s system 16.11s, MEM: 1157.91 MB total, 1120.63 MB resident
Yosys 0.8+615 (git sha1 0218e641, clang 7.0.0-3 -fPIC -Os)
Time spent: 29% 1x abc9 (103 sec), 13% 312x write_xaiger (45 sec), ...
```

EDIT: Currently merged with #1253 (thus that should be merged first) to give:
```
CPU: user 190.63s system 16.80s, MEM: 1147.50 MB total, 1108.03 MB resident
Yosys 0.8+623 (git sha1 5301c527, clang 7.0.0-3 -fPIC -Os)
Time spent: 16% 61x techmap (34 sec), 14% 24x opt_clean (29 sec), ...
```