### PR TITLE
Since $_ANDNOT_ is not symmetric, do not sort leaves (retry)

### DIFF
--- a/passes/techmap/extract_fa.cc
+++ b/passes/techmap/extract_fa.cc
@@ -153,11 +153,12 @@ struct ExtractFaWorker
 		}
 	}
 
-	void check_partition(SigBit root, pool<SigBit> &leaves)
+	void check_partition(SigBit root, pool<SigBit> &leaves, IdString cell_type)
 	{
 		if (config.enable_ha && GetSize(leaves) == 2)
 		{
-			leaves.sort();
+			if (!cell_type.in("$_ANDNOT_", "$_ORNOT_"))
+				leaves.sort();
 
 			SigBit A = SigSpec(leaves)[0];
 			SigBit B = SigSpec(leaves)[1];
@@ -237,7 +238,7 @@ struct ExtractFaWorker
 		}
 	}
 
-	void find_partitions(SigBit root, pool<SigBit> &leaves, pool<pool<SigBit>> &cache, int maxdepth, int maxbreadth)
+	void find_partitions(SigBit root, pool<SigBit> &leaves, pool<pool<SigBit>> &cache, int maxdepth, int maxbreadth, IdString cell_type)
 	{
 		if (cache.count(leaves))
 			return;
@@ -248,7 +249,7 @@ struct ExtractFaWorker
 		// log("\n");
 
 		cache.insert(leaves);
-		check_partition(root, leaves);
+		check_partition(root, leaves, cell_type);
 
 		if (maxdepth == 0)
 			return;
@@ -270,7 +271,7 @@ struct ExtractFaWorker
 			if (GetSize(new_leaves) > maxbreadth)
 				continue;
 
-			find_partitions(root, new_leaves, cache, maxdepth-1, maxbreadth);
+			find_partitions(root, new_leaves, cache, maxdepth-1, maxbreadth, cell_type);
 		}
 	}
 
@@ -302,7 +303,7 @@ struct ExtractFaWorker
 			count_func2 = 0;
 			count_func3 = 0;
 
-			find_partitions(root, leaves, cache, config.maxdepth, config.maxbreadth);
+			find_partitions(root, leaves, cache, config.maxdepth, config.maxbreadth, it.second->type);
 
 			if (config.verbose && count_func2 > 0)
 				log("    extracted %d two-input functions\n", count_func2);


### PR DESCRIPTION
Retry of #1288 which caused yosys-tests to fail on Jenkins, but that I couldn't reproduce locally. I suspect that indicates that sorting was necessary to get a canonical result...

This is a much less heavy-handed approach, which only blocks sorting for `$_ANDNOT_` and `$_ORNOT_` cells. Are there any other 2-input or 3-input cells we should be blocking sort on?