### PR TITLE
read_verilog: allow width detection of unreachable ternary operation branches to fail

### DIFF
--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -250,8 +250,8 @@ namespace AST
 		void dumpVlog(FILE *f, std::string indent) const;
 
 		// used by genRTLIL() for detecting expression width and sign
-		void detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *found_real = NULL);
-		void detectSignWidth(int &width_hint, bool &sign_hint, bool *found_real = NULL);
+		void detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *found_real = NULL, bool can_fail = false);
+		void detectSignWidth(int &width_hint, bool &sign_hint, bool *found_real = NULL, bool can_fail = false);
 
 		// create RTLIL code for this AST node
 		// for expressions the resulting signal vector is returned

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -769,8 +769,10 @@ void AstNode::detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *foun
 		break;
 
 	case AST_TERNARY:
-		children.at(1)->detectSignWidthWorker(width_hint, sign_hint, found_real);
-		children.at(2)->detectSignWidthWorker(width_hint, sign_hint, found_real);
+		if (children.at(0)->type != AST_CONSTANT || children.at(0)->asBool())
+			children.at(1)->detectSignWidthWorker(width_hint, sign_hint, found_real);
+		if (children.at(0)->type != AST_CONSTANT || !children.at(0)->asBool())
+			children.at(2)->detectSignWidthWorker(width_hint, sign_hint, found_real);
 		break;
 
 	case AST_MEMRD:
@@ -1334,18 +1336,31 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 				detectSignWidth(width_hint, sign_hint);
 
 			RTLIL::SigSpec cond = children[0]->genRTLIL();
-			RTLIL::SigSpec val1 = children[1]->genRTLIL(width_hint, sign_hint);
-			RTLIL::SigSpec val2 = children[2]->genRTLIL(width_hint, sign_hint);
+			RTLIL::SigSpec sig;
+			if (cond.is_fully_const()) {
+				if (cond.as_bool()) {
+					sig = children[1]->genRTLIL(width_hint, sign_hint);
+					widthExtend(this, sig, sig.size(), children[1]->is_signed);
+				}
+				else {
+					sig = children[2]->genRTLIL(width_hint, sign_hint);
+					widthExtend(this, sig, sig.size(), children[2]->is_signed);
+				}
+			}
+			else {
+				RTLIL::SigSpec val1 = children[1]->genRTLIL(width_hint, sign_hint);
+				RTLIL::SigSpec val2 = children[2]->genRTLIL(width_hint, sign_hint);
 
-			if (cond.size() > 1)
-				cond = uniop2rtlil(this, "$reduce_bool", 1, cond, false);
+				if (cond.size() > 1)
+					cond = uniop2rtlil(this, "$reduce_bool", 1, cond, false);
 
-			int width = max(val1.size(), val2.size());
-			is_signed = children[1]->is_signed && children[2]->is_signed;
-			widthExtend(this, val1, width, is_signed);
-			widthExtend(this, val2, width, is_signed);
+				int width = max(val1.size(), val2.size());
+				is_signed = children[1]->is_signed && children[2]->is_signed;
+				widthExtend(this, val1, width, is_signed);
+				widthExtend(this, val2, width, is_signed);
 
-			RTLIL::SigSpec sig = mux2rtlil(this, cond, val1, val2);
+				sig = mux2rtlil(this, cond, val1, val2);
+			}
 
 			if (sig.size() < width_hint)
 				sig.extend_u0(width_hint, sign_hint);

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -769,10 +769,8 @@ void AstNode::detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *foun
 		break;
 
 	case AST_TERNARY:
-		if (children.at(0)->type != AST_CONSTANT || children.at(0)->asBool())
-			children.at(1)->detectSignWidthWorker(width_hint, sign_hint, found_real);
-		if (children.at(0)->type != AST_CONSTANT || !children.at(0)->asBool())
-			children.at(2)->detectSignWidthWorker(width_hint, sign_hint, found_real);
+		children.at(1)->detectSignWidthWorker(width_hint, sign_hint, found_real);
+		children.at(2)->detectSignWidthWorker(width_hint, sign_hint, found_real);
 		break;
 
 	case AST_MEMRD:
