### PR TITLE
Gowin: add and test DFF init values

### DIFF
--- a/techlibs/gowin/cells_map.v
+++ b/techlibs/gowin/cells_map.v
@@ -1,82 +1,231 @@
+`default_nettype none
 //All DFF* have INIT, but the hardware is always initialised to the reset
 //value regardless. The parameter is ignored.
 
 // DFFN      D Flip-Flop with Negative-Edge Clock
-module  \$_DFF_N_ (input D, C, output Q); DFFN _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C)); endmodule
+module  \$_DFF_N_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, output Q);
+	generate
+    if (_TECHMAP_WIREINIT_Q_ === 1'b1)
+			DFFNS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(1'b0));
+    else
+			DFFN _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C));
+  endgenerate
+	wire _TECHMAP_REMOVEINIT_Q_ = 1;
+endmodule
+
 // DFF       D Flip-Flop
-module  \$_DFF_P_ (input D, C, output Q); DFF _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C)); endmodule
+module  \$_DFF_P_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, output Q);
+	generate
+    if (_TECHMAP_WIREINIT_Q_ === 1'b1)
+			DFFS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(1'b0));
+    else
+			DFF _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C));
+  endgenerate
+	wire _TECHMAP_REMOVEINIT_Q_ = 1;
+endmodule
 
 // DFFE      D Flip-Flop with Clock Enable
-module  \$_DFFE_PP_ (input D, C, E, output Q); DFFE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(E)); endmodule
-module  \$_DFFE_PN_ (input D, C, E, output Q); DFFE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(!E)); endmodule
+module  \$_DFFE_PP_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, E, output Q);
+	generate
+    if (_TECHMAP_WIREINIT_Q_ === 1'b1)
+			DFFSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(E), .SET(1'b0));
+    else
+			DFFE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(E));
+  endgenerate
+	wire _TECHMAP_REMOVEINIT_Q_ = 1;
+endmodule
+
+module  \$_DFFE_PN_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, E, output Q);
+	generate
+    if (_TECHMAP_WIREINIT_Q_ === 1'b1)
+			DFFSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(!E), .SET(1'b0));
+    else
+			DFFE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(!E));
+  endgenerate
+	wire _TECHMAP_REMOVEINIT_Q_ = 1;
+endmodule
 
 // DFFNE     D Flip-Flop with Negative-Edge Clock and Clock Enable
-module  \$_DFFE_NP_ (input D, C, E, output Q); DFFNE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(E)); endmodule
-module  \$_DFFE_NN_ (input D, C, E, output Q); DFFNE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(!E)); endmodule
+module  \$_DFFE_NP_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, E, output Q);
+	generate
+    if (_TECHMAP_WIREINIT_Q_ === 1'b1)
+			DFFNSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(E), .SET(1'b0));
+    else
+			DFFNE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(E));
+  endgenerate
+	wire _TECHMAP_REMOVEINIT_Q_ = 1;
+endmodule
+
+module  \$_DFFE_NN_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, E, output Q);
+	generate
+    if (_TECHMAP_WIREINIT_Q_ === 1'b1)
+			DFFNSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(!E), .SET(1'b0));
+    else
+			DFFNE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(!E));
+  endgenerate
+	wire _TECHMAP_REMOVEINIT_Q_ = 1;
+endmodule
 
 // DFFR      D Flip-Flop with Synchronous Reset
-module  \$__DFFS_PN0_ (input D, C, R, output Q); DFFR _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(!R)); endmodule
-module  \$__DFFS_PP0_ (input D, C, R, output Q); DFFR _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(R)); endmodule
+module  \$__DFFS_PN0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+	DFFR _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(!R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
+
+module  \$__DFFS_PP0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+	DFFR _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
 
 // DFFNR     D Flip-Flop with Negative-Edge Clock and Synchronous Reset
-module  \$__DFFS_NN0_ (input D, C, R, output Q); DFFNR _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(!R)); endmodule
-module  \$__DFFS_NP0_ (input D, C, R, output Q); DFFNR _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(R)); endmodule
+module  \$__DFFS_NN0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+  DFFNR _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(!R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
+module  \$__DFFS_NP0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+  DFFNR _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
 
 // DFFRE     D Flip-Flop with Clock Enable and Synchronous Reset
-module  \$__DFFSE_PN0 (input D, C, R, E, output Q); DFFRE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(!R), .CE(E)); endmodule
-module  \$__DFFSE_PP0 (input D, C, R, E, output Q); DFFRE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(R), .CE(E)); endmodule
+module  \$__DFFSE_PN0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+  DFFRE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(!R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
+module  \$__DFFSE_PP0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+  DFFRE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
 
 // DFFNRE    D Flip-Flop with Negative-Edge Clock,Clock Enable, and Synchronous Reset
-module  \$__DFFNSE_PN0 (input D, C, R, E, output Q); DFFNRE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(!R), .CE(E)); endmodule
-module  \$__DFFNSE_PP0 (input D, C, R, E, output Q); DFFNRE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(R), .CE(E)); endmodule
+module  \$__DFFSE_NN0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+  DFFNRE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(!R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
+module  \$__DFFSE_NP0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+  DFFNRE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
 
 // DFFS      D Flip-Flop with Synchronous Set
-module  \$__DFFS_PN1_ (input D, C, R, output Q); DFFS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(!R)); endmodule
-module  \$__DFFS_PP1_ (input D, C, R, output Q); DFFS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(R)); endmodule
+module  \$__DFFS_PN1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+  DFFS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(!R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+module  \$__DFFS_PP1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+  DFFS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
 
 // DFFNS     D Flip-Flop with Negative-Edge Clock and Synchronous Set
-module  \$__DFFS_NN1_ (input D, C, R, output Q); DFFNS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(!R)); endmodule
-module  \$__DFFS_NP1_ (input D, C, R, output Q); DFFNS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(R)); endmodule
+module  \$__DFFS_NN1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+  DFFNS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(!R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+module  \$__DFFS_NP1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+  DFFNS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
 
 // DFFSE     D Flip-Flop with Clock Enable and Synchronous Set
-module  \$__DFFSE_PN1 (input D, C, R, E, output Q); DFFSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(!R), .CE(E)); endmodule
-module  \$__DFFSE_PP1 (input D, C, R, E, output Q); DFFSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(R), .CE(E)); endmodule
+module  \$__DFFSE_PN1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+  DFFSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(!R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+module  \$__DFFSE_PP1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+  DFFSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
 
 // DFFNSE    D Flip-Flop with Negative-Edge Clock,Clock Enable,and Synchronous Set
-module  \$__DFFSE_NN1 (input D, C, R, E, output Q); DFFNSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(!R), .CE(E)); endmodule
-module  \$__DFFSE_NP1 (input D, C, R, E, output Q); DFFNSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(R), .CE(E)); endmodule
+module  \$__DFFSE_NN1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+  DFFNSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(!R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+module  \$__DFFSE_NP1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+  DFFNSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
 
 // DFFP      D Flip-Flop with Asynchronous Preset
-module  \$_DFF_PP1_ (input D, C, R, output Q); DFFP _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(R)); endmodule
-module  \$_DFF_PN1_ (input D, C, R, output Q); DFFP _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(!R)); endmodule
+module  \$_DFF_PP1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+  DFFP _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+module  \$_DFF_PN1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+  DFFP _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(!R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
 
 // DFFNP     D Flip-Flop with Negative-Edge Clock and Asynchronous Preset
-module  \$_DFF_NP1_ (input D, C, R, output Q); DFFNP _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(R)); endmodule
-module  \$_DFF_NN1_ (input D, C, R, output Q); DFFNP _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(!R)); endmodule
+module  \$_DFF_NP1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+  DFFNP _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+module  \$_DFF_NN1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+  DFFNP _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(!R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
 
 // DFFC      D Flip-Flop with Asynchronous Clear
-module  \$_DFF_PP0_ (input D, C, R, output Q); DFFC _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(R)); endmodule
-module  \$_DFF_PN0_ (input D, C, R, output Q); DFFC _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(!R)); endmodule
+module  \$_DFF_PP0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+  DFFC _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
+module  \$_DFF_PN0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+  DFFC _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(!R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
 
 // DFFNC     D Flip-Flop with Negative-Edge Clock and Asynchronous Clear
-module  \$_DFF_NP0_ (input D, C, R, output Q); DFFNC _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(R)); endmodule
-module  \$_DFF_NN0_ (input D, C, R, output Q); DFFNC _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(!R)); endmodule
+module  \$_DFF_NP0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+  DFFNC _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
+module  \$_DFF_NN0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+  DFFNC _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(!R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
 
 // DFFPE     D Flip-Flop with Clock Enable and Asynchronous Preset
-module  \$__DFFE_PP1 (input D, C, R, E, output Q); DFFPE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(R), .CE(E)); endmodule
-module  \$__DFFE_PN1 (input D, C, R, E, output Q); DFFPE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(!R), .CE(E)); endmodule
+module  \$__DFFE_PP1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+  DFFPE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+module  \$__DFFE_PN1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+  DFFPE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(!R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
 
 // DFFNPE    D Flip-Flop with Negative-Edge Clock,Clock Enable, and Asynchronous Preset
-module  \$__DFFE_NP1 (input D, C, R, E, output Q); DFFNPE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(R), .CE(E)); endmodule
-module  \$__DFFE_NN1 (input D, C, R, E, output Q); DFFNPE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(!R), .CE(E)); endmodule
+module  \$__DFFE_NP1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+  DFFNPE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+module  \$__DFFE_NN1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+  DFFNPE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(!R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
 
 // DFFCE     D Flip-Flop with Clock Enable and Asynchronous Clear
-module  \$__DFFE_PP0 (input D, C, R, E, output Q); DFFCE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(R), .CE(E)); endmodule
-module  \$__DFFE_PN0 (input D, C, R, E, output Q); DFFCE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(!R), .CE(E)); endmodule
+module  \$__DFFE_PP0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+  DFFCE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
+module  \$__DFFE_PN0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+  DFFCE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(!R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
 
 // DFFNCE    D Flip-Flop with Negative-Edge Clock,Clock Enable and Asynchronous Clear
-module  \$__DFFE_NP0 (input D, C, R, E, output Q); DFFNCE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(R), .CE(E)); endmodule
-module  \$__DFFE_NN0 (input D, C, R, E, output Q); DFFNCE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(!R), .CE(E)); endmodule
+module  \$__DFFE_NP0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+  DFFNCE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
+module  \$__DFFE_NN0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+  DFFNCE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(!R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
 
 
 module \$lut (A, Y);

--- a/techlibs/gowin/cells_map.v
+++ b/techlibs/gowin/cells_map.v
@@ -2,281 +2,281 @@
 //All DFF* have INIT, but the hardware is always initialised to the reset
 //value regardless. The parameter is ignored.
 
-// DFFN      D Flip-Flop with Negative-Edge Clock
-module  \$_DFF_N_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, output Q);
+// DFFN			 D Flip-Flop with Negative-Edge Clock
+module	\$_DFF_N_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, output Q);
 	generate
-    if (_TECHMAP_WIREINIT_Q_ === 1'b1)
+		if (_TECHMAP_WIREINIT_Q_ === 1'b1)
 			DFFNS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(1'b0));
-    else
+		else
 			DFFN _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C));
-  endgenerate
+	endgenerate
 	wire _TECHMAP_REMOVEINIT_Q_ = 1;
 endmodule
 
-// DFF       D Flip-Flop
-module  \$_DFF_P_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, output Q);
+// DFF			 D Flip-Flop
+module	\$_DFF_P_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, output Q);
 	generate
-    if (_TECHMAP_WIREINIT_Q_ === 1'b1)
+		if (_TECHMAP_WIREINIT_Q_ === 1'b1)
 			DFFS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(1'b0));
-    else
+		else
 			DFF _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C));
-  endgenerate
+	endgenerate
 	wire _TECHMAP_REMOVEINIT_Q_ = 1;
 endmodule
 
-// DFFE      D Flip-Flop with Clock Enable
-module  \$_DFFE_PP_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, E, output Q);
+// DFFE			 D Flip-Flop with Clock Enable
+module	\$_DFFE_PP_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, E, output Q);
 	generate
-    if (_TECHMAP_WIREINIT_Q_ === 1'b1)
+		if (_TECHMAP_WIREINIT_Q_ === 1'b1)
 			DFFSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(E), .SET(1'b0));
-    else
+		else
 			DFFE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(E));
-  endgenerate
+	endgenerate
 	wire _TECHMAP_REMOVEINIT_Q_ = 1;
 endmodule
 
-module  \$_DFFE_PN_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, E, output Q);
+module	\$_DFFE_PN_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, E, output Q);
 	generate
-    if (_TECHMAP_WIREINIT_Q_ === 1'b1)
+		if (_TECHMAP_WIREINIT_Q_ === 1'b1)
 			DFFSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(!E), .SET(1'b0));
-    else
+		else
 			DFFE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(!E));
-  endgenerate
+	endgenerate
 	wire _TECHMAP_REMOVEINIT_Q_ = 1;
 endmodule
 
-// DFFNE     D Flip-Flop with Negative-Edge Clock and Clock Enable
-module  \$_DFFE_NP_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, E, output Q);
+// DFFNE		 D Flip-Flop with Negative-Edge Clock and Clock Enable
+module	\$_DFFE_NP_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, E, output Q);
 	generate
-    if (_TECHMAP_WIREINIT_Q_ === 1'b1)
+		if (_TECHMAP_WIREINIT_Q_ === 1'b1)
 			DFFNSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(E), .SET(1'b0));
-    else
+		else
 			DFFNE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(E));
-  endgenerate
+	endgenerate
 	wire _TECHMAP_REMOVEINIT_Q_ = 1;
 endmodule
 
-module  \$_DFFE_NN_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, E, output Q);
+module	\$_DFFE_NN_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, E, output Q);
 	generate
-    if (_TECHMAP_WIREINIT_Q_ === 1'b1)
+		if (_TECHMAP_WIREINIT_Q_ === 1'b1)
 			DFFNSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(!E), .SET(1'b0));
-    else
+		else
 			DFFNE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CE(!E));
-  endgenerate
+	endgenerate
 	wire _TECHMAP_REMOVEINIT_Q_ = 1;
 endmodule
 
-// DFFR      D Flip-Flop with Synchronous Reset
-module  \$__DFFS_PN0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+// DFFR			 D Flip-Flop with Synchronous Reset
+module	\$__DFFS_PN0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
 	DFFR _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(!R));
 	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
 endmodule
 
-module  \$__DFFS_PP0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+module	\$__DFFS_PP0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
 	DFFR _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(R));
 	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
 endmodule
 
-// DFFNR     D Flip-Flop with Negative-Edge Clock and Synchronous Reset
-module  \$__DFFS_NN0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
-  DFFNR _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(!R));
+// DFFNR		 D Flip-Flop with Negative-Edge Clock and Synchronous Reset
+module	\$__DFFS_NN0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+	DFFNR _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(!R));
 	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
 endmodule
-module  \$__DFFS_NP0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
-  DFFNR _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(R));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
-endmodule
-
-// DFFRE     D Flip-Flop with Clock Enable and Synchronous Reset
-module  \$__DFFSE_PN0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
-  DFFRE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(!R), .CE(E));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
-endmodule
-module  \$__DFFSE_PP0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
-  DFFRE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(R), .CE(E));
+module	\$__DFFS_NP0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+	DFFNR _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(R));
 	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
 endmodule
 
-// DFFNRE    D Flip-Flop with Negative-Edge Clock,Clock Enable, and Synchronous Reset
-module  \$__DFFSE_NN0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
-  DFFNRE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(!R), .CE(E));
+// DFFRE		 D Flip-Flop with Clock Enable and Synchronous Reset
+module	\$__DFFSE_PN0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+	DFFRE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(!R), .CE(E));
 	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
 endmodule
-module  \$__DFFSE_NP0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
-  DFFNRE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(R), .CE(E));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
-endmodule
-
-// DFFS      D Flip-Flop with Synchronous Set
-module  \$__DFFS_PN1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
-  DFFS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(!R));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
-endmodule
-module  \$__DFFS_PP1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
-  DFFS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(R));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
-endmodule
-
-// DFFNS     D Flip-Flop with Negative-Edge Clock and Synchronous Set
-module  \$__DFFS_NN1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
-  DFFNS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(!R));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
-endmodule
-module  \$__DFFS_NP1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
-  DFFNS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(R));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
-endmodule
-
-// DFFSE     D Flip-Flop with Clock Enable and Synchronous Set
-module  \$__DFFSE_PN1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
-  DFFSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(!R), .CE(E));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
-endmodule
-module  \$__DFFSE_PP1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
-  DFFSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(R), .CE(E));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
-endmodule
-
-// DFFNSE    D Flip-Flop with Negative-Edge Clock,Clock Enable,and Synchronous Set
-module  \$__DFFSE_NN1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
-  DFFNSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(!R), .CE(E));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
-endmodule
-module  \$__DFFSE_NP1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
-  DFFNSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(R), .CE(E));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
-endmodule
-
-// DFFP      D Flip-Flop with Asynchronous Preset
-module  \$_DFF_PP1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
-  DFFP _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(R));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
-endmodule
-module  \$_DFF_PN1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
-  DFFP _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(!R));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
-endmodule
-
-// DFFNP     D Flip-Flop with Negative-Edge Clock and Asynchronous Preset
-module  \$_DFF_NP1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
-  DFFNP _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(R));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
-endmodule
-module  \$_DFF_NN1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
-  DFFNP _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(!R));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
-endmodule
-
-// DFFC      D Flip-Flop with Asynchronous Clear
-module  \$_DFF_PP0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
-  DFFC _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(R));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
-endmodule
-module  \$_DFF_PN0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
-  DFFC _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(!R));
+module	\$__DFFSE_PP0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+	DFFRE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(R), .CE(E));
 	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
 endmodule
 
-// DFFNC     D Flip-Flop with Negative-Edge Clock and Asynchronous Clear
-module  \$_DFF_NP0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
-  DFFNC _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(R));
+// DFFNRE		 D Flip-Flop with Negative-Edge Clock,Clock Enable, and Synchronous Reset
+module	\$__DFFSE_NN0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+	DFFNRE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(!R), .CE(E));
 	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
 endmodule
-module  \$_DFF_NN0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
-  DFFNC _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(!R));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
-endmodule
-
-// DFFPE     D Flip-Flop with Clock Enable and Asynchronous Preset
-module  \$__DFFE_PP1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
-  DFFPE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(R), .CE(E));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
-endmodule
-module  \$__DFFE_PN1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
-  DFFPE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(!R), .CE(E));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
-endmodule
-
-// DFFNPE    D Flip-Flop with Negative-Edge Clock,Clock Enable, and Asynchronous Preset
-module  \$__DFFE_NP1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
-  DFFNPE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(R), .CE(E));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
-endmodule
-module  \$__DFFE_NN1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
-  DFFNPE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(!R), .CE(E));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
-endmodule
-
-// DFFCE     D Flip-Flop with Clock Enable and Asynchronous Clear
-module  \$__DFFE_PP0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
-  DFFCE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(R), .CE(E));
-	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
-endmodule
-module  \$__DFFE_PN0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
-  DFFCE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(!R), .CE(E));
+module	\$__DFFSE_NP0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+	DFFNRE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .RESET(R), .CE(E));
 	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
 endmodule
 
-// DFFNCE    D Flip-Flop with Negative-Edge Clock,Clock Enable and Asynchronous Clear
-module  \$__DFFE_NP0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
-  DFFNCE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(R), .CE(E));
+// DFFS			 D Flip-Flop with Synchronous Set
+module	\$__DFFS_PN1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+	DFFS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(!R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+module	\$__DFFS_PP1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+	DFFS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+
+// DFFNS		 D Flip-Flop with Negative-Edge Clock and Synchronous Set
+module	\$__DFFS_NN1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+	DFFNS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(!R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+module	\$__DFFS_NP1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+	DFFNS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+
+// DFFSE		 D Flip-Flop with Clock Enable and Synchronous Set
+module	\$__DFFSE_PN1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+	DFFSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(!R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+module	\$__DFFSE_PP1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+	DFFSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+
+// DFFNSE		 D Flip-Flop with Negative-Edge Clock,Clock Enable,and Synchronous Set
+module	\$__DFFSE_NN1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+	DFFNSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(!R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+module	\$__DFFSE_NP1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+	DFFNSE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .SET(R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+
+// DFFP			 D Flip-Flop with Asynchronous Preset
+module	\$_DFF_PP1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+	DFFP _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+module	\$_DFF_PN1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+	DFFP _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(!R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+
+// DFFNP		 D Flip-Flop with Negative-Edge Clock and Asynchronous Preset
+module	\$_DFF_NP1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+	DFFNP _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+module	\$_DFF_NN1_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+	DFFNP _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(!R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+
+// DFFC			 D Flip-Flop with Asynchronous Clear
+module	\$_DFF_PP0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+	DFFC _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(R));
 	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
 endmodule
-module  \$__DFFE_NN0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
-  DFFNCE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(!R), .CE(E));
+module	\$_DFF_PN0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+	DFFC _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(!R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
+
+// DFFNC		 D Flip-Flop with Negative-Edge Clock and Asynchronous Clear
+module	\$_DFF_NP0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+	DFFNC _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
+module	\$_DFF_NN0_ #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, output Q);
+	DFFNC _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(!R));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
+
+// DFFPE		 D Flip-Flop with Clock Enable and Asynchronous Preset
+module	\$__DFFE_PP1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+	DFFPE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+module	\$__DFFE_PN1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+	DFFPE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(!R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+
+// DFFNPE		 D Flip-Flop with Negative-Edge Clock,Clock Enable, and Asynchronous Preset
+module	\$__DFFE_NP1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+	DFFNPE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+module	\$__DFFE_NN1 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+	DFFNPE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .PRESET(!R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b0;
+endmodule
+
+// DFFCE		 D Flip-Flop with Clock Enable and Asynchronous Clear
+module	\$__DFFE_PP0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+	DFFCE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
+module	\$__DFFE_PN0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+	DFFCE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(!R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
+
+// DFFNCE		 D Flip-Flop with Negative-Edge Clock,Clock Enable and Asynchronous Clear
+module	\$__DFFE_NP0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+	DFFNCE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(R), .CE(E));
+	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
+endmodule
+module	\$__DFFE_NN0 #(parameter _TECHMAP_WIREINIT_Q_ = 1'bx) (input D, C, R, E, output Q);
+	DFFNCE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .CLK(C), .CLEAR(!R), .CE(E));
 	wire _TECHMAP_REMOVEINIT_Q_ = _TECHMAP_WIREINIT_Q_ !== 1'b1;
 endmodule
 
 
 module \$lut (A, Y);
-  parameter WIDTH = 0;
-  parameter LUT = 0;
+	parameter WIDTH = 0;
+	parameter LUT = 0;
 
-  input [WIDTH-1:0] A;
-  output Y;
+	input [WIDTH-1:0] A;
+	output Y;
 
-  generate
-    if (WIDTH == 1) begin
-      LUT1 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.F(Y),
-        .I0(A[0]));
-    end else
-    if (WIDTH == 2) begin
-      LUT2 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.F(Y),
-        .I0(A[0]), .I1(A[1]));
-    end else
-    if (WIDTH == 3) begin
-      LUT3 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.F(Y),
-        .I0(A[0]), .I1(A[1]), .I2(A[2]));
-    end else
-    if (WIDTH == 4) begin
-      LUT4 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.F(Y),
-        .I0(A[0]), .I1(A[1]), .I2(A[2]), .I3(A[3]));
-    end else
-    if (WIDTH == 5) begin
-      wire f0, f1;
-      \$lut #(.LUT(LUT[15: 0]), .WIDTH(4)) lut0 (.A(A[3:0]), .Y(f0));
-      \$lut #(.LUT(LUT[31:16]), .WIDTH(4)) lut1 (.A(A[3:0]), .Y(f1));
-      MUX2_LUT5 mux5(.I0(f0), .I1(f1), .S0(A[4]), .O(Y));
-    end else
-    if (WIDTH == 6) begin
-      wire f0, f1;
-      \$lut #(.LUT(LUT[31: 0]), .WIDTH(5)) lut0 (.A(A[4:0]), .Y(f0));
-      \$lut #(.LUT(LUT[63:32]), .WIDTH(5)) lut1 (.A(A[4:0]), .Y(f1));
-      MUX2_LUT6 mux6(.I0(f0), .I1(f1), .S0(A[5]), .O(Y));
-    end else
-    if (WIDTH == 7) begin
-      wire f0, f1;
-      \$lut #(.LUT(LUT[63: 0]), .WIDTH(6)) lut0 (.A(A[5:0]), .Y(f0));
-      \$lut #(.LUT(LUT[127:64]), .WIDTH(6)) lut1 (.A(A[5:0]), .Y(f1));
-      MUX2_LUT7 mux7(.I0(f0), .I1(f1), .S0(A[6]), .O(Y));
-    end else
-    if (WIDTH == 8) begin
-      wire f0, f1;
-      \$lut #(.LUT(LUT[127: 0]), .WIDTH(7)) lut0 (.A(A[6:0]), .Y(f0));
-      \$lut #(.LUT(LUT[255:128]), .WIDTH(7)) lut1 (.A(A[6:0]), .Y(f1));
-      MUX2_LUT8 mux8(.I0(f0), .I1(f1), .S0(A[7]), .O(Y));
-    end else begin
-      wire _TECHMAP_FAIL_ = 1;
-    end
-  endgenerate
+	generate
+		if (WIDTH == 1) begin
+			LUT1 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.F(Y),
+				.I0(A[0]));
+		end else
+		if (WIDTH == 2) begin
+			LUT2 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.F(Y),
+				.I0(A[0]), .I1(A[1]));
+		end else
+		if (WIDTH == 3) begin
+			LUT3 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.F(Y),
+				.I0(A[0]), .I1(A[1]), .I2(A[2]));
+		end else
+		if (WIDTH == 4) begin
+			LUT4 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.F(Y),
+				.I0(A[0]), .I1(A[1]), .I2(A[2]), .I3(A[3]));
+		end else
+		if (WIDTH == 5) begin
+			wire f0, f1;
+			\$lut #(.LUT(LUT[15: 0]), .WIDTH(4)) lut0 (.A(A[3:0]), .Y(f0));
+			\$lut #(.LUT(LUT[31:16]), .WIDTH(4)) lut1 (.A(A[3:0]), .Y(f1));
+			MUX2_LUT5 mux5(.I0(f0), .I1(f1), .S0(A[4]), .O(Y));
+		end else
+		if (WIDTH == 6) begin
+			wire f0, f1;
+			\$lut #(.LUT(LUT[31: 0]), .WIDTH(5)) lut0 (.A(A[4:0]), .Y(f0));
+			\$lut #(.LUT(LUT[63:32]), .WIDTH(5)) lut1 (.A(A[4:0]), .Y(f1));
+			MUX2_LUT6 mux6(.I0(f0), .I1(f1), .S0(A[5]), .O(Y));
+		end else
+		if (WIDTH == 7) begin
+			wire f0, f1;
+			\$lut #(.LUT(LUT[63: 0]), .WIDTH(6)) lut0 (.A(A[5:0]), .Y(f0));
+			\$lut #(.LUT(LUT[127:64]), .WIDTH(6)) lut1 (.A(A[5:0]), .Y(f1));
+			MUX2_LUT7 mux7(.I0(f0), .I1(f1), .S0(A[6]), .O(Y));
+		end else
+		if (WIDTH == 8) begin
+			wire f0, f1;
+			\$lut #(.LUT(LUT[127: 0]), .WIDTH(7)) lut0 (.A(A[6:0]), .Y(f0));
+			\$lut #(.LUT(LUT[255:128]), .WIDTH(7)) lut1 (.A(A[6:0]), .Y(f1));
+			MUX2_LUT8 mux8(.I0(f0), .I1(f1), .S0(A[7]), .O(Y));
+		end else begin
+			wire _TECHMAP_FAIL_ = 1;
+		end
+	endgenerate
 endmodule

--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -216,7 +216,7 @@ struct SynthGowinPass : public ScriptPass
 		if (check_label("map_ffs"))
 		{
 			run("dffsr2dff");
-			run("dff2dffs");
+			run("dff2dffs -match-init");
 			run("opt_clean");
 			if (!nodffe)
 				run("dff2dffe -direct-match $_DFF_* -direct-match $__DFFS_*");

--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -67,6 +67,9 @@ struct SynthGowinPass : public ScriptPass
 		log("    -nowidelut\n");
 		log("        do not use muxes to implement LUTs larger than LUT4s\n");
 		log("\n");
+		log("    -noiopads\n");
+		log("        do not emit IOB at top level ports\n");
+		log("\n");
 		log("    -abc9\n");
 		log("        use new ABC9 flow (EXPERIMENTAL)\n");
 		log("\n");
@@ -77,7 +80,7 @@ struct SynthGowinPass : public ScriptPass
 	}
 
 	string top_opt, vout_file;
-	bool retime, nobram, nodram, flatten, nodffe, nowidelut, abc9;
+	bool retime, nobram, nodram, flatten, nodffe, nowidelut, abc9, noiopads;
 
 	void clear_flags() YS_OVERRIDE
 	{
@@ -90,6 +93,7 @@ struct SynthGowinPass : public ScriptPass
 		nodram = false;
 		nowidelut = false;
 		abc9 = false;
+		noiopads = false;
 	}
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
@@ -142,6 +146,10 @@ struct SynthGowinPass : public ScriptPass
 			}
 			if (args[argidx] == "-abc9") {
 				abc9 = true;
+				continue;
+			}
+			if (args[argidx] == "-noiopads") {
+				noiopads = true;
 				continue;
 			}
 			break;
@@ -236,8 +244,9 @@ struct SynthGowinPass : public ScriptPass
 			run("techmap -map +/gowin/cells_map.v");
 			run("setundef -undriven -params -zero");
 			run("hilomap -singleton -hicell VCC V -locell GND G");
-			run("iopadmap -bits -inpad IBUF O:I -outpad OBUF I:O "
-				"-toutpad TBUF OEN:I:O -tinoutpad IOBUF OEN:O:I:IO", "(unless -noiopads)");
+			if (!noiopads || help_mode)
+				run("iopadmap -bits -inpad IBUF O:I -outpad OBUF I:O "
+					"-toutpad TBUF OEN:I:O -tinoutpad IOBUF OEN:O:I:IO", "(unless -noiopads)");
 			run("clean");
 
 		}

--- a/tests/arch/gowin/adffs.ys
+++ b/tests/arch/gowin/adffs.ys
@@ -34,11 +34,12 @@ proc
 equiv_opt -async2sync -assert -map +/gowin/cells_sim.v synth_gowin # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd dffs # Constrain all select calls below inside the top module
-select -assert-count 1 t:DFFS
+select -assert-count 1 t:DFF
+select -assert-count 1 t:LUT2
 select -assert-count 4 t:IBUF
 select -assert-count 1 t:OBUF
 
-select -assert-none t:DFFS t:IBUF t:OBUF %% t:* %D
+select -assert-none t:DFF t:LUT2 t:IBUF t:OBUF %% t:* %D
 
 
 design -load read

--- a/tests/arch/gowin/init.v
+++ b/tests/arch/gowin/init.v
@@ -1,0 +1,224 @@
+module myDFF (output reg Q, input CLK, D);
+	parameter [0:0] INIT = 1'b0;
+	initial Q = INIT;
+	always @(posedge CLK)
+		Q <= D;
+endmodule
+
+module myDFFE (output reg Q, input D, CLK, CE);
+  parameter [0:0] INIT = 1'b0;
+  initial Q = INIT;
+  always @(posedge CLK) begin
+    if (CE)
+      Q <= D;
+  end
+endmodule // DFFE (positive clock edge; clock enable)
+
+
+module myDFFS (output reg Q, input D, CLK, SET);
+  parameter [0:0] INIT = 1'b1;
+  initial Q = INIT;
+  always @(posedge CLK) begin
+    if (SET)
+      Q <= 1'b1;
+    else
+      Q <= D;
+  end
+endmodule // DFFS (positive clock edge; synchronous set)
+
+
+module myDFFSE (output reg Q, input D, CLK, CE, SET);
+  parameter [0:0] INIT = 1'b1;
+  initial Q = INIT;
+  always @(posedge CLK) begin
+    if (SET)
+      Q <= 1'b1;
+    else if (CE)
+      Q <= D;
+end
+endmodule // DFFSE (positive clock edge; synchronous set takes precedence over clock enable)
+
+
+module myDFFR (output reg Q, input D, CLK, RESET);
+  parameter [0:0] INIT = 1'b0;
+  initial Q = INIT;
+  always @(posedge CLK) begin
+    if (RESET)
+      Q <= 1'b0;
+    else
+      Q <= D;
+  end
+endmodule // DFFR (positive clock edge; synchronous reset)
+
+
+module myDFFRE (output reg Q, input D, CLK, CE, RESET);
+  parameter [0:0] INIT = 1'b0;
+  initial Q = INIT;
+  always @(posedge CLK) begin
+    if (RESET)
+      Q <= 1'b0;
+    else if (CE)
+      Q <= D;
+  end
+endmodule // DFFRE (positive clock edge; synchronous reset takes precedence over clock enable)
+
+
+module myDFFP (output reg Q, input D, CLK, PRESET);
+  parameter [0:0] INIT = 1'b1;
+  initial Q = INIT;
+  always @(posedge CLK or posedge PRESET) begin
+    if(PRESET)
+      Q <= 1'b1;
+    else
+      Q <= D;
+  end
+endmodule // DFFP (positive clock edge; asynchronous preset)
+
+
+module myDFFPE (output reg Q, input D, CLK, CE, PRESET);
+  parameter [0:0] INIT = 1'b1;
+  initial Q = INIT;
+  always @(posedge CLK or posedge PRESET) begin
+    if(PRESET)
+      Q <= 1'b1;
+    else if (CE)
+      Q <= D;
+  end
+endmodule // DFFPE (positive clock edge; asynchronous preset; clock enable)
+
+
+module myDFFC (output reg Q, input D, CLK, CLEAR);
+  parameter [0:0] INIT = 1'b0;
+  initial Q = INIT;
+  always @(posedge CLK or posedge CLEAR) begin
+    if(CLEAR)
+      Q <= 1'b0;
+    else
+      Q <= D;
+  end
+endmodule // DFFC (positive clock edge; asynchronous clear)
+
+
+module myDFFCE (output reg Q, input D, CLK, CE, CLEAR);
+  parameter [0:0] INIT = 1'b0;
+  initial Q = INIT;
+  always @(posedge CLK or posedge CLEAR) begin
+    if(CLEAR)
+      Q <= 1'b0;
+    else if (CE)
+      Q <= D;
+  end
+endmodule // DFFCE (positive clock edge; asynchronous clear; clock enable)
+
+
+module myDFFN (output reg Q, input CLK, D);
+	parameter [0:0] INIT = 1'b0;
+	initial Q = INIT;
+	always @(negedge CLK)
+		Q <= D;
+endmodule
+
+module myDFFNE (output reg Q, input D, CLK, CE);
+  parameter [0:0] INIT = 1'b0;
+  initial Q = INIT;
+  always @(negedge CLK) begin
+    if (CE)
+      Q <= D;
+  end
+endmodule // DFFNE (negative clock edge; clock enable)
+
+
+module myDFFNS (output reg Q, input D, CLK, SET);
+  parameter [0:0] INIT = 1'b1;
+  initial Q = INIT;
+  always @(negedge CLK) begin
+    if (SET)
+      Q <= 1'b1;
+    else
+      Q <= D;
+  end
+endmodule // DFFNS (negative clock edge; synchronous set)
+
+
+module myDFFNSE (output reg Q, input D, CLK, CE, SET);
+  parameter [0:0] INIT = 1'b1;
+  initial Q = INIT;
+  always @(negedge CLK) begin
+    if (SET)
+      Q <= 1'b1;
+    else if (CE)
+      Q <= D;
+end
+endmodule // DFFNSE (negative clock edge; synchronous set takes precedence over clock enable)
+
+
+module myDFFNR (output reg Q, input D, CLK, RESET);
+  parameter [0:0] INIT = 1'b0;
+  initial Q = INIT;
+  always @(negedge CLK) begin
+    if (RESET)
+      Q <= 1'b0;
+    else
+      Q <= D;
+  end
+endmodule // DFFNR (negative clock edge; synchronous reset)
+
+
+module myDFFNRE (output reg Q, input D, CLK, CE, RESET);
+  parameter [0:0] INIT = 1'b0;
+  initial Q = INIT;
+  always @(negedge CLK) begin
+    if (RESET)
+      Q <= 1'b0;
+    else if (CE)
+      Q <= D;
+  end
+endmodule // DFFNRE (negative clock edge; synchronous reset takes precedence over clock enable)
+
+
+module myDFFNP (output reg Q, input D, CLK, PRESET);
+  parameter [0:0] INIT = 1'b1;
+  initial Q = INIT;
+  always @(negedge CLK or posedge PRESET) begin
+    if(PRESET)
+      Q <= 1'b1;
+    else
+      Q <= D;
+  end
+endmodule // DFFNP (negative clock edge; asynchronous preset)
+
+
+module myDFFNPE (output reg Q, input D, CLK, CE, PRESET);
+  parameter [0:0] INIT = 1'b1;
+  initial Q = INIT;
+  always @(negedge CLK or posedge PRESET) begin
+    if(PRESET)
+      Q <= 1'b1;
+    else if (CE)
+      Q <= D;
+  end
+endmodule // DFFNPE (negative clock edge; asynchronous preset; clock enable)
+
+
+module myDFFNC (output reg Q, input D, CLK, CLEAR);
+  parameter [0:0] INIT = 1'b0;
+  initial Q = INIT;
+  always @(negedge CLK or posedge CLEAR) begin
+    if(CLEAR)
+      Q <= 1'b0;
+    else
+      Q <= D;
+  end
+endmodule // DFFNC (negative clock edge; asynchronous clear)
+
+
+module myDFFNCE (output reg Q, input D, CLK, CE, CLEAR);
+  parameter [0:0] INIT = 1'b0;
+  initial Q = INIT;
+  always @(negedge CLK or posedge CLEAR) begin
+    if(CLEAR)
+      Q <= 1'b0;
+    else if (CE)
+      Q <= D;
+  end
+endmodule // DFFNCE (negative clock edge; asynchronous clear; clock enable)

--- a/tests/arch/gowin/init.v
+++ b/tests/arch/gowin/init.v
@@ -6,108 +6,108 @@ module myDFF (output reg Q, input CLK, D);
 endmodule
 
 module myDFFE (output reg Q, input D, CLK, CE);
-  parameter [0:0] INIT = 1'b0;
-  initial Q = INIT;
-  always @(posedge CLK) begin
-    if (CE)
-      Q <= D;
-  end
+	parameter [0:0] INIT = 1'b0;
+	initial Q = INIT;
+	always @(posedge CLK) begin
+		if (CE)
+			Q <= D;
+	end
 endmodule // DFFE (positive clock edge; clock enable)
 
 
 module myDFFS (output reg Q, input D, CLK, SET);
-  parameter [0:0] INIT = 1'b1;
-  initial Q = INIT;
-  always @(posedge CLK) begin
-    if (SET)
-      Q <= 1'b1;
-    else
-      Q <= D;
-  end
+	parameter [0:0] INIT = 1'b1;
+	initial Q = INIT;
+	always @(posedge CLK) begin
+		if (SET)
+			Q <= 1'b1;
+		else
+			Q <= D;
+	end
 endmodule // DFFS (positive clock edge; synchronous set)
 
 
 module myDFFSE (output reg Q, input D, CLK, CE, SET);
-  parameter [0:0] INIT = 1'b1;
-  initial Q = INIT;
-  always @(posedge CLK) begin
-    if (SET)
-      Q <= 1'b1;
-    else if (CE)
-      Q <= D;
+	parameter [0:0] INIT = 1'b1;
+	initial Q = INIT;
+	always @(posedge CLK) begin
+		if (SET)
+			Q <= 1'b1;
+		else if (CE)
+			Q <= D;
 end
 endmodule // DFFSE (positive clock edge; synchronous set takes precedence over clock enable)
 
 
 module myDFFR (output reg Q, input D, CLK, RESET);
-  parameter [0:0] INIT = 1'b0;
-  initial Q = INIT;
-  always @(posedge CLK) begin
-    if (RESET)
-      Q <= 1'b0;
-    else
-      Q <= D;
-  end
+	parameter [0:0] INIT = 1'b0;
+	initial Q = INIT;
+	always @(posedge CLK) begin
+		if (RESET)
+			Q <= 1'b0;
+		else
+			Q <= D;
+	end
 endmodule // DFFR (positive clock edge; synchronous reset)
 
 
 module myDFFRE (output reg Q, input D, CLK, CE, RESET);
-  parameter [0:0] INIT = 1'b0;
-  initial Q = INIT;
-  always @(posedge CLK) begin
-    if (RESET)
-      Q <= 1'b0;
-    else if (CE)
-      Q <= D;
-  end
+	parameter [0:0] INIT = 1'b0;
+	initial Q = INIT;
+	always @(posedge CLK) begin
+		if (RESET)
+			Q <= 1'b0;
+		else if (CE)
+			Q <= D;
+	end
 endmodule // DFFRE (positive clock edge; synchronous reset takes precedence over clock enable)
 
 
 module myDFFP (output reg Q, input D, CLK, PRESET);
-  parameter [0:0] INIT = 1'b1;
-  initial Q = INIT;
-  always @(posedge CLK or posedge PRESET) begin
-    if(PRESET)
-      Q <= 1'b1;
-    else
-      Q <= D;
-  end
+	parameter [0:0] INIT = 1'b1;
+	initial Q = INIT;
+	always @(posedge CLK or posedge PRESET) begin
+		if(PRESET)
+			Q <= 1'b1;
+		else
+			Q <= D;
+	end
 endmodule // DFFP (positive clock edge; asynchronous preset)
 
 
 module myDFFPE (output reg Q, input D, CLK, CE, PRESET);
-  parameter [0:0] INIT = 1'b1;
-  initial Q = INIT;
-  always @(posedge CLK or posedge PRESET) begin
-    if(PRESET)
-      Q <= 1'b1;
-    else if (CE)
-      Q <= D;
-  end
+	parameter [0:0] INIT = 1'b1;
+	initial Q = INIT;
+	always @(posedge CLK or posedge PRESET) begin
+		if(PRESET)
+			Q <= 1'b1;
+		else if (CE)
+			Q <= D;
+	end
 endmodule // DFFPE (positive clock edge; asynchronous preset; clock enable)
 
 
 module myDFFC (output reg Q, input D, CLK, CLEAR);
-  parameter [0:0] INIT = 1'b0;
-  initial Q = INIT;
-  always @(posedge CLK or posedge CLEAR) begin
-    if(CLEAR)
-      Q <= 1'b0;
-    else
-      Q <= D;
-  end
+	parameter [0:0] INIT = 1'b0;
+	initial Q = INIT;
+	always @(posedge CLK or posedge CLEAR) begin
+		if(CLEAR)
+			Q <= 1'b0;
+		else
+			Q <= D;
+	end
 endmodule // DFFC (positive clock edge; asynchronous clear)
 
 
 module myDFFCE (output reg Q, input D, CLK, CE, CLEAR);
-  parameter [0:0] INIT = 1'b0;
-  initial Q = INIT;
-  always @(posedge CLK or posedge CLEAR) begin
-    if(CLEAR)
-      Q <= 1'b0;
-    else if (CE)
-      Q <= D;
-  end
+	parameter [0:0] INIT = 1'b0;
+	initial Q = INIT;
+	always @(posedge CLK or posedge CLEAR) begin
+		if(CLEAR)
+			Q <= 1'b0;
+		else if (CE)
+			Q <= D;
+	end
 endmodule // DFFCE (positive clock edge; asynchronous clear; clock enable)
 
 
@@ -119,106 +119,106 @@ module myDFFN (output reg Q, input CLK, D);
 endmodule
 
 module myDFFNE (output reg Q, input D, CLK, CE);
-  parameter [0:0] INIT = 1'b0;
-  initial Q = INIT;
-  always @(negedge CLK) begin
-    if (CE)
-      Q <= D;
-  end
+	parameter [0:0] INIT = 1'b0;
+	initial Q = INIT;
+	always @(negedge CLK) begin
+		if (CE)
+			Q <= D;
+	end
 endmodule // DFFNE (negative clock edge; clock enable)
 
 
 module myDFFNS (output reg Q, input D, CLK, SET);
-  parameter [0:0] INIT = 1'b1;
-  initial Q = INIT;
-  always @(negedge CLK) begin
-    if (SET)
-      Q <= 1'b1;
-    else
-      Q <= D;
-  end
+	parameter [0:0] INIT = 1'b1;
+	initial Q = INIT;
+	always @(negedge CLK) begin
+		if (SET)
+			Q <= 1'b1;
+		else
+			Q <= D;
+	end
 endmodule // DFFNS (negative clock edge; synchronous set)
 
 
 module myDFFNSE (output reg Q, input D, CLK, CE, SET);
-  parameter [0:0] INIT = 1'b1;
-  initial Q = INIT;
-  always @(negedge CLK) begin
-    if (SET)
-      Q <= 1'b1;
-    else if (CE)
-      Q <= D;
+	parameter [0:0] INIT = 1'b1;
+	initial Q = INIT;
+	always @(negedge CLK) begin
+		if (SET)
+			Q <= 1'b1;
+		else if (CE)
+			Q <= D;
 end
 endmodule // DFFNSE (negative clock edge; synchronous set takes precedence over clock enable)
 
 
 module myDFFNR (output reg Q, input D, CLK, RESET);
-  parameter [0:0] INIT = 1'b0;
-  initial Q = INIT;
-  always @(negedge CLK) begin
-    if (RESET)
-      Q <= 1'b0;
-    else
-      Q <= D;
-  end
+	parameter [0:0] INIT = 1'b0;
+	initial Q = INIT;
+	always @(negedge CLK) begin
+		if (RESET)
+			Q <= 1'b0;
+		else
+			Q <= D;
+	end
 endmodule // DFFNR (negative clock edge; synchronous reset)
 
 
 module myDFFNRE (output reg Q, input D, CLK, CE, RESET);
-  parameter [0:0] INIT = 1'b0;
-  initial Q = INIT;
-  always @(negedge CLK) begin
-    if (RESET)
-      Q <= 1'b0;
-    else if (CE)
-      Q <= D;
-  end
+	parameter [0:0] INIT = 1'b0;
+	initial Q = INIT;
+	always @(negedge CLK) begin
+		if (RESET)
+			Q <= 1'b0;
+		else if (CE)
+			Q <= D;
+	end
 endmodule // DFFNRE (negative clock edge; synchronous reset takes precedence over clock enable)
 
 
 module myDFFNP (output reg Q, input D, CLK, PRESET);
-  parameter [0:0] INIT = 1'b1;
-  initial Q = INIT;
-  always @(negedge CLK or posedge PRESET) begin
-    if(PRESET)
-      Q <= 1'b1;
-    else
-      Q <= D;
-  end
+	parameter [0:0] INIT = 1'b1;
+	initial Q = INIT;
+	always @(negedge CLK or posedge PRESET) begin
+		if(PRESET)
+			Q <= 1'b1;
+		else
+			Q <= D;
+	end
 endmodule // DFFNP (negative clock edge; asynchronous preset)
 
 
 module myDFFNPE (output reg Q, input D, CLK, CE, PRESET);
-  parameter [0:0] INIT = 1'b1;
-  initial Q = INIT;
-  always @(negedge CLK or posedge PRESET) begin
-    if(PRESET)
-      Q <= 1'b1;
-    else if (CE)
-      Q <= D;
-  end
+	parameter [0:0] INIT = 1'b1;
+	initial Q = INIT;
+	always @(negedge CLK or posedge PRESET) begin
+		if(PRESET)
+			Q <= 1'b1;
+		else if (CE)
+			Q <= D;
+	end
 endmodule // DFFNPE (negative clock edge; asynchronous preset; clock enable)
 
 
 module myDFFNC (output reg Q, input D, CLK, CLEAR);
-  parameter [0:0] INIT = 1'b0;
-  initial Q = INIT;
-  always @(negedge CLK or posedge CLEAR) begin
-    if(CLEAR)
-      Q <= 1'b0;
-    else
-      Q <= D;
-  end
+	parameter [0:0] INIT = 1'b0;
+	initial Q = INIT;
+	always @(negedge CLK or posedge CLEAR) begin
+		if(CLEAR)
+			Q <= 1'b0;
+		else
+			Q <= D;
+	end
 endmodule // DFFNC (negative clock edge; asynchronous clear)
 
 
 module myDFFNCE (output reg Q, input D, CLK, CE, CLEAR);
-  parameter [0:0] INIT = 1'b0;
-  initial Q = INIT;
-  always @(negedge CLK or posedge CLEAR) begin
-    if(CLEAR)
-      Q <= 1'b0;
-    else if (CE)
-      Q <= D;
-  end
+	parameter [0:0] INIT = 1'b0;
+	initial Q = INIT;
+	always @(negedge CLK or posedge CLEAR) begin
+		if(CLEAR)
+			Q <= 1'b0;
+		else if (CE)
+			Q <= D;
+	end
 endmodule // DFFNCE (negative clock edge; asynchronous clear; clock enable)

--- a/tests/arch/gowin/init.ys
+++ b/tests/arch/gowin/init.ys
@@ -36,7 +36,8 @@ design -load read
 # these should synth to a flop with reset
 chparam -set INIT 1 myDFF myDFFN myDFFE myDFFNE
 
-# these should give a warning
+# async should give a warning
+# sync should synth to a mux
 chparam -set INIT 0 myDFF*S* myDFF*P*
 chparam -set INIT 1 myDFF*R* myDFF*C*
 
@@ -45,28 +46,29 @@ flatten
 synth_gowin -run coarse:
 
 # check the flops mapped as expected
-select -assert-count 0 t:DFF
+select -assert-count 1 t:DFF
 select -assert-count 1 t:DFFC
 select -assert-count 1 t:DFFCE
-select -assert-count 0 t:DFFE
-select -assert-count 0 t:DFFN
+select -assert-count 1 t:DFFE
+select -assert-count 1 t:DFFN
 select -assert-count 1 t:DFFNC
 select -assert-count 1 t:DFFNCE
-select -assert-count 0 t:DFFNE
+select -assert-count 1 t:DFFNE
 select -assert-count 1 t:DFFNP
 select -assert-count 1 t:DFFNPE
-select -assert-count 1 t:DFFNR
-select -assert-count 1 t:DFFNRE
+select -assert-count 0 t:DFFNR
+select -assert-count 0 t:DFFNRE
 select -assert-count 2 t:DFFNS
 select -assert-count 2 t:DFFNSE
 select -assert-count 1 t:DFFP
 select -assert-count 1 t:DFFPE
-select -assert-count 1 t:DFFR
-select -assert-count 1 t:DFFRE
+select -assert-count 0 t:DFFR
+select -assert-count 0 t:DFFRE
 select -assert-count 2 t:DFFS
 select -assert-count 2 t:DFFSE
+select -assert-count 12 t:LUT2
 
 # check the expected leftover init values
 # this would happen if your reset value is not the initial value
 # which would be weird
-select -assert-count 16 a:init
+select -assert-count 8 a:init

--- a/tests/arch/gowin/init.ys
+++ b/tests/arch/gowin/init.ys
@@ -1,0 +1,72 @@
+read_verilog init.v
+read_verilog -lib +/gowin/cells_sim.v
+design -save read
+
+proc
+flatten
+synth_gowin -run coarse:
+
+# check if all init values are handled
+check -assert -noinit
+# check if every flop mapped correctly
+select -assert-count 1 t:DFF
+select -assert-count 1 t:DFFC
+select -assert-count 1 t:DFFCE
+select -assert-count 1 t:DFFE
+select -assert-count 1 t:DFFN
+select -assert-count 1 t:DFFNC
+select -assert-count 1 t:DFFNCE
+select -assert-count 1 t:DFFNE
+select -assert-count 1 t:DFFNP
+select -assert-count 1 t:DFFNPE
+select -assert-count 1 t:DFFNR
+select -assert-count 1 t:DFFNRE
+select -assert-count 1 t:DFFNS
+select -assert-count 1 t:DFFNSE
+select -assert-count 1 t:DFFP
+select -assert-count 1 t:DFFPE
+select -assert-count 1 t:DFFR
+select -assert-count 1 t:DFFRE
+select -assert-count 1 t:DFFS
+select -assert-count 1 t:DFFSE
+
+delete
+design -load read
+
+# these should synth to a flop with reset
+chparam -set INIT 1 myDFF myDFFN myDFFE myDFFNE
+
+# these should give a warning
+chparam -set INIT 0 myDFF*S* myDFF*P*
+chparam -set INIT 1 myDFF*R* myDFF*C*
+
+proc
+flatten
+synth_gowin -run coarse:
+
+# check the flops mapped as expected
+select -assert-count 0 t:DFF
+select -assert-count 1 t:DFFC
+select -assert-count 1 t:DFFCE
+select -assert-count 0 t:DFFE
+select -assert-count 0 t:DFFN
+select -assert-count 1 t:DFFNC
+select -assert-count 1 t:DFFNCE
+select -assert-count 0 t:DFFNE
+select -assert-count 1 t:DFFNP
+select -assert-count 1 t:DFFNPE
+select -assert-count 1 t:DFFNR
+select -assert-count 1 t:DFFNRE
+select -assert-count 2 t:DFFNS
+select -assert-count 2 t:DFFNSE
+select -assert-count 1 t:DFFP
+select -assert-count 1 t:DFFPE
+select -assert-count 1 t:DFFR
+select -assert-count 1 t:DFFRE
+select -assert-count 2 t:DFFS
+select -assert-count 2 t:DFFSE
+
+# check the expected leftover init values
+# this would happen if your reset value is not the initial value
+# which would be weird
+select -assert-count 16 a:init


### PR DESCRIPTION
In the previous Gowin patch, it was found that DFF init behavior was not supported in hardware and removed. Upon closer inspection it was found that in fact the hardware initializes to the reset value. In the vendor tools, the following code
```verilog
module myDFF (output reg Q = 1, input CLK, D);
	always @(posedge CLK)
		Q <= D;
endmodule
```
Synthesizes to the following DFFS with the reset tied to ground.
```verilog
DFFS Q_0 (
	.Q(Q_c),
	.D(D_c),
	.CLK(CLK_c),
	.SET(GND)
);
```
This pull request adds the same behavior to all Gowin flip-flops that don't use a reset.
In case a reset is used, the wire init parameter is only removed if it is compatible with the reset value.

This PR also adds tests for all DFF types and their init values, and fixed a few typos in previously untested DFF types.

Finally, it fixes a small discrepancy in the help. A `-noiopads` option was mentioned, but not actually implemented. Now it is.

One thing I don't like about this PR is that the test code is basically a copy of `cell_sim.v` with different names. Directly using the cell library resulted in weird issues.