### PR TITLE
techmap -max_iter to apply to each module individually

### DIFF
--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -943,7 +943,8 @@ struct TechmapPass : public Pass {
 		log("        instead of inlining them.\n");
 		log("\n");
 		log("    -max_iter <number>\n");
-		log("        only run the specified number of iterations.\n");
+		log("        only run the specified number of iterations for each module.\n");
+		log("        default: unlimited\n");
 		log("\n");
 		log("    -recursive\n");
 		log("        instead of the iterative breadth-first algorithm use a recursive\n");
@@ -1157,15 +1158,16 @@ struct TechmapPass : public Pass {
 			RTLIL::Module *module = *worker.module_queue.begin();
 			worker.module_queue.erase(module);
 
+			int module_max_iter = max_iter;
 			bool did_something = true;
 			std::set<RTLIL::Cell*> handled_cells;
 			while (did_something) {
 				did_something = false;
-					if (worker.techmap_module(design, module, map, handled_cells, celltypeMap, false))
-						did_something = true;
+				if (worker.techmap_module(design, module, map, handled_cells, celltypeMap, false))
+					did_something = true;
 				if (did_something)
 					module->check();
-				if (max_iter > 0 && --max_iter == 0)
+				if (module_max_iter > 0 && --module_max_iter == 0)
 					break;
 			}
 		}

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -943,7 +943,7 @@ struct TechmapPass : public Pass {
 		log("        instead of inlining them.\n");
 		log("\n");
 		log("    -max_iter <number>\n");
-		log("        only run the specified number of iterations for each module.\n");
+		log("        only run the specified number of iterations on each module.\n");
 		log("        default: unlimited\n");
 		log("\n");
 		log("    -recursive\n");

--- a/tests/techmap/recursive.v
+++ b/tests/techmap/recursive.v
@@ -1,0 +1,8 @@
+module top;
+sub s0();
+foo f0();
+endmodule
+
+module foo;
+sub s0();
+endmodule

--- a/tests/techmap/recursive_map.v
+++ b/tests/techmap/recursive_map.v
@@ -1,0 +1,4 @@
+module sub;
+    sub _TECHMAP_REPLACE_ ();
+    bar f0();
+endmodule

--- a/tests/techmap/recursive_runtest.sh
+++ b/tests/techmap/recursive_runtest.sh
@@ -1,0 +1,3 @@
+set -ev
+
+../../yosys -p 'hierarchy -top top; techmap -map recursive_map.v -max_iter 1; select -assert-count 2 t:sub; select -assert-count 2 t:bar' recursive.v


### PR DESCRIPTION
Previously, `techmap -max_iter` is shared between all modules, which is not my expectation of what `-max_iter` should be.

The problem stemming from this is that if there's a hit in one module, based on this line:
https://github.com/YosysHQ/yosys/blob/076af2e6176ecc440be7b7fa984ea5b461bb95de/passes/techmap/techmap.cc#L1168
the next module will be unable to decrement the variable nor break out of the loop.

This means that it will run until a fixed point is reached (and in my niche rule that replaces a module with itself plus something else, run forever).