### PR TITLE
Suppress some compiler warnings occurring when applying NDEBUG

### DIFF
--- a/backends/ilang/ilang_backend.cc
+++ b/backends/ilang/ilang_backend.cc
@@ -352,9 +352,7 @@ void ILANG_BACKEND::dump_module(std::ostream &f, std::string indent, RTLIL::Modu
 
 void ILANG_BACKEND::dump_design(std::ostream &f, RTLIL::Design *design, bool only_selected, bool flag_m, bool flag_n)
 {
-#ifndef NDEBUG
 	int init_autoidx = autoidx;
-#endif
 
 	if (!flag_m) {
 		int count_selected_mods = 0;

--- a/frontends/aiger/aigerparse.cc
+++ b/frontends/aiger/aigerparse.cc
@@ -49,8 +49,8 @@ inline int32_t from_big_endian(int32_t i32) {
 #endif
 }
 
-#define log_debug2(...) ;
-//#define log_debug2(...) log_debug(__VA_ARGS__)
+//#define log_debug2(...) do { log_debug(__VA_ARGS__); } while (0)
+#define log_debug2(...) do { if (0) log_debug(__VA_ARGS__); } while (0)
 
 struct ConstEvalAig
 {

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -89,11 +89,10 @@ YS_NORETURN void log_cmd_error(const char *format, ...) YS_ATTRIBUTE(format(prin
 
 #ifndef NDEBUG
 static inline bool ys_debug(int n = 0) { if (log_force_debug) return true; log_debug_suppressed += n; return false; }
-#  define log_debug(...) do { if (ys_debug(1)) log(__VA_ARGS__); } while (0)
 #else
-static inline bool ys_debug(int n = 0) { (void) n; return false; }
-#  define log_debug(_fmt, ...) do { } while (0)
+static constexpr inline bool ys_debug(int /*n*/ = 0) { return false; }
 #endif
+#define log_debug(...) do { if (ys_debug(1)) log(__VA_ARGS__); } while (0)
 
 static inline void log_suppressed() {
 	if (log_debug_suppressed && !log_make_debug) {

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -91,7 +91,7 @@ YS_NORETURN void log_cmd_error(const char *format, ...) YS_ATTRIBUTE(format(prin
 static inline bool ys_debug(int n = 0) { if (log_force_debug) return true; log_debug_suppressed += n; return false; }
 #  define log_debug(...) do { if (ys_debug(1)) log(__VA_ARGS__); } while (0)
 #else
-static inline bool ys_debug(int n = 0) { return false; }
+static inline bool ys_debug(int n = 0) { (void) n; return false; }
 #  define log_debug(_fmt, ...) do { } while (0)
 #endif
 
@@ -154,7 +154,7 @@ static inline void log_assert_worker(bool cond, const char *expr, const char *fi
 }
 #  define log_assert(_assert_expr_) YOSYS_NAMESPACE_PREFIX log_assert_worker(_assert_expr_, #_assert_expr_, __FILE__, __LINE__)
 #else
-#  define log_assert(_assert_expr_)
+#  define log_assert(_assert_expr_) (void)(_assert_expr_);
 #endif
 
 #define log_abort() YOSYS_NAMESPACE_PREFIX log_error("Abort in %s:%d.\n", __FILE__, __LINE__)

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -153,7 +153,7 @@ static inline void log_assert_worker(bool cond, const char *expr, const char *fi
 }
 #  define log_assert(_assert_expr_) YOSYS_NAMESPACE_PREFIX log_assert_worker(_assert_expr_, #_assert_expr_, __FILE__, __LINE__)
 #else
-#  define log_assert(_assert_expr_) (void)(_assert_expr_);
+#  define log_assert(_assert_expr_) do { if (0) (void)(_assert_expr_); } while (0)
 #endif
 
 #define log_abort() YOSYS_NAMESPACE_PREFIX log_error("Abort in %s:%d.\n", __FILE__, __LINE__)

--- a/kernel/macc.h
+++ b/kernel/macc.h
@@ -107,10 +107,8 @@ struct Macc
 		std::vector<RTLIL::State> config_bits = cell->getParam("\\CONFIG").bits;
 		int config_cursor = 0;
 
-#ifndef NDEBUG
 		int config_width = cell->getParam("\\CONFIG_WIDTH").as_int();
 		log_assert(GetSize(config_bits) >= config_width);
-#endif
 
 		int num_bits = 0;
 		if (config_bits[config_cursor++] == RTLIL::S1) num_bits |= 1;


### PR DESCRIPTION
Specifically, during `NDEBUG`:

* aigerparse.cc's log_debug2 now calls `if (0) log_debug(__VA_ARGS__);` (where `log_debug` is a NOOP) in order to suppress unused warnings.
* `log_debug` now calls a `constexpr` function that always returns false and thus will never print any debug message
* `log_assert` now explicitly ignores the expression using `(void)(expr);`