### PR TITLE
Fix $__ICE40_CARRY_WRAPPER, restore abc9 functionality

### DIFF
--- a/techlibs/ice40/abc_hx.box
+++ b/techlibs/ice40/abc_hx.box
@@ -3,11 +3,11 @@
 # NB: Inputs/Outputs must be ordered alphabetically
 #     (with exceptions for carry in/out)
 
-# Inputs: A B CI
+# Inputs: A B I0 I3 CI
 # Outputs: O CO
 #   (NB: carry chain input/output must be last
 #        input/output and have been moved there
 #        overriding the alphabetical ordering)
-$__ICE40_FULL_ADDER 1 1 3 2
-400 379 316
-259 231 126
+$__ICE40_FULL_ADDER 1 1 5 2
+400 379 449 316 316
+259 231 -   -   126

--- a/techlibs/ice40/abc_hx.box
+++ b/techlibs/ice40/abc_hx.box
@@ -8,6 +8,6 @@
 #   (NB: carry chain input/output must be last
 #        input/output and have been moved there
 #        overriding the alphabetical ordering)
-$__ICE40_FULL_ADDER 1 1 5 2
+$__ICE40_CARRY_WRAPPER 1 1 5 2
 400 379 449 316 316
 259 231 -   -   126

--- a/techlibs/ice40/abc_lp.box
+++ b/techlibs/ice40/abc_lp.box
@@ -8,6 +8,6 @@
 #   (NB: carry chain input/output must be last
 #        input/output and have been moved there
 #        overriding the alphabetical ordering)
-$__ICE40_FULL_ADDER 1 1 5 2
+$__ICE40_CARRY_WRAPPER 1 1 5 2
 589 558 661 465 465
 675 609 -   -   186

--- a/techlibs/ice40/abc_lp.box
+++ b/techlibs/ice40/abc_lp.box
@@ -3,11 +3,11 @@
 # NB: Inputs/Outputs must be ordered alphabetically
 #     (with exceptions for carry in/out)
 
-# Inputs: A B CI
+# Inputs: A B I0 I3 CI
 # Outputs: O CO
 #   (NB: carry chain input/output must be last
 #        input/output and have been moved there
 #        overriding the alphabetical ordering)
-$__ICE40_FULL_ADDER 1 1 3 2
-589 558 465
-675 609 186 
+$__ICE40_FULL_ADDER 1 1 5 2
+589 558 661 465 465
+675 609 -   -   186

--- a/techlibs/ice40/abc_u.box
+++ b/techlibs/ice40/abc_u.box
@@ -8,6 +8,6 @@
 #   (NB: carry chain input/output must be last
 #        input/output and have been moved there
 #        overriding the alphabetical ordering)
-$__ICE40_FULL_ADDER 1 1 5 2
+$__ICE40_CARRY_WRAPPER 1 1 5 2
 1231 1205 1285 874 874
 675  609  -    -   278

--- a/techlibs/ice40/abc_u.box
+++ b/techlibs/ice40/abc_u.box
@@ -3,11 +3,11 @@
 # NB: Inputs/Outputs must be ordered alphabetically
 #     (with exceptions for carry in/out)
 
-# Inputs: A B CI
+# Inputs: A B I0 I3 CI
 # Outputs: O CO
 #   (NB: carry chain input/output must be last
 #        input/output and have been moved there
 #        overriding the alphabetical ordering)
-$__ICE40_FULL_ADDER 1 1 3 2
-1231 1205 874
-675  609  278
+$__ICE40_FULL_ADDER 1 1 5 2
+1231 1205 1285 874 874
+675  609  -    -   278

