### PR TITLE
Valid to have attribute starting with SB_CARRY.

### DIFF
--- a/techlibs/ice40/ice40_opt.cc
+++ b/techlibs/ice40/ice40_opt.cc
@@ -128,6 +128,8 @@ static void run_ice40_opts(Module *module)
 							new_attr.insert(std::make_pair(a.first, a.second));
 						else if (a.first.in(ID(SB_LUT4.name), ID::keep, ID(module_not_derived)))
 							continue;
+						else if (a.first.begins_with("\\SB_CARRY.\\"))
+							continue;
 						else
 							log_abort();
 					cell->attributes = std::move(new_attr);


### PR DESCRIPTION
Right now executing synth_ice40 on https://github.com/YosysHQ/yosys-tests/blob/master/regression/issue_00160/top.v fails since there is attribute named SB_CARRY. even if carry part is optimized out from carry wrapper 