### PR TITLE
Fix extra space issue in parameter of json backend.

### DIFF
--- a/backends/json/json.cc
+++ b/backends/json/json.cc
@@ -99,7 +99,7 @@ struct JsonWriter
 				} else if (state == 1 && c != ' ')
 					state = 2;
 			}
-			if (state < 2)
+			if (state == 1)
 				str += " ";
 			f << get_string(str);
 		} else


### PR DESCRIPTION
This pull request fixes (what I think is) the root cause of [1341](https://github.com/YosysHQ/yosys/issues/1341). The yosys, nextpnr-ice40, and -ecp5 tests pass locally, but I'm nervous that this change may affect parts of the toolchain I'm unaware of. Please think of it as a mere starting point for a real fix. 