### PR TITLE
opt_reduce: Call check() per run rather than per optimised cell

### DIFF
--- a/passes/opt/opt_reduce.cc
+++ b/passes/opt/opt_reduce.cc
@@ -235,7 +235,6 @@ struct OptReduceWorker
 			log("      New connections: %s = %s\n", log_signal(old_sig_conn.first), log_signal(old_sig_conn.second));
 
 			module->connect(old_sig_conn);
-			module->check();
 
 			did_something = true;
 			total_count++;
@@ -324,6 +323,8 @@ struct OptReduceWorker
 				opt_mux(cell);
 			}
 		}
+
+		module->check();
 	}
 };
 


### PR DESCRIPTION
This avoids effectively n^2 performance scaling on designs where there is a lot of opt_reduce, Chisel output seems particularly liable to this.