### PR TITLE
Define environ, fixes #1424

### DIFF
--- a/frontends/rpc/rpc_frontend.cc
+++ b/frontends/rpc/rpc_frontend.cc
@@ -34,6 +34,8 @@
 #include "libs/sha1/sha1.h"
 #include "kernel/yosys.h"
 
+extern char **environ;
+
 YOSYS_NAMESPACE_BEGIN
 
 #if defined(_WIN32)


### PR DESCRIPTION
Kept it out of ifdef __APPLE__ since it can help on systems like BSD, and it does not heart mingw or linux builds