### PR TITLE
ice40_dsp to allow signed multipliers

### DIFF
--- a/passes/pmgen/ice40_dsp.cc
+++ b/passes/pmgen/ice40_dsp.cc
@@ -64,11 +64,6 @@ void create_ice40_dsp(ice40_dsp_pm &pm)
 
 	bool mul_signed = st.mul->getParam("\\A_SIGNED").as_bool();
 
-	if (mul_signed) {
-		log("  inference of signed iCE40 DSP arithmetic is currently not supported.\n");
-		return;
-	}
-
 	log("  replacing $mul with SB_MAC16 cell.\n");
 
 	Cell *cell = pm.module->addCell(NEW_ID, "\\SB_MAC16");

--- a/tests/ice40/macc.v
+++ b/tests/ice40/macc.v
@@ -2,8 +2,8 @@
 Example from: https://www.latticesemi.com/-/media/LatticeSemi/Documents/UserManuals/EI/iCEcube201701UserGuide.ashx?document_id=52071 [p. 77].
 */
 module top(clk,a,b,c,set);
-parameter A_WIDTH = 4;
-parameter B_WIDTH = 3;
+parameter A_WIDTH = 6 /*4*/;
+parameter B_WIDTH = 6 /*3*/;
 input set;
 input clk;
 input signed [(A_WIDTH - 1):0] a;

--- a/tests/ice40/macc.ys
+++ b/tests/ice40/macc.ys
@@ -1,10 +1,13 @@
 read_verilog macc.v
 proc
 hierarchy -top top
-equiv_opt -assert -map +/ice40/cells_sim.v synth_ice40 -dsp # equivalency check
+#equiv_opt -assert -map +/ice40/cells_sim.v synth_ice40 -dsp # equivalency check
+
+equiv_opt -run :prove -map +/ice40/cells_sim.v synth_ice40 -dsp
+async2sync
+equiv_opt -run prove: -assert null
+
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
-select -assert-count 38 t:SB_LUT4
-select -assert-count 3 t:SB_CARRY
-select -assert-count 7 t:SB_DFFSR
-select -assert-none t:SB_LUT4 t:SB_CARRY t:SB_DFFSR %% t:* %D
+select -assert-count 1 t:SB_MAC16
+select -assert-none t:SB_MAC16 %% t:* %D


### PR DESCRIPTION
@cliffordwolf what was the reason behind why signed multipliers were rejected in: https://github.com/YosysHQ/yosys/commit/dca65d83a0037539464d303ea8751a3e06a92e03?

Also modified existing testcase to be wider to go over our thresholds for DSP inference.