### PR TITLE
print_stats footer to return peak memory, option for including children

### DIFF
--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -564,6 +564,7 @@ int main(int argc, char **argv)
 #ifdef _WIN32
 		log("End of script. Logfile hash: %s\n", hash.c_str());
 #else
+		std::string meminfo;
 		std::string stats_divider = ", ";
 
 		struct rusage ru_buffer;
@@ -577,10 +578,13 @@ int main(int argc, char **argv)
 			ru_buffer.ru_stime.tv_usec += ru_buffer_children.ru_stime.tv_usec;
 			ru_buffer.ru_maxrss = std::max(ru_buffer.ru_maxrss, ru_buffer_children.ru_maxrss);
 		}
-		log("End of script. Logfile hash: %s%sCPU: user %.2fs system %.2fs, MEM: %.2f MB peak\n", hash.c_str(),
-				stats_divider.c_str(), ru_buffer.ru_utime.tv_sec + 1e-6 * ru_buffer.ru_utime.tv_usec,
-				ru_buffer.ru_stime.tv_sec + 1e-6 * ru_buffer.ru_stime.tv_usec,
+#  if defined(__linux__) || defined(__FreeBSD__)
+		meminfo = stringf(", MEM: %.2f MB peak",
 				ru_buffer.ru_maxrss / 1024.0);
+#endif
+		log("End of script. Logfile hash: %s%sCPU: user %.2fs system %.2fs%s\n", hash.c_str(),
+				stats_divider.c_str(), ru_buffer.ru_utime.tv_sec + 1e-6 * ru_buffer.ru_utime.tv_usec,
+				ru_buffer.ru_stime.tv_sec + 1e-6 * ru_buffer.ru_stime.tv_usec, meminfo.c_str());
 #endif
 		log("%s\n", yosys_version_str);
 

--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -564,39 +564,23 @@ int main(int argc, char **argv)
 #ifdef _WIN32
 		log("End of script. Logfile hash: %s\n", hash.c_str());
 #else
-		std::string meminfo;
 		std::string stats_divider = ", ";
-#  if defined(__linux__)
-		std::ifstream statm;
-		statm.open(stringf("/proc/%lld/statm", (long long)getpid()));
-		if (statm.is_open()) {
-			int sz_total, sz_resident;
-			statm >> sz_total >> sz_resident;
-			meminfo = stringf(", MEM: %.2f MB total, %.2f MB resident",
-					sz_total * (getpagesize() / 1024.0 / 1024.0),
-					sz_resident * (getpagesize() / 1024.0 / 1024.0));
-			stats_divider = "\n";
-		}
-#  elif defined(__FreeBSD__)
-		pid_t pid = getpid();
-		int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, (int)pid};
-		struct kinfo_proc kip;
-		size_t kip_len = sizeof(kip);
-		if (sysctl(mib, 4, &kip, &kip_len, NULL, 0) == 0) {
-			vm_size_t sz_total = kip.ki_size;
-			segsz_t sz_resident = kip.ki_rssize;
-			meminfo = stringf(", MEM: %.2f MB total, %.2f MB resident",
-				(int)sz_total / 1024.0 / 1024.0,
-				(int)sz_resident * (getpagesize() / 1024.0 / 1024.0));
-			stats_divider = "\n";
-		}
-#  endif
 
 		struct rusage ru_buffer;
 		getrusage(RUSAGE_SELF, &ru_buffer);
-		log("End of script. Logfile hash: %s%sCPU: user %.2fs system %.2fs%s\n", hash.c_str(),
+		if (yosys_design->scratchpad_get_bool("print_stats.include_children")) {
+			struct rusage ru_buffer_children;
+			getrusage(RUSAGE_CHILDREN, &ru_buffer_children);
+			ru_buffer.ru_utime.tv_sec += ru_buffer_children.ru_utime.tv_sec;
+			ru_buffer.ru_utime.tv_usec += ru_buffer_children.ru_utime.tv_usec;
+			ru_buffer.ru_stime.tv_sec += ru_buffer_children.ru_stime.tv_sec;
+			ru_buffer.ru_stime.tv_usec += ru_buffer_children.ru_stime.tv_usec;
+			ru_buffer.ru_maxrss = std::max(ru_buffer.ru_maxrss, ru_buffer_children.ru_maxrss);
+		}
+		log("End of script. Logfile hash: %s%sCPU: user %.2fs system %.2fs, MEM: %.2f MB peak\n", hash.c_str(),
 				stats_divider.c_str(), ru_buffer.ru_utime.tv_sec + 1e-6 * ru_buffer.ru_utime.tv_usec,
-				ru_buffer.ru_stime.tv_sec + 1e-6 * ru_buffer.ru_stime.tv_usec, meminfo.c_str());
+				ru_buffer.ru_stime.tv_sec + 1e-6 * ru_buffer.ru_stime.tv_usec,
+				ru_buffer.ru_maxrss / 1024.0);
 #endif
 		log("%s\n", yosys_version_str);
 


### PR DESCRIPTION
Use `ru_maxrss` for peak memory utilisation, rather than two current memory values on exit.

`scratchpad -set print_stats.include_children 1` to include runtime and peak memory usage of child processes.