### PR TITLE
memory_collect: Copy attr from RTLIL::Memory to  cell

### DIFF
--- a/passes/memory/memory_collect.cc
+++ b/passes/memory/memory_collect.cc
@@ -218,6 +218,10 @@ Cell *handle_memory(Module *module, RTLIL::Memory *memory)
 	mem->setPort("\\RD_DATA", sig_rd_data);
 	mem->setPort("\\RD_EN", sig_rd_en);
 
+	// Copy attributes from RTLIL memory to $mem
+	for (auto attr : memory->attributes)
+		mem->attributes[attr.first] = attr.second;
+
 	for (auto c : memcells)
 		module->remove(c);
 


### PR DESCRIPTION
This would be a prerequisite for any memory mapping decisions (e.g. type of memory) based on attributes