### PR TITLE
ice40: Demote conflicting FF init values to a warning

### DIFF
--- a/techlibs/ice40/ice40_ffinit.cc
+++ b/techlibs/ice40/ice40_ffinit.cc
@@ -78,10 +78,12 @@ struct Ice40FfinitPass : public Pass {
 						continue;
 
 					if (initbits.count(bit)) {
-						if (initbits.at(bit) != val)
-							log_error("Conflicting init values for signal %s (%s = %s, %s = %s).\n",
+						if (initbits.at(bit) != val) {
+							log_warning("Conflicting init values for signal %s (%s = %s, %s = %s).\n",
 									log_signal(bit), log_signal(SigBit(wire, i)), log_signal(val),
 									log_signal(initbit_to_wire[bit]), log_signal(initbits.at(bit)));
+							initbits.at(bit) = State::Sx;
+						}
 						continue;
 					}
 
@@ -114,6 +116,10 @@ struct Ice40FfinitPass : public Pass {
 					continue;
 
 				State val = initbits.at(bit_q);
+
+				if (val == State::Sx)
+					continue;
+
 				handled_initbits.insert(bit_q);
 
 				log("FF init value for cell %s (%s): %s = %c\n", log_id(cell), log_id(cell->type),


### PR DESCRIPTION
This duplicates for Ice40 a change already made for ECP5: https://github.com/YosysHQ/yosys/pull/850/commits/777864d02ea3382c822a764e928e06b6142da6ec

Following conversation about LiteDRAM here: https://github.com/enjoy-digital/litedram/issues/96