### PR TITLE
equiv_opt to call async2sync when not -multiclock like SymbiYosys

### DIFF
--- a/passes/equiv/equiv_opt.cc
+++ b/passes/equiv/equiv_opt.cc
@@ -156,6 +156,8 @@ struct EquivOptPass:public ScriptPass
 		if (check_label("prove")) {
 			if (multiclock || help_mode)
 				run("clk2fflogic", "(only with -multiclock)");
+			else
+				run("async2sync", "(only without -multiclock)");
 			run("equiv_make gold gate equiv");
 			if (help_mode)
 				run("equiv_induct [-undef] equiv");


### PR DESCRIPTION
Just like sby does here:
https://github.com/YosysHQ/SymbiYosys/blob/06cc339957a56bf413da911d6c0aa01503590802/sbysrc/sby_core.py#L346-L349
and cleans up small barnacles like this:
https://github.com/YosysHQ/yosys/blob/8c2dd518b908644c9181526e193b8211734e8cef/tests/xilinx/latches.ys#L5-L7