### PR TITLE
ast: Add support for $sformatf system function

### DIFF
--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -244,6 +244,7 @@ namespace AST
 		void replace_variables(std::map<std::string, varinfo_t> &variables, AstNode *fcall);
 		AstNode *eval_const_function(AstNode *fcall);
 		bool is_simple_const_expr();
+		std::string process_format_str(const std::string &sformat, int next_arg, int stage, int width_hint, bool sign_hint);
 
 		// create a human-readable text representation of the AST (for debugging)
 		void dumpAst(FILE *f, std::string indent) const;

--- a/tests/various/sformatf.ys
+++ b/tests/various/sformatf.ys
@@ -1,0 +1,12 @@
+read_verilog <<EOT
+
+module top;
+	localparam a = $sformatf("0x%x", 8'h5A);
+	localparam b = $sformatf("%d", 4'b011);
+	generate
+		if (a != "0x5a") $error("a incorrect!");
+		if (b != "3") $error("b incorrect!");
+	endgenerate
+endmodule
+
+EOT


### PR DESCRIPTION
This refactors the formatting code used by $display and $write into a function that is then also be used to implement the ~$sprintf~ $sformatf system function; which I want to use in the CrossLink-NX support as Radiant tends to use C-style parameters in Verilog strings rather than Verilog numeric parameters... (and it would be best to stay compatible).

edit: just after submitting the PR I realised the standard-compliant name is $sformatf, not $sprintf (which is some kind of non-standard feature), derp.