### PR TITLE
In sat: 'x' in init attr should be ignored

### DIFF
--- a/passes/sat/sat.cc
+++ b/passes/sat/sat.cc
@@ -268,9 +268,7 @@ struct SatHelper
 				RTLIL::SigSpec removed_bits;
 				for (int i = 0; i < lhs.size(); i++) {
 					RTLIL::SigSpec bit = lhs.extract(i, 1);
-					if (bit.is_fully_const() && rhs[i] == State::Sx)
-						rhs[i] = bit;
-					if (!satgen.initial_state.check_all(bit)) {
+					if (rhs[i] == State::Sx || !satgen.initial_state.check_all(bit)) {
 						removed_bits.append(bit);
 						lhs.remove(i, 1);
 						rhs.remove(i, 1);

--- a/passes/sat/sat.cc
+++ b/passes/sat/sat.cc
@@ -268,6 +268,8 @@ struct SatHelper
 				RTLIL::SigSpec removed_bits;
 				for (int i = 0; i < lhs.size(); i++) {
 					RTLIL::SigSpec bit = lhs.extract(i, 1);
+					if (bit.is_fully_const() && rhs[i] == State::Sx)
+						rhs[i] = bit;
 					if (!satgen.initial_state.check_all(bit)) {
 						removed_bits.append(bit);
 						lhs.remove(i, 1);

--- a/tests/sat/initval.v
+++ b/tests/sat/initval.v
@@ -13,7 +13,7 @@ module test(input clk, input [3:0] bar, output [3:0] foo);
     last_bar <= bar;
 
   always @*
-    asdf[2:0] <= 3'b111;
+    asdf[2:0] = 3'b111;
 
   assert property (foo == {last_bar[3:2], bar[1:0]});
 endmodule

--- a/tests/sat/initval.v
+++ b/tests/sat/initval.v
@@ -1,6 +1,7 @@
 module test(input clk, input [3:0] bar, output [3:0] foo);
   reg [3:0] foo = 0;
   reg [3:0] last_bar = 0;
+  reg [3:0] asdf = 4'b1xxx;
 
   always @*
     foo[1:0] <= bar[1:0];
@@ -10,6 +11,9 @@ module test(input clk, input [3:0] bar, output [3:0] foo);
 
   always @(posedge clk)
     last_bar <= bar;
+
+  always @*
+    asdf[2:0] <= 3'b111;
 
   assert property (foo == {last_bar[3:2], bar[1:0]});
 endmodule

--- a/tests/sat/initval.v
+++ b/tests/sat/initval.v
@@ -1,4 +1,4 @@
-module test(input clk, input [3:0] bar, output [3:0] foo);
+module test(input clk, input [3:0] bar, output [3:0] foo, asdf);
   reg [3:0] foo = 0;
   reg [3:0] last_bar = 0;
   reg [3:0] asdf = 4'b1xxx;
@@ -12,6 +12,8 @@ module test(input clk, input [3:0] bar, output [3:0] foo);
   always @(posedge clk)
     last_bar <= bar;
 
+  always @(posedge clk)
+    asdf[3] <= bar[3];
   always @*
     asdf[2:0] = 3'b111;
 

--- a/tests/sat/initval.ys
+++ b/tests/sat/initval.ys
@@ -1,4 +1,4 @@
 read_verilog -sv initval.v
-proc;;
+proc;
 
 sat -seq 10 -prove-asserts

--- a/tests/sat/initval.ys
+++ b/tests/sat/initval.ys
@@ -1,4 +1,4 @@
 read_verilog -sv initval.v
-proc;
+proc;;
 
 sat -seq 10 -prove-asserts


### PR DESCRIPTION
Attached testcase works if `sat -enable_undef` is specified, even though it shouldn't be necessary as there is no ambiguity.

Also removal of one colon is necessary otherwise signal is collapsed and no init.