### PR TITLE
"abc -dff" to no longer retime by default

### DIFF
--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -29,17 +29,17 @@
 // Kahn, Arthur B. (1962), "Topological sorting of large networks", Communications of the ACM 5 (11): 558-562, doi:10.1145/368996.369025
 // http://en.wikipedia.org/wiki/Topological_sorting
 
-#define ABC_COMMAND_LIB "strash; ifraig; scorr; dc2; dretime; retime {D}; strash; &get -n; &dch -f; &nf {D}; &put"
-#define ABC_COMMAND_CTR "strash; ifraig; scorr; dc2; dretime; retime {D}; strash; &get -n; &dch -f; &nf {D}; &put; buffer; upsize {D}; dnsize {D}; stime -p"
-#define ABC_COMMAND_LUT "strash; ifraig; scorr; dc2; dretime; retime {D}; strash; dch -f; if; mfs2"
-#define ABC_COMMAND_SOP "strash; ifraig; scorr; dc2; dretime; retime {D}; strash; dch -f; cover {I} {P}"
-#define ABC_COMMAND_DFL "strash; ifraig; scorr; dc2; dretime; retime {D}; strash; &get -n; &dch -f; &nf {D}; &put"
+#define ABC_COMMAND_LIB "strash; ifraig; scorr; dc2; dretime; strash; &get -n; &dch -f; &nf {D}; &put"
+#define ABC_COMMAND_CTR "strash; ifraig; scorr; dc2; dretime; strash; &get -n; &dch -f; &nf {D}; &put; buffer; upsize {D}; dnsize {D}; stime -p"
+#define ABC_COMMAND_LUT "strash; ifraig; scorr; dc2; dretime; strash; dch -f; if; mfs2"
+#define ABC_COMMAND_SOP "strash; ifraig; scorr; dc2; dretime; strash; dch -f; cover {I} {P}"
+#define ABC_COMMAND_DFL "strash; ifraig; scorr; dc2; dretime; strash; &get -n; &dch -f; &nf {D}; &put"
 
-#define ABC_FAST_COMMAND_LIB "strash; dretime; retime {D}; map {D}"
-#define ABC_FAST_COMMAND_CTR "strash; dretime; retime {D}; map {D}; buffer; upsize {D}; dnsize {D}; stime -p"
-#define ABC_FAST_COMMAND_LUT "strash; dretime; retime {D}; if"
-#define ABC_FAST_COMMAND_SOP "strash; dretime; retime {D}; cover -I {I} -P {P}"
-#define ABC_FAST_COMMAND_DFL "strash; dretime; retime {D}; map"
+#define ABC_FAST_COMMAND_LIB "strash; dretime; map {D}"
+#define ABC_FAST_COMMAND_CTR "strash; dretime; map {D}; buffer; upsize {D}; dnsize {D}; stime -p"
+#define ABC_FAST_COMMAND_LUT "strash; dretime; if"
+#define ABC_FAST_COMMAND_SOP "strash; dretime; cover -I {I} -P {P}"
+#define ABC_FAST_COMMAND_DFL "strash; dretime; map"
 
 #include "kernel/register.h"
 #include "kernel/sigtools.h"
@@ -746,6 +746,10 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 		abc_script += fast_mode ? ABC_FAST_COMMAND_SOP : ABC_COMMAND_SOP;
 	else
 		abc_script += fast_mode ? ABC_FAST_COMMAND_DFL : ABC_COMMAND_DFL;
+
+	if (script_file.empty() && !delay_target.empty())
+		for (size_t pos = abc_script.find("dretime;"); pos != std::string::npos; pos = abc_script.find("dretime;", pos+1))
+			abc_script = abc_script.substr(0, pos) + "dretime; retime -o {D};" + abc_script.substr(pos+8);
 
 	for (size_t pos = abc_script.find("{D}"); pos != std::string::npos; pos = abc_script.find("{D}", pos))
 		abc_script = abc_script.substr(0, pos) + delay_target + abc_script.substr(pos+3);

