### PR TITLE
RFC: techmap to recognise wires named "_TECHMAP_REPLACE_.<suffix>"

### DIFF
--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -257,6 +257,12 @@ struct TechmapWorker
 					w->add_strpool_attribute(ID(src), extra_src_attrs);
 			}
 			design->select(module, w);
+
+			if (it.second->name.begins_with("\\_TECHMAP_REPLACE_.")) {
+				IdString replace_name = stringf("%s%s", orig_cell_name.c_str(), it.second->name.c_str() + strlen("\\_TECHMAP_REPLACE_"));
+				Wire *replace_w = module->addWire(replace_name, it.second);
+				module->connect(replace_w, w);
+			}
 		}
 
 		SigMap tpl_sigmap(tpl);
@@ -1198,6 +1204,10 @@ struct TechmapPass : public Pass {
 		log("\n");
 		log("A cell with the name _TECHMAP_REPLACE_ in the map file will inherit the name\n");
 		log("and attributes of the cell that is being replaced.\n");
+		log("A wire with a name of the form `_TECHMAP_REPLACE_.<suffix>` in the map file will\n");
+		log("cause a new wire alias to be created with its name set to the original but with\n");
+		log("its `_TECHMAP_REPLACE_' prefix to be substituted with the name of the cell being\n");
+		log("replaced.\n");
 		log("\n");
 		log("See 'help extract' for a pass that does the opposite thing.\n");
 		log("\n");

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -384,6 +384,8 @@ struct TechmapWorker
 
 			if (techmap_replace_cell)
 				c_name = orig_cell_name;
+			else if (it.second->name.begins_with("\\_TECHMAP_REPLACE_."))
+				c_name = stringf("%s%s", orig_cell_name.c_str(), c_name.c_str() + strlen("\\_TECHMAP_REPLACE_"));
 			else
 				apply_prefix(cell->name, c_name);
 
@@ -1204,10 +1206,12 @@ struct TechmapPass : public Pass {
 		log("\n");
 		log("A cell with the name _TECHMAP_REPLACE_ in the map file will inherit the name\n");
 		log("and attributes of the cell that is being replaced.\n");
-		log("A wire with a name of the form `_TECHMAP_REPLACE_.<suffix>` in the map file will\n");
-		log("cause a new wire alias to be created with its name set to the original but with\n");
-		log("its `_TECHMAP_REPLACE_' prefix to be substituted with the name of the cell being\n");
-		log("replaced.\n");
+		log("A cell with a name of the form `_TECHMAP_REPLACE_.<suffix>` in the map file will\n");
+		log("be named thus but with the `_TECHMAP_REPLACE_' prefix substituted with the name\n");
+		log("of the cell being replaced.\n");
+		log("Similarly, a wire named in the form `_TECHMAP_REPLACE_.<suffix>` will cause a\n");
+		log("new wire alias to be created and named as above but with the `_TECHMAP_REPLACE_'\n");
+		log("prefix also substituted.\n");
 		log("\n");
 		log("See 'help extract' for a pass that does the opposite thing.\n");
 		log("\n");

--- a/tests/techmap/techmap_replace.ys
+++ b/tests/techmap/techmap_replace.ys
@@ -1,0 +1,16 @@
+read_verilog <<EOT
+module sub(input i, output o, input j);
+foobar _TECHMAP_REPLACE_(i, o, j);
+wire _TECHMAP_REPLACE_.asdf = i ;
+endmodule
+EOT
+design -stash techmap
+
+read_verilog <<EOT
+module top(input i, output o);
+sub s0(i, o);
+endmodule
+EOT
+
+techmap -map %techmap
+select -assert-any w:s0.asdf

--- a/tests/techmap/techmap_replace.ys
+++ b/tests/techmap/techmap_replace.ys
@@ -2,6 +2,7 @@ read_verilog <<EOT
 module sub(input i, output o, input j);
 foobar _TECHMAP_REPLACE_(i, o, j);
 wire _TECHMAP_REPLACE_.asdf = i ;
+barfoo _TECHMAP_REPLACE_.blah (i, o, j);
 endmodule
 EOT
 design -stash techmap
@@ -14,3 +15,4 @@ EOT
 
 techmap -map %techmap
 select -assert-any w:s0.asdf
+select -assert-any c:s0.blah


### PR DESCRIPTION
... and to substitute the original cell name and alias them to the auto-generated wire.

Useful for creating wires that have a predictable name (not `$techmapNNN...`) that can be recovered by other passes.

Could be used to create `(* hierconn *)` signals, for example, too.