### PR TITLE
Use ID::{A,B,Y,keep,blackbox,whitebox} instead of ID()

### DIFF
--- a/kernel/cellaigs.cc
+++ b/kernel/cellaigs.cc
@@ -292,19 +292,19 @@ Aig::Aig(Cell *cell)
 
 	if (cell->type.in(ID($not), ID($_NOT_), ID($pos), ID($_BUF_)))
 	{
-		for (int i = 0; i < GetSize(cell->getPort(ID(Y))); i++) {
-			int A = mk.inport(ID(A), i);
+		for (int i = 0; i < GetSize(cell->getPort(ID::Y)); i++) {
+			int A = mk.inport(ID::A, i);
 			int Y = cell->type.in(ID($not), ID($_NOT_)) ? mk.not_gate(A) : A;
-			mk.outport(Y, ID(Y), i);
+			mk.outport(Y, ID::Y, i);
 		}
 		goto optimize;
 	}
 
 	if (cell->type.in(ID($and), ID($_AND_), ID($_NAND_), ID($or), ID($_OR_), ID($_NOR_), ID($xor), ID($xnor), ID($_XOR_), ID($_XNOR_), ID($_ANDNOT_), ID($_ORNOT_)))
 	{
-		for (int i = 0; i < GetSize(cell->getPort(ID(Y))); i++) {
-			int A = mk.inport(ID(A), i);
-			int B = mk.inport(ID(B), i);
+		for (int i = 0; i < GetSize(cell->getPort(ID::Y)); i++) {
+			int A = mk.inport(ID::A, i);
+			int B = mk.inport(ID::B, i);
 			int Y = cell->type.in(ID($and), ID($_AND_))   ? mk.and_gate(A, B) :
 			        cell->type.in(ID($_NAND_))          ? mk.nand_gate(A, B) :
 			        cell->type.in(ID($or), ID($_OR_))     ? mk.or_gate(A, B) :
@@ -313,7 +313,7 @@ Aig::Aig(Cell *cell)
 			        cell->type.in(ID($xnor), ID($_XNOR_)) ? mk.xnor_gate(A, B) :
 			        cell->type.in(ID($_ANDNOT_))        ? mk.andnot_gate(A, B) :
 			        cell->type.in(ID($_ORNOT_))         ? mk.ornot_gate(A, B) : -1;
-			mk.outport(Y, ID(Y), i);
+			mk.outport(Y, ID::Y, i);
 		}
 		goto optimize;
 	}
@@ -321,22 +321,22 @@ Aig::Aig(Cell *cell)
 	if (cell->type.in(ID($mux), ID($_MUX_)))
 	{
 		int S = mk.inport(ID(S));
-		for (int i = 0; i < GetSize(cell->getPort(ID(Y))); i++) {
-			int A = mk.inport(ID(A), i);
-			int B = mk.inport(ID(B), i);
+		for (int i = 0; i < GetSize(cell->getPort(ID::Y)); i++) {
+			int A = mk.inport(ID::A, i);
+			int B = mk.inport(ID::B, i);
 			int Y = mk.mux_gate(A, B, S);
 			if (cell->type == ID($_NMUX_))
 				Y = mk.not_gate(Y);
-			mk.outport(Y, ID(Y), i);
+			mk.outport(Y, ID::Y, i);
 		}
 		goto optimize;
 	}
 
 	if (cell->type.in(ID($reduce_and), ID($reduce_or), ID($reduce_xor), ID($reduce_xnor), ID($reduce_bool)))
 	{
-		int Y = mk.inport(ID(A), 0);
-		for (int i = 1; i < GetSize(cell->getPort(ID(A))); i++) {
-			int A = mk.inport(ID(A), i);
+		int Y = mk.inport(ID::A, 0);
+		for (int i = 1; i < GetSize(cell->getPort(ID::A)); i++) {
+			int A = mk.inport(ID::A, i);
 			if (cell->type == ID($reduce_and))  Y = mk.and_gate(A, Y);
 			if (cell->type == ID($reduce_or))   Y = mk.or_gate(A, Y);
 			if (cell->type == ID($reduce_bool)) Y = mk.or_gate(A, Y);
@@ -345,35 +345,35 @@ Aig::Aig(Cell *cell)
 		}
 		if (cell->type == ID($reduce_xnor))
 			Y = mk.not_gate(Y);
-		mk.outport(Y, ID(Y), 0);
-		for (int i = 1; i < GetSize(cell->getPort(ID(Y))); i++)
-			mk.outport(mk.bool_node(false), ID(Y), i);
+		mk.outport(Y, ID::Y, 0);
+		for (int i = 1; i < GetSize(cell->getPort(ID::Y)); i++)
+			mk.outport(mk.bool_node(false), ID::Y, i);
 		goto optimize;
 	}
 
 	if (cell->type.in(ID($logic_not), ID($logic_and), ID($logic_or)))
 	{
-		int A = mk.inport(ID(A), 0), Y = -1;
-		for (int i = 1; i < GetSize(cell->getPort(ID(A))); i++)
-			A = mk.or_gate(mk.inport(ID(A), i), A);
+		int A = mk.inport(ID::A, 0), Y = -1;
+		for (int i = 1; i < GetSize(cell->getPort(ID::A)); i++)
+			A = mk.or_gate(mk.inport(ID::A, i), A);
 		if (cell->type.in(ID($logic_and), ID($logic_or))) {
-			int B = mk.inport(ID(B), 0);
-			for (int i = 1; i < GetSize(cell->getPort(ID(B))); i++)
-				B = mk.or_gate(mk.inport(ID(B), i), B);
+			int B = mk.inport(ID::B, 0);
+			for (int i = 1; i < GetSize(cell->getPort(ID::B)); i++)
+				B = mk.or_gate(mk.inport(ID::B, i), B);
 			if (cell->type == ID($logic_and)) Y = mk.and_gate(A, B);
 			if (cell->type == ID($logic_or))  Y = mk.or_gate(A, B);
 		} else {
 			if (cell->type == ID($logic_not)) Y = mk.not_gate(A);
 		}
-		mk.outport_bool(Y, ID(Y));
+		mk.outport_bool(Y, ID::Y);
 		goto optimize;
 	}
 
 	if (cell->type.in(ID($add), ID($sub)))
 	{
-		int width = GetSize(cell->getPort(ID(Y)));
-		vector<int> A = mk.inport_vec(ID(A), width);
-		vector<int> B = mk.inport_vec(ID(B), width);
+		int width = GetSize(cell->getPort(ID::Y));
+		vector<int> A = mk.inport_vec(ID::A, width);
+		vector<int> B = mk.inport_vec(ID::B, width);
 		int carry = mk.bool_node(false);
 		if (cell->type == ID($sub)) {
 			for (auto &n : B)
@@ -381,15 +381,15 @@ Aig::Aig(Cell *cell)
 			carry = mk.not_gate(carry);
 		}
 		vector<int> Y = mk.adder(A, B, carry);
-		mk.outport_vec(Y, ID(Y));
+		mk.outport_vec(Y, ID::Y);
 		goto optimize;
 	}
 
 	if (cell->type == ID($alu))
 	{
-		int width = GetSize(cell->getPort(ID(Y)));
-		vector<int> A = mk.inport_vec(ID(A), width);
-		vector<int> B = mk.inport_vec(ID(B), width);
+		int width = GetSize(cell->getPort(ID::Y));
+		vector<int> A = mk.inport_vec(ID::A, width);
+		vector<int> B = mk.inport_vec(ID::B, width);
 		int carry = mk.inport(ID(CI));
 		int binv = mk.inport(ID(BI));
 		for (auto &n : B)
@@ -398,7 +398,7 @@ Aig::Aig(Cell *cell)
 		vector<int> Y = mk.adder(A, B, carry, &X, &CO);
 		for (int i = 0; i < width; i++)
 			X[i] = mk.xor_gate(A[i], B[i]);
-		mk.outport_vec(Y, ID(Y));
+		mk.outport_vec(Y, ID::Y);
 		mk.outport_vec(X, ID(X));
 		mk.outport_vec(CO, ID(CO));
 		goto optimize;
@@ -406,57 +406,57 @@ Aig::Aig(Cell *cell)
 
 	if (cell->type.in(ID($eq), ID($ne)))
 	{
-		int width = max(GetSize(cell->getPort(ID(A))), GetSize(cell->getPort(ID(B))));
-		vector<int> A = mk.inport_vec(ID(A), width);
-		vector<int> B = mk.inport_vec(ID(B), width);
+		int width = max(GetSize(cell->getPort(ID::A)), GetSize(cell->getPort(ID::B)));
+		vector<int> A = mk.inport_vec(ID::A, width);
+		vector<int> B = mk.inport_vec(ID::B, width);
 		int Y = mk.bool_node(false);
 		for (int i = 0; i < width; i++)
 			Y = mk.or_gate(Y, mk.xor_gate(A[i], B[i]));
 		if (cell->type == ID($eq))
 			Y = mk.not_gate(Y);
-		mk.outport_bool(Y, ID(Y));
+		mk.outport_bool(Y, ID::Y);
 		goto optimize;
 	}
 
 	if (cell->type == ID($_AOI3_))
 	{
-		int A = mk.inport(ID(A));
-		int B = mk.inport(ID(B));
+		int A = mk.inport(ID::A);
+		int B = mk.inport(ID::B);
 		int C = mk.inport(ID(C));
 		int Y = mk.nor_gate(mk.and_gate(A, B), C);
-		mk.outport(Y, ID(Y));
+		mk.outport(Y, ID::Y);
 		goto optimize;
 	}
 
 	if (cell->type == ID($_OAI3_))
 	{
-		int A = mk.inport(ID(A));
-		int B = mk.inport(ID(B));
+		int A = mk.inport(ID::A);
+		int B = mk.inport(ID::B);
 		int C = mk.inport(ID(C));
 		int Y = mk.nand_gate(mk.or_gate(A, B), C);
-		mk.outport(Y, ID(Y));
+		mk.outport(Y, ID::Y);
 		goto optimize;
 	}
 
 	if (cell->type == ID($_AOI4_))
 	{
-		int A = mk.inport(ID(A));
-		int B = mk.inport(ID(B));
+		int A = mk.inport(ID::A);
+		int B = mk.inport(ID::B);
 		int C = mk.inport(ID(C));
 		int D = mk.inport(ID(D));
 		int Y = mk.nor_gate(mk.and_gate(A, B), mk.and_gate(C, D));
-		mk.outport(Y, ID(Y));
+		mk.outport(Y, ID::Y);
 		goto optimize;
 	}
 
 	if (cell->type == ID($_OAI4_))
 	{
-		int A = mk.inport(ID(A));
-		int B = mk.inport(ID(B));
+		int A = mk.inport(ID::A);
+		int B = mk.inport(ID::B);
 		int C = mk.inport(ID(C));
 		int D = mk.inport(ID(D));
 		int Y = mk.nand_gate(mk.or_gate(A, B), mk.or_gate(C, D));
-		mk.outport(Y, ID(Y));
+		mk.outport(Y, ID::Y);
 		goto optimize;
 	}
 

--- a/kernel/celledges.cc
+++ b/kernel/celledges.cc
@@ -24,7 +24,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 void bitwise_unary_op(AbstractCellEdgesDatabase *db, RTLIL::Cell *cell)
 {
-	IdString A = ID(A), Y = ID(Y);
+	IdString A = ID::A, Y = ID::Y;
 
 	bool is_signed = cell->getParam(ID(A_SIGNED)).as_bool();
 	int a_width = GetSize(cell->getPort(A));
@@ -41,7 +41,7 @@ void bitwise_unary_op(AbstractCellEdgesDatabase *db, RTLIL::Cell *cell)
 
 void bitwise_binary_op(AbstractCellEdgesDatabase *db, RTLIL::Cell *cell)
 {
-	IdString A = ID(A), B = ID(B), Y = ID(Y);
+	IdString A = ID::A, B = ID::B, Y = ID::Y;
 
 	bool is_signed = cell->getParam(ID(A_SIGNED)).as_bool();
 	int a_width = GetSize(cell->getPort(A));
@@ -71,7 +71,7 @@ void bitwise_binary_op(AbstractCellEdgesDatabase *db, RTLIL::Cell *cell)
 
 void arith_neg_op(AbstractCellEdgesDatabase *db, RTLIL::Cell *cell)
 {
-	IdString A = ID(A), Y = ID(Y);
+	IdString A = ID::A, Y = ID::Y;
 
 	bool is_signed = cell->getParam(ID(A_SIGNED)).as_bool();
 	int a_width = GetSize(cell->getPort(A));
@@ -87,7 +87,7 @@ void arith_neg_op(AbstractCellEdgesDatabase *db, RTLIL::Cell *cell)
 
 void arith_binary_op(AbstractCellEdgesDatabase *db, RTLIL::Cell *cell)
 {
-	IdString A = ID(A), B = ID(B), Y = ID(Y);
+	IdString A = ID::A, B = ID::B, Y = ID::Y;
 
 	bool is_signed = cell->getParam(ID(A_SIGNED)).as_bool();
 	int a_width = GetSize(cell->getPort(A));
@@ -114,7 +114,7 @@ void arith_binary_op(AbstractCellEdgesDatabase *db, RTLIL::Cell *cell)
 
 void reduce_op(AbstractCellEdgesDatabase *db, RTLIL::Cell *cell)
 {
-	IdString A = ID(A), Y = ID(Y);
+	IdString A = ID::A, Y = ID::Y;
 
 	int a_width = GetSize(cell->getPort(A));
 
@@ -124,7 +124,7 @@ void reduce_op(AbstractCellEdgesDatabase *db, RTLIL::Cell *cell)
 
 void compare_op(AbstractCellEdgesDatabase *db, RTLIL::Cell *cell)
 {
-	IdString A = ID(A), B = ID(B), Y = ID(Y);
+	IdString A = ID::A, B = ID::B, Y = ID::Y;
 
 	int a_width = GetSize(cell->getPort(A));
 	int b_width = GetSize(cell->getPort(B));
@@ -138,7 +138,7 @@ void compare_op(AbstractCellEdgesDatabase *db, RTLIL::Cell *cell)
 
 void mux_op(AbstractCellEdgesDatabase *db, RTLIL::Cell *cell)
 {
-	IdString A = ID(A), B = ID(B), S = ID(S), Y = ID(Y);
+	IdString A = ID::A, B = ID::B, S = ID(S), Y = ID::Y;
 
 	int a_width = GetSize(cell->getPort(A));
 	int b_width = GetSize(cell->getPort(B));

--- a/kernel/celltypes.h
+++ b/kernel/celltypes.h
@@ -84,7 +84,7 @@ struct CellTypes
 	{
 		setup_internals_eval();
 
-		IdString A = ID(A), B = ID(B), EN = ID(EN), Y = ID(Y);
+		IdString A = ID::A, B = ID::B, EN = ID(EN), Y = ID::Y;
 		IdString SRC = ID(SRC), DST = ID(DST), DAT = ID(DAT);
 		IdString EN_SRC = ID(EN_SRC), EN_DST = ID(EN_DST);
 
@@ -121,7 +121,7 @@ struct CellTypes
 			ID($add), ID($sub), ID($mul), ID($div), ID($mod), ID($pow),
 			ID($logic_and), ID($logic_or), ID($concat), ID($macc)
 		};
-		IdString A = ID(A), B = ID(B), S = ID(S), Y = ID(Y);
+		IdString A = ID::A, B = ID::B, S = ID(S), Y = ID::Y;
 		IdString P = ID(P), G = ID(G), C = ID(C), X = ID(X);
 		IdString BI = ID(BI), CI = ID(CI), CO = ID(CO), EN = ID(EN);
 
@@ -177,19 +177,19 @@ struct CellTypes
 	{
 		setup_stdcells_eval();
 
-		IdString A = ID(A), E = ID(E), Y = ID(Y);
+		IdString A = ID::A, E = ID(E), Y = ID::Y;
 
 		setup_type(ID($_TBUF_), {A, E}, {Y}, true);
 	}
 
 	void setup_stdcells_eval()
 	{
-		IdString A = ID(A), B = ID(B), C = ID(C), D = ID(D);
+		IdString A = ID::A, B = ID::B, C = ID(C), D = ID(D);
 		IdString E = ID(E), F = ID(F), G = ID(G), H = ID(H);
 		IdString I = ID(I), J = ID(J), K = ID(K), L = ID(L);
 		IdString M = ID(M), N = ID(N), O = ID(O), P = ID(P);
 		IdString S = ID(S), T = ID(T), U = ID(U), V = ID(V);
-		IdString Y = ID(Y);
+		IdString Y = ID::Y;
 
 		setup_type(ID($_BUF_), {A}, {Y}, true);
 		setup_type(ID($_NOT_), {A}, {Y}, true);

--- a/kernel/consteval.h
+++ b/kernel/consteval.h
@@ -128,8 +128,8 @@ struct ConstEval
 
 		RTLIL::SigSpec sig_a, sig_b, sig_s, sig_y;
 
-		log_assert(cell->hasPort(ID(Y)));
-		sig_y = values_map(assign_map(cell->getPort(ID(Y))));
+		log_assert(cell->hasPort(ID::Y));
+		sig_y = values_map(assign_map(cell->getPort(ID::Y)));
 		if (sig_y.is_fully_const())
 			return true;
 
@@ -139,11 +139,11 @@ struct ConstEval
 				return false;
 		}
 
-		if (cell->hasPort(ID(A)))
-			sig_a = cell->getPort(ID(A));
+		if (cell->hasPort(ID::A))
+			sig_a = cell->getPort(ID::A);
 
-		if (cell->hasPort(ID(B)))
-			sig_b = cell->getPort(ID(B));
+		if (cell->hasPort(ID::B))
+			sig_b = cell->getPort(ID::B);
 
 		if (cell->type.in(ID($mux), ID($pmux), ID($_MUX_), ID($_NMUX_)))
 		{
@@ -298,11 +298,11 @@ struct ConstEval
 					return false;
 			}
 
-			RTLIL::Const result(0, GetSize(cell->getPort(ID(Y))));
+			RTLIL::Const result(0, GetSize(cell->getPort(ID::Y)));
 			if (!macc.eval(result))
 				log_abort();
 
-			set(cell->getPort(ID(Y)), result);
+			set(cell->getPort(ID::Y), result);
 		}
 		else
 		{

--- a/kernel/macc.h
+++ b/kernel/macc.h
@@ -99,10 +99,10 @@ struct Macc
 
 	void from_cell(RTLIL::Cell *cell)
 	{
-		RTLIL::SigSpec port_a = cell->getPort(ID(A));
+		RTLIL::SigSpec port_a = cell->getPort(ID::A);
 
 		ports.clear();
-		bit_ports = cell->getPort(ID(B));
+		bit_ports = cell->getPort(ID::B);
 
 		std::vector<RTLIL::State> config_bits = cell->getParam(ID(CONFIG)).bits;
 		int config_cursor = 0;
@@ -191,8 +191,8 @@ struct Macc
 			port_a.append(port.in_b);
 		}
 
-		cell->setPort(ID(A), port_a);
-		cell->setPort(ID(B), bit_ports);
+		cell->setPort(ID::A, port_a);
+		cell->setPort(ID::B, bit_ports);
 		cell->setParam(ID(CONFIG), config_bits);
 		cell->setParam(ID(CONFIG_WIDTH), GetSize(config_bits));
 		cell->setParam(ID(A_WIDTH), GetSize(port_a));

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -717,7 +717,7 @@ void RTLIL::Module::makeblackbox()
 	processes.clear();
 
 	remove(delwires);
-	set_bool_attribute(ID(blackbox));
+	set_bool_attribute(ID::blackbox);
 }
 
 void RTLIL::Module::reprocess_module(RTLIL::Design *, dict<RTLIL::IdString, RTLIL::Module *>)
@@ -845,8 +845,8 @@ namespace {
 
 			if (cell->type.in(ID($not), ID($pos), ID($neg))) {
 				param_bool(ID(A_SIGNED));
-				port(ID(A), param(ID(A_WIDTH)));
-				port(ID(Y), param(ID(Y_WIDTH)));
+				port(ID::A, param(ID(A_WIDTH)));
+				port(ID::Y, param(ID(Y_WIDTH)));
 				check_expected();
 				return;
 			}
@@ -854,17 +854,17 @@ namespace {
 			if (cell->type.in(ID($and), ID($or), ID($xor), ID($xnor))) {
 				param_bool(ID(A_SIGNED));
 				param_bool(ID(B_SIGNED));
-				port(ID(A), param(ID(A_WIDTH)));
-				port(ID(B), param(ID(B_WIDTH)));
-				port(ID(Y), param(ID(Y_WIDTH)));
+				port(ID::A, param(ID(A_WIDTH)));
+				port(ID::B, param(ID(B_WIDTH)));
+				port(ID::Y, param(ID(Y_WIDTH)));
 				check_expected();
 				return;
 			}
 
 			if (cell->type.in(ID($reduce_and), ID($reduce_or), ID($reduce_xor), ID($reduce_xnor), ID($reduce_bool))) {
 				param_bool(ID(A_SIGNED));
-				port(ID(A), param(ID(A_WIDTH)));
-				port(ID(Y), param(ID(Y_WIDTH)));
+				port(ID::A, param(ID(A_WIDTH)));
+				port(ID::Y, param(ID(Y_WIDTH)));
 				check_expected();
 				return;
 			}
@@ -872,9 +872,9 @@ namespace {
 			if (cell->type.in(ID($shl), ID($shr), ID($sshl), ID($sshr), ID($shift), ID($shiftx))) {
 				param_bool(ID(A_SIGNED));
 				param_bool(ID(B_SIGNED));
-				port(ID(A), param(ID(A_WIDTH)));
-				port(ID(B), param(ID(B_WIDTH)));
-				port(ID(Y), param(ID(Y_WIDTH)));
+				port(ID::A, param(ID(A_WIDTH)));
+				port(ID::B, param(ID(B_WIDTH)));
+				port(ID::Y, param(ID(Y_WIDTH)));
 				check_expected(false);
 				return;
 			}
@@ -882,9 +882,9 @@ namespace {
 			if (cell->type.in(ID($lt), ID($le), ID($eq), ID($ne), ID($eqx), ID($nex), ID($ge), ID($gt))) {
 				param_bool(ID(A_SIGNED));
 				param_bool(ID(B_SIGNED));
-				port(ID(A), param(ID(A_WIDTH)));
-				port(ID(B), param(ID(B_WIDTH)));
-				port(ID(Y), param(ID(Y_WIDTH)));
+				port(ID::A, param(ID(A_WIDTH)));
+				port(ID::B, param(ID(B_WIDTH)));
+				port(ID::Y, param(ID(Y_WIDTH)));
 				check_expected();
 				return;
 			}
@@ -892,19 +892,19 @@ namespace {
 			if (cell->type.in(ID($add), ID($sub), ID($mul), ID($div), ID($mod), ID($pow))) {
 				param_bool(ID(A_SIGNED));
 				param_bool(ID(B_SIGNED));
-				port(ID(A), param(ID(A_WIDTH)));
-				port(ID(B), param(ID(B_WIDTH)));
-				port(ID(Y), param(ID(Y_WIDTH)));
+				port(ID::A, param(ID(A_WIDTH)));
+				port(ID::B, param(ID(B_WIDTH)));
+				port(ID::Y, param(ID(Y_WIDTH)));
 				check_expected(cell->type != ID($pow));
 				return;
 			}
 
 			if (cell->type == ID($fa)) {
-				port(ID(A), param(ID(WIDTH)));
-				port(ID(B), param(ID(WIDTH)));
+				port(ID::A, param(ID(WIDTH)));
+				port(ID::B, param(ID(WIDTH)));
 				port(ID(C), param(ID(WIDTH)));
 				port(ID(X), param(ID(WIDTH)));
-				port(ID(Y), param(ID(WIDTH)));
+				port(ID::Y, param(ID(WIDTH)));
 				check_expected();
 				return;
 			}
@@ -921,12 +921,12 @@ namespace {
 			if (cell->type == ID($alu)) {
 				param_bool(ID(A_SIGNED));
 				param_bool(ID(B_SIGNED));
-				port(ID(A), param(ID(A_WIDTH)));
-				port(ID(B), param(ID(B_WIDTH)));
+				port(ID::A, param(ID(A_WIDTH)));
+				port(ID::B, param(ID(B_WIDTH)));
 				port(ID(CI), 1);
 				port(ID(BI), 1);
 				port(ID(X), param(ID(Y_WIDTH)));
-				port(ID(Y), param(ID(Y_WIDTH)));
+				port(ID::Y, param(ID(Y_WIDTH)));
 				port(ID(CO), param(ID(Y_WIDTH)));
 				check_expected();
 				return;
@@ -935,9 +935,9 @@ namespace {
 			if (cell->type == ID($macc)) {
 				param(ID(CONFIG));
 				param(ID(CONFIG_WIDTH));
-				port(ID(A), param(ID(A_WIDTH)));
-				port(ID(B), param(ID(B_WIDTH)));
-				port(ID(Y), param(ID(Y_WIDTH)));
+				port(ID::A, param(ID(A_WIDTH)));
+				port(ID::B, param(ID(B_WIDTH)));
+				port(ID::Y, param(ID(Y_WIDTH)));
 				check_expected();
 				Macc().from_cell(cell);
 				return;
@@ -945,8 +945,8 @@ namespace {
 
 			if (cell->type == ID($logic_not)) {
 				param_bool(ID(A_SIGNED));
-				port(ID(A), param(ID(A_WIDTH)));
-				port(ID(Y), param(ID(Y_WIDTH)));
+				port(ID::A, param(ID(A_WIDTH)));
+				port(ID::Y, param(ID(Y_WIDTH)));
 				check_expected();
 				return;
 			}
@@ -954,17 +954,17 @@ namespace {
 			if (cell->type.in(ID($logic_and), ID($logic_or))) {
 				param_bool(ID(A_SIGNED));
 				param_bool(ID(B_SIGNED));
-				port(ID(A), param(ID(A_WIDTH)));
-				port(ID(B), param(ID(B_WIDTH)));
-				port(ID(Y), param(ID(Y_WIDTH)));
+				port(ID::A, param(ID(A_WIDTH)));
+				port(ID::B, param(ID(B_WIDTH)));
+				port(ID::Y, param(ID(Y_WIDTH)));
 				check_expected(false);
 				return;
 			}
 
 			if (cell->type == ID($slice)) {
 				param(ID(OFFSET));
-				port(ID(A), param(ID(A_WIDTH)));
-				port(ID(Y), param(ID(Y_WIDTH)));
+				port(ID::A, param(ID(A_WIDTH)));
+				port(ID::Y, param(ID(Y_WIDTH)));
 				if (param(ID(OFFSET)) + param(ID(Y_WIDTH)) > param(ID(A_WIDTH)))
 					error(__LINE__);
 				check_expected();
@@ -972,35 +972,35 @@ namespace {
 			}
 
 			if (cell->type == ID($concat)) {
-				port(ID(A), param(ID(A_WIDTH)));
-				port(ID(B), param(ID(B_WIDTH)));
-				port(ID(Y), param(ID(A_WIDTH)) + param(ID(B_WIDTH)));
+				port(ID::A, param(ID(A_WIDTH)));
+				port(ID::B, param(ID(B_WIDTH)));
+				port(ID::Y, param(ID(A_WIDTH)) + param(ID(B_WIDTH)));
 				check_expected();
 				return;
 			}
 
 			if (cell->type == ID($mux)) {
-				port(ID(A), param(ID(WIDTH)));
-				port(ID(B), param(ID(WIDTH)));
+				port(ID::A, param(ID(WIDTH)));
+				port(ID::B, param(ID(WIDTH)));
 				port(ID(S), 1);
-				port(ID(Y), param(ID(WIDTH)));
+				port(ID::Y, param(ID(WIDTH)));
 				check_expected();
 				return;
 			}
 
 			if (cell->type == ID($pmux)) {
-				port(ID(A), param(ID(WIDTH)));
-				port(ID(B), param(ID(WIDTH)) * param(ID(S_WIDTH)));
+				port(ID::A, param(ID(WIDTH)));
+				port(ID::B, param(ID(WIDTH)) * param(ID(S_WIDTH)));
 				port(ID(S), param(ID(S_WIDTH)));
-				port(ID(Y), param(ID(WIDTH)));
+				port(ID::Y, param(ID(WIDTH)));
 				check_expected();
 				return;
 			}
 
 			if (cell->type == ID($lut)) {
 				param(ID(LUT));
-				port(ID(A), param(ID(WIDTH)));
-				port(ID(Y), 1);
+				port(ID::A, param(ID(WIDTH)));
+				port(ID::Y, 1);
 				check_expected();
 				return;
 			}
@@ -1008,8 +1008,8 @@ namespace {
 			if (cell->type == ID($sop)) {
 				param(ID(DEPTH));
 				param(ID(TABLE));
-				port(ID(A), param(ID(WIDTH)));
-				port(ID(Y), 1);
+				port(ID::A, param(ID(WIDTH)));
+				port(ID::Y, 1);
 				check_expected();
 				return;
 			}
@@ -1175,36 +1175,36 @@ namespace {
 			}
 
 			if (cell->type == ID($tribuf)) {
-				port(ID(A), param(ID(WIDTH)));
-				port(ID(Y), param(ID(WIDTH)));
+				port(ID::A, param(ID(WIDTH)));
+				port(ID::Y, param(ID(WIDTH)));
 				port(ID(EN), 1);
 				check_expected();
 				return;
 			}
 
 			if (cell->type.in(ID($assert), ID($assume), ID($live), ID($fair), ID($cover))) {
-				port(ID(A), 1);
+				port(ID::A, 1);
 				port(ID(EN), 1);
 				check_expected();
 				return;
 			}
 
 			if (cell->type == ID($initstate)) {
-				port(ID(Y), 1);
+				port(ID::Y, 1);
 				check_expected();
 				return;
 			}
 
 			if (cell->type.in(ID($anyconst), ID($anyseq), ID($allconst), ID($allseq))) {
-				port(ID(Y), param(ID(WIDTH)));
+				port(ID::Y, param(ID(WIDTH)));
 				check_expected();
 				return;
 			}
 
 			if (cell->type == ID($equiv)) {
-				port(ID(A), 1);
-				port(ID(B), 1);
-				port(ID(Y), 1);
+				port(ID::A, 1);
+				port(ID::B, 1);
+				port(ID::Y, 1);
 				check_expected();
 				return;
 			}
@@ -1831,8 +1831,8 @@ RTLIL::Cell *RTLIL::Module::addCell(RTLIL::IdString name, const RTLIL::Cell *oth
 		cell->parameters[ID(A_SIGNED)] = is_signed;         \
 		cell->parameters[ID(A_WIDTH)] = sig_a.size();       \
 		cell->parameters[ID(Y_WIDTH)] = sig_y.size();       \
-		cell->setPort(ID(A), sig_a);                        \
-		cell->setPort(ID(Y), sig_y);                        \
+		cell->setPort(ID::A, sig_a);                        \
+		cell->setPort(ID::Y, sig_y);                        \
 		cell->set_src_attribute(src);                       \
 		return cell;                                        \
 	} \
@@ -1860,9 +1860,9 @@ DEF_METHOD(LogicNot,   1, ID($logic_not))
 		cell->parameters[ID(A_WIDTH)] = sig_a.size();       \
 		cell->parameters[ID(B_WIDTH)] = sig_b.size();       \
 		cell->parameters[ID(Y_WIDTH)] = sig_y.size();       \
-		cell->setPort(ID(A), sig_a);                        \
-		cell->setPort(ID(B), sig_b);                        \
-		cell->setPort(ID(Y), sig_y);                        \
+		cell->setPort(ID::A, sig_a);                        \
+		cell->setPort(ID::B, sig_b);                        \
+		cell->setPort(ID::Y, sig_y);                        \
 		cell->set_src_attribute(src);                       \
 		return cell;                                        \
 	} \
@@ -1903,10 +1903,10 @@ DEF_METHOD(LogicOr,  1, ID($logic_or))
 		RTLIL::Cell *cell = addCell(name, _type);                 \
 		cell->parameters[ID(WIDTH)] = sig_a.size();               \
 		if (_pmux) cell->parameters[ID(S_WIDTH)] = sig_s.size();  \
-		cell->setPort(ID(A), sig_a);                              \
-		cell->setPort(ID(B), sig_b);                              \
+		cell->setPort(ID::A, sig_a);                              \
+		cell->setPort(ID::B, sig_b);                              \
 		cell->setPort(ID(S), sig_s);                              \
-		cell->setPort(ID(Y), sig_y);                              \
+		cell->setPort(ID::Y, sig_y);                              \
 		cell->set_src_attribute(src);                             \
 		return cell;                                              \
 	} \
@@ -2006,9 +2006,9 @@ RTLIL::Cell* RTLIL::Module::addPow(RTLIL::IdString name, RTLIL::SigSpec sig_a, R
 	cell->parameters[ID(A_WIDTH)] = sig_a.size();
 	cell->parameters[ID(B_WIDTH)] = sig_b.size();
 	cell->parameters[ID(Y_WIDTH)] = sig_y.size();
-	cell->setPort(ID(A), sig_a);
-	cell->setPort(ID(B), sig_b);
-	cell->setPort(ID(Y), sig_y);
+	cell->setPort(ID::A, sig_a);
+	cell->setPort(ID::B, sig_b);
+	cell->setPort(ID::Y, sig_y);
 	cell->set_src_attribute(src);
 	return cell;
 }
@@ -2019,8 +2019,8 @@ RTLIL::Cell* RTLIL::Module::addSlice(RTLIL::IdString name, RTLIL::SigSpec sig_a,
 	cell->parameters[ID(A_WIDTH)] = sig_a.size();
 	cell->parameters[ID(Y_WIDTH)] = sig_y.size();
 	cell->parameters[ID(OFFSET)] = offset;
-	cell->setPort(ID(A), sig_a);
-	cell->setPort(ID(Y), sig_y);
+	cell->setPort(ID::A, sig_a);
+	cell->setPort(ID::Y, sig_y);
 	cell->set_src_attribute(src);
 	return cell;
 }
@@ -2030,9 +2030,9 @@ RTLIL::Cell* RTLIL::Module::addConcat(RTLIL::IdString name, RTLIL::SigSpec sig_a
 	RTLIL::Cell *cell = addCell(name, ID($concat));
 	cell->parameters[ID(A_WIDTH)] = sig_a.size();
 	cell->parameters[ID(B_WIDTH)] = sig_b.size();
-	cell->setPort(ID(A), sig_a);
-	cell->setPort(ID(B), sig_b);
-	cell->setPort(ID(Y), sig_y);
+	cell->setPort(ID::A, sig_a);
+	cell->setPort(ID::B, sig_b);
+	cell->setPort(ID::Y, sig_y);
 	cell->set_src_attribute(src);
 	return cell;
 }
@@ -2042,8 +2042,8 @@ RTLIL::Cell* RTLIL::Module::addLut(RTLIL::IdString name, RTLIL::SigSpec sig_a, R
 	RTLIL::Cell *cell = addCell(name, ID($lut));
 	cell->parameters[ID(LUT)] = lut;
 	cell->parameters[ID(WIDTH)] = sig_a.size();
-	cell->setPort(ID(A), sig_a);
-	cell->setPort(ID(Y), sig_y);
+	cell->setPort(ID::A, sig_a);
+	cell->setPort(ID::Y, sig_y);
 	cell->set_src_attribute(src);
 	return cell;
 }
@@ -2052,9 +2052,9 @@ RTLIL::Cell* RTLIL::Module::addTribuf(RTLIL::IdString name, RTLIL::SigSpec sig_a
 {
 	RTLIL::Cell *cell = addCell(name, ID($tribuf));
 	cell->parameters[ID(WIDTH)] = sig_a.size();
-	cell->setPort(ID(A), sig_a);
+	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID(EN), sig_en);
-	cell->setPort(ID(Y), sig_y);
+	cell->setPort(ID::Y, sig_y);
 	cell->set_src_attribute(src);
 	return cell;
 }
@@ -2062,7 +2062,7 @@ RTLIL::Cell* RTLIL::Module::addTribuf(RTLIL::IdString name, RTLIL::SigSpec sig_a
 RTLIL::Cell* RTLIL::Module::addAssert(RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_en, const std::string &src)
 {
 	RTLIL::Cell *cell = addCell(name, ID($assert));
-	cell->setPort(ID(A), sig_a);
+	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID(EN), sig_en);
 	cell->set_src_attribute(src);
 	return cell;
@@ -2071,7 +2071,7 @@ RTLIL::Cell* RTLIL::Module::addAssert(RTLIL::IdString name, RTLIL::SigSpec sig_a
 RTLIL::Cell* RTLIL::Module::addAssume(RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_en, const std::string &src)
 {
 	RTLIL::Cell *cell = addCell(name, ID($assume));
-	cell->setPort(ID(A), sig_a);
+	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID(EN), sig_en);
 	cell->set_src_attribute(src);
 	return cell;
@@ -2080,7 +2080,7 @@ RTLIL::Cell* RTLIL::Module::addAssume(RTLIL::IdString name, RTLIL::SigSpec sig_a
 RTLIL::Cell* RTLIL::Module::addLive(RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_en, const std::string &src)
 {
 	RTLIL::Cell *cell = addCell(name, ID($live));
-	cell->setPort(ID(A), sig_a);
+	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID(EN), sig_en);
 	cell->set_src_attribute(src);
 	return cell;
@@ -2089,7 +2089,7 @@ RTLIL::Cell* RTLIL::Module::addLive(RTLIL::IdString name, RTLIL::SigSpec sig_a, 
 RTLIL::Cell* RTLIL::Module::addFair(RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_en, const std::string &src)
 {
 	RTLIL::Cell *cell = addCell(name, ID($fair));
-	cell->setPort(ID(A), sig_a);
+	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID(EN), sig_en);
 	cell->set_src_attribute(src);
 	return cell;
@@ -2098,7 +2098,7 @@ RTLIL::Cell* RTLIL::Module::addFair(RTLIL::IdString name, RTLIL::SigSpec sig_a, 
 RTLIL::Cell* RTLIL::Module::addCover(RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_en, const std::string &src)
 {
 	RTLIL::Cell *cell = addCell(name, ID($cover));
-	cell->setPort(ID(A), sig_a);
+	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID(EN), sig_en);
 	cell->set_src_attribute(src);
 	return cell;
@@ -2107,9 +2107,9 @@ RTLIL::Cell* RTLIL::Module::addCover(RTLIL::IdString name, RTLIL::SigSpec sig_a,
 RTLIL::Cell* RTLIL::Module::addEquiv(RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, RTLIL::SigSpec sig_y, const std::string &src)
 {
 	RTLIL::Cell *cell = addCell(name, ID($equiv));
-	cell->setPort(ID(A), sig_a);
-	cell->setPort(ID(B), sig_b);
-	cell->setPort(ID(Y), sig_y);
+	cell->setPort(ID::A, sig_a);
+	cell->setPort(ID::B, sig_b);
+	cell->setPort(ID::Y, sig_y);
 	cell->set_src_attribute(src);
 	return cell;
 }
@@ -2308,7 +2308,7 @@ RTLIL::SigSpec RTLIL::Module::Anyconst(RTLIL::IdString name, int width, const st
 	RTLIL::SigSpec sig = addWire(NEW_ID, width);
 	Cell *cell = addCell(name, ID($anyconst));
 	cell->setParam(ID(WIDTH), width);
-	cell->setPort(ID(Y), sig);
+	cell->setPort(ID::Y, sig);
 	cell->set_src_attribute(src);
 	return sig;
 }
@@ -2318,7 +2318,7 @@ RTLIL::SigSpec RTLIL::Module::Anyseq(RTLIL::IdString name, int width, const std:
 	RTLIL::SigSpec sig = addWire(NEW_ID, width);
 	Cell *cell = addCell(name, ID($anyseq));
 	cell->setParam(ID(WIDTH), width);
-	cell->setPort(ID(Y), sig);
+	cell->setPort(ID::Y, sig);
 	cell->set_src_attribute(src);
 	return sig;
 }
@@ -2328,7 +2328,7 @@ RTLIL::SigSpec RTLIL::Module::Allconst(RTLIL::IdString name, int width, const st
 	RTLIL::SigSpec sig = addWire(NEW_ID, width);
 	Cell *cell = addCell(name, ID($allconst));
 	cell->setParam(ID(WIDTH), width);
-	cell->setPort(ID(Y), sig);
+	cell->setPort(ID::Y, sig);
 	cell->set_src_attribute(src);
 	return sig;
 }
@@ -2338,7 +2338,7 @@ RTLIL::SigSpec RTLIL::Module::Allseq(RTLIL::IdString name, int width, const std:
 	RTLIL::SigSpec sig = addWire(NEW_ID, width);
 	Cell *cell = addCell(name, ID($allseq));
 	cell->setParam(ID(WIDTH), width);
-	cell->setPort(ID(Y), sig);
+	cell->setPort(ID::Y, sig);
 	cell->set_src_attribute(src);
 	return sig;
 }
@@ -2347,7 +2347,7 @@ RTLIL::SigSpec RTLIL::Module::Initstate(RTLIL::IdString name, const std::string 
 {
 	RTLIL::SigSpec sig = addWire(NEW_ID);
 	Cell *cell = addCell(name, ID($initstate));
-	cell->setPort(ID(Y), sig);
+	cell->setPort(ID::Y, sig);
 	cell->set_src_attribute(src);
 	return sig;
 }
@@ -2569,7 +2569,7 @@ void RTLIL::Cell::fixup_parameters(bool set_a_signed, bool set_b_signed)
 		return;
 
 	if (type == ID($mux) || type == ID($pmux)) {
-		parameters[ID(WIDTH)] = GetSize(connections_[ID(Y)]);
+		parameters[ID(WIDTH)] = GetSize(connections_[ID::Y]);
 		if (type == ID($pmux))
 			parameters[ID(S_WIDTH)] = GetSize(connections_[ID(S)]);
 		check();
@@ -2577,12 +2577,12 @@ void RTLIL::Cell::fixup_parameters(bool set_a_signed, bool set_b_signed)
 	}
 
 	if (type == ID($lut) || type == ID($sop)) {
-		parameters[ID(WIDTH)] = GetSize(connections_[ID(A)]);
+		parameters[ID(WIDTH)] = GetSize(connections_[ID::A]);
 		return;
 	}
 
 	if (type == ID($fa)) {
-		parameters[ID(WIDTH)] = GetSize(connections_[ID(Y)]);
+		parameters[ID(WIDTH)] = GetSize(connections_[ID::Y]);
 		return;
 	}
 
@@ -2593,28 +2593,28 @@ void RTLIL::Cell::fixup_parameters(bool set_a_signed, bool set_b_signed)
 
 	bool signedness_ab = !type.in(ID($slice), ID($concat), ID($macc));
 
-	if (connections_.count(ID(A))) {
+	if (connections_.count(ID::A)) {
 		if (signedness_ab) {
 			if (set_a_signed)
 				parameters[ID(A_SIGNED)] = true;
 			else if (parameters.count(ID(A_SIGNED)) == 0)
 				parameters[ID(A_SIGNED)] = false;
 		}
-		parameters[ID(A_WIDTH)] = GetSize(connections_[ID(A)]);
+		parameters[ID(A_WIDTH)] = GetSize(connections_[ID::A]);
 	}
 
-	if (connections_.count(ID(B))) {
+	if (connections_.count(ID::B)) {
 		if (signedness_ab) {
 			if (set_b_signed)
 				parameters[ID(B_SIGNED)] = true;
 			else if (parameters.count(ID(B_SIGNED)) == 0)
 				parameters[ID(B_SIGNED)] = false;
 		}
-		parameters[ID(B_WIDTH)] = GetSize(connections_[ID(B)]);
+		parameters[ID(B_WIDTH)] = GetSize(connections_[ID::B]);
 	}
 
-	if (connections_.count(ID(Y)))
-		parameters[ID(Y_WIDTH)] = GetSize(connections_[ID(Y)]);
+	if (connections_.count(ID::Y))
+		parameters[ID(Y_WIDTH)] = GetSize(connections_[ID::Y]);
 
 	if (connections_.count(ID(Q)))
 		parameters[ID(WIDTH)] = GetSize(connections_[ID(Q)]);

--- a/kernel/satgen.h
+++ b/kernel/satgen.h
@@ -281,9 +281,9 @@ struct SatGen
 
 		if (model_undef && (cell->type.in(ID($add), ID($sub), ID($mul), ID($div), ID($mod)) || is_arith_compare))
 		{
-			std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep);
-			std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID(B)), timestep);
-			std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
+			std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID::B), timestep);
+			std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 			if (is_arith_compare)
 				extendSignalWidth(undef_a, undef_b, cell, true);
 			else
@@ -294,7 +294,7 @@ struct SatGen
 			int undef_y_bit = ez->OR(undef_any_a, undef_any_b);
 
 			if (cell->type.in(ID($div), ID($mod))) {
-				std::vector<int> b = importSigSpec(cell->getPort(ID(B)), timestep);
+				std::vector<int> b = importSigSpec(cell->getPort(ID::B), timestep);
 				undef_y_bit = ez->OR(undef_y_bit, ez->NOT(ez->expression(ezSAT::OpOr, b)));
 			}
 
@@ -313,9 +313,9 @@ struct SatGen
 		if (cell->type.in(ID($_AND_), ID($_NAND_), ID($_OR_), ID($_NOR_), ID($_XOR_), ID($_XNOR_), ID($_ANDNOT_), ID($_ORNOT_),
 				ID($and), ID($or), ID($xor), ID($xnor), ID($add), ID($sub)))
 		{
-			std::vector<int> a = importDefSigSpec(cell->getPort(ID(A)), timestep);
-			std::vector<int> b = importDefSigSpec(cell->getPort(ID(B)), timestep);
-			std::vector<int> y = importDefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> a = importDefSigSpec(cell->getPort(ID::A), timestep);
+			std::vector<int> b = importDefSigSpec(cell->getPort(ID::B), timestep);
+			std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 			extendSignalWidth(a, b, y, cell);
 
 			std::vector<int> yy = model_undef ? ez->vec_var(y.size()) : y;
@@ -343,9 +343,9 @@ struct SatGen
 
 			if (model_undef && !arith_undef_handled)
 			{
-				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep);
-				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID(B)), timestep);
-				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
+				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID::B), timestep);
+				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 				extendSignalWidth(undef_a, undef_b, undef_y, cell, false);
 
 				if (cell->type.in(ID($and), ID($_AND_), ID($_NAND_))) {
@@ -384,7 +384,7 @@ struct SatGen
 			}
 			else if (model_undef)
 			{
-				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 				undefGating(y, yy, undef_y);
 			}
 			return true;
@@ -395,11 +395,11 @@ struct SatGen
 			bool aoi_mode = cell->type.in(ID($_AOI3_), ID($_AOI4_));
 			bool three_mode = cell->type.in(ID($_AOI3_), ID($_OAI3_));
 
-			int a = importDefSigSpec(cell->getPort(ID(A)), timestep).at(0);
-			int b = importDefSigSpec(cell->getPort(ID(B)), timestep).at(0);
+			int a = importDefSigSpec(cell->getPort(ID::A), timestep).at(0);
+			int b = importDefSigSpec(cell->getPort(ID::B), timestep).at(0);
 			int c = importDefSigSpec(cell->getPort(ID(C)), timestep).at(0);
 			int d = three_mode ? (aoi_mode ? ez->CONST_TRUE : ez->CONST_FALSE) : importDefSigSpec(cell->getPort(ID(D)), timestep).at(0);
-			int y = importDefSigSpec(cell->getPort(ID(Y)), timestep).at(0);
+			int y = importDefSigSpec(cell->getPort(ID::Y), timestep).at(0);
 			int yy = model_undef ? ez->literal() : y;
 
 			if (cell->type.in(ID($_AOI3_), ID($_AOI4_)))
@@ -409,11 +409,11 @@ struct SatGen
 
 			if (model_undef)
 			{
-				int undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep).at(0);
-				int undef_b = importUndefSigSpec(cell->getPort(ID(B)), timestep).at(0);
+				int undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep).at(0);
+				int undef_b = importUndefSigSpec(cell->getPort(ID::B), timestep).at(0);
 				int undef_c = importUndefSigSpec(cell->getPort(ID(C)), timestep).at(0);
 				int undef_d = three_mode ? ez->CONST_FALSE : importUndefSigSpec(cell->getPort(ID(D)), timestep).at(0);
-				int undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep).at(0);
+				int undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep).at(0);
 
 				if (aoi_mode)
 				{
@@ -458,16 +458,16 @@ struct SatGen
 
 		if (cell->type.in(ID($_NOT_), ID($not)))
 		{
-			std::vector<int> a = importDefSigSpec(cell->getPort(ID(A)), timestep);
-			std::vector<int> y = importDefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> a = importDefSigSpec(cell->getPort(ID::A), timestep);
+			std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 			extendSignalWidthUnary(a, y, cell);
 
 			std::vector<int> yy = model_undef ? ez->vec_var(y.size()) : y;
 			ez->assume(ez->vec_eq(ez->vec_not(a), yy));
 
 			if (model_undef) {
-				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep);
-				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
+				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 				extendSignalWidthUnary(undef_a, undef_y, cell, false);
 				ez->assume(ez->vec_eq(undef_a, undef_y));
 				undefGating(y, yy, undef_y);
@@ -477,10 +477,10 @@ struct SatGen
 
 		if (cell->type.in(ID($_MUX_), ID($mux), ID($_NMUX_)))
 		{
-			std::vector<int> a = importDefSigSpec(cell->getPort(ID(A)), timestep);
-			std::vector<int> b = importDefSigSpec(cell->getPort(ID(B)), timestep);
+			std::vector<int> a = importDefSigSpec(cell->getPort(ID::A), timestep);
+			std::vector<int> b = importDefSigSpec(cell->getPort(ID::B), timestep);
 			std::vector<int> s = importDefSigSpec(cell->getPort(ID(S)), timestep);
-			std::vector<int> y = importDefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 
 			std::vector<int> yy = model_undef ? ez->vec_var(y.size()) : y;
 			if (cell->type == ID($_NMUX_))
@@ -490,10 +490,10 @@ struct SatGen
 
 			if (model_undef)
 			{
-				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep);
-				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID(B)), timestep);
+				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
+				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID::B), timestep);
 				std::vector<int> undef_s = importUndefSigSpec(cell->getPort(ID(S)), timestep);
-				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 
 				std::vector<int> unequal_ab = ez->vec_not(ez->vec_iff(a, b));
 				std::vector<int> undef_ab = ez->vec_or(unequal_ab, ez->vec_or(undef_a, undef_b));
@@ -506,10 +506,10 @@ struct SatGen
 
 		if (cell->type == ID($pmux))
 		{
-			std::vector<int> a = importDefSigSpec(cell->getPort(ID(A)), timestep);
-			std::vector<int> b = importDefSigSpec(cell->getPort(ID(B)), timestep);
+			std::vector<int> a = importDefSigSpec(cell->getPort(ID::A), timestep);
+			std::vector<int> b = importDefSigSpec(cell->getPort(ID::B), timestep);
 			std::vector<int> s = importDefSigSpec(cell->getPort(ID(S)), timestep);
-			std::vector<int> y = importDefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 
 			std::vector<int> yy = model_undef ? ez->vec_var(y.size()) : y;
 
@@ -522,10 +522,10 @@ struct SatGen
 
 			if (model_undef)
 			{
-				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep);
-				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID(B)), timestep);
+				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
+				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID::B), timestep);
 				std::vector<int> undef_s = importUndefSigSpec(cell->getPort(ID(S)), timestep);
-				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 
 				int maybe_a = ez->CONST_TRUE;
 
@@ -557,8 +557,8 @@ struct SatGen
 
 		if (cell->type.in(ID($pos), ID($neg)))
 		{
-			std::vector<int> a = importDefSigSpec(cell->getPort(ID(A)), timestep);
-			std::vector<int> y = importDefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> a = importDefSigSpec(cell->getPort(ID::A), timestep);
+			std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 			extendSignalWidthUnary(a, y, cell);
 
 			std::vector<int> yy = model_undef ? ez->vec_var(y.size()) : y;
@@ -572,8 +572,8 @@ struct SatGen
 
 			if (model_undef)
 			{
-				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep);
-				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
+				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 				extendSignalWidthUnary(undef_a, undef_y, cell);
 
 				if (cell->type == ID($pos)) {
@@ -591,8 +591,8 @@ struct SatGen
 
 		if (cell->type.in(ID($reduce_and), ID($reduce_or), ID($reduce_xor), ID($reduce_xnor), ID($reduce_bool), ID($logic_not)))
 		{
-			std::vector<int> a = importDefSigSpec(cell->getPort(ID(A)), timestep);
-			std::vector<int> y = importDefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> a = importDefSigSpec(cell->getPort(ID::A), timestep);
+			std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 
 			std::vector<int> yy = model_undef ? ez->vec_var(y.size()) : y;
 
@@ -611,8 +611,8 @@ struct SatGen
 
 			if (model_undef)
 			{
-				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep);
-				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
+				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 				int aX = ez->expression(ezSAT::OpOr, undef_a);
 
 				if (cell->type == ID($reduce_and)) {
@@ -638,12 +638,12 @@ struct SatGen
 
 		if (cell->type.in(ID($logic_and), ID($logic_or)))
 		{
-			std::vector<int> vec_a = importDefSigSpec(cell->getPort(ID(A)), timestep);
-			std::vector<int> vec_b = importDefSigSpec(cell->getPort(ID(B)), timestep);
+			std::vector<int> vec_a = importDefSigSpec(cell->getPort(ID::A), timestep);
+			std::vector<int> vec_b = importDefSigSpec(cell->getPort(ID::B), timestep);
 
 			int a = ez->expression(ez->OpOr, vec_a);
 			int b = ez->expression(ez->OpOr, vec_b);
-			std::vector<int> y = importDefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 
 			std::vector<int> yy = model_undef ? ez->vec_var(y.size()) : y;
 
@@ -656,9 +656,9 @@ struct SatGen
 
 			if (model_undef)
 			{
-				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep);
-				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID(B)), timestep);
-				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
+				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID::B), timestep);
+				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 
 				int a0 = ez->NOT(ez->OR(ez->expression(ezSAT::OpOr, vec_a), ez->expression(ezSAT::OpOr, undef_a)));
 				int b0 = ez->NOT(ez->OR(ez->expression(ezSAT::OpOr, vec_b), ez->expression(ezSAT::OpOr, undef_b)));
@@ -685,16 +685,16 @@ struct SatGen
 		if (cell->type.in(ID($lt), ID($le), ID($eq), ID($ne), ID($eqx), ID($nex), ID($ge), ID($gt)))
 		{
 			bool is_signed = cell->parameters[ID(A_SIGNED)].as_bool() && cell->parameters[ID(B_SIGNED)].as_bool();
-			std::vector<int> a = importDefSigSpec(cell->getPort(ID(A)), timestep);
-			std::vector<int> b = importDefSigSpec(cell->getPort(ID(B)), timestep);
-			std::vector<int> y = importDefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> a = importDefSigSpec(cell->getPort(ID::A), timestep);
+			std::vector<int> b = importDefSigSpec(cell->getPort(ID::B), timestep);
+			std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 			extendSignalWidth(a, b, cell);
 
 			std::vector<int> yy = model_undef ? ez->vec_var(y.size()) : y;
 
 			if (model_undef && cell->type.in(ID($eqx), ID($nex))) {
-				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep);
-				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID(B)), timestep);
+				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
+				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID::B), timestep);
 				extendSignalWidth(undef_a, undef_b, cell, true);
 				a = ez->vec_or(a, undef_a);
 				b = ez->vec_or(b, undef_b);
@@ -717,9 +717,9 @@ struct SatGen
 
 			if (model_undef && cell->type.in(ID($eqx), ID($nex)))
 			{
-				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep);
-				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID(B)), timestep);
-				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
+				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID::B), timestep);
+				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 				extendSignalWidth(undef_a, undef_b, cell, true);
 
 				if (cell->type == ID($eqx))
@@ -734,9 +734,9 @@ struct SatGen
 			}
 			else if (model_undef && cell->type.in(ID($eq), ID($ne)))
 			{
-				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep);
-				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID(B)), timestep);
-				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
+				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID::B), timestep);
+				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 				extendSignalWidth(undef_a, undef_b, cell, true);
 
 				int undef_any_a = ez->expression(ezSAT::OpOr, undef_a);
@@ -758,7 +758,7 @@ struct SatGen
 			else
 			{
 				if (model_undef) {
-					std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+					std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 					undefGating(y, yy, undef_y);
 				}
 				log_assert(!model_undef || arith_undef_handled);
@@ -768,9 +768,9 @@ struct SatGen
 
 		if (cell->type.in(ID($shl), ID($shr), ID($sshl), ID($sshr), ID($shift), ID($shiftx)))
 		{
-			std::vector<int> a = importDefSigSpec(cell->getPort(ID(A)), timestep);
-			std::vector<int> b = importDefSigSpec(cell->getPort(ID(B)), timestep);
-			std::vector<int> y = importDefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> a = importDefSigSpec(cell->getPort(ID::A), timestep);
+			std::vector<int> b = importDefSigSpec(cell->getPort(ID::B), timestep);
+			std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 
 			int extend_bit = ez->CONST_FALSE;
 
@@ -801,9 +801,9 @@ struct SatGen
 
 			if (model_undef)
 			{
-				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep);
-				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID(B)), timestep);
-				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
+				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID::B), timestep);
+				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 				std::vector<int> undef_a_shifted;
 
 				extend_bit = cell->type == ID($shiftx) ? ez->CONST_TRUE : ez->CONST_FALSE;
@@ -840,9 +840,9 @@ struct SatGen
 
 		if (cell->type == ID($mul))
 		{
-			std::vector<int> a = importDefSigSpec(cell->getPort(ID(A)), timestep);
-			std::vector<int> b = importDefSigSpec(cell->getPort(ID(B)), timestep);
-			std::vector<int> y = importDefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> a = importDefSigSpec(cell->getPort(ID::A), timestep);
+			std::vector<int> b = importDefSigSpec(cell->getPort(ID::B), timestep);
+			std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 			extendSignalWidth(a, b, y, cell);
 
 			std::vector<int> yy = model_undef ? ez->vec_var(y.size()) : y;
@@ -859,7 +859,7 @@ struct SatGen
 
 			if (model_undef) {
 				log_assert(arith_undef_handled);
-				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 				undefGating(y, yy, undef_y);
 			}
 			return true;
@@ -867,9 +867,9 @@ struct SatGen
 
 		if (cell->type == ID($macc))
 		{
-			std::vector<int> a = importDefSigSpec(cell->getPort(ID(A)), timestep);
-			std::vector<int> b = importDefSigSpec(cell->getPort(ID(B)), timestep);
-			std::vector<int> y = importDefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> a = importDefSigSpec(cell->getPort(ID::A), timestep);
+			std::vector<int> b = importDefSigSpec(cell->getPort(ID::B), timestep);
+			std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 
 			Macc macc;
 			macc.from_cell(cell);
@@ -918,13 +918,13 @@ struct SatGen
 
 			if (model_undef)
 			{
-				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep);
-				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID(B)), timestep);
+				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
+				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID::B), timestep);
 
 				int undef_any_a = ez->expression(ezSAT::OpOr, undef_a);
 				int undef_any_b = ez->expression(ezSAT::OpOr, undef_b);
 
-				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 				ez->assume(ez->vec_eq(undef_y, std::vector<int>(GetSize(y), ez->OR(undef_any_a, undef_any_b))));
 
 				undefGating(y, tmp, undef_y);
@@ -937,9 +937,9 @@ struct SatGen
 
 		if (cell->type.in(ID($div), ID($mod)))
 		{
-			std::vector<int> a = importDefSigSpec(cell->getPort(ID(A)), timestep);
-			std::vector<int> b = importDefSigSpec(cell->getPort(ID(B)), timestep);
-			std::vector<int> y = importDefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> a = importDefSigSpec(cell->getPort(ID::A), timestep);
+			std::vector<int> b = importDefSigSpec(cell->getPort(ID::B), timestep);
+			std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 			extendSignalWidth(a, b, y, cell);
 
 			std::vector<int> yy = model_undef ? ez->vec_var(y.size()) : y;
@@ -993,11 +993,11 @@ struct SatGen
 						only_first_one.at(0) = ez->CONST_TRUE;
 						div_zero_result = ez->vec_ite(a.back(), only_first_one, all_ones);
 					} else {
-						div_zero_result.insert(div_zero_result.end(), cell->getPort(ID(A)).size(), ez->CONST_TRUE);
+						div_zero_result.insert(div_zero_result.end(), cell->getPort(ID::A).size(), ez->CONST_TRUE);
 						div_zero_result.insert(div_zero_result.end(), y.size() - div_zero_result.size(), ez->CONST_FALSE);
 					}
 				} else {
-					int copy_a_bits = min(cell->getPort(ID(A)).size(), cell->getPort(ID(B)).size());
+					int copy_a_bits = min(cell->getPort(ID::A).size(), cell->getPort(ID::B).size());
 					div_zero_result.insert(div_zero_result.end(), a.begin(), a.begin() + copy_a_bits);
 					if (cell->parameters[ID(A_SIGNED)].as_bool() && cell->parameters[ID(B_SIGNED)].as_bool())
 						div_zero_result.insert(div_zero_result.end(), y.size() - div_zero_result.size(), div_zero_result.back());
@@ -1009,7 +1009,7 @@ struct SatGen
 
 			if (model_undef) {
 				log_assert(arith_undef_handled);
-				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 				undefGating(y, yy, undef_y);
 			}
 			return true;
@@ -1017,8 +1017,8 @@ struct SatGen
 
 		if (cell->type == ID($lut))
 		{
-			std::vector<int> a = importDefSigSpec(cell->getPort(ID(A)), timestep);
-			std::vector<int> y = importDefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> a = importDefSigSpec(cell->getPort(ID::A), timestep);
+			std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 
 			std::vector<int> lut;
 			for (auto bit : cell->getParam(ID(LUT)).bits)
@@ -1029,7 +1029,7 @@ struct SatGen
 
 			if (model_undef)
 			{
-				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep);
+				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
 				std::vector<int> t(lut), u(GetSize(t), ez->CONST_FALSE);
 
 				for (int i = GetSize(a)-1; i >= 0; i--)
@@ -1047,7 +1047,7 @@ struct SatGen
 				log_assert(GetSize(t) == 1);
 				log_assert(GetSize(u) == 1);
 				undefGating(y, t, u);
-				ez->assume(ez->vec_eq(importUndefSigSpec(cell->getPort(ID(Y)), timestep), u));
+				ez->assume(ez->vec_eq(importUndefSigSpec(cell->getPort(ID::Y), timestep), u));
 			}
 			else
 			{
@@ -1067,8 +1067,8 @@ struct SatGen
 
 		if (cell->type == ID($sop))
 		{
-			std::vector<int> a = importDefSigSpec(cell->getPort(ID(A)), timestep);
-			int y = importDefSigSpec(cell->getPort(ID(Y)), timestep).at(0);
+			std::vector<int> a = importDefSigSpec(cell->getPort(ID::A), timestep);
+			int y = importDefSigSpec(cell->getPort(ID::Y), timestep).at(0);
 
 			int width = cell->getParam(ID(WIDTH)).as_int();
 			int depth = cell->getParam(ID(DEPTH)).as_int();
@@ -1096,8 +1096,8 @@ struct SatGen
 			if (model_undef)
 			{
 				std::vector<int> products, undef_products;
-				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep);
-				int undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep).at(0);
+				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
+				int undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep).at(0);
 
 				for (int i = 0; i < depth; i++)
 				{
@@ -1149,10 +1149,10 @@ struct SatGen
 
 		if (cell->type == ID($fa))
 		{
-			std::vector<int> a = importDefSigSpec(cell->getPort(ID(A)), timestep);
-			std::vector<int> b = importDefSigSpec(cell->getPort(ID(B)), timestep);
+			std::vector<int> a = importDefSigSpec(cell->getPort(ID::A), timestep);
+			std::vector<int> b = importDefSigSpec(cell->getPort(ID::B), timestep);
 			std::vector<int> c = importDefSigSpec(cell->getPort(ID(C)), timestep);
-			std::vector<int> y = importDefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 			std::vector<int> x = importDefSigSpec(cell->getPort(ID(X)), timestep);
 
 			std::vector<int> yy = model_undef ? ez->vec_var(y.size()) : y;
@@ -1167,11 +1167,11 @@ struct SatGen
 
 			if (model_undef)
 			{
-				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep);
-				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID(B)), timestep);
+				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
+				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID::B), timestep);
 				std::vector<int> undef_c = importUndefSigSpec(cell->getPort(ID(C)), timestep);
 
