### PR TITLE
verific: unflatten struct ports

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -1891,6 +1891,9 @@ void verific_import(Design *design, const std::map<std::string,std::string> &par
 	if (!verific_error_msg.empty())
 		log_error("%s\n", verific_error_msg.c_str());
 
+	for (auto nl : nl_todo)
+	    nl->ChangePortBusStructures(1 /* hierarchical */);
+
 	VerificExtNets worker;
 	for (auto nl : nl_todo)
 		worker.run(nl);

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -2470,6 +2470,9 @@ struct VerificPass : public Pass {
 					worker.run(nl);
 			}
 
+			for (auto nl : nl_todo)
+				nl->ChangePortBusStructures(1 /* hierarchical */);
+
 			if (!dumpfile.empty()) {
 				VeriWrite veri_writer;
 				veri_writer.WriteFile(dumpfile.c_str(), Netlist::PresentDesign());


### PR DESCRIPTION
Fixes YosysHQ/SymbiYosys#69.

Previously:
```
$ ./yosys -Qp "verific -sv bug69.sv; verific -import -all; dump i:in*"

-- Running command `verific -sv bug69.sv; verific -import -all; dump i:in*' --

1. Executing VERIFIC (loading SystemVerilog and VHDL designs using Verific).
Built with Verific Dec19_SW_Release, released at Tue Dec 31 23:22:23 2019.
VERIFIC-COMMENT [VERI-1482] Analyzing Verilog file 'bug69.sv'

2. Executing VERIFIC (loading SystemVerilog and VHDL designs using Verific).
Built with Verific Dec19_SW_Release, released at Tue Dec 31 23:22:23 2019.
Running hier_tree::ElaborateAll().
VERIFIC-INFO [VERI-1018] bug69.sv:6: compiling module 'mcve'
Importing module mcve.
Importing module \$unit_bug69_sv.


  attribute \src "bug69.sv:6"
  wire width 2 input 1 \in
```

Now:
```
$ ./yosys -Qp "verific -sv bug69.sv; verific -import -all; dump i:in*"

-- Running command `verific -sv bug69.sv; verific -import -all; dump i:in*' --

1. Executing VERIFIC (loading SystemVerilog and VHDL designs using Verific).
Built with Verific Dec19_SW_Release, released at Tue Dec 31 23:22:23 2019.
VERIFIC-COMMENT [VERI-1482] Analyzing Verilog file 'bug69.sv'

2. Executing VERIFIC (loading SystemVerilog and VHDL designs using Verific).
Built with Verific Dec19_SW_Release, released at Tue Dec 31 23:22:23 2019.
Running hier_tree::ElaborateAll().
VERIFIC-INFO [VERI-1018] bug69.sv:6: compiling module 'mcve'
Importing module mcve.
Importing module \$unit_bug69_sv.


  attribute \src "bug69.sv:6"
  wire input 2 \in.other

  attribute \src "bug69.sv:6"
  wire input 1 \in.element
```