### PR TITLE
Ignore all generated headers for pmgen pass

### DIFF
--- a/passes/pmgen/.gitignore
+++ b/passes/pmgen/.gitignore
@@ -1,2 +1,1 @@
-/ice40_dsp_pm.h
-/peepopt_pm.h
+/*_pm.h


### PR DESCRIPTION
new file appeared passes/pmgen/ice40_wrapcarry_pm.h, but we can make this general naming nomenclature