### PR TITLE
async2sync to be called by equiv_opt only when -async2sync given

### DIFF
--- a/passes/equiv/equiv_opt.cc
+++ b/passes/equiv/equiv_opt.cc
@@ -32,8 +32,7 @@ struct EquivOptPass:public ScriptPass
 		log("\n");
 		log("    equiv_opt [options] [command]\n");
 		log("\n");
-		log("This command uses temporal induction to check circuit equivalence before and\n");
-                log("after an optimization pass.\n");
+		log("This command checks circuit equivalence before and after an optimization pass.\n");
 		log("\n");
 		log("    -run <from_label>:<to_label>\n");
 		log("        only run the commands between the labels (see below). an empty\n");
@@ -157,7 +156,7 @@ struct EquivOptPass:public ScriptPass
 		if (check_label("prove")) {
 			if (multiclock || help_mode)
 				run("clk2fflogic", "(only with -multiclock)");
-			if (!multiclock || help_mode)
+			else
 				run("async2sync", "(only without -multiclock)");
 			run("equiv_make gold gate equiv");
 			if (help_mode)

--- a/passes/equiv/equiv_opt.cc
+++ b/passes/equiv/equiv_opt.cc
@@ -156,8 +156,6 @@ struct EquivOptPass:public ScriptPass
 		if (check_label("prove")) {
 			if (multiclock || help_mode)
 				run("clk2fflogic", "(only with -multiclock)");
-			else
-				run("async2sync", "(only without -multiclock)");
 			run("equiv_make gold gate equiv");
 			if (help_mode)
 				run("equiv_induct [-undef] equiv");

--- a/passes/equiv/equiv_opt.cc
+++ b/passes/equiv/equiv_opt.cc
@@ -50,6 +50,9 @@ struct EquivOptPass:public ScriptPass
 		log("    -multiclock\n");
 		log("        run clk2fflogic before equivalence checking.\n");
 		log("\n");
+		log("    -async2sync\n");
+		log("        run async2sync before equivalence checking.\n");
+		log("\n");
 		log("    -undef\n");
 		log("        enable modelling of undef states during equiv_induct.\n");
 		log("\n");
@@ -166,7 +169,7 @@ struct EquivOptPass:public ScriptPass
 			if (multiclock || help_mode)
 				run("clk2fflogic", "(only with -multiclock)");
 			if (async2sync || help_mode)
-				run("async2sync", "(only with -async2sync)");
+				run("async2sync", " (only with -async2sync)");
 			run("equiv_make gold gate equiv");
 			if (help_mode)
 				run("equiv_induct [-undef] equiv");

--- a/passes/equiv/equiv_opt.cc
+++ b/passes/equiv/equiv_opt.cc
@@ -32,7 +32,8 @@ struct EquivOptPass:public ScriptPass
 		log("\n");
 		log("    equiv_opt [options] [command]\n");
 		log("\n");
-		log("This command checks circuit equivalence before and after an optimization pass.\n");
+		log("This command uses temporal induction to check circuit equivalence before and\n");
+		log("after an optimization pass.\n");
 		log("\n");
 		log("    -run <from_label>:<to_label>\n");
 		log("        only run the commands between the labels (see below). an empty\n");

--- a/tests/ice40/latches.ys
+++ b/tests/ice40/latches.ys
@@ -1,14 +1,11 @@
 read_verilog latches.v
-design -save read
 
 proc
-async2sync # converts latches to a 'sync' variant clocked by a 'super'-clock
 flatten
-synth_ice40
-equiv_opt -assert -map +/ice40/cells_sim.v synth_ice40 # equivalency check
-design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
+# Can't run any sort of equivalence check because latches are blown to LUTs
+#equiv_opt -async2sync -assert -map +/ice40/cells_sim.v synth_ice40 # equivalency check
 
-design -load read
+#design -load preopt
 synth_ice40
 cd top
 select -assert-count 4 t:SB_LUT4

--- a/tests/xilinx/latches.ys
+++ b/tests/xilinx/latches.ys
@@ -2,9 +2,7 @@ read_verilog latches.v
 
 proc
 flatten
-equiv_opt -assert -run :prove -map +/xilinx/cells_sim.v synth_xilinx # equivalency check
-async2sync
-equiv_opt -assert -run prove: -map +/xilinx/cells_sim.v synth_xilinx # equivalency check
+equiv_opt -async2sync -assert -map +/xilinx/cells_sim.v synth_xilinx # equivalency check
 
 design -load preopt
 synth_xilinx


### PR DESCRIPTION
Make #1412 more conservative by only calling `async2sync` when new option `equiv_opt -async2sync` is given, since @daveshah1 kindly provided a counter example: https://github.com/YosysHQ/yosys/pull/1412#issuecomment-536680733

This new `-async2sync` option is mutex to `-multiclock`

Also disables equiv checking in ice40/latches.ys since it was broken.