### PR TITLE
Add flatten handling of pre-existing wires as created by interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,9 @@ Verilog Attributes and non-standard features
   that represent module parameters or localparams (when the HDL front-end
   is run in ``-pwires`` mode).
 
+- Wires marked with the ``hierconn`` attribute are connected to wires with the
+  same name when they are imported from sub-modules by ``flatten``.
+
 - The ``clkbuf_driver`` attribute can be set on an output port of a blackbox
   module to mark it as a clock buffer output, and thus prevent ``clkbufmap``
   from inserting another clock buffer on a net driven by such output.

--- a/README.md
+++ b/README.md
@@ -333,7 +333,8 @@ Verilog Attributes and non-standard features
   is run in ``-pwires`` mode).
 
 - Wires marked with the ``hierconn`` attribute are connected to wires with the
-  same name when they are imported from sub-modules by ``flatten``.
+  same name (format ``cell_name.identifier``) when they are imported from
+  sub-modules by ``flatten``.
 
 - The ``clkbuf_driver`` attribute can be set on an output port of a blackbox
   module to mark it as a clock buffer output, and thus prevent ``clkbufmap``


### PR DESCRIPTION
Fixes #1145.

This inadvertently also enables the following:

```
module top (input [3:0] A, B, output [3:0] X, Y);
  (* keep *) wire [3:0] bar.internal;
  assign Y = bar.internal;
  foo bar ( A, B, X );
endmodule

module foo (input [3:0] din1, din2, output [3:0] dout);
  (* keep *) wire [3:0] internal = din1 & din2;
  assign dout = din1 | din2;
endmodule
```

`yosys -p 'read_verilog test.v; prep -top top; flatten;; show'`

![image](https://user-images.githubusercontent.com/619764/63728990-f9389d80-c865-11e9-8ebc-584e82c4790d.png)
