### PR TITLE
Open aig frontend as binary file

### DIFF
--- a/frontends/aiger/aigerparse.cc
+++ b/frontends/aiger/aigerparse.cc
@@ -1056,7 +1056,7 @@ struct AigerFrontend : public Frontend {
 			}
 			break;
 		}
-		extra_args(f, filename, args, argidx);
+		extra_args(f, filename, args, argidx, true);
 
 		if (module_name.empty()) {
 #ifdef _WIN32

--- a/frontends/aiger/aigerparse.cc
+++ b/frontends/aiger/aigerparse.cc
@@ -285,6 +285,8 @@ end_of_header:
 		}
 		else if (c == 'c') {
 			f.ignore(1);
+			if (f.peek() == '\r')
+				f.ignore(1);
 			if (f.peek() == '\n')
 				break;
 			// Else constraint (TODO)
@@ -1062,7 +1064,9 @@ struct AigerFrontend : public Frontend {
 #ifdef _WIN32
 			char fname[_MAX_FNAME];
 			_splitpath(filename.c_str(), NULL /* drive */, NULL /* dir */, fname, NULL /* ext */);
-			module_name = fname;
+			char* bn = strdup(fname);
+			module_name = RTLIL::escape_id(bn);
+			free(bn);
 #else
 			char* bn = strdup(filename.c_str());
 			module_name = RTLIL::escape_id(bn);

--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -439,7 +439,7 @@ void Frontend::execute(std::vector<std::string> args, RTLIL::Design *design)
 FILE *Frontend::current_script_file = NULL;
 std::string Frontend::last_here_document;
 
-void Frontend::extra_args(std::istream *&f, std::string &filename, std::vector<std::string> args, size_t argidx)
+void Frontend::extra_args(std::istream *&f, std::string &filename, std::vector<std::string> args, size_t argidx, bool bin_input)
 {
 	bool called_with_fp = f != NULL;
 
@@ -489,7 +489,7 @@ void Frontend::extra_args(std::istream *&f, std::string &filename, std::vector<s
 				next_args.insert(next_args.end(), filenames.begin()+1, filenames.end());
 			}
 			std::ifstream *ff = new std::ifstream;
-			ff->open(filename.c_str());
+			ff->open(filename.c_str(), bin_input ? std::ifstream::binary : std::ifstream::in);
 			yosys_input_files.insert(filename);
 			if (ff->fail())
 				delete ff;

--- a/kernel/register.h
+++ b/kernel/register.h
@@ -94,7 +94,7 @@ struct Frontend : Pass
 	virtual void execute(std::istream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) = 0;
 
 	static std::vector<std::string> next_args;
-	void extra_args(std::istream *&f, std::string &filename, std::vector<std::string> args, size_t argidx);
+	void extra_args(std::istream *&f, std::string &filename, std::vector<std::string> args, size_t argidx, bool bin_input = false);
 
 	static void frontend_call(RTLIL::Design *design, std::istream *f, std::string filename, std::string command);
 	static void frontend_call(RTLIL::Design *design, std::istream *f, std::string filename, std::vector<std::string> args);

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -471,7 +471,7 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *current_module, std::stri
 			log_error("ABC: execution of command \"%s\" failed: return code %d.\n", buffer.c_str(), ret);
 
 		buffer = stringf("%s/%s", tempdir_name.c_str(), "output.aig");
-		ifs.open(buffer);
+		ifs.open(buffer, std::ifstream::binary);
 		if (ifs.fail())
 			log_error("Can't open ABC output file `%s'.\n", buffer.c_str());
 


### PR DESCRIPTION
Reading of generated aig files fails when they are in binary format, made change to support frontends with binary input, and use binary stream to open xaig output in ABC9 after generate.
This fixes hang on read in issue #1407 
