### PR TITLE
xilinx: use RAM32M/RAM64M for memories with two read ports

### DIFF
--- a/techlibs/xilinx/lutrams.txt
+++ b/techlibs/xilinx/lutrams.txt
@@ -153,7 +153,7 @@ endmatch
 
 match $__XILINX_RAM32X2Q
   min bits 5
-  min rports 3
+  min rports 2
   min wports 1
   make_outreg
   or_next_if_better
@@ -161,7 +161,7 @@ endmatch
 
 match $__XILINX_RAM64X1Q
   min bits 5
-  min rports 3
+  min rports 2
   min wports 1
   make_outreg
 endmatch


### PR DESCRIPTION
This fixes inefficient LUT RAM usage for memories with one write
and two read ports (commonly used as register files).