### PR TITLE
Fixed some missing "verilog_" in documentation

### DIFF
--- a/frontends/verilog/preproc.cc
+++ b/frontends/verilog/preproc.cc
@@ -28,7 +28,7 @@
  *
  *  Ad-hoc implementation of a Verilog preprocessor. The directives `define,
  *  `include, `ifdef, `ifndef, `else and `endif are handled here. All other
- *  directives are handled by the lexer (see lexer.l).
+ *  directives are handled by the lexer (see verilog_lexer.l).
  *
  */
 

--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -28,7 +28,7 @@
  *
  *  A simple lexer for Verilog code. Non-preprocessor compiler directives are
  *  handled here. The preprocessor stuff is handled in preproc.cc. Everything
- *  else is left to the bison parser (see parser.y).
+ *  else is left to the bison parser (see verilog_parser.y).
  *
  */
 

--- a/manual/CHAPTER_Verilog.tex
+++ b/manual/CHAPTER_Verilog.tex
@@ -93,7 +93,7 @@ frontends/verilog/preproc.cc} in the Yosys source tree.
 
 \begin{sloppypar}
 The Verilog Lexer is written using the lexer generator {\it flex} \citeweblink{flex}. Its source code
-can be found in {\tt frontends/verilog/lexer.l} in the Yosys source tree.
+can be found in {\tt frontends/verilog/verilog\_lexer.l} in the Yosys source tree.
 The lexer does little more than identifying all keywords and literals
 recognised by the Yosys Verilog frontend.
 \end{sloppypar}
@@ -115,7 +115,7 @@ whenever possible.)
 \subsection{The Verilog Parser}
 
 The Verilog Parser is written using the parser generator {\it bison} \citeweblink{bison}. Its source code
-can be found in {\tt frontends/verilog/parser.y} in the Yosys source tree.
+can be found in {\tt frontends/verilog/verilog\_parser.y} in the Yosys source tree.
 
 It generates an AST using the \lstinline[language=C++]{AST::AstNode} data structure
 defined in {\tt frontends/ast/ast.h}. An \lstinline[language=C++]{AST::AstNode} object has


### PR DESCRIPTION
Is a minimal contribution, but I was surfing the source code of the Verilog frontend and I found a name mismatch between the documentation and the real name of lexer and parser files.

I have not the setup to run `make manual`, but I used '\\_' in the LaTeX source.