-				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 				std::vector<int> undef_x = importUndefSigSpec(cell->getPort(ID(X)), timestep);
 
 				ez->assume(ez->vec_eq(undef_y, ez->vec_or(ez->vec_or(undef_a, undef_b), undef_c)));
@@ -1217,9 +1217,9 @@ struct SatGen
 
 		if (cell->type == ID($alu))
 		{
-			std::vector<int> a = importDefSigSpec(cell->getPort(ID(A)), timestep);
-			std::vector<int> b = importDefSigSpec(cell->getPort(ID(B)), timestep);
-			std::vector<int> y = importDefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> a = importDefSigSpec(cell->getPort(ID::A), timestep);
+			std::vector<int> b = importDefSigSpec(cell->getPort(ID::B), timestep);
+			std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 			std::vector<int> x = importDefSigSpec(cell->getPort(ID(X)), timestep);
 			std::vector<int> ci = importDefSigSpec(cell->getPort(ID(CI)), timestep);
 			std::vector<int> bi = importDefSigSpec(cell->getPort(ID(BI)), timestep);
@@ -1248,12 +1248,12 @@ struct SatGen
 
 			if (model_undef)
 			{
-				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep);
-				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID(B)), timestep);
+				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
+				std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID::B), timestep);
 				std::vector<int> undef_ci = importUndefSigSpec(cell->getPort(ID(CI)), timestep);
 				std::vector<int> undef_bi = importUndefSigSpec(cell->getPort(ID(BI)), timestep);
 
