### PR TITLE
Implement macromodule inlining

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -940,6 +940,7 @@ static AstModule* process_module(AstNode *ast, bool defer, AstNode *original_ast
 	current_module->attributes["\\src"] = stringf("%s:%d", ast->filename.c_str(), ast->linenum);
 	current_module->set_bool_attribute("\\cells_not_processed");
 
+	ast = ast->clone();
 	current_ast_mod = ast;
 	AstNode *ast_before_simplify;
 	if (original_ast != NULL)
@@ -1129,6 +1130,7 @@ static AstModule* process_module(AstNode *ast, bool defer, AstNode *original_ast
 		log("--- END OF RTLIL DUMP ---\n");
 	}
 
+	delete ast;
 	return current_module;
 }
 

--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -146,6 +146,7 @@ YOSYS_NAMESPACE_END
 }
 
 "module"       { return TOK_MODULE; }
+"macromodule"  { return TOK_MACROMODULE; }
 "endmodule"    { return TOK_ENDMODULE; }
 "function"     { return TOK_FUNCTION; }
 "endfunction"  { return TOK_ENDFUNCTION; }

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -136,7 +136,7 @@ struct specify_rise_fall {
 %token <string> TOK_SVA_LABEL TOK_SPECIFY_OPER TOK_MSG_TASKS
 %token TOK_ASSERT TOK_ASSUME TOK_RESTRICT TOK_COVER TOK_FINAL
 %token ATTR_BEGIN ATTR_END DEFATTR_BEGIN DEFATTR_END
-%token TOK_MODULE TOK_ENDMODULE TOK_PARAMETER TOK_LOCALPARAM TOK_DEFPARAM
+%token TOK_MODULE TOK_MACROMODULE TOK_ENDMODULE TOK_PARAMETER TOK_LOCALPARAM TOK_DEFPARAM
 %token TOK_PACKAGE TOK_ENDPACKAGE TOK_PACKAGESEP
 %token TOK_INTERFACE TOK_ENDINTERFACE TOK_MODPORT TOK_VAR
 %token TOK_INPUT TOK_OUTPUT TOK_INOUT TOK_WIRE TOK_WAND TOK_WOR TOK_REG TOK_LOGIC
@@ -156,7 +156,7 @@ struct specify_rise_fall {
 %type <ast> range range_or_multirange  non_opt_range non_opt_multirange range_or_signed_int
 %type <ast> wire_type expr basic_expr concat_list rvalue lvalue lvalue_concat_list
 %type <string> opt_label opt_sva_label tok_prim_wrapper hierarchical_id
-%type <boolean> opt_signed opt_property unique_case_attr
+%type <boolean> opt_signed opt_property unique_case_attr module_keyword
 %type <al> attr case_attr
 
 %type <specify_target_ptr> specify_target
@@ -290,8 +290,16 @@ hierarchical_id:
 		$$ = $1;
 	};
 
+module_keyword:
+	TOK_MACROMODULE {
+		$$ = true;
+	} |
+	TOK_MODULE {
+		$$ = false;
+	};
+
 module:
-	attr TOK_MODULE TOK_ID {
+	attr module_keyword TOK_ID {
 		do_not_require_port_stubs = false;
 		AstNode *mod = new AstNode(AST_MODULE);
 		ast_stack.back()->children.push_back(mod);
@@ -300,6 +308,7 @@ module:
 		port_stubs.clear();
 		port_counter = 0;
 		mod->str = *$3;
+		mod->is_signed = $2;
 		append_attr(mod, $1);
 		delete $3;
 	} module_para_opt module_args_opt ';' module_body TOK_ENDMODULE {

--- a/tests/simple/hiermacro.v
+++ b/tests/simple/hiermacro.v
@@ -1,0 +1,26 @@
+
+(* top *)
+module top(a, b, y1, y2, y3, y4);
+input [3:0] a;
+input signed [3:0] b;
+output [7:0] y1, y2, y3, y4;
+
+// this version triggers a bug in Icarus Verilog
+// submod #(-3'sd1, 3'b111 + 3'b001) foo (a, b, y1, y2, y3, y4);
+
+// this version is handled correctly by Icarus Verilog
+submod #(-3'sd1, -3'sd1) foo (a, b, y1, y2, y3, y4);
+
+endmodule
+
+(* gentb_skip *)
+macromodule submod(a, b, y1, y2, y3, y4);
+parameter c = 0;
+parameter [7:0] d = 0;
+input [3:0] a, b;
+output [7:0] y1, y2, y3, y4;
+assign y1 = a;
+assign y2 = b;
+assign y3 = c;
+assign y4 = d;
+endmodule

--- a/tests/simple/macrotask.v
+++ b/tests/simple/macrotask.v
@@ -1,0 +1,70 @@
+
+macromodule task_func_test01_impl();
+reg [7:0] x, y, z, w;
+
+function [7:0] sum_shift;
+input [3:0] s1, s2, s3;
+sum_shift = s1 + (s2 << 2) + (s3 << 4);
+endfunction
+
+task reset_w;
+w = 0;
+endtask
+
+task add_to;
+output [7:0] out;
+input [7:0] in;
+out = out + in;
+endtask
+
+task cycle;
+input [7:0] a, b, c;
+output [7:0] ret_x, ret_y, ret_z, ret_w;
+begin
+	x = sum_shift(a, b, c);
+	y = sum_shift(a[7:4], b[5:2], c[3:0]);
+	z = sum_shift(a[0], b[5:4], c >> 5) ^ sum_shift(1, 2, 3);
+
+	reset_w;
+	add_to(w, x);
+	add_to(w, y);
+	add_to(w, z);
+  ret_x = x;
+  ret_y = y;
+  ret_z = z;
+  ret_w = w;
+end
+endtask
+
+endmodule
+
+module task_func_test01(clk, a, b, c, x, y, z, w);
+input clk;
+input [7:0] a, b, c;
+output reg [7:0] x, y, z, w;
+task_func_test01_impl impl();
+always @(posedge clk) begin
+	impl.cycle(a, b, c, x, y, z, w);
+end
+endmodule
+
+// -------------------------------------------------------------------
+
+macromodule task_func_test05_impl(data_in,data_out);
+	input data_in;
+	output reg data_out;
+
+	task myTask;
+		data_out = data_in;
+	endtask
+endmodule
+
+module task_func_test05(data_in,data_out,clk);
+	input data_in;
+	output data_out;
+	input clk;
+  task_func_test05_impl impl(data_in, data_out);
+	always @(posedge clk) begin
+		impl.myTask();
+	end
+endmodule

--- a/tests/simple/paramacromods.v
+++ b/tests/simple/paramacromods.v
@@ -1,0 +1,54 @@
+
+macromodule pm_test1(a, b, x, y);
+
+input [7:0] a, b;
+output [7:0] x, y;
+
+inc #(.step(3)) inc_a (.in(a), .out(x));
+inc #(.width(4), .step(7)) inc_b (b, y);
+
+endmodule
+
+// -----------------------------------
+
+macromodule pm_test2(a, b, x, y);
+
+input [7:0] a, b;
+output [7:0] x, y;
+
+inc #(5) inc_a (.in(a), .out(x));
+inc #(4, 7) inc_b (b, y);
+
+endmodule
+
+// -----------------------------------
+
+// // TODO: make this work
+// // for now, it's "not supported"
+// macromodule pm_test3(a, b, x, y);
+//
+// input [7:0] a, b;
+// output [7:0] x, y;
+//
+// inc inc_a (.in(a), .out(x));
+// inc inc_b (b, y);
+//
+// defparam inc_a.step = 3;
+// defparam inc_b.step = 7;
+// defparam inc_b.width = 4;
+//
+// endmodule
+
+// -----------------------------------
+
+macromodule inc(in, out);
+
+parameter width = 8;
+parameter step = 1;
+
+input [width-1:0] in;
+output [width-1:0] out;
+
+assign out = in + step;
+
+endmodule


### PR DESCRIPTION
Proposed commit message:

> The `macromodule` keyword can now be used instead of `module` in places
> where `module` was previously accepted. Instantiations of such modules
> will be synthesized by inlining. Further, macromodule inlining is
> performed before task/function inlining, so tasks defined in a
> macromodule can be called from its parent module. This last behavior is
> experimental, undocumented, and may disappear at any time.

This is my first contribution to yosys. I think it is far along enough to be worth reviewing, but not ready to be merged quite yet. There are a few specific todo-s I would like advice on:

- [ ] are the changes to `ast.cc` a good way to keep around the unsimplified AST of each module?
- [ ] should children of inlined modules be always appended to the current module, not the current block?
- [ ] should `prefixWith` do something different for `GENBLOCK`?
- [ ] is it important to support inlining for `macromodule` instantiations whose parameters are set using `defparam`?
- [ ] are the tests sufficient?
- [ ] TODO store macromodule/module distinction in a better-named field than `is_signed`, but what?