### PR TITLE
Makefile: don't assume python is called `python3`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,9 +147,9 @@ $(info $(subst $$--$$,$(newline),$(shell sed 's,^,[Makefile.conf] ,; s,$$,$$--$$
 include Makefile.conf
 endif
 
+PYTHON_EXECUTABLE := $(shell if python3 -c ""; then echo "python3"; else echo "python"; fi)
 ifeq ($(ENABLE_PYOSYS),1)
 PYTHON_VERSION_TESTCODE := "import sys;t='{v[0]}.{v[1]}'.format(v=list(sys.version_info[:2]));print(t)"
-PYTHON_EXECUTABLE := $(shell if python3 -c ""; then echo "python3"; else echo "python"; fi)
 PYTHON_VERSION := $(shell $(PYTHON_EXECUTABLE) -c ""$(PYTHON_VERSION_TESTCODE)"")
 PYTHON_MAJOR_VERSION := $(shell echo $(PYTHON_VERSION) | cut -f1 -d.)
 PYTHON_PREFIX := $(shell $(PYTHON_EXECUTABLE)-config --prefix)

--- a/passes/pmgen/Makefile.inc
+++ b/passes/pmgen/Makefile.inc
@@ -1,5 +1,5 @@
 %_pm.h: passes/pmgen/pmgen.py %.pmg
-	$(P) mkdir -p passes/pmgen && python3 $< -o $@ -p $(subst _pm.h,,$(notdir $@)) $(filter-out $<,$^)
+	$(P) mkdir -p passes/pmgen && $(PYTHON_EXECUTABLE) $< -o $@ -p $(subst _pm.h,,$(notdir $@)) $(filter-out $<,$^)
 
 # --------------------------------------
 
@@ -38,7 +38,7 @@ PEEPOPT_PATTERN += passes/pmgen/peepopt_muldiv.pmg
 PEEPOPT_PATTERN += passes/pmgen/peepopt_dffmux.pmg
 
 passes/pmgen/peepopt_pm.h: passes/pmgen/pmgen.py $(PEEPOPT_PATTERN)
-	$(P) mkdir -p passes/pmgen && python3 $< -o $@ -p peepopt $(filter-out $<,$^)
+	$(P) mkdir -p passes/pmgen && $(PYTHON_EXECUTABLE) $< -o $@ -p peepopt $(filter-out $<,$^)
 
 # --------------------------------------
 

--- a/techlibs/common/Makefile.inc
+++ b/techlibs/common/Makefile.inc
@@ -9,12 +9,12 @@ GENFILES += techlibs/common/simcells_help.inc
 
 techlibs/common/simlib_help.inc: techlibs/common/cellhelp.py techlibs/common/simlib.v
 	$(Q) mkdir -p techlibs/common
-	$(P) python3 $^ > $@.new
+	$(P) $(PYTHON_EXECUTABLE) $^ > $@.new
 	$(Q) mv $@.new $@
 
 techlibs/common/simcells_help.inc: techlibs/common/cellhelp.py techlibs/common/simcells.v
 	$(Q) mkdir -p techlibs/common
-	$(P) python3 $^ > $@.new
+	$(P) $(PYTHON_EXECUTABLE) $^ > $@.new
 	$(Q) mv $@.new $@
 
 kernel/register.o: techlibs/common/simlib_help.inc techlibs/common/simcells_help.inc

--- a/techlibs/ecp5/Makefile.inc
+++ b/techlibs/ecp5/Makefile.inc
@@ -27,12 +27,12 @@ EXTRA_OBJS += techlibs/ecp5/brams_init.mk techlibs/ecp5/brams_connect.mk
 
 techlibs/ecp5/brams_init.mk: techlibs/ecp5/brams_init.py
 	$(Q) mkdir -p techlibs/ecp5
-	$(P) python3 $<
+	$(P) $(PYTHON_EXECUTABLE) $<
 	$(Q) touch $@
 
 techlibs/ecp5/brams_connect.mk: techlibs/ecp5/brams_connect.py
 	$(Q) mkdir -p techlibs/ecp5
-	$(P) python3 $<
+	$(P) $(PYTHON_EXECUTABLE) $<
 	$(Q) touch $@
 
 

--- a/techlibs/ice40/Makefile.inc
+++ b/techlibs/ice40/Makefile.inc
@@ -14,7 +14,7 @@ EXTRA_OBJS += techlibs/ice40/brams_init.mk
 
 techlibs/ice40/brams_init.mk: techlibs/ice40/brams_init.py
 	$(Q) mkdir -p techlibs/ice40
-	$(P) python3 $<
+	$(P) $(PYTHON_EXECUTABLE) $<
 	$(Q) touch techlibs/ice40/brams_init.mk
 
 techlibs/ice40/brams_init1.vh: techlibs/ice40/brams_init.mk

--- a/techlibs/xilinx/Makefile.inc
+++ b/techlibs/xilinx/Makefile.inc
@@ -13,7 +13,7 @@ EXTRA_OBJS += techlibs/xilinx/brams_init.mk
 
 techlibs/xilinx/brams_init.mk: techlibs/xilinx/brams_init.py
 	$(Q) mkdir -p techlibs/xilinx
-	$(P) python3 $<
+	$(P) $(PYTHON_EXECUTABLE) $<
 	$(Q) touch $@
 
 techlibs/xilinx/brams_init_36.vh: techlibs/xilinx/brams_init.mk


### PR DESCRIPTION
On some architectures, notably on Windows, the official name for the
Python binary from python.org is `python`.  The build system assumes
that python is called `python3`, which breaks under this architecture.

There is already infrastructure in place to determine the name of the
Python binary when building PYOSYS.  Since Python is now always required
to build Yosys, enable this check universally which sets the
`PYTHON_EXECUTABLE` variable.

Then, reuse this variable in other Makefiles as necessary, rather than
hardcoding `python3` everywhere.