### PR TITLE
Revert "write_xaiger: only instantiate each whitebox cell type once"

### DIFF
--- a/backends/aiger/xaiger.cc
+++ b/backends/aiger/xaiger.cc
@@ -605,25 +605,15 @@ struct XAigerWriter
 			RTLIL::Module *holes_module = module->design->addModule("$__holes__");
 			log_assert(holes_module);
 
-			dict<IdString, Cell*> cell_cache;
-
 			int port_id = 1;
 			int box_count = 0;
 			for (auto cell : box_list) {
 				RTLIL::Module* box_module = module->design->module(cell->type);
-				log_assert(box_module);
-				IdString derived_name = box_module->derive(module->design, cell->parameters);
-				box_module = module->design->module(derived_name);
-				if (box_module->has_processes())
-					log_error("ABC9 box '%s' contains processes!\n", box_module->name.c_str());
-
 				int box_inputs = 0, box_outputs = 0;
-				auto r = cell_cache.insert(std::make_pair(derived_name, nullptr));
-				Cell *holes_cell = r.first->second;
-				if (r.second && !holes_cell && box_module->get_bool_attribute("\\whitebox")) {
+				Cell *holes_cell = nullptr;
+				if (box_module->get_bool_attribute("\\whitebox")) {
 					holes_cell = holes_module->addCell(cell->name, cell->type);
 					holes_cell->parameters = cell->parameters;
-					r.first->second = holes_cell;
 				}
 
 				// NB: Assume box_module->ports are sorted alphabetically
@@ -632,8 +622,8 @@ struct XAigerWriter
 					RTLIL::Wire *w = box_module->wire(port_name);
 					log_assert(w);
 					RTLIL::Wire *holes_wire;
-					RTLIL::SigSpec port_sig;
-					if (w->port_input)
+					RTLIL::SigSpec port_wire;
+					if (w->port_input) {
 						for (int i = 0; i < GetSize(w); i++) {
 							box_inputs++;
 							holes_wire = holes_module->wire(stringf("\\i%d", box_inputs));
@@ -644,29 +634,28 @@ struct XAigerWriter
 								holes_module->ports.push_back(holes_wire->name);
 							}
 							if (holes_cell)
-								port_sig.append(holes_wire);
+								port_wire.append(holes_wire);
 						}
+						if (!port_wire.empty())
+							holes_cell->setPort(w->name, port_wire);
+					}
 					if (w->port_output) {
 						box_outputs += GetSize(w);
 						for (int i = 0; i < GetSize(w); i++) {
 							if (GetSize(w) == 1)
-								holes_wire = holes_module->addWire(stringf("%s.%s", cell->name.c_str(), log_id(w->name)));
+								holes_wire = holes_module->addWire(stringf("%s.%s", cell->name.c_str(), w->name.c_str()));
 							else
-								holes_wire = holes_module->addWire(stringf("%s.%s[%d]", cell->name.c_str(), log_id(w->name), i));
+								holes_wire = holes_module->addWire(stringf("%s.%s[%d]", cell->name.c_str(), w->name.c_str(), i));
 							holes_wire->port_output = true;
 							holes_wire->port_id = port_id++;
 							holes_module->ports.push_back(holes_wire->name);
 							if (holes_cell)
-								port_sig.append(holes_wire);
+								port_wire.append(holes_wire);
 							else
 								holes_module->connect(holes_wire, State::S0);
 						}
-					}
-					if (!port_sig.empty()) {
-						if (r.second)
-							holes_cell->setPort(w->name, port_sig);
-						else
-							holes_module->connect(holes_cell->getPort(w->name), port_sig);
+						if (!port_wire.empty())
+							holes_cell->setPort(w->name, port_wire);
 					}
 				}
 
@@ -696,11 +685,14 @@ struct XAigerWriter
 				RTLIL::Selection& sel = holes_module->design->selection_stack.back();
 				sel.select(holes_module);
 
+				// TODO: Should not need to opt_merge if we only instantiate
+				//       each box type once...
+				Pass::call(holes_module->design, "opt_merge -share_all");
+
 				Pass::call(holes_module->design, "flatten -wb");
 
-				// Cannot techmap/aigmap/check all lib_whitebox-es outside of write_xaiger
-				//   since boxes may contain parameters in which case `flatten` would have
-				//   created a new $paramod ...
+				// TODO: Should techmap/aigmap/check all lib_whitebox-es just once,
+				//       instead of per write_xaiger call
 				Pass::call(holes_module->design, "techmap");
 				Pass::call(holes_module->design, "aigmap");
 				for (auto cell : holes_module->cells())


### PR DESCRIPTION
Reverts YosysHQ/yosys#1588

This is a priority as it causes abc9 flows for ecp5 and ice40 to totally break.

Even the following small example:

```verilog
module led_blink (
        input clk,
        output ledc
    );
 
    reg [6:0] led_counter = 0;
    always @( posedge clk ) begin
            led_counter <= led_counter + 1;
    end
    assign ledc = !led_counter[ 6:3 ];
 
endmodule
```

fails `prep; equiv_opt -map +/ecp5/cells_sim.v synth_ecp5 -abc9` with:

```
  Unproven $equiv $auto$equiv_make.cc:251:find_same_wires$3852: \ledc_gold \ledc_gate
  Unproven $equiv $auto$equiv_make.cc:280:find_same_wires$3851: \led_counter_gold [6] \led_counter_gate [6]
  Unproven $equiv $auto$equiv_make.cc:280:find_same_wires$3849: \led_counter_gold [4] \led_counter_gate [4]
  Unproven $equiv $auto$equiv_make.cc:280:find_same_wires$3847: \led_counter_gold [2] \led_counter_gate [2]
Found a total of 4 unproven $equiv cells.
```
and indeed something very strange is going on with these bits:
![Screenshot from 2019-12-27 23-30-03](https://user-images.githubusercontent.com/5521177/71535813-e364e300-2900-11ea-808c-1ba6d62160d4.png)

