### PR TITLE
MSVC2 fixes

### DIFF
--- a/backends/smt2/Makefile.inc
+++ b/backends/smt2/Makefile.inc
@@ -16,7 +16,7 @@ yosys-smtbmc-script.py: backends/smt2/smtbmc.py
 		-e "s|#!/usr/bin/env python3|#!$(PYTHON)|" < $< > $@
 
 yosys-smtbmc.exe: misc/launcher.c yosys-smtbmc-script.py
-	$(P) gcc -DGUI=0 -O -s -o $@ $<
+	$(P) $(CXX) -DGUI=0 -O -s -o $@ $<
 # Other targets
 else
 TARGETS += yosys-smtbmc

--- a/misc/launcher.c
+++ b/misc/launcher.c
@@ -65,7 +65,7 @@ SOFTWARE. */
 
 int child_pid=0;
 
-int fail(char *format, char *data) {
+int fail(const char *format, const char *data) {
     /* Print error message to stderr and return 2 */
     fprintf(stderr, format, data);
     return 2;
@@ -76,7 +76,7 @@ char *quoted(char *data) {
 
     /* We allocate twice as much space as needed to deal with worse-case
        of having to escape everything. */
-    char *result = calloc(ln*2+3, sizeof(char));
+    char *result = (char *)calloc(ln*2+3, sizeof(char));
     char *presult = result;
 
     *presult++ = '"';
@@ -120,7 +120,7 @@ char *loadable_exe(char *exename) {
     if (!hPython) return NULL; */
 
     /* Return the absolute filename for spawnv */
-    result = calloc(MAX_PATH, sizeof(char));
+    result = (char *)calloc(MAX_PATH, sizeof(char));
     strncpy(result, exename, MAX_PATH);
     /*if (result) GetModuleFileNameA(hPython, result, MAX_PATH);
 
@@ -158,7 +158,7 @@ char **parse_argv(char *cmdline, int *argc)
 {
     /* Parse a command line in-place using MS C rules */
 
-    char **result = calloc(strlen(cmdline), sizeof(char *));
+    char **result = (char **)calloc(strlen(cmdline), sizeof(char *));
     char *output = cmdline;
     char c;
     int nb = 0;

--- a/passes/opt/opt_share.cc
+++ b/passes/opt/opt_share.cc
@@ -108,12 +108,13 @@ bool cell_supported(RTLIL::Cell *cell)
 	return false;
 }
 
-std::map<IdString, IdString> mergeable_type_map{
-  {ID($sub), ID($add)},
-};
+std::map<IdString, IdString> mergeable_type_map;
 
 bool mergeable(RTLIL::Cell *a, RTLIL::Cell *b)
 {
+	if (mergeable_type_map.empty()) {
+		mergeable_type_map.insert({ID($sub), ID($add)});
+	}
 	auto a_type = a->type;
 	if (mergeable_type_map.count(a_type))
 		a_type = mergeable_type_map.at(a_type);

--- a/tests/ice40/div_mod.ys
+++ b/tests/ice40/div_mod.ys
@@ -4,6 +4,6 @@ flatten
 equiv_opt -assert -map +/ice40/cells_sim.v synth_ice40 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
-select -assert-count 62 t:SB_LUT4
+select -assert-count 59 t:SB_LUT4
 select -assert-count 41 t:SB_CARRY
 select -assert-none t:SB_LUT4 t:SB_CARRY %% t:* %D


### PR DESCRIPTION
This fixes two issues with Yosys when building for MSVC2:

1. The Makefile assumes the compiler is always called `gcc`, which isn't always true.
2. Patch 3d3779b0376b8204ed7637053176a07b7271ac1d added a static map that contains a static class with static members, which might get initialized in an incorrect order.