### PR TITLE
iopad mapping should take care of existing io buffers

### DIFF
--- a/passes/techmap/iopadmap.cc
+++ b/passes/techmap/iopadmap.cc
@@ -234,6 +234,9 @@ struct IopadmapPass : public Pass {
 						SigBit wire_bit(wire, i);
 						Cell *tbuf_cell = nullptr;
 
+						if (skip_wire_bits.count(wire_bit))
+							continue;
+
 						if (tbuf_bits.count(wire_bit))
 							tbuf_cell = tbuf_bits.at(wire_bit);
 

--- a/tests/arch/xilinx/bug1605.ys
+++ b/tests/arch/xilinx/bug1605.ys
@@ -1,0 +1,19 @@
+read_verilog <<EOT
+module top(inout io);
+    wire in;
+    wire t;
+    wire o;
+
+    IOBUF IOBUF(
+      .I(in),
+      .T(t),
+      .IO(io),
+      .O(o)
+    );
+endmodule
+EOT
+
+synth_xilinx
+cd top
+select -assert-count 1 t:IOBUF
+select -assert-none t:* t:IOBUF %d


### PR DESCRIPTION
module top(inout io);

wire in;
wire t;
wire o;
IOBUF IOBUF(
	.I(in),
	.T(t),
	.IO(io),
	.O(o)
);

endmodule

This simple case create 2 IOBUF cells instead of keeping just one manually instantiated.
Thanks @mwkmwkmwk for suggesting what to check.