--- a/techlibs/achronix/synth_achronix.cc
+++ b/techlibs/achronix/synth_achronix.cc
@@ -52,7 +52,7 @@ struct SynthAchronixPass : public ScriptPass {
     log("        do not flatten design before synthesis\n");
     log("\n");
     log("    -retime\n");
-    log("        run 'abc' with -dff option\n");
+    log("        run 'abc' with '-dff -D 1' options\n");
     log("\n");
     log("\n");
     log("The following commands are executed by this synthesis command:\n");

--- a/techlibs/achronix/synth_achronix.cc
+++ b/techlibs/achronix/synth_achronix.cc
@@ -152,12 +152,12 @@ struct SynthAchronixPass : public ScriptPass {
         run("clean -purge");
         run("setundef -undriven -zero");
         if (retime || help_mode)
-          run("abc -markgroups -dff", "(only if -retime)");
+          run("abc -markgroups -dff -D 1", "(only if -retime)");
       }
 
     if (check_label("map_luts"))
       {
-        run("abc -lut 4" + string(retime ? " -dff" : ""));
+        run("abc -lut 4" + string(retime ? " -dff -D 1" : ""));
         run("clean");
       }
 

--- a/techlibs/anlogic/synth_anlogic.cc
+++ b/techlibs/anlogic/synth_anlogic.cc
@@ -164,7 +164,7 @@ struct SynthAnlogicPass : public ScriptPass
 			run("opt -undriven -fine");
 			run("techmap -map +/techmap.v -map +/anlogic/arith_map.v");
 			if (retime || help_mode)
-				run("abc -dff", "(only if -retime)");
+				run("abc -dff -D 1", "(only if -retime)");
 		}
 
 		if (check_label("map_ffs"))

--- a/techlibs/anlogic/synth_anlogic.cc
+++ b/techlibs/anlogic/synth_anlogic.cc
@@ -58,7 +58,7 @@ struct SynthAnlogicPass : public ScriptPass
 		log("        do not flatten design before synthesis\n");
 		log("\n");
 		log("    -retime\n");
-		log("        run 'abc' with -dff option\n");
+		log("        run 'abc' with '-dff -D 1' options\n");
 		log("\n");
 		log("\n");
 		log("The following commands are executed by this synthesis command:\n");

--- a/techlibs/coolrunner2/synth_coolrunner2.cc
+++ b/techlibs/coolrunner2/synth_coolrunner2.cc
@@ -55,7 +55,7 @@ struct SynthCoolrunner2Pass : public ScriptPass
 		log("        do not flatten design before synthesis\n");
 		log("\n");
 		log("    -retime\n");
-		log("        run 'abc' with -dff option\n");
+		log("        run 'abc' with '-dff -D 1' options\n");
 		log("\n");
 		log("\n");
 		log("The following commands are executed by this synthesis command:\n");

--- a/techlibs/coolrunner2/synth_coolrunner2.cc
+++ b/techlibs/coolrunner2/synth_coolrunner2.cc
@@ -161,7 +161,7 @@ struct SynthCoolrunner2Pass : public ScriptPass
 
 		if (check_label("map_pla"))
 		{
-			run("abc -sop -I 40 -P 56");
+			run("abc -sop -I 40 -P 56" + string(retime ? " -dff -D 1" : ""));
 			run("clean");
 		}
 

--- a/techlibs/easic/synth_easic.cc
+++ b/techlibs/easic/synth_easic.cc
@@ -158,7 +158,7 @@ struct SynthEasicPass : public ScriptPass
 			run("techmap");
 			run("opt -fast");
 			if (retime || help_mode) {
-				run("abc -dff", " (only if -retime)");
+				run("abc -dff -D 1", " (only if -retime)");
 				run("opt_clean", "(only if -retime)");
 			}
 		}

--- a/techlibs/easic/synth_easic.cc
+++ b/techlibs/easic/synth_easic.cc
@@ -56,7 +56,7 @@ struct SynthEasicPass : public ScriptPass
 		log("        do not flatten design before synthesis\n");
 		log("\n");
 		log("    -retime\n");
-		log("        run 'abc' with -dff option\n");
+		log("        run 'abc' with '-dff -D 1' options\n");
 		log("\n");
 		log("\n");
 		log("The following commands are executed by this synthesis command:\n");

--- a/techlibs/ecp5/synth_ecp5.cc
+++ b/techlibs/ecp5/synth_ecp5.cc
@@ -62,7 +62,7 @@ struct SynthEcp5Pass : public ScriptPass
 		log("        do not flatten design before synthesis\n");
 		log("\n");
 		log("    -retime\n");
-		log("        run 'abc' with -dff option\n");
+		log("        run 'abc' with '-dff -D 1' options\n");
 		log("\n");
 		log("    -noccu2\n");
 		log("        do not use CCU2 cells in output netlist\n");

