### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ matrix:
           sources:
             - llvm-toolchain-xenial-8
           packages:
-            - clang-8.0
+            - clang-8
             - gperf
             - build-essential
             - bison
@@ -128,7 +128,7 @@ matrix:
             - libboost-filesystem-dev
             - zlib1g-dev
       env:
-        - MATRIX_EVAL="CONFIG=clang && CC=clang-8.0 && CXX=clang++-8.0"
+        - MATRIX_EVAL="CONFIG=clang && CC=clang-8 && CXX=clang++-8"
 
 #   # Latest clang on Mac OS X
 #   - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-bionic-8.0
+            - llvm-toolchain-xenial-8
           packages:
             - clang-8.0
             - gperf

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,14 @@ env:
 
 matrix:
   include:
-    # Latest gcc-4.8, earliest version supported by Travis
+    # Earliest gcc version that works
+    #   4.8 and 4.9 fails to compile iverilog giving:
+    #   "undefined reference to `__warn_memset_zero_len'"
     - os: linux
       addons:
         apt:
           packages:
-            - g++-4.9
+            - g++-5
             - gperf
             - build-essential
             - bison
@@ -38,7 +40,7 @@ matrix:
             - libboost-filesystem-dev
             - zlib1g-dev
       env:
-        - MATRIX_EVAL="CONFIG=gcc && CC=gcc-4.9 && CXX=g++-4.9"
+        - MATRIX_EVAL="CONFIG=gcc && CC=gcc-5 && CXX=g++-5"
 
     # Latest gcc supported on Travis Linux
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,12 @@ env:
 
 matrix:
   include:
-    # Earliest gcc version that works
-    #   4.8 and 4.9 fails to compile iverilog giving:
-    #   "undefined reference to `__warn_memset_zero_len'"
+    # Latest gcc-4.8, earliest version supported by Travis
     - os: linux
       addons:
         apt:
           packages:
-            - g++-5
+            - g++-4.9
             - gperf
             - build-essential
             - bison
@@ -40,7 +38,7 @@ matrix:
             - libboost-filesystem-dev
             - zlib1g-dev
       env:
-        - MATRIX_EVAL="CONFIG=gcc && CC=gcc-5 && CXX=g++-5"
+        - MATRIX_EVAL="CONFIG=gcc && CC=gcc-4.9 && CXX=g++-4.9"
 
     # Latest gcc supported on Travis Linux
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       addons:
         apt:
           packages:
-            - g++-4.9
+            - g++-4.8
             - gperf
             - build-essential
             - bison
@@ -38,7 +38,7 @@ matrix:
             - libboost-filesystem-dev
             - zlib1g-dev
       env:
-        - MATRIX_EVAL="CONFIG=gcc && CC=gcc-4.9 && CXX=g++-4.9"
+        - MATRIX_EVAL="CONFIG=gcc && CC=gcc-4.8 && CXX=g++-4.8"
 
     # Latest gcc supported on Travis Linux
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       addons:
         apt:
           packages:
-            - g++-4.8
+            - g++-4.9
             - gperf
             - build-essential
             - bison
@@ -38,36 +38,7 @@ matrix:
             - libboost-filesystem-dev
             - zlib1g-dev
       env:
-        - MATRIX_EVAL="CONFIG=gcc && CC=gcc-4.8 && CXX=g++-4.8"
-
-    # Latest gcc-6 on Travis Linux
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-6
-            - gperf
-            - build-essential
-            - bison
-            - flex
-            - libreadline-dev
-            - gawk
-            - tcl-dev
-            - libffi-dev
-            - git
-            - graphviz
-            - xdot
-            - pkg-config
-            - python
-            - python3
-            - libboost-system-dev
-            - libboost-python-dev
-            - libboost-filesystem-dev
-            - zlib1g-dev
-      env:
-        - MATRIX_EVAL="CONFIG=gcc && CC=gcc-6 && CXX=g++-6"
+        - MATRIX_EVAL="CONFIG=gcc && CC=gcc-4.9 && CXX=g++-4.9"
 
     # Latest gcc supported on Travis Linux
     - os: linux
@@ -76,7 +47,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-7
+            - g++-9
             - gperf
             - build-essential
             - bison
@@ -96,7 +67,7 @@ matrix:
             - libboost-filesystem-dev
             - zlib1g-dev
       env:
-        - MATRIX_EVAL="CONFIG=gcc && CC=gcc-7 && CXX=g++-7"
+        - MATRIX_EVAL="CONFIG=gcc && CC=gcc-9 && CXX=g++-9"
 
     # Clang which ships on Trusty Linux
     - os: linux
@@ -133,9 +104,9 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-trusty-5.0
+            - llvm-toolchain-bionic-8.0
           packages:
-            - clang-5.0
+            - clang-8.0
             - gperf
             - build-essential
             - bison
@@ -155,7 +126,7 @@ matrix:
             - libboost-filesystem-dev
             - zlib1g-dev
       env:
-        - MATRIX_EVAL="CONFIG=clang && CC=clang-5.0 && CXX=clang++-5.0"
+        - MATRIX_EVAL="CONFIG=clang && CC=clang-8.0 && CXX=clang++-8.0"
 
 #   # Latest clang on Mac OS X
 #   - os: osx

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -51,7 +51,7 @@ fi
 		git clone git://github.com/steveicarus/iverilog.git
 		cd iverilog
 		autoconf
-		./configure --prefix=$HOME/.local-bin
+		CC=gcc CXX=g++ ./configure --prefix=$HOME/.local-bin
 		make
 		make install
 		echo


### PR DESCRIPTION
A few days ago something with our Travis CI setup (or the repos it depends on) changed:

* gcc-4.8 was refusing to compile iverilog:
```
In file included from /usr/include/string.h:635:0,
                 from lexor.cc:21:
In function 'void* memset(void*, int, size_t)',
    inlined from 'int yylex()' at ./lexor.lex:96:29:
/usr/include/x86_64-linux-gnu/bits/string3.h:86:32: warning: call to '__warn_memset_zero_len' declared with attribute warning: memset used with constant zero length parameter; this could be due to transposed parameters
       __warn_memset_zero_len ();
```
* clang-5 was no longer installing
```
The following packages have unmet dependencies:
 clang-5.0 : Depends: libjsoncpp0 (>= 0.6.0~rc2) but it is not installable
E: Unable to correct problems, you have held broken packages.
```
Both from: https://travis-ci.org/YosysHQ/yosys/builds/571943817

This PR:
* Compiles iverilog using the default system (gcc) compiler, rather than the compiler specified for that job
* Removes gcc-6 job
* Replaces gcc-7 job with gcc-9
* Installs clang-8 from the xenial repository (same 16.04 as the VM), and not clang-5 from (older) trusty