### PR TITLE
abc9: add some scripts/options into "scratchpad"

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -46,6 +46,7 @@ IdString RTLIL::ID::Y;
 IdString RTLIL::ID::keep;
 IdString RTLIL::ID::whitebox;
 IdString RTLIL::ID::blackbox;
+dict<std::string, std::string> RTLIL::constpad;
 
 RTLIL::Const::Const()
 {

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -377,6 +377,8 @@ namespace RTLIL
 		extern IdString blackbox;
 	};
 
+	extern dict<std::string, std::string> constpad;
+
 	static inline std::string escape_id(std::string str) {
 		if (str.size() > 0 && str[0] != '\\' && str[0] != '$')
 			return "\\" + str;

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -524,6 +524,15 @@ void yosys_setup()
 		PyRun_SimpleString("import sys");
 	#endif
 
+	RTLIL::constpad["abc9.script.default"] = "&scorr; &sweep; &dc2; &dch -f; &ps; &if {C} {W} {D} -v; &mfs";
+	RTLIL::constpad["abc9.script.default.area"] = "&scorr; &sweep; &dc2; &dch -f; &ps; &if {C} {W} {D} -a -v; &mfs";
+	RTLIL::constpad["abc9.script.default.fast"] = "&if {W} {D}";
+	RTLIL::constpad["abc9.script.flow3"] = "&scorr; &sweep;" \
+		"&if {C} {W} {D}; &save; &st; &syn2; &if {C} {W} {D} -v; &save; &load; "\
+		"&st; &if {C} -g -K 6; &dch -f; &if {C} {W} {D} -v; &save; &load; "\
+		"&st; &if {C} -g -K 6; &synch2; &if {C} {W} {D} -v; &save; &load; "\
+		"&mfs";
+
 	Pass::init_register();
 	yosys_design = new RTLIL::Design;
 	yosys_celltypes.setup();

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -524,13 +524,39 @@ void yosys_setup()
 		PyRun_SimpleString("import sys");
 	#endif
 
-	RTLIL::constpad["abc9.script.default"] = "&scorr; &sweep; &dc2; &dch -f; &ps; &if {C} {W} {D} -v; &mfs";
-	RTLIL::constpad["abc9.script.default.area"] = "&scorr; &sweep; &dc2; &dch -f; &ps; &if {C} {W} {D} -a -v; &mfs";
-	RTLIL::constpad["abc9.script.default.fast"] = "&if {W} {D}";
+	RTLIL::constpad["abc9.script.default"] = "&scorr; &sweep; &dc2; &dch -f; &ps; &if {C} {W} {D} {R} -v; &mfs";
+	RTLIL::constpad["abc9.script.default.area"] = "&scorr; &sweep; &dc2; &dch -f; &ps; &if {C} {W} {D} {R} -a -v; &mfs";
+	RTLIL::constpad["abc9.script.default.fast"] = "&if {C} {W} {D} {R}";
+	// Based on ABC's &flow
+	RTLIL::constpad["abc9.script.flow"] = "&scorr; &sweep;" \
+		/* Round 1 */ \
+		"&unmap; &if {C} {W} {D} {R}; &mfs;" \
+		"&st; &dsdb;" \
+		"&unmap; &if {C} {W} {D} {R}; &mfs;" \
+		"&st; &syn2 -m -R 10; &dsdb;" \
+		"&blut -a -K 6;" \
+		"&unmap; &if {C} {W} {D} {R}; &mfs;" \
+		/* Round 2 */ \
+		"&st; &sopb;" \
+		"&unmap; &if {C} {W} {D} {R}; &mfs;" \
+		"&st; &dsdb;" \
+		"&unmap; &if {C} {W} {D} {R}; &mfs;" \
+		"&st; &syn2 -m -R 10; &dsdb;" \
+		"&blut -a -K 6;" \
+		"&unmap; &if {C} {W} {D} {R} -v; &mfs";
+	// Based on ABC's &flow2
+	RTLIL::constpad["abc9.script.flow2"] = "&scorr; &sweep;" \
+		/* Comm1 */ "&synch2 -K 6 -C 500; &if -m {C} {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save;"\
+		/* Comm2 */ "&dch -C 500; &if -m {C} {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save;"\
+		"&load; &st; &sopb -R 10 -C 4; " \
+		/* Comm3 */ "&synch2 -K 6 -C 500; &if -m "/*"-E 5"*/" {C} {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save;"\
+		/* Comm2 */ "&dch -C 500; &if -m {C} {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save; "\
+		"&load";
+	// Based on ABC's &flow3
 	RTLIL::constpad["abc9.script.flow3"] = "&scorr; &sweep;" \
-		"&if {C} {W} {D}; &save; &st; &syn2; &if {C} {W} {D} -v; &save; &load; "\
-		"&st; &if {C} -g -K 6; &dch -f; &if {C} {W} {D} -v; &save; &load; "\
-		"&st; &if {C} -g -K 6; &synch2; &if {C} {W} {D} -v; &save; &load; "\
+		"&if {C} {W} {D}; &save; &st; &syn2; &if {C} {W} {D} {R} -v; &save; &load;"\
+		"&st; &if {C} -g -K 6; &dch -f; &if {C} {W} {D} {R} -v; &save; &load;"\
+		"&st; &if {C} -g -K 6; &synch2; &if {C} {W} {D} {R} -v; &save; &load;"\
 		"&mfs";
 
 	Pass::init_register();

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -524,41 +524,6 @@ void yosys_setup()
 		PyRun_SimpleString("import sys");
 	#endif
 
-	RTLIL::constpad["abc9.script.default"] = "&scorr; &sweep; &dc2; &dch -f; &ps; &if {C} {W} {D} {R} -v; &mfs";
-	RTLIL::constpad["abc9.script.default.area"] = "&scorr; &sweep; &dc2; &dch -f; &ps; &if {C} {W} {D} {R} -a -v; &mfs";
-	RTLIL::constpad["abc9.script.default.fast"] = "&if {C} {W} {D} {R}";
-	// Based on ABC's &flow
-	RTLIL::constpad["abc9.script.flow"] = "&scorr; &sweep;" \
-		/* Round 1 */ \
-		"&unmap; &if {C} {W} {D} {R}; &mfs;" \
-		"&st; &dsdb;" \
-		"&unmap; &if {C} {W} {D} {R}; &mfs;" \
-		"&st; &syn2 -m -R 10; &dsdb;" \
-		"&blut -a -K 6;" \
-		"&unmap; &if {C} {W} {D} {R}; &mfs;" \
-		/* Round 2 */ \
-		"&st; &sopb;" \
-		"&unmap; &if {C} {W} {D} {R}; &mfs;" \
-		"&st; &dsdb;" \
-		"&unmap; &if {C} {W} {D} {R}; &mfs;" \
-		"&st; &syn2 -m -R 10; &dsdb;" \
-		"&blut -a -K 6;" \
-		"&unmap; &if {C} {W} {D} {R} -v; &mfs";
-	// Based on ABC's &flow2
-	RTLIL::constpad["abc9.script.flow2"] = "&scorr; &sweep;" \
-		/* Comm1 */ "&synch2 -K 6 -C 500; &if -m {C} {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save;"\
-		/* Comm2 */ "&dch -C 500; &if -m {C} {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save;"\
-		"&load; &st; &sopb -R 10 -C 4; " \
-		/* Comm3 */ "&synch2 -K 6 -C 500; &if -m "/*"-E 5"*/" {C} {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save;"\
-		/* Comm2 */ "&dch -C 500; &if -m {C} {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save; "\
-		"&load";
-	// Based on ABC's &flow3
-	RTLIL::constpad["abc9.script.flow3"] = "&scorr; &sweep;" \
-		"&if {C} {W} {D}; &save; &st; &syn2; &if {C} {W} {D} {R} -v; &save; &load;"\
-		"&st; &if {C} -g -K 6; &dch -f; &if {C} {W} {D} {R} -v; &save; &load;"\
-		"&st; &if {C} -g -K 6; &synch2; &if {C} {W} {D} {R} -v; &save; &load;"\
-		"&mfs";
-
 	Pass::init_register();
 	yosys_design = new RTLIL::Design;
 	yosys_celltypes.setup();

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -302,7 +302,7 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *module, std::string scrip
 		for (size_t pos = abc9_script.find("&mfs"); pos != std::string::npos; pos = abc9_script.find("&mfs", pos))
 			abc9_script = abc9_script.erase(pos, strlen("&mfs"));
 
-	abc9_script += stringf("&ps -l; &write -n %s/output.aig", tempdir_name.c_str());
+	abc9_script += stringf("&ps -l; &write -n %s/output.aig; time", tempdir_name.c_str());
 	abc9_script = add_echos_to_abc9_cmd(abc9_script);
 
 	for (size_t i = 0; i+1 < abc9_script.size(); i++)

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -737,21 +737,29 @@ struct Abc9Pass : public Pass {
 		RTLIL::constpad["abc9.script.default.fast"] = "+&if {C} {W} {D} {R} -v";
 		// Based on ABC's &flow
 		RTLIL::constpad["abc9.script.flow"] = "+&scorr; &sweep;" \
+			"&dch -C 500;" \
 			/* Round 1 */ \
-			"&unmap; &if {C} {W} {D} {R}; &mfs;" \
+			/* Map 1 */ "&unmap; &if {C} {W} {D} {R} -v; &save; &load; &mfs;" \
 			"&st; &dsdb;" \
-			"&unmap; &if {C} {W} {D} {R}; &mfs;" \
+			/* Map 2 */ "&unmap; &if {C} {W} {D} {R} -v; &save; &load; &mfs;" \
 			"&st; &syn2 -m -R 10; &dsdb;" \
 			"&blut -a -K 6;" \
-			"&unmap; &if {C} {W} {D} {R}; &mfs;" \
+			/* Map 3 */ "&unmap; &if {C} {W} {D} {R} -v; &save; &load; &mfs;" \
 			/* Round 2 */ \
 			"&st; &sopb;" \
-			"&unmap; &if {C} {W} {D} {R}; &mfs;" \
+			/* Map 1 */ "&unmap; &if {C} {W} {D} {R} -v; &save; &load; &mfs;" \
 			"&st; &dsdb;" \
-			"&unmap; &if {C} {W} {D} {R}; &mfs;" \
+			/* Map 2 */ "&unmap; &if {C} {W} {D} {R} -v; &save; &load; &mfs;" \
 			"&st; &syn2 -m -R 10; &dsdb;" \
 			"&blut -a -K 6;" \
-			"&unmap; &if {C} {W} {D} {R} -v; &mfs";
+			/* Map 3 */ "&unmap; &if {C} {W} {D} {R} -v; &save; &load; &mfs;" \
+			/* Round 3 */ \
+			/* Map 1 */ "&unmap; &if {C} {W} {D} {R} -v; &save; &load; &mfs;" \
+			"&st; &dsdb;" \
+			/* Map 2 */ "&unmap; &if {C} {W} {D} {R} -v; &save; &load; &mfs;" \
+			"&st; &syn2 -m -R 10; &dsdb;" \
+			"&blut -a -K 6;" \
+			/* Map 3 */ "&unmap; &if {C} {W} {D} {R} -v; &save; &load; &mfs;";
 		// Based on ABC's &flow2
 		RTLIL::constpad["abc9.script.flow2"] = "+&scorr; &sweep;" \
 			/* Comm1 */ "&synch2 -K 6 -C 500; &if -m {C} {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save;"\

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -300,9 +300,9 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *module, std::string scrip
 
 	std::string R;
 	if (design->scratchpad.count("abc9.if.R"))
-		C = "-C " + design->scratchpad_get_string("abc9.if.R");
+		R = "-R " + design->scratchpad_get_string("abc9.if.R");
 	for (size_t pos = abc9_script.find("{R}"); pos != std::string::npos; pos = abc9_script.find("{R}", pos))
-		abc9_script = abc9_script.substr(0, pos) + C + abc9_script.substr(pos+3);
+		abc9_script = abc9_script.substr(0, pos) + R + abc9_script.substr(pos+3);
 
 	if (nomfs)
 		for (size_t pos = abc9_script.find("&mfs"); pos != std::string::npos; pos = abc9_script.find("&mfs", pos))
@@ -803,14 +803,14 @@ struct Abc9Pass : public Pass {
 		log("        if no -script parameter is given, the following scripts are used:\n");
 		log("\n");
 		log("        for -lut/-luts:\n");
-		log("%s\n", fold_abc9_cmd(RTLIL::constpad.at("abc9.script.default")).c_str());
+		log("%s\n", fold_abc9_cmd(RTLIL::constpad.at("abc9.script.default")).c_str()+1);
 		log("\n");
 		log("    -fast\n");
 		log("        use different default scripts that are slightly faster (at the cost\n");
 		log("        of output quality):\n");
 		log("\n");
 		log("        for -lut/-luts:\n");
-		log("%s\n", fold_abc9_cmd(RTLIL::constpad.at("abc9.script.default.fast")).c_str());
+		log("%s\n", fold_abc9_cmd(RTLIL::constpad.at("abc9.script.default.fast")).c_str()+1);
 		log("\n");
 		log("    -D <picoseconds>\n");
 		log("        set delay target. the string {D} in the default scripts above is\n");

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -304,10 +304,6 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *module, std::string scrip
 	for (size_t pos = abc9_script.find("{R}"); pos != std::string::npos; pos = abc9_script.find("{R}", pos))
 		abc9_script = abc9_script.substr(0, pos) + R + abc9_script.substr(pos+3);
 
-	if (nomfs)
-		for (size_t pos = abc9_script.find("&mfs"); pos != std::string::npos; pos = abc9_script.find("&mfs", pos))
-			abc9_script = abc9_script.erase(pos, strlen("&mfs"));
-
 	abc9_script += stringf("; &ps -l; &write -n %s/output.aig;", tempdir_name.c_str());
 	if (design->scratchpad_get_bool("abc9.verify")) {
 		if (dff_mode)

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -267,16 +267,21 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *module, std::string scrip
 	abc9_script += stringf("&read %s/input.xaig; &ps; ", tempdir_name.c_str());
 
 	if (!script_file.empty()) {
-		if (script_file[0] == '+') {
-			for (size_t i = 1; i < script_file.size(); i++)
-				if (script_file[i] == '\'')
-					abc9_script += "'\\''";
-				else if (script_file[i] == ',')
-					abc9_script += " ";
-				else
-					abc9_script += script_file[i];
-		} else
+		if (check_file_exists(script_file))
 			abc9_script += stringf("source %s", script_file.c_str());
+		else {
+			if (script_file[0] == '+') {
+				for (size_t i = 1; i < script_file.size(); i++)
+					if (script_file[i] == '\'')
+						abc9_script += "'\\''";
+					else if (script_file[i] == ',')
+						abc9_script += " ";
+					else
+						abc9_script += script_file[i];
+			}
+			else
+				abc9_script += script_file;
+		}
 	} else if (!lut_costs.empty() || !lut_file.empty()) {
 		abc9_script += fast_mode ? RTLIL::constpad.at("abc9.script.default.fast")
 			: RTLIL::constpad.at("abc9.script.default");
@@ -302,7 +307,7 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *module, std::string scrip
 		for (size_t pos = abc9_script.find("&mfs"); pos != std::string::npos; pos = abc9_script.find("&mfs", pos))
 			abc9_script = abc9_script.erase(pos, strlen("&mfs"));
 
-	abc9_script += stringf("&ps -l; &write -n %s/output.aig; time", tempdir_name.c_str());
+	abc9_script += stringf("; &ps -l; &write -n %s/output.aig; time", tempdir_name.c_str());
 	abc9_script = add_echos_to_abc9_cmd(abc9_script);
 
 	for (size_t i = 0; i+1 < abc9_script.size(); i++)
@@ -924,7 +929,7 @@ struct Abc9Pass : public Pass {
 		extra_args(args, argidx, design);
 
 		rewrite_filename(script_file);
-		if (!script_file.empty() && !is_absolute_path(script_file) && script_file[0] != '+')
+		if (!script_file.empty() && !is_absolute_path(script_file) && check_file_exists(script_file))
 			script_file = std::string(pwd) + "/" + script_file;
 
 		// handle -lut / -luts args

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -309,7 +309,7 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *module, std::string scrip
 			abc9_script = abc9_script.erase(pos, strlen("&mfs"));
 
 	abc9_script += stringf("; &ps -l; &write -n %s/output.aig;", tempdir_name.c_str());
-	if (design->scratchpad_get_bool("abc9.debug")) {
+	if (design->scratchpad_get_bool("abc9.verify")) {
 		if (dff_mode)
 			abc9_script += "verify -s;";
 		else

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -734,7 +734,7 @@ struct Abc9Pass : public Pass {
 	{
 		RTLIL::constpad["abc9.script.default"] = "+&scorr; &sweep; &dc2; &dch -f; &ps; &if {C} {W} {D} {R} -v; &mfs";
 		RTLIL::constpad["abc9.script.default.area"] = "+&scorr; &sweep; &dc2; &dch -f; &ps; &if {C} {W} {D} {R} -a -v; &mfs";
-		RTLIL::constpad["abc9.script.default.fast"] = "+&if {C} {W} {D} {R}";
+		RTLIL::constpad["abc9.script.default.fast"] = "+&if {C} {W} {D} {R} -v";
 		// Based on ABC's &flow
 		RTLIL::constpad["abc9.script.flow"] = "+&scorr; &sweep;" \
 			/* Round 1 */ \

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -292,8 +292,11 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *module, std::string scrip
 	for (size_t pos = abc9_script.find("{W}"); pos != std::string::npos; pos = abc9_script.find("{W}", pos))
 		abc9_script = abc9_script.substr(0, pos) + wire_delay + abc9_script.substr(pos+3);
 
+	std::string C;
+	if (design->scratchpad.count("abc9.if.C"))
+		C = "-C " + design->scratchpad_get_string("abc9.if.C");
 	for (size_t pos = abc9_script.find("{C}"); pos != std::string::npos; pos = abc9_script.find("{C}", pos))
-		abc9_script = abc9_script.substr(0, pos) + design->scratchpad_get_string("abc9.if.C", "") + abc9_script.substr(pos+3);
+		abc9_script = abc9_script.substr(0, pos) + C + abc9_script.substr(pos+3);
 
 	if (nomfs)
 		for (size_t pos = abc9_script.find("&mfs"); pos != std::string::npos; pos = abc9_script.find("&mfs", pos))

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -303,6 +303,12 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *module, std::string scrip
 	for (size_t pos = abc9_script.find("{C}"); pos != std::string::npos; pos = abc9_script.find("{C}", pos))
 		abc9_script = abc9_script.substr(0, pos) + C + abc9_script.substr(pos+3);
 
+	std::string R;
+	if (design->scratchpad.count("abc9.if.R"))
+		C = "-C " + design->scratchpad_get_string("abc9.if.R");
+	for (size_t pos = abc9_script.find("{R}"); pos != std::string::npos; pos = abc9_script.find("{R}", pos))
+		abc9_script = abc9_script.substr(0, pos) + C + abc9_script.substr(pos+3);
+
 	if (nomfs)
 		for (size_t pos = abc9_script.find("&mfs"); pos != std::string::npos; pos = abc9_script.find("&mfs", pos))
 			abc9_script = abc9_script.erase(pos, strlen("&mfs"));

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -308,7 +308,14 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *module, std::string scrip
 		for (size_t pos = abc9_script.find("&mfs"); pos != std::string::npos; pos = abc9_script.find("&mfs", pos))
 			abc9_script = abc9_script.erase(pos, strlen("&mfs"));
 
-	abc9_script += stringf("; &ps -l; &write -n %s/output.aig; time", tempdir_name.c_str());
+	abc9_script += stringf("; &ps -l; &write -n %s/output.aig;", tempdir_name.c_str());
+	if (design->scratchpad_get_bool("abc9.debug")) {
+		if (dff_mode)
+			abc9_script += "verify -s;";
+		else
+			abc9_script += "verify;";
+	}
+	abc9_script += "time";
 	abc9_script = add_echos_to_abc9_cmd(abc9_script);
 
 	for (size_t i = 0; i+1 < abc9_script.size(); i++)
@@ -909,6 +916,11 @@ struct Abc9Pass : public Pass {
 			wire_delay = "-W " + design->scratchpad_get_string("abc9.W");
 		}
 		nomfs = design->scratchpad_get_bool("abc9.nomfs", nomfs);
+
+		if (design->scratchpad_get_bool("abc9.debug")) {
+			cleanup = false;
+			show_tempdir = true;
+		}
 
 		size_t argidx;
 		char pwd [PATH_MAX];

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -308,7 +308,7 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *module, std::string scrip
 		for (size_t pos = abc9_script.find("&mfs"); pos != std::string::npos; pos = abc9_script.find("&mfs", pos))
 			abc9_script = abc9_script.erase(pos, strlen("&mfs"));
 
-	abc9_script += stringf("&ps -l; &write -n %s/output.aig; time", tempdir_name.c_str());
+	abc9_script += stringf("; &ps -l; &write -n %s/output.aig; time", tempdir_name.c_str());
 	abc9_script = add_echos_to_abc9_cmd(abc9_script);
 
 	for (size_t i = 0; i+1 < abc9_script.size(); i++)

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -278,8 +278,8 @@ void abc9_module(RTLIL::Design *design, RTLIL::Module *module, std::string scrip
 		} else
 			abc9_script += stringf("source %s", script_file.c_str());
 	} else if (!lut_costs.empty() || !lut_file.empty()) {
-		abc9_script += fast_mode ? RTLIL::constpad.at("abc9.script.default.fast")
-			: RTLIL::constpad.at("abc9.script.default");
+		abc9_script += fast_mode ? RTLIL::constpad.at("abc9.script.default.fast").substr(1,std::string::npos)
+			: RTLIL::constpad.at("abc9.script.default").substr(1,std::string::npos);
 	} else
 		log_abort();
 
@@ -732,11 +732,11 @@ struct Abc9Pass : public Pass {
 	Abc9Pass() : Pass("abc9", "use ABC9 for technology mapping") { }
 	void on_register() YS_OVERRIDE
 	{
-		RTLIL::constpad["abc9.script.default"] = "&scorr; &sweep; &dc2; &dch -f; &ps; &if {C} {W} {D} {R} -v; &mfs";
-		RTLIL::constpad["abc9.script.default.area"] = "&scorr; &sweep; &dc2; &dch -f; &ps; &if {C} {W} {D} {R} -a -v; &mfs";
-		RTLIL::constpad["abc9.script.default.fast"] = "&if {C} {W} {D} {R}";
+		RTLIL::constpad["abc9.script.default"] = "+&scorr; &sweep; &dc2; &dch -f; &ps; &if {C} {W} {D} {R} -v; &mfs";
+		RTLIL::constpad["abc9.script.default.area"] = "+&scorr; &sweep; &dc2; &dch -f; &ps; &if {C} {W} {D} {R} -a -v; &mfs";
+		RTLIL::constpad["abc9.script.default.fast"] = "+&if {C} {W} {D} {R}";
 		// Based on ABC's &flow
-		RTLIL::constpad["abc9.script.flow"] = "&scorr; &sweep;" \
+		RTLIL::constpad["abc9.script.flow"] = "+&scorr; &sweep;" \
 			/* Round 1 */ \
 			"&unmap; &if {C} {W} {D} {R}; &mfs;" \
 			"&st; &dsdb;" \
@@ -753,7 +753,7 @@ struct Abc9Pass : public Pass {
 			"&blut -a -K 6;" \
 			"&unmap; &if {C} {W} {D} {R} -v; &mfs";
 		// Based on ABC's &flow2
-		RTLIL::constpad["abc9.script.flow2"] = "&scorr; &sweep;" \
+		RTLIL::constpad["abc9.script.flow2"] = "+&scorr; &sweep;" \
 			/* Comm1 */ "&synch2 -K 6 -C 500; &if -m {C} {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save;"\
 			/* Comm2 */ "&dch -C 500; &if -m {C} {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save;"\
 			"&load; &st; &sopb -R 10 -C 4; " \
@@ -761,7 +761,7 @@ struct Abc9Pass : public Pass {
 			/* Comm2 */ "&dch -C 500; &if -m {C} {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save; "\
 			"&load";
 		// Based on ABC's &flow3
-		RTLIL::constpad["abc9.script.flow3"] = "&scorr; &sweep;" \
+		RTLIL::constpad["abc9.script.flow3"] = "+&scorr; &sweep;" \
 			"&if {C} {W} {D}; &save; &st; &syn2; &if {C} {W} {D} {R} -v; &save; &load;"\
 			"&st; &if {C} -g -K 6; &dch -f; &if {C} {W} {D} {R} -v; &save; &load;"\
 			"&st; &if {C} -g -K 6; &synch2; &if {C} {W} {D} {R} -v; &save; &load;"\

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -810,14 +810,14 @@ struct Abc9Pass : public Pass {
 		log("        if no -script parameter is given, the following scripts are used:\n");
 		log("\n");
 		log("        for -lut/-luts:\n");
-		log("%s\n", fold_abc9_cmd(RTLIL::constpad.at("abc9.script.default")).c_str()+1);
+		log("%s\n", fold_abc9_cmd(RTLIL::constpad.at("abc9.script.default").substr(1,std::string::npos)).c_str());
 		log("\n");
 		log("    -fast\n");
 		log("        use different default scripts that are slightly faster (at the cost\n");
 		log("        of output quality):\n");
 		log("\n");
 		log("        for -lut/-luts:\n");
-		log("%s\n", fold_abc9_cmd(RTLIL::constpad.at("abc9.script.default.fast")).c_str()+1);
+		log("%s\n", fold_abc9_cmd(RTLIL::constpad.at("abc9.script.default.fast").substr(1,std::string::npos)).c_str());
 		log("\n");
 		log("    -D <picoseconds>\n");
 		log("        set delay target. the string {D} in the default scripts above is\n");

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -563,7 +563,6 @@ struct SynthXilinxPass : public ScriptPass
 					abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k).c_str());
 				else
 					abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k).c_str());
-				abc9_opts += " -nomfs";
 				if (nowidelut)
 					abc9_opts += " -lut +/xilinx/abc9_xc7_nowide.lut";
 				else

--- a/tests/techmap/abc9.ys
+++ b/tests/techmap/abc9.ys
@@ -1,0 +1,40 @@
+read_verilog <<EOT
+`define N 256
+module top(input [`N-1:0] a, output o);
+wire [`N-2:0] w;
+assign w[0] = a[0] & a[1];
+genvar i;
+generate for (i = 1; i < `N-1; i++)
+assign w[i] = w[i-1] & a[i+1];
+endgenerate
+assign o = w[`N-2];
+endmodule
+EOT
+simplemap
+dump
+design -save gold
+
+abc9 -lut 4
+
+design -load gold
+abc9 -lut 4 -fast
+
+design -load gold
+scratchpad -copy abc9.script.default.area abc9.script
+abc9 -lut 4
+
+design -load gold
+scratchpad -copy abc9.script.default.fast abc9.script
+abc9 -lut 4
+
+design -load gold
+scratchpad -copy abc9.script.flow abc9.script
+abc9 -lut 4
+
+design -load gold
+scratchpad -copy abc9.script.flow2 abc9.script
+abc9 -lut 4
+
+design -load gold
+scratchpad -copy abc9.script.flow3 abc9.script
+abc9 -lut 4


### PR DESCRIPTION
~DEPENDENCY: #1622~

Example usage:
`scratchpad -copy abc9.script.flow3 abc9.script` before `synth_xilinx -abc9`

* Added an `RTLIL::constpad` global for storing constant things that can be read from and copied into a design's scratchpad (initialised by `Pass::on_register()`) -- readable but not writable by the `scratchpad` command
* Added the following constpad entries for now:
```
abc9.script.default # (as before)
abc9.script.default.area # (as abc9.script.default, but with the "-a" option to &if)
abc9.script.default.fast # (as before)
abc9.script.flow
abc9.script.flow2
abc9.script.flow3
```
* `abc9.if.C` to control `&if -C`
* `abc9.if.R` to control `&if -R`
* `abc9.debug` as alias to `abc9.nocleanup` and `abc9.showtmp`
* `abc9.verify` to add `verify [-s]` to end of script