--- a/techlibs/ecp5/synth_ecp5.cc
+++ b/techlibs/ecp5/synth_ecp5.cc
@@ -290,7 +290,7 @@ struct SynthEcp5Pass : public ScriptPass
 			else
 				run("techmap -map +/techmap.v -map +/ecp5/arith_map.v");
 			if (retime || help_mode)
-				run("abc -dff", "(only if -retime)");
+				run("abc -dff -D 1", "(only if -retime)");
 		}
 
 		if (check_label("map_ffs"))

--- a/techlibs/efinix/synth_efinix.cc
+++ b/techlibs/efinix/synth_efinix.cc
@@ -58,7 +58,7 @@ struct SynthEfinixPass : public ScriptPass
 		log("        do not flatten design before synthesis\n");
 		log("\n");
 		log("    -retime\n");
-		log("        run 'abc' with -dff option\n");
+		log("        run 'abc' with '-dff -D 1' options\n");
 		log("\n");
 		log("\n");
 		log("The following commands are executed by this synthesis command:\n");
@@ -164,7 +164,7 @@ struct SynthEfinixPass : public ScriptPass
 			run("opt -undriven -fine");
 			run("techmap -map +/techmap.v -map +/efinix/arith_map.v");
 			if (retime || help_mode)
-				run("abc -dff", "(only if -retime)");
+				run("abc -dff -D 1", "(only if -retime)");
 		}
 
 		if (check_label("map_ffs"))

--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -209,7 +209,7 @@ struct SynthGowinPass : public ScriptPass
 			run("techmap -map +/techmap.v -map +/gowin/arith_map.v");
 			run("techmap -map +/techmap.v");
 			if (retime || help_mode)
-				run("abc -dff", "(only if -retime)");
+				run("abc -dff -D 1", "(only if -retime)");
 			run("splitnets");
 		}
 

--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -62,16 +62,16 @@ struct SynthGowinPass : public ScriptPass
 		log("        do not flatten design before synthesis\n");
 		log("\n");
 		log("    -retime\n");
-		log("        run 'abc' with -dff option\n");
+		log("        run 'abc' with '-dff -D 1' options\n");
 		log("\n");
 		log("    -nowidelut\n");
 		log("        do not use muxes to implement LUTs larger than LUT4s\n");
 		log("\n");
 		log("    -noiopads\n");
 		log("        do not emit IOB at top level ports\n");
-		log("\n");
-		log("    -abc9\n");
-		log("        use new ABC9 flow (EXPERIMENTAL)\n");
+		//log("\n");
+		//log("    -abc9\n");
+		//log("        use new ABC9 flow (EXPERIMENTAL)\n");
 		log("\n");
 		log("\n");
 		log("The following commands are executed by this synthesis command:\n");
@@ -144,10 +144,10 @@ struct SynthGowinPass : public ScriptPass
 				nowidelut = true;
 				continue;
 			}
-			if (args[argidx] == "-abc9") {
-				abc9 = true;
-				continue;
-			}
+			//if (args[argidx] == "-abc9") {
+			//	abc9 = true;
+			//	continue;
+			//}
 			if (args[argidx] == "-noiopads") {
 				noiopads = true;
 				continue;
@@ -227,13 +227,13 @@ struct SynthGowinPass : public ScriptPass
 
 		if (check_label("map_luts"))
 		{
-			if (nowidelut && abc9) {
+			/*if (nowidelut && abc9) {
 				run("abc9 -lut 4");
-			} else if (nowidelut && !abc9) {
+			} else*/ if (nowidelut && !abc9) {
 				run("abc -lut 4");
-			} else if (!nowidelut && abc9) {
+			} else /*if (!nowidelut && abc9) {
 				run("abc9 -lut 4:8");
-			} else if (!nowidelut && !abc9) {
+			} else*/ if (!nowidelut && !abc9) {
 				run("abc -lut 4:8");
 			}
 			run("clean");

--- a/techlibs/greenpak4/synth_greenpak4.cc
+++ b/techlibs/greenpak4/synth_greenpak4.cc
@@ -165,7 +165,7 @@ struct SynthGreenPAK4Pass : public ScriptPass
 			run("dfflibmap -prepare -liberty +/greenpak4/gp_dff.lib");
 			run("opt -fast");
 			if (retime || help_mode)
-				run("abc -dff", "(only if -retime)");
+				run("abc -dff -D 1", "(only if -retime)");
 		}
 
 		if (check_label("map_luts"))

--- a/techlibs/greenpak4/synth_greenpak4.cc
+++ b/techlibs/greenpak4/synth_greenpak4.cc
@@ -59,7 +59,7 @@ struct SynthGreenPAK4Pass : public ScriptPass
 		log("        do not flatten design before synthesis\n");
 		log("\n");
 		log("    -retime\n");
-		log("        run 'abc' with -dff option\n");
+		log("        run 'abc' with '-dff -D 1' options\n");
 		log("\n");
 		log("\n");
 		log("The following commands are executed by this synthesis command:\n");

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -65,7 +65,7 @@ struct SynthIce40Pass : public ScriptPass
 		log("        do not flatten design before synthesis\n");
 		log("\n");
 		log("    -retime\n");
-		log("        run 'abc' with -dff option\n");
+		log("        run 'abc' with '-dff -D 1' options\n");
 		log("\n");
 		log("    -nocarry\n");
 		log("        do not use SB_CARRY cells in output netlist\n");

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -316,7 +316,7 @@ struct SynthIce40Pass : public ScriptPass
 				run("techmap -map +/techmap.v -map +/ice40/arith_map.v");
 			}
 			if (retime || help_mode)
-				run(abc + " -dff", "(only if -retime)");
+				run(abc + " -dff -D 1", "(only if -retime)");
 			run("ice40_opt");
 		}
 

