### PR TITLE
edif: Just ignore connections to 'z

### DIFF
--- a/backends/edif/edif.cc
+++ b/backends/edif/edif.cc
@@ -404,6 +404,8 @@ struct EdifBackend : public Backend {
 						for (auto &ref : it.second)
 							log_warning("Exporting x-bit on %s as zero bit.\n", ref.c_str());
 						sig = RTLIL::State::S0;
+					} else if (sig == RTLIL::State::Sz) {
+						continue;
 					} else {
 						for (auto &ref : it.second)
 							log_error("Don't know how to handle %s on %s.\n", log_signal(sig), ref.c_str());


### PR DESCRIPTION
Connecting a const 'z to a net should be equivalent to not connecting it
at all, so let's just ignore such connections on output.

Reported by heijligen on IRC.