### PR TITLE
Since $_ANDNOT_ is not symmetric, do not sort leaves

### DIFF
--- a/passes/techmap/extract_fa.cc
+++ b/passes/techmap/extract_fa.cc
@@ -153,12 +153,10 @@ struct ExtractFaWorker
 		}
 	}
 
-	void check_partition(SigBit root, pool<SigBit> &leaves)
+	void check_partition(SigBit root, const pool<SigBit> &leaves)
 	{
 		if (config.enable_ha && GetSize(leaves) == 2)
 		{
-			leaves.sort();
-
 			SigBit A = SigSpec(leaves)[0];
 			SigBit B = SigSpec(leaves)[1];
 
@@ -196,8 +194,6 @@ struct ExtractFaWorker
 
 		if (config.enable_fa && GetSize(leaves) == 3)
 		{
-			leaves.sort();
-
 			SigBit A = SigSpec(leaves)[0];
 			SigBit B = SigSpec(leaves)[1];
 			SigBit C = SigSpec(leaves)[2];
@@ -237,7 +233,7 @@ struct ExtractFaWorker
 		}
 	}
 
-	void find_partitions(SigBit root, pool<SigBit> &leaves, pool<pool<SigBit>> &cache, int maxdepth, int maxbreadth)
+	void find_partitions(SigBit root, const pool<SigBit> &leaves, pool<const pool<SigBit>> &cache, int maxdepth, int maxbreadth)
 	{
 		if (cache.count(leaves))
 			return;
@@ -293,8 +289,8 @@ struct ExtractFaWorker
 				continue;
 
 			SigBit root = it.first;
-			pool<SigBit> leaves = { root };
-			pool<pool<SigBit>> cache;
+			const pool<SigBit> leaves = { root };
+			pool<const pool<SigBit>> cache;
 
 			if (config.verbose)
 				log("  checking %s\n", log_signal(it.first));


### PR DESCRIPTION
Fixes #1284 

@cliffordwolf: Not sure what the value of `leaves.sort()` was to begin with?