### PR TITLE
Call memory_dff before DSP mapping to reserve registers (fixes #1447)

### DIFF
--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -273,6 +273,7 @@ struct SynthIce40Pass : public ScriptPass
 			run("opt_expr");
 			run("opt_clean");
 			if (help_mode || dsp) {
+				run("memory_dff");
 				run("techmap -map +/mul2dsp.v -map +/ice40/dsp_map.v -D DSP_A_MAXWIDTH=16 -D DSP_B_MAXWIDTH=16 "
 						"-D DSP_A_MINWIDTH=2 -D DSP_B_MINWIDTH=2 -D DSP_Y_MINWIDTH=11 "
 						"-D DSP_NAME=$__MUL16X16", "(if -dsp)");

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -341,6 +341,7 @@ struct SynthXilinxPass : public ScriptPass
 
 		if (check_label("map_dsp", "(skip if '-nodsp')")) {
 			if (!nodsp || help_mode) {
+				run("memory_dff"); // xilinx_dsp will merge registers, reserve memory port registers first
 				// NB: Xilinx multipliers are signed only
 				run("techmap -map +/mul2dsp.v -map +/xilinx/dsp_map.v -D DSP_A_MAXWIDTH=25 "
 					"-D DSP_A_MAXWIDTH_PARTIAL=18 -D DSP_B_MAXWIDTH=18 "    // Partial multipliers are intentionally


### PR DESCRIPTION
DSP mapping runs before `memory` so it can sometimes merge an intended read register into DSP. Avoid this by calling `memory_dff` before `xilinx_dsp`/`ice40_dsp`.

With the testcase from #1447:
`synth_xilinx -flatten`
Before this commit:
```
=== testcase ===

   Number of wires:               2225
   Number of wire bits:           8039
   Number of public wires:          16
   Number of public wire bits:    1745
   Number of memories:               0
   Number of memory bits:            0
   Number of processes:              0
   Number of cells:               2946
     BUFG                            1
     DSP48E1                        32
     FDRE                          552
     LUT2                          981
     LUT3                          128
     MUXCY                         494
     RAM128X1D                     256
     XORCY                         502

   Estimated number of LCs:        555
```

After this commit:
```
=== testcase ===

   Number of wires:               1968
   Number of wire bits:           7980
   Number of public wires:          18
   Number of public wire bits:    2001
   Number of memories:               0
   Number of memory bits:            0
   Number of processes:              0
   Number of cells:               2562
     BUFG                            1
     DSP48E1                        32
     FDRE                          552
     LUT2                          979
     MUXCY                         494
     RAMB36E1                        2
     XORCY                         502

   Estimated number of LCs:        490
```

`synth_ice40 -flatten -dsp`
Before this commit:
```
=== testcase ===

   Number of wires:              27105
   Number of wire bits:          64694
   Number of public wires:         272
   Number of public wire bits:   34513
   Number of memories:               0
   Number of memory bits:            0
   Number of processes:              0
   Number of cells:              61137
     SB_CARRY                      492
     SB_DFF                        520
     SB_DFFE                     32768
     SB_LUT4                     27325
     SB_MAC16                       32

```
After this commit:
```
=== testcase ===

   Number of wires:                147
   Number of wire bits:           5358
   Number of public wires:          18
   Number of public wire bits:    2001
   Number of memories:               0
   Number of memory bits:            0
   Number of processes:              0
   Number of cells:               1553
     SB_CARRY                      492
     SB_DFF                        520
     SB_LUT4                       501
     SB_MAC16                       32
     SB_RAM40_4K                     8
```