### PR TITLE
Use `command -v` rather than `which`

### DIFF
--- a/tests/simple/run-test.sh
+++ b/tests/simple/run-test.sh
@@ -12,7 +12,7 @@ done
 shift "$((OPTIND-1))"
 
 # check for Icarus Verilog
-if ! which iverilog > /dev/null ; then
+if ! command -v iverilog > /dev/null ; then
   echo "$0: Error: Icarus Verilog 'iverilog' not found."
   exit 1
 fi

--- a/tests/simple_abc9/run-test.sh
+++ b/tests/simple_abc9/run-test.sh
@@ -12,7 +12,7 @@ done
 shift "$((OPTIND-1))"
 
 # check for Icarus Verilog
-if ! which iverilog > /dev/null ; then
+if ! command -v iverilog > /dev/null ; then
   echo "$0: Error: Icarus Verilog 'iverilog' not found."
   exit 1
 fi


### PR DESCRIPTION
`which` is [non-portable](https://twitter.com/whitequark/status/1168670168173559808), requiring an additional package installation on some systems, as I ran into trying to get the NixOS package to run yosys tests; the most common alternative, `type -p` is [POSIX-portable in terms of return value, but not output](https://twitter.com/dev_console/status/1168672291271692288). That doesn't matter particularly here, but I've replaced it with `command -v`, which is [portable in return value and output](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html).