@@ -1336,31 +1334,18 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 				detectSignWidth(width_hint, sign_hint);
 
 			RTLIL::SigSpec cond = children[0]->genRTLIL();
-			RTLIL::SigSpec sig;
-			if (cond.is_fully_const()) {
-				if (cond.as_bool()) {
-					sig = children[1]->genRTLIL(width_hint, sign_hint);
-					widthExtend(this, sig, sig.size(), children[1]->is_signed);
-				}
-				else {
-					sig = children[2]->genRTLIL(width_hint, sign_hint);
-					widthExtend(this, sig, sig.size(), children[2]->is_signed);
-				}
-			}
-			else {
-				RTLIL::SigSpec val1 = children[1]->genRTLIL(width_hint, sign_hint);
-				RTLIL::SigSpec val2 = children[2]->genRTLIL(width_hint, sign_hint);
+			RTLIL::SigSpec val1 = children[1]->genRTLIL(width_hint, sign_hint);
+			RTLIL::SigSpec val2 = children[2]->genRTLIL(width_hint, sign_hint);
 
-				if (cond.size() > 1)
-					cond = uniop2rtlil(this, "$reduce_bool", 1, cond, false);
+			if (cond.size() > 1)
+				cond = uniop2rtlil(this, "$reduce_bool", 1, cond, false);
 
-				int width = max(val1.size(), val2.size());
-				is_signed = children[1]->is_signed && children[2]->is_signed;
-				widthExtend(this, val1, width, is_signed);
-				widthExtend(this, val2, width, is_signed);
+			int width = max(val1.size(), val2.size());
+			is_signed = children[1]->is_signed && children[2]->is_signed;
+			widthExtend(this, val1, width, is_signed);
+			widthExtend(this, val2, width, is_signed);
 
-				sig = mux2rtlil(this, cond, val1, val2);
-			}
+			RTLIL::SigSpec sig = mux2rtlil(this, cond, val1, val2);
 
 			if (sig.size() < width_hint)
 				sig.extend_u0(width_hint, sign_hint);

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -572,6 +572,7 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 	case AST_TERNARY:
 		detect_width_simple = true;
 		child_0_is_self_determined = true;
+		while (children[0]->simplify(true, false, false, 1, -1, false, false)) { }
 		break;
 
 	case AST_MEMRD:
@@ -605,9 +606,11 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 	if (type == AST_TERNARY) {
 		int width_hint_left, width_hint_right;
 		bool sign_hint_left, sign_hint_right;
-		bool found_real_left, found_real_right;
-		children[1]->detectSignWidth(width_hint_left, sign_hint_left, &found_real_left);
-		children[2]->detectSignWidth(width_hint_right, sign_hint_right, &found_real_right);
+		bool found_real_left = false, found_real_right = false;
+		if (children[0]->type != AST_CONSTANT || children[0]->asBool())
+			children[1]->detectSignWidth(width_hint_left, sign_hint_left, &found_real_left);
+		if (children[0]->type != AST_CONSTANT || !children[0]->asBool())
+			children[2]->detectSignWidth(width_hint_right, sign_hint_right, &found_real_right);
 		if (found_real_left || found_real_right) {
 			child_1_is_self_determined = true;
 			child_2_is_self_determined = true;

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -606,8 +606,10 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 		int width_hint_left, width_hint_right;
 		bool sign_hint_left, sign_hint_right;
 		bool found_real_left, found_real_right;
-		children[1]->detectSignWidth(width_hint_left, sign_hint_left, &found_real_left);
-		children[2]->detectSignWidth(width_hint_right, sign_hint_right, &found_real_right);
+		children[1]->detectSignWidth(width_hint_left, sign_hint_left, &found_real_left,
+				children[0]->type == AST_CONSTANT && !children[0]->asBool() /* can_fail */);
+		children[2]->detectSignWidth(width_hint_right, sign_hint_right, &found_real_right,
+				children[0]->type == AST_CONSTANT && children[0]->asBool() /* can_fail */);
 		if (found_real_left || found_real_right) {
 			child_1_is_self_determined = true;
 			child_2_is_self_determined = true;

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -572,7 +572,6 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 	case AST_TERNARY:
 		detect_width_simple = true;
 		child_0_is_self_determined = true;
-		while (children[0]->simplify(true, false, false, 1, -1, false, false)) { }
 		break;
 
 	case AST_MEMRD:
@@ -606,11 +605,9 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 	if (type == AST_TERNARY) {
 		int width_hint_left, width_hint_right;
 		bool sign_hint_left, sign_hint_right;
-		bool found_real_left = false, found_real_right = false;
-		if (children[0]->type != AST_CONSTANT || children[0]->asBool())
-			children[1]->detectSignWidth(width_hint_left, sign_hint_left, &found_real_left);
-		if (children[0]->type != AST_CONSTANT || !children[0]->asBool())
-			children[2]->detectSignWidth(width_hint_right, sign_hint_right, &found_real_right);
+		bool found_real_left, found_real_right;
+		children[1]->detectSignWidth(width_hint_left, sign_hint_left, &found_real_left);
+		children[2]->detectSignWidth(width_hint_right, sign_hint_right, &found_real_right);
 		if (found_real_left || found_real_right) {
 			child_1_is_self_determined = true;
 			child_2_is_self_determined = true;

--- a/tests/arch/efinix/mux.ys
+++ b/tests/arch/efinix/mux.ys
@@ -36,6 +36,6 @@ proc
 equiv_opt -assert -map +/efinix/cells_sim.v synth_efinix # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux16 # Constrain all select calls below inside the top module
-select -assert-count 12 t:EFX_LUT4
+select -assert-count 11 t:EFX_LUT4
 
 select -assert-none t:EFX_LUT4 %% t:* %D

--- a/tests/various/bug1649.ys
+++ b/tests/various/bug1649.ys
@@ -1,0 +1,43 @@
+read_verilog <<EOT
+module delay #(parameter width=2, taps=1)(
+       input clk,
+       input [width-1:0] d_in,
+       output reg [width-1:0] d_out
+);
+
+generate
+        genvar k;
+        reg [width-1:0] mem[0:taps-1];
+
+        for (k=0;k<taps;k=k+1) begin : delay_gen
+                always @(posedge clk) begin
+						//if (k == 0)
+						//	mem[k] = d_in;
+						//else
+						//	mem[k] = mem[k-1];
+                        mem[k] <= k==0 ? d_in : mem[k-1]; // <<<<<<<<< ERROR IS HERE
+                end
+        end
+endgenerate
+
+always @(posedge clk) begin
+        b <= mem[taps-1];
+end
+
+endmodule
+
+
+module top (input clk, input wire [3:0] a, output wire [3:0] b);
+        delay #(.width(4), .taps(1))  d(clk, a, b);
+endmodule
+EOT
+
+
+design -reset
+read_verilog <<EOT
+module top(output o1, o2);
+wire i [0:0]; // Only errors out on unpacked...
+assign o1 = (0 == 0) ? i[0] : i[-1];
+assign o2 = (1 > 1) ? i[1] : i[0];
+endmodule
+EOT


### PR DESCRIPTION
Fixes #1649, and fixes even something as simple as this:
```
module top(output o1, o2);
wire i [0:0]; // Only errors out on unpacked...
assign o1 = (0 == 0) ? i[0] : i[-1];
assign o2 = (1 > 1) ? i[1] : i[0];
endmodule
```
where one branch is unreachable.

I'm not sure how other tools handle both testcases (perhaps OP @jeremyherbert would be so kind to check) but I see no reason not to implement this. I've been bitten a few times by this that I've committed using `generate-if` to muscle-memory at the expense of elegance.