### PR TITLE
Enum support

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,17 @@ Verilog Attributes and non-standard features
         ...
       endmodule
 
+- The ``wiretype`` attribute is added by the verilog parser for wires of a
+  typedef'd type to indicate the type identifier.
+
+- Various ``enum_{width}_{value}`` attributes are added to wires of an
+  enumerated type to give a map of possible enum items to their values.
+
+- The ``enum_base_type`` attribute is added to enum items to indicate which
+  enum they belong to (enums -- anonymous and otherwise -- are
+  automatically named with an auto-incrementing counter). Note that enums
+  are currently not strongly typed.
+
 - A limited subset of DPI-C functions is supported. The plugin mechanism
   (see ``help plugin``) can be used to load .so files with implementations
   of DPI-C routines. As a non-standard extension it is possible to specify
@@ -527,6 +538,12 @@ from SystemVerilog:
   SystemVerilog files being read into the same design afterwards.
 
 - typedefs are supported (including inside packages)
+	- type identifiers must currently be enclosed in (parentheses) when declaring
+	  signals of that type (this is syntactically incorrect SystemVerilog)
+	- type casts are currently not supported
+
+- enums are supported (including inside packages)
+	- but are currently not strongly typed
 
 - SystemVerilog interfaces (SVIs) are supported. Modports for specifying whether
   ports are inputs or outputs are supported.

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -88,6 +88,8 @@ std::string AST::type2str(AstNodeType type)
 	X(AST_LIVE)
 	X(AST_FAIR)
 	X(AST_COVER)
+	X(AST_ENUM)
+	X(AST_ENUM_ITEM)
 	X(AST_FCALL)
 	X(AST_TO_BITS)
 	X(AST_TO_SIGNED)
@@ -202,6 +204,7 @@ AstNode::AstNode(AstNodeType type, AstNode *child1, AstNode *child2, AstNode *ch
 	is_logic = false;
 	is_signed = false;
 	is_string = false;
+	is_enum = false;
 	is_wand = false;
 	is_wor = false;
 	is_unsized = false;
@@ -320,6 +323,9 @@ void AstNode::dumpAst(FILE *f, std::string indent) const
 		for (int v : multirange_dimensions)
 			fprintf(f, " %d", v);
 		fprintf(f, " ]");
+	}
+	if (is_enum) {
+		fprintf(f, " type=enum");
 	}
 	fprintf(f, "\n");
 
@@ -1174,7 +1180,15 @@ void AST::process(RTLIL::Design *design, AstNode *ast, bool dump_ast1, bool dump
 			for (auto n : design->verilog_packages){
 				for (auto o : n->children) {
 					AstNode *cloned_node = o->clone();
-					cloned_node->str = n->str + std::string("::") + cloned_node->str.substr(1);
+					log("cloned node %s\n", type2str(cloned_node->type).c_str());
+					if (cloned_node->type == AST_ENUM){
+						for (auto e : cloned_node->children){
+							log_assert(e->type == AST_ENUM_ITEM);
+							e->str = n->str + std::string("::") + e->str.substr(1);
+						}
+					} else {
+						cloned_node->str = n->str + std::string("::") + cloned_node->str.substr(1);
+					}
 					(*it)->children.push_back(cloned_node);
 				}
 			}
@@ -1203,10 +1217,13 @@ void AST::process(RTLIL::Design *design, AstNode *ast, bool dump_ast1, bool dump
 
 			design->add(process_module(*it, defer));
 		}
-		else if ((*it)->type == AST_PACKAGE)
+		else if ((*it)->type == AST_PACKAGE) {
 			design->verilog_packages.push_back((*it)->clone());
-		else
+		}
+		else {
+			// must be global definition
 			design->verilog_globals.push_back((*it)->clone());
+		}
 	}
 }
 

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -1222,6 +1222,7 @@ void AST::process(RTLIL::Design *design, AstNode *ast, bool dump_ast1, bool dump
 		}
 		else {
 			// must be global definition
+			(*it)->simplify(false, false, false, 1, -1, false, false); //process enum/other declarations
 			design->verilog_globals.push_back((*it)->clone());
 		}
 	}

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -68,6 +68,8 @@ namespace AST
 		AST_LIVE,
 		AST_FAIR,
 		AST_COVER,
