### PR TITLE
ecp5: Make -abc9 the default

### DIFF
--- a/tests/arch/ecp5/add_sub.ys
+++ b/tests/arch/ecp5/add_sub.ys
@@ -4,6 +4,8 @@ proc
 equiv_opt -assert -map +/ecp5/cells_sim.v synth_ecp5 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
-select -assert-count 10 t:LUT4
-select -assert-none t:LUT4 %% t:* %D
+select -assert-count 11 t:LUT4
+select -assert-count 2 t:PFUMX
+
+select -assert-none t:LUT4 t:PFUMX %% t:* %D
 

--- a/tests/arch/ecp5/counter.ys
+++ b/tests/arch/ecp5/counter.ys
@@ -5,6 +5,7 @@ flatten
 equiv_opt -map +/ecp5/cells_sim.v synth_ecp5 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
+select -assert-count 1 t:LUT4
 select -assert-count 4 t:CCU2C
 select -assert-count 8 t:TRELLIS_FF
-select -assert-none t:CCU2C t:TRELLIS_FF %% t:* %D
+select -assert-none t:LUT4 t:CCU2C t:TRELLIS_FF %% t:* %D

--- a/tests/arch/ecp5/memory.ys
+++ b/tests/arch/ecp5/memory.ys
@@ -11,9 +11,9 @@ sat -verify -prove-asserts -seq 5 -set-init-zero -show-inputs -show-outputs mite
 
 design -load postopt
 cd top
-select -assert-count 24 t:L6MUX21
-select -assert-count 71 t:LUT4
-select -assert-count 32 t:PFUMX
+select -assert-count 8 t:L6MUX21
+select -assert-count 47 t:LUT4
+select -assert-count 16 t:PFUMX
 select -assert-count 8 t:TRELLIS_DPR16X4
 select -assert-count 35 t:TRELLIS_FF
 select -assert-none t:L6MUX21 t:LUT4 t:PFUMX t:TRELLIS_DPR16X4 t:TRELLIS_FF %% t:* %D

--- a/tests/arch/ecp5/mux.ys
+++ b/tests/arch/ecp5/mux.ys
@@ -27,11 +27,10 @@ proc
 equiv_opt -assert -map +/ecp5/cells_sim.v synth_ecp5 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux8 # Constrain all select calls below inside the top module
-select -assert-count 1 t:L6MUX21
-select -assert-count 7 t:LUT4
-select -assert-count 2 t:PFUMX
+select -assert-count 6 t:LUT4
+select -assert-count 1 t:PFUMX
 
-select -assert-none t:LUT4 t:L6MUX21 t:PFUMX %% t:* %D
+select -assert-none t:LUT4 t:PFUMX %% t:* %D
 
 design -load read
 hierarchy -top mux16
@@ -39,8 +38,8 @@ proc
 equiv_opt -assert -map +/ecp5/cells_sim.v synth_ecp5 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux16 # Constrain all select calls below inside the top module
-select -assert-count 8 t:L6MUX21
-select -assert-count 26 t:LUT4
-select -assert-count 12 t:PFUMX
+select -assert-count 2 t:L6MUX21
+select -assert-count 18 t:LUT4
+select -assert-count 5 t:PFUMX
 
 select -assert-none t:LUT4 t:L6MUX21 t:PFUMX %% t:* %D


### PR DESCRIPTION
abc9 gives substantially better area on almost any non-trivial design by virtue of using wide LUTs in a vaguely sensible way. Several third party frameworks like LiteX have been using it as default for a while, so it seems time for it to be the default for everyone - and give them a better impression of the capabilities of the open source tools!

Fixes #1323