-				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 				std::vector<int> undef_x = importUndefSigSpec(cell->getPort(ID(X)), timestep);
 				std::vector<int> undef_co = importUndefSigSpec(cell->getPort(ID(CO)), timestep);
 
@@ -1283,17 +1283,17 @@ struct SatGen
 
 		if (cell->type == ID($slice))
 		{
-			RTLIL::SigSpec a = cell->getPort(ID(A));
-			RTLIL::SigSpec y = cell->getPort(ID(Y));
+			RTLIL::SigSpec a = cell->getPort(ID::A);
+			RTLIL::SigSpec y = cell->getPort(ID::Y);
 			ez->assume(signals_eq(a.extract(cell->parameters.at(ID(OFFSET)).as_int(), y.size()), y, timestep));
 			return true;
 		}
 
 		if (cell->type == ID($concat))
 		{
-			RTLIL::SigSpec a = cell->getPort(ID(A));
-			RTLIL::SigSpec b = cell->getPort(ID(B));
-			RTLIL::SigSpec y = cell->getPort(ID(Y));
+			RTLIL::SigSpec a = cell->getPort(ID::A);
+			RTLIL::SigSpec b = cell->getPort(ID::B);
+			RTLIL::SigSpec y = cell->getPort(ID::Y);
 
 			RTLIL::SigSpec ab = a;
 			ab.append(b);
@@ -1333,16 +1333,16 @@ struct SatGen
 			if (timestep < 2)
 				return true;
 
-			std::vector<int> d = importDefSigSpec(cell->getPort(ID(Y)), timestep-1);
-			std::vector<int> q = importDefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> d = importDefSigSpec(cell->getPort(ID::Y), timestep-1);
+			std::vector<int> q = importDefSigSpec(cell->getPort(ID::Y), timestep);
 
 			std::vector<int> qq = model_undef ? ez->vec_var(q.size()) : q;
 			ez->assume(ez->vec_eq(d, qq));
 
 			if (model_undef)
 			{
-				std::vector<int> undef_d = importUndefSigSpec(cell->getPort(ID(Y)), timestep-1);
-				std::vector<int> undef_q = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_d = importUndefSigSpec(cell->getPort(ID::Y), timestep-1);
+				std::vector<int> undef_q = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 
 				ez->assume(ez->vec_eq(undef_d, undef_q));
 				undefGating(q, qq, undef_q);
@@ -1357,16 +1357,16 @@ struct SatGen
 
 		if (cell->type.in(ID($_BUF_), ID($equiv)))
 		{
-			std::vector<int> a = importDefSigSpec(cell->getPort(ID(A)), timestep);
-			std::vector<int> y = importDefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> a = importDefSigSpec(cell->getPort(ID::A), timestep);
+			std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 			extendSignalWidthUnary(a, y, cell);
 
 			std::vector<int> yy = model_undef ? ez->vec_var(y.size()) : y;
 			ez->assume(ez->vec_eq(a, yy));
 
 			if (model_undef) {
-				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID(A)), timestep);
-				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
+				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 				extendSignalWidthUnary(undef_a, undef_y, cell, false);
 				ez->assume(ez->vec_eq(undef_a, undef_y));
 				undefGating(y, yy, undef_y);
@@ -1380,12 +1380,12 @@ struct SatGen
 			if (initstates.count(key) == 0)
 				initstates[key] = false;
 
-			std::vector<int> y = importDefSigSpec(cell->getPort(ID(Y)), timestep);
+			std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 			log_assert(GetSize(y) == 1);
 			ez->SET(y[0], initstates[key] ? ez->CONST_TRUE : ez->CONST_FALSE);
 
 			if (model_undef) {
-				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID(Y)), timestep);
+				std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
 				log_assert(GetSize(undef_y) == 1);
 				ez->SET(undef_y[0], ez->CONST_FALSE);
 			}
@@ -1396,7 +1396,7 @@ struct SatGen
 		if (cell->type == ID($assert))
 		{
 			std::string pf = prefix + (timestep == -1 ? "" : stringf("@%d:", timestep));
-			asserts_a[pf].append((*sigmap)(cell->getPort(ID(A))));
+			asserts_a[pf].append((*sigmap)(cell->getPort(ID::A)));
 			asserts_en[pf].append((*sigmap)(cell->getPort(ID(EN))));
 			return true;
 		}
