### PR TITLE
verilog: preserve size of $genval$-s in for loops

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1204,7 +1204,6 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 			varbuf->range_right = resolved->range_right;
 			varbuf->range_swapped = resolved->range_swapped;
 			varbuf->range_valid = resolved->range_valid;
-			log_dump(varbuf->range_left, varbuf->range_right);
 		}
 
 		AstNode *backup_scope_varbuf = current_scope[varbuf->str];

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1198,6 +1198,15 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 		varbuf = new AstNode(AST_LOCALPARAM, varbuf);
 		varbuf->str = init_ast->children[0]->str;
 
+		auto resolved = current_scope.at(init_ast->children[0]->str);
+		if (resolved->range_valid) {
+			varbuf->range_left = resolved->range_left;
+			varbuf->range_right = resolved->range_right;
+			varbuf->range_swapped = resolved->range_swapped;
+			varbuf->range_valid = resolved->range_valid;
+			log_dump(varbuf->range_left, varbuf->range_right);
+		}
+
 		AstNode *backup_scope_varbuf = current_scope[varbuf->str];
 		current_scope[varbuf->str] = varbuf;
 
@@ -2998,6 +3007,14 @@ void AstNode::expand_genblock(std::string index_var, std::string prefix, std::ma
 			current_ast_mod->children.push_back(p);
 			str = p->str;
 			id2ast = p;
+
+			auto resolved = current_scope.at(index_var);
+			if (resolved->range_valid) {
+				p->range_left = resolved->range_left;
+				p->range_right = resolved->range_right;
+				p->range_swapped = resolved->range_swapped;
+				p->range_valid = resolved->range_valid;
+			}
 		}
 	}
 

--- a/tests/various/bug1531.ys
+++ b/tests/various/bug1531.ys
@@ -1,0 +1,34 @@
+read_verilog <<EOT
+module top (y, clk, w);
+   output reg y = 1'b0;
+   input clk, w;
+   reg [1:0] i = 2'b00;
+   always @(posedge clk)
+     // If the constant below is set to 2'b00, the correct output is generated.
+     //       vvvv
+     for (i = 1'b0; i < 2'b01; i = i + 2'b01) 
+       y <= w || i[1:1];
+endmodule
+EOT
+
+synth
+design -stash gate
+
+read_verilog <<EOT
+module gold (y, clk, w);
+  input clk;
+  wire [1:0] i;
+  input w;
+  output y;
+  reg y = 1'h0;
+  always @(posedge clk)
+      y <= w;
+  assign i = 2'h0;
+endmodule
+EOT
+proc gold
+
+design -import gate -as gate
+
+miter -equiv -flatten -make_assert -make_outputs gold gate miter
+sat -seq 10 -verify -prove-asserts -show-ports miter


### PR DESCRIPTION
Fixes #1531 