+		AST_ENUM,
+		AST_ENUM_ITEM,
 
 		AST_FCALL,
 		AST_TO_BITS,
@@ -181,6 +183,8 @@ namespace AST
 		int port_id, range_left, range_right;
 		uint32_t integer;
 		double realvalue;
+		// set for IDs typed to an enumeration, not used
+		bool is_enum;
 
 		// if this is a multirange memory then this vector contains offset and length of each dimension
 		std::vector<int> multirange_dimensions;
@@ -285,6 +289,9 @@ namespace AST
 		int isConst() const; // return '1' for AST_CONSTANT and '2' for AST_REALVALUE
 		double asReal(bool is_signed);
 		RTLIL::Const realAsConst(int width);
+
+		// helpers for enum
+		void allocateDefaultEnumValues();
 	};
 
 	// process an AST tree (ast must point to an AST_DESIGN node) and generate RTLIL code

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -595,6 +595,9 @@ void AstNode::detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *foun
 
 	switch (type)
 	{
+	case AST_NONE:
+		// unallocated enum, ignore
+		break;
 	case AST_CONSTANT:
 		width_hint = max(width_hint, int(bits.size()));
 		if (!is_signed)
@@ -612,7 +615,7 @@ void AstNode::detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *foun
 			id_ast = current_scope.at(str);
 		if (!id_ast)
 			log_file_error(filename, linenum, "Failed to resolve identifier %s for width detection!\n", str.c_str());
-		if (id_ast->type == AST_PARAMETER || id_ast->type == AST_LOCALPARAM) {
+		if (id_ast->type == AST_PARAMETER || id_ast->type == AST_LOCALPARAM || id_ast->type == AST_ENUM_ITEM) {
 			if (id_ast->children.size() > 1 && id_ast->children[1]->range_valid) {
 				this_width = id_ast->children[1]->range_left - id_ast->children[1]->range_right + 1;
 			} else
@@ -861,6 +864,7 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 	case AST_GENIF:
 	case AST_GENCASE:
 	case AST_PACKAGE:
+	case AST_ENUM:
 	case AST_MODPORT:
 	case AST_MODPORTMEMBER:
 	case AST_TYPEDEF:
@@ -1022,7 +1026,7 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 				else
 					log_file_error(filename, linenum, "Identifier `%s' is implicitly declared and `default_nettype is set to none.\n", str.c_str());
 			}
-			else if (id2ast->type == AST_PARAMETER || id2ast->type == AST_LOCALPARAM) {
+			else if (id2ast->type == AST_PARAMETER || id2ast->type == AST_LOCALPARAM || id2ast->type == AST_ENUM_ITEM) {
 				if (id2ast->children[0]->type != AST_CONSTANT)
 					log_file_error(filename, linenum, "Parameter %s does not evaluate to constant value!\n", str.c_str());
 				chunk = RTLIL::Const(id2ast->children[0]->bits);

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -324,7 +324,7 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 		const_fold = true;
 
 	// in certain cases a function must be evaluated constant. this is what in_param controls.
-	if (type == AST_PARAMETER || type == AST_LOCALPARAM || type == AST_LOCALPARAM || type == AST_ENUM_ITEM || type == AST_DEFPARAM || type == AST_PARASET || type == AST_PREFIX)
+	if (type == AST_PARAMETER || type == AST_LOCALPARAM || type == AST_ENUM_ITEM || type == AST_DEFPARAM || type == AST_PARASET || type == AST_PREFIX)
 		in_param = true;
 
 	std::map<std::string, AstNode*> backup_scope;
@@ -1089,8 +1089,10 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 				case AST_TASK:
 				case AST_DPI_FUNCTION:
 					//log("found child %s, %s\n", type2str(node->type).c_str(), node->str.c_str());
-					log("add %s, type %s to scope\n", str.c_str(), type2str(node->type).c_str());
-					current_scope[node->str] = node;
+					if (str == node->str) {
+						log("add %s, type %s to scope\n", str.c_str(), type2str(node->type).c_str());
+						current_scope[node->str] = node;
+					}
 					break;
 				case AST_ENUM:
 					for (auto enum_node : node->children) {
@@ -1327,7 +1329,7 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 			}
 
 			if (buf->type != AST_CONSTANT)
-				log_file_error(filename, linenum, "Right hand side of 3rd expression of generate for-loop is not constant!\n");
+				log_file_error(filename, linenum, "Right hand side of 3rd expression of generate for-loop is not constant (%s)!\n", type2str(buf->type).c_str());
 
 			delete varbuf->children[0];
 			varbuf->children[0] = buf;

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -2637,10 +2637,9 @@ skip_dynamic_range_lvalue_expansion:;
 					wire->is_output = false;
 					wire->is_reg = true;
 					wire->attributes["\\nosync"] = AstNode::mkconst_int(1, false);
-					if (child->type == AST_ENUM_ITEM){
+					if (child->type == AST_ENUM_ITEM)
 						wire->attributes["\\enum_base_type"] = child->attributes["\\enum_base_type"];
 
-					}
 					wire_cache[child->str] = wire;
 
 					current_ast_mod->children.push_back(wire);

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -428,6 +428,13 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 			if (node->type == AST_PARAMETER || node->type == AST_LOCALPARAM || node->type == AST_WIRE || node->type == AST_AUTOWIRE || node->type == AST_MEMORY || node->type == AST_TYPEDEF)
 				while (node->simplify(true, false, false, 1, -1, false, node->type == AST_PARAMETER || node->type == AST_LOCALPARAM))
 					did_something = true;
+			if (node->type == AST_ENUM) {
+				for (auto enode : node->children){
+					log_assert(enode->type==AST_ENUM_ITEM);
+					while (node->simplify(true, false, false, 1, -1, false, node->type == AST_ENUM_ITEM))
+						did_something = true;
+				}
+			}
 		}
 	}
 

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -3097,6 +3097,26 @@ void AstNode::expand_genblock(std::string index_var, std::string prefix, std::ma
 				child->str = new_name;
 			current_scope[new_name] = child;
 		}
+		if (child->type == AST_ENUM){
+			for (auto enode : child->children){
+				log_assert(enode->type == AST_ENUM_ITEM);
+				if (backup_name_map.size() == 0)
+					backup_name_map = name_map;
+				std::string new_name = prefix[0] == '\\' ? prefix.substr(1) : prefix;
+				size_t pos = enode->str.rfind('.');
+				if (pos == std::string::npos)
+					pos = enode->str[0] == '\\' && prefix[0] == '\\' ? 1 : 0;
+				else
+					pos = pos + 1;
+				new_name = enode->str.substr(0, pos) + new_name + enode->str.substr(pos);
+				if (new_name[0] != '$' && new_name[0] != '\\')
+					new_name = prefix[0] + new_name;
+				name_map[enode->str] = new_name;
+
+				enode->str = new_name;
+				current_scope[new_name] = enode;
+			}
+		}
 	}
 
 	for (size_t i = 0; i < children.size(); i++) {

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -108,6 +108,20 @@ struct specify_rise_fall {
 	specify_triple fall;
 };
 
+static AstNode *makeRange(int msb = 31, int lsb = 0, bool isSigned = true)
+{
+	auto range = new AstNode(AST_RANGE);
+	range->children.push_back(AstNode::mkconst_int(msb, true));
+	range->children.push_back(AstNode::mkconst_int(lsb, true));
+	range->is_signed = isSigned;
+	return range;
+}
+
+static void addRange(AstNode *parent, int msb = 31, int lsb = 0, bool isSigned = true)
+{
+	auto range = makeRange(msb, lsb, isSigned);
+	parent->children.push_back(range);
+}
 %}
 
 %define api.prefix {frontend_verilog_yy}
@@ -157,6 +171,7 @@ struct specify_rise_fall {
 %type <ast> range range_or_multirange  non_opt_range non_opt_multirange range_or_signed_int
 %type <ast> wire_type expr basic_expr concat_list rvalue lvalue lvalue_concat_list
 %type <string> opt_label opt_sva_label tok_prim_wrapper hierarchical_id hierarchical_type_id
+%type <ast> opt_enum_init
 %type <boolean> opt_signed opt_property unique_case_attr always_comb_or_latch always_or_always_ff
 %type <al> attr case_attr
 
@@ -428,7 +443,9 @@ package:
 	};
 
 package_body:
-	package_body package_body_stmt |;
+	package_body package_body_stmt
+	| // optional
+	;
 
 package_body_stmt:
 	typedef_decl |
@@ -604,6 +621,7 @@ module_body:
 
 module_body_stmt:
 	task_func_decl | specify_block | param_decl | localparam_decl | typedef_decl | defparam_decl | specparam_declaration | wire_decl | assign_stmt | cell_stmt |
+	enum_decl |
 	always_stmt | TOK_GENERATE module_gen_body TOK_ENDGENERATE | defattr | assert_property | checker_decl | ignored_specify_block;
 
 checker_decl:
@@ -1223,6 +1241,77 @@ single_defparam_decl:
 			node->children.push_back($1);
 		ast_stack.back()->children.push_back(node);
 	};
