### PR TITLE
[WIP] Add WASI platform support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CONFIG := clang
 # CONFIG := gcc-4.8
 # CONFIG := afl-gcc
 # CONFIG := emcc
+# CONFIG := wasi
 # CONFIG := mxe
 # CONFIG := msys2
 # CONFIG := msys2-64
@@ -256,6 +257,32 @@ yosysjs-$(YOSYS_VER).zip: yosys.js viz.js misc/yosysjs/*
 
 yosys.html: misc/yosys.html
 	$(P) cp misc/yosys.html yosys.html
+
+else ifeq ($(CONFIG),wasi)
+ifeq ($(WASI_PREFIX),)
+CXX = clang
+LD = clang++
+AR = ar
+RANLIB = ranlib
+WASIFLAGS :=
+else
+CXX = $(WASI_PREFIX)/bin/clang
+LD = $(WASI_PREFIX)/bin/clang++
+AR = $(WASI_PREFIX)/bin/ar
+RANLIB = $(WASI_PREFIX)/bin/ranlib
+WASIFLAGS := --sysroot $(WASI_PREFIX)/share/wasi-sysroot
+endif
+CXXFLAGS := $(WASIFLAGS) -std=c++11 -Os $(CXXFLAGS)
+LDFLAGS := $(WASIFLAGS) $(LDFLAGS)
+ABCMKARGS += AR="$(AR)" RANLIB="$(RANLIB)"
+ABCMKARGS += ARCHFLAGS="$(WASIFLAGS) -DABC_USE_STDINT_H -DABC_NO_DYNAMIC_LINKING -DABC_NO_RLIMIT"
+ABCMKARGS += OPTFLAGS="-Os"
+EXE = .wasm
+
+ifeq ($(ENABLE_ABC),1)
+LINK_ABC := 1
+DISABLE_ABC_THREADS := 1
+endif
 
 else ifeq ($(CONFIG),mxe)
 PKG_CONFIG = /usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-pkg-config

--- a/frontends/rpc/rpc_frontend.cc
+++ b/frontends/rpc/rpc_frontend.cc
@@ -22,6 +22,8 @@
 // are not always transparent or easy to change. Given that generated HDL code get be extremely large, it is
 // unwise to rely on those limits being large enough, and using byte-oriented sockets is guaranteed to work.
 
+#if !defined(__wasm)
+
 #ifndef _WIN32
 #include <unistd.h>
 #include <spawn.h>
@@ -593,3 +595,5 @@ cleanup_path:
 } RpcFrontend;
 
 YOSYS_NAMESPACE_END
+
+#endif

--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -155,6 +155,23 @@ int yosys_history_offset = 0;
 std::string yosys_history_file;
 #endif
 
+#if defined(__wasm)
+extern "C" {
+	// FIXME: WASI does not currently support exceptions.
+	void* __cxa_allocate_exception(size_t thrown_size) throw() {
+		return malloc(thrown_size);
+	}
+	bool __cxa_uncaught_exception() throw();
+	void __cxa_throw(void* thrown_exception, struct std::type_info * tinfo, void (*dest)(void*)) {
+		std::terminate();
+	}
+
+	// FIXME: these are called from abc, even if the system headers don't define them.
+	int system(const char *) { std::terminate(); }
+	int mkstemp(char *) { std::terminate(); }
+}
+#endif
+
 void yosys_atexit()
 {
 #if defined(YOSYS_ENABLE_READLINE) || defined(YOSYS_ENABLE_EDITLINE)

--- a/libs/ezsat/ezminisat.cc
+++ b/libs/ezsat/ezminisat.cc
@@ -29,11 +29,12 @@
 
 #include <limits.h>
 #include <stdint.h>
-#include <csignal>
 #include <cinttypes>
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__wasm)
+#  include <csignal>
 #  include <unistd.h>
+#  define HAS_ALARM
 #endif
 
 #include "../minisat/Solver.h"
@@ -84,7 +85,7 @@ bool ezMiniSAT::eliminated(int idx)
 }
 #endif
 
-#ifndef _WIN32
+#if defined(HAS_ALARM)
 ezMiniSAT *ezMiniSAT::alarmHandlerThis = NULL;
 clock_t ezMiniSAT::alarmHandlerTimeout = 0;
 
@@ -183,7 +184,7 @@ contradiction:
 #endif
 	}
 
-#ifndef _WIN32
+#if defined(HAS_ALARM)
 	struct sigaction sig_action;
 	struct sigaction old_sig_action;
 	int old_alarm_timeout = 0;
@@ -202,7 +203,7 @@ contradiction:
 
 	bool foundSolution = minisatSolver->solve(assumps);
 
-#ifndef _WIN32
+#if defined(HAS_ALARM)
 	if (solverTimeout > 0) {
 		if (alarmHandlerTimeout == 0)
 			solverTimoutStatus = true;

--- a/libs/minisat/System.cc
+++ b/libs/minisat/System.cc
@@ -73,7 +73,7 @@ static inline int memReadPeak(void)
 }
 
 double Minisat::memUsed() { return (double)memReadStat(0) * (double)getpagesize() / (1024*1024); }
-double Minisat::memUsedPeak(bool strictlyPeak) { 
+double Minisat::memUsedPeak(bool strictlyPeak) {
     double peak = memReadPeak() / (double)1024;
     return peak == 0 && !strictlyPeak ? memUsed() : peak; }
 
@@ -101,7 +101,7 @@ double Minisat::memUsedPeak(bool) { return 0; }
 #endif
 
 
-#if !defined(_MSC_VER) && !defined(__MINGW32__)
+#if !defined(_MSC_VER) && !defined(__MINGW32__) && !defined(__wasm)
 void Minisat::limitMemory(uint64_t max_mem_mb)
 {
 // FIXME: OpenBSD does not support RLIMIT_AS. Not sure how well RLIMIT_DATA works instead.
@@ -133,7 +133,7 @@ void Minisat::limitMemory(uint64_t /*max_mem_mb*/)
 #endif
 
 
