### PR TITLE
Adding dffeas_init to better determine init value for this cell

### DIFF
--- a/techlibs/intel/Makefile.inc
+++ b/techlibs/intel/Makefile.inc
@@ -1,5 +1,6 @@
 
 OBJS += techlibs/intel/synth_intel.o
+OBJS += techlibs/intel/dffeas_init.o
 
 $(eval $(call add_share_file,share/intel/common,techlibs/intel/common/m9k_bb.v))
 $(eval $(call add_share_file,share/intel/common,techlibs/intel/common/altpll_bb.v))

--- a/techlibs/intel/cyclone10/cells_map.v
+++ b/techlibs/intel/cyclone10/cells_map.v
@@ -24,36 +24,43 @@
 // Normal mode DFF negedge clk, negedge reset
 module  \$_DFF_N_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Normal mode DFF
 module  \$_DFF_P_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 // Async Active Low Reset DFF
 module  \$_DFF_PN0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up("power_up")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Async Active High Reset DFF
 module  \$_DFF_PP0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    wire R_i = ~ R;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R_i), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 module  \$__DFFE_PP0 (input D, C, E, R, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    wire E_i = ~ E;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(E_i), .sload(1'b0));
 endmodule
+
+module \$_DFF_PN1_ (input D, C, R, output Q);
+   parameter WYSIWYG="TRUE";
+   parameter power_up=1'b0;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(!R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+endmodule
+
 
 // Input buffer map
 module \$__inpad (input I, output O);

--- a/techlibs/intel/cycloneiv/cells_map.v
+++ b/techlibs/intel/cycloneiv/cells_map.v
@@ -24,35 +24,41 @@
 // Normal mode DFF negedge clk, negedge reset
 module  \$_DFF_N_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Normal mode DFF
 module  \$_DFF_P_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 // Async Active Low Reset DFF
 module  \$_DFF_PN0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up("power_up")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Async Active High Reset DFF
 module  \$_DFF_PP0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    wire R_i = ~ R;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R_i), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 module  \$__DFFE_PP0 (input D, C, E, R, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    wire E_i = ~ E;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(E_i), .sload(1'b0));
+endmodule
+
+module \$_DFF_PN1_ (input D, C, R, output Q);
+   parameter WYSIWYG="TRUE";
+   parameter power_up=1'b0;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(!R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 // Input buffer map

--- a/techlibs/intel/cycloneive/cells_map.v
+++ b/techlibs/intel/cycloneive/cells_map.v
@@ -24,36 +24,43 @@
 // Normal mode DFF negedge clk, negedge reset
 module  \$_DFF_N_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Normal mode DFF
 module  \$_DFF_P_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 // Async Active Low Reset DFF
 module  \$_DFF_PN0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up("power_up")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Async Active High Reset DFF
 module  \$_DFF_PP0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    wire R_i = ~ R;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R_i), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 module  \$__DFFE_PP0 (input D, C, E, R, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    wire E_i = ~ E;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(E_i), .sload(1'b0));
 endmodule
+
+module \$_DFF_PN1_ (input D, C, R, output Q);
+   parameter WYSIWYG="TRUE";
+   parameter power_up=1'b0;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(!R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+endmodule
+
 
 // Input buffer map
 module \$__inpad (input I, output O);

--- a/techlibs/intel/cyclonev/cells_map.v
+++ b/techlibs/intel/cyclonev/cells_map.v
@@ -26,36 +26,43 @@
 // Normal mode DFF negedge clk, negedge reset
 module  \$_DFF_N_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Normal mode DFF
 module  \$_DFF_P_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 // Async Active Low Reset DFF
 module  \$_DFF_PN0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up("power_up")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Async Active High Reset DFF
 module  \$_DFF_PP0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    wire R_i = ~ R;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R_i), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 module  \$__DFFE_PP0 (input D, C, E, R, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    wire E_i = ~ E;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(E_i), .sload(1'b0));
 endmodule
+
+module \$_DFF_PN1_ (input D, C, R, output Q);
+   parameter WYSIWYG="TRUE";
+   parameter power_up=1'b0;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(!R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+endmodule
+
 
 // Input buffer map
 module \$__inpad (input I, output O);

--- a/techlibs/intel/dffeas_init.cc
+++ b/techlibs/intel/dffeas_init.cc
@@ -1,0 +1,75 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/yosys.h"
+#include "kernel/sigtools.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+struct DffeasInitPass : public Pass {
+	DffeasInitPass() : Pass("dffeas_init", "Determine the init value of dffeas cells") { }
+	void help() YS_OVERRIDE
+	{
+		log("\n");
+		log("    dffeas_init [selection]\n");
+		log("\n");
+		log("Determine the init value of dffeas cells.\n");
+		log("\n");
+	}
+
+	Const dffeas_init(Const value)
+	{
+		if (GetSize(value) !=0 ){
+			if (value[0] == State::S1)
+				value = Const("high");
+			else if (value[0] == State::S0)
+				value = Const("low");
+			else
+				value = Const("dont_care");
+		}
+
+		return value;
+	}
+
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	{
+		log_header(design, "Executing DETERMINE_INIT pass (determine init value for cells).\n");
+
+		extra_args(args, args.size(), design);
+
+		int cnt = 0;
+                Const value;
+		for (auto module : design->selected_modules())
+		{
+			for (auto cell : module->selected_cells())
+			{
+				if (cell->type == "\\dffeas")
+				{
+					cell->setParam("\\power_up", dffeas_init(cell->getParam("\\power_up")));
+					cnt++;
+				}
+			}
+		}
+		log_header(design, "Updated %d dffeas cells with determined init value.\n", cnt);
+	}
+} DffeasInitPass;
+
+PRIVATE_NAMESPACE_END
+

--- a/techlibs/intel/max10/cells_map.v
+++ b/techlibs/intel/max10/cells_map.v
@@ -24,35 +24,41 @@
 // Normal mode DFF negedge clk, negedge reset
 module  \$_DFF_N_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Normal mode DFF
 module  \$_DFF_P_ (input D, C, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 // Async Active Low Reset DFF
 module  \$_DFF_PN0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
-   dffeas #(.is_wysiwyg(WYSIWYG), .power_up("power_up")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+   parameter power_up=1'b0;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 // Async Active High Reset DFF
 module  \$_DFF_PP0_ (input D, C, R, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    wire R_i = ~ R;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R_i), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 module  \$__DFFE_PP0 (input D, C, E, R, output Q);
    parameter WYSIWYG="TRUE";
-   parameter power_up=1'bx;
+   parameter power_up=1'b0;
    wire E_i = ~ E;
    dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(E_i), .sload(1'b0));
+endmodule
+
+module \$_DFF_PN1_ (input D, C, R, output Q);
+   parameter WYSIWYG="TRUE";
+   parameter power_up=1'b0;
+   dffeas #(.is_wysiwyg(WYSIWYG), .power_up(power_up)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(!R), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
 endmodule
 
 // Input buffer map

--- a/techlibs/intel/synth_intel.cc
+++ b/techlibs/intel/synth_intel.cc
@@ -225,7 +225,8 @@ struct SynthIntelPass : public ScriptPass {
 			if (iopads || help_mode)
 				run("iopadmap -bits -outpad $__outpad I:O -inpad $__inpad O:I", "(if -iopads)");
                         run(stringf("techmap -map +/intel/%s/cells_map.v", family_opt.c_str()));
-			run("dffinit -highlow -ff dffeas q power_up");
+			run("dffinit -ff dffeas q power_up");
+			run("dffeas_init");
 			run("clean -purge");
 		}
 


### PR DESCRIPTION
@eddiehung 
This PR is to solve #1368 . The dffinit pass used in _synth_intel_ with -highlow argument is causing issues in multi-bit values (parameters as strings are causing some problems). 
I'm removing -highlow argument and generating the parameter needed for dffeas with __dffeas_init__. In such way, Yosys can dump the cell with the parameter _power_up_ = bit and then, convert that bit into what the VQM expects.

I ran synthesis test only succesfully. Please advise if I should run any other test.

* Run Yosys.
```bash
read_verilog -sv pattern_gen.v
synth_intel -family max10 -top pattern_gen -vqm pattern_gen.vqm
```
* Run Quartus with generated VQM:
```bash
quartus_map pattern_gen --part=EP4CE22F17C6
```
* Log:
```bash
    Info: Quartus Prime Analysis & Synthesis was successful. 0 errors, 4 warnings
    Info: Peak virtual memory: 941 megabytes
    Info: Processing ended: Thu Sep 12 15:05:09 2019
    Info: Elapsed time: 00:00:16
    Info: Total CPU time (on all processors): 00:00:41
```

Below is an excerpt of generated VQM for both Quartus and Yosys:
``` bash
Quartus:
dffeas \ctr[0]~I (
        .clk(\clk~input ),
        .d(\Selector66~0 ),
        .clrn(\rst_n~input ),
        .q(\ctr[0] ));
defparam \ctr[0]~I .power_up = "low";
defparam \ctr[0]~I .is_wysiwyg = "true";

Yosys:
  dffeas syn__346_ (
    .aload(1'b0),
    .asdata(1'b0),
    .clk(clk),
    .clrn(rst_n),
    .d(syn__000_[0]),
    .ena(1'b1),
    .prn(1'b1),
    .q(data[0]),
    .sclr(1'b0),
    .sload(1'b0)
  );
  defparam syn__346_.is_wysiwyg = "TRUE";
  defparam syn__346_.power_up = "low";

```