@@ -1404,7 +1404,7 @@ struct SatGen
 		if (cell->type == ID($assume))
 		{
 			std::string pf = prefix + (timestep == -1 ? "" : stringf("@%d:", timestep));
-			assumes_a[pf].append((*sigmap)(cell->getPort(ID(A))));
+			assumes_a[pf].append((*sigmap)(cell->getPort(ID::A)));
 			assumes_en[pf].append((*sigmap)(cell->getPort(ID(EN))));
 			return true;
 		}

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -210,7 +210,7 @@ namespace RTLIL {
 	struct Module;
 	struct Design;
 	struct Monitor;
-    namespace ID {}
+	namespace ID {}
 }
 
 namespace AST {

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -210,7 +210,6 @@ namespace RTLIL {
 	struct Module;
 	struct Design;
 	struct Monitor;
-	namespace ID {}
 }
 
 namespace AST {
@@ -225,7 +224,6 @@ using RTLIL::Wire;
 using RTLIL::Cell;
 using RTLIL::Module;
 using RTLIL::Design;
-namespace ID = ::YOSYS_NAMESPACE::RTLIL::ID;
 
 namespace hashlib {
 	template<> struct hash_ops<RTLIL::Wire*> : hash_obj_ops {};
@@ -317,6 +315,7 @@ RTLIL::IdString new_id(std::string file, int line, std::string func);
 //
 #define ID(_id) ([]() { const char *p = "\\" #_id, *q = p[1] == '$' ? p+1 : p; \
         static const YOSYS_NAMESPACE_PREFIX RTLIL::IdString id(q); return id; })()
+namespace ID = RTLIL::ID;
 
 RTLIL::Design *yosys_get_design();
 std::string proc_self_dirname();

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -210,6 +210,7 @@ namespace RTLIL {
 	struct Module;
 	struct Design;
 	struct Monitor;
+    namespace ID {}
 }
 
 namespace AST {
@@ -224,6 +225,7 @@ using RTLIL::Wire;
 using RTLIL::Cell;
 using RTLIL::Module;
 using RTLIL::Design;
+namespace ID = RTLIL::ID;
 
 namespace hashlib {
 	template<> struct hash_ops<RTLIL::Wire*> : hash_obj_ops {};

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -225,7 +225,7 @@ using RTLIL::Wire;
 using RTLIL::Cell;
 using RTLIL::Module;
 using RTLIL::Design;
-namespace ID = RTLIL::ID;
+namespace ID = ::YOSYS_NAMESPACE::RTLIL::ID;
 
 namespace hashlib {
 	template<> struct hash_ops<RTLIL::Wire*> : hash_obj_ops {};

--- a/passes/opt/muxpack.cc
+++ b/passes/opt/muxpack.cc
@@ -135,7 +135,7 @@ struct MuxpackWorker
 	{
 		for (auto wire : module->wires())
 		{
-			if (wire->port_output || wire->get_bool_attribute(ID(keep))) {
+			if (wire->port_output || wire->get_bool_attribute(ID::keep)) {
 				for (auto bit : sigmap(wire))
 					sigbit_with_non_chain_users.insert(bit);
 			}
@@ -143,7 +143,7 @@ struct MuxpackWorker
 
 		for (auto cell : module->cells())
 		{
-			if (cell->type.in(ID($mux), ID($pmux)) && !cell->get_bool_attribute(ID(keep)))
+			if (cell->type.in(ID($mux), ID($pmux)) && !cell->get_bool_attribute(ID::keep))
 			{
 				SigSpec a_sig = sigmap(cell->getPort(ID::A));
 				SigSpec b_sig;

--- a/passes/opt/muxpack.cc
+++ b/passes/opt/muxpack.cc
@@ -38,19 +38,19 @@ struct ExclusiveDatabase
 		pool<Cell*> reduce_or;
 		for (auto cell : module->cells()) {
 			if (cell->type == ID($eq)) {
-				nonconst_sig = sigmap(cell->getPort(ID(A)));
-				const_sig = sigmap(cell->getPort(ID(B)));
+				nonconst_sig = sigmap(cell->getPort(ID::A));
+				const_sig = sigmap(cell->getPort(ID::B));
 				if (!const_sig.is_fully_const()) {
 					if (!nonconst_sig.is_fully_const())
 						continue;
 					std::swap(nonconst_sig, const_sig);
 				}
-				y_port = sigmap(cell->getPort(ID(Y)));
+				y_port = sigmap(cell->getPort(ID::Y));
 			}
 			else if (cell->type == ID($logic_not)) {
-				nonconst_sig = sigmap(cell->getPort(ID(A)));
+				nonconst_sig = sigmap(cell->getPort(ID::A));
 				const_sig = Const(State::S0, GetSize(nonconst_sig));
-				y_port = sigmap(cell->getPort(ID(Y)));
+				y_port = sigmap(cell->getPort(ID::Y));
 			}
 			else if (cell->type == ID($reduce_or)) {
 				reduce_or.insert(cell);
@@ -66,7 +66,7 @@ struct ExclusiveDatabase
 		for (auto cell : reduce_or) {
 			nonconst_sig = SigSpec();
 			std::vector<Const> values;
-			SigSpec a_port = sigmap(cell->getPort(ID(A)));
+			SigSpec a_port = sigmap(cell->getPort(ID::A));
 			for (auto bit : a_port) {
 				auto it = sig_cmp_prev.find(bit);
 				if (it == sig_cmp_prev.end()) {
@@ -84,7 +84,7 @@ struct ExclusiveDatabase
 			}
 			if (nonconst_sig.empty())
 				continue;
-			y_port = sigmap(cell->getPort(ID(Y)));
+			y_port = sigmap(cell->getPort(ID::Y));
 			sig_cmp_prev[y_port] = std::make_pair(nonconst_sig,std::move(values));
 		}
 	}
@@ -145,11 +145,11 @@ struct MuxpackWorker
 		{
 			if (cell->type.in(ID($mux), ID($pmux)) && !cell->get_bool_attribute(ID(keep)))
 			{
-				SigSpec a_sig = sigmap(cell->getPort(ID(A)));
+				SigSpec a_sig = sigmap(cell->getPort(ID::A));
 				SigSpec b_sig;
 				if (cell->type == ID($mux))
-					b_sig = sigmap(cell->getPort(ID(B)));
-				SigSpec y_sig = sigmap(cell->getPort(ID(Y)));
+					b_sig = sigmap(cell->getPort(ID::B));
+				SigSpec y_sig = sigmap(cell->getPort(ID::Y));
    
 				if (sig_chain_next.count(a_sig))
 					for (auto a_bit : a_sig.bits())
@@ -186,9 +186,9 @@ struct MuxpackWorker
 		{
 			log_debug("Considering %s (%s)\n", log_id(cell), log_id(cell->type));
 
-			SigSpec a_sig = sigmap(cell->getPort(ID(A)));
+			SigSpec a_sig = sigmap(cell->getPort(ID::A));
 			if (cell->type == ID($mux)) {
-				SigSpec b_sig = sigmap(cell->getPort(ID(B)));
+				SigSpec b_sig = sigmap(cell->getPort(ID::B));
 				if (sig_chain_prev.count(a_sig) + sig_chain_prev.count(b_sig) != 1)
 					goto start_cell;
 
@@ -230,7 +230,7 @@ struct MuxpackWorker
 		{
 			chain.push_back(c);
 
-			SigSpec y_sig = sigmap(c->getPort(ID(Y)));
+			SigSpec y_sig = sigmap(c->getPort(ID::Y));
 
 			if (sig_chain_next.count(y_sig) == 0)
 				break;
@@ -270,28 +270,28 @@ struct MuxpackWorker
 			pmux_count += 1;
 
 			first_cell->type = ID($pmux);
-			SigSpec b_sig = first_cell->getPort(ID(B));
+			SigSpec b_sig = first_cell->getPort(ID::B);
 			SigSpec s_sig = first_cell->getPort(ID(S));
 
 			for (int i = 1; i < cases; i++) {
 				Cell* prev_cell = chain[cursor+i-1];
 				Cell* cursor_cell = chain[cursor+i];
-				if (sigmap(prev_cell->getPort(ID(Y))) == sigmap(cursor_cell->getPort(ID(A)))) {
-					b_sig.append(cursor_cell->getPort(ID(B)));
+				if (sigmap(prev_cell->getPort(ID::Y)) == sigmap(cursor_cell->getPort(ID::A))) {
+					b_sig.append(cursor_cell->getPort(ID::B));
 					s_sig.append(cursor_cell->getPort(ID(S)));
 				}
 				else {
 					log_assert(cursor_cell->type == ID($mux));
-					b_sig.append(cursor_cell->getPort(ID(A)));
+					b_sig.append(cursor_cell->getPort(ID::A));
 					s_sig.append(module->LogicNot(NEW_ID, cursor_cell->getPort(ID(S))));
 				}
 				remove_cells.insert(cursor_cell);
 			}
 
-			first_cell->setPort(ID(B), b_sig);
+			first_cell->setPort(ID::B, b_sig);
 			first_cell->setPort(ID(S), s_sig);
 			first_cell->setParam(ID(S_WIDTH), GetSize(s_sig));
-			first_cell->setPort(ID(Y), last_cell->getPort(ID(Y)));
+			first_cell->setPort(ID::Y, last_cell->getPort(ID::Y));
 
 			cursor += cases;
 		}

--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -482,8 +482,8 @@ void rmunused_module(RTLIL::Module *module, bool purge_mode, bool verbose, bool 
 	for (auto cell : module->cells())
 		if (cell->type.in(ID($pos), ID($_BUF_)) && !cell->has_keep_attr()) {
 			bool is_signed = cell->type == ID($pos) && cell->getParam(ID(A_SIGNED)).as_bool();
-			RTLIL::SigSpec a = cell->getPort(ID(A));
-			RTLIL::SigSpec y = cell->getPort(ID(Y));
+			RTLIL::SigSpec a = cell->getPort(ID::A);
+			RTLIL::SigSpec y = cell->getPort(ID::Y);
 			a.extend_u0(GetSize(y), is_signed);
 			module->connect(y, a);
 			delcells.push_back(cell);
@@ -491,7 +491,7 @@ void rmunused_module(RTLIL::Module *module, bool purge_mode, bool verbose, bool 
 	for (auto cell : delcells) {
 		if (verbose)
 			log_debug("  removing buffer cell `%s': %s = %s\n", cell->name.c_str(),
-					log_signal(cell->getPort(ID(Y))), log_signal(cell->getPort(ID(A))));
+					log_signal(cell->getPort(ID::Y)), log_signal(cell->getPort(ID::A)));
 		module->remove(cell);
 	}
 	if (!delcells.empty())

--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -52,7 +52,7 @@ struct keep_cache_t
 			return cache.at(module);
 
 		cache[module] = true;
-		if (!module->get_bool_attribute(ID(keep))) {
+		if (!module->get_bool_attribute(ID::keep)) {
 			bool found_keep = false;
 			for (auto cell : module->cells())
 				if (query(cell)) found_keep = true;
@@ -122,7 +122,7 @@ void rmunused_module_cells(Module *module, bool verbose)
 
 	for (auto &it : module->wires_) {
 		Wire *wire = it.second;
-		if (wire->port_output || wire->get_bool_attribute(ID(keep))) {
+		if (wire->port_output || wire->get_bool_attribute(ID::keep)) {
 			for (auto bit : sigmap(wire))
 			for (auto c : wire2driver[bit])
 				queue.insert(c), unused.erase(c);
@@ -297,7 +297,7 @@ bool rmunused_module_signals(RTLIL::Module *module, bool purge_mode, bool verbos
 			if (!wire->port_input)
 				used_signals_nodrivers.add(sig);
 		}
-		if (wire->get_bool_attribute(ID(keep))) {
+		if (wire->get_bool_attribute(ID::keep)) {
 			RTLIL::SigSpec sig = RTLIL::SigSpec(wire);
 			assign_map.apply(sig);
 			used_signals.add(sig);
@@ -323,7 +323,7 @@ bool rmunused_module_signals(RTLIL::Module *module, bool purge_mode, bool verbos
 			if (wire->port_id == 0)
 				goto delete_this_wire;
 		} else
-		if (wire->port_id != 0 || wire->get_bool_attribute(ID(keep)) || !initval.is_fully_undef()) {
+		if (wire->port_id != 0 || wire->get_bool_attribute(ID::keep) || !initval.is_fully_undef()) {
 			// do not delete anything with "keep" or module ports or initialized wires
 		} else
 		if (!purge_mode && check_public_name(wire->name) && (raw_used_signals.check_any(s1) || used_signals.check_any(s2) || s1 != s2)) {

--- a/passes/opt/opt_demorgan.cc
+++ b/passes/opt/opt_demorgan.cc
@@ -38,7 +38,7 @@ void demorgan_worker(
 	if( (cell->type != ID($reduce_and)) && (cell->type != ID($reduce_or)) )
 		return;
 
-	auto insig = sigmap(cell->getPort(ID(A)));
+	auto insig = sigmap(cell->getPort(ID::A));
 	log("Inspecting %s cell %s (%d inputs)\n", log_id(cell->type), log_id(cell->name), GetSize(insig));
 	int num_inverted = 0;
 	for(int i=0; i<GetSize(insig); i++)
@@ -51,7 +51,7 @@ void demorgan_worker(
 		bool inverted = false;
 		for(auto x : ports)
 		{
-			if(x.port == ID(Y) && x.cell->type == ID($_NOT_))
+			if(x.port == ID::Y && x.cell->type == ID($_NOT_))
 			{
 				inverted = true;
 				break;
@@ -85,7 +85,7 @@ void demorgan_worker(
 		RTLIL::Cell* srcinv = NULL;
 		for(auto x : ports)
 		{
-			if(x.port == ID(Y) && x.cell->type == ID($_NOT_))
+			if(x.port == ID::Y && x.cell->type == ID($_NOT_))
 			{
 				srcinv = x.cell;
 				break;
@@ -103,7 +103,7 @@ void demorgan_worker(
 		//We ARE inverted - bypass it
 		//Don't automatically delete the inverter since other stuff might still use it
 		else
-			insig[i] = srcinv->getPort(ID(A));
+			insig[i] = srcinv->getPort(ID::A);
 	}
 
 	//Cosmetic fixup: If our input is just a scrambled version of one bus, rearrange it
@@ -151,7 +151,7 @@ void demorgan_worker(
 	}
 
 	//Push the new input signal back to the reduction (after bypassing/adding inverters)
-	cell->setPort(ID(A), insig);
+	cell->setPort(ID::A, insig);
 
 	//Change the cell type
 	if(cell->type == ID($reduce_and))
@@ -161,10 +161,10 @@ void demorgan_worker(
 	//don't change XOR
 
 	//Add an inverter to the output
-	auto inverted_output = cell->getPort(ID(Y));
+	auto inverted_output = cell->getPort(ID::Y);
 	auto uninverted_output = m->addWire(NEW_ID);
 	m->addNot(NEW_ID, RTLIL::SigSpec(uninverted_output), inverted_output);
-	cell->setPort(ID(Y), uninverted_output);
+	cell->setPort(ID::Y, uninverted_output);
 }
 
 struct OptDemorganPass : public Pass {

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -134,14 +134,14 @@ void replace_cell(SigMap &assign_map, RTLIL::Module *module, RTLIL::Cell *cell, 
 
 bool group_cell_inputs(RTLIL::Module *module, RTLIL::Cell *cell, bool commutative, SigMap &sigmap)
 {
-	IdString b_name = cell->hasPort(ID(B)) ? ID(B) : ID(A);
+	IdString b_name = cell->hasPort(ID::B) ? ID::B : ID::A;
 
 	bool a_signed = cell->parameters.at(ID(A_SIGNED)).as_bool();
 	bool b_signed = cell->parameters.at(b_name.str() + "_SIGNED").as_bool();
 
-	RTLIL::SigSpec sig_a = sigmap(cell->getPort(ID(A)));
+	RTLIL::SigSpec sig_a = sigmap(cell->getPort(ID::A));
 	RTLIL::SigSpec sig_b = sigmap(cell->getPort(b_name));
-	RTLIL::SigSpec sig_y = sigmap(cell->getPort(ID(Y)));
+	RTLIL::SigSpec sig_y = sigmap(cell->getPort(ID::Y));
 
 	sig_a.extend_u0(sig_y.size(), a_signed);
 	sig_b.extend_u0(sig_y.size(), b_signed);
@@ -208,24 +208,24 @@ bool group_cell_inputs(RTLIL::Module *module, RTLIL::Cell *cell, bool commutativ
 
 		RTLIL::Cell *c = module->addCell(NEW_ID, cell->type);
 
-		c->setPort(ID(A), new_a);
+		c->setPort(ID::A, new_a);
 		c->parameters[ID(A_WIDTH)] = new_a.size();
 		c->parameters[ID(A_SIGNED)] = false;
 
-		if (b_name == ID(B)) {
-			c->setPort(ID(B), new_b);
+		if (b_name == ID::B) {
+			c->setPort(ID::B, new_b);
 			c->parameters[ID(B_WIDTH)] = new_b.size();
 			c->parameters[ID(B_SIGNED)] = false;
 		}
 
-		c->setPort(ID(Y), new_y);
+		c->setPort(ID::Y, new_y);
 		c->parameters[ID(Y_WIDTH)] = new_y->width;
 		c->check();
 
 		module->connect(new_conn);
 
 		log_debug("  New cell `%s': A=%s", log_id(c), log_signal(new_a));
-		if (b_name == ID(B))
+		if (b_name == ID::B)
 			log_debug(", B=%s", log_signal(new_b));
 		log_debug("\n");
 	}
@@ -368,11 +368,11 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 	for (auto cell : module->cells())
 		if (design->selected(module, cell) && cell->type[0] == '$') {
 			if (cell->type.in(ID($_NOT_), ID($not), ID($logic_not)) &&
-					cell->getPort(ID(A)).size() == 1 && cell->getPort(ID(Y)).size() == 1)
-				invert_map[assign_map(cell->getPort(ID(Y)))] = assign_map(cell->getPort(ID(A)));
+					cell->getPort(ID::A).size() == 1 && cell->getPort(ID::Y).size() == 1)
+				invert_map[assign_map(cell->getPort(ID::Y))] = assign_map(cell->getPort(ID::A));
 			if (cell->type.in(ID($mux), ID($_MUX_)) &&
-					cell->getPort(ID(A)) == SigSpec(State::S1) && cell->getPort(ID(B)) == SigSpec(State::S0))
-				invert_map[assign_map(cell->getPort(ID(Y)))] = assign_map(cell->getPort(ID(S)));
+					cell->getPort(ID::A) == SigSpec(State::S1) && cell->getPort(ID::B) == SigSpec(State::S0))
+				invert_map[assign_map(cell->getPort(ID::Y))] = assign_map(cell->getPort(ID(S)));
 			if (ct_combinational.cell_known(cell->type))
 				for (auto &conn : cell->connections()) {
 					RTLIL::SigSpec sig = assign_map(conn.second);
@@ -396,7 +396,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 	for (auto cell : cells.sorted)
 	{
 #define ACTION_DO(_p_, _s_) do { cover("opt.opt_expr.action_" S__LINE__); replace_cell(assign_map, module, cell, input.as_string(), _p_, _s_); goto next_cell; } while (0)
-#define ACTION_DO_Y(_v_) ACTION_DO(ID(Y), RTLIL::SigSpec(RTLIL::State::S ## _v_))
+#define ACTION_DO_Y(_v_) ACTION_DO(ID::Y, RTLIL::SigSpec(RTLIL::State::S ## _v_))
 
 		if (clkinv)
 		{
@@ -439,23 +439,23 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 		if (cell->type.in(ID($reduce_and), ID($_AND_)))
 			detect_const_and = true;
 
-		if (cell->type.in(ID($and), ID($logic_and)) && GetSize(cell->getPort(ID(A))) == 1 && GetSize(cell->getPort(ID(B))) == 1 && !cell->getParam(ID(A_SIGNED)).as_bool())
+		if (cell->type.in(ID($and), ID($logic_and)) && GetSize(cell->getPort(ID::A)) == 1 && GetSize(cell->getPort(ID::B)) == 1 && !cell->getParam(ID(A_SIGNED)).as_bool())
 			detect_const_and = true;
 
 		if (cell->type.in(ID($reduce_or), ID($reduce_bool), ID($_OR_)))
 			detect_const_or = true;
 
-		if (cell->type.in(ID($or), ID($logic_or)) && GetSize(cell->getPort(ID(A))) == 1 && GetSize(cell->getPort(ID(B))) == 1 && !cell->getParam(ID(A_SIGNED)).as_bool())
+		if (cell->type.in(ID($or), ID($logic_or)) && GetSize(cell->getPort(ID::A)) == 1 && GetSize(cell->getPort(ID::B)) == 1 && !cell->getParam(ID(A_SIGNED)).as_bool())
 			detect_const_or = true;
 
 		if (detect_const_and || detect_const_or)
 		{
-			pool<SigBit> input_bits = assign_map(cell->getPort(ID(A))).to_sigbit_pool();
+			pool<SigBit> input_bits = assign_map(cell->getPort(ID::A)).to_sigbit_pool();
 			bool found_zero = false, found_one = false, found_undef = false, found_inv = false, many_conconst = false;
 			SigBit non_const_input = State::Sm;
 
-			if (cell->hasPort(ID(B))) {
-				vector<SigBit> more_bits = assign_map(cell->getPort(ID(B))).to_sigbit_vector();
+			if (cell->hasPort(ID::B)) {
+				vector<SigBit> more_bits = assign_map(cell->getPort(ID::B)).to_sigbit_vector();
 				input_bits.insert(more_bits.begin(), more_bits.end());
 			}
 
@@ -478,25 +478,25 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 			if (detect_const_and && (found_zero || found_inv)) {
 				cover("opt.opt_expr.const_and");
-				replace_cell(assign_map, module, cell, "const_and", ID(Y), RTLIL::State::S0);
+				replace_cell(assign_map, module, cell, "const_and", ID::Y, RTLIL::State::S0);
 				goto next_cell;
 			}
 
 			if (detect_const_or && (found_one || found_inv)) {
 				cover("opt.opt_expr.const_or");
-				replace_cell(assign_map, module, cell, "const_or", ID(Y), RTLIL::State::S1);
+				replace_cell(assign_map, module, cell, "const_or", ID::Y, RTLIL::State::S1);
 				goto next_cell;
 			}
 
 			if (non_const_input != State::Sm && !found_undef) {
 				cover("opt.opt_expr.and_or_buffer");
-				replace_cell(assign_map, module, cell, "and_or_buffer", ID(Y), non_const_input);
+				replace_cell(assign_map, module, cell, "and_or_buffer", ID::Y, non_const_input);
 				goto next_cell;
 			}
 		}
 
 		if (cell->type.in(ID($reduce_and), ID($reduce_or), ID($reduce_bool), ID($reduce_xor), ID($reduce_xnor), ID($neg)) &&
-				GetSize(cell->getPort(ID(A))) == 1 && GetSize(cell->getPort(ID(Y))) == 1)
+				GetSize(cell->getPort(ID::A)) == 1 && GetSize(cell->getPort(ID::Y)) == 1)
 		{
 			if (cell->type == ID($reduce_xnor)) {
 				cover("opt.opt_expr.reduce_xnor_not");
@@ -506,7 +506,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 				did_something = true;
 			} else {
 				cover("opt.opt_expr.unary_buffer");
-				replace_cell(assign_map, module, cell, "unary_buffer", ID(Y), cell->getPort(ID(A)));
+				replace_cell(assign_map, module, cell, "unary_buffer", ID::Y, cell->getPort(ID::A));
 			}
 			goto next_cell;
 		}
@@ -521,7 +521,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 			{
 				SigBit neutral_bit = cell->type == ID($reduce_and) ? State::S1 : State::S0;
 
-				RTLIL::SigSpec sig_a = assign_map(cell->getPort(ID(A)));
+				RTLIL::SigSpec sig_a = assign_map(cell->getPort(ID::A));
 				RTLIL::SigSpec new_sig_a;
 
 				for (auto bit : sig_a)
@@ -534,7 +534,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 					cover_list("opt.opt_expr.fine.neutral_A", "$logic_not", "$logic_and", "$logic_or", "$reduce_or", "$reduce_and", "$reduce_bool", cell->type.str());
 					log_debug("Replacing port A of %s cell `%s' in module `%s' with shorter expression: %s -> %s\n",
 							cell->type.c_str(), cell->name.c_str(), module->name.c_str(), log_signal(sig_a), log_signal(new_sig_a));
-					cell->setPort(ID(A), new_sig_a);
+					cell->setPort(ID::A, new_sig_a);
 					cell->parameters.at(ID(A_WIDTH)) = GetSize(new_sig_a);
 					did_something = true;
 				}
@@ -544,7 +544,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 			{
 				SigBit neutral_bit = State::S0;
 
-				RTLIL::SigSpec sig_b = assign_map(cell->getPort(ID(B)));
+				RTLIL::SigSpec sig_b = assign_map(cell->getPort(ID::B));
 				RTLIL::SigSpec new_sig_b;
 
 				for (auto bit : sig_b)
@@ -557,7 +557,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 					cover_list("opt.opt_expr.fine.neutral_B", "$logic_and", "$logic_or", cell->type.str());
 					log_debug("Replacing port B of %s cell `%s' in module `%s' with shorter expression: %s -> %s\n",
 							cell->type.c_str(), cell->name.c_str(), module->name.c_str(), log_signal(sig_b), log_signal(new_sig_b));
-					cell->setPort(ID(B), new_sig_b);
+					cell->setPort(ID::B, new_sig_b);
 					cell->parameters.at(ID(B_WIDTH)) = GetSize(new_sig_b);
 					did_something = true;
 				}
@@ -565,7 +565,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 			if (cell->type == ID($reduce_and))
 			{
-				RTLIL::SigSpec sig_a = assign_map(cell->getPort(ID(A)));
+				RTLIL::SigSpec sig_a = assign_map(cell->getPort(ID::A));
 
 				RTLIL::State new_a = RTLIL::State::S1;
 				for (auto &bit : sig_a.to_sigbit_vector())
@@ -583,7 +583,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 					cover("opt.opt_expr.fine.$reduce_and");
 					log_debug("Replacing port A of %s cell `%s' in module `%s' with constant driver: %s -> %s\n",
 							cell->type.c_str(), cell->name.c_str(), module->name.c_str(), log_signal(sig_a), log_signal(new_a));
-					cell->setPort(ID(A), sig_a = new_a);
+					cell->setPort(ID::A, sig_a = new_a);
 					cell->parameters.at(ID(A_WIDTH)) = 1;
 					did_something = true;
 				}
@@ -591,7 +591,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 			if (cell->type.in(ID($logic_not), ID($logic_and), ID($logic_or), ID($reduce_or), ID($reduce_bool)))
 			{
-				RTLIL::SigSpec sig_a = assign_map(cell->getPort(ID(A)));
+				RTLIL::SigSpec sig_a = assign_map(cell->getPort(ID::A));
 
 				RTLIL::State new_a = RTLIL::State::S0;
 				for (auto &bit : sig_a.to_sigbit_vector())
@@ -609,7 +609,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 					cover_list("opt.opt_expr.fine.A", "$logic_not", "$logic_and", "$logic_or", "$reduce_or", "$reduce_bool", cell->type.str());
 					log_debug("Replacing port A of %s cell `%s' in module `%s' with constant driver: %s -> %s\n",
 							cell->type.c_str(), cell->name.c_str(), module->name.c_str(), log_signal(sig_a), log_signal(new_a));
-					cell->setPort(ID(A), sig_a = new_a);
+					cell->setPort(ID::A, sig_a = new_a);
 					cell->parameters.at(ID(A_WIDTH)) = 1;
 					did_something = true;
 				}
@@ -617,7 +617,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 			if (cell->type.in(ID($logic_and), ID($logic_or)))
 			{
-				RTLIL::SigSpec sig_b = assign_map(cell->getPort(ID(B)));
+				RTLIL::SigSpec sig_b = assign_map(cell->getPort(ID::B));
 
 				RTLIL::State new_b = RTLIL::State::S0;
 				for (auto &bit : sig_b.to_sigbit_vector())
@@ -635,7 +635,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 					cover_list("opt.opt_expr.fine.B", "$logic_and", "$logic_or", cell->type.str());
 					log_debug("Replacing port B of %s cell `%s' in module `%s' with constant driver: %s -> %s\n",
 							cell->type.c_str(), cell->name.c_str(), module->name.c_str(), log_signal(sig_b), log_signal(new_b));
-					cell->setPort(ID(B), sig_b = new_b);
+					cell->setPort(ID::B, sig_b = new_b);
 					cell->parameters.at(ID(B_WIDTH)) = 1;
 					did_something = true;
 				}
@@ -643,9 +643,9 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 			if (cell->type.in(ID($add), ID($sub)))
 			{
-				RTLIL::SigSpec sig_a = assign_map(cell->getPort(ID(A)));
-				RTLIL::SigSpec sig_b = assign_map(cell->getPort(ID(B)));
-				RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+				RTLIL::SigSpec sig_a = assign_map(cell->getPort(ID::A));
+				RTLIL::SigSpec sig_b = assign_map(cell->getPort(ID::B));
+				RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 				bool sub = cell->type == ID($sub);
 
 				int i;
@@ -659,9 +659,9 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 				}
 				if (i > 0) {
 					cover_list("opt.opt_expr.fine", "$add", "$sub", cell->type.str());
-					cell->setPort(ID(A), sig_a.extract_end(i));
-					cell->setPort(ID(B), sig_b.extract_end(i));
-					cell->setPort(ID(Y), sig_y.extract_end(i));
+					cell->setPort(ID::A, sig_a.extract_end(i));
+					cell->setPort(ID::B, sig_b.extract_end(i));
+					cell->setPort(ID::Y, sig_y.extract_end(i));
 					cell->fixup_parameters();
 					did_something = true;
 				}
@@ -669,12 +669,12 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 			if (cell->type == "$alu")
 			{
-				RTLIL::SigSpec sig_a = assign_map(cell->getPort(ID(A)));
-				RTLIL::SigSpec sig_b = assign_map(cell->getPort(ID(B)));
+				RTLIL::SigSpec sig_a = assign_map(cell->getPort(ID::A));
+				RTLIL::SigSpec sig_b = assign_map(cell->getPort(ID::B));
 				RTLIL::SigBit sig_ci = assign_map(cell->getPort(ID(CI)));
 				RTLIL::SigBit sig_bi = assign_map(cell->getPort(ID(BI)));
 				RTLIL::SigSpec sig_x = cell->getPort(ID(X));
-				RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+				RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 				RTLIL::SigSpec sig_co = cell->getPort(ID(CO));
 
 				if (sig_ci.wire || sig_bi.wire)
@@ -704,10 +704,10 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 				}
 				if (i > 0) {
 					cover("opt.opt_expr.fine.$alu");
-					cell->setPort(ID(A), sig_a.extract_end(i));
-					cell->setPort(ID(B), sig_b.extract_end(i));
+					cell->setPort(ID::A, sig_a.extract_end(i));
+					cell->setPort(ID::B, sig_b.extract_end(i));
 					cell->setPort(ID(X), sig_x.extract_end(i));
-					cell->setPort(ID(Y), sig_y.extract_end(i));
+					cell->setPort(ID::Y, sig_y.extract_end(i));
 					cell->setPort(ID(CO), sig_co.extract_end(i));
 					cell->fixup_parameters();
 					did_something = true;
@@ -718,8 +718,8 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 		if (cell->type.in(ID($reduce_xor), ID($reduce_xnor), ID($shift), ID($shiftx), ID($shl), ID($shr), ID($sshl), ID($sshr),
 					ID($lt), ID($le), ID($ge), ID($gt), ID($neg), ID($add), ID($sub), ID($mul), ID($div), ID($mod), ID($pow)))
 		{
-			RTLIL::SigSpec sig_a = assign_map(cell->getPort(ID(A)));
-			RTLIL::SigSpec sig_b = cell->hasPort(ID(B)) ? assign_map(cell->getPort(ID(B))) : RTLIL::SigSpec();
+			RTLIL::SigSpec sig_a = assign_map(cell->getPort(ID::A));
+			RTLIL::SigSpec sig_b = cell->hasPort(ID::B) ? assign_map(cell->getPort(ID::B)) : RTLIL::SigSpec();
 
 			if (cell->type.in(ID($shl), ID($shr), ID($sshl), ID($sshr), ID($shift), ID($shiftx)))
 				sig_a = RTLIL::SigSpec();
@@ -737,33 +737,33 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 				cover_list("opt.opt_expr.xbit", "$reduce_xor", "$reduce_xnor", "$shl", "$shr", "$sshl", "$sshr", "$shift", "$shiftx",
 						"$lt", "$le", "$ge", "$gt", "$neg", "$add", "$sub", "$mul", "$div", "$mod", "$pow", cell->type.str());
 				if (cell->type.in(ID($reduce_xor), ID($reduce_xnor), ID($lt), ID($le), ID($ge), ID($gt)))
-					replace_cell(assign_map, module, cell, "x-bit in input", ID(Y), RTLIL::State::Sx);
+					replace_cell(assign_map, module, cell, "x-bit in input", ID::Y, RTLIL::State::Sx);
 				else
-					replace_cell(assign_map, module, cell, "x-bit in input", ID(Y), RTLIL::SigSpec(RTLIL::State::Sx, cell->getPort(ID(Y)).size()));
+					replace_cell(assign_map, module, cell, "x-bit in input", ID::Y, RTLIL::SigSpec(RTLIL::State::Sx, cell->getPort(ID::Y).size()));
 				goto next_cell;
 			}
 		}
 
-		if (cell->type.in(ID($_NOT_), ID($not), ID($logic_not)) && cell->getPort(ID(Y)).size() == 1 &&
-				invert_map.count(assign_map(cell->getPort(ID(A)))) != 0) {
+		if (cell->type.in(ID($_NOT_), ID($not), ID($logic_not)) && cell->getPort(ID::Y).size() == 1 &&
+				invert_map.count(assign_map(cell->getPort(ID::A))) != 0) {
 			cover_list("opt.opt_expr.invert.double", "$_NOT_", "$not", "$logic_not", cell->type.str());
-			replace_cell(assign_map, module, cell, "double_invert", ID(Y), invert_map.at(assign_map(cell->getPort(ID(A)))));
+			replace_cell(assign_map, module, cell, "double_invert", ID::Y, invert_map.at(assign_map(cell->getPort(ID::A))));
 			goto next_cell;
 		}
 
 		if (cell->type.in(ID($_MUX_), ID($mux)) && invert_map.count(assign_map(cell->getPort(ID(S)))) != 0) {
 			cover_list("opt.opt_expr.invert.muxsel", "$_MUX_", "$mux", cell->type.str());
 			log_debug("Optimizing away select inverter for %s cell `%s' in module `%s'.\n", log_id(cell->type), log_id(cell), log_id(module));
-			RTLIL::SigSpec tmp = cell->getPort(ID(A));
-			cell->setPort(ID(A), cell->getPort(ID(B)));
-			cell->setPort(ID(B), tmp);
+			RTLIL::SigSpec tmp = cell->getPort(ID::A);
+			cell->setPort(ID::A, cell->getPort(ID::B));
+			cell->setPort(ID::B, tmp);
 			cell->setPort(ID(S), invert_map.at(assign_map(cell->getPort(ID(S)))));
 			did_something = true;
 			goto next_cell;
 		}
 
 		if (cell->type == ID($_NOT_)) {
-			RTLIL::SigSpec input = cell->getPort(ID(A));
+			RTLIL::SigSpec input = cell->getPort(ID::A);
 			assign_map.apply(input);
 			if (input.match("1")) ACTION_DO_Y(0);
 			if (input.match("0")) ACTION_DO_Y(1);
@@ -772,8 +772,8 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 		if (cell->type == ID($_AND_)) {
 			RTLIL::SigSpec input;
-			input.append(cell->getPort(ID(B)));
-			input.append(cell->getPort(ID(A)));
+			input.append(cell->getPort(ID::B));
+			input.append(cell->getPort(ID::A));
 			assign_map.apply(input);
 			if (input.match(" 0")) ACTION_DO_Y(0);
 			if (input.match("0 ")) ACTION_DO_Y(0);
@@ -785,14 +785,14 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 				if (input.match(" *")) ACTION_DO_Y(0);
 				if (input.match("* ")) ACTION_DO_Y(0);
 			}
-			if (input.match(" 1")) ACTION_DO(ID(Y), input.extract(1, 1));
-			if (input.match("1 ")) ACTION_DO(ID(Y), input.extract(0, 1));
+			if (input.match(" 1")) ACTION_DO(ID::Y, input.extract(1, 1));
+			if (input.match("1 ")) ACTION_DO(ID::Y, input.extract(0, 1));
 		}
 
 		if (cell->type == ID($_OR_)) {
 			RTLIL::SigSpec input;
-			input.append(cell->getPort(ID(B)));
-			input.append(cell->getPort(ID(A)));
+			input.append(cell->getPort(ID::B));
+			input.append(cell->getPort(ID::A));
 			assign_map.apply(input);
 			if (input.match(" 1")) ACTION_DO_Y(1);
 			if (input.match("1 ")) ACTION_DO_Y(1);
@@ -804,14 +804,14 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 				if (input.match(" *")) ACTION_DO_Y(1);
 				if (input.match("* ")) ACTION_DO_Y(1);
 			}
-			if (input.match(" 0")) ACTION_DO(ID(Y), input.extract(1, 1));
-			if (input.match("0 ")) ACTION_DO(ID(Y), input.extract(0, 1));
+			if (input.match(" 0")) ACTION_DO(ID::Y, input.extract(1, 1));
+			if (input.match("0 ")) ACTION_DO(ID::Y, input.extract(0, 1));
 		}
 
 		if (cell->type == ID($_XOR_)) {
 			RTLIL::SigSpec input;
-			input.append(cell->getPort(ID(B)));
-			input.append(cell->getPort(ID(A)));
+			input.append(cell->getPort(ID::B));
+			input.append(cell->getPort(ID::A));
 			assign_map.apply(input);
 			if (input.match("00")) ACTION_DO_Y(0);
 			if (input.match("01")) ACTION_DO_Y(1);
@@ -819,26 +819,26 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 			if (input.match("11")) ACTION_DO_Y(0);
 			if (input.match(" *")) ACTION_DO_Y(x);
 			if (input.match("* ")) ACTION_DO_Y(x);
-			if (input.match(" 0")) ACTION_DO(ID(Y), input.extract(1, 1));
-			if (input.match("0 ")) ACTION_DO(ID(Y), input.extract(0, 1));
+			if (input.match(" 0")) ACTION_DO(ID::Y, input.extract(1, 1));
+			if (input.match("0 ")) ACTION_DO(ID::Y, input.extract(0, 1));
 		}
 
 		if (cell->type == ID($_MUX_)) {
 			RTLIL::SigSpec input;
 			input.append(cell->getPort(ID(S)));
-			input.append(cell->getPort(ID(B)));
-			input.append(cell->getPort(ID(A)));
+			input.append(cell->getPort(ID::B));
+			input.append(cell->getPort(ID::A));
 			assign_map.apply(input);
 			if (input.extract(2, 1) == input.extract(1, 1))
-				ACTION_DO(ID(Y), input.extract(2, 1));
-			if (input.match("  0")) ACTION_DO(ID(Y), input.extract(2, 1));
-			if (input.match("  1")) ACTION_DO(ID(Y), input.extract(1, 1));
-			if (input.match("01 ")) ACTION_DO(ID(Y), input.extract(0, 1));
+				ACTION_DO(ID::Y, input.extract(2, 1));
+			if (input.match("  0")) ACTION_DO(ID::Y, input.extract(2, 1));
+			if (input.match("  1")) ACTION_DO(ID::Y, input.extract(1, 1));
+			if (input.match("01 ")) ACTION_DO(ID::Y, input.extract(0, 1));
 			if (input.match("10 ")) {
 				cover("opt.opt_expr.mux_to_inv");
 				cell->type = ID($_NOT_);
-				cell->setPort(ID(A), input.extract(0, 1));
-				cell->unsetPort(ID(B));
+				cell->setPort(ID::A, input.extract(0, 1));
+				cell->unsetPort(ID::B);
 				cell->unsetPort(ID(S));
 				goto next_cell;
 			}
@@ -848,24 +848,24 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 			if (input.match("01*")) ACTION_DO_Y(x);
 			if (input.match("10*")) ACTION_DO_Y(x);
 			if (mux_undef) {
-				if (input.match("*  ")) ACTION_DO(ID(Y), input.extract(1, 1));
-				if (input.match(" * ")) ACTION_DO(ID(Y), input.extract(2, 1));
-				if (input.match("  *")) ACTION_DO(ID(Y), input.extract(2, 1));
+				if (input.match("*  ")) ACTION_DO(ID::Y, input.extract(1, 1));
+				if (input.match(" * ")) ACTION_DO(ID::Y, input.extract(2, 1));
+				if (input.match("  *")) ACTION_DO(ID::Y, input.extract(2, 1));
 			}
 		}
 
 		if (cell->type.in(ID($_TBUF_), ID($tribuf))) {
 			RTLIL::SigSpec input = cell->getPort(cell->type == ID($_TBUF_) ? ID(E) : ID(EN));
-			RTLIL::SigSpec a = cell->getPort(ID(A));
+			RTLIL::SigSpec a = cell->getPort(ID::A);
 			assign_map.apply(input);
 			assign_map.apply(a);
 			if (input == State::S1)
-				ACTION_DO(ID(Y), cell->getPort(ID(A)));
+				ACTION_DO(ID::Y, cell->getPort(ID::A));
 			if (input == State::S0 && !a.is_fully_undef()) {
 				cover("opt.opt_expr.action_" S__LINE__);
 				log_debug("Replacing data input of %s cell `%s' in module `%s' with constant undef.\n",
 					cell->type.c_str(), cell->name.c_str(), module->name.c_str());
-				cell->setPort(ID(A), SigSpec(State::Sx, GetSize(a)));
+				cell->setPort(ID::A, SigSpec(State::Sx, GetSize(a)));
 				did_something = true;
 				goto next_cell;
 			}
@@ -873,8 +873,8 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 		if (cell->type.in(ID($eq), ID($ne), ID($eqx), ID($nex)))
 		{
-			RTLIL::SigSpec a = cell->getPort(ID(A));
-			RTLIL::SigSpec b = cell->getPort(ID(B));
+			RTLIL::SigSpec a = cell->getPort(ID::A);
+			RTLIL::SigSpec b = cell->getPort(ID::B);
 
 			if (cell->parameters[ID(A_WIDTH)].as_int() != cell->parameters[ID(B_WIDTH)].as_int()) {
 				int width = max(cell->parameters[ID(A_WIDTH)].as_int(), cell->parameters[ID(B_WIDTH)].as_int());
@@ -890,7 +890,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 					cover_list("opt.opt_expr.eqneq.isneq", "$eq", "$ne", "$eqx", "$nex", cell->type.str());
 					RTLIL::SigSpec new_y = RTLIL::SigSpec(cell->type.in(ID($eq), ID($eqx)) ?  RTLIL::State::S0 : RTLIL::State::S1);
 					new_y.extend_u0(cell->parameters[ID(Y_WIDTH)].as_int(), false);
-					replace_cell(assign_map, module, cell, "isneq", ID(Y), new_y);
+					replace_cell(assign_map, module, cell, "isneq", ID::Y, new_y);
 					goto next_cell;
 				}
 				if (a[i] == b[i])
@@ -903,14 +903,14 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 				cover_list("opt.opt_expr.eqneq.empty", "$eq", "$ne", "$eqx", "$nex", cell->type.str());
 				RTLIL::SigSpec new_y = RTLIL::SigSpec(cell->type.in(ID($eq), ID($eqx)) ?  RTLIL::State::S1 : RTLIL::State::S0);
 				new_y.extend_u0(cell->parameters[ID(Y_WIDTH)].as_int(), false);
-				replace_cell(assign_map, module, cell, "empty", ID(Y), new_y);
+				replace_cell(assign_map, module, cell, "empty", ID::Y, new_y);
 				goto next_cell;
 			}
 
 			if (new_a.size() < a.size() || new_b.size() < b.size()) {
 				cover_list("opt.opt_expr.eqneq.resize", "$eq", "$ne", "$eqx", "$nex", cell->type.str());
-				cell->setPort(ID(A), new_a);
-				cell->setPort(ID(B), new_b);
+				cell->setPort(ID::A, new_a);
+				cell->setPort(ID::B, new_b);
 				cell->parameters[ID(A_WIDTH)] = new_a.size();
 				cell->parameters[ID(B_WIDTH)] = new_b.size();
 			}
@@ -919,27 +919,27 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 		if (cell->type.in(ID($eq), ID($ne)) && cell->parameters[ID(Y_WIDTH)].as_int() == 1 &&
 				cell->parameters[ID(A_WIDTH)].as_int() == 1 && cell->parameters[ID(B_WIDTH)].as_int() == 1)
 		{
-			RTLIL::SigSpec a = assign_map(cell->getPort(ID(A)));
-			RTLIL::SigSpec b = assign_map(cell->getPort(ID(B)));
+			RTLIL::SigSpec a = assign_map(cell->getPort(ID::A));
+			RTLIL::SigSpec b = assign_map(cell->getPort(ID::B));
 
 			if (a.is_fully_const() && !b.is_fully_const()) {
 				cover_list("opt.opt_expr.eqneq.swapconst", "$eq", "$ne", cell->type.str());
-				cell->setPort(ID(A), b);
-				cell->setPort(ID(B), a);
+				cell->setPort(ID::A, b);
+				cell->setPort(ID::B, a);
 				std::swap(a, b);
 			}
 
 			if (b.is_fully_const()) {
 				if (b.as_bool() == (cell->type == ID($eq))) {
 					RTLIL::SigSpec input = b;
-					ACTION_DO(ID(Y), cell->getPort(ID(A)));
+					ACTION_DO(ID::Y, cell->getPort(ID::A));
 				} else {
 					cover_list("opt.opt_expr.eqneq.isnot", "$eq", "$ne", cell->type.str());
 					log_debug("Replacing %s cell `%s' in module `%s' with inverter.\n", log_id(cell->type), log_id(cell), log_id(module));
 					cell->type = ID($not);
 					cell->parameters.erase(ID(B_WIDTH));
 					cell->parameters.erase(ID(B_SIGNED));
-					cell->unsetPort(ID(B));
+					cell->unsetPort(ID::B);
 					did_something = true;
 				}
 				goto next_cell;
@@ -947,33 +947,33 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 		}
 
 		if (cell->type.in(ID($eq), ID($ne)) &&
-				(assign_map(cell->getPort(ID(A))).is_fully_zero() || assign_map(cell->getPort(ID(B))).is_fully_zero()))
+				(assign_map(cell->getPort(ID::A)).is_fully_zero() || assign_map(cell->getPort(ID::B)).is_fully_zero()))
 		{
 			cover_list("opt.opt_expr.eqneq.cmpzero", "$eq", "$ne", cell->type.str());
 			log_debug("Replacing %s cell `%s' in module `%s' with %s.\n", log_id(cell->type), log_id(cell),
 					log_id(module), "$eq" ? "$logic_not" : "$reduce_bool");
 			cell->type = cell->type == ID($eq) ? ID($logic_not) : ID($reduce_bool);
-			if (assign_map(cell->getPort(ID(A))).is_fully_zero()) {
-				cell->setPort(ID(A), cell->getPort(ID(B)));
+			if (assign_map(cell->getPort(ID::A)).is_fully_zero()) {
+				cell->setPort(ID::A, cell->getPort(ID::B));
 				cell->setParam(ID(A_SIGNED), cell->getParam(ID(B_SIGNED)));
 				cell->setParam(ID(A_WIDTH), cell->getParam(ID(B_WIDTH)));
 			}
-			cell->unsetPort(ID(B));
+			cell->unsetPort(ID::B);
 			cell->unsetParam(ID(B_SIGNED));
 			cell->unsetParam(ID(B_WIDTH));
 			did_something = true;
 			goto next_cell;
 		}
 
-		if (cell->type.in(ID($shl), ID($shr), ID($sshl), ID($sshr), ID($shift), ID($shiftx)) && assign_map(cell->getPort(ID(B))).is_fully_const())
+		if (cell->type.in(ID($shl), ID($shr), ID($sshl), ID($sshr), ID($shift), ID($shiftx)) && assign_map(cell->getPort(ID::B)).is_fully_const())
 		{
 			bool sign_ext = cell->type == ID($sshr) && cell->getParam(ID(A_SIGNED)).as_bool();
-			int shift_bits = assign_map(cell->getPort(ID(B))).as_int(cell->type.in(ID($shift), ID($shiftx)) && cell->getParam(ID(B_SIGNED)).as_bool());
+			int shift_bits = assign_map(cell->getPort(ID::B)).as_int(cell->type.in(ID($shift), ID($shiftx)) && cell->getParam(ID(B_SIGNED)).as_bool());
 
 			if (cell->type.in(ID($shl), ID($sshl)))
 				shift_bits *= -1;
 
-			RTLIL::SigSpec sig_a = assign_map(cell->getPort(ID(A)));
+			RTLIL::SigSpec sig_a = assign_map(cell->getPort(ID::A));
 			RTLIL::SigSpec sig_y(cell->type == ID($shiftx) ? RTLIL::State::Sx : RTLIL::State::S0, cell->getParam(ID(Y_WIDTH)).as_int());
 
 			if (GetSize(sig_a) < GetSize(sig_y))
@@ -990,9 +990,9 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 			cover_list("opt.opt_expr.constshift", "$shl", "$shr", "$sshl", "$sshr", "$shift", "$shiftx", cell->type.str());
 
 			log_debug("Replacing %s cell `%s' (B=%s, SHR=%d) in module `%s' with fixed wiring: %s\n",
-					log_id(cell->type), log_id(cell), log_signal(assign_map(cell->getPort(ID(B)))), shift_bits, log_id(module), log_signal(sig_y));
+					log_id(cell->type), log_id(cell), log_signal(assign_map(cell->getPort(ID::B))), shift_bits, log_id(module), log_signal(sig_y));
 
-			module->connect(cell->getPort(ID(Y)), sig_y);
+			module->connect(cell->getPort(ID::Y), sig_y);
 			module->remove(cell);
 
 			did_something = true;
@@ -1007,8 +1007,8 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 			if (cell->type.in(ID($add), ID($sub), ID($or), ID($xor)))
 			{
-				RTLIL::SigSpec a = assign_map(cell->getPort(ID(A)));
-				RTLIL::SigSpec b = assign_map(cell->getPort(ID(B)));
+				RTLIL::SigSpec a = assign_map(cell->getPort(ID::A));
+				RTLIL::SigSpec b = assign_map(cell->getPort(ID::B));
 
 				if (cell->type != ID($sub) && a.is_fully_const() && a.as_bool() == false)
 					identity_wrt_b = true;
@@ -1019,7 +1019,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 			if (cell->type.in(ID($shl), ID($shr), ID($sshl), ID($sshr), ID($shift), ID($shiftx)))
 			{
-				RTLIL::SigSpec b = assign_map(cell->getPort(ID(B)));
+				RTLIL::SigSpec b = assign_map(cell->getPort(ID::B));
 
 				if (b.is_fully_const() && b.as_bool() == false)
 					identity_wrt_a = true;
@@ -1027,8 +1027,8 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 			if (cell->type == ID($mul))
 			{
-				RTLIL::SigSpec a = assign_map(cell->getPort(ID(A)));
-				RTLIL::SigSpec b = assign_map(cell->getPort(ID(B)));
+				RTLIL::SigSpec a = assign_map(cell->getPort(ID::A));
+				RTLIL::SigSpec b = assign_map(cell->getPort(ID::B));
 
 				if (a.is_fully_const() && is_one_or_minus_one(a.as_const(), cell->getParam(ID(A_SIGNED)).as_bool(), arith_inverse))
 					identity_wrt_b = true;
@@ -1039,7 +1039,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 			if (cell->type == ID($div))
 			{
-				RTLIL::SigSpec b = assign_map(cell->getPort(ID(B)));
+				RTLIL::SigSpec b = assign_map(cell->getPort(ID::B));
 
 				if (b.is_fully_const() && b.size() <= 32 && b.as_int() == 1)
 					identity_wrt_a = true;
@@ -1056,13 +1056,13 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 					cell->type.c_str(), cell->name.c_str(), module->name.c_str(), identity_wrt_a ? 'A' : 'B');
 
 				if (!identity_wrt_a) {
-					cell->setPort(ID(A), cell->getPort(ID(B)));
+					cell->setPort(ID::A, cell->getPort(ID::B));
 					cell->parameters.at(ID(A_WIDTH)) = cell->parameters.at(ID(B_WIDTH));
 					cell->parameters.at(ID(A_SIGNED)) = cell->parameters.at(ID(B_SIGNED));
 				}
 
 				cell->type = arith_inverse ? ID($neg) : ID($pos);
-				cell->unsetPort(ID(B));
+				cell->unsetPort(ID::B);
 				cell->parameters.erase(ID(B_WIDTH));
 				cell->parameters.erase(ID(B_SIGNED));
 				cell->check();
@@ -1073,18 +1073,18 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 		}
 
 		if (mux_bool && cell->type.in(ID($mux), ID($_MUX_)) &&
-				cell->getPort(ID(A)) == State::S0 && cell->getPort(ID(B)) == State::S1) {
+				cell->getPort(ID::A) == State::S0 && cell->getPort(ID::B) == State::S1) {
 			cover_list("opt.opt_expr.mux_bool", "$mux", "$_MUX_", cell->type.str());
-			replace_cell(assign_map, module, cell, "mux_bool", ID(Y), cell->getPort(ID(S)));
+			replace_cell(assign_map, module, cell, "mux_bool", ID::Y, cell->getPort(ID(S)));
 			goto next_cell;
 		}
 
 		if (mux_bool && cell->type.in(ID($mux), ID($_MUX_)) &&
-				cell->getPort(ID(A)) == State::S1 && cell->getPort(ID(B)) == State::S0) {
+				cell->getPort(ID::A) == State::S1 && cell->getPort(ID::B) == State::S0) {
 			cover_list("opt.opt_expr.mux_invert", "$mux", "$_MUX_", cell->type.str());
 			log_debug("Replacing %s cell `%s' in module `%s' with inverter.\n", log_id(cell->type), log_id(cell), log_id(module));
-			cell->setPort(ID(A), cell->getPort(ID(S)));
-			cell->unsetPort(ID(B));
+			cell->setPort(ID::A, cell->getPort(ID(S)));
+			cell->unsetPort(ID::B);
 			cell->unsetPort(ID(S));
 			if (cell->type == ID($mux)) {
 				Const width = cell->parameters[ID(WIDTH)];
@@ -1099,10 +1099,10 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 			goto next_cell;
 		}
 
-		if (consume_x && mux_bool && cell->type.in(ID($mux), ID($_MUX_)) && cell->getPort(ID(A)) == State::S0) {
+		if (consume_x && mux_bool && cell->type.in(ID($mux), ID($_MUX_)) && cell->getPort(ID::A) == State::S0) {
 			cover_list("opt.opt_expr.mux_and", "$mux", "$_MUX_", cell->type.str());
 			log_debug("Replacing %s cell `%s' in module `%s' with and-gate.\n", log_id(cell->type), log_id(cell), log_id(module));
-			cell->setPort(ID(A), cell->getPort(ID(S)));
+			cell->setPort(ID::A, cell->getPort(ID(S)));
 			cell->unsetPort(ID(S));
 			if (cell->type == ID($mux)) {
 				Const width = cell->parameters[ID(WIDTH)];
@@ -1119,10 +1119,10 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 			goto next_cell;
 		}
 
-		if (consume_x && mux_bool && cell->type.in(ID($mux), ID($_MUX_)) && cell->getPort(ID(B)) == State::S1) {
+		if (consume_x && mux_bool && cell->type.in(ID($mux), ID($_MUX_)) && cell->getPort(ID::B) == State::S1) {
 			cover_list("opt.opt_expr.mux_or", "$mux", "$_MUX_", cell->type.str());
 			log_debug("Replacing %s cell `%s' in module `%s' with or-gate.\n", log_id(cell->type), log_id(cell), log_id(module));
-			cell->setPort(ID(B), cell->getPort(ID(S)));
+			cell->setPort(ID::B, cell->getPort(ID(S)));
 			cell->unsetPort(ID(S));
 			if (cell->type == ID($mux)) {
 				Const width = cell->parameters[ID(WIDTH)];
@@ -1141,22 +1141,22 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 		if (mux_undef && cell->type.in(ID($mux), ID($pmux))) {
 			RTLIL::SigSpec new_a, new_b, new_s;
-			int width = cell->getPort(ID(A)).size();
-			if ((cell->getPort(ID(A)).is_fully_undef() && cell->getPort(ID(B)).is_fully_undef()) ||
+			int width = cell->getPort(ID::A).size();
+			if ((cell->getPort(ID::A).is_fully_undef() && cell->getPort(ID::B).is_fully_undef()) ||
 					cell->getPort(ID(S)).is_fully_undef()) {
 				cover_list("opt.opt_expr.mux_undef", "$mux", "$pmux", cell->type.str());
-				replace_cell(assign_map, module, cell, "mux_undef", ID(Y), cell->getPort(ID(A)));
+				replace_cell(assign_map, module, cell, "mux_undef", ID::Y, cell->getPort(ID::A));
 				goto next_cell;
 			}
 			for (int i = 0; i < cell->getPort(ID(S)).size(); i++) {
-				RTLIL::SigSpec old_b = cell->getPort(ID(B)).extract(i*width, width);
+				RTLIL::SigSpec old_b = cell->getPort(ID::B).extract(i*width, width);
 				RTLIL::SigSpec old_s = cell->getPort(ID(S)).extract(i, 1);
 				if (old_b.is_fully_undef() || old_s.is_fully_undef())
 					continue;
 				new_b.append(old_b);
 				new_s.append(old_s);
 			}
-			new_a = cell->getPort(ID(A));
+			new_a = cell->getPort(ID::A);
 			if (new_a.is_fully_undef() && new_s.size() > 0) {
 				new_a = new_b.extract((new_s.size()-1)*width, width);
 				new_b = new_b.extract(0, (new_s.size()-1)*width);
@@ -1164,20 +1164,20 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 			}
 			if (new_s.size() == 0) {
 				cover_list("opt.opt_expr.mux_empty", "$mux", "$pmux", cell->type.str());
-				replace_cell(assign_map, module, cell, "mux_empty", ID(Y), new_a);
+				replace_cell(assign_map, module, cell, "mux_empty", ID::Y, new_a);
 				goto next_cell;
 			}
 			if (new_a == RTLIL::SigSpec(RTLIL::State::S0) && new_b == RTLIL::SigSpec(RTLIL::State::S1)) {
 				cover_list("opt.opt_expr.mux_sel01", "$mux", "$pmux", cell->type.str());
-				replace_cell(assign_map, module, cell, "mux_sel01", ID(Y), new_s);
+				replace_cell(assign_map, module, cell, "mux_sel01", ID::Y, new_s);
 				goto next_cell;
 			}
 			if (cell->getPort(ID(S)).size() != new_s.size()) {
 				cover_list("opt.opt_expr.mux_reduce", "$mux", "$pmux", cell->type.str());
 				log_debug("Optimized away %d select inputs of %s cell `%s' in module `%s'.\n",
 						GetSize(cell->getPort(ID(S))) - GetSize(new_s), log_id(cell->type), log_id(cell), log_id(module));
-				cell->setPort(ID(A), new_a);
-				cell->setPort(ID(B), new_b);
+				cell->setPort(ID::A, new_a);
+				cell->setPort(ID::B, new_b);
 				cell->setPort(ID(S), new_s);
 				if (new_s.size() > 1) {
 					cell->type = ID($pmux);
@@ -1192,7 +1192,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 #define FOLD_1ARG_CELL(_t) \
 		if (cell->type == "$" #_t) { \
-			RTLIL::SigSpec a = cell->getPort(ID(A)); \
+			RTLIL::SigSpec a = cell->getPort(ID::A); \
 			assign_map.apply(a); \
 			if (a.is_fully_const()) { \
 				RTLIL::Const dummy_arg(RTLIL::State::S0, 1); \
@@ -1200,14 +1200,14 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 						cell->parameters[ID(A_SIGNED)].as_bool(), false, \
 						cell->parameters[ID(Y_WIDTH)].as_int())); \
 				cover("opt.opt_expr.const.$" #_t); \
-				replace_cell(assign_map, module, cell, stringf("%s", log_signal(a)), ID(Y), y); \
+				replace_cell(assign_map, module, cell, stringf("%s", log_signal(a)), ID::Y, y); \
 				goto next_cell; \
 			} \
 		}
 #define FOLD_2ARG_CELL(_t) \
 		if (cell->type == "$" #_t) { \
-			RTLIL::SigSpec a = cell->getPort(ID(A)); \
-			RTLIL::SigSpec b = cell->getPort(ID(B)); \
+			RTLIL::SigSpec a = cell->getPort(ID::A); \
+			RTLIL::SigSpec b = cell->getPort(ID::B); \
 			assign_map.apply(a), assign_map.apply(b); \
 			if (a.is_fully_const() && b.is_fully_const()) { \
 				RTLIL::SigSpec y(RTLIL::const_ ## _t(a.as_const(), b.as_const(), \
@@ -1215,7 +1215,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 						cell->parameters[ID(B_SIGNED)].as_bool(), \
 						cell->parameters[ID(Y_WIDTH)].as_int())); \
 				cover("opt.opt_expr.const.$" #_t); \
-				replace_cell(assign_map, module, cell, stringf("%s, %s", log_signal(a), log_signal(b)), ID(Y), y); \
+				replace_cell(assign_map, module, cell, stringf("%s, %s", log_signal(a), log_signal(b)), ID::Y, y); \
 				goto next_cell; \
 			} \
 		}
@@ -1263,12 +1263,12 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 		// be very conservative with optimizing $mux cells as we do not want to break mux trees
 		if (cell->type == ID($mux)) {
 			RTLIL::SigSpec input = assign_map(cell->getPort(ID(S)));
-			RTLIL::SigSpec inA = assign_map(cell->getPort(ID(A)));
-			RTLIL::SigSpec inB = assign_map(cell->getPort(ID(B)));
+			RTLIL::SigSpec inA = assign_map(cell->getPort(ID::A));
+			RTLIL::SigSpec inB = assign_map(cell->getPort(ID::B));
 			if (input.is_fully_const())
-				ACTION_DO(ID(Y), input.as_bool() ? cell->getPort(ID(B)) : cell->getPort(ID(A)));
+				ACTION_DO(ID::Y, input.as_bool() ? cell->getPort(ID::B) : cell->getPort(ID::A));
 			else if (inA == inB)
-				ACTION_DO(ID(Y), cell->getPort(ID(A)));
+				ACTION_DO(ID::Y, cell->getPort(ID::A));
 		}
 
 		if (!keepdc && cell->type == ID($mul))
@@ -1277,9 +1277,9 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 			bool b_signed = cell->parameters[ID(B_SIGNED)].as_bool();
 			bool swapped_ab = false;
 
-			RTLIL::SigSpec sig_a = assign_map(cell->getPort(ID(A)));
-			RTLIL::SigSpec sig_b = assign_map(cell->getPort(ID(B)));
-			RTLIL::SigSpec sig_y = assign_map(cell->getPort(ID(Y)));
+			RTLIL::SigSpec sig_a = assign_map(cell->getPort(ID::A));
+			RTLIL::SigSpec sig_b = assign_map(cell->getPort(ID::B));
+			RTLIL::SigSpec sig_y = assign_map(cell->getPort(ID::Y));
 
 			if (sig_b.is_fully_const() && sig_b.size() <= 32)
 				std::swap(sig_a, sig_b), std::swap(a_signed, b_signed), swapped_ab = true;
@@ -1314,7 +1314,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 								a_val, cell->name.c_str(), module->name.c_str(), i);
 
 						if (!swapped_ab) {
-							cell->setPort(ID(A), cell->getPort(ID(B)));
+							cell->setPort(ID::A, cell->getPort(ID::B));
 							cell->parameters.at(ID(A_WIDTH)) = cell->parameters.at(ID(B_WIDTH));
 							cell->parameters.at(ID(A_SIGNED)) = cell->parameters.at(ID(B_SIGNED));
 						}
@@ -1327,7 +1327,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 						cell->type = ID($shl);
 						cell->parameters[ID(B_WIDTH)] = GetSize(new_b);
 						cell->parameters[ID(B_SIGNED)] = false;
-						cell->setPort(ID(B), new_b);
+						cell->setPort(ID::B, new_b);
 						cell->check();
 
 						did_something = true;
@@ -1339,8 +1339,8 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 		if (!keepdc && cell->type.in(ID($div), ID($mod)))
 		{
 			bool b_signed = cell->parameters[ID(B_SIGNED)].as_bool();
-			SigSpec sig_b = assign_map(cell->getPort(ID(B)));
-			SigSpec sig_y = assign_map(cell->getPort(ID(Y)));
+			SigSpec sig_b = assign_map(cell->getPort(ID::B));
+			SigSpec sig_y = assign_map(cell->getPort(ID::Y));
 
 			if (sig_b.is_fully_def() && sig_b.size() <= 32)
 			{
@@ -1378,7 +1378,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 							cell->type = ID($shr);
 							cell->parameters[ID(B_WIDTH)] = GetSize(new_b);
 							cell->parameters[ID(B_SIGNED)] = false;
-							cell->setPort(ID(B), new_b);
+							cell->setPort(ID::B, new_b);
 							cell->check();
 						}
 						else
@@ -1395,7 +1395,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 							cell->type = ID($and);
 							cell->parameters[ID(B_WIDTH)] = GetSize(new_b);
-							cell->setPort(ID(B), new_b);
+							cell->setPort(ID::B, new_b);
 							cell->check();
 						}
 
@@ -1421,8 +1421,8 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 			bool is_signed = cell->getParam(ID(A_SIGNED)).as_bool();
 			int width = is_signed ? std::min(a_width, b_width) : std::max(a_width, b_width);
 
-			SigSpec sig_a = cell->getPort(ID(A));
-			SigSpec sig_b = cell->getPort(ID(B));
+			SigSpec sig_a = cell->getPort(ID::A);
+			SigSpec sig_b = cell->getPort(ID::B);
 
 			int redundant_bits = 0;
 
@@ -1452,7 +1452,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 			if (contradiction_cache.find(State::S0) == contradiction_cache.find(State::S1))
 			{
-				SigSpec y_sig = cell->getPort(ID(Y));
+				SigSpec y_sig = cell->getPort(ID::Y);
 				Const y_value(cell->type.in(ID($eq), ID($eqx)) ? 0 : 1, GetSize(y_sig));
 
 				log_debug("Replacing cell `%s' in module `%s' with constant driver %s.\n",
@@ -1470,8 +1470,8 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 				log_debug("Removed %d redundant input bits from %s cell `%s' in module `%s'.\n",
 						redundant_bits, log_id(cell->type), log_id(cell), log_id(module));
 
-				cell->setPort(ID(A), sig_a);
-				cell->setPort(ID(B), sig_b);
+				cell->setPort(ID::A, sig_a);
+				cell->setPort(ID::B, sig_b);
 				cell->setParam(ID(A_WIDTH), GetSize(sig_a));
 				cell->setParam(ID(B_WIDTH), GetSize(sig_b));
 
@@ -1484,8 +1484,8 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 		if (do_fine && cell->type.in(ID($lt), ID($ge), ID($gt), ID($le)))
 		{
 			IdString cmp_type = cell->type;
-			SigSpec var_sig = cell->getPort(ID(A));
-			SigSpec const_sig = cell->getPort(ID(B));
+			SigSpec var_sig = cell->getPort(ID::A);
+			SigSpec const_sig = cell->getPort(ID::B);
 			int var_width = cell->parameters[ID(A_WIDTH)].as_int();
 			int const_width = cell->parameters[ID(B_WIDTH)].as_int();
 			bool is_signed = cell->getParam(ID(A_SIGNED)).as_bool();
@@ -1507,7 +1507,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 			if (const_sig.is_fully_def() && const_sig.is_fully_const())
 			{
 				std::string condition, replacement;
-				SigSpec replace_sig(State::S0, GetSize(cell->getPort(ID(Y))));
+				SigSpec replace_sig(State::S0, GetSize(cell->getPort(ID::Y)));
 				bool replace = false;
 				bool remove = false;
 
@@ -1550,14 +1550,14 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 						{
 							condition   = stringf("unsigned X<%s", log_signal(const_sig));
 							replacement = stringf("!X[%d:%d]", var_width - 1, const_bit_hot);
-							module->addLogicNot(NEW_ID, var_high_sig, cell->getPort(ID(Y)));
+							module->addLogicNot(NEW_ID, var_high_sig, cell->getPort(ID::Y));
 							remove = true;
 						}
 						if (cmp_type == ID($ge))
 						{
 							condition   = stringf("unsigned X>=%s", log_signal(const_sig));
 							replacement = stringf("|X[%d:%d]", var_width - 1, const_bit_hot);
-							module->addReduceOr(NEW_ID, var_high_sig, cell->getPort(ID(Y)));
+							module->addReduceOr(NEW_ID, var_high_sig, cell->getPort(ID::Y));
 							remove = true;
 						}
 					}
@@ -1599,7 +1599,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 					{
 						condition   = "signed X>=0";
 						replacement = stringf("X[%d]", var_width - 1);
-						module->addNot(NEW_ID, var_sig[var_width - 1], cell->getPort(ID(Y)));
+						module->addNot(NEW_ID, var_sig[var_width - 1], cell->getPort(ID::Y));
 						remove = true;
 					}
 				}
@@ -1609,7 +1609,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 					log_debug("Replacing %s cell `%s' (implementing %s) with %s.\n",
 							log_id(cell->type), log_id(cell), condition.c_str(), replacement.c_str());
 					if (replace)
-						module->connect(cell->getPort(ID(Y)), replace_sig);
+						module->connect(cell->getPort(ID::Y), replace_sig);
 					module->remove(cell);
 					did_something = true;
 					goto next_cell;

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -61,7 +61,7 @@ void replace_undriven(RTLIL::Design *design, RTLIL::Module *module)
 		}
 		if (wire->port_input)
 			driven_signals.add(sigmap(wire));
-		if (wire->port_output || wire->get_bool_attribute(ID(keep)))
+		if (wire->port_output || wire->get_bool_attribute(ID::keep))
 			used_signals.add(sigmap(wire));
 		all_signals.add(sigmap(wire));
 	}

--- a/passes/opt/opt_lut.cc
+++ b/passes/opt/opt_lut.cc
@@ -104,7 +104,7 @@ struct OptLutWorker
 				if (cell->has_keep_attr())
 					continue;
 				SigBit lut_output = cell->getPort(ID::Y);
-				if (lut_output.wire->get_bool_attribute(ID(keep)))
+				if (lut_output.wire->get_bool_attribute(ID::keep))
 					continue;
 
 				int lut_width = cell->getParam(ID(WIDTH)).as_int();

--- a/passes/opt/opt_lut.cc
+++ b/passes/opt/opt_lut.cc
@@ -40,7 +40,7 @@ struct OptLutWorker
 
 	bool evaluate_lut(RTLIL::Cell *lut, dict<SigBit, bool> inputs)
 	{
-		SigSpec lut_input = sigmap(lut->getPort(ID(A)));
+		SigSpec lut_input = sigmap(lut->getPort(ID::A));
 		int lut_width = lut->getParam(ID(WIDTH)).as_int();
 		Const lut_table = lut->getParam(ID(LUT));
 		int lut_index = 0;
@@ -103,12 +103,12 @@ struct OptLutWorker
 			{
 				if (cell->has_keep_attr())
 					continue;
-				SigBit lut_output = cell->getPort(ID(Y));
+				SigBit lut_output = cell->getPort(ID::Y);
 				if (lut_output.wire->get_bool_attribute(ID(keep)))
 					continue;
 
 				int lut_width = cell->getParam(ID(WIDTH)).as_int();
-				SigSpec lut_input = cell->getPort(ID(A));
+				SigSpec lut_input = cell->getPort(ID::A);
 				int lut_arity = 0;
 
 				log_debug("Found $lut\\WIDTH=%d cell %s.%s.\n", lut_width, log_id(module), log_id(cell));
@@ -205,7 +205,7 @@ struct OptLutWorker
 			}
 
 			auto lut = worklist.pop();
-			SigSpec lut_input = sigmap(lut->getPort(ID(A)));
+			SigSpec lut_input = sigmap(lut->getPort(ID::A));
 			pool<int> &lut_dlogic_inputs = luts_dlogic_inputs[lut];
 
 			vector<SigBit> lut_inputs;
@@ -267,7 +267,7 @@ struct OptLutWorker
 					log_debug("  Not eliminating cell (connected to dedicated logic).\n");
 				else
 				{
-					SigSpec lut_output = lut->getPort(ID(Y));
+					SigSpec lut_output = lut->getPort(ID::Y);
 					for (auto &port : index.query_ports(lut_output))
 					{
 						if (port.cell != lut && luts.count(port.cell))
@@ -303,13 +303,13 @@ struct OptLutWorker
 			}
 
 			auto lutA = worklist.pop();
-			SigSpec lutA_input = sigmap(lutA->getPort(ID(A)));
-			SigSpec lutA_output = sigmap(lutA->getPort(ID(Y))[0]);
+			SigSpec lutA_input = sigmap(lutA->getPort(ID::A));
+			SigSpec lutA_output = sigmap(lutA->getPort(ID::Y)[0]);
 			int lutA_width = lutA->getParam(ID(WIDTH)).as_int();
 			int lutA_arity = luts_arity[lutA];
 			pool<int> &lutA_dlogic_inputs = luts_dlogic_inputs[lutA];
 
-			auto lutA_output_ports = index.query_ports(lutA->getPort(ID(Y)));
+			auto lutA_output_ports = index.query_ports(lutA->getPort(ID::Y));
 			if (lutA_output_ports.size() != 2)
 				continue;
 
@@ -321,15 +321,15 @@ struct OptLutWorker
 				if (luts.count(port.cell))
 				{
 					auto lutB = port.cell;
-					SigSpec lutB_input = sigmap(lutB->getPort(ID(A)));
-					SigSpec lutB_output = sigmap(lutB->getPort(ID(Y))[0]);
+					SigSpec lutB_input = sigmap(lutB->getPort(ID::A));
+					SigSpec lutB_output = sigmap(lutB->getPort(ID::Y)[0]);
 					int lutB_width = lutB->getParam(ID(WIDTH)).as_int();
 					int lutB_arity = luts_arity[lutB];
 					pool<int> &lutB_dlogic_inputs = luts_dlogic_inputs[lutB];
 
 					log_debug("Found %s.%s (cell A) feeding %s.%s (cell B).\n", log_id(module), log_id(lutA), log_id(module), log_id(lutB));
 
-					if (index.query_is_output(lutA->getPort(ID(Y))))
+					if (index.query_is_output(lutA->getPort(ID::Y)))
 					{
 						log_debug("  Not combining LUTs (cascade connection feeds module output).\n");
 						continue;
@@ -441,7 +441,7 @@ struct OptLutWorker
 					}
 
 					int lutM_width = lutM->getParam(ID(WIDTH)).as_int();
-					SigSpec lutM_input = sigmap(lutM->getPort(ID(A)));
+					SigSpec lutM_input = sigmap(lutM->getPort(ID::A));
 					std::vector<SigBit> lutM_new_inputs;
 					for (int i = 0; i < lutM_width; i++)
 					{
@@ -487,8 +487,8 @@ struct OptLutWorker
 					log_debug("  Merged truth table: %s.\n", lutM_new_table.as_string().c_str());
 
 					lutM->setParam(ID(LUT), lutM_new_table);
-					lutM->setPort(ID(A), lutM_new_inputs);
-					lutM->setPort(ID(Y), lutB_output);
+					lutM->setPort(ID::A, lutM_new_inputs);
+					lutM->setPort(ID::Y, lutB_output);
 
 					luts_arity[lutM] = lutM_arity;
 					luts.erase(lutR);

--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -48,7 +48,7 @@ struct OptMergeWorker
 	static void sort_pmux_conn(dict<RTLIL::IdString, RTLIL::SigSpec> &conn)
 	{
 		SigSpec sig_s = conn.at(ID(S));
-		SigSpec sig_b = conn.at(ID(B));
+		SigSpec sig_b = conn.at(ID::B);
 
 		int s_width = GetSize(sig_s);
 		int width = GetSize(sig_b) / s_width;
@@ -60,11 +60,11 @@ struct OptMergeWorker
 		std::sort(sb_pairs.begin(), sb_pairs.end());
 
 		conn[ID(S)] = SigSpec();
-		conn[ID(B)] = SigSpec();
+		conn[ID::B] = SigSpec();
 
 		for (auto &it : sb_pairs) {
 			conn[ID(S)].append(it.first);
-			conn[ID(B)].append(it.second);
+			conn[ID::B].append(it.second);
 		}
 	}
 
@@ -97,28 +97,28 @@ struct OptMergeWorker
 		if (cell->type.in(ID($and), ID($or), ID($xor), ID($xnor), ID($add), ID($mul),
 				ID($logic_and), ID($logic_or), ID($_AND_), ID($_OR_), ID($_XOR_))) {
 			alt_conn = *conn;
-			if (assign_map(alt_conn.at(ID(A))) < assign_map(alt_conn.at(ID(B)))) {
-				alt_conn[ID(A)] = conn->at(ID(B));
-				alt_conn[ID(B)] = conn->at(ID(A));
+			if (assign_map(alt_conn.at(ID::A)) < assign_map(alt_conn.at(ID::B))) {
+				alt_conn[ID::A] = conn->at(ID::B);
+				alt_conn[ID::B] = conn->at(ID::A);
 			}
 			conn = &alt_conn;
 		} else
 		if (cell->type.in(ID($reduce_xor), ID($reduce_xnor))) {
 			alt_conn = *conn;
-			assign_map.apply(alt_conn.at(ID(A)));
-			alt_conn.at(ID(A)).sort();
+			assign_map.apply(alt_conn.at(ID::A));
+			alt_conn.at(ID::A).sort();
 			conn = &alt_conn;
 		} else
 		if (cell->type.in(ID($reduce_and), ID($reduce_or), ID($reduce_bool))) {
 			alt_conn = *conn;
-			assign_map.apply(alt_conn.at(ID(A)));
-			alt_conn.at(ID(A)).sort_and_unify();
+			assign_map.apply(alt_conn.at(ID::A));
+			alt_conn.at(ID::A).sort_and_unify();
 			conn = &alt_conn;
 		} else
 		if (cell->type == ID($pmux)) {
 			alt_conn = *conn;
-			assign_map.apply(alt_conn.at(ID(A)));
-			assign_map.apply(alt_conn.at(ID(B)));
+			assign_map.apply(alt_conn.at(ID::A));
+			assign_map.apply(alt_conn.at(ID::B));
 			assign_map.apply(alt_conn.at(ID(S)));
 			sort_pmux_conn(alt_conn);
 			conn = &alt_conn;
@@ -191,24 +191,24 @@ struct OptMergeWorker
 
 		if (cell1->type == ID($and) || cell1->type == ID($or) || cell1->type == ID($xor) || cell1->type == ID($xnor) || cell1->type == ID($add) || cell1->type == ID($mul) ||
 				cell1->type == ID($logic_and) || cell1->type == ID($logic_or) || cell1->type == ID($_AND_) || cell1->type == ID($_OR_) || cell1->type == ID($_XOR_)) {
-			if (conn1.at(ID(A)) < conn1.at(ID(B))) {
-				RTLIL::SigSpec tmp = conn1[ID(A)];
-				conn1[ID(A)] = conn1[ID(B)];
-				conn1[ID(B)] = tmp;
+			if (conn1.at(ID::A) < conn1.at(ID::B)) {
+				RTLIL::SigSpec tmp = conn1[ID::A];
+				conn1[ID::A] = conn1[ID::B];
+				conn1[ID::B] = tmp;
 			}
-			if (conn2.at(ID(A)) < conn2.at(ID(B))) {
-				RTLIL::SigSpec tmp = conn2[ID(A)];
-				conn2[ID(A)] = conn2[ID(B)];
-				conn2[ID(B)] = tmp;
+			if (conn2.at(ID::A) < conn2.at(ID::B)) {
+				RTLIL::SigSpec tmp = conn2[ID::A];
+				conn2[ID::A] = conn2[ID::B];
+				conn2[ID::B] = tmp;
 			}
 		} else
 		if (cell1->type == ID($reduce_xor) || cell1->type == ID($reduce_xnor)) {
-			conn1[ID(A)].sort();
-			conn2[ID(A)].sort();
+			conn1[ID::A].sort();
+			conn2[ID::A].sort();
 		} else
 		if (cell1->type == ID($reduce_and) || cell1->type == ID($reduce_or) || cell1->type == ID($reduce_bool)) {
-			conn1[ID(A)].sort_and_unify();
-			conn2[ID(A)].sort_and_unify();
+			conn1[ID::A].sort_and_unify();
+			conn2[ID::A].sort_and_unify();
 		} else
 		if (cell1->type == ID($pmux)) {
 			sort_pmux_conn(conn1);

--- a/passes/opt/opt_muxtree.cc
+++ b/passes/opt/opt_muxtree.cc
@@ -86,10 +86,10 @@ struct OptMuxtreeWorker
 		{
 			if (cell->type.in(ID($mux), ID($pmux)))
 			{
-				RTLIL::SigSpec sig_a = cell->getPort(ID(A));
-				RTLIL::SigSpec sig_b = cell->getPort(ID(B));
+				RTLIL::SigSpec sig_a = cell->getPort(ID::A);
+				RTLIL::SigSpec sig_b = cell->getPort(ID::B);
 				RTLIL::SigSpec sig_s = cell->getPort(ID(S));
-				RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+				RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 
 				muxinfo_t muxinfo;
 				muxinfo.cell = cell;
@@ -227,10 +227,10 @@ struct OptMuxtreeWorker
 				continue;
 			}
 
-			RTLIL::SigSpec sig_a = mi.cell->getPort(ID(A));
-			RTLIL::SigSpec sig_b = mi.cell->getPort(ID(B));
+			RTLIL::SigSpec sig_a = mi.cell->getPort(ID::A);
+			RTLIL::SigSpec sig_b = mi.cell->getPort(ID::B);
 			RTLIL::SigSpec sig_s = mi.cell->getPort(ID(S));
-			RTLIL::SigSpec sig_y = mi.cell->getPort(ID(Y));
+			RTLIL::SigSpec sig_y = mi.cell->getPort(ID::Y);
 
 			RTLIL::SigSpec sig_ports = sig_b;
 			sig_ports.append(sig_a);
@@ -255,8 +255,8 @@ struct OptMuxtreeWorker
 					}
 				}
 
-				mi.cell->setPort(ID(A), new_sig_a);
-				mi.cell->setPort(ID(B), new_sig_b);
+				mi.cell->setPort(ID::A, new_sig_a);
+				mi.cell->setPort(ID::B, new_sig_b);
 				mi.cell->setPort(ID(S), new_sig_s);
 				if (GetSize(new_sig_s) == 1) {
 					mi.cell->type = ID($mux);
@@ -364,8 +364,8 @@ struct OptMuxtreeWorker
 
 		int width = 0;
 		idict<int> ctrl_bits;
-		if (portname == ID(B))
-			width = GetSize(muxinfo.cell->getPort(ID(A)));
+		if (portname == ID::B)
+			width = GetSize(muxinfo.cell->getPort(ID::A));
 		for (int bit : sig2bits(muxinfo.cell->getPort(ID(S)), false))
 			ctrl_bits(bit);
 
@@ -414,8 +414,8 @@ struct OptMuxtreeWorker
 
 		// set input ports to constants if we find known active or inactive signals
 		if (do_replace_known) {
-			replace_known(knowledge, muxinfo, ID(A));
-			replace_known(knowledge, muxinfo, ID(B));
+			replace_known(knowledge, muxinfo, ID::A);
+			replace_known(knowledge, muxinfo, ID::B);
 		}
 
 		// if there is a constant activated port we just use it

--- a/passes/opt/opt_muxtree.cc
+++ b/passes/opt/opt_muxtree.cc
@@ -137,7 +137,7 @@ struct OptMuxtreeWorker
 			}
 		}
 		for (auto wire : module->wires()) {
-			if (wire->port_output || wire->get_bool_attribute(ID(keep)))
+			if (wire->port_output || wire->get_bool_attribute(ID::keep))
 				for (int idx : sig2bits(RTLIL::SigSpec(wire)))
 					bit2info[idx].seen_non_mux = true;
 		}

--- a/passes/opt/opt_rmdff.cc
+++ b/passes/opt/opt_rmdff.cc
@@ -347,8 +347,8 @@ bool handle_dff(RTLIL::Module *mod, RTLIL::Cell *dff)
 		std::set<RTLIL::Cell*> muxes;
 		mux_drivers.find(sig_d, muxes);
 		for (auto mux : muxes) {
-			RTLIL::SigSpec sig_a = assign_map(mux->getPort(ID(A)));
-			RTLIL::SigSpec sig_b = assign_map(mux->getPort(ID(B)));
+			RTLIL::SigSpec sig_a = assign_map(mux->getPort(ID::A));
+			RTLIL::SigSpec sig_b = assign_map(mux->getPort(ID::B));
 			if (sig_a == sig_q && sig_b.is_fully_const() && (!has_init || val_init == sig_b.as_const())) {
 				mod->connect(sig_q, sig_b);
 				goto delete_dff;
@@ -625,8 +625,8 @@ struct OptRmdffPass : public Pass {
 				}
 
 				if (cell->type.in(ID($mux), ID($pmux))) {
-					if (cell->getPort(ID(A)).size() == cell->getPort(ID(B)).size())
-						mux_drivers.insert(assign_map(cell->getPort(ID(Y))), cell);
+					if (cell->getPort(ID::A).size() == cell->getPort(ID::B).size())
+						mux_drivers.insert(assign_map(cell->getPort(ID::Y)), cell);
 					continue;
 				}
 

--- a/passes/opt/pmux2shiftx.cc
+++ b/passes/opt/pmux2shiftx.cc
@@ -73,9 +73,9 @@ struct OnehotDatabase
 
 			if (cell->type.in(ID($mux), ID($pmux)))
 			{
-				output = cell->getPort(ID(Y));
-				inputs.push_back(cell->getPort(ID(A)));
-				SigSpec B = cell->getPort(ID(B));
+				output = cell->getPort(ID::Y);
+				inputs.push_back(cell->getPort(ID::A));
+				SigSpec B = cell->getPort(ID::B);
 				for (int i = 0; i < GetSize(B); i += GetSize(output))
 					inputs.push_back(B.extract(i, GetSize(output)));
 			}
@@ -296,8 +296,8 @@ struct Pmux2ShiftxPass : public Pass {
 				{
 					dict<SigBit, State> bits;
 
-					SigSpec A = sigmap(cell->getPort(ID(A)));
-					SigSpec B = sigmap(cell->getPort(ID(B)));
+					SigSpec A = sigmap(cell->getPort(ID::A));
+					SigSpec B = sigmap(cell->getPort(ID::B));
 
 					int a_width = cell->getParam(ID(A_WIDTH)).as_int();
 					int b_width = cell->getParam(ID(B_WIDTH)).as_int();
@@ -335,7 +335,7 @@ struct Pmux2ShiftxPass : public Pass {
 						entry.second.bits.push_back(it.second);
 					}
 
-					eqdb[sigmap(cell->getPort(ID(Y))[0])] = entry;
+					eqdb[sigmap(cell->getPort(ID::Y)[0])] = entry;
 					goto next_cell;
 				}
 
@@ -343,7 +343,7 @@ struct Pmux2ShiftxPass : public Pass {
 				{
 					dict<SigBit, State> bits;
 
-					SigSpec A = sigmap(cell->getPort(ID(A)));
+					SigSpec A = sigmap(cell->getPort(ID::A));
 
 					for (int i = 0; i < GetSize(A); i++)
 						bits[A[i]] = State::S0;
@@ -356,7 +356,7 @@ struct Pmux2ShiftxPass : public Pass {
 						entry.second.bits.push_back(it.second);
 					}
 
-					eqdb[sigmap(cell->getPort(ID(Y))[0])] = entry;
+					eqdb[sigmap(cell->getPort(ID::Y)[0])] = entry;
 					goto next_cell;
 				}
 		next_cell:;
@@ -377,8 +377,8 @@ struct Pmux2ShiftxPass : public Pass {
 
 				dict<SigSpec, pool<int>> seldb;
 
-				SigSpec A = cell->getPort(ID(A));
-				SigSpec B = cell->getPort(ID(B));
+				SigSpec A = cell->getPort(ID::A);
+				SigSpec B = cell->getPort(ID::B);
 				SigSpec S = sigmap(cell->getPort(ID(S)));
 				for (int i = 0; i < GetSize(S); i++)
 				{
@@ -401,7 +401,7 @@ struct Pmux2ShiftxPass : public Pass {
 				}
 
 				SigSpec updated_S = cell->getPort(ID(S));
-				SigSpec updated_B = cell->getPort(ID(B));
+				SigSpec updated_B = cell->getPort(ID::B);
 
 				while (!seldb.empty())
 				{
@@ -728,7 +728,7 @@ struct Pmux2ShiftxPass : public Pass {
 
 				// update $pmux cell
 				cell->setPort(ID(S), updated_S);
-				cell->setPort(ID(B), updated_B);
+				cell->setPort(ID::B, updated_B);
 				cell->setParam(ID(S_WIDTH), GetSize(updated_S));
 			}
 		}
@@ -782,8 +782,8 @@ struct OnehotPass : public Pass {
 				if (cell->type != ID($eq))
 					continue;
 
-				SigSpec A = sigmap(cell->getPort(ID(A)));
-				SigSpec B = sigmap(cell->getPort(ID(B)));
+				SigSpec A = sigmap(cell->getPort(ID::A));
+				SigSpec B = sigmap(cell->getPort(ID::B));
 
 				int a_width = cell->getParam(ID(A_WIDTH)).as_int();
 				int b_width = cell->getParam(ID(B_WIDTH)).as_int();
@@ -830,7 +830,7 @@ struct OnehotPass : public Pass {
 					continue;
 				}
 
-				SigSpec Y = cell->getPort(ID(Y));
+				SigSpec Y = cell->getPort(ID::Y);
 
 				if (not_onehot)
 				{

--- a/passes/opt/share.cc
+++ b/passes/opt/share.cc
@@ -128,7 +128,7 @@ struct ShareWorker
 	static int bits_macc(RTLIL::Cell *c)
 	{
 		Macc m(c);
-		int width = GetSize(c->getPort(ID(Y)));
+		int width = GetSize(c->getPort(ID::Y));
 		return bits_macc(m, width);
 	}
 
@@ -242,7 +242,7 @@ struct ShareWorker
 	{
 		Macc m1(c1), m2(c2), supermacc;
 
-		int w1 = GetSize(c1->getPort(ID(Y))), w2 = GetSize(c2->getPort(ID(Y)));
+		int w1 = GetSize(c1->getPort(ID::Y)), w2 = GetSize(c2->getPort(ID::Y));
 		int width = max(w1, w2);
 
 		m1.optimize(w1);
@@ -328,11 +328,11 @@ struct ShareWorker
 		{
 			RTLIL::SigSpec sig_y = module->addWire(NEW_ID, width);
 
-			supercell_aux->insert(module->addPos(NEW_ID, sig_y, c1->getPort(ID(Y))));
-			supercell_aux->insert(module->addPos(NEW_ID, sig_y, c2->getPort(ID(Y))));
+			supercell_aux->insert(module->addPos(NEW_ID, sig_y, c1->getPort(ID::Y)));
+			supercell_aux->insert(module->addPos(NEW_ID, sig_y, c2->getPort(ID::Y)));
 
 			supercell->setParam(ID(Y_WIDTH), width);
-			supercell->setPort(ID(Y), sig_y);
+			supercell->setPort(ID::Y, sig_y);
 
 			supermacc.optimize(width);
 			supermacc.to_cell(supercell);
@@ -513,11 +513,11 @@ struct ShareWorker
 			if (c1->parameters.at(ID(A_SIGNED)).as_bool() != c2->parameters.at(ID(A_SIGNED)).as_bool())
 			{
 				RTLIL::Cell *unsigned_cell = c1->parameters.at(ID(A_SIGNED)).as_bool() ? c2 : c1;
-				if (unsigned_cell->getPort(ID(A)).to_sigbit_vector().back() != RTLIL::State::S0) {
+				if (unsigned_cell->getPort(ID::A).to_sigbit_vector().back() != RTLIL::State::S0) {
 					unsigned_cell->parameters.at(ID(A_WIDTH)) = unsigned_cell->parameters.at(ID(A_WIDTH)).as_int() + 1;
-					RTLIL::SigSpec new_a = unsigned_cell->getPort(ID(A));
+					RTLIL::SigSpec new_a = unsigned_cell->getPort(ID::A);
 					new_a.append_bit(RTLIL::State::S0);
-					unsigned_cell->setPort(ID(A), new_a);
+					unsigned_cell->setPort(ID::A, new_a);
 				}
 				unsigned_cell->parameters.at(ID(A_SIGNED)) = true;
 				unsigned_cell->check();
@@ -526,11 +526,11 @@ struct ShareWorker
 			bool a_signed = c1->parameters.at(ID(A_SIGNED)).as_bool();
 			log_assert(a_signed == c2->parameters.at(ID(A_SIGNED)).as_bool());
 
-			RTLIL::SigSpec a1 = c1->getPort(ID(A));
-			RTLIL::SigSpec y1 = c1->getPort(ID(Y));
+			RTLIL::SigSpec a1 = c1->getPort(ID::A);
+			RTLIL::SigSpec y1 = c1->getPort(ID::Y);
 
-			RTLIL::SigSpec a2 = c2->getPort(ID(A));
-			RTLIL::SigSpec y2 = c2->getPort(ID(Y));
+			RTLIL::SigSpec a2 = c2->getPort(ID::A);
+			RTLIL::SigSpec y2 = c2->getPort(ID::Y);
 
 			int a_width = max(a1.size(), a2.size());
 			int y_width = max(y1.size(), y2.size());
@@ -547,8 +547,8 @@ struct ShareWorker
 			supercell->parameters[ID(A_SIGNED)] = a_signed;
 			supercell->parameters[ID(A_WIDTH)] = a_width;
 			supercell->parameters[ID(Y_WIDTH)] = y_width;
-			supercell->setPort(ID(A), a);
-			supercell->setPort(ID(Y), y);
+			supercell->setPort(ID::A, a);
+			supercell->setPort(ID::Y, y);
 
 			supercell_aux.insert(module->addPos(NEW_ID, y, y1));
 			supercell_aux.insert(module->addPos(NEW_ID, y, y2));
@@ -571,9 +571,9 @@ struct ShareWorker
 
 				if (score_flipped < score_unflipped)
 				{
-					RTLIL::SigSpec tmp = c2->getPort(ID(A));
-					c2->setPort(ID(A), c2->getPort(ID(B)));
-					c2->setPort(ID(B), tmp);
+					RTLIL::SigSpec tmp = c2->getPort(ID::A);
+					c2->setPort(ID::A, c2->getPort(ID::B));
+					c2->setPort(ID::B, tmp);
 
 					std::swap(c2->parameters.at(ID(A_WIDTH)), c2->parameters.at(ID(B_WIDTH)));
 					std::swap(c2->parameters.at(ID(A_SIGNED)), c2->parameters.at(ID(B_SIGNED)));
@@ -585,11 +585,11 @@ struct ShareWorker
 
 			{
 				RTLIL::Cell *unsigned_cell = c1->parameters.at(ID(A_SIGNED)).as_bool() ? c2 : c1;
-				if (unsigned_cell->getPort(ID(A)).to_sigbit_vector().back() != RTLIL::State::S0) {
+				if (unsigned_cell->getPort(ID::A).to_sigbit_vector().back() != RTLIL::State::S0) {
 					unsigned_cell->parameters.at(ID(A_WIDTH)) = unsigned_cell->parameters.at(ID(A_WIDTH)).as_int() + 1;
-					RTLIL::SigSpec new_a = unsigned_cell->getPort(ID(A));
+					RTLIL::SigSpec new_a = unsigned_cell->getPort(ID::A);
 					new_a.append_bit(RTLIL::State::S0);
-					unsigned_cell->setPort(ID(A), new_a);
+					unsigned_cell->setPort(ID::A, new_a);
 				}
 				unsigned_cell->parameters.at(ID(A_SIGNED)) = true;
 				modified_src_cells = true;
@@ -598,11 +598,11 @@ struct ShareWorker
 			if (c1->parameters.at(ID(B_SIGNED)).as_bool() != c2->parameters.at(ID(B_SIGNED)).as_bool())
 			{
 				RTLIL::Cell *unsigned_cell = c1->parameters.at(ID(B_SIGNED)).as_bool() ? c2 : c1;
-				if (unsigned_cell->getPort(ID(B)).to_sigbit_vector().back() != RTLIL::State::S0) {
+				if (unsigned_cell->getPort(ID::B).to_sigbit_vector().back() != RTLIL::State::S0) {
 					unsigned_cell->parameters.at(ID(B_WIDTH)) = unsigned_cell->parameters.at(ID(B_WIDTH)).as_int() + 1;
-					RTLIL::SigSpec new_b = unsigned_cell->getPort(ID(B));
+					RTLIL::SigSpec new_b = unsigned_cell->getPort(ID::B);
 					new_b.append_bit(RTLIL::State::S0);
-					unsigned_cell->setPort(ID(B), new_b);
+					unsigned_cell->setPort(ID::B, new_b);
 				}
 				unsigned_cell->parameters.at(ID(B_SIGNED)) = true;
 				modified_src_cells = true;
@@ -622,13 +622,13 @@ struct ShareWorker
 			if (c1->type == ID($shl) || c1->type == ID($shr) || c1->type == ID($sshl) || c1->type == ID($sshr))
 				b_signed = false;
 
-			RTLIL::SigSpec a1 = c1->getPort(ID(A));
-			RTLIL::SigSpec b1 = c1->getPort(ID(B));
-			RTLIL::SigSpec y1 = c1->getPort(ID(Y));
+			RTLIL::SigSpec a1 = c1->getPort(ID::A);
+			RTLIL::SigSpec b1 = c1->getPort(ID::B);
+			RTLIL::SigSpec y1 = c1->getPort(ID::Y);
 
-			RTLIL::SigSpec a2 = c2->getPort(ID(A));
-			RTLIL::SigSpec b2 = c2->getPort(ID(B));
-			RTLIL::SigSpec y2 = c2->getPort(ID(Y));
+			RTLIL::SigSpec a2 = c2->getPort(ID::A);
+			RTLIL::SigSpec b2 = c2->getPort(ID::B);
+			RTLIL::SigSpec y2 = c2->getPort(ID::Y);
 
 			int a_width = max(a1.size(), a2.size());
 			int b_width = max(b1.size(), b2.size());
@@ -669,9 +669,9 @@ struct ShareWorker
 			supercell->parameters[ID(A_WIDTH)] = a_width;
 			supercell->parameters[ID(B_WIDTH)] = b_width;
 			supercell->parameters[ID(Y_WIDTH)] = y_width;
-			supercell->setPort(ID(A), a);
-			supercell->setPort(ID(B), b);
-			supercell->setPort(ID(Y), y);
+			supercell->setPort(ID::A, a);
+			supercell->setPort(ID::B, b);
+			supercell->setPort(ID::Y, y);
 			if (c1->type == ID($alu)) {
 				RTLIL::Wire *ci = module->addWire(NEW_ID), *bi = module->addWire(NEW_ID);
 				supercell_aux.insert(module->addMux(NEW_ID, c2->getPort(ID(CI)), c1->getPort(ID(CI)), act, ci));
@@ -874,7 +874,7 @@ struct ShareWorker
 			}
 			for (auto &pbit : modwalker.signal_consumers[bit]) {
 				log_assert(fwd_ct.cell_known(pbit.cell->type));
-				if ((pbit.cell->type == ID($mux) || pbit.cell->type == ID($pmux)) && (pbit.port == ID(A) || pbit.port == ID(B)))
+				if ((pbit.cell->type == ID($mux) || pbit.cell->type == ID($pmux)) && (pbit.port == ID::A || pbit.port == ID::B))
 					driven_data_muxes.insert(pbit.cell);
 				else
 					driven_cells.insert(pbit.cell);
@@ -891,8 +891,8 @@ struct ShareWorker
 			std::set<int> used_in_b_parts;
 
 			int width = c->parameters.at(ID(WIDTH)).as_int();
-			std::vector<RTLIL::SigBit> sig_a = modwalker.sigmap(c->getPort(ID(A)));
-			std::vector<RTLIL::SigBit> sig_b = modwalker.sigmap(c->getPort(ID(B)));
+			std::vector<RTLIL::SigBit> sig_a = modwalker.sigmap(c->getPort(ID::A));
+			std::vector<RTLIL::SigBit> sig_b = modwalker.sigmap(c->getPort(ID::B));
 			std::vector<RTLIL::SigBit> sig_s = modwalker.sigmap(c->getPort(ID(S)));
 
 			for (auto &bit : sig_a)

--- a/passes/opt/wreduce.cc
+++ b/passes/opt/wreduce.cc
@@ -398,7 +398,7 @@ struct WreduceWorker
 		SigMap init_attr_sigmap = mi.sigmap;
 
 		for (auto w : module->wires()) {
-			if (w->get_bool_attribute(ID(keep)))
+			if (w->get_bool_attribute(ID::keep))
 				for (auto bit : mi.sigmap(w))
 					keep_bits.insert(bit);
 			if (w->attributes.count(ID(init))) {

--- a/passes/opt/wreduce.cc
+++ b/passes/opt/wreduce.cc
@@ -64,10 +64,10 @@ struct WreduceWorker
 	{
 		// Reduce size of MUX if inputs agree on a value for a bit or a output bit is unused
 
-		SigSpec sig_a = mi.sigmap(cell->getPort(ID(A)));
-		SigSpec sig_b = mi.sigmap(cell->getPort(ID(B)));
+		SigSpec sig_a = mi.sigmap(cell->getPort(ID::A));
+		SigSpec sig_b = mi.sigmap(cell->getPort(ID::B));
 		SigSpec sig_s = mi.sigmap(cell->getPort(ID(S)));
-		SigSpec sig_y = mi.sigmap(cell->getPort(ID(Y)));
+		SigSpec sig_y = mi.sigmap(cell->getPort(ID::Y));
 		std::vector<SigBit> bits_removed;
 
 		if (sig_y.has_const())
@@ -130,9 +130,9 @@ struct WreduceWorker
 		for (auto bit : new_work_queue_bits)
 			work_queue_bits.insert(bit);
 
-		cell->setPort(ID(A), new_sig_a);
-		cell->setPort(ID(B), new_sig_b);
-		cell->setPort(ID(Y), new_sig_y);
+		cell->setPort(ID::A, new_sig_a);
+		cell->setPort(ID::B, new_sig_b);
+		cell->setPort(ID::Y, new_sig_y);
 		cell->fixup_parameters();
 
 		module->connect(sig_y.extract(n_kept, n_removed), sig_removed);
@@ -270,7 +270,7 @@ struct WreduceWorker
 		if (cell->type.in(ID($dff), ID($adff)))
 			return run_cell_dff(cell);
 
-		SigSpec sig = mi.sigmap(cell->getPort(ID(Y)));
+		SigSpec sig = mi.sigmap(cell->getPort(ID::Y));
 
 		if (sig.has_const())
 			return;
@@ -278,8 +278,8 @@ struct WreduceWorker
 
 		// Reduce size of ports A and B based on constant input bits and size of output port
 
-		int max_port_a_size = cell->hasPort(ID(A)) ? GetSize(cell->getPort(ID(A))) : -1;
-		int max_port_b_size = cell->hasPort(ID(B)) ? GetSize(cell->getPort(ID(B))) : -1;
+		int max_port_a_size = cell->hasPort(ID::A) ? GetSize(cell->getPort(ID::A)) : -1;
+		int max_port_b_size = cell->hasPort(ID::B) ? GetSize(cell->getPort(ID::B)) : -1;
 
 		if (cell->type.in(ID($not), ID($pos), ID($neg), ID($and), ID($or), ID($xor), ID($add), ID($sub))) {
 			max_port_a_size = min(max_port_a_size, GetSize(sig));
@@ -295,8 +295,8 @@ struct WreduceWorker
 		if (max_port_b_size >= 0)
 			run_reduce_inport(cell, 'B', max_port_b_size, port_b_signed, did_something);
 
-		if (cell->hasPort(ID(A)) && cell->hasPort(ID(B)) && port_a_signed && port_b_signed) {
-			SigSpec sig_a = mi.sigmap(cell->getPort(ID(A))), sig_b = mi.sigmap(cell->getPort(ID(B)));
+		if (cell->hasPort(ID::A) && cell->hasPort(ID::B) && port_a_signed && port_b_signed) {
+			SigSpec sig_a = mi.sigmap(cell->getPort(ID::A)), sig_b = mi.sigmap(cell->getPort(ID::B));
 			if (GetSize(sig_a) > 0 && sig_a[GetSize(sig_a)-1] == State::S0 &&
 					GetSize(sig_b) > 0 && sig_b[GetSize(sig_b)-1] == State::S0) {
 				log("Converting cell %s.%s (%s) from signed to unsigned.\n",
@@ -309,8 +309,8 @@ struct WreduceWorker
 			}
 		}
 
-		if (cell->hasPort(ID(A)) && !cell->hasPort(ID(B)) && port_a_signed) {
-			SigSpec sig_a = mi.sigmap(cell->getPort(ID(A)));
+		if (cell->hasPort(ID::A) && !cell->hasPort(ID::B) && port_a_signed) {
+			SigSpec sig_a = mi.sigmap(cell->getPort(ID::A));
 			if (GetSize(sig_a) > 0 && sig_a[GetSize(sig_a)-1] == State::S0) {
 				log("Converting cell %s.%s (%s) from signed to unsigned.\n",
 						log_id(module), log_id(cell), log_id(cell->type));
@@ -347,8 +347,8 @@ struct WreduceWorker
 			bool is_signed = cell->getParam(ID(A_SIGNED)).as_bool() || cell->type == ID($sub);
 
 			int a_size = 0, b_size = 0;
-			if (cell->hasPort(ID(A))) a_size = GetSize(cell->getPort(ID(A)));
-			if (cell->hasPort(ID(B))) b_size = GetSize(cell->getPort(ID(B)));
+			if (cell->hasPort(ID::A)) a_size = GetSize(cell->getPort(ID::A));
+			if (cell->hasPort(ID::B)) b_size = GetSize(cell->getPort(ID::B));
 
 			int max_y_size = max(a_size, b_size);
 
@@ -374,7 +374,7 @@ struct WreduceWorker
 		if (bits_removed) {
 			log("Removed top %d bits (of %d) from port Y of cell %s.%s (%s).\n",
 					bits_removed, GetSize(sig) + bits_removed, log_id(module), log_id(cell), log_id(cell->type));
-			cell->setPort(ID(Y), sig);
+			cell->setPort(ID::Y, sig);
 			did_something = true;
 		}
 
@@ -530,10 +530,10 @@ struct WreducePass : public Pass {
 			{
 				if (c->type.in(ID($reduce_and), ID($reduce_or), ID($reduce_xor), ID($reduce_xnor), ID($reduce_bool),
 						ID($lt), ID($le), ID($eq), ID($ne), ID($eqx), ID($nex), ID($ge), ID($gt),
-						ID($logic_not), ID($logic_and), ID($logic_or)) && GetSize(c->getPort(ID(Y))) > 1) {
-					SigSpec sig = c->getPort(ID(Y));
+						ID($logic_not), ID($logic_and), ID($logic_or)) && GetSize(c->getPort(ID::Y)) > 1) {
+					SigSpec sig = c->getPort(ID::Y);
 					if (!sig.has_const()) {
-						c->setPort(ID(Y), sig[0]);
+						c->setPort(ID::Y, sig[0]);
 						c->setParam(ID(Y_WIDTH), 1);
 						sig.remove(0);
 						module->connect(sig, Const(0, GetSize(sig)));
@@ -542,7 +542,7 @@ struct WreducePass : public Pass {
 
 				if (c->type.in(ID($div), ID($mod), ID($pow)))
 				{
-					SigSpec A = c->getPort(ID(A));
+					SigSpec A = c->getPort(ID::A);
 					int original_a_width = GetSize(A);
 					if (c->getParam(ID(A_SIGNED)).as_bool()) {
 						while (GetSize(A) > 1 && A[GetSize(A)-1] == State::S0 && A[GetSize(A)-2] == State::S0)
@@ -554,11 +554,11 @@ struct WreducePass : public Pass {
 					if (original_a_width != GetSize(A)) {
 						log("Removed top %d bits (of %d) from port A of cell %s.%s (%s).\n",
 								original_a_width-GetSize(A), original_a_width, log_id(module), log_id(c), log_id(c->type));
-						c->setPort(ID(A), A);
+						c->setPort(ID::A, A);
 						c->setParam(ID(A_WIDTH), GetSize(A));
 					}
 
-					SigSpec B = c->getPort(ID(B));
+					SigSpec B = c->getPort(ID::B);
 					int original_b_width = GetSize(B);
 					if (c->getParam(ID(B_SIGNED)).as_bool()) {
 						while (GetSize(B) > 1 && B[GetSize(B)-1] == State::S0 && B[GetSize(B)-2] == State::S0)
@@ -570,7 +570,7 @@ struct WreducePass : public Pass {
 					if (original_b_width != GetSize(B)) {
 						log("Removed top %d bits (of %d) from port B of cell %s.%s (%s).\n",
 								original_b_width-GetSize(B), original_b_width, log_id(module), log_id(c), log_id(c->type));
-						c->setPort(ID(B), B);
+						c->setPort(ID::B, B);
 						c->setParam(ID(B_WIDTH), GetSize(B));
 					}
 				}

--- a/passes/opt/wreduce.cc
+++ b/passes/opt/wreduce.cc
@@ -22,7 +22,6 @@
 #include "kernel/modtools.h"
 
 USING_YOSYS_NAMESPACE
-using namespace RTLIL;
 
 PRIVATE_NAMESPACE_BEGIN
 
@@ -77,15 +76,15 @@ struct WreduceWorker
 		{
 			auto info = mi.query(sig_y[i]);
 			if (!info->is_output && GetSize(info->ports) <= 1 && !keep_bits.count(mi.sigmap(sig_y[i]))) {
-				bits_removed.push_back(Sx);
+				bits_removed.push_back(State::Sx);
 				continue;
 			}
 
 			SigBit ref = sig_a[i];
 			for (int k = 0; k < GetSize(sig_s); k++) {
-				if ((config->keepdc || (ref != Sx && sig_b[k*GetSize(sig_a) + i] != Sx)) && ref != sig_b[k*GetSize(sig_a) + i])
+				if ((config->keepdc || (ref != State::Sx && sig_b[k*GetSize(sig_a) + i] != State::Sx)) && ref != sig_b[k*GetSize(sig_a) + i])
 					goto no_match_ab;
-				if (sig_b[k*GetSize(sig_a) + i] != Sx)
+				if (sig_b[k*GetSize(sig_a) + i] != State::Sx)
 					ref = sig_b[k*GetSize(sig_a) + i];
 			}
 			if (0)
@@ -245,7 +244,7 @@ struct WreduceWorker
 			while (GetSize(sig) > 1 && sig[GetSize(sig)-1] == sig[GetSize(sig)-2])
 				work_queue_bits.insert(sig[GetSize(sig)-1]), sig.remove(GetSize(sig)-1), bits_removed++;
 		} else {
-			while (GetSize(sig) > 1 && sig[GetSize(sig)-1] == S0)
+			while (GetSize(sig) > 1 && sig[GetSize(sig)-1] == State::S0)
 				work_queue_bits.insert(sig[GetSize(sig)-1]), sig.remove(GetSize(sig)-1), bits_removed++;
 		}
 
@@ -359,7 +358,7 @@ struct WreduceWorker
 				max_y_size = a_size + b_size;
 
 			while (GetSize(sig) > 1 && GetSize(sig) > max_y_size) {
-				module->connect(sig[GetSize(sig)-1], is_signed ? sig[GetSize(sig)-2] : S0);
+				module->connect(sig[GetSize(sig)-1], is_signed ? sig[GetSize(sig)-2] : State::S0);
 				sig.remove(GetSize(sig)-1);
 				bits_removed++;
 			}

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -211,8 +211,8 @@ void extract_cell(RTLIL::Cell *cell, bool keepff)
 
 	if (cell->type.in(ID($_BUF_), ID($_NOT_)))
 	{
-		RTLIL::SigSpec sig_a = cell->getPort(ID(A));
-		RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+		RTLIL::SigSpec sig_a = cell->getPort(ID::A);
+		RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 
 		assign_map.apply(sig_a);
 		assign_map.apply(sig_y);
@@ -225,9 +225,9 @@ void extract_cell(RTLIL::Cell *cell, bool keepff)
 
 	if (cell->type.in(ID($_AND_), ID($_NAND_), ID($_OR_), ID($_NOR_), ID($_XOR_), ID($_XNOR_), ID($_ANDNOT_), ID($_ORNOT_)))
 	{
-		RTLIL::SigSpec sig_a = cell->getPort(ID(A));
-		RTLIL::SigSpec sig_b = cell->getPort(ID(B));
-		RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+		RTLIL::SigSpec sig_a = cell->getPort(ID::A);
+		RTLIL::SigSpec sig_b = cell->getPort(ID::B);
+		RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 
 		assign_map.apply(sig_a);
 		assign_map.apply(sig_b);
@@ -261,10 +261,10 @@ void extract_cell(RTLIL::Cell *cell, bool keepff)
 
 	if (cell->type.in(ID($_MUX_), ID($_NMUX_)))
 	{
-		RTLIL::SigSpec sig_a = cell->getPort(ID(A));
-		RTLIL::SigSpec sig_b = cell->getPort(ID(B));
+		RTLIL::SigSpec sig_a = cell->getPort(ID::A);
+		RTLIL::SigSpec sig_b = cell->getPort(ID::B);
 		RTLIL::SigSpec sig_s = cell->getPort(ID(S));
-		RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+		RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 
 		assign_map.apply(sig_a);
 		assign_map.apply(sig_b);
@@ -283,10 +283,10 @@ void extract_cell(RTLIL::Cell *cell, bool keepff)
 
 	if (cell->type.in(ID($_AOI3_), ID($_OAI3_)))
 	{
-		RTLIL::SigSpec sig_a = cell->getPort(ID(A));
-		RTLIL::SigSpec sig_b = cell->getPort(ID(B));
+		RTLIL::SigSpec sig_a = cell->getPort(ID::A);
+		RTLIL::SigSpec sig_b = cell->getPort(ID::B);
 		RTLIL::SigSpec sig_c = cell->getPort(ID(C));
-		RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+		RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 
 		assign_map.apply(sig_a);
 		assign_map.apply(sig_b);
@@ -305,11 +305,11 @@ void extract_cell(RTLIL::Cell *cell, bool keepff)
 
 	if (cell->type.in(ID($_AOI4_), ID($_OAI4_)))
 	{
-		RTLIL::SigSpec sig_a = cell->getPort(ID(A));
-		RTLIL::SigSpec sig_b = cell->getPort(ID(B));
+		RTLIL::SigSpec sig_a = cell->getPort(ID::A);
+		RTLIL::SigSpec sig_b = cell->getPort(ID::B);
 		RTLIL::SigSpec sig_c = cell->getPort(ID(C));
 		RTLIL::SigSpec sig_d = cell->getPort(ID(D));
-		RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+		RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 
 		assign_map.apply(sig_a);
 		assign_map.apply(sig_b);
@@ -1042,63 +1042,63 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 				cell_stats[RTLIL::unescape_id(c->type)]++;
 				if (c->type.in(ID(ZERO), ID(ONE))) {
 					RTLIL::SigSig conn;
-					conn.first = RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(Y)).as_wire()->name)]);
+					conn.first = RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::Y).as_wire()->name)]);
 					conn.second = RTLIL::SigSpec(c->type == ID(ZERO) ? 0 : 1, 1);
 					module->connect(conn);
 					continue;
 				}
 				if (c->type == ID(BUF)) {
 					RTLIL::SigSig conn;
-					conn.first = RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(Y)).as_wire()->name)]);
-					conn.second = RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(A)).as_wire()->name)]);
+					conn.first = RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::Y).as_wire()->name)]);
+					conn.second = RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::A).as_wire()->name)]);
 					module->connect(conn);
 					continue;
 				}
 				if (c->type == ID(NOT)) {
 					RTLIL::Cell *cell = module->addCell(remap_name(c->name), ID($_NOT_));
 					if (markgroups) cell->attributes[ID(abcgroup)] = map_autoidx;
-					cell->setPort(ID(A), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(A)).as_wire()->name)]));
-					cell->setPort(ID(Y), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(Y)).as_wire()->name)]));
+					cell->setPort(ID::A, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::A).as_wire()->name)]));
+					cell->setPort(ID::Y, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::Y).as_wire()->name)]));
 					design->select(module, cell);
 					continue;
 				}
 				if (c->type.in(ID(AND), ID(OR), ID(XOR), ID(NAND), ID(NOR), ID(XNOR), ID(ANDNOT), ID(ORNOT))) {
 					RTLIL::Cell *cell = module->addCell(remap_name(c->name), stringf("$_%s_", c->type.c_str()+1));
 					if (markgroups) cell->attributes[ID(abcgroup)] = map_autoidx;
-					cell->setPort(ID(A), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(A)).as_wire()->name)]));
-					cell->setPort(ID(B), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(B)).as_wire()->name)]));
-					cell->setPort(ID(Y), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(Y)).as_wire()->name)]));
+					cell->setPort(ID::A, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::A).as_wire()->name)]));
+					cell->setPort(ID::B, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::B).as_wire()->name)]));
+					cell->setPort(ID::Y, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::Y).as_wire()->name)]));
 					design->select(module, cell);
 					continue;
 				}
 				if (c->type.in(ID(MUX), ID(NMUX))) {
 					RTLIL::Cell *cell = module->addCell(remap_name(c->name), stringf("$_%s_", c->type.c_str()+1));
 					if (markgroups) cell->attributes[ID(abcgroup)] = map_autoidx;
-					cell->setPort(ID(A), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(A)).as_wire()->name)]));
-					cell->setPort(ID(B), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(B)).as_wire()->name)]));
+					cell->setPort(ID::A, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::A).as_wire()->name)]));
+					cell->setPort(ID::B, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::B).as_wire()->name)]));
 					cell->setPort(ID(S), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(S)).as_wire()->name)]));
-					cell->setPort(ID(Y), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(Y)).as_wire()->name)]));
+					cell->setPort(ID::Y, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::Y).as_wire()->name)]));
 					design->select(module, cell);
 					continue;
 				}
 				if (c->type == ID(MUX4)) {
 					RTLIL::Cell *cell = module->addCell(remap_name(c->name), ID($_MUX4_));
 					if (markgroups) cell->attributes[ID(abcgroup)] = map_autoidx;
-					cell->setPort(ID(A), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(A)).as_wire()->name)]));
-					cell->setPort(ID(B), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(B)).as_wire()->name)]));
+					cell->setPort(ID::A, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::A).as_wire()->name)]));
+					cell->setPort(ID::B, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::B).as_wire()->name)]));
 					cell->setPort(ID(C), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(C)).as_wire()->name)]));
 					cell->setPort(ID(D), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(D)).as_wire()->name)]));
 					cell->setPort(ID(S), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(S)).as_wire()->name)]));
 					cell->setPort(ID(T), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(T)).as_wire()->name)]));