--- a/techlibs/ice40/cells_sim.v
+++ b/techlibs/ice40/cells_sim.v
@@ -149,7 +149,7 @@ module \$__ICE40_CARRY_WRAPPER (
 	input A, B,
 	(* abc_carry *)
 	input CI,
-	input I0, I3,
+	input I0, I3
 );
 	parameter LUT = 0;
 	SB_CARRY carry (

--- a/techlibs/ice40/cells_sim.v
+++ b/techlibs/ice40/cells_sim.v
@@ -142,15 +142,16 @@ module SB_CARRY (output CO, input I0, I1, CI);
 endmodule
 
 (* abc_box_id = 1, lib_whitebox *)
-module \$__ICE40_FULL_ADDER (
+module \$__ICE40_CARRY_WRAPPER (
 	(* abc_carry *)
 	output CO,
 	output O,
-	input A,
-	input B,
+	input A, B,
 	(* abc_carry *)
-	input CI
+	input CI,
+	input I0, I3,
 );
+	parameter LUT = 0;
 	SB_CARRY carry (
 		.I0(A),
 		.I1(B),
@@ -158,16 +159,12 @@ module \$__ICE40_FULL_ADDER (
 		.CO(CO)
 	);
 	SB_LUT4 #(
-		//         I0: 1010 1010 1010 1010
-		//         I1: 1100 1100 1100 1100
-		//         I2: 1111 0000 1111 0000
-		//         I3: 1111 1111 0000 0000
-		.LUT_INIT(16'b 0110_1001_1001_0110)
+		.LUT_INIT(LUT)
 	) adder (
-		.I0(1'b0),
+		.I0(I0),
 		.I1(A),
 		.I2(B),
-		.I3(CI),
+		.I3(I3),
 		.O(O)
 	);
 endmodule

--- a/techlibs/ice40/ice40_opt.cc
+++ b/techlibs/ice40/ice40_opt.cc
@@ -83,6 +83,51 @@ static void run_ice40_opts(Module *module)
 			}
 			continue;
 		}
+
+		if (cell->type == "$__ICE40_FULL_ADDER")
+		{
+			SigSpec non_const_inputs, replacement_output;
+			int count_zeros = 0, count_ones = 0;
+
+			SigBit inbit[3] = {
+				cell->getPort("\\A"),
+				cell->getPort("\\B"),
+				cell->getPort("\\CI")
+			};
+			for (int i = 0; i < 3; i++)
+				if (inbit[i].wire == nullptr) {
+					if (inbit[i] == State::S1)
+						count_ones++;
+					else
+						count_zeros++;
+				} else
+					non_const_inputs.append(inbit[i]);
+
+			if (count_zeros >= 2)
+				replacement_output = State::S0;
+			else if (count_ones >= 2)
+				replacement_output = State::S1;
+			else if (GetSize(non_const_inputs) == 1)
+				replacement_output = non_const_inputs;
+
+			if (GetSize(replacement_output)) {
+				optimized_co.insert(sigmap(cell->getPort("\\CO")[0]));
+				module->connect(cell->getPort("\\CO")[0], replacement_output);
+				module->design->scratchpad_set_bool("opt.did_something", true);
+				log("Optimized $__ICE40_FULL_ADDER cell back to logic (without SB_CARRY) %s.%s: CO=%s\n",
+						log_id(module), log_id(cell), log_signal(replacement_output));
+				cell->type = "$lut";
+				cell->setPort("\\A", { State::S0, inbit[0], inbit[1], inbit[2] });
+				cell->setPort("\\Y", cell->getPort("\\O"));
+				cell->unsetPort("\\B");
+				cell->unsetPort("\\CI");
+				cell->unsetPort("\\CO");
+				cell->unsetPort("\\O");
+				cell->setParam("\\LUT", RTLIL::Const::from_string("0110100110010110"));
+				cell->setParam("\\WIDTH", 4);
+			}
+			continue;
+		}
 	}
 
 	for (auto cell : sb_lut_cells)

--- a/techlibs/ice40/ice40_opt.cc
+++ b/techlibs/ice40/ice40_opt.cc
@@ -84,7 +84,7 @@ static void run_ice40_opts(Module *module)
 			continue;
 		}
 
