### PR TITLE
Use $(shell :; ...) in Makefile to force shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ ifeq ($(OS), Darwin)
 PLUGIN_LDFLAGS += -undefined dynamic_lookup
 
 # homebrew search paths
-ifneq ($(shell command -v brew),)
+ifneq ($(shell :; command -v brew),)
 BREW_PREFIX := $(shell brew --prefix)/opt
 $(info $$BREW_PREFIX is [${BREW_PREFIX}])
 ifeq ($(ENABLE_PYOSYS),1)
@@ -102,8 +102,8 @@ PKG_CONFIG_PATH := $(BREW_PREFIX)/tcl-tk/lib/pkgconfig:$(PKG_CONFIG_PATH)
 export PATH := $(BREW_PREFIX)/bison/bin:$(BREW_PREFIX)/gettext/bin:$(BREW_PREFIX)/flex/bin:$(PATH)
 
 # macports search paths
-else ifneq ($(shell command -v port),)
-PORT_PREFIX := $(patsubst %/bin/port,%,$(shell command -v port))
+else ifneq ($(shell :; command -v port),)
+PORT_PREFIX := $(patsubst %/bin/port,%,$(shell :; command -v port))
 CXXFLAGS += -I$(PORT_PREFIX)/include
 LDFLAGS += -L$(PORT_PREFIX)/lib
 PKG_CONFIG_PATH := $(PORT_PREFIX)/lib/pkgconfig:$(PKG_CONFIG_PATH)


### PR DESCRIPTION
Did you think that `$(shell command -v ...)` would actually get run by
the shell? Foolish mortal; GNU Make is obviously far more wise than
thee, as it optimizes it to a direct -- and hence broken (since
`command` is a shell builtin) -- exec. This horrifying contortion
ensures that an actual shell runs the command and fixes the behaviour.

@Shizmob found the source of this misbehaviour; turns out gmake has a
hard-coded, incomplete list of shell builtins:

https://github.com/mirror/make/blob/715c787dc69bac37827a7d6ea6d40a86c55b5583/src/job.c#L2691

This contains `command`, but the whole function is full of horrible
heuristic garbage so who knows. I'm so sorry.