### PR TITLE
Don't filter commits by author when composing YOSYS_VER

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ LDFLAGS += -rdynamic
 LDLIBS += -lrt
 endif
 
-YOSYS_VER := 0.8+$(shell cd $(YOSYS_SRC) && test -e .git && { git log --author=clifford@clifford.at --oneline 4d4665b.. 2> /dev/null | wc -l; })
+YOSYS_VER := 0.8+$(shell cd $(YOSYS_SRC) && test -e .git && { git log --oneline 4d4665b.. 2> /dev/null | wc -l; })
 GIT_REV := $(shell cd $(YOSYS_SRC) && git rev-parse --short HEAD 2> /dev/null || echo UNKNOWN)
 OBJS = kernel/version_$(GIT_REV).o
 


### PR DESCRIPTION
I'm not sure why it tries to filter by email, but this seems wrong. This came to my attention because YOSYS_VER causes issues downstream, like in NixOS, which has to patch these constructs out as `.git` is not available.