### PR TITLE
zinit: fixes for $_DFF_[NP][NP][01]_and $adff cells with init = 1'b1

### DIFF
--- a/passes/techmap/zinit.cc
+++ b/passes/techmap/zinit.cc
@@ -143,7 +143,7 @@ struct ZinitPass : public Pass {
 				/*if (cell->type.in(ID($_DFFSR_NNN_), ID($_DFFSR_NNP_), ID($_DFFSR_NPN_), ID($_DFFSR_NPP_),
 							ID($_DFFSR_PNN_), ID($_DFFSR_PNP_), ID($_DFFSR_PPN_), ID($_DFFSR_PPP_)))
 				{
-					// TODO: I think I need a $_DFFRS_* cell where R has priority over S...
+					// TODO: I think I need a $_DFFRS_* cell where S has priority over R...
 					std::swap(cell->connections_.at(ID(R)), cell->connections_.at(ID(S)));
 				}
 				else*/ if (cell->type.in(ID($_DFF_NN0_), ID($_DFF_NN1_), ID($_DFF_NP0_), ID($_DFF_NP1_),

--- a/passes/techmap/zinit.cc
+++ b/passes/techmap/zinit.cc
@@ -141,9 +141,10 @@ struct ZinitPass : public Pass {
 				cell->setPort(ID::Q, initwire);
 			}
 
-			for (auto &it : initbits)
-				if (donebits.count(it.first) == 0)
-					log_error("Failed to handle init bit %s = %s.\n", log_signal(it.first), log_signal(it.second));
+			if (!design->selected_whole_module(module))
+				for (auto &it : initbits)
+					if (donebits.count(it.first) == 0)
+						log_error("Failed to handle init bit %s = %s.\n", log_signal(it.first), log_signal(it.second));
 		}
 	}
 } ZinitPass;

--- a/passes/techmap/zinit.cc
+++ b/passes/techmap/zinit.cc
@@ -153,9 +153,11 @@ struct ZinitPass : public Pass {
 				else if (cell->type.in(ID($_DFF_NN0_), ID($_DFF_NN1_), ID($_DFF_NP0_), ID($_DFF_NP1_),
 							ID($_DFF_PN0_), ID($_DFF_PN1_), ID($_DFF_PP0_), ID($_DFF_PP1_)))
 				{
-					std::string t = cell->type.str();
-					t[8] = (t[8] == '0' ? '1' : '0');
-					cell->type = t;
+					if (initval == State::S1) {
+						std::string t = cell->type.str();
+						t[8] = (t[8] == '0' ? '1' : '0');
+						cell->type = t;
+					}
 				}
 			}
 		}

--- a/passes/techmap/zinit.cc
+++ b/passes/techmap/zinit.cc
@@ -139,6 +139,20 @@ struct ZinitPass : public Pass {
 
 				cell->setPort(ID::D, sig_d);
 				cell->setPort(ID::Q, initwire);
+
+				/*if (cell->type.in(ID($_DFFSR_NNN_), ID($_DFFSR_NNP_), ID($_DFFSR_NPN_), ID($_DFFSR_NPP_),
+							ID($_DFFSR_PNN_), ID($_DFFSR_PNP_), ID($_DFFSR_PPN_), ID($_DFFSR_PPP_)))
+				{
+					// TODO: I think I need a $_DFFRS_* cell where R has priority over S...
+					std::swap(cell->connections_.at(ID(R)), cell->connections_.at(ID(S)));
+				}
+				else*/ if (cell->type.in(ID($_DFF_NN0_), ID($_DFF_NN1_), ID($_DFF_NP0_), ID($_DFF_NP1_),
+							ID($_DFF_PN0_), ID($_DFF_PN1_), ID($_DFF_PP0_), ID($_DFF_PP1_)))
+				{
+					std::string t = cell->type.str();
+					t[8] = (t[8] == '0' ? '1' : '0');
+					cell->type = t;
+				}
 			}
 
 			if (!design->selected_whole_module(module))

