### PR TITLE
extract_fa: Un-inverting AND with an inverted input also inverts input to X{,N}OR

### DIFF
--- a/passes/techmap/extract_fa.cc
+++ b/passes/techmap/extract_fa.cc
@@ -153,11 +153,12 @@ struct ExtractFaWorker
 		}
 	}
 
-	void check_partition(SigBit root, pool<SigBit> &leaves)
+	void check_partition(SigBit root, pool<SigBit> &leaves, IdString cell_type)
 	{
 		if (config.enable_ha && GetSize(leaves) == 2)
 		{
-			leaves.sort();
+			if (!cell_type.in("$_ANDNOT_", "$_ORNOT_"))
+				leaves.sort();
 
 			SigBit A = SigSpec(leaves)[0];
 			SigBit B = SigSpec(leaves)[1];
@@ -237,7 +238,7 @@ struct ExtractFaWorker
 		}
 	}
 
-	void find_partitions(SigBit root, pool<SigBit> &leaves, pool<pool<SigBit>> &cache, int maxdepth, int maxbreadth)
+	void find_partitions(SigBit root, pool<SigBit> &leaves, pool<pool<SigBit>> &cache, int maxdepth, int maxbreadth, IdString cell_type)
 	{
 		if (cache.count(leaves))
 			return;
@@ -248,7 +249,7 @@ struct ExtractFaWorker
 		// log("\n");
 
 		cache.insert(leaves);
-		check_partition(root, leaves);
+		check_partition(root, leaves, cell_type);
 
 		if (maxdepth == 0)
 			return;
@@ -270,7 +271,7 @@ struct ExtractFaWorker
 			if (GetSize(new_leaves) > maxbreadth)
 				continue;
 
-			find_partitions(root, new_leaves, cache, maxdepth-1, maxbreadth);
+			find_partitions(root, new_leaves, cache, maxdepth-1, maxbreadth, cell_type);
 		}
 	}
 
@@ -302,7 +303,7 @@ struct ExtractFaWorker
 			count_func2 = 0;
 			count_func3 = 0;
 
-			find_partitions(root, leaves, cache, config.maxdepth, config.maxbreadth);
+			find_partitions(root, leaves, cache, config.maxdepth, config.maxbreadth, it.second->type);
 
 			if (config.verbose && count_func2 > 0)
 				log("    extracted %d two-input functions\n", count_func2);

--- a/passes/techmap/extract_fa.cc
+++ b/passes/techmap/extract_fa.cc
@@ -513,13 +513,13 @@ struct ExtractFaWorker
 				}
 
 				if (func2.at(key).count(xor2_func)) {
-					SigBit YY = invert_xy ? module->NotGate(NEW_ID, Y) : Y;
+					SigBit YY = invert_xy || (f2i.inv_a && !f2i.inv_b) || (!f2i.inv_a && f2i.inv_b) ? module->NotGate(NEW_ID, Y) : Y;
 					for (auto bit : func2.at(key).at(xor2_func))
 						assign_new_driver(bit, YY);
 				}
 
 				if (func2.at(key).count(xnor2_func)) {
-					SigBit YY = invert_xy ? Y : module->NotGate(NEW_ID, Y);
+					SigBit YY = invert_xy || (f2i.inv_a && !f2i.inv_b) || (!f2i.inv_a && f2i.inv_b) ? Y : module->NotGate(NEW_ID, Y);
 					for (auto bit : func2.at(key).at(xnor2_func))
 						assign_new_driver(bit, YY);
 				}

--- a/passes/techmap/extract_fa.cc
+++ b/passes/techmap/extract_fa.cc
@@ -153,12 +153,11 @@ struct ExtractFaWorker
 		}
 	}
 
-	void check_partition(SigBit root, pool<SigBit> &leaves, IdString cell_type)
+	void check_partition(SigBit root, pool<SigBit> &leaves)
 	{
 		if (config.enable_ha && GetSize(leaves) == 2)
 		{
-			if (!cell_type.in("$_ANDNOT_", "$_ORNOT_"))
-				leaves.sort();
+			leaves.sort();
 
 			SigBit A = SigSpec(leaves)[0];
 			SigBit B = SigSpec(leaves)[1];
@@ -238,7 +237,7 @@ struct ExtractFaWorker
 		}
 	}
 
-	void find_partitions(SigBit root, pool<SigBit> &leaves, pool<pool<SigBit>> &cache, int maxdepth, int maxbreadth, IdString cell_type)
+	void find_partitions(SigBit root, pool<SigBit> &leaves, pool<pool<SigBit>> &cache, int maxdepth, int maxbreadth)
 	{
 		if (cache.count(leaves))
 			return;
@@ -249,7 +248,7 @@ struct ExtractFaWorker
 		// log("\n");
 
 		cache.insert(leaves);
-		check_partition(root, leaves, cell_type);
+		check_partition(root, leaves);
 
 		if (maxdepth == 0)
 			return;
@@ -271,7 +270,7 @@ struct ExtractFaWorker
 			if (GetSize(new_leaves) > maxbreadth)
 				continue;
 
-			find_partitions(root, new_leaves, cache, maxdepth-1, maxbreadth, cell_type);
+			find_partitions(root, new_leaves, cache, maxdepth-1, maxbreadth);
 		}
 	}
 
@@ -303,7 +302,7 @@ struct ExtractFaWorker
 			count_func2 = 0;
 			count_func3 = 0;
 
-			find_partitions(root, leaves, cache, config.maxdepth, config.maxbreadth, it.second->type);
+			find_partitions(root, leaves, cache, config.maxdepth, config.maxbreadth);
 
 			if (config.verbose && count_func2 > 0)
 				log("    extracted %d two-input functions\n", count_func2);


### PR DESCRIPTION
Fixes #1284 (again, again).

See: https://github.com/YosysHQ/yosys/issues/1284#issuecomment-521455881 for an explanation of why this is necessary.