-		if (cell->type == "$__ICE40_FULL_ADDER")
+		if (cell->type == "$__ICE40_CARRY_WRAPPER")
 		{
 			SigSpec non_const_inputs, replacement_output;
 			int count_zeros = 0, count_ones = 0;
@@ -114,13 +114,15 @@ static void run_ice40_opts(Module *module)
 				optimized_co.insert(sigmap(cell->getPort("\\CO")[0]));
 				module->connect(cell->getPort("\\CO")[0], replacement_output);
 				module->design->scratchpad_set_bool("opt.did_something", true);
-				log("Optimized $__ICE40_FULL_ADDER cell back to logic (without SB_CARRY) %s.%s: CO=%s\n",
+				log("Optimized $__ICE40_CARRY_WRAPPER cell back to logic (without SB_CARRY) %s.%s: CO=%s\n",
 						log_id(module), log_id(cell), log_signal(replacement_output));
 				cell->type = "$lut";
-				cell->setPort("\\A", { State::S0, inbit[0], inbit[1], inbit[2] });
+				cell->setPort("\\A", { cell->getPort("\\I0"), inbit[0], inbit[1], cell->getPort("\\I3") });
 				cell->setPort("\\Y", cell->getPort("\\O"));
 				cell->unsetPort("\\B");
 				cell->unsetPort("\\CI");
+				cell->unsetPort("\\I0");
+				cell->unsetPort("\\I3");
 				cell->unsetPort("\\CO");
 				cell->unsetPort("\\O");
 				cell->setParam("\\LUT", RTLIL::Const::from_string("0110100110010110"));

--- a/techlibs/ice40/ice40_opt.cc
+++ b/techlibs/ice40/ice40_opt.cc
@@ -125,7 +125,6 @@ static void run_ice40_opts(Module *module)
 				cell->unsetPort("\\I3");
 				cell->unsetPort("\\CO");
 				cell->unsetPort("\\O");
-				cell->setParam("\\LUT", RTLIL::Const::from_string("0110100110010110"));
 				cell->setParam("\\WIDTH", 4);
 			}
 			continue;

--- a/techlibs/ice40/ice40_opt.cc
+++ b/techlibs/ice40/ice40_opt.cc
@@ -83,51 +83,6 @@ static void run_ice40_opts(Module *module)
 			}
 			continue;
 		}
-
-		if (cell->type == "$__ICE40_FULL_ADDER")
-		{
-			SigSpec non_const_inputs, replacement_output;
-			int count_zeros = 0, count_ones = 0;
-
-			SigBit inbit[3] = {
-				cell->getPort("\\A"),
-				cell->getPort("\\B"),
-				cell->getPort("\\CI")
-			};
-			for (int i = 0; i < 3; i++)
-				if (inbit[i].wire == nullptr) {
-					if (inbit[i] == State::S1)
-						count_ones++;
-					else
-						count_zeros++;
-				} else
-					non_const_inputs.append(inbit[i]);
-
-			if (count_zeros >= 2)
-				replacement_output = State::S0;
-			else if (count_ones >= 2)
-				replacement_output = State::S1;
-			else if (GetSize(non_const_inputs) == 1)
-				replacement_output = non_const_inputs;
-
-			if (GetSize(replacement_output)) {
-				optimized_co.insert(sigmap(cell->getPort("\\CO")[0]));
-				module->connect(cell->getPort("\\CO")[0], replacement_output);
-				module->design->scratchpad_set_bool("opt.did_something", true);
-				log("Optimized $__ICE40_FULL_ADDER cell back to logic (without SB_CARRY) %s.%s: CO=%s\n",
-						log_id(module), log_id(cell), log_signal(replacement_output));
-				cell->type = "$lut";
-				cell->setPort("\\A", { State::S0, inbit[0], inbit[1], inbit[2] });
-				cell->setPort("\\Y", cell->getPort("\\O"));
-				cell->unsetPort("\\B");
-				cell->unsetPort("\\CI");
-				cell->unsetPort("\\CO");
-				cell->unsetPort("\\O");
-				cell->setParam("\\LUT", RTLIL::Const::from_string("0110100110010110"));
-				cell->setParam("\\WIDTH", 4);
-			}
-			continue;
-		}
 	}
 
 	for (auto cell : sb_lut_cells)

