### PR TITLE
sv: Error checking for always_comb, always_latch and always_ff

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -51,6 +51,8 @@ Yosys 0.9 .. Yosys 0.9-dev
     - "synth_ice40 -dsp" to infer DSP blocks
     - Added latch support to synth_xilinx
     - Added "check -mapped"
+    - Added checking of SystemVerilog always block types (always_comb,
+      always_latch and always_ff)
 
 Yosys 0.8 .. Yosys 0.9
 ----------------------

--- a/README.md
+++ b/README.md
@@ -371,6 +371,11 @@ Verilog Attributes and non-standard features
   for example, to specify the clk-to-Q delay of a flip-flop for consideration
   during techmapping.
 
+- The frontend sets attributes ``always_comb``, ``always_latch`` and
+  ``always_ff`` on processes derived from SystemVerilog style always blocks
+  according to the type of the always. These are checked for correctness in
+  ``proc_dlatch``.
+
 - In addition to the ``(* ... *)`` attribute syntax, Yosys supports
   the non-standard ``{* ... *}`` attribute syntax to set default attributes
   for everything that comes after the ``{* ... *}`` statement. (Reset

--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -188,9 +188,9 @@ YOSYS_NAMESPACE_END
 "unique0"      { SV_KEYWORD(TOK_UNIQUE); }
 "priority"     { SV_KEYWORD(TOK_PRIORITY); }
 
-"always_comb"  { SV_KEYWORD(TOK_ALWAYS); }
-"always_ff"    { SV_KEYWORD(TOK_ALWAYS); }
-"always_latch" { SV_KEYWORD(TOK_ALWAYS); }
+"always_comb"  { SV_KEYWORD(TOK_ALWAYS_COMB); }
+"always_ff"    { SV_KEYWORD(TOK_ALWAYS_FF); }
+"always_latch" { SV_KEYWORD(TOK_ALWAYS_LATCH); }
 
  /* use special token for labels on assert, assume, cover, and restrict because it's insanley complex
     to fix parsing of cells otherwise. (the current cell parser forces a reduce very early to update some

--- a/tests/various/svalways.sh
+++ b/tests/various/svalways.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+trap 'echo "ERROR in svalways.sh" >&2; exit 1' ERR
+
+# Good case
+../../yosys -f "verilog -sv" -qp proc - <<EOT
+module top(input clk, en, d, output reg p, q, r);
+
+always_ff @(posedge clk)
+	p <= d;
+
+always_comb
+	q = ~d;
+
+always_latch
+	if (en) r = d;
+
+endmodule
+EOT
+
+# Incorrect always_comb syntax
+((../../yosys -f "verilog -sv" -qp proc -|| true) <<EOT
+module top(input d, output reg q);
+
+always_comb @(d)
+	q = ~d;
+
+endmodule
+EOT
+) 2>&1 | grep -F "<stdin>:3: ERROR: syntax error, unexpected '@'" > /dev/null
+
+# Incorrect use of always_comb
+((../../yosys -f "verilog -sv" -qp proc -|| true) <<EOT
+module top(input en, d, output reg q);
+
+always_comb
+	if (en) q = d;
+
+endmodule
+EOT
+) 2>&1 | grep -F "ERROR: Latch inferred for signal \`\\top.\\q' from always_comb process" > /dev/null
+
+# Incorrect use of always_latch
+((../../yosys -f "verilog -sv" -qp proc -|| true) <<EOT
+module top(input en, d, output reg q);
+
+always_latch
+	q = !d;
+
+endmodule
+EOT
+) 2>&1 | grep -F "ERROR: No latch inferred for signal \`\\top.\\q' from always_latch process" > /dev/null
+
+# Incorrect use of always_ff
+((../../yosys -f "verilog -sv" -qp proc -|| true) <<EOT
+module top(input en, d, output reg q);
+
+always_ff @(*)
+	q = !d;
+
+endmodule
+EOT
+) 2>&1 | grep -F "ERROR: Found non edge/level sensitive event in always_ff process" > /dev/null


### PR DESCRIPTION
This handles always_comb, always_latch and always_ff correctly. Sensitivity lists after always_(comb|latch) are now a syntax error as they should be; and an attribute is set on the process according to the type of always.

Checking of the types is done in `proc_dlatch`. Checking for correct use of `always_ff` here feels a bit iffy here; but the sequence inside `proc` means that doing it inside `proc_dff` seems tricky.

My understanding is that latches in always_comb; and vice versa; are only supposed to be a warning according to the standard. This PR implements what 99% of users would expect and throws an error in these cases, happy to change that if strict standards compliance is preferred.