### PR TITLE
tests: arch: xilinx: Change order of arguments in macc.sh

### DIFF
--- a/tests/arch/xilinx/macc.sh
+++ b/tests/arch/xilinx/macc.sh
@@ -1,3 +1,3 @@
-../../../yosys -qp "synth_xilinx -top macc2; rename -top macc2_uut" macc.v -o macc_uut.v
+../../../yosys -qp "synth_xilinx -top macc2; rename -top macc2_uut" -o macc_uut.v macc.v
 iverilog -o test_macc macc_tb.v macc_uut.v macc.v ../../../techlibs/xilinx/cells_sim.v
 vvp -N ./test_macc


### PR DESCRIPTION
Environment:
- macOS Sierra (10.12.6)
- clang (8.1.0)
- iverilog (7f95abc)

Running **macc.sh** script in **tests/arch/xilinx**  results in following error:
```
Running macc.sh..
ERROR: Can't guess frontend for input file `-o' (missing -f option)!
macc_uut.v: No such file or directory
macc_tb.v:77: error: Unknown module type: macc2
macc_tb.v:87: error: Unknown module type: macc2_uut
3 error(s) during elaboration.
*** These modules were missing:
        macc2 referenced 1 times.
        macc2_uut referenced 1 times.
***
./test_macc: Unable to open input file.
make[1]: *** [run-macc.sh] Error 255
make: *** [test] Error 2
```
Changing the argument order in **macc.sh** fixed the issue.