### PR TITLE
Support binary files for backends, fixes #1407

### DIFF
--- a/backends/aiger/aiger.cc
+++ b/backends/aiger/aiger.cc
@@ -777,7 +777,7 @@ struct AigerBackend : public Backend {
 			}
 			break;
 		}
-		extra_args(f, filename, args, argidx);
+		extra_args(f, filename, args, argidx, !ascii_mode);
 
 		Module *top_module = design->top_module();
 

--- a/backends/aiger/xaiger.cc
+++ b/backends/aiger/xaiger.cc
@@ -856,7 +856,7 @@ struct XAigerBackend : public Backend {
 			}
 			break;
 		}
-		extra_args(f, filename, args, argidx);
+		extra_args(f, filename, args, argidx, !ascii_mode);
 
 		Module *top_module = design->top_module();
 

--- a/backends/protobuf/protobuf.cc
+++ b/backends/protobuf/protobuf.cc
@@ -266,7 +266,7 @@ struct ProtobufBackend : public Backend {
 			}
 			break;
 		}
-		extra_args(f, filename, args, argidx);
+		extra_args(f, filename, args, argidx, !text_mode);
 
 		log_header(design, "Executing Protobuf backend.\n");
 
@@ -338,7 +338,7 @@ struct ProtobufPass : public Pass {
 		if (!filename.empty()) {
 			rewrite_filename(filename);
 			std::ofstream *ff = new std::ofstream;
-			ff->open(filename.c_str(), std::ofstream::trunc);
+			ff->open(filename.c_str(), text_mode ? std::ofstream::trunc : (std::ofstream::trunc | std::ofstream::binary));
 			if (ff->fail()) {
 				delete ff;
 				log_error("Can't open file `%s' for writing: %s\n", filename.c_str(), strerror(errno));

--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -612,7 +612,7 @@ void Backend::execute(std::vector<std::string> args, RTLIL::Design *design)
 		delete f;
 }
 
-void Backend::extra_args(std::ostream *&f, std::string &filename, std::vector<std::string> args, size_t argidx)
+void Backend::extra_args(std::ostream *&f, std::string &filename, std::vector<std::string> args, size_t argidx, bool bin_output)
 {
 	bool called_with_fp = f != NULL;
 
@@ -647,7 +647,7 @@ void Backend::extra_args(std::ostream *&f, std::string &filename, std::vector<st
 #endif
 		} else {
 			std::ofstream *ff = new std::ofstream;
-			ff->open(filename.c_str(), std::ofstream::trunc);
+			ff->open(filename.c_str(), bin_output ? (std::ofstream::trunc | std::ofstream::binary) : std::ofstream::trunc);
 			yosys_output_files.insert(filename);
 			if (ff->fail()) {
 				delete ff;

--- a/kernel/register.h
+++ b/kernel/register.h
@@ -109,7 +109,7 @@ struct Backend : Pass
 	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE YS_FINAL;
 	virtual void execute(std::ostream *&f, std::string filename,  std::vector<std::string> args, RTLIL::Design *design) = 0;
 
-	void extra_args(std::ostream *&f, std::string &filename, std::vector<std::string> args, size_t argidx);
+	void extra_args(std::ostream *&f, std::string &filename, std::vector<std::string> args, size_t argidx, bool bin_output = false);
 
 	static void backend_call(RTLIL::Design *design, std::ostream *f, std::string filename, std::string command);
 	static void backend_call(RTLIL::Design *design, std::ostream *f, std::string filename, std::vector<std::string> args);


### PR DESCRIPTION
In cases when we need to provide binary output of backend it is important to set that flag, otherwise writing of \n will produce system specific EOL, causing creation of invalid file.