-#if !defined(_MSC_VER) && !defined(__MINGW32__)
+#if !defined(_MSC_VER) && !defined(__MINGW32__) && !defined(__wasm)
 void Minisat::limitTime(uint32_t max_cpu_time)
 {
     if (max_cpu_time != 0){
@@ -156,9 +156,13 @@ void Minisat::limitTime(uint32_t /*max_cpu_time*/)
 
 void Minisat::sigTerm(void handler(int))
 {
+#if defined(__wasm)
+	(void)handler;
+#else
     signal(SIGINT, handler);
     signal(SIGTERM,handler);
 #ifdef SIGXCPU
     signal(SIGXCPU,handler);
+#endif
 #endif
 }

--- a/passes/cmds/cover.cc
+++ b/passes/cmds/cover.cc
@@ -101,8 +101,8 @@ struct CoverPass : public Pass {
 				const std::string &filename = args[++argidx];
 				FILE *f = nullptr;
 				if (args[argidx-1] == "-d") {
-			#ifdef _WIN32
-					log_cmd_error("The 'cover -d' option is not supported on win32.\n");
+			#if defined(_WIN32) || defined(__wasm)
+					log_cmd_error("The 'cover -d' option is not supported on this platform.\n");
 			#else
 					char filename_buffer[4096];
 					snprintf(filename_buffer, 4096, "%s/yosys_cover_%d_XXXXXX.txt", filename.c_str(), getpid());

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1511,11 +1511,15 @@ struct AbcPass : public Pass {
 #endif
 
 		size_t argidx;
+#if defined(__wasm)
+		const char *pwd = ".";
+#else
 		char pwd [PATH_MAX];
 		if (!getcwd(pwd, sizeof(pwd))) {
 			log_cmd_error("getcwd failed: %s\n", strerror(errno));
 			log_abort();
 		}
+#endif
 		for (argidx = 1; argidx < args.size(); argidx++) {
 			std::string arg = args[argidx];
 			if (arg == "-exe" && argidx+1 < args.size()) {

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -942,11 +942,15 @@ struct Abc9Pass : public Pass {
 #endif
 
 		size_t argidx;
+#if defined(__wasm)
+		const char *pwd = ".";
+#else
 		char pwd [PATH_MAX];
 		if (!getcwd(pwd, sizeof(pwd))) {
 			log_cmd_error("getcwd failed: %s\n", strerror(errno));
 			log_abort();
 		}
+#endif
 		for (argidx = 1; argidx < args.size(); argidx++) {
 			std::string arg = args[argidx];
 			if (arg == "-exe" && argidx+1 < args.size()) {


### PR DESCRIPTION
WASI stands for "Web Assembly System Interface". Web Assembly is a portable compilation target for systems languages like C++ that can be built once and then compiled again down to any modern 32- or 64-bit ISA. Web Assembly System Interface is a POSIX-like ABI for Web Assembly that enables most libc and a few common POSIX functions. A Web Assembly file built against WASI is a single artifact that can be run with reasonable performance on many major OSes and architectures as easy as `wasm-compiler application.wasm` (where `wasm-compiler` is one of the many implementations like [wasmtime](https://github.com/CraneStation/wasmtime) or [lucet](https://github.com/fastly/lucet)).

The reason I'm interested in WASI is that it would be convenient to ship a fallback Yosys binary built to Web Assembly to lower the effort required to use nMigen, which has Yosys as a hard dependency. Of course, it is possible to build Yosys for all major platforms and architectures directly, but it would be much nicer if building artifacts for a half dozen OS/architecture combinations was someone else's problem, wouldn't it?

This PR requires ABC commit whitequark/abc@5e71f1d0b, which is just the composition of berkeley-abc/abc#57 and berkeley-abc/abc#58. To build Yosys against WASI, download the latest [wasi-sdk](https://github.com/CraneStation/wasi-sdk/releases) and unpack it to `${WASI_PREFIX}`, then run:

```
git -C abc fetch https://github.com/whitequark/abc tmp
make CONFIG=wasi ENABLE_TCL=0 ENABLE_PLUGINS=0 ENABLE_READLINE=0 ENABLE_ZLIB=0 ABCREV=5e71f1d0b
```

This will produce `yosys.wasm`, which can be run with e.g. [wasmtime](https://github.com/CraneStation/wasmtime):

```
cargo install -f wasmtime
wasmtime -o -c --mapdir=/share::share --dir=. ./yosys.wasm -- -p synth_ice40 picorv32.v
```

or [lucet](https://github.com/fastly/lucet):

```
cargo install -f lucetc
RUSTFLAGS="-C link-args=-rdynamic" cargo install -f lucet-wasi
wget https://github.com/fastly/lucet/blob/4d12bc6da6adbbf62b0c2639819baefac84e9320/lucet-wasi/bindings.json
lucetc yosys.wasm --bindings bindings.json -o yosys.so
lucet-wasi --dir share:/share --dir . yosys.so -- -p synth_ice40 picorv32.v
```

Unfortunately... neither of these actually works.

 * wasmtime crashes in an opaque way (CraneStation/wasmtime#537); this could be a bug in wasmtime, a bug in wasi-sdk, a bug in clang, or (unlikely but possible) a bug in yosys. In different conditions (loading an ilang file and runing `synth_ice40`), the crash appears as `__cxa_guard_acquire detected recursive initialization`.
 * lucet crashes trying to compile the binary, also in an opaque way (fastly/lucet#361). The wasm file passes validation so this is definitely a bug in lucet.

In terms of unfinished work, this PR includes two FIXMEs:
 * abc requires `system`, but WASI does not have any way to spawn processes. Stubbing it out (like it's done right now) is probably just fine.
 * more importantly, Web Assembly/WASI currently do not support C++ exceptions. I would personally prefer to add a configuration flag that allows building Yosys without exceptions, since most (all?) of them are intended to crash the process anyway. Web Assembly will gain support for exceptions (and setjmp/longjmp, which are also not supported) at some point in the future but it is unlikely to be soon.