--- a/tests/ice40/ice40_opt.ys
+++ b/tests/ice40/ice40_opt.ys
@@ -1,5 +1,5 @@
 read_verilog -icells -formal <<EOT
-module top(input CI, I0, output CO, O);
+module top(input CI, I0, output [1:0] CO, output O);
     wire A = 1'b0, B = 1'b0;
 	\$__ICE40_CARRY_WRAPPER #(
 		//    A[0]: 1010 1010 1010 1010
@@ -7,18 +7,20 @@ module top(input CI, I0, output CO, O);
 		//    A[2]: 1111 0000 1111 0000
 		//    A[3]: 1111 1111 0000 0000
 		.LUT(~16'b 0110_1001_1001_0110)
-	) fadd (
+	) u0 (
 		.A(A),
 		.B(B),
 		.CI(CI),
 		.I0(I0),
 		.I3(CI),
-		.CO(CO),
+		.CO(CO[0]),
 		.O(O)
 	);
+    SB_CARRY u1 (.I0(~A), .I1(~B), .CI(CI), .CO(CO[1]));
 endmodule
 EOT
 
 equiv_opt -assert -map +/ice40/cells_map.v -map +/ice40/cells_sim.v ice40_opt
 design -load postopt
+select -assert-count 1 t:*
 select -assert-count 1 t:$lut

--- a/tests/ice40/ice40_opt.ys
+++ b/tests/ice40/ice40_opt.ys
@@ -1,0 +1,24 @@
+read_verilog -icells -formal <<EOT
+module top(input CI, I0, output CO, O);
+    wire A = 1'b0, B = 1'b0;
+	\$__ICE40_CARRY_WRAPPER #(
+		//    A[0]: 1010 1010 1010 1010
+		//    A[1]: 1100 1100 1100 1100
+		//    A[2]: 1111 0000 1111 0000
+		//    A[3]: 1111 1111 0000 0000
+		.LUT(~16'b 0110_1001_1001_0110)
+	) fadd (
+		.A(A),
+		.B(B),
+		.CI(CI),
+		.I0(I0),
+		.I3(CI),
+		.CO(CO),
+		.O(O)
+	);
+endmodule
+EOT
+
+equiv_opt -assert -map +/ice40/cells_map.v -map +/ice40/cells_sim.v ice40_opt
+design -load postopt
+select -assert-count 1 t:$lut

--- a/tests/ice40/run-test.sh
+++ b/tests/ice40/run-test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+{
+echo "all::"
+for x in *.ys; do
+	echo "all:: run-$x"
+	echo "run-$x:"
+	echo "	@echo 'Running $x..'"
+	echo "	@../../yosys -ql ${x%.ys}.log $x"
+done
+for s in *.sh; do
+	if [ "$s" != "run-test.sh" ]; then
+		echo "all:: run-$s"
+		echo "run-$s:"
+		echo "	@echo 'Running $s..'"
+		echo "	@bash $s"
+	fi
+done
+} > run-test.mk
+exec ${MAKE:-make} -f run-test.mk


### PR DESCRIPTION
Sorry for my incompetence! I've just realised that `abc9` ice40 has not been using boxes at all, and discovered these remnants from #1290 and #1260 which addressed #1205 originally.

~I've also had to remove optimising `$__ICE40_CARRY_WRAPPER` (or the deprecated `$__ICE40_FULL_ADDER`) from `ice40_opt` since we can't reason with it the same way -- it can't be guaranteed to implement the sum part of the full adder since the LUT mask could be different, and I0 and I3 could have be non-zero and non-CI respectively.
*EDIT:* Not sure if this is desirable for non-abc9 flows. For `-abc9` it is possible that abc9 may be able to reason about the box and optimise it away entirely (but not demote it back to a soft `$lut` and use that during techmapping). Perhaps it is better to restore its handling in `ice40_opt` and only operate on the "common" case of its use as a full-adder? Let me sit on it a little more, and RFC please.~