-					cell->setPort(ID(Y), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(Y)).as_wire()->name)]));
+					cell->setPort(ID::Y, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::Y).as_wire()->name)]));
 					design->select(module, cell);
 					continue;
 				}
 				if (c->type == ID(MUX8)) {
 					RTLIL::Cell *cell = module->addCell(remap_name(c->name), ID($_MUX8_));
 					if (markgroups) cell->attributes[ID(abcgroup)] = map_autoidx;
-					cell->setPort(ID(A), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(A)).as_wire()->name)]));
-					cell->setPort(ID(B), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(B)).as_wire()->name)]));
+					cell->setPort(ID::A, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::A).as_wire()->name)]));
+					cell->setPort(ID::B, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::B).as_wire()->name)]));
 					cell->setPort(ID(C), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(C)).as_wire()->name)]));
 					cell->setPort(ID(D), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(D)).as_wire()->name)]));
 					cell->setPort(ID(E), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(E)).as_wire()->name)]));
@@ -1108,15 +1108,15 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 					cell->setPort(ID(S), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(S)).as_wire()->name)]));
 					cell->setPort(ID(T), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(T)).as_wire()->name)]));
 					cell->setPort(ID(U), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(U)).as_wire()->name)]));
-					cell->setPort(ID(Y), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(Y)).as_wire()->name)]));
+					cell->setPort(ID::Y, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::Y).as_wire()->name)]));
 					design->select(module, cell);
 					continue;
 				}
 				if (c->type == ID(MUX16)) {
 					RTLIL::Cell *cell = module->addCell(remap_name(c->name), ID($_MUX16_));
 					if (markgroups) cell->attributes[ID(abcgroup)] = map_autoidx;
-					cell->setPort(ID(A), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(A)).as_wire()->name)]));
-					cell->setPort(ID(B), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(B)).as_wire()->name)]));
+					cell->setPort(ID::A, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::A).as_wire()->name)]));
+					cell->setPort(ID::B, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::B).as_wire()->name)]));
 					cell->setPort(ID(C), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(C)).as_wire()->name)]));
 					cell->setPort(ID(D), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(D)).as_wire()->name)]));
 					cell->setPort(ID(E), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(E)).as_wire()->name)]));
