### PR TITLE
Redirect fuser stderr to /dev/null

### DIFF
--- a/passes/cmds/show.cc
+++ b/passes/cmds/show.cc
@@ -873,7 +873,7 @@ struct ShowPass : public Pass {
 			#ifdef __APPLE__
 			std::string cmd = stringf("ps -fu %d | grep -q '[ ]%s' || xdot '%s' &", getuid(), dot_file.c_str(), dot_file.c_str());
 			#else
-			std::string cmd = stringf("{ test -f '%s.pid' && fuser -s '%s.pid'; } || ( echo $$ >&3; exec xdot '%s'; ) 3> '%s.pid' &", dot_file.c_str(), dot_file.c_str(), dot_file.c_str(), dot_file.c_str());
+			std::string cmd = stringf("{ test -f '%s.pid' && fuser -s '%s.pid' 2> /dev/null; } || ( echo $$ >&3; exec xdot '%s'; ) 3> '%s.pid' &", dot_file.c_str(), dot_file.c_str(), dot_file.c_str(), dot_file.c_str());
 			#endif
 			log("Exec: %s\n", cmd.c_str());
 			if (run_command(cmd) != 0)


### PR DESCRIPTION
On Arch linux `fuser` seems to try to read  file descriptors of other users, giving permission errors:

```
$ fuser -s *
Cannot stat file /proc/951/fd/0: Permission denied
Cannot stat file /proc/951/fd/1: Permission denied
Cannot stat file /proc/951/fd/2: Permission denied
Cannot stat file /proc/951/fd/3: Permission denied
Cannot stat file /proc/951/fd/4: Permission denied
Cannot stat file /proc/951/fd/5: Permission denied
Cannot stat file /proc/951/fd/6: Permission denied
Cannot stat file /proc/951/fd/7: Permission denied
Cannot stat file /proc/951/fd/8: Permission denied
Cannot stat file /proc/951/fd/9: Permission denied
Cannot stat file /proc/951/fd/10: Permission denied
Cannot stat file /proc/951/fd/11: Permission denied
Cannot stat file /proc/951/fd/12: Permission denied
Cannot stat file /proc/951/fd/13: Permission denied
Cannot stat file /proc/951/fd/14: Permission denied
Cannot stat file /proc/951/fd/15: Permission denied
Cannot stat file /proc/951/fd/16: Permission denied
Cannot stat file /proc/951/fd/17: Permission denied
Cannot stat file /proc/951/fd/18: Permission denied
Cannot stat file /proc/951/fd/19: Permission denied
Cannot stat file /proc/951/fd/20: Permission denied
Cannot stat file /proc/951/fd/21: Permission denied
Cannot stat file /proc/951/fd/22: Permission denied
Cannot stat file /proc/951/fd/23: Permission denied
Cannot stat file /proc/951/fd/24: Permission denied
Cannot stat file /proc/951/fd/25: Permission denied
Cannot stat file /proc/951/fd/26: Permission denied
Cannot stat file /proc/951/fd/27: Permission denied
Cannot stat file /proc/951/fd/28: Permission denied
Cannot stat file /proc/951/fd/29: Permission denied
Cannot stat file /proc/951/fd/30: Permission denied
Cannot stat file /proc/951/fd/31: Permission denied
Cannot stat file /proc/951/fd/32: Permission denied
Cannot stat file /proc/951/fd/33: Permission denied
Cannot stat file /proc/951/fd/34: Permission denied
Cannot stat file /proc/951/fd/35: Permission denied
Cannot stat file /proc/951/fd/36: Permission denied
Cannot stat file /proc/951/fd/37: Permission denied
Cannot stat file /proc/951/fd/38: Permission denied
Cannot stat file /proc/951/fd/39: Permission denied
Cannot stat file /proc/951/fd/41: Permission denied
Cannot stat file /proc/951/fd/42: Permission denied
Cannot stat file /proc/951/fd/43: Permission denied
Cannot stat file /proc/951/fd/44: Permission denied
Cannot stat file /proc/951/fd/45: Permission denied
Cannot stat file /proc/951/fd/46: Permission denied
Cannot stat file /proc/951/fd/47: Permission denied
Cannot stat file /proc/951/fd/48: Permission denied
Cannot stat file /proc/951/fd/51: Permission denied
Cannot stat file /proc/951/fd/68: Permission denied
```

This PR simply silences this output. If there is a better way to do this, I'd be happy to hear it.