### PR TITLE
Add __STDC_FORMAT_MACROS before <inttypes.h> as per @mithro

### DIFF
--- a/frontends/aiger/aigerparse.cc
+++ b/frontends/aiger/aigerparse.cc
@@ -30,6 +30,7 @@
 #include <libkern/OSByteOrder.h>
 #define __builtin_bswap32 OSSwapInt32
 #endif
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #include "kernel/yosys.h"


### PR DESCRIPTION
I can't seem to reproduce #1271 locally, but patch proposed by @mithro does not seem to be any harm.

Fixes #1271 