### PR TITLE
Change order of parameters, to work on other OS

### DIFF
--- a/tests/ice40/run-test.sh
+++ b/tests/ice40/run-test.sh
@@ -6,7 +6,7 @@ for x in *.ys; do
 	echo "all:: run-$x"
 	echo "run-$x:"
 	echo "	@echo 'Running $x..'"
-	echo "	@../../yosys -ql ${x%.ys}.log $x -w 'Yosys has only limited support for tri-state logic at the moment.'"
+	echo "	@../../yosys -ql ${x%.ys}.log -w 'Yosys has only limited support for tri-state logic at the moment.' $x"
 done
 for s in *.sh; do
 	if [ "$s" != "run-test.sh" ]; then


### PR DESCRIPTION
Due to a difference how getopt works on GNU library and other implementation, changed order of parameters, since in strict systems non-option arguments must be at the end of argument list.