### PR TITLE
[WIP] Update ABC to 9017fa9, run "short_names" when not running "dress"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ OBJS = kernel/version_$(GIT_REV).o
 # is just a symlink to your actual ABC working directory, as 'make mrproper'
 # will remove the 'abc' directory and you do not want to accidentally
 # delete your work on ABC..
-ABCREV = 5776ad0
+ABCREV = 9017fa9
 ABCPULL = 1
 ABCURL ?= https://github.com/berkeley-abc/abc
 ABCMKARGS = CC="$(CXX)" CXX="$(CXX)" ABC_USE_LIBSTDCXX=1

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -761,8 +761,7 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 
 	for (size_t pos = abc_script.find("{S}"); pos != std::string::npos; pos = abc_script.find("{S}", pos))
 		abc_script = abc_script.substr(0, pos) + lutin_shared + abc_script.substr(pos+3);
-	if (abc_dress)
-		abc_script += "; dress";
+	abc_script += abc_dress ? "; dress" : "; short_names";
 	abc_script += stringf("; write_blif %s/output.blif", tempdir_name.c_str());
 	abc_script = add_echos_to_abc_cmd(abc_script);
 


### PR DESCRIPTION
This fixes a problem with ABC where ABC sometimes fails with an error like the following.

```
+ write_blif output.blif
Abc_NtkCheck: Repeated CI names: n1121_o2 and n1121_o2.
Abc_NtkCheck: Repeated CI names: n1121_o2 and n1121_o2.
Abc_NtkCheck: Repeated CI names: n1121_o2 and n1121_o2.
Abc_NtkCheck: Repeated CI names: n1185_o2 and n1185_o2.
Abc_NtkCheck: Repeated CI names: n1187_o2 and n1187_o2.
Abc_NtkCheck: Repeated CI names: n1236_o2 and n1236_o2.
Abc_NtkCheck: Repeated CI names: n1236_o2 and n1236_o2.
Abc_NtkCheck: Repeated CI names: n1288_o2 and n1288_o2.
Abc_NtkCheck: Repeated CI names: n1384_o2 and n1384_o2.
Abc_NtkCheck: Repeated CI names: n1605_o2 and n1605_o2.
Abc_NtkCheck: Repeated CI names: n1605_o2 and n1605_o2.
Abc_NtkCheck: Repeated CI names: n1611_o2 and n1611_o2.
Abc_NtkCheck: Repeated CI names: n1611_o2 and n1611_o2.
Abc_NtkCheck: Repeated CI names: n1611_o2 and n1611_o2.
Abc_NtkCheck: Repeated CI names: n1611_o2 and n1611_o2.
Abc_NtkCheck: Repeated CI names: n1683_o2 and n1683_o2.
Abc_NtkCheck: Repeated CI names: n1714_o2 and n1714_o2.
Abc_NtkCheck: Repeated CI names: n1714_o2 and n1714_o2.
Abc_NtkCheck: Repeated CI names: n1714_o2 and n1714_o2.
Abc_NtkCheck: Repeated CI names: n3788_o2 and n3788_o2.
yosys-abc: src/base/abc/abcFanio.c:92: void Abc_ObjAddFanin(Abc_Obj_t *, Abc_Obj_t *): Assertion `!Abc_ObjIsNet(pObj) || !Abc_ObjFaninNum(pObj)' failed.
Aborted (core dumped)
```