@@ -1135,28 +1135,28 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 					cell->setPort(ID(T), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(T)).as_wire()->name)]));
 					cell->setPort(ID(U), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(U)).as_wire()->name)]));
 					cell->setPort(ID(V), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(V)).as_wire()->name)]));
-					cell->setPort(ID(Y), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(Y)).as_wire()->name)]));
+					cell->setPort(ID::Y, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::Y).as_wire()->name)]));
 					design->select(module, cell);
 					continue;
 				}
 				if (c->type.in(ID(AOI3), ID(OAI3))) {
 					RTLIL::Cell *cell = module->addCell(remap_name(c->name), stringf("$_%s_", c->type.c_str()+1));
 					if (markgroups) cell->attributes[ID(abcgroup)] = map_autoidx;
-					cell->setPort(ID(A), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(A)).as_wire()->name)]));
-					cell->setPort(ID(B), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(B)).as_wire()->name)]));
+					cell->setPort(ID::A, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::A).as_wire()->name)]));
+					cell->setPort(ID::B, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::B).as_wire()->name)]));
 					cell->setPort(ID(C), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(C)).as_wire()->name)]));
-					cell->setPort(ID(Y), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(Y)).as_wire()->name)]));
+					cell->setPort(ID::Y, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::Y).as_wire()->name)]));
 					design->select(module, cell);
 					continue;
 				}
 				if (c->type.in(ID(AOI4), ID(OAI4))) {
 					RTLIL::Cell *cell = module->addCell(remap_name(c->name), stringf("$_%s_", c->type.c_str()+1));
 					if (markgroups) cell->attributes[ID(abcgroup)] = map_autoidx;
-					cell->setPort(ID(A), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(A)).as_wire()->name)]));
-					cell->setPort(ID(B), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(B)).as_wire()->name)]));
+					cell->setPort(ID::A, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::A).as_wire()->name)]));
+					cell->setPort(ID::B, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::B).as_wire()->name)]));
 					cell->setPort(ID(C), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(C)).as_wire()->name)]));
 					cell->setPort(ID(D), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(D)).as_wire()->name)]));
