### PR TITLE
Export wire properties in EDIF

### DIFF
--- a/backends/edif/edif.cc
+++ b/backends/edif/edif.cc
@@ -326,7 +326,7 @@ struct EdifBackend : public Backend {
 				continue;
 
 			SigMap sigmap(module);
-			std::map<RTLIL::SigSpec, std::set<std::string>> net_join_db;	
+			std::map<RTLIL::SigSpec, std::set<std::string>> net_join_db;
 
 			*f << stringf("    (cell %s\n", EDIF_DEF(module->name));
 			*f << stringf("      (cellType GENERIC)\n");

--- a/backends/edif/edif.cc
+++ b/backends/edif/edif.cc
@@ -300,13 +300,33 @@ struct EdifBackend : public Backend {
 		*f << stringf("  (library DESIGN\n");
 		*f << stringf("    (edifLevel 0)\n");
 		*f << stringf("    (technology (numberDefinition))\n");
+
+		auto add_prop = [&](IdString name, Const val) {
+			if ((val.flags & RTLIL::CONST_FLAG_STRING) != 0)
+				*f << stringf("\n            (property %s (string \"%s\"))", EDIF_DEF(name), val.decode_string().c_str());
+			else if (val.bits.size() <= 32 && RTLIL::SigSpec(val).is_fully_def())
+				*f << stringf("\n            (property %s (integer %u))", EDIF_DEF(name), val.as_int());
+			else {
+				std::string hex_string = "";
+				for (size_t i = 0; i < val.bits.size(); i += 4) {
+					int digit_value = 0;
+					if (i+0 < val.bits.size() && val.bits.at(i+0) == RTLIL::State::S1) digit_value |= 1;
+					if (i+1 < val.bits.size() && val.bits.at(i+1) == RTLIL::State::S1) digit_value |= 2;
+					if (i+2 < val.bits.size() && val.bits.at(i+2) == RTLIL::State::S1) digit_value |= 4;
+					if (i+3 < val.bits.size() && val.bits.at(i+3) == RTLIL::State::S1) digit_value |= 8;
+					char digit_str[2] = { "0123456789abcdef"[digit_value], 0 };
+					hex_string = std::string(digit_str) + hex_string;
+				}
+				*f << stringf("\n            (property %s (string \"%d'h%s\"))", EDIF_DEF(name), GetSize(val.bits), hex_string.c_str());
+			}
+		};		
 		for (auto module : sorted_modules)
 		{
 			if (module->get_blackbox_attribute())
 				continue;
 
 			SigMap sigmap(module);
-			std::map<RTLIL::SigSpec, std::set<std::string>> net_join_db;
+			std::map<RTLIL::SigSpec, std::set<std::string>> net_join_db;	
 
 			*f << stringf("    (cell %s\n", EDIF_DEF(module->name));
 			*f << stringf("      (cellType GENERIC)\n");
@@ -323,14 +343,23 @@ struct EdifBackend : public Backend {
 				else if (!wire->port_input)
 					dir = "OUTPUT";
 				if (wire->width == 1) {
-					*f << stringf("          (port %s (direction %s))\n", EDIF_DEF(wire->name), dir);
+					*f << stringf("          (port %s (direction %s)", EDIF_DEF(wire->name), dir);
+					if (attr_properties)
+						for (auto &p : wire->attributes)
+							add_prop(p.first, p.second);
+					*f << ")\n";
 					RTLIL::SigSpec sig = sigmap(RTLIL::SigSpec(wire));
 					net_join_db[sig].insert(stringf("(portRef %s)", EDIF_REF(wire->name)));
 				} else {
 					int b[2];
 					b[wire->upto ? 0 : 1] = wire->start_offset;
 					b[wire->upto ? 1 : 0] = wire->start_offset + GetSize(wire) - 1;
-					*f << stringf("          (port (array %s %d) (direction %s))\n", EDIF_DEFR(wire->name, port_rename, b[0], b[1]), wire->width, dir);
+					*f << stringf("          (port (array %s %d) (direction %s)", EDIF_DEFR(wire->name, port_rename, b[0], b[1]), wire->width, dir);
+					if (attr_properties)
+						for (auto &p : wire->attributes)
+							add_prop(p.first, p.second);
+
+					*f << ")\n";
 					for (int i = 0; i < wire->width; i++) {
 						RTLIL::SigSpec sig = sigmap(RTLIL::SigSpec(wire, i));
 						net_join_db[sig].insert(stringf("(portRef (member %s %d))", EDIF_REF(wire->name), GetSize(wire)-i-1));
@@ -348,27 +377,6 @@ struct EdifBackend : public Backend {
 				*f << stringf("          (instance %s\n", EDIF_DEF(cell->name));
 				*f << stringf("            (viewRef VIEW_NETLIST (cellRef %s%s))", EDIF_REF(cell->type),
 						lib_cell_ports.count(cell->type) > 0 ? " (libraryRef LIB)" : "");
-
-				auto add_prop = [&](IdString name, Const val) {
-					if ((val.flags & RTLIL::CONST_FLAG_STRING) != 0)
-						*f << stringf("\n            (property %s (string \"%s\"))", EDIF_DEF(name), val.decode_string().c_str());
-					else if (val.bits.size() <= 32 && RTLIL::SigSpec(val).is_fully_def())
-						*f << stringf("\n            (property %s (integer %u))", EDIF_DEF(name), val.as_int());
-					else {
-						std::string hex_string = "";
-						for (size_t i = 0; i < val.bits.size(); i += 4) {
-							int digit_value = 0;
-							if (i+0 < val.bits.size() && val.bits.at(i+0) == RTLIL::State::S1) digit_value |= 1;
-							if (i+1 < val.bits.size() && val.bits.at(i+1) == RTLIL::State::S1) digit_value |= 2;
-							if (i+2 < val.bits.size() && val.bits.at(i+2) == RTLIL::State::S1) digit_value |= 4;
-							if (i+3 < val.bits.size() && val.bits.at(i+3) == RTLIL::State::S1) digit_value |= 8;
-							char digit_str[2] = { "0123456789abcdef"[digit_value], 0 };
-							hex_string = std::string(digit_str) + hex_string;
-						}
-						*f << stringf("\n            (property %s (string \"%d'h%s\"))", EDIF_DEF(name), GetSize(val.bits), hex_string.c_str());
-					}
-				};
-
 				for (auto &p : cell->parameters)
 					add_prop(p.first, p.second);
 				if (attr_properties)
@@ -431,8 +439,12 @@ struct EdifBackend : public Backend {
 						*f << stringf("            (portRef %c (instanceRef GND))\n", gndvccy ? 'Y' : 'G');
 					if (sig == RTLIL::State::S1)
 						*f << stringf("            (portRef %c (instanceRef VCC))\n", gndvccy ? 'Y' : 'P');
-				}
-				*f << stringf("          ))\n");
+				}				
+				*f << stringf("            )");
+				if (attr_properties && sig.wire != NULL)
+					for (auto &p : sig.wire->attributes)
+						add_prop(p.first, p.second);
+				*f << stringf("\n          )\n");
 			}
 			*f << stringf("        )\n");
 			*f << stringf("      )\n");

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -515,7 +515,7 @@ struct SynthXilinxPass : public ScriptPass
 				techmap_args += " -map +/xilinx/arith_map.v";
 				if (vpr)
 					techmap_args += " -D _EXPLICIT_CARRY";
-				else if (abc9)
+				else
 					techmap_args += " -D _CLB_CARRY";
 			}
 			run("techmap " + techmap_args);

--- a/tests/arch/xilinx/add_sub.ys
+++ b/tests/arch/xilinx/add_sub.ys
@@ -4,8 +4,8 @@ proc
 equiv_opt -assert -map +/xilinx/cells_sim.v synth_xilinx -noiopad # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
-select -assert-count 14 t:LUT2
-select -assert-count 6 t:MUXCY
-select -assert-count 8 t:XORCY
-select -assert-none t:LUT2 t:MUXCY t:XORCY %% t:* %D
+stat
+select -assert-count 16 t:LUT2
+select -assert-count 2 t:CARRY4
+select -assert-none t:LUT2 t:CARRY4 %% t:* %D
 

--- a/tests/arch/xilinx/counter.ys
+++ b/tests/arch/xilinx/counter.ys
@@ -5,10 +5,9 @@ flatten
 equiv_opt -async2sync -assert -map +/xilinx/cells_sim.v synth_xilinx -noiopad # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
-
+stat
 select -assert-count 1 t:BUFG
 select -assert-count 8 t:FDCE
 select -assert-count 1 t:INV
-select -assert-count 7 t:MUXCY
-select -assert-count 8 t:XORCY
-select -assert-none t:BUFG t:FDCE t:INV t:MUXCY t:XORCY %% t:* %D
+select -assert-count 2 t:CARRY4
+select -assert-none t:BUFG t:FDCE t:INV t:CARRY4 %% t:* %D

--- a/tests/arch/xilinx/fsm.ys
+++ b/tests/arch/xilinx/fsm.ys
@@ -14,6 +14,6 @@ select -assert-count 1 t:BUFG
 select -assert-count 4 t:FDRE
 select -assert-count 1 t:FDSE
 select -assert-count 1 t:LUT2
-select -assert-count 2 t:LUT3
-select -assert-count 4 t:LUT5
-select -assert-none t:BUFG t:FDRE t:FDSE t:LUT2 t:LUT3 t:LUT5 %% t:* %D
+select -assert-count 3 t:LUT5
+select -assert-count 1 t:LUT6
+select -assert-none t:BUFG t:FDRE t:FDSE t:LUT2 t:LUT5 t:LUT6 %% t:* %D

--- a/tests/arch/xilinx/fsm.ys
+++ b/tests/arch/xilinx/fsm.ys
@@ -9,11 +9,11 @@ sat -verify -prove-asserts -show-public -set-at 1 in_reset 1 -seq 20 -prove-skip
 
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd fsm # Constrain all select calls below inside the top module
-
+stat
 select -assert-count 1 t:BUFG
 select -assert-count 4 t:FDRE
 select -assert-count 1 t:FDSE
 select -assert-count 1 t:LUT2
-select -assert-count 3 t:LUT5
-select -assert-count 1 t:LUT6
-select -assert-none t:BUFG t:FDRE t:FDSE t:LUT2 t:LUT5 t:LUT6 %% t:* %D
+select -assert-count 2 t:LUT3
+select -assert-count 4 t:LUT5
+select -assert-none t:BUFG t:FDRE t:FDSE t:LUT2 t:LUT3 t:LUT5 %% t:* %D


### PR DESCRIPTION
In Yosys+Vivado flow preserving DONT_TOUCH in EDIF is essential to make design work on real hardware.
Also used CARRY4 for abc1 pass for adder, otherwise design is not possible to place if there are dont_touch attributes set on wires for XORCY/MUXCY