--- a/tests/techmap/zinit.ys
+++ b/tests/techmap/zinit.ys
@@ -23,6 +23,8 @@ design -load postopt
 select -assert-count 20 t:$_NOT_
 select -assert-count 1 w:unused a:init %i
 select -assert-count 1 w:Q a:init=13'bxxxx1xxxxxxxx %i
+select -assert-count 4 c:dff0 c:dff2 c:dff4 c:dff6 %% t:$_DFF_??1_ %i
+select -assert-count 4 c:dff1 c:dff3 c:dff5 c:dff7 %% t:$_DFF_??0_ %i
 
 
 design -reset
@@ -45,6 +47,11 @@ $adff #(.WIDTH(2), .CLK_POLARITY(1), .ARST_POLARITY(1'b0), .ARST_VALUE(2'b10)) d
 $adff #(.WIDTH(2), .CLK_POLARITY(0), .ARST_POLARITY(1'b1), .ARST_VALUE(2'b01)) dff9 (.CLK(C), .ARST(R), .D(D), .Q(Q[12:11]));
 endmodule
 EOT
+equiv_opt -assert -map +/simcells.v -multiclock zinit
+design -load postopt
+
 select -assert-count 0 t:$_NOT_
 select -assert-count 1 w:unused a:init %i
-select -assert-count 1 w:Q a:init=13'bx00x100000000 %i
+select -assert-count 1 w:Q a:init=13'bxxxx1xxxxxxxx %i
+select -assert-count 4 c:dff0 c:dff2 c:dff4 c:dff6 %% t:$_DFF_??0_ %i
+select -assert-count 4 c:dff1 c:dff3 c:dff5 c:dff7 %% t:$_DFF_??1_ %i

--- a/tests/techmap/zinit.ys
+++ b/tests/techmap/zinit.ys
@@ -1,5 +1,5 @@
 read_verilog -icells <<EOT
