### PR TITLE
error if multiple -g options are given for abc

### DIFF
--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1623,6 +1623,8 @@ struct AbcPass : public Pass {
 				continue;
 			}
 			if (arg == "-g" && argidx+1 < args.size()) {
+				if (g_arg_from_cmd)
+					log_cmd_error("Can only use -g once. Please combine.");
 				g_arg = args[++argidx];
 				g_argidx = argidx;
 				g_arg_from_cmd = true;


### PR DESCRIPTION
Previously, multiple -g options passed to abc would all affect the enabled gates, but with the latest changes only the last option would be honored. Since the behavior might now be different, throw an error if multiple -g options are given to ensure it's at least not a silent surprise.