### PR TITLE
abc9 to not call "clean" at end of run (often called outside)

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,23 @@ Verilog Attributes and non-standard features
   it as the external-facing pin of an I/O pad, and prevents ``iopadmap``
   from inserting another pad cell on it.
 
+- The module attribute ``abc_box_id`` specifies a positive integer linking a
+  blackbox or whitebox definition to a corresponding entry in a `abc9`
+  box-file.
+
+- The port attribute ``abc_scc_break`` indicates a module input port that will
+  be treated as a primary output during `abc9` techmapping. Doing so eliminates
+  the possibility of a strongly-connected component (i.e. a combinatorial loop)
+  existing. Typically, this is specified for sequential inputs on otherwise
+  combinatorial boxes -- for example, applying ``abc_scc_break`` onto the `D`
+  port of a LUTRAM cell prevents `abc9` from interpreting any `Q` -> `D` paths
+  as a combinatorial loop.
+
+- The port attribute ``abc_carry`` marks the carry-in (if an input port) and
+  carry-out (if output port) ports of a box. This information is necessary for
+  `abc9` to preserve the integrity of carry-chains. Specifying this attribute
+  onto a bus port will affect only its most significant bit.
+
 - In addition to the ``(* ... *)`` attribute syntax, Yosys supports
   the non-standard ``{* ... *}`` attribute syntax to set default attributes
   for everything that comes after the ``{* ... *}`` statement. (Reset
@@ -422,23 +439,6 @@ Verilog Attributes and non-standard features
   special ``$specify2``, ``$specify3``, and ``$specrule`` cells, for use in
   blackboxes and whiteboxes. Use ``read_verilog -specify`` to enable this
   functionality. (By default specify .. endspecify blocks are ignored.)
-
-- The module attribute ``abc_box_id`` specifies a positive integer linking a
-  blackbox or whitebox definition to a corresponding entry in a `abc9`
-  box-file.
-
-- The port attribute ``abc_scc_break`` indicates a module input port that will
-  be treated as a primary output during `abc9` techmapping. Doing so eliminates
-  the possibility of a strongly-connected component (i.e. a combinatorial loop)
-  existing. Typically, this is specified for sequential inputs on otherwise
-  combinatorial boxes -- for example, applying ``abc_scc_break`` onto the `D`
-  port of a LUTRAM cell prevents `abc9` from interpreting any `Q` -> `D` paths
-  as a combinatorial loop.
-
-- The port attribute ``abc_carry`` marks the carry-in (if an input port) and
-  carry-out (if output port) ports of a box. This information is necessary for
-  `abc9` to preserve the integrity of carry-chains. Specifying this attribute
-  onto a bus port will affect only its most significant bit.
 
 
 Non-standard or SystemVerilog features for formal verification

--- a/frontends/aiger/aigerparse.cc
+++ b/frontends/aiger/aigerparse.cc
@@ -974,7 +974,7 @@ void AigerReader::post_process()
 	// operate (and run checks on) this one module
 	RTLIL::Design *mapped_design = new RTLIL::Design;
 	mapped_design->add(module);
-	Pass::call(mapped_design, "clean");
+	Pass::call(mapped_design, "clean -purge");
 	mapped_design->modules_.erase(module->name);
 	delete mapped_design;
 

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -1300,9 +1300,6 @@ struct Abc9Pass : public Pass {
 
 		assign_map.clear();
 
-		// The "clean" pass also contains a design->check() call
-		Pass::call(design, "clean");
-
 		log_pop();
 	}
 } Abc9Pass;

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -694,28 +694,25 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 		int in_wires = 0, out_wires = 0;
 
 		// Stitch in mapped_mod's inputs/outputs into module
-		for (auto &it : mapped_mod->wires_) {
-			RTLIL::Wire *w = it.second;
-			if (!w->port_input && !w->port_output)
-				continue;
-			RTLIL::Wire *wire = module->wire(w->name);
+		for (auto port : mapped_mod->ports) {
+			RTLIL::Wire *w = mapped_mod->wire(port);
+			RTLIL::Wire *wire = module->wire(port);
 			log_assert(wire);
-			RTLIL::Wire *remap_wire = module->wire(remap_name(w->name));
+			RTLIL::Wire *remap_wire = module->wire(remap_name(port));
 			RTLIL::SigSpec signal = RTLIL::SigSpec(wire, 0, GetSize(remap_wire));
 			log_assert(GetSize(signal) >= GetSize(remap_wire));
 
-			log_assert(w->port_input || w->port_output);
 			RTLIL::SigSig conn;
-			if (w->port_input) {
-				conn.first = remap_wire;
-				conn.second = signal;
-				in_wires++;
-				module->connect(conn);
-			}
 			if (w->port_output) {
 				conn.first = signal;
 				conn.second = remap_wire;
 				out_wires++;
+				module->connect(conn);
+			}
+			else if (w->port_input) {
+				conn.first = remap_wire;
+				conn.second = signal;
+				in_wires++;
 				module->connect(conn);
 			}
 		}

--- a/tests/simple_abc9/run-test.sh
+++ b/tests/simple_abc9/run-test.sh
@@ -20,4 +20,10 @@ fi
 cp ../simple/*.v .
 cp ../simple/*.sv .
 DOLLAR='?'
-exec ${MAKE:-make} -f ../tools/autotest.mk $seed *.v EXTRA_FLAGS="-n 300 -p 'hierarchy; synth -run coarse; opt -full; techmap; abc9 -lut 4 -box ../abc.box; stat; check -assert; select -assert-none t:${DOLLAR}_NOT_ t:${DOLLAR}_AND_ %%'"
+exec ${MAKE:-make} -f ../tools/autotest.mk $seed *.v EXTRA_FLAGS="-n 300 -p '\
+    hierarchy; \
+    synth -run coarse; \
+    opt -full; \
+    techmap; abc9 -lut 4 -box ../abc.box; \
+    check -assert; \
+    select -assert-none t:${DOLLAR}_NOT_ t:${DOLLAR}_AND_ %%'"


### PR DESCRIPTION
For example, the `synth_*` passes will often call `clean` after `abc`/`abc9` anyway.

Plus some README.md shuffling.

Also fixed an issue with inout ports when stitching in the circuit from `abc9`.