### PR TITLE
Do not map $eq and $ne in cmp2lut, only proper arithmetic cmp

### DIFF
--- a/techlibs/common/cmp2lut.v
+++ b/techlibs/common/cmp2lut.v
@@ -7,7 +7,7 @@
 // with n <= k inputs should be techmapped in this way, because this shortens the critical path
 // from n to 1 by avoiding carry chains.
 
-(* techmap_celltype = "$eq $ne $lt $le $gt $ge" *)
+(* techmap_celltype = "$lt $le $gt $ge" *)
 module _90_lut_cmp_ (A, B, Y);
 
 parameter A_SIGNED = 0;

--- a/tests/arch/anlogic/fsm.ys
+++ b/tests/arch/anlogic/fsm.ys
@@ -1,12 +1,15 @@
 read_verilog ../common/fsm.v
 hierarchy -top fsm
 proc
-#flatten
-#ERROR: Found 4 unproven $equiv cells in 'equiv_status -assert'.
-#equiv_opt -assert -map +/anlogic/cells_sim.v synth_anlogic # equivalency check
-equiv_opt -map +/anlogic/cells_sim.v synth_anlogic # equivalency check
+flatten
+
+equiv_opt -run :prove -map +/anlogic/cells_sim.v synth_anlogic
+miter -equiv -make_assert -flatten gold gate miter
+sat -verify -prove-asserts -show-public -set-at 1 in_reset 1 -seq 20 -prove-skip 1 miter
+
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd fsm # Constrain all select calls below inside the top module
+
 select -assert-count 1 t:AL_MAP_LUT2
 select -assert-count 5 t:AL_MAP_LUT5
 select -assert-count 1 t:AL_MAP_LUT6

--- a/tests/arch/ecp5/fsm.ys
+++ b/tests/arch/ecp5/fsm.ys
@@ -2,11 +2,16 @@ read_verilog ../common/fsm.v
 hierarchy -top fsm
 proc
 flatten
-equiv_opt -assert -map +/ecp5/cells_sim.v synth_ecp5 # equivalency check
+
+equiv_opt -run :prove -map +/ecp5/cells_sim.v synth_ecp5
+miter -equiv -make_assert -flatten gold gate miter
+sat -verify -prove-asserts -show-public -set-at 1 in_reset 1 -seq 20 -prove-skip 1 miter
+
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd fsm # Constrain all select calls below inside the top module
+
 select -assert-count 1 t:L6MUX21
-select -assert-count 13 t:LUT4
-select -assert-count 5 t:PFUMX
-select -assert-count 5 t:TRELLIS_FF
+select -assert-count 15 t:LUT4
+select -assert-count 6 t:PFUMX
+select -assert-count 6 t:TRELLIS_FF
 select -assert-none t:L6MUX21 t:LUT4 t:PFUMX t:TRELLIS_FF %% t:* %D

--- a/tests/arch/efinix/fsm.ys
+++ b/tests/arch/efinix/fsm.ys
@@ -2,9 +2,11 @@ read_verilog ../common/fsm.v
 hierarchy -top fsm
 proc
 flatten
-#ERROR: Found 4 unproven $equiv cells in 'equiv_status -assert'.
-#equiv_opt -assert -map +/efinix/cells_sim.v synth_efinix # equivalency check
-equiv_opt -map +/efinix/cells_sim.v synth_efinix # equivalency check
+
+equiv_opt -run :prove -map +/efinix/cells_sim.v synth_efinix
+miter -equiv -make_assert -flatten gold gate miter
+sat -verify -prove-asserts -show-public -set-at 1 in_reset 1 -seq 20 -prove-skip 1 miter
+
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd fsm # Constrain all select calls below inside the top module
 

--- a/tests/arch/ice40/fsm.ys
+++ b/tests/arch/ice40/fsm.ys
@@ -2,12 +2,15 @@ read_verilog ../common/fsm.v
 hierarchy -top fsm
 proc
 flatten
-equiv_opt -assert -map +/ice40/cells_sim.v synth_ice40 # equivalency check
+
+equiv_opt -run :prove -map +/ice40/cells_sim.v synth_ice40
+miter -equiv -make_assert -flatten gold gate miter
+sat -verify -prove-asserts -show-public -set-at 1 in_reset 1 -seq 20 -prove-skip 1 miter
+
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd fsm # Constrain all select calls below inside the top module
 
+select -assert-count 4 t:SB_DFF
 select -assert-count 2 t:SB_DFFESR
-select -assert-count 2 t:SB_DFFSR
-select -assert-count 1 t:SB_DFFSS
-select -assert-count 13 t:SB_LUT4
-select -assert-none t:SB_DFFESR t:SB_DFFSR t:SB_DFFSS t:SB_LUT4 %% t:* %D
+select -assert-count 15 t:SB_LUT4
+select -assert-none t:SB_DFFESR t:SB_DFF t:SB_LUT4 %% t:* %D

--- a/tests/arch/xilinx/fsm.ys
+++ b/tests/arch/xilinx/fsm.ys
@@ -2,7 +2,11 @@ read_verilog ../common/fsm.v
 hierarchy -top fsm
 proc
 flatten
-equiv_opt -assert -map +/xilinx/cells_sim.v synth_xilinx # equivalency check
+
+equiv_opt -run :prove -map +/xilinx/cells_sim.v synth_xilinx
+miter -equiv -make_assert -flatten gold gate miter
+sat -verify -prove-asserts -show-public -set-at 1 in_reset 1 -seq 20 -prove-skip 1 miter
+
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd fsm # Constrain all select calls below inside the top module
 


### PR DESCRIPTION
Those are not being mapped by `alumacc` anyway, logic optimization will yield the obvious solution, and converting those `$eq/$ne` cells to other cell types will prevent other coarse-grain optimizations that do not understand the `$lut` circuits.

(This fails some tests atm because right now `fsm` is being prevent from running on some archs because of this, and the fsm arch test is broken if `fsm` actually does something.)