### PR TITLE
sat passes when it should fail if sigmap(wire) has dupes, but differing \init

### DIFF
--- a/passes/sat/sat.cc
+++ b/passes/sat/sat.cc
@@ -265,15 +265,18 @@ struct SatHelper
 				RTLIL::SigSpec rhs = it.second->attributes.at("\\init");
 				log_assert(lhs.size() == rhs.size());
 
+				dict<RTLIL::SigBit,SigBit> seen_init;
 				RTLIL::SigSpec removed_bits;
 				for (int i = 0; i < lhs.size(); i++) {
 					RTLIL::SigSpec bit = lhs.extract(i, 1);
-					if (rhs[i] == State::Sx || !satgen.initial_state.check_all(bit)) {
+					if (rhs[i] == State::Sx || !satgen.initial_state.check_all(bit) || seen_init.at(bit, rhs[i]) != rhs[i]) {
 						removed_bits.append(bit);
 						lhs.remove(i, 1);
 						rhs.remove(i, 1);
 						i--;
 					}
+					else
+						seen_init[bit] = rhs[i];
 				}
 
 				if (removed_bits.size())

--- a/tests/sat/initval.ys
+++ b/tests/sat/initval.ys
@@ -2,3 +2,23 @@ read_verilog -sv initval.v
 proc;;
 
 sat -seq 10 -prove-asserts
+
+read_verilog <<EOT
+module gold(input clk, input i, output reg [1:0] o);
+initial o = 2'b10;
+always @(posedge clk)
+   o[0] <= {i,i};
+endmodule
+
+module gate(input clk, input i, output reg [1:0] o);
+initial o = 2'b10;
+always @(posedge clk)
+   o[0] <= i;
+always @*
+   o[1] <= o[0];
+endmodule
+EOT
+
+proc
+miter -equiv -flatten -make_assert -make_outputs gold gate miter
+sat -seq 1 -falsify -prove-asserts -show-ports miter


### PR DESCRIPTION
See test for testcase.

Found while bug-hunting in #1427 