### PR TITLE
sat: suppress 'Warning: ignoring initial value on non-register: ...' when init[i] = 1'bx

### DIFF
--- a/passes/sat/sat.cc
+++ b/passes/sat/sat.cc
@@ -269,7 +269,8 @@ struct SatHelper
 				for (int i = 0; i < lhs.size(); i++) {
 					RTLIL::SigSpec bit = lhs.extract(i, 1);
 					if (rhs[i] == State::Sx || !satgen.initial_state.check_all(bit)) {
-						removed_bits.append(bit);
+						if (rhs[i] != State::Sx)
+							removed_bits.append(bit);
 						lhs.remove(i, 1);
 						rhs.remove(i, 1);
 						i--;

--- a/tests/sat/initval.ys
+++ b/tests/sat/initval.ys
@@ -5,12 +5,11 @@ sat -seq 10 -prove-asserts
 
 design -reset
 read_verilog -icells <<EOT
-module top(input clk, i, output o, p);
-(* init = 1'b0 *)
-wire o;
-(* init = 1'bx *)
-wire p = o;
-$_DFF_P_ dff (.C(clk), .D(i), .Q(o));
+module top(input clk, i, output [1:0] o);
+(* init = 2'bx0 *)
+wire [1:0] o;
+assign o[1] = o[0];
+$_DFF_P_ dff (.C(clk), .D(i), .Q(o[0]));
 endmodule
 EOT
 sat -seq 1

--- a/tests/sat/initval.ys
+++ b/tests/sat/initval.ys
@@ -6,6 +6,8 @@ sat -seq 10 -prove-asserts
 design -reset
 read_verilog -icells <<EOT
 module top(input clk, i, output o, p);
+(* init = 1'b0 *)
+wire o;
 (* init = 1'bx *)
 wire p = o;
 $_DFF_P_ dff (.C(clk), .D(i), .Q(o));

--- a/tests/sat/initval.ys
+++ b/tests/sat/initval.ys
@@ -2,3 +2,13 @@ read_verilog -sv initval.v
 proc;;
 
 sat -seq 10 -prove-asserts
+
+design -reset
+read_verilog -icells <<EOT
+module top(input clk, i, output o, p);
+(* init = 1'bx *)
+wire p = o;
+$_DFF_P_ dff (.C(clk), .D(i), .Q(o));
+endmodule
+EOT
+sat -seq 1


### PR DESCRIPTION
The attached testcase is synthetic (should never have an `init` on a wire) but can occur when other passes (e.g. #1566) set certain bit(s) to be so (which may not be a whole wire).