### PR TITLE
Add an info string symbol for bad states in btor backend

### DIFF
--- a/backends/btor/btor.cc
+++ b/backends/btor/btor.cc
@@ -1070,7 +1070,16 @@ struct BtorWorker
 					bad_properties.push_back(nid_en_and_not_a);
 				} else {
 					int nid = next_nid++;
-					btorf("%d bad %d\n", nid, nid_en_and_not_a);
+
+					string infostr =
+						cell->attributes.count("\\src")
+						? cell->attributes.at("\\src")
+						.decode_string()
+						.c_str()
+						: log_id(cell);
+
+					std::replace(infostr.begin(), infostr.end(), ' ', '_');
+					btorf("%d bad %d %s\n", nid, nid_en_and_not_a, infostr.c_str());
 				}
 
 				btorf_pop(log_id(cell));


### PR DESCRIPTION
When my Verilog has lots of embedded assertions, sometimes it can be difficult to tell which assertion the bad nodes in btor correspond to.

This PR would add an info string symbol to label bad states in the btor output. Any node in btor can have an associated symbol, and this one is just a convenience to help identify which assertion in the Verilog code is associated with this particular bad node.

If you like this idea, but not the style, I'm happy to make changes. Furthermore, for named assertions, it might be nice to use the name. Where is that information stored? E.g.
```
assertion_name : assert(...);
```

Thanks for all your work on Yosys!