+
+enum_type: TOK_ENUM {
+		// create parent node for the enum
+		astbuf2 = new AstNode(AST_ENUM);
+		ast_stack.back()->children.push_back(astbuf2);
+		// create the template for the names
+		astbuf1 = new AstNode(AST_ENUM_ITEM);
+		astbuf1->children.push_back(AstNode::mkconst_int(0, true));
+	 } param_signed enum_base_type '{' enum_name_list '}' {  // create template for the enum vars
+								auto tnode = astbuf1->clone();
+								delete astbuf1;
+								astbuf1 = tnode;
+								tnode->type = AST_WIRE;
+								// drop constant but keep any range
+								delete tnode->children[0];
+								tnode->children.erase(tnode->children.begin()); }
+	 ;
+
+enum_base_type: int_vec param_range
+	| int_atom
+	| /* nothing */		{ addRange(astbuf1); }
+	;
+
+int_atom: TOK_INTEGER		{ addRange(astbuf1); }		// probably should do byte, range [7:0] here
+	;
+
+int_vec: TOK_REG		{ astbuf1->is_reg = true; }	// lexer returns this for logic|bit too
+	;
+
+enum_name_list:
+	enum_name_decl
+	| enum_name_list ',' enum_name_decl
+	;
+
+enum_name_decl:
+	TOK_ID opt_enum_init {
+		// put in fn
+		log_assert(astbuf1);
+		log_assert(astbuf2);
+		auto node = astbuf1->clone();
+		node->str = *$1;
+		delete $1;
+		delete node->children[0];
+		node->children[0] = $2 ?: new AstNode(AST_NONE);
+		astbuf2->children.push_back(node);
+	}
+	;
+
+opt_enum_init:
+	'=' basic_expr		{ $$ = $2; }	// TODO: restrict this
+	| /* optional */	{ $$ = NULL; }
+	;
+
+enum_var_list:
+	enum_var
+	| enum_var_list ',' enum_var
+	;
+
+enum_var: TOK_ID {
+		log_assert(astbuf1);
+		log_assert(astbuf2);
+		auto node = astbuf1->clone();
+		ast_stack.back()->children.push_back(node);
+		node->str = *$1;
+		delete $1;
+		node->is_enum = true;
+	}
+	;
+
+enum_decl: enum_type enum_var_list ';'			{ delete astbuf1; }
+	;
 
 wire_decl:
 	attr wire_type range {

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -1261,13 +1261,14 @@ enum_type: TOK_ENUM {
 
 enum_base_type: int_vec param_range
 	| int_atom
-	| /* nothing */		{ addRange(astbuf1); }
+	| /* nothing */		{astbuf1->is_reg = true; addRange(astbuf1); }
 	;
 
-int_atom: TOK_INTEGER		{ addRange(astbuf1); }		// probably should do byte, range [7:0] here
+int_atom: TOK_INTEGER		{astbuf1->is_reg=true; addRange(astbuf1); }		// probably should do byte, range [7:0] here
 	;
 
-int_vec: TOK_REG		{ astbuf1->is_reg = true; }	// lexer returns this for logic|bit too
+int_vec: TOK_REG {astbuf1->is_reg = true;}
+	| TOK_LOGIC  {astbuf1->is_logic = true;}
 	;
 
 enum_name_list:

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -1243,9 +1243,12 @@ single_defparam_decl:
 	};
 
 enum_type: TOK_ENUM {
+		static int enum_count;
 		// create parent node for the enum
 		astbuf2 = new AstNode(AST_ENUM);
 		ast_stack.back()->children.push_back(astbuf2);
+		astbuf2->str = std::string("$enum");
+		astbuf2->str += std::to_string(enum_count++);
 		// create the template for the names
 		astbuf1 = new AstNode(AST_ENUM_ITEM);
 		astbuf1->children.push_back(AstNode::mkconst_int(0, true));
@@ -1254,6 +1257,7 @@ enum_type: TOK_ENUM {
 								delete astbuf1;
 								astbuf1 = tnode;
 								tnode->type = AST_WIRE;
+								tnode->attributes["\\enum_type"] = AstNode::mkconst_str(astbuf2->str);
 								// drop constant but keep any range
 								delete tnode->children[0];
 								tnode->children.erase(tnode->children.begin()); }
@@ -1311,7 +1315,10 @@ enum_var: TOK_ID {
 	}
 	;
 
-enum_decl: enum_type enum_var_list ';'			{ delete astbuf1; }
+enum_decl: enum_type enum_var_list ';'			{
+		//enum_type creates astbuf1 for use by typedef only
+		delete astbuf1;
+	}
 	;
 
 wire_decl:

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -1523,7 +1523,12 @@ typedef_decl:
 
 		ast_stack.back()->children.push_back(new AstNode(AST_TYPEDEF, astbuf1));
 		ast_stack.back()->children.back()->str = *$4;
-	};
+	} |
+	TOK_TYPEDEF enum_type TOK_ID ';' {
+		ast_stack.back()->children.push_back(new AstNode(AST_TYPEDEF, astbuf1));
+		ast_stack.back()->children.back()->str = *$3;
+	}
+	;
 
 cell_stmt:
 	attr TOK_ID {

--- a/tests/svtypes/enum_simple.sv
+++ b/tests/svtypes/enum_simple.sv
@@ -1,0 +1,47 @@
+
+module enum_simple(input clk, input rst);
+
+	enum {s0, s1, s2, s3} test_enum;
+	typedef enum logic [1:0] {
+		ts0, ts1, ts2, ts3
+	} states_t;
+	(states_t) state;
+	(states_t) enum_const = s1;
+
+	always @(posedge clk) begin
+		if (rst) begin
+			test_enum <= s3;
+			state <= ts0;
+		end else begin
+			//test_enum
+			if (test_enum == s0)
+				test_enum <= s1;
+			else if (test_enum == s1)
+				test_enum <= s2;
+			else if (test_enum == s2)
+				test_enum <= s3;
+			else if (test_enum == s3)
+				test_enum <= s0;
+			else
+				assert(1'b0); //should be unreachable
+
+			//state
+			if (state == ts0)
+				state <= ts1;
+			else if (state == ts1)
+				state <= ts2;
+			else if (state == ts2)
+				state <= ts0;
+			else
+				assert(1'b0); //should be unreachable
+		end
+	end
+
+	always @(*) begin
+		assert(state != 2'h3);
+		assert(s0 == '0);
+		assert(ts0 == '0);
+		assert(enum_const == s1);
+	end
+
+endmodule

--- a/tests/svtypes/enum_simple.sv
+++ b/tests/svtypes/enum_simple.sv
@@ -6,7 +6,7 @@ module enum_simple(input clk, input rst);
 		ts0, ts1, ts2, ts3
 	} states_t;
 	(states_t) state;
-	(states_t) enum_const = s1;
+	(states_t) enum_const = ts1;
 
 	always @(posedge clk) begin
 		if (rst) begin
@@ -41,7 +41,7 @@ module enum_simple(input clk, input rst);
 		assert(state != 2'h3);
 		assert(s0 == '0);
 		assert(ts0 == '0);
-		assert(enum_const == s1);
+		assert(enum_const == ts1);
 	end
 
 endmodule

--- a/tests/svtypes/enum_simple.ys
+++ b/tests/svtypes/enum_simple.ys
@@ -1,0 +1,5 @@
+
+read_verilog -sv enum_simple.sv
+hierarchy; proc; opt
+sat -verify -seq 1 -set-at 1 rst 1 -tempinduct -prove-asserts -show-all
+

--- a/tests/svtypes/typedef_package.sv
+++ b/tests/svtypes/typedef_package.sv
@@ -1,11 +1,14 @@
 package pkg;
 	typedef logic [7:0] uint8_t;
+	typedef enum logic [7:0] {bb=8'hBB} enum8_t;
 endpackage
 
 module top;
 
 	(* keep *) (pkg::uint8_t) a = 8'hAA;
+	(* keep *) (pkg::enum8_t) b_enum = pkg::bb;
 
 	always @* assert(a == 8'hAA);
+	always @* assert(b_enum == 8'hBB);
 
 endmodule

--- a/tests/svtypes/typedef_scopes.sv
+++ b/tests/svtypes/typedef_scopes.sv
@@ -27,7 +27,7 @@ module top;
 	end
 
 	(inner_type) inner_i2 = 8'h42;
-	(inner_type) inner_enum2 = s4;
+	(inner_enum_t) inner_enum2 = s4;
 	always @(*) assert(inner_i2 == 4'h2);
 	always @(*) assert(inner_enum2 == 3'h4);
 

--- a/tests/svtypes/typedef_scopes.sv
+++ b/tests/svtypes/typedef_scopes.sv
@@ -1,23 +1,35 @@
 
 typedef logic [3:0] outer_uint4_t;
+typedef enum logic {s0, s1} outer_enum_t;
 
 module top;
 
 	(outer_uint4_t) u4_i = 8'hA5;
+	(outer_enum_t) enum4_i = s0;
 	always @(*) assert(u4_i == 4'h5);
+	always @(*) assert(enum4_i == 1'b0);
 
 	typedef logic [3:0] inner_type;
+	typedef enum logic [2:0] {s2=2, s3, s4} inner_enum_t;
 	(inner_type) inner_i1 = 8'h5A;
+	(inner_enum_t) inner_enum1 = s3;
 	always @(*) assert(inner_i1 == 4'hA);
+	always @(*) assert(inner_enum1 == 3'h3);
 
 	if (1) begin: genblock
 		typedef logic [7:0] inner_type;
-		(inner_type) inner_gb_i = 8'hA5;
+		parameter (inner_type) inner_const = 8'hA5;
+ 		typedef enum logic [2:0] {s5=5, s6, s7} inner_enum_t;
+		(inner_type) inner_gb_i = inner_const; //8'hA5;
+ 		(inner_enum_t) inner_gb_enum1 = s7;
 		always @(*) assert(inner_gb_i == 8'hA5);
+ 		always @(*) assert(inner_gb_enum1 == 3'h7);
 	end
 
 	(inner_type) inner_i2 = 8'h42;
+	(inner_type) inner_enum2 = s4;
 	always @(*) assert(inner_i2 == 4'h2);
+	always @(*) assert(inner_enum2 == 3'h4);
 
 
 endmodule


### PR DESCRIPTION
I rebased PeterCrozier's enum work onto current master
    
I tried to keep only the enum-related changes, and minimize the diff. (The original commit also had a lot of work done to get typedefs working, but yosys has diverged quite a bit since the 2018-03-09 commit, with a new typedef implementation https://github.com/YosysHQ/yosys/pull/1389.) I did not include the import related changes either.

I added support for enum typedefs at the toplevel scope and in generate if blocks, and some simple tests. It works so far for my purposes, but any comments are welcome. The enums are currently not strongly typed.

Resolves #248
    
Original commit:
"Initial implementation of enum, typedef, import.  Still a WIP."
https://github.com/PeterCrozier/yosys/commit/881833aa738e7404987646ea8076284e911fce3f