### PR TITLE
coolrunner2: remove spurious log_pop() call, fixes #1463

### DIFF
--- a/techlibs/coolrunner2/synth_coolrunner2.cc
+++ b/techlibs/coolrunner2/synth_coolrunner2.cc
@@ -194,8 +194,6 @@ struct SynthCoolrunner2Pass : public ScriptPass
 			if (!json_file.empty() || help_mode)
 				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file.c_str()));
 		}
-
-		log_pop();
 	}
 } SynthCoolrunner2Pass;
 


### PR DESCRIPTION
This was causing a segmentation fault because there is no accompanying
log_push() call so header_count.size() became -1.

Signed-off-by: Martin Pietryka <martin@pietryka.at>