### PR TITLE
opt_lut to ignore LUT cells, or those that drive bits, with (* keep *)

### DIFF
--- a/passes/opt/opt_lut.cc
+++ b/passes/opt/opt_lut.cc
@@ -101,6 +101,12 @@ struct OptLutWorker
 		{
 			if (cell->type == "$lut")
 			{
+				if (cell->has_keep_attr())
+					continue;
+				SigBit lut_output = cell->getPort("\\Y");
+				if (lut_output.wire->get_bool_attribute("\\keep"))
+					continue;
+
 				int lut_width = cell->getParam("\\WIDTH").as_int();
 				SigSpec lut_input = cell->getPort("\\A");
 				int lut_arity = 0;


### PR DESCRIPTION
Fixes #1254 

Before, and/or without any `(* keep *)`:
```
   Number of cells:                 71
     SB_CARRY                       22
     SB_DFF                         23
     SB_DFFE                         1
     SB_LUT4                        25
```

After:
```
   Number of cells:                 77
     SB_CARRY                       22
     SB_DFF                         23
     SB_DFFE                         1
     SB_LUT4                        31
```
when either of the two `(* keep *)` attributes are present:
```
module top (
    output LED
);
        // ring oscillator

        (* keep *) wire [6:0] buffers_in, buffers_out;
        assign buffers_in = {buffers_out[5:0], buffers_out[6]};

        (* keep *) SB_LUT4 #(
                .LUT_INIT(16'd1)
        ) buffers [6:0] (
                .O(buffers_out),
                .I0(buffers_in),
                .I1(1'b0),
                .I2(1'b0),
                .I3(1'b0)
        );

        // frequency counter

        reg [23:0] counter = 0;
        always @(posedge buffers_out[6]) begin
                counter <= counter + 1;
        end

        assign LED = counter[23];

endmodule
```