### PR TITLE
Fix for non-deterministic test

### DIFF
--- a/tests/arch/efinix/mux.ys
+++ b/tests/arch/efinix/mux.ys
@@ -36,6 +36,6 @@ proc
 equiv_opt -assert -map +/efinix/cells_sim.v synth_efinix # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux16 # Constrain all select calls below inside the top module
-select -assert-min 11 t:EFX_LUT4
+select -assert-max 12 t:EFX_LUT4
 
 select -assert-none t:EFX_LUT4 %% t:* %D

--- a/tests/arch/efinix/mux.ys
+++ b/tests/arch/efinix/mux.ys
@@ -36,6 +36,6 @@ proc
 equiv_opt -assert -map +/efinix/cells_sim.v synth_efinix # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux16 # Constrain all select calls below inside the top module
-select -assert-count 12 t:EFX_LUT4
+select -assert-min 11 t:EFX_LUT4
 
 select -assert-none t:EFX_LUT4 %% t:* %D


### PR DESCRIPTION
There seams to be non-deterministic behavior. Output blif that yosys generates contains always same number of elements:

Extracted 49 gates and 69 wires to a netlist network with 20 inputs and 1 outputs.

But order of those is not deterministic, so abc produce different number of $lut  cells, when we just run mux16 then it is 11, when we run others before we have 12.
Strange is that with clang and gcc on Linux and msvc on Windows we have same problem (12 luts), but on clang 10 on macOS (11 luts) it works fine even others are executed before.

This is fix for #1556

We also have same issue appearing on xilinx pull request for same mux test.