### PR TITLE
Add "autoname" pass and use it in "synth_ice40"

### DIFF
--- a/passes/cmds/Makefile.inc
+++ b/passes/cmds/Makefile.inc
@@ -5,6 +5,7 @@ OBJS += passes/cmds/design.o
 OBJS += passes/cmds/select.o
 OBJS += passes/cmds/show.o
 OBJS += passes/cmds/rename.o
+OBJS += passes/cmds/autoname.o
 OBJS += passes/cmds/connect.o
 OBJS += passes/cmds/scatter.o
 OBJS += passes/cmds/setundef.o

--- a/passes/cmds/autoname.cc
+++ b/passes/cmds/autoname.cc
@@ -1,0 +1,134 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/yosys.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+int autoname_worker(Module *module)
+{
+	dict<Cell*, pair<int, IdString>> proposed_cell_names;
+	dict<Wire*, pair<int, IdString>> proposed_wire_names;
+	dict<Wire*, int> wire_score;
+	int best_score = -1;
+
+	for (auto cell : module->selected_cells())
+	for (auto &conn : cell->connections())
+	for (auto bit : conn.second)
+		if (bit.wire != nullptr)
+			wire_score[bit.wire]++;
+
+	for (auto cell : module->selected_cells()) {
+		if (cell->name[0] == '$') {
+			for (auto &conn : cell->connections()) {
+				string suffix = stringf("_%s_%s", log_id(cell->type), log_id(conn.first));
+				for (auto bit : conn.second)
+					if (bit.wire != nullptr && bit.wire->name[0] != '$') {
+						IdString new_name(bit.wire->name.str() + suffix);
+						int score = wire_score.at(bit.wire);
+						if (cell->output(conn.first)) score = 0;
+						score = 10000*score + new_name.size();
+						if (!proposed_cell_names.count(cell) || score < proposed_cell_names.at(cell).first) {
+							if (best_score < 0 || score < best_score)
+								best_score = score;
+							proposed_cell_names[cell] = make_pair(score, new_name);
+						}
+					}
+			}
+		} else {
+			for (auto &conn : cell->connections()) {
+				string suffix = stringf("_%s", log_id(conn.first));
+				for (auto bit : conn.second)
+					if (bit.wire != nullptr && bit.wire->name[0] == '$') {
+						IdString new_name(cell->name.str() + suffix);
+						int score = wire_score.at(bit.wire);
+						if (cell->output(conn.first)) score = 0;
+						score = 10000*score + new_name.size();
+						if (!proposed_wire_names.count(bit.wire) || score < proposed_wire_names.at(bit.wire).first) {
+							if (best_score < 0 || score < best_score)
+								best_score = score;
+							proposed_wire_names[bit.wire] = make_pair(score, new_name);
+						}
+					}
+			}
+		}
+	}
+
+	for (auto &it : proposed_cell_names) {
+		if (best_score*2 < it.second.first)
+			continue;
+		IdString n = module->uniquify(it.second.second);
+		log_debug("Rename cell %s in %s to %s.\n", log_id(it.first), log_id(module), log_id(n));
+		module->rename(it.first, n);
+	}
+
+	for (auto &it : proposed_wire_names) {
+		if (best_score*2 < it.second.first)
+			continue;
+		IdString n = module->uniquify(it.second.second);
+		log_debug("Rename wire %s in %s to %s.\n", log_id(it.first), log_id(module), log_id(n));
+		module->rename(it.first, n);
+	}
+
+	return proposed_cell_names.size() + proposed_wire_names.size();
+}
+
+struct AutonamePass : public Pass {
+	AutonamePass() : Pass("autoname", "automatically assign names to objects") { }
+	void help() YS_OVERRIDE
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    autoname [selection]\n");
+		log("\n");
+		log("Assign auto-generated public names to objects with private names (the ones\n");
+		log("with $-prefix).\n");
+		log("\n");
+	}
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	{
+		size_t argidx;
+		for (argidx = 1; argidx < args.size(); argidx++)
+		{
+			// if (args[argidx] == "-foo") {
+			// 	foo = true;
+			// 	continue;
+			// }
+			break;
+		}
+
+		log_header(design, "Executing AUTONAME pass.\n");
+
+		for (auto module : design->selected_modules())
+		{
+			int count = 0, iter = 0;
+			while (1) {
+				iter++;
+				int n = autoname_worker(module);
+				if (!n) break;
+				count += n;
+			}
+			if (count > 0)
+				log("Renamed %d objects in module %s (%d iterations).\n", count, log_id(module), iter);
+		}
+	}
+} AutonamePass;
+
+PRIVATE_NAMESPACE_END

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -380,6 +380,7 @@ struct SynthIce40Pass : public ScriptPass
 
 		if (check_label("check"))
 		{
+			run("autoname");
 			run("hierarchy -check");
 			run("stat");
 			run("check -noinit");


### PR DESCRIPTION
For the most part this is useful for getting easier-to-understand timing reports. For example, with `autoname`:

```
Info: Critical path report for clock 'clock_$glb_clk' (posedge -> posedge):
Info: curr total
Info:  0.5  0.5  Source cpu.ldst.mem_valid_reg_SB_DFFESR_Q_DFFLC.O
Info:  1.1  1.7    Net cpu.mem_valid_ldst budget -0.257000 ns (4,2) -> (4,8)
Info:                Sink cpu.ldst.insn_ld_SB_LUT4_I1_LC.I3
Info:  0.3  2.0  Source cpu.ldst.insn_ld_SB_LUT4_I1_LC.O
Info:  0.6  2.6    Net cpu.ldst.insn_ld_SB_LUT4_I1_O budget -0.257000 ns (4,8) -> (3,9)
Info:                Sink cpu.arb_mem_ctrl_SB_LUT4_O_LC.I2
Info:  0.4  2.9  Source cpu.arb_mem_ctrl_SB_LUT4_O_LC.O
Info:  0.6  3.5    Net mem_insn_d budget -0.257000 ns (3,9) -> (2,9)
Info:                Sink cpu.ctrl.mem_kill_reg_SB_LUT4_I3_LC.I2
Info:  0.4  3.9  Source cpu.ctrl.mem_kill_reg_SB_LUT4_I3_LC.O
Info:  0.6  4.5    Net cpu.ctrl.mem_kill_reg_SB_LUT4_I3_O budget 0.197000 ns (2,9) -> (2,10)
Info:                Sink cpu.ctrl.mem_kill_reg_SB_LUT4_I3_O_SB_LUT4_I0_2_LC.I0
Info:  0.4  5.0  Source cpu.ctrl.mem_kill_reg_SB_LUT4_I3_O_SB_LUT4_I0_2_LC.O
Info:  1.6  6.6    Net cpu.ctrl.mem_kill_reg_SB_LUT4_I3_O_SB_LUT4_I0_2_O budget 1.124000 ns (2,10) -> (5,3)
Info:                Sink cpu.ctrl.next_pcpi_prefix_SB_LUT4_O_15_LC.I1
Info:  0.4  7.0  Source cpu.ctrl.next_pcpi_prefix_SB_LUT4_O_15_LC.O
Info:  1.3  8.3    Net cpu.decode_insn[0] budget 0.856000 ns (5,3) -> (5,7)
Info:                Sink cpu.ctrl.next_pcpi_valid_SB_LUT4_O_I1_SB_LUT4_O_I2_SB_LUT4_O_LC.I3
Info:  0.3  8.6  Source cpu.ctrl.next_pcpi_valid_SB_LUT4_O_I1_SB_LUT4_O_I2_SB_LUT4_O_LC.O
Info:  1.7 10.3    Net cpu.ctrl.next_pcpi_valid_SB_LUT4_O_I1_SB_LUT4_O_I2 budget 0.198000 ns (5,7) -> (5,15)
Info:                Sink cpu.ctrl.next_pcpi_valid_SB_LUT4_O_I1_SB_LUT4_O_I3_SB_LUT4_I1_LC.I0
Info:  0.4 10.8  Source cpu.ctrl.next_pcpi_valid_SB_LUT4_O_I1_SB_LUT4_O_I3_SB_LUT4_I1_LC.O
Info:  0.9 11.7    Net cpu.ctrl.next_pcpi_valid_SB_LUT4_O_I1_SB_LUT4_O_I3_SB_LUT4_I1_O budget 0.246000 ns (5,15) -> (2,15)
Info:                Sink cpu.ctrl.next_pcpi_valid_SB_LUT4_O_I1_SB_LUT4_I0_LC.I2
Info:  0.4 12.1  Source cpu.ctrl.next_pcpi_valid_SB_LUT4_O_I1_SB_LUT4_I0_LC.O
Info:  0.6 12.7    Net cpu.ctrl.next_pcpi_valid_SB_LUT4_O_I1_SB_LUT4_I0_O budget 0.453000 ns (2,15) -> (2,15)
Info:                Sink cpu.ctrl.next_pc_SB_LUT4_O_30_LC.I3
Info:  0.3 13.0  Source cpu.ctrl.next_pc_SB_LUT4_O_30_LC.O
Info:  1.0 13.9    Net cpu.ctrl.next_pc[1] budget 0.277000 ns (2,15) -> (2,16)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_2$CARRY.I2
Info:  0.2 14.2  Source cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_2$CARRY.COUT
Info:  0.0 14.2    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[1] budget 0.000000 ns (2,16) -> (2,16)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_1_LC.CIN
Info:  0.1 14.3  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_1_LC.COUT
Info:  0.0 14.3    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[2] budget 0.000000 ns (2,16) -> (2,16)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_LC.CIN
Info:  0.1 14.4  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_LC.COUT
Info:  0.0 14.4    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[3] budget 0.000000 ns (2,16) -> (2,16)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_6_LC.CIN
Info:  0.1 14.5  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_6_LC.COUT
Info:  0.0 14.5    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[4] budget 0.000000 ns (2,16) -> (2,16)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_5_LC.CIN
Info:  0.1 14.7  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_5_LC.COUT
Info:  0.0 14.7    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[5] budget 0.000000 ns (2,16) -> (2,16)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_4_LC.CIN
Info:  0.1 14.8  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_4_LC.COUT
Info:  0.0 14.8    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[6] budget 0.000000 ns (2,16) -> (2,16)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_3_LC.CIN
Info:  0.1 14.9  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_3_LC.COUT
Info:  0.0 14.9    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[7] budget 0.000000 ns (2,16) -> (2,16)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_2_LC.CIN
Info:  0.1 15.0  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_2_LC.COUT
Info:  0.2 15.2    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[8] budget 0.190000 ns (2,16) -> (2,17)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_1_LC.CIN
Info:  0.1 15.4  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_1_LC.COUT
Info:  0.0 15.4    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[9] budget 0.000000 ns (2,17) -> (2,17)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_LC.CIN
Info:  0.1 15.5  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_LC.COUT
Info:  0.0 15.5    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[10] budget 0.000000 ns (2,17) -> (2,17)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_27_LC.CIN
Info:  0.1 15.6  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_27_LC.COUT
Info:  0.0 15.6    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[11] budget 0.000000 ns (2,17) -> (2,17)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_26_LC.CIN
Info:  0.1 15.7  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_26_LC.COUT
Info:  0.0 15.7    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[12] budget 0.000000 ns (2,17) -> (2,17)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_25_LC.CIN
Info:  0.1 15.9  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_25_LC.COUT
Info:  0.0 15.9    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[13] budget 0.000000 ns (2,17) -> (2,17)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_24_LC.CIN
Info:  0.1 16.0  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_24_LC.COUT
Info:  0.0 16.0    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[14] budget 0.000000 ns (2,17) -> (2,17)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_23_LC.CIN
Info:  0.1 16.1  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_23_LC.COUT
Info:  0.0 16.1    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[15] budget 0.000000 ns (2,17) -> (2,17)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_22_LC.CIN
Info:  0.1 16.2  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_22_LC.COUT
Info:  0.2 16.4    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[16] budget 0.190000 ns (2,17) -> (2,18)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_21_LC.CIN
Info:  0.1 16.6  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_21_LC.COUT
Info:  0.0 16.6    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[17] budget 0.000000 ns (2,18) -> (2,18)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_20_LC.CIN
Info:  0.1 16.7  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_20_LC.COUT
Info:  0.0 16.7    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[18] budget 0.000000 ns (2,18) -> (2,18)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_19_LC.CIN
Info:  0.1 16.8  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_19_LC.COUT
Info:  0.0 16.8    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[19] budget 0.000000 ns (2,18) -> (2,18)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_18_LC.CIN
Info:  0.1 16.9  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_18_LC.COUT
Info:  0.0 16.9    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[20] budget 0.000000 ns (2,18) -> (2,18)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_17_LC.CIN
Info:  0.1 17.1  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_17_LC.COUT
Info:  0.0 17.1    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[21] budget 0.000000 ns (2,18) -> (2,18)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_16_LC.CIN
Info:  0.1 17.2  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_16_LC.COUT
Info:  0.0 17.2    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[22] budget 0.000000 ns (2,18) -> (2,18)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_15_LC.CIN
Info:  0.1 17.3  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_15_LC.COUT
Info:  0.0 17.3    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[23] budget 0.000000 ns (2,18) -> (2,18)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_14_LC.CIN
Info:  0.1 17.5  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_14_LC.COUT
Info:  0.2 17.6    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[24] budget 0.190000 ns (2,18) -> (2,19)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_13_LC.CIN
Info:  0.1 17.8  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_13_LC.COUT
Info:  0.0 17.8    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[25] budget 0.000000 ns (2,19) -> (2,19)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_12_LC.CIN
Info:  0.1 17.9  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_12_LC.COUT
Info:  0.0 17.9    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[26] budget 0.000000 ns (2,19) -> (2,19)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_11_LC.CIN
Info:  0.1 18.0  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_11_LC.COUT
Info:  0.0 18.0    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[27] budget 0.000000 ns (2,19) -> (2,19)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_10_LC.CIN
Info:  0.1 18.2  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_10_LC.COUT
Info:  0.0 18.2    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[28] budget 0.000000 ns (2,19) -> (2,19)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_9_LC.CIN
Info:  0.1 18.3  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_9_LC.COUT
Info:  0.0 18.3    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[29] budget 0.000000 ns (2,19) -> (2,19)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_8_LC.CIN
Info:  0.1 18.4  Source cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_8_LC.COUT
Info:  0.3 18.7    Net cpu.ctrl.next_insn_buf_vld_SB_CARRY_I0_CO[30] budget 0.260000 ns (2,19) -> (2,19)
Info:                Sink cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_7_LC.I3
Info:  0.3 19.0  Setup cpu.ctrl.next_insn_buf_vld_SB_LUT4_I1_O_SB_LUT4_O_7_LC.I3
Info: 8.1 ns logic, 10.9 ns routing
```