### PR TITLE
use CC not CXX to compile abc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ bumpversion:
 ABCREV = 623b5e8
 ABCPULL = 1
 ABCURL ?= https://github.com/berkeley-abc/abc
-ABCMKARGS = CC="$(CXX)" CXX="$(CXX)" ABC_USE_LIBSTDCXX=1
+ABCMKARGS = CC="$(CC)" CXX="$(CXX)" ABC_USE_LIBSTDCXX=1
 
 # set ABCEXTERNAL = <abc-command> to use an external ABC instance
 # Note: The in-tree ABC (yosys-abc) will not be installed when ABCEXTERNAL is set.


### PR DESCRIPTION
Compiling Yosys w/ "make CC=gcc CPP=cpp CXX=g++ PREFIX=/usr docdir=/usr/doc/yosys ABCREV=default" I otherwise get:
/usr/lib64/gcc/x86_64-t2-linux-gnu/8.1.0/../../../../x86_64-t2-linux-gnu/bin/ld: src/base/main/mainInit.o: in function `Abc_FrameInit':
mainInit.c:(.text+0xcf): undefined reference to `Glucose_Init(Abc_Frame_t_*)'
/usr/lib64/gcc/x86_64-t2-linux-gnu/8.1.0/../../../../x86_64-t2-linux-gnu/bin/ld: src/base/main/mainInit.o: in function `Abc_FrameEnd':
mainInit.c:(.text+0x1b1): undefined reference to `Glucose_End(Abc_Frame_t_*)'
/usr/lib64/gcc/x86_64-t2-linux-gnu/8.1.0/../../../../x86_64-t2-linux-gnu/bin/ld: src/base/acb/acbFunc.o: in function `Acb_NtkEcoPerform(Acb_Ntk_t_*, Acb_Ntk_t_*, char*, int)':
acbFunc.c:(.text+0xd125): undefined reference to `Abc_SopSynthesizeOne(char*, int)'