-					cell->setPort(ID(Y), RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID(Y)).as_wire()->name)]));
+					cell->setPort(ID::Y, RTLIL::SigSpec(module->wires_[remap_name(c->getPort(ID::Y).as_wire()->name)]));
 					design->select(module, cell);
 					continue;
 				}
@@ -1207,9 +1207,9 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 				continue;
 			}
 
-			if (c->type == ID($lut) && GetSize(c->getPort(ID(A))) == 1 && c->getParam(ID(LUT)).as_int() == 2) {
-				SigSpec my_a = module->wires_[remap_name(c->getPort(ID(A)).as_wire()->name)];
-				SigSpec my_y = module->wires_[remap_name(c->getPort(ID(Y)).as_wire()->name)];
+			if (c->type == ID($lut) && GetSize(c->getPort(ID::A)) == 1 && c->getParam(ID(LUT)).as_int() == 2) {
+				SigSpec my_a = module->wires_[remap_name(c->getPort(ID::A).as_wire()->name)];
+				SigSpec my_y = module->wires_[remap_name(c->getPort(ID::Y).as_wire()->name)];
 				module->connect(my_y, my_a);
 				continue;
 			}

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -198,7 +198,7 @@ void extract_cell(RTLIL::Cell *cell, bool keepff)
 		if (keepff)
 			for (auto &c : sig_q.chunks())
 				if (c.wire != NULL)
-					c.wire->attributes[ID(keep)] = 1;
+					c.wire->attributes[ID::keep] = 1;
 
 		assign_map.apply(sig_d);
 		assign_map.apply(sig_q);
@@ -787,7 +787,7 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 		extract_cell(c, keepff);
 
 	for (auto &wire_it : module->wires_) {
-		if (wire_it.second->port_id > 0 || wire_it.second->get_bool_attribute(ID(keep)))
+		if (wire_it.second->port_id > 0 || wire_it.second->get_bool_attribute(ID::keep))
 			mark_port(RTLIL::SigSpec(wire_it.second));
 	}
 

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -582,13 +582,13 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 
 			RTLIL::Cell *cell = nullptr;
 			if (c->type == ID($_NOT_)) {
-				RTLIL::SigBit a_bit = c->getPort(ID(A));
-				RTLIL::SigBit y_bit = c->getPort(ID(Y));
+				RTLIL::SigBit a_bit = c->getPort(ID::A);
+				RTLIL::SigBit y_bit = c->getPort(ID::Y);
 				bit_users[a_bit].insert(c->name);
 				bit_drivers[y_bit].insert(c->name);
 
 				if (!a_bit.wire) {
-					c->setPort(ID(Y), module->addWire(NEW_ID));
+					c->setPort(ID::Y, module->addWire(NEW_ID));
 					RTLIL::Wire *wire = module->wire(remap_name(y_bit.wire->name));
 					log_assert(wire);
 					module->connect(RTLIL::SigBit(wire, y_bit.offset), State::S1);
@@ -616,7 +616,7 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 								RTLIL::SigBit(module->wires_.at(remap_name(a_bit.wire->name)), a_bit.offset),
 								RTLIL::SigBit(module->wires_.at(remap_name(y_bit.wire->name)), y_bit.offset),
 								RTLIL::Const::from_string("01"));
-						bit2sinks[cell->getPort(ID(A))].push_back(cell);
+						bit2sinks[cell->getPort(ID::A)].push_back(cell);
 						cell_stats[ID($lut)]++;
 					}
 					else
@@ -632,9 +632,9 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 
 			RTLIL::Cell *existing_cell = nullptr;
 			if (c->type == ID($lut)) {
-				if (GetSize(c->getPort(ID(A))) == 1 && c->getParam(ID(LUT)) == RTLIL::Const::from_string("01")) {
-					SigSpec my_a = module->wires_.at(remap_name(c->getPort(ID(A)).as_wire()->name));
-					SigSpec my_y = module->wires_.at(remap_name(c->getPort(ID(Y)).as_wire()->name));
+				if (GetSize(c->getPort(ID::A)) == 1 && c->getParam(ID(LUT)) == RTLIL::Const::from_string("01")) {
+					SigSpec my_a = module->wires_.at(remap_name(c->getPort(ID::A).as_wire()->name));
+					SigSpec my_y = module->wires_.at(remap_name(c->getPort(ID::Y).as_wire()->name));
 					module->connect(my_y, my_a);
 					if (markgroups) c->attributes[ID(abcgroup)] = map_autoidx;
 					log_abort();
@@ -751,8 +751,8 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 			if (it == not2drivers.end())
 				continue;
 			RTLIL::Cell *driver_lut = it->second;
-			RTLIL::SigBit a_bit = not_cell->getPort(ID(A));
-			RTLIL::SigBit y_bit = not_cell->getPort(ID(Y));
+			RTLIL::SigBit a_bit = not_cell->getPort(ID::A);
+			RTLIL::SigBit y_bit = not_cell->getPort(ID::Y);
 			RTLIL::Const driver_mask;
 
 			a_bit.wire = module->wires_.at(remap_name(a_bit.wire->name));
@@ -768,7 +768,7 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 
 			// Push downstream LUTs past inverter
 			for (auto sink_cell : jt->second) {
-				SigSpec A = sink_cell->getPort(ID(A));
+				SigSpec A = sink_cell->getPort(ID::A);
 				RTLIL::Const mask = sink_cell->getParam(ID(LUT));
 				int index = 0;
 				for (; index < GetSize(A); index++)
@@ -782,7 +782,7 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 					i += 1 << (index+1);
 				}
 				A[index] = y_bit;
-				sink_cell->setPort(ID(A), A);
+				sink_cell->setPort(ID::A, A);
 				sink_cell->setParam(ID(LUT), mask);
 			}
 
@@ -798,10 +798,10 @@ clone_lut:
 				else if (b == RTLIL::State::S1) b = RTLIL::State::S0;
 			}
 			auto cell = module->addLut(NEW_ID,
-					driver_lut->getPort(ID(A)),
+					driver_lut->getPort(ID::A),
 					y_bit,
 					driver_mask);
-			for (auto &bit : cell->connections_.at(ID(A))) {
+			for (auto &bit : cell->connections_.at(ID::A)) {
 				bit.wire = module->wires_.at(remap_name(bit.wire->name));
 				bit2sinks[bit].push_back(cell);
 			}

--- a/passes/techmap/alumacc.cc
+++ b/passes/techmap/alumacc.cc
@@ -91,7 +91,7 @@ struct AlumaccWorker
 
 		RTLIL::SigSpec get_sf() {
 			if (GetSize(cached_sf) == 0) {
-				cached_sf = alu_cell->getPort(ID(Y));
+				cached_sf = alu_cell->getPort(ID::Y);
 				cached_sf = cached_sf[GetSize(cached_sf)-1];
 			}
 			return cached_sf;
@@ -134,7 +134,7 @@ struct AlumaccWorker
 			Macc::port_t new_port;
 
 			n->cell = cell;
-			n->y = sigmap(cell->getPort(ID(Y)));
+			n->y = sigmap(cell->getPort(ID::Y));
 			n->users = 0;
 
 			for (auto bit : n->y)
@@ -142,7 +142,7 @@ struct AlumaccWorker
 
 			if (cell->type.in(ID($pos), ID($neg)))
 			{
-				new_port.in_a = sigmap(cell->getPort(ID(A)));
+				new_port.in_a = sigmap(cell->getPort(ID::A));
 				new_port.is_signed = cell->getParam(ID(A_SIGNED)).as_bool();
 				new_port.do_subtract = cell->type == ID($neg);
 				n->macc.ports.push_back(new_port);
@@ -150,12 +150,12 @@ struct AlumaccWorker
 
 			if (cell->type.in(ID($add), ID($sub)))
 			{
-				new_port.in_a = sigmap(cell->getPort(ID(A)));
+				new_port.in_a = sigmap(cell->getPort(ID::A));
 				new_port.is_signed = cell->getParam(ID(A_SIGNED)).as_bool();
 				new_port.do_subtract = false;
 				n->macc.ports.push_back(new_port);
 
-				new_port.in_a = sigmap(cell->getPort(ID(B)));
+				new_port.in_a = sigmap(cell->getPort(ID::B));
 				new_port.is_signed = cell->getParam(ID(B_SIGNED)).as_bool();
 				new_port.do_subtract = cell->type == ID($sub);
 				n->macc.ports.push_back(new_port);
@@ -163,8 +163,8 @@ struct AlumaccWorker
 
 			if (cell->type.in(ID($mul)))
 			{
-				new_port.in_a = sigmap(cell->getPort(ID(A)));
-				new_port.in_b = sigmap(cell->getPort(ID(B)));
+				new_port.in_a = sigmap(cell->getPort(ID::A));
+				new_port.in_b = sigmap(cell->getPort(ID::B));
 				new_port.is_signed = cell->getParam(ID(A_SIGNED)).as_bool();
 				new_port.do_subtract = false;
 				n->macc.ports.push_back(new_port);
@@ -361,7 +361,7 @@ struct AlumaccWorker
 
 			n->macc.optimize(GetSize(n->y));
 			n->macc.to_cell(cell);
-			cell->setPort(ID(Y), n->y);
+			cell->setPort(ID::Y, n->y);
 			cell->fixup_parameters();
 			module->remove(n->cell);
 			delete n;
@@ -390,9 +390,9 @@ struct AlumaccWorker
 			bool cmp_equal = cell->type.in(ID($le), ID($ge));
 			bool is_signed = cell->getParam(ID(A_SIGNED)).as_bool();
 
-			RTLIL::SigSpec A = sigmap(cell->getPort(ID(A)));
-			RTLIL::SigSpec B = sigmap(cell->getPort(ID(B)));
-			RTLIL::SigSpec Y = sigmap(cell->getPort(ID(Y)));
+			RTLIL::SigSpec A = sigmap(cell->getPort(ID::A));
+			RTLIL::SigSpec B = sigmap(cell->getPort(ID::B));
+			RTLIL::SigSpec Y = sigmap(cell->getPort(ID::Y));
 
 			if (B < A && GetSize(B)) {
 				cmp_less = !cmp_less;
@@ -430,9 +430,9 @@ struct AlumaccWorker
 			bool cmp_equal = cell->type.in(ID($eq), ID($eqx));
 			bool is_signed = cell->getParam(ID(A_SIGNED)).as_bool();
 
-			RTLIL::SigSpec A = sigmap(cell->getPort(ID(A)));
-			RTLIL::SigSpec B = sigmap(cell->getPort(ID(B)));
-			RTLIL::SigSpec Y = sigmap(cell->getPort(ID(Y)));
+			RTLIL::SigSpec A = sigmap(cell->getPort(ID::A));
+			RTLIL::SigSpec B = sigmap(cell->getPort(ID::B));
+			RTLIL::SigSpec Y = sigmap(cell->getPort(ID::Y));
 
 			if (B < A && GetSize(B))
 				std::swap(A, B);
@@ -482,11 +482,11 @@ struct AlumaccWorker
 			if (n->cells.size() > 0)
 				n->alu_cell->set_src_attribute(n->cells[0]->get_src_attribute());
 
-			n->alu_cell->setPort(ID(A), n->a);
-			n->alu_cell->setPort(ID(B), n->b);
+			n->alu_cell->setPort(ID::A, n->a);
+			n->alu_cell->setPort(ID::B, n->b);
 			n->alu_cell->setPort(ID(CI), GetSize(n->c) ? n->c : State::S0);
 			n->alu_cell->setPort(ID(BI), n->invert_b ? State::S1 : State::S0);
-			n->alu_cell->setPort(ID(Y), n->y);
+			n->alu_cell->setPort(ID::Y, n->y);
 			n->alu_cell->setPort(ID(X), module->addWire(NEW_ID, GetSize(n->y)));
 			n->alu_cell->setPort(ID(CO), module->addWire(NEW_ID, GetSize(n->y)));
 			n->alu_cell->fixup_parameters(n->is_signed, n->is_signed);

--- a/passes/techmap/deminout.cc
+++ b/passes/techmap/deminout.cc
@@ -83,13 +83,13 @@ struct DeminoutPass : public Pass {
 						for (auto bit : sigmap(conn.second))
 							bits_used.insert(bit);
 
-					if (conn.first == ID(Y) && cell->type.in(ID($mux), ID($pmux), ID($_MUX_), ID($_TBUF_), ID($tribuf)))
+					if (conn.first == ID::Y && cell->type.in(ID($mux), ID($pmux), ID($_MUX_), ID($_TBUF_), ID($tribuf)))
 					{
 						bool tribuf = cell->type.in(ID($_TBUF_), ID($tribuf));
 
 						if (!tribuf) {
 							for (auto &c : cell->connections()) {
-								if (!c.first.in(ID(A), ID(B)))
+								if (!c.first.in(ID::A, ID::B))
 									continue;
 								for (auto b : sigmap(c.second))
 									if (b == State::Sz)

--- a/passes/techmap/dff2dffe.cc
+++ b/passes/techmap/dff2dffe.cc
@@ -53,7 +53,7 @@ struct Dff2dffeWorker
 
 		for (auto cell : module->cells()) {
 			if (cell->type.in(ID($mux), ID($pmux), ID($_MUX_))) {
-				RTLIL::SigSpec sig_y = sigmap(cell->getPort(ID(Y)));
+				RTLIL::SigSpec sig_y = sigmap(cell->getPort(ID::Y));
 				for (int i = 0; i < GetSize(sig_y); i++)
 					bit2mux[sig_y[i]] = cell_int_t(cell, i);
 			}
@@ -86,8 +86,8 @@ struct Dff2dffeWorker
 			return ret;
 
 		cell_int_t mux_cell_int = bit2mux.at(d);
-		RTLIL::SigSpec sig_a = sigmap(mux_cell_int.first->getPort(ID(A)));
-		RTLIL::SigSpec sig_b = sigmap(mux_cell_int.first->getPort(ID(B)));
+		RTLIL::SigSpec sig_a = sigmap(mux_cell_int.first->getPort(ID::A));
+		RTLIL::SigSpec sig_b = sigmap(mux_cell_int.first->getPort(ID::B));
 		RTLIL::SigSpec sig_s = sigmap(mux_cell_int.first->getPort(ID(S)));
 		int width = GetSize(sig_a), index = mux_cell_int.second;
 
@@ -97,9 +97,9 @@ struct Dff2dffeWorker
 				ret = find_muxtree_feedback_patterns(sig_b[i*width + index], q, path);
 
 				if (sig_b[i*width + index] == q) {
-					RTLIL::SigSpec s = mux_cell_int.first->getPort(ID(B));
+					RTLIL::SigSpec s = mux_cell_int.first->getPort(ID::B);
 					s[i*width + index] = RTLIL::Sx;
-					mux_cell_int.first->setPort(ID(B), s);
+					mux_cell_int.first->setPort(ID::B, s);
 				}
 
 				return ret;
@@ -120,9 +120,9 @@ struct Dff2dffeWorker
 				ret.insert(pat);
 
 			if (sig_b[i*width + index] == q) {
-				RTLIL::SigSpec s = mux_cell_int.first->getPort(ID(B));
+				RTLIL::SigSpec s = mux_cell_int.first->getPort(ID::B);
 				s[i*width + index] = RTLIL::Sx;
-				mux_cell_int.first->setPort(ID(B), s);
+				mux_cell_int.first->setPort(ID::B, s);
 			}
 		}
 
@@ -130,9 +130,9 @@ struct Dff2dffeWorker
 			ret.insert(pat);
 
 		if (sig_a[index] == q) {
-			RTLIL::SigSpec s = mux_cell_int.first->getPort(ID(A));
+			RTLIL::SigSpec s = mux_cell_int.first->getPort(ID::A);
 			s[index] = RTLIL::Sx;
-			mux_cell_int.first->setPort(ID(A), s);
+			mux_cell_int.first->setPort(ID::A, s);
 		}
 
 		return ret;

--- a/passes/techmap/dff2dffs.cc
+++ b/passes/techmap/dff2dffs.cc
@@ -72,11 +72,11 @@ struct Dff2dffsPass : public Pass {
 				if (cell->type != ID($_MUX_))
 					continue;
 
-				SigBit bit_a = sigmap(cell->getPort(ID(A)));
-				SigBit bit_b = sigmap(cell->getPort(ID(B)));
+				SigBit bit_a = sigmap(cell->getPort(ID::A));
+				SigBit bit_b = sigmap(cell->getPort(ID::B));
 
 				if (bit_a.wire == nullptr || bit_b.wire == nullptr)
-					sr_muxes[sigmap(cell->getPort(ID(Y)))] = cell;
+					sr_muxes[sigmap(cell->getPort(ID::Y))] = cell;
 			}
 
 			for (auto cell : ff_cells)
@@ -92,8 +92,8 @@ struct Dff2dffsPass : public Pass {
 					continue;
 
 				Cell *mux_cell = sr_muxes.at(bit_d);
-				SigBit bit_a = sigmap(mux_cell->getPort(ID(A)));
-				SigBit bit_b = sigmap(mux_cell->getPort(ID(B)));
+				SigBit bit_a = sigmap(mux_cell->getPort(ID::A));
+				SigBit bit_b = sigmap(mux_cell->getPort(ID::B));
 				SigBit bit_s = sigmap(mux_cell->getPort(ID(S)));
 
 				log("  Merging %s (A=%s, B=%s, S=%s) into %s (%s).\n", log_id(mux_cell),

--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -485,7 +485,7 @@ static void dfflibmap(RTLIL::Design *design, RTLIL::Module *module, bool prepare
 		if (design->selected(module, it.second) && cell_mappings.count(it.second->type) > 0)
 			cell_list.push_back(it.second);
 		if (it.second->type == ID($_NOT_))
-			notmap[sigmap(it.second->getPort(ID(A)))].insert(it.second);
+			notmap[sigmap(it.second->getPort(ID::A))].insert(it.second);
 	}
 
 	std::map<std::string, int> stats;
@@ -519,8 +519,8 @@ static void dfflibmap(RTLIL::Design *design, RTLIL::Module *module, bool prepare
 				sig = module->addWire(NEW_ID, GetSize(old_sig));
 				if (has_q && has_qn) {
 					for (auto &it : notmap[sigmap(old_sig)]) {
-						module->connect(it->getPort(ID(Y)), sig);
-						it->setPort(ID(Y), module->addWire(NEW_ID, GetSize(old_sig)));
+						module->connect(it->getPort(ID::Y), sig);
+						it->setPort(ID::Y, module->addWire(NEW_ID, GetSize(old_sig)));
 					}
 				} else {
 					module->addNotGate(NEW_ID, sig, old_sig);

--- a/passes/techmap/extract_fa.cc
+++ b/passes/techmap/extract_fa.cc
@@ -89,7 +89,7 @@ struct ExtractFaWorker
 					ID($_XOR_), ID($_XNOR_), ID($_ANDNOT_), ID($_ORNOT_), ID($_MUX_), ID($_NMUX_),
 					ID($_AOI3_), ID($_OAI3_), ID($_AOI4_), ID($_OAI4_)))
 			{
-				SigBit y = sigmap(SigBit(cell->getPort(ID(Y))));
+				SigBit y = sigmap(SigBit(cell->getPort(ID::Y)));
 				log_assert(driver.count(y) == 0);
 				driver[y] = cell;
 			}
@@ -262,8 +262,8 @@ struct ExtractFaWorker
 			pool<SigBit> new_leaves = leaves;
 
 			new_leaves.erase(bit);
-			if (cell->hasPort(ID(A))) new_leaves.insert(sigmap(SigBit(cell->getPort(ID(A)))));
-			if (cell->hasPort(ID(B))) new_leaves.insert(sigmap(SigBit(cell->getPort(ID(B)))));
+			if (cell->hasPort(ID::A)) new_leaves.insert(sigmap(SigBit(cell->getPort(ID::A))));
+			if (cell->hasPort(ID::B)) new_leaves.insert(sigmap(SigBit(cell->getPort(ID::B))));
 			if (cell->hasPort(ID(C))) new_leaves.insert(sigmap(SigBit(cell->getPort(ID(C)))));
 			if (cell->hasPort(ID(D))) new_leaves.insert(sigmap(SigBit(cell->getPort(ID(D)))));
 
@@ -277,8 +277,8 @@ struct ExtractFaWorker
 	void assign_new_driver(SigBit bit, SigBit new_driver)
 	{
 		Cell *cell = driver.at(bit);
-		if (sigmap(cell->getPort(ID(Y))) == bit) {
-			cell->setPort(ID(Y), module->addWire(NEW_ID));
+		if (sigmap(cell->getPort(ID::Y)) == bit) {
+			cell->setPort(ID::Y, module->addWire(NEW_ID));
 			module->connect(bit, new_driver);
 		}
 	}
@@ -395,15 +395,15 @@ struct ExtractFaWorker
 
 					log("      Created $fa cell %s.\n", log_id(cell));
 
-					cell->setPort(ID(A), f3i.inv_a ? module->NotGate(NEW_ID, A) : A);
-					cell->setPort(ID(B), f3i.inv_b ? module->NotGate(NEW_ID, B) : B);
+					cell->setPort(ID::A, f3i.inv_a ? module->NotGate(NEW_ID, A) : A);
+					cell->setPort(ID::B, f3i.inv_b ? module->NotGate(NEW_ID, B) : B);
 					cell->setPort(ID(C), f3i.inv_c ? module->NotGate(NEW_ID, C) : C);
 
 					X = module->addWire(NEW_ID);
 					Y = module->addWire(NEW_ID);
 
 					cell->setPort(ID(X), X);
-					cell->setPort(ID(Y), Y);
+					cell->setPort(ID::Y, Y);
 
 					facache[fakey] = make_tuple(X, Y, cell);
 				}
@@ -501,15 +501,15 @@ struct ExtractFaWorker
 
 					log("      Created $fa cell %s.\n", log_id(cell));
 
-					cell->setPort(ID(A), f2i.inv_a ? module->NotGate(NEW_ID, A) : A);
-					cell->setPort(ID(B), f2i.inv_b ? module->NotGate(NEW_ID, B) : B);
+					cell->setPort(ID::A, f2i.inv_a ? module->NotGate(NEW_ID, A) : A);
+					cell->setPort(ID::B, f2i.inv_b ? module->NotGate(NEW_ID, B) : B);
 					cell->setPort(ID(C), State::S0);
 
 					X = module->addWire(NEW_ID);
 					Y = module->addWire(NEW_ID);
 
 					cell->setPort(ID(X), X);
-					cell->setPort(ID(Y), Y);
+					cell->setPort(ID::Y, Y);
 				}
 
 				if (func2.at(key).count(xor2_func)) {

--- a/passes/techmap/extract_reduce.cc
+++ b/passes/techmap/extract_reduce.cc
@@ -148,7 +148,7 @@ struct ExtractReducePass : public Pass
 
 						head_cell = x;
 
-						auto y = sigmap(x->getPort(ID(Y)));
+						auto y = sigmap(x->getPort(ID::Y));
 						log_assert(y.size() == 1);
 
 						// Should only continue if there is one fanout back into a cell (not to a port)
@@ -166,7 +166,7 @@ struct ExtractReducePass : public Pass
 				{
 					//BFS, following all chains until they hit a cell of a different type
 					//Pick the longest one
-					auto y = sigmap(cell->getPort(ID(Y)));
+					auto y = sigmap(cell->getPort(ID::Y));
 					pool<Cell*> current_loads = sig_to_sink[y];
 					pool<Cell*> next_loads;
 
@@ -233,7 +233,7 @@ struct ExtractReducePass : public Pass
 
 						cur_supercell.insert(x);
 
-						auto a = sigmap(x->getPort(ID(A)));
+						auto a = sigmap(x->getPort(ID::A));
 						log_assert(a.size() == 1);
 
 						// Must have only one sink unless we're going off chain
@@ -249,7 +249,7 @@ struct ExtractReducePass : public Pass
 							}
 						}
 
-						auto b = sigmap(x->getPort(ID(B)));
+						auto b = sigmap(x->getPort(ID::B));
 						log_assert(b.size() == 1);
 
 						// Must have only one sink
@@ -279,16 +279,16 @@ struct ExtractReducePass : public Pass
 						pool<SigBit> input_pool_intermed;
 						for (auto x : cur_supercell)
 						{
-							input_pool.insert(sigmap(x->getPort(ID(A)))[0]);
-							input_pool.insert(sigmap(x->getPort(ID(B)))[0]);
-							input_pool_intermed.insert(sigmap(x->getPort(ID(Y)))[0]);
+							input_pool.insert(sigmap(x->getPort(ID::A))[0]);
+							input_pool.insert(sigmap(x->getPort(ID::B))[0]);
+							input_pool_intermed.insert(sigmap(x->getPort(ID::Y))[0]);
 						}
 						SigSpec input;
 						for (auto b : input_pool)
 							if (input_pool_intermed.count(b) == 0)
 								input.append_bit(b);
 
-						SigBit output = sigmap(head_cell->getPort(ID(Y))[0]);
+						SigBit output = sigmap(head_cell->getPort(ID::Y)[0]);
 
 						auto new_reduce_cell = module->addCell(NEW_ID,
 							gt == GateType::And ? ID($reduce_and) :
@@ -297,8 +297,8 @@ struct ExtractReducePass : public Pass
 						new_reduce_cell->setParam(ID(A_SIGNED), 0);
 						new_reduce_cell->setParam(ID(A_WIDTH), input.size());
 						new_reduce_cell->setParam(ID(Y_WIDTH), 1);
-						new_reduce_cell->setPort(ID(A), input);
-						new_reduce_cell->setPort(ID(Y), output);
+						new_reduce_cell->setPort(ID::A, input);
+						new_reduce_cell->setPort(ID::Y, output);
 
 						if(allow_off_chain)
 							consumed_cells.insert(head_cell);

--- a/passes/techmap/iopadmap.cc
+++ b/passes/techmap/iopadmap.cc
@@ -226,7 +226,7 @@ struct IopadmapPass : public Pass {
 							cell->setPort(RTLIL::escape_id(tinoutpad_portname2), owire);
 							cell->setPort(RTLIL::escape_id(tinoutpad_portname3), data_sig);
 							cell->setPort(RTLIL::escape_id(tinoutpad_portname4), wire_bit);
-							cell->attributes[ID(keep)] = RTLIL::Const(1);
+							cell->attributes[ID::keep] = RTLIL::Const(1);
 
 							for (auto cn : tbuf_cache.second) {
 								auto c = module->cell(cn);
@@ -263,7 +263,7 @@ struct IopadmapPass : public Pass {
 							cell->setPort(RTLIL::escape_id(toutpad_portname), en_sig);
 							cell->setPort(RTLIL::escape_id(toutpad_portname2), data_sig);
 							cell->setPort(RTLIL::escape_id(toutpad_portname3), wire_bit);
-							cell->attributes[ID(keep)] = RTLIL::Const(1);
+							cell->attributes[ID::keep] = RTLIL::Const(1);
 
 							for (auto cn : tbuf_cache.second) {
 								auto c = module->cell(cn);
@@ -390,7 +390,7 @@ struct IopadmapPass : public Pass {
 							cell->parameters[RTLIL::escape_id(widthparam)] = RTLIL::Const(1);
 						if (!nameparam.empty())
 							cell->parameters[RTLIL::escape_id(nameparam)] = RTLIL::Const(stringf("%s[%d]", RTLIL::id2cstr(wire->name), i));
-						cell->attributes[ID(keep)] = RTLIL::Const(1);
+						cell->attributes[ID::keep] = RTLIL::Const(1);
 					}
 				}
 				else
@@ -403,7 +403,7 @@ struct IopadmapPass : public Pass {
 						cell->parameters[RTLIL::escape_id(widthparam)] = RTLIL::Const(wire->width);
 					if (!nameparam.empty())
 						cell->parameters[RTLIL::escape_id(nameparam)] = RTLIL::Const(RTLIL::id2cstr(wire->name));
-					cell->attributes[ID(keep)] = RTLIL::Const(1);
+					cell->attributes[ID::keep] = RTLIL::Const(1);
 				}
 
 				wire->port_id = 0;

--- a/passes/techmap/iopadmap.cc
+++ b/passes/techmap/iopadmap.cc
@@ -180,7 +180,7 @@ struct IopadmapPass : public Pass {
 
 				for (auto cell : module->cells())
 					if (cell->type == ID($_TBUF_)) {
-						SigBit bit = sigmap(cell->getPort(ID(Y)).as_bit());
+						SigBit bit = sigmap(cell->getPort(ID::Y).as_bit());
 						tbuf_bits[bit].first = cell->name;
 					}
 
@@ -213,7 +213,7 @@ struct IopadmapPass : public Pass {
 							continue;
 
 						SigBit en_sig = tbuf_cell->getPort(ID(E)).as_bit();
-						SigBit data_sig = tbuf_cell->getPort(ID(A)).as_bit();
+						SigBit data_sig = tbuf_cell->getPort(ID::A).as_bit();
 
 						if (wire->port_input && !tinoutpad_celltype.empty())
 						{

--- a/passes/techmap/lut2mux.cc
+++ b/passes/techmap/lut2mux.cc
@@ -25,8 +25,8 @@ PRIVATE_NAMESPACE_BEGIN
 
 int lut2mux(Cell *cell)
 {
-	SigSpec sig_a = cell->getPort(ID(A));
-	SigSpec sig_y = cell->getPort(ID(Y));
+	SigSpec sig_a = cell->getPort(ID::A);
+	SigSpec sig_y = cell->getPort(ID::Y);
 	Const lut = cell->getParam(ID(LUT));
 	int count = 1;
 

--- a/passes/techmap/maccmap.cc
+++ b/passes/techmap/maccmap.cc
@@ -113,10 +113,10 @@ struct MaccmapWorker
 
 			RTLIL::Cell *cell = module->addCell(NEW_ID, ID($fa));
 			cell->setParam(ID(WIDTH), width);
-			cell->setPort(ID(A), in1);
-			cell->setPort(ID(B), in2);
+			cell->setPort(ID::A, in1);
+			cell->setPort(ID::B, in2);
 			cell->setPort(ID(C), in3);
-			cell->setPort(ID(Y), w1);
+			cell->setPort(ID::Y, w1);
 			cell->setPort(ID(X), w2);
 
 			out1 = {out_zeros_msb, w1, out_zeros_lsb};
@@ -238,11 +238,11 @@ struct MaccmapWorker
 
 
 		RTLIL::Cell *c = module->addCell(NEW_ID, ID($alu));
-		c->setPort(ID(A), summands.front());
-		c->setPort(ID(B), summands.back());
+		c->setPort(ID::A, summands.front());
+		c->setPort(ID::B, summands.back());
 		c->setPort(ID(CI), State::S0);
 		c->setPort(ID(BI), State::S0);
-		c->setPort(ID(Y), module->addWire(NEW_ID, width));
+		c->setPort(ID::Y, module->addWire(NEW_ID, width));
 		c->setPort(ID(X), module->addWire(NEW_ID, width));
 		c->setPort(ID(CO), module->addWire(NEW_ID, width));
 		c->fixup_parameters();
@@ -253,7 +253,7 @@ struct MaccmapWorker
 		}
 		log_assert(tree_sum_bits.empty());
 
-		return c->getPort(ID(Y));
+		return c->getPort(ID::Y);
 	}
 };
 
@@ -264,17 +264,17 @@ extern void maccmap(RTLIL::Module *module, RTLIL::Cell *cell, bool unmap = false
 
 void maccmap(RTLIL::Module *module, RTLIL::Cell *cell, bool unmap)
 {
-	int width = GetSize(cell->getPort(ID(Y)));
+	int width = GetSize(cell->getPort(ID::Y));
 
 	Macc macc;
 	macc.from_cell(cell);
 
 	RTLIL::SigSpec all_input_bits;
-	all_input_bits.append(cell->getPort(ID(A)));
-	all_input_bits.append(cell->getPort(ID(B)));
+	all_input_bits.append(cell->getPort(ID::A));
+	all_input_bits.append(cell->getPort(ID::B));
 
 	if (all_input_bits.to_sigbit_set().count(RTLIL::Sx)) {
-		module->connect(cell->getPort(ID(Y)), RTLIL::SigSpec(RTLIL::Sx, width));
+		module->connect(cell->getPort(ID::Y), RTLIL::SigSpec(RTLIL::Sx, width));
 		return;
 	}
 
@@ -339,9 +339,9 @@ void maccmap(RTLIL::Module *module, RTLIL::Cell *cell, bool unmap)
 		}
 
 		if (summands.front().second)
-			module->addNeg(NEW_ID, summands.front().first, cell->getPort(ID(Y)));
+			module->addNeg(NEW_ID, summands.front().first, cell->getPort(ID::Y));
 		else
-			module->connect(cell->getPort(ID(Y)), summands.front().first);
+			module->connect(cell->getPort(ID::Y), summands.front().first);
 	}
 	else
 	{
@@ -356,7 +356,7 @@ void maccmap(RTLIL::Module *module, RTLIL::Cell *cell, bool unmap)
 		for (auto &bit : macc.bit_ports)
 			worker.add(bit, 0);
 
-		module->connect(cell->getPort(ID(Y)), worker.synth());
+		module->connect(cell->getPort(ID::Y), worker.synth());
 	}
 }
 

--- a/passes/techmap/muxcover.cc
+++ b/passes/techmap/muxcover.cc
@@ -122,7 +122,7 @@ struct MuxcoverWorker
 				}
 			}
 			if (cell->type == ID($_MUX_))
-				sig_to_mux[sigmap(cell->getPort(ID(Y)))] = cell;
+				sig_to_mux[sigmap(cell->getPort(ID::Y))] = cell;
 		}
 
 		log("  Treeifying %d MUXes:\n", GetSize(sig_to_mux));
@@ -141,8 +141,8 @@ struct MuxcoverWorker
 				if (sig_to_mux.count(bit) && (bit == rootsig || !roots.count(bit))) {
 					Cell *c = sig_to_mux.at(bit);
 					tree.muxes[bit] = c;
-					wavefront.insert(sigmap(c->getPort(ID(A))));
-					wavefront.insert(sigmap(c->getPort(ID(B))));
+					wavefront.insert(sigmap(c->getPort(ID::A)));
+					wavefront.insert(sigmap(c->getPort(ID::B)));
 				}
 			}
 
@@ -517,31 +517,31 @@ struct MuxcoverWorker
 		if (GetSize(mux.inputs) == 2) {
 			count_muxes_by_type[0]++;
 			Cell *cell = module->addCell(NEW_ID, ID($_MUX_));
-			cell->setPort(ID(A), mux.inputs[0]);
-			cell->setPort(ID(B), mux.inputs[1]);
+			cell->setPort(ID::A, mux.inputs[0]);
+			cell->setPort(ID::B, mux.inputs[1]);
 			cell->setPort(ID(S), mux.selects[0]);
-			cell->setPort(ID(Y), bit);
+			cell->setPort(ID::Y, bit);
 			return;
 		}
 
 		if (GetSize(mux.inputs) == 4) {
 			count_muxes_by_type[1]++;
 			Cell *cell = module->addCell(NEW_ID, ID($_MUX4_));
-			cell->setPort(ID(A), mux.inputs[0]);
-			cell->setPort(ID(B), mux.inputs[1]);
+			cell->setPort(ID::A, mux.inputs[0]);
+			cell->setPort(ID::B, mux.inputs[1]);
 			cell->setPort(ID(C), mux.inputs[2]);
 			cell->setPort(ID(D), mux.inputs[3]);
 			cell->setPort(ID(S), mux.selects[0]);
 			cell->setPort(ID(T), mux.selects[1]);
-			cell->setPort(ID(Y), bit);
+			cell->setPort(ID::Y, bit);
 			return;
 		}
 
 		if (GetSize(mux.inputs) == 8) {
 			count_muxes_by_type[2]++;
 			Cell *cell = module->addCell(NEW_ID, ID($_MUX8_));
-			cell->setPort(ID(A), mux.inputs[0]);
-			cell->setPort(ID(B), mux.inputs[1]);
+			cell->setPort(ID::A, mux.inputs[0]);
+			cell->setPort(ID::B, mux.inputs[1]);
 			cell->setPort(ID(C), mux.inputs[2]);
 			cell->setPort(ID(D), mux.inputs[3]);
 			cell->setPort(ID(E), mux.inputs[4]);
@@ -551,15 +551,15 @@ struct MuxcoverWorker
 			cell->setPort(ID(S), mux.selects[0]);
 			cell->setPort(ID(T), mux.selects[1]);
 			cell->setPort(ID(U), mux.selects[2]);
-			cell->setPort(ID(Y), bit);
+			cell->setPort(ID::Y, bit);
 			return;
 		}
 
 		if (GetSize(mux.inputs) == 16) {
 			count_muxes_by_type[3]++;
 			Cell *cell = module->addCell(NEW_ID, ID($_MUX16_));
-			cell->setPort(ID(A), mux.inputs[0]);
-			cell->setPort(ID(B), mux.inputs[1]);
+			cell->setPort(ID::A, mux.inputs[0]);
+			cell->setPort(ID::B, mux.inputs[1]);
 			cell->setPort(ID(C), mux.inputs[2]);
 			cell->setPort(ID(D), mux.inputs[3]);
 			cell->setPort(ID(E), mux.inputs[4]);
@@ -578,7 +578,7 @@ struct MuxcoverWorker
 			cell->setPort(ID(T), mux.selects[1]);
 			cell->setPort(ID(U), mux.selects[2]);
 			cell->setPort(ID(V), mux.selects[3]);
-			cell->setPort(ID(Y), bit);
+			cell->setPort(ID::Y, bit);
 			return;
 		}
 

--- a/passes/techmap/nlutmap.cc
+++ b/passes/techmap/nlutmap.cc
@@ -85,7 +85,7 @@ struct NlutmapWorker
 				if (cell->type != ID($lut) || mapped_cells.count(cell))
 					continue;
 
-				if (GetSize(cell->getPort(ID(A))) == lut_size || lut_size == 2)
+				if (GetSize(cell->getPort(ID::A)) == lut_size || lut_size == 2)
 					candidate_ratings[cell] = 0;
 
 				for (auto &conn : cell->connections())

--- a/passes/techmap/pmuxtree.cc
+++ b/passes/techmap/pmuxtree.cc
@@ -92,18 +92,18 @@ struct PmuxtreePass : public Pass {
 			if (cell->type != ID($pmux))
 				continue;
 
-			SigSpec sig_data = cell->getPort(ID(B));
+			SigSpec sig_data = cell->getPort(ID::B);
 			SigSpec sig_sel = cell->getPort(ID(S));
 
-			if (!cell->getPort(ID(A)).is_fully_undef()) {
-				sig_data.append(cell->getPort(ID(A)));
+			if (!cell->getPort(ID::A).is_fully_undef()) {
+				sig_data.append(cell->getPort(ID::A));
 				SigSpec sig_sel_or = module->ReduceOr(NEW_ID, sig_sel);
 				sig_sel.append(module->Not(NEW_ID, sig_sel_or));
 			}
 
 			SigSpec result, result_or;
 			result = recursive_mux_generator(module, sig_data, sig_sel, result_or);
-			module->connect(cell->getPort(ID(Y)), result);
+			module->connect(cell->getPort(ID::Y), result);
 			module->remove(cell);
 		}
 	}

--- a/passes/techmap/shregmap.cc
+++ b/passes/techmap/shregmap.cc
@@ -107,16 +107,16 @@ struct ShregmapTechXilinx7 : ShregmapTech
 			if (cell->type == ID($shiftx)) {
 				if (cell->getParam(ID(Y_WIDTH)) != 1) continue;
 				int j = 0;
-				for (auto bit : sigmap(cell->getPort(ID(A))))
+				for (auto bit : sigmap(cell->getPort(ID::A)))
 					sigbit_to_shiftx_offset[bit] = std::make_tuple(cell, j++, 0);
 				log_assert(j == cell->getParam(ID(A_WIDTH)).as_int());
 			}
 			else if (cell->type == ID($mux)) {
 				int j = 0;
-				for (auto bit : sigmap(cell->getPort(ID(A))))
+				for (auto bit : sigmap(cell->getPort(ID::A)))
 					sigbit_to_shiftx_offset[bit] = std::make_tuple(cell, 0, j++);
 				j = 0;
-				for (auto bit : sigmap(cell->getPort(ID(B))))
+				for (auto bit : sigmap(cell->getPort(ID::B)))
 					sigbit_to_shiftx_offset[bit] = std::make_tuple(cell, 1, j++);
 			}
 		}
@@ -128,9 +128,9 @@ struct ShregmapTechXilinx7 : ShregmapTech
 		if (it == sigbit_to_shiftx_offset.end())
 			return;
 		if (cell) {
-			if (cell->type == ID($shiftx) && port == ID(A))
+			if (cell->type == ID($shiftx) && port == ID::A)
 				return;
-			if (cell->type == ID($mux) && port.in(ID(A), ID(B)))
+			if (cell->type == ID($mux) && port.in(ID::A, ID::B))
 				return;
 		}
 		sigbit_to_shiftx_offset.erase(it);
@@ -183,7 +183,7 @@ struct ShregmapTechXilinx7 : ShregmapTech
 			// Due to padding the most significant bits of A may be 1'bx,
 			//   and if so, discount them
 			if (GetSize(taps) < shiftx->getParam(ID(A_WIDTH)).as_int()) {
-				const SigSpec A = shiftx->getPort(ID(A));
+				const SigSpec A = shiftx->getPort(ID::A);
 				const int A_width = shiftx->getParam(ID(A_WIDTH)).as_int();
 				for (int i = GetSize(taps); i < A_width; ++i)
 					if (A[i] != RTLIL::Sx) return false;
@@ -223,14 +223,14 @@ struct ShregmapTechXilinx7 : ShregmapTech
 		Cell* shiftx = std::get<0>(it->second);
 		RTLIL::SigSpec l_wire, q_wire;
 		if (shiftx->type == ID($shiftx)) {
-			l_wire = shiftx->getPort(ID(B));
-			q_wire = shiftx->getPort(ID(Y));
-			shiftx->setPort(ID(Y), cell->module->addWire(NEW_ID));
+			l_wire = shiftx->getPort(ID::B);
+			q_wire = shiftx->getPort(ID::Y);
+			shiftx->setPort(ID::Y, cell->module->addWire(NEW_ID));
 		}
 		else if (shiftx->type == ID($mux)) {
 			l_wire = shiftx->getPort(ID(S));
-			q_wire = shiftx->getPort(ID(Y));
-			shiftx->setPort(ID(Y), cell->module->addWire(NEW_ID));
+			q_wire = shiftx->getPort(ID::Y);
+			shiftx->setPort(ID::Y, cell->module->addWire(NEW_ID));
 		}
 		else log_abort();
 

--- a/passes/techmap/shregmap.cc
+++ b/passes/techmap/shregmap.cc
@@ -263,7 +263,7 @@ struct ShregmapWorker
 	{
 		for (auto wire : module->wires())
 		{
-			if (wire->port_output || wire->get_bool_attribute(ID(keep))) {
+			if (wire->port_output || wire->get_bool_attribute(ID::keep)) {
 				for (auto bit : sigmap(wire)) {
 					sigbit_with_non_chain_users.insert(bit);
 					if (opts.tech) opts.tech->non_chain_user(bit, nullptr, {});
@@ -283,7 +283,7 @@ struct ShregmapWorker
 
 		for (auto cell : module->cells())
 		{
-			if (opts.ffcells.count(cell->type) && !cell->get_bool_attribute(ID(keep)))
+			if (opts.ffcells.count(cell->type) && !cell->get_bool_attribute(ID::keep))
 			{
 				IdString d_port = opts.ffcells.at(cell->type).first;
 				IdString q_port = opts.ffcells.at(cell->type).second;

--- a/passes/techmap/simplemap.cc
+++ b/passes/techmap/simplemap.cc
@@ -28,23 +28,23 @@ YOSYS_NAMESPACE_BEGIN
 
 void simplemap_not(RTLIL::Module *module, RTLIL::Cell *cell)
 {
-	RTLIL::SigSpec sig_a = cell->getPort(ID(A));
-	RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+	RTLIL::SigSpec sig_a = cell->getPort(ID::A);
+	RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 
 	sig_a.extend_u0(GetSize(sig_y), cell->parameters.at(ID(A_SIGNED)).as_bool());
 
 	for (int i = 0; i < GetSize(sig_y); i++) {
 		RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_NOT_));
 		gate->add_strpool_attribute(ID(src), cell->get_strpool_attribute(ID(src)));
-		gate->setPort(ID(A), sig_a[i]);
-		gate->setPort(ID(Y), sig_y[i]);
+		gate->setPort(ID::A, sig_a[i]);
+		gate->setPort(ID::Y, sig_y[i]);
 	}
 }
 
 void simplemap_pos(RTLIL::Module *module, RTLIL::Cell *cell)
 {
-	RTLIL::SigSpec sig_a = cell->getPort(ID(A));
-	RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+	RTLIL::SigSpec sig_a = cell->getPort(ID::A);
+	RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 
 	sig_a.extend_u0(GetSize(sig_y), cell->parameters.at(ID(A_SIGNED)).as_bool());
 
@@ -53,9 +53,9 @@ void simplemap_pos(RTLIL::Module *module, RTLIL::Cell *cell)
 
 void simplemap_bitop(RTLIL::Module *module, RTLIL::Cell *cell)
 {
-	RTLIL::SigSpec sig_a = cell->getPort(ID(A));
-	RTLIL::SigSpec sig_b = cell->getPort(ID(B));
-	RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+	RTLIL::SigSpec sig_a = cell->getPort(ID::A);
+	RTLIL::SigSpec sig_b = cell->getPort(ID::B);
+	RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 
 	sig_a.extend_u0(GetSize(sig_y), cell->parameters.at(ID(A_SIGNED)).as_bool());
 	sig_b.extend_u0(GetSize(sig_y), cell->parameters.at(ID(B_SIGNED)).as_bool());
@@ -67,8 +67,8 @@ void simplemap_bitop(RTLIL::Module *module, RTLIL::Cell *cell)
 		for (int i = 0; i < GetSize(sig_y); i++) {
 			RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_NOT_));
 			gate->add_strpool_attribute(ID(src), cell->get_strpool_attribute(ID(src)));
-			gate->setPort(ID(A), sig_t[i]);
-			gate->setPort(ID(Y), sig_y[i]);
+			gate->setPort(ID::A, sig_t[i]);
+			gate->setPort(ID::Y, sig_y[i]);
 		}
 
 		sig_y = sig_t;
@@ -84,16 +84,16 @@ void simplemap_bitop(RTLIL::Module *module, RTLIL::Cell *cell)
 	for (int i = 0; i < GetSize(sig_y); i++) {
 		RTLIL::Cell *gate = module->addCell(NEW_ID, gate_type);
 		gate->add_strpool_attribute(ID(src), cell->get_strpool_attribute(ID(src)));
-		gate->setPort(ID(A), sig_a[i]);
-		gate->setPort(ID(B), sig_b[i]);
-		gate->setPort(ID(Y), sig_y[i]);
+		gate->setPort(ID::A, sig_a[i]);
+		gate->setPort(ID::B, sig_b[i]);
+		gate->setPort(ID::Y, sig_y[i]);
 	}
 }
 
 void simplemap_reduce(RTLIL::Module *module, RTLIL::Cell *cell)
 {
-	RTLIL::SigSpec sig_a = cell->getPort(ID(A));
-	RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+	RTLIL::SigSpec sig_a = cell->getPort(ID::A);
+	RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 
 	if (sig_y.size() == 0)
 		return;
@@ -135,9 +135,9 @@ void simplemap_reduce(RTLIL::Module *module, RTLIL::Cell *cell)
 
 			RTLIL::Cell *gate = module->addCell(NEW_ID, gate_type);
 			gate->add_strpool_attribute(ID(src), cell->get_strpool_attribute(ID(src)));
-			gate->setPort(ID(A), sig_a[i]);
-			gate->setPort(ID(B), sig_a[i+1]);
-			gate->setPort(ID(Y), sig_t[i/2]);
+			gate->setPort(ID::A, sig_a[i]);
+			gate->setPort(ID::B, sig_a[i+1]);
+			gate->setPort(ID::Y, sig_t[i/2]);
 			last_output_cell = gate;
 		}
 
@@ -148,8 +148,8 @@ void simplemap_reduce(RTLIL::Module *module, RTLIL::Cell *cell)
 		RTLIL::SigSpec sig_t = module->addWire(NEW_ID);
 		RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_NOT_));
 		gate->add_strpool_attribute(ID(src), cell->get_strpool_attribute(ID(src)));
-		gate->setPort(ID(A), sig_a);
-		gate->setPort(ID(Y), sig_t);
+		gate->setPort(ID::A, sig_a);
+		gate->setPort(ID::Y, sig_t);
 		last_output_cell = gate;
 		sig_a = sig_t;
 	}
@@ -157,7 +157,7 @@ void simplemap_reduce(RTLIL::Module *module, RTLIL::Cell *cell)
 	if (last_output_cell == NULL) {
 		module->connect(RTLIL::SigSig(sig_y, sig_a));
 	} else {
-		last_output_cell->setPort(ID(Y), sig_y);
+		last_output_cell->setPort(ID::Y, sig_y);
 	}
 }
 
@@ -176,9 +176,9 @@ static void logic_reduce(RTLIL::Module *module, RTLIL::SigSpec &sig, RTLIL::Cell
 
 			RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_OR_));
 			gate->add_strpool_attribute(ID(src), cell->get_strpool_attribute(ID(src)));
-			gate->setPort(ID(A), sig[i]);
-			gate->setPort(ID(B), sig[i+1]);
-			gate->setPort(ID(Y), sig_t[i/2]);
+			gate->setPort(ID::A, sig[i]);
+			gate->setPort(ID::B, sig[i+1]);
+			gate->setPort(ID::Y, sig_t[i/2]);
 		}
 
 		sig = sig_t;
@@ -190,10 +190,10 @@ static void logic_reduce(RTLIL::Module *module, RTLIL::SigSpec &sig, RTLIL::Cell
 
 void simplemap_lognot(RTLIL::Module *module, RTLIL::Cell *cell)
 {
-	RTLIL::SigSpec sig_a = cell->getPort(ID(A));
+	RTLIL::SigSpec sig_a = cell->getPort(ID::A);
 	logic_reduce(module, sig_a, cell);
 
-	RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+	RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 
 	if (sig_y.size() == 0)
 		return;
@@ -205,19 +205,19 @@ void simplemap_lognot(RTLIL::Module *module, RTLIL::Cell *cell)
 
 	RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_NOT_));
 	gate->add_strpool_attribute(ID(src), cell->get_strpool_attribute(ID(src)));
-	gate->setPort(ID(A), sig_a);
-	gate->setPort(ID(Y), sig_y);
+	gate->setPort(ID::A, sig_a);
+	gate->setPort(ID::Y, sig_y);
 }
 
 void simplemap_logbin(RTLIL::Module *module, RTLIL::Cell *cell)
 {
-	RTLIL::SigSpec sig_a = cell->getPort(ID(A));
+	RTLIL::SigSpec sig_a = cell->getPort(ID::A);
 	logic_reduce(module, sig_a, cell);
 
-	RTLIL::SigSpec sig_b = cell->getPort(ID(B));
+	RTLIL::SigSpec sig_b = cell->getPort(ID::B);
 	logic_reduce(module, sig_b, cell);
 
-	RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+	RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 
 	if (sig_y.size() == 0)
 		return;
@@ -234,16 +234,16 @@ void simplemap_logbin(RTLIL::Module *module, RTLIL::Cell *cell)
 
 	RTLIL::Cell *gate = module->addCell(NEW_ID, gate_type);
 	gate->add_strpool_attribute(ID(src), cell->get_strpool_attribute(ID(src)));
-	gate->setPort(ID(A), sig_a);
-	gate->setPort(ID(B), sig_b);
-	gate->setPort(ID(Y), sig_y);
+	gate->setPort(ID::A, sig_a);
+	gate->setPort(ID::B, sig_b);
+	gate->setPort(ID::Y, sig_y);
 }
 
 void simplemap_eqne(RTLIL::Module *module, RTLIL::Cell *cell)
 {
-	RTLIL::SigSpec sig_a = cell->getPort(ID(A));
-	RTLIL::SigSpec sig_b = cell->getPort(ID(B));
-	RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+	RTLIL::SigSpec sig_a = cell->getPort(ID::A);
+	RTLIL::SigSpec sig_b = cell->getPort(ID::B);
+	RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 	bool is_signed = cell->parameters.at(ID(A_SIGNED)).as_bool();
 	bool is_ne = cell->type.in(ID($ne), ID($nex));
 
@@ -269,38 +269,38 @@ void simplemap_eqne(RTLIL::Module *module, RTLIL::Cell *cell)
 
 void simplemap_mux(RTLIL::Module *module, RTLIL::Cell *cell)
 {
-	RTLIL::SigSpec sig_a = cell->getPort(ID(A));
-	RTLIL::SigSpec sig_b = cell->getPort(ID(B));
-	RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+	RTLIL::SigSpec sig_a = cell->getPort(ID::A);
+	RTLIL::SigSpec sig_b = cell->getPort(ID::B);
+	RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 
 	for (int i = 0; i < GetSize(sig_y); i++) {
 		RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_MUX_));
 		gate->add_strpool_attribute(ID(src), cell->get_strpool_attribute(ID(src)));
-		gate->setPort(ID(A), sig_a[i]);
-		gate->setPort(ID(B), sig_b[i]);
+		gate->setPort(ID::A, sig_a[i]);
+		gate->setPort(ID::B, sig_b[i]);
 		gate->setPort(ID(S), cell->getPort(ID(S)));
-		gate->setPort(ID(Y), sig_y[i]);
+		gate->setPort(ID::Y, sig_y[i]);
 	}
 }
 
 void simplemap_tribuf(RTLIL::Module *module, RTLIL::Cell *cell)
 {
-	RTLIL::SigSpec sig_a = cell->getPort(ID(A));
+	RTLIL::SigSpec sig_a = cell->getPort(ID::A);
 	RTLIL::SigSpec sig_e = cell->getPort(ID(EN));
-	RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+	RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 
 	for (int i = 0; i < GetSize(sig_y); i++) {
 		RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_TBUF_));
 		gate->add_strpool_attribute(ID(src), cell->get_strpool_attribute(ID(src)));
-		gate->setPort(ID(A), sig_a[i]);
+		gate->setPort(ID::A, sig_a[i]);
 		gate->setPort(ID(E), sig_e);
-		gate->setPort(ID(Y), sig_y[i]);
+		gate->setPort(ID::Y, sig_y[i]);
 	}
 }
 
 void simplemap_lut(RTLIL::Module *module, RTLIL::Cell *cell)
 {
-	SigSpec lut_ctrl = cell->getPort(ID(A));
+	SigSpec lut_ctrl = cell->getPort(ID::A);
 	SigSpec lut_data = cell->getParam(ID(LUT));
 	lut_data.extend_u0(1 << cell->getParam(ID(WIDTH)).as_int());
 
@@ -310,20 +310,20 @@ void simplemap_lut(RTLIL::Module *module, RTLIL::Cell *cell)
 		for (int i = 0; i < GetSize(lut_data); i += 2) {
 			RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_MUX_));
 			gate->add_strpool_attribute(ID(src), cell->get_strpool_attribute(ID(src)));
-			gate->setPort(ID(A), lut_data[i]);
-			gate->setPort(ID(B), lut_data[i+1]);
+			gate->setPort(ID::A, lut_data[i]);
+			gate->setPort(ID::B, lut_data[i+1]);
 			gate->setPort(ID(S), lut_ctrl[idx]);
-			gate->setPort(ID(Y), new_lut_data[i/2]);
+			gate->setPort(ID::Y, new_lut_data[i/2]);
 		}
 		lut_data = new_lut_data;
 	}
 
-	module->connect(cell->getPort(ID(Y)), lut_data);
+	module->connect(cell->getPort(ID::Y), lut_data);
 }
 
 void simplemap_sop(RTLIL::Module *module, RTLIL::Cell *cell)
 {
-	SigSpec ctrl = cell->getPort(ID(A));
+	SigSpec ctrl = cell->getPort(ID::A);
 	SigSpec table = cell->getParam(ID(TABLE));
 
 	int width = cell->getParam(ID(WIDTH)).as_int();
@@ -348,22 +348,22 @@ void simplemap_sop(RTLIL::Module *module, RTLIL::Cell *cell)
 		products.append(GetSize(in) > 0 ? module->Eq(NEW_ID, in, pat) : State::S1);
 	}
 
-	module->connect(cell->getPort(ID(Y)), module->ReduceOr(NEW_ID, products));
+	module->connect(cell->getPort(ID::Y), module->ReduceOr(NEW_ID, products));
 }
 
 void simplemap_slice(RTLIL::Module *module, RTLIL::Cell *cell)
 {
 	int offset = cell->parameters.at(ID(OFFSET)).as_int();
-	RTLIL::SigSpec sig_a = cell->getPort(ID(A));
-	RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+	RTLIL::SigSpec sig_a = cell->getPort(ID::A);
+	RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 	module->connect(RTLIL::SigSig(sig_y, sig_a.extract(offset, sig_y.size())));
 }
 
 void simplemap_concat(RTLIL::Module *module, RTLIL::Cell *cell)
 {
-	RTLIL::SigSpec sig_ab = cell->getPort(ID(A));
-	sig_ab.append(cell->getPort(ID(B)));
-	RTLIL::SigSpec sig_y = cell->getPort(ID(Y));
+	RTLIL::SigSpec sig_ab = cell->getPort(ID::A);
+	sig_ab.append(cell->getPort(ID::B));
+	RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 	module->connect(RTLIL::SigSig(sig_y, sig_ab));
 }
 

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -520,7 +520,7 @@ struct TechmapWorker
 								int port_counter = 1;
 								for (auto &c : extmapper_cell->connections_) {
 									RTLIL::Wire *w = extmapper_module->addWire(c.first, GetSize(c.second));
-									if (w->name.in(ID(Y), ID(Q)))
+									if (w->name.in(ID::Y, ID(Q)))
 										w->port_output = true;
 									else
 										w->port_input = true;

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -145,7 +145,7 @@ struct TechmapWorker
 				record.wire = it.second;
 				record.value = it.second;
 				result[p].push_back(record);
-				it.second->attributes[ID(keep)] = RTLIL::Const(1);
+				it.second->attributes[ID::keep] = RTLIL::Const(1);
 				it.second->attributes[ID(_techmap_special_)] = RTLIL::Const(1);
 			}
 		}

--- a/passes/techmap/tribuf.cc
+++ b/passes/techmap/tribuf.cc
@@ -64,37 +64,37 @@ struct TribufWorker {
 		for (auto cell : module->selected_cells())
 		{
 			if (cell->type == ID($tribuf))
-				tribuf_cells[sigmap(cell->getPort(ID(Y)))].push_back(cell);
+				tribuf_cells[sigmap(cell->getPort(ID::Y))].push_back(cell);
 
 			if (cell->type == ID($_TBUF_))
-				tribuf_cells[sigmap(cell->getPort(ID(Y)))].push_back(cell);
+				tribuf_cells[sigmap(cell->getPort(ID::Y))].push_back(cell);
 
 			if (cell->type.in(ID($mux), ID($_MUX_)))
 			{
 				IdString en_port = cell->type == ID($mux) ? ID(EN) : ID(E);
 				IdString tri_type = cell->type == ID($mux) ? ID($tribuf) : ID($_TBUF_);
 
-				if (is_all_z(cell->getPort(ID(A))) && is_all_z(cell->getPort(ID(B)))) {
+				if (is_all_z(cell->getPort(ID::A)) && is_all_z(cell->getPort(ID::B))) {
 					module->remove(cell);
 					continue;
 				}
 
-				if (is_all_z(cell->getPort(ID(A)))) {
-					cell->setPort(ID(A), cell->getPort(ID(B)));
+				if (is_all_z(cell->getPort(ID::A))) {
+					cell->setPort(ID::A, cell->getPort(ID::B));
 					cell->setPort(en_port, cell->getPort(ID(S)));
-					cell->unsetPort(ID(B));
+					cell->unsetPort(ID::B);
 					cell->unsetPort(ID(S));
 					cell->type = tri_type;
-					tribuf_cells[sigmap(cell->getPort(ID(Y)))].push_back(cell);
+					tribuf_cells[sigmap(cell->getPort(ID::Y))].push_back(cell);
 					continue;
 				}
 
-				if (is_all_z(cell->getPort(ID(B)))) {
+				if (is_all_z(cell->getPort(ID::B))) {
 					cell->setPort(en_port, module->Not(NEW_ID, cell->getPort(ID(S))));
-					cell->unsetPort(ID(B));
+					cell->unsetPort(ID::B);
 					cell->unsetPort(ID(S));
 					cell->type = tri_type;
-					tribuf_cells[sigmap(cell->getPort(ID(Y)))].push_back(cell);
+					tribuf_cells[sigmap(cell->getPort(ID::Y))].push_back(cell);
 					continue;
 				}
 			}
@@ -122,7 +122,7 @@ struct TribufWorker {
 						pmux_s.append(cell->getPort(ID(EN)));
 					else
 						pmux_s.append(cell->getPort(ID(E)));
-					pmux_b.append(cell->getPort(ID(A)));
+					pmux_b.append(cell->getPort(ID::A));
 					module->remove(cell);
 				}
 


### PR DESCRIPTION
Thought I'd try using the existing globals too.

Note I've aliased the `RTLIL::ID` namespace as the `ID` namespace:
https://github.com/YosysHQ/yosys/blob/453a9429b67551f94f8c714c24f12929e472052c/kernel/yosys.h#L228

Not sure what's possible with dollar-identifiers (e.g. `$and`) globals, though...