### PR TITLE
write_xaiger improvements

### DIFF
--- a/backends/aiger/xaiger.cc
+++ b/backends/aiger/xaiger.cc
@@ -174,6 +174,7 @@ struct XAigerWriter
 					if (bit != wirebit)
 						alias_map[bit] = wirebit;
 					input_bits.insert(wirebit);
+					undriven_bits.erase(bit);
 				}
 
 				if (wire->port_output || keep) {
@@ -181,18 +182,14 @@ struct XAigerWriter
 						if (bit != wirebit)
 							alias_map[wirebit] = bit;
 						output_bits.insert(wirebit);
+						if (!wire->port_input)
+							unused_bits.erase(bit);
 					}
 					else
 						log_debug("Skipping PO '%s' driven by 1'bx\n", log_signal(wirebit));
 				}
 			}
 		}
-
-		for (auto bit : input_bits)
-			undriven_bits.erase(sigmap(bit));
-		for (auto bit : output_bits)
-			if (!bit.wire->port_input)
-				unused_bits.erase(bit);
 
 		// TODO: Speed up toposort -- ultimately we care about
 		//       box ordering, but not individual AIG cells

--- a/backends/aiger/xaiger.cc
+++ b/backends/aiger/xaiger.cc
@@ -816,7 +816,7 @@ struct XAigerBackend : public Backend {
 		log("        write ASCII version of AIGER format\n");
 		log("\n");
 		log("    -map <filename>\n");
-		log("        write an extra file with port and latch symbols\n");
+		log("        write an extra file with port and box symbols\n");
 		log("\n");
 		log("    -vmap <filename>\n");
 		log("        like -map, but more verbose\n");

--- a/backends/aiger/xaiger.cc
+++ b/backends/aiger/xaiger.cc
@@ -153,11 +153,6 @@ struct XAigerWriter
 			if (wire->port_input)
 				sigmap.add(wire);
 
-		// promote output wires
-		for (auto wire : module->wires())
-			if (wire->port_output)
-				sigmap.add(wire);
-
 		for (auto wire : module->wires())
 		{
 			bool keep = wire->attributes.count("\\keep");

--- a/backends/aiger/xaiger.cc
+++ b/backends/aiger/xaiger.cc
@@ -168,7 +168,7 @@ struct XAigerWriter
 				}
 
 				if (keep)
-					keep_bits.insert(bit);
+					keep_bits.insert(wirebit);
 
 				if (wire->port_input || keep) {
 					if (bit != wirebit)

--- a/tests/simple_abc9/abc9.v
+++ b/tests/simple_abc9/abc9.v
@@ -218,12 +218,6 @@ module MUXF8(input I0, I1, S, output O);
 endmodule
 
 // Citation: https://github.com/alexforencich/verilog-ethernet
-// TODO: yosys -p "synth_xilinx -abc9 -top abc9_test022" abc9.v -q
-// returns before b4321a31
-//   Warning: Wire abc9_test022.\m_eth_payload_axis_tkeep [7] is used but has no
-//   driver.
-//   Warning: Wire abc9_test022.\m_eth_payload_axis_tkeep [3] is used but has no
-//   driver.
 module abc9_test022
 (
     input  wire        clk,
@@ -237,9 +231,6 @@ module abc9_test022
 endmodule
 
 // Citation: https://github.com/riscv/riscv-bitmanip
-// TODO: yosys -p "synth_xilinx -abc9 -top abc9_test023" abc9.v -q
-// returns before 14233843
-//   Warning: Wire abc9_test023.\dout [1] is used but has no driver.
 module abc9_test023 #(
 	parameter integer N = 2,
 	parameter integer M = 2


### PR DESCRIPTION
* Do not promote output wires, as it is necessary to see when they are driven by inputs
* Do not sigmap `(* keep *)` bits