### PR TITLE
Revert "Optimise write_xaiger"

### DIFF
--- a/backends/aiger/xaiger.cc
+++ b/backends/aiger/xaiger.cc
@@ -605,25 +605,15 @@ struct XAigerWriter
 			RTLIL::Module *holes_module = module->design->addModule("$__holes__");
 			log_assert(holes_module);
 
-			dict<IdString, Cell*> cell_cache;
-
 			int port_id = 1;
 			int box_count = 0;
 			for (auto cell : box_list) {
 				RTLIL::Module* box_module = module->design->module(cell->type);
-				log_assert(box_module);
-				IdString derived_name = box_module->derive(module->design, cell->parameters);
-				box_module = module->design->module(derived_name);
-				if (box_module->has_processes())
-					log_error("ABC9 box '%s' contains processes!\n", box_module->name.c_str());
-
 				int box_inputs = 0, box_outputs = 0;
-				auto r = cell_cache.insert(std::make_pair(derived_name, nullptr));
-				Cell *holes_cell = r.first->second;
-				if (r.second && !holes_cell && box_module->get_bool_attribute("\\whitebox")) {
+				Cell *holes_cell = nullptr;
+				if (box_module->get_bool_attribute("\\whitebox")) {
 					holes_cell = holes_module->addCell(cell->name, cell->type);
 					holes_cell->parameters = cell->parameters;
-					r.first->second = holes_cell;
 				}
 
 				// NB: Assume box_module->ports are sorted alphabetically
@@ -632,8 +622,8 @@ struct XAigerWriter
 					RTLIL::Wire *w = box_module->wire(port_name);
 					log_assert(w);
 					RTLIL::Wire *holes_wire;
-					RTLIL::SigSpec port_sig;
-					if (w->port_input)
+					RTLIL::SigSpec port_wire;
+					if (w->port_input) {
 						for (int i = 0; i < GetSize(w); i++) {
 							box_inputs++;
 							holes_wire = holes_module->wire(stringf("\\i%d", box_inputs));
@@ -644,29 +634,28 @@ struct XAigerWriter
 								holes_module->ports.push_back(holes_wire->name);
 							}
 							if (holes_cell)
-								port_sig.append(holes_wire);
+								port_wire.append(holes_wire);
 						}
+						if (!port_wire.empty())
+							holes_cell->setPort(w->name, port_wire);
+					}
 					if (w->port_output) {
 						box_outputs += GetSize(w);
 						for (int i = 0; i < GetSize(w); i++) {
 							if (GetSize(w) == 1)
-								holes_wire = holes_module->addWire(stringf("%s.%s", cell->name.c_str(), log_id(w->name)));
+								holes_wire = holes_module->addWire(stringf("%s.%s", cell->name.c_str(), w->name.c_str()));
 							else
-								holes_wire = holes_module->addWire(stringf("%s.%s[%d]", cell->name.c_str(), log_id(w->name), i));
+								holes_wire = holes_module->addWire(stringf("%s.%s[%d]", cell->name.c_str(), w->name.c_str(), i));
 							holes_wire->port_output = true;
 							holes_wire->port_id = port_id++;
 							holes_module->ports.push_back(holes_wire->name);
 							if (holes_cell)
-								port_sig.append(holes_wire);
+								port_wire.append(holes_wire);
 							else
 								holes_module->connect(holes_wire, State::S0);
 						}
-					}
-					if (!port_sig.empty()) {
-						if (r.second)
-							holes_cell->setPort(w->name, port_sig);
-						else
-							holes_module->connect(holes_cell->getPort(w->name), port_sig);
+						if (!port_wire.empty())
+							holes_cell->setPort(w->name, port_wire);
 					}
 				}
 
@@ -696,8 +685,16 @@ struct XAigerWriter
 				RTLIL::Selection& sel = holes_module->design->selection_stack.back();
 				sel.select(holes_module);
 
+				// TODO: Should not need to opt_merge if we only instantiate
+				//       each box type once...
+				Pass::call(holes_module->design, "opt_merge -share_all");
+
 				Pass::call(holes_module->design, "flatten -wb");
 
+				// TODO: Should techmap/aigmap/check all lib_whitebox-es just once,
+				//       instead of per write_xaiger call
+				Pass::call(holes_module->design, "techmap");
+				Pass::call(holes_module->design, "aigmap");
 				for (auto cell : holes_module->cells())
 					if (!cell->type.in("$_NOT_", "$_AND_"))
 						log_error("Whitebox contents cannot be represented as AIG. Please verify whiteboxes are synthesisable.\n");

--- a/techlibs/ecp5/synth_ecp5.cc
+++ b/techlibs/ecp5/synth_ecp5.cc
@@ -321,11 +321,6 @@ struct SynthEcp5Pass : public ScriptPass
 				run("techmap " + techmap_args);
 
 			if (abc9) {
-				run("select -set abc9_boxes A:abc9_box_id A:whitebox=1");
-				run("wbflip @abc9_boxes");
-				run("techmap -autoproc @abc9_boxes");
-				run("aigmap @abc9_boxes");
-				run("wbflip @abc9_boxes");
 				run("read_verilog -icells -lib +/ecp5/abc9_model.v");
 				if (nowidelut)
 					run("abc9 -lut +/ecp5/abc9_5g_nowide.lut -box +/ecp5/abc9_5g.box -W 200 -nomfs");

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -350,11 +350,6 @@ struct SynthIce40Pass : public ScriptPass
 			}
 			if (!noabc) {
 				if (abc == "abc9") {
-					run("select -set abc9_boxes A:abc9_box_id A:whitebox=1");
-					run("wbflip @abc9_boxes");
-					run("techmap -autoproc @abc9_boxes");
-					run("aigmap @abc9_boxes");
-					run("wbflip @abc9_boxes");
 					run("read_verilog -icells -lib +/ice40/abc9_model.v");
 					int wire_delay;
 					if (device_opt == "lp")

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -540,11 +540,6 @@ struct SynthXilinxPass : public ScriptPass
 					log_warning("'synth_xilinx -abc9' not currently supported for the '%s' family, "
 							"will use timing for 'xc7' instead.\n", family.c_str());
 				run("techmap -map +/xilinx/abc9_map.v -max_iter 1");
-				run("select -set abc9_boxes A:abc9_box_id A:whitebox=1");
-				run("wbflip @abc9_boxes");
-				run("techmap -autoproc @abc9_boxes");
-				run("aigmap @abc9_boxes");
-				run("wbflip @abc9_boxes");
 				run("read_verilog -icells -lib +/xilinx/abc9_model.v");
 				std::string abc9_opts = " -box +/xilinx/abc9_xc7.box";
 				abc9_opts += stringf(" -W %d", XC7_WIRE_DELAY);


### PR DESCRIPTION
Reverts YosysHQ/yosys#1535

It looks we can't aigmap the abc9 whiteboxes since they might contain parameters, in which case Yosys will go back to the AST to generate a paramod...