### PR TITLE
Fix lexing of integer literals

### DIFF
--- a/frontends/verilog/const2ast.cc
+++ b/frontends/verilog/const2ast.cc
@@ -199,13 +199,13 @@ AstNode *VERILOG_FRONTEND::const2ast(std::string code, char case_type, bool warn
 	if (str == endptr)
 		len_in_bits = -1;
 
-	// The "<bits>'s?[bodhBODH]<digits>" syntax
+	// The "<bits>'[sS]?[bodhBODH]<digits>" syntax
 	if (*endptr == '\'')
 	{
 		std::vector<RTLIL::State> data;
 		bool is_signed = false;
 		bool is_unsized = len_in_bits < 0;
-		if (*(endptr+1) == 's') {
+		if (*(endptr+1) == 's' || *(endptr+1) == 'S') {
 			is_signed = true;
 			endptr++;
 		}

--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -239,7 +239,7 @@ YOSYS_NAMESPACE_END
 	return TOK_CONSTVAL;
 }
 
-[0-9]*[ \t]*\'[sS]?[bodhBODH][ \t\r\n]*[0-9a-fA-FzxZX?_]+ {
+[0-9]*[ \t]*\'[sS]?[bodhBODH]?[ \t\r\n]*[0-9a-fA-FzxZX?_]+ {
 	frontend_verilog_yylval.string = new std::string(yytext);
 	return TOK_CONSTVAL;
 }

--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -239,7 +239,7 @@ YOSYS_NAMESPACE_END
 	return TOK_CONSTVAL;
 }
 
-[0-9]*[ \t]*\'s?[bodhBODH]*[ \t\r\n]*[0-9a-fA-FzxZX?_]+ {
+[0-9]*[ \t]*\'[sS]?[bodhBODH][ \t\r\n]*[0-9a-fA-FzxZX?_]+ {
 	frontend_verilog_yylval.string = new std::string(yytext);
 	return TOK_CONSTVAL;
 }


### PR DESCRIPTION
This reverts a change introduced in 34417ce55 by @mmicko that caused #1364. It also adds support for uppercase `S` as signedness indicator.