### PR TITLE
Avoid work in replace() if rules empty.

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -3083,6 +3083,7 @@ void RTLIL::SigSpec::replace(const dict<RTLIL::SigBit, RTLIL::SigBit> &rules, RT
 	log_assert(other != NULL);
 	log_assert(width_ == other->width_);
 
+	if (rules.empty()) return;
 	unpack();
 	other->unpack();
 
@@ -3107,6 +3108,7 @@ void RTLIL::SigSpec::replace(const std::map<RTLIL::SigBit, RTLIL::SigBit> &rules
 	log_assert(other != NULL);
 	log_assert(width_ == other->width_);
 
+	if (rules.empty()) return;
 	unpack();
 	other->unpack();
 


### PR DESCRIPTION
This speeds up processing when number of bits are large but there
is actually nothing to replace. Adresses part of #1382 