### PR TITLE
Make RTLIL attributes accessible via pyosys

### DIFF
--- a/misc/py_wrap_generator.py
+++ b/misc/py_wrap_generator.py
@@ -914,7 +914,7 @@ class WClass:
 		body = self.gen_boost_py_body()
 		base_info = ""
 		if self.base_class is not None:
-			base_info = ", bases<%s::%s>" % (self.base_class.namespace, self.base_class.name)
+			base_info = ", bases<" + (self.base_class.name) + ">"
 
 		if self.link_type == link_types.derive:
 			text = "\n\t\tclass_<" + self.name + base_info + ">(\"Cpp" + self.name + "\""

--- a/misc/py_wrap_generator.py
+++ b/misc/py_wrap_generator.py
@@ -721,6 +721,7 @@ class WClass:
 	name = None
 	namespace = None
 	link_type = None
+	base_class = None
 	id_ = None
 	string_id = None
 	hash_id = None
@@ -732,6 +733,7 @@ class WClass:
 	def __init__(self, name, link_type, id_, string_id = None, hash_id = None, needs_clone = False):
 		self.name = name
 		self.namespace = None
+		self.base_class = None
 		self.link_type = link_type
 		self.id_ = id_
 		self.string_id = string_id
@@ -1971,9 +1973,21 @@ def parse_header(source):
 			for namespace in impl_namespaces:
 				complete_namespace += "::" + namespace
 			debug("\tFound " + struct_name + " in " + complete_namespace,2)
+
+			base_class_name = None
+			if len(ugly_line.split(" : ")) > 1: # class is derived
+				deriv_str = ugly_line.split(" : ")[1]
+				if len(deriv_str.split("::")) > 1: # namespace of base class is given
+					base_class_name = deriv_str.split("::", 1)[1]
+				else:
+					base_class_name = deriv_str.split(" ")[0]
+				debug("\t  " + struct_name + " is derived from " + base_class_name,2)
+			base_class = class_by_name(base_class_name)
+
 			class_ = (class_by_name(struct_name), ugly_line.count("{"))#calc_ident(line))
 			if struct_name in classnames:
 				class_[0].namespace = complete_namespace
+				class_[0].base_class = base_class
 			i += 1
 			continue
 
@@ -2142,6 +2156,21 @@ def expand_functions():
 				new_funs.extend(expand_function(fun))
 			class_.found_funs = new_funs
 
+def inherit_members():
+	for source in sources:
+		for class_ in source.classes:
+			if class_.base_class:
+				base_funs = copy.deepcopy(class_.base_class.found_funs)
+				for fun in base_funs:
+					fun.member_of = class_
+					fun.namespace = class_.namespace
+				base_vars = copy.deepcopy(class_.base_class.found_vars)
+				for var in base_vars:
+					var.member_of = class_
+					var.namespace = class_.namespace
+				class_.found_funs.extend(base_funs)
+				class_.found_vars.extend(base_vars)
+
 def clean_duplicates():
 	for source in sources:
 		for class_ in source.classes:
@@ -2178,6 +2207,7 @@ def gen_wrappers(filename, debug_level_ = 0):
 		parse_header(source)
 
 	expand_functions()
+	inherit_members()
 	clean_duplicates()
 
 	import shutil

--- a/misc/py_wrap_generator.py
+++ b/misc/py_wrap_generator.py
@@ -806,6 +806,8 @@ class WClass:
 
 			for con in self.found_constrs:
 				text += con.gen_decl()
+			if self.base_class is not None:
+				text += "\n\t\tvirtual ~" + self.name + "() { };"
 			for var in self.found_vars:
 				text += var.gen_decl()
 			for fun in self.found_funs:
@@ -910,15 +912,19 @@ class WClass:
 
 	def gen_boost_py(self):
 		body = self.gen_boost_py_body()
+		base_info = ""
+		if self.base_class is not None:
+			base_info = ", bases<%s::%s>" % (self.base_class.namespace, self.base_class.name)
+
 		if self.link_type == link_types.derive:
-			text = "\n\t\tclass_<" + self.name + ">(\"Cpp" + self.name + "\""
+			text = "\n\t\tclass_<" + self.name + base_info + ">(\"Cpp" + self.name + "\""
 			text += body
 			text += "\n\t\tclass_<" + self.name
 			text += "Wrap, boost::noncopyable"
 			text += ">(\"" + self.name + "\""
 			text += body
 		else:
-			text = "\n\t\tclass_<" + self.name + ">(\"" + self.name + "\""
+			text = "\n\t\tclass_<" + self.name + base_info + ">(\"" + self.name + "\""
 			text += body
 		return text
 	


### PR DESCRIPTION
Currently, the pyosys wrapper generator disregards any information on inheritance. As most of the RTLIL classes (Module, Cell, Wire, ...) derive their attribute capabilites from AttrObject, their accessors are lost during wrapper generation.

This patch adds a basic notion of inheritance to the wrapper generation process. Now one can do:

```
[thasti@pc]$ cat test.v 
module test();
    (* my_attr = 1 *) wire attrwire;
endmodule

[thasti@pc]$ cat yo.py 
from pyosys import libyosys as ys

design = ys.Design()
ys.run_pass("read_verilog test.v", design)
mod = design.module(ys.IdString("\\test"))
print("Module Source Attribute: %s " % mod.get_src_attribute())
wire = mod.wire(ys.IdString(ys.IdString("\\attrwire")))
print("All Wire Attributes: %s" % wire.attributes)

[thasti@pc]$ python yo.py 

-- Running command `read_verilog test.v' --

1. Executing Verilog-2005 frontend: test.v
Parsing Verilog input from `test.v' to AST representation.
Generating RTLIL representation for module `\test'.
Successfully finished Verilog frontend.
Module Source Attribute: test.v:1 
All Wire Attributes: {IdString "\my_attr": Const "00000000000000000000000000000001", IdString "\src": Const "0111010001100101011100110111010000101110011101100011101000110010"}
[thasti@pc]$ 
```