-module top(input C, R, input [1:0] D, (* init = {12{1'b1}} *) output [11:0] Q);
+module top(input C, R, input [1:0] D, (* init = {2'b10, 2'b01, 1'b1, {8{1'b1}}} *) output [12:0] Q);
 
 (* init = 1'b1 *)
 wire unused;
@@ -13,11 +13,38 @@ $_DFF_PN1_ dff5 (.C(C), .D(D[0]), .R(R), .Q(Q[5]));
 $_DFF_PP0_ dff6 (.C(C), .D(D[0]), .R(R), .Q(Q[6]));
 $_DFF_PP1_ dff7 (.C(C), .D(D[0]), .R(R), .Q(Q[7]));
 
-$adff #(.WIDTH(2), .CLK_POLARITY(1), .ARST_POLARITY(1'b0), .ARST_VALUE(2'd2)) dff8 (.CLK(C), .ARST(R), .D(D), .Q(Q[9:8]));
-$adff #(.WIDTH(2), .CLK_POLARITY(0), .ARST_POLARITY(1'b1), .ARST_VALUE(2'd1)) dff9 (.CLK(C), .ARST(R), .D(D), .Q(Q[11:10]));
+$adff #(.WIDTH(2), .CLK_POLARITY(1), .ARST_POLARITY(1'b0), .ARST_VALUE(2'b10)) dff8 (.CLK(C), .ARST(R), .D(D), .Q(Q[10:9]));
+$adff #(.WIDTH(2), .CLK_POLARITY(0), .ARST_POLARITY(1'b1), .ARST_VALUE(2'b01)) dff9 (.CLK(C), .ARST(R), .D(D), .Q(Q[12:11]));
 endmodule
 EOT
-equiv_opt -map +/simcells.v -multiclock zinit
+equiv_opt -assert -map +/simcells.v -multiclock zinit
 design -load postopt
 
+select -assert-count 20 t:$_NOT_
 select -assert-count 1 w:unused a:init %i
+select -assert-count 1 w:Q a:init=13'bxxxx1xxxxxxxx %i
+
+
+design -reset
+read_verilog -icells <<EOT
+module top(input C, R, input [1:0] D, (* init = {2'bx0, 2'b0x, 1'b1, {8{1'b0}}} *) output [12:0] Q);
+
+(* init = 1'b1 *)
+wire unused;
+
+$_DFF_NN0_ dff0 (.C(C), .D(D[0]), .R(R), .Q(Q[0]));
+$_DFF_NN1_ dff1 (.C(C), .D(D[0]), .R(R), .Q(Q[1]));
+$_DFF_NP0_ dff2 (.C(C), .D(D[0]), .R(R), .Q(Q[2]));
+$_DFF_NP1_ dff3 (.C(C), .D(D[0]), .R(R), .Q(Q[3]));
+$_DFF_PN0_ dff4 (.C(C), .D(D[0]), .R(R), .Q(Q[4]));
+$_DFF_PN1_ dff5 (.C(C), .D(D[0]), .R(R), .Q(Q[5]));
+$_DFF_PP0_ dff6 (.C(C), .D(D[0]), .R(R), .Q(Q[6]));
+$_DFF_PP1_ dff7 (.C(C), .D(D[0]), .R(R), .Q(Q[7]));
+
+$adff #(.WIDTH(2), .CLK_POLARITY(1), .ARST_POLARITY(1'b0), .ARST_VALUE(2'b10)) dff8 (.CLK(C), .ARST(R), .D(D), .Q(Q[10:9]));
+$adff #(.WIDTH(2), .CLK_POLARITY(0), .ARST_POLARITY(1'b1), .ARST_VALUE(2'b01)) dff9 (.CLK(C), .ARST(R), .D(D), .Q(Q[12:11]));
+endmodule
+EOT
+select -assert-count 0 t:$_NOT_
+select -assert-count 1 w:unused a:init %i
+select -assert-count 1 w:Q a:init=13'bx00x100000000 %i

--- a/tests/techmap/zinit.ys
+++ b/tests/techmap/zinit.ys
@@ -1,0 +1,24 @@
+read_verilog -icells <<EOT
+module top(input C, D, S, R, output [16:0] Q);
+(* init = {17{1'b1}} *)
+wire [16:0] Q;
+$_DFF_NN0_ dff0 (.C(C), .D(D), .R(R), .Q(Q[0]));
+$_DFF_NN1_ dff1 (.C(C), .D(D), .R(R), .Q(Q[1]));
+$_DFF_NP0_ dff2 (.C(C), .D(D), .R(R), .Q(Q[2]));
+$_DFF_NP1_ dff3 (.C(C), .D(D), .R(R), .Q(Q[3]));
+$_DFF_PN0_ dff4 (.C(C), .D(D), .R(R), .Q(Q[4]));
+$_DFF_PN1_ dff5 (.C(C), .D(D), .R(R), .Q(Q[5]));
+$_DFF_PP0_ dff6 (.C(C), .D(D), .R(R), .Q(Q[6]));
+$_DFF_PP1_ dff7 (.C(C), .D(D), .R(R), .Q(Q[7]));
+
+//$_DFFSR_NNN_ dffsr0 (.C(C), .D(D), .S(S), .R(R), .Q(Q[8]));
+//$_DFFSR_NNP_ dffsr1 (.C(C), .D(D), .S(S), .R(R), .Q(Q[9]));
+//$_DFFSR_NPN_ dffsr2 (.C(C), .D(D), .S(S), .R(R), .Q(Q[10]));
+//$_DFFSR_NPP_ dffsr3 (.C(C), .D(D), .S(S), .R(R), .Q(Q[11]));
+//$_DFFSR_PNN_ dffsr4 (.C(C), .D(D), .S(S), .R(R), .Q(Q[12]));
+//$_DFFSR_PNP_ dffsr5 (.C(C), .D(D), .S(S), .R(R), .Q(Q[13]));
+//$_DFFSR_PPN_ dffsr6 (.C(C), .D(D), .S(S), .R(R), .Q(Q[14]));
+//$_DFFSR_PPP_ dffsr7 (.C(C), .D(D), .S(S), .R(R), .Q(Q[15]));
+endmodule
+EOT
+equiv_opt -map +/simcells.v -multiclock zinit

--- a/tests/techmap/zinit.ys
+++ b/tests/techmap/zinit.ys
@@ -1,24 +1,23 @@
 read_verilog -icells <<EOT
-module top(input C, D, S, R, output [16:0] Q);
-(* init = {17{1'b1}} *)
-wire [16:0] Q;
-$_DFF_NN0_ dff0 (.C(C), .D(D), .R(R), .Q(Q[0]));
-$_DFF_NN1_ dff1 (.C(C), .D(D), .R(R), .Q(Q[1]));
-$_DFF_NP0_ dff2 (.C(C), .D(D), .R(R), .Q(Q[2]));
-$_DFF_NP1_ dff3 (.C(C), .D(D), .R(R), .Q(Q[3]));
-$_DFF_PN0_ dff4 (.C(C), .D(D), .R(R), .Q(Q[4]));
-$_DFF_PN1_ dff5 (.C(C), .D(D), .R(R), .Q(Q[5]));
-$_DFF_PP0_ dff6 (.C(C), .D(D), .R(R), .Q(Q[6]));
-$_DFF_PP1_ dff7 (.C(C), .D(D), .R(R), .Q(Q[7]));
+module top(input C, R, input [1:0] D, (* init = {12{1'b1}} *) output [11:0] Q);
 
-//$_DFFSR_NNN_ dffsr0 (.C(C), .D(D), .S(S), .R(R), .Q(Q[8]));
-//$_DFFSR_NNP_ dffsr1 (.C(C), .D(D), .S(S), .R(R), .Q(Q[9]));
-//$_DFFSR_NPN_ dffsr2 (.C(C), .D(D), .S(S), .R(R), .Q(Q[10]));
-//$_DFFSR_NPP_ dffsr3 (.C(C), .D(D), .S(S), .R(R), .Q(Q[11]));
-//$_DFFSR_PNN_ dffsr4 (.C(C), .D(D), .S(S), .R(R), .Q(Q[12]));
-//$_DFFSR_PNP_ dffsr5 (.C(C), .D(D), .S(S), .R(R), .Q(Q[13]));
-//$_DFFSR_PPN_ dffsr6 (.C(C), .D(D), .S(S), .R(R), .Q(Q[14]));
-//$_DFFSR_PPP_ dffsr7 (.C(C), .D(D), .S(S), .R(R), .Q(Q[15]));
+(* init = 1'b1 *)
+wire unused;
+
+$_DFF_NN0_ dff0 (.C(C), .D(D[0]), .R(R), .Q(Q[0]));
+$_DFF_NN1_ dff1 (.C(C), .D(D[0]), .R(R), .Q(Q[1]));
+$_DFF_NP0_ dff2 (.C(C), .D(D[0]), .R(R), .Q(Q[2]));
+$_DFF_NP1_ dff3 (.C(C), .D(D[0]), .R(R), .Q(Q[3]));
+$_DFF_PN0_ dff4 (.C(C), .D(D[0]), .R(R), .Q(Q[4]));
+$_DFF_PN1_ dff5 (.C(C), .D(D[0]), .R(R), .Q(Q[5]));
+$_DFF_PP0_ dff6 (.C(C), .D(D[0]), .R(R), .Q(Q[6]));
+$_DFF_PP1_ dff7 (.C(C), .D(D[0]), .R(R), .Q(Q[7]));
+
+$adff #(.WIDTH(2), .CLK_POLARITY(1), .ARST_POLARITY(1'b0), .ARST_VALUE(2'd2)) dff8 (.CLK(C), .ARST(R), .D(D), .Q(Q[9:8]));
+$adff #(.WIDTH(2), .CLK_POLARITY(0), .ARST_POLARITY(1'b1), .ARST_VALUE(2'd1)) dff9 (.CLK(C), .ARST(R), .D(D), .Q(Q[11:10]));
 endmodule
 EOT
 equiv_opt -map +/simcells.v -multiclock zinit
+design -load postopt
+
+select -assert-count 1 w:unused a:init %i


### PR DESCRIPTION
* Fixes `zinit` to handle coarse and fine-grained async flops
* Disables support for `$dffsr` and `$_DFFSR_[NP][NP][NP]_`
* `(* init *)` attributes only erased when consumed by `zinit`