--- a/techlibs/intel/synth_intel.cc
+++ b/techlibs/intel/synth_intel.cc
@@ -71,7 +71,7 @@ struct SynthIntelPass : public ScriptPass {
 		log("        do not flatten design before synthesis\n");
 		log("\n");
 		log("    -retime\n");
-		log("        run 'abc' with -dff option\n");
+		log("        run 'abc' with '-dff -D 1' options\n");
 		log("\n");
 		log("The following commands are executed by this synthesis command:\n");
 		help_script();

--- a/techlibs/intel/synth_intel.cc
+++ b/techlibs/intel/synth_intel.cc
@@ -210,7 +210,7 @@ struct SynthIntelPass : public ScriptPass {
 			run("clean -purge");
 			run("setundef -undriven -zero");
 			if (retime || help_mode)
-				run("abc -markgroups -dff", "(only if -retime)");
+				run("abc -markgroups -dff -D 1", "(only if -retime)");
 		}
 
 		if (check_label("map_luts")) {

--- a/techlibs/sf2/synth_sf2.cc
+++ b/techlibs/sf2/synth_sf2.cc
@@ -67,7 +67,7 @@ struct SynthSf2Pass : public ScriptPass
 		log("        insert direct PAD->global_net buffers\n");
 		log("\n");
 		log("    -retime\n");
-		log("        run 'abc' with -dff option\n");
+		log("        run 'abc' with '-dff -D 1' options\n");
 		log("\n");
 		log("\n");
 		log("The following commands are executed by this synthesis command:\n");

--- a/techlibs/sf2/synth_sf2.cc
+++ b/techlibs/sf2/synth_sf2.cc
@@ -181,7 +181,7 @@ struct SynthSf2Pass : public ScriptPass
 			run("opt -undriven -fine");
 			run("techmap -map +/techmap.v -map +/sf2/arith_map.v");
 			if (retime || help_mode)
-				run("abc -dff", "(only if -retime)");
+				run("abc -dff -D 1", "(only if -retime)");
 		}
 
 		if (check_label("map_ffs"))

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -555,9 +555,9 @@ struct SynthXilinxPass : public ScriptPass
 			}
 			else {
 				if (nowidelut)
-					run("abc -luts 2:2,3,6:5" + string(retime ? " -dff" : ""));
+					run("abc -luts 2:2,3,6:5" + string(retime ? " -dff -D 1" : ""));
 				else
-					run("abc -luts 2:2,3,6:5,10,20" + string(retime ? " -dff" : ""));
+					run("abc -luts 2:2,3,6:5,10,20" + string(retime ? " -dff -D 1" : ""));
 			}
 			run("clean");
 

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -110,7 +110,7 @@ struct SynthXilinxPass : public ScriptPass
 		log("        flatten design before synthesis\n");
 		log("\n");
 		log("    -retime\n");
-		log("        run 'abc' with -dff option\n");
+		log("        run 'abc' with '-dff -D 1' options\n");
 		log("\n");
 		log("    -abc9\n");
 		log("        use new ABC9 flow (EXPERIMENTAL)\n");


### PR DESCRIPTION
Partially reverts https://github.com/YosysHQ/yosys/pull/917 since `abc9` does not support retiming.

`synth_* -retime` option now calls `abc -dff -D 1` to preserve old behaviour.