### PR TITLE
Fix crash on wire declaration with delay

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -476,7 +476,7 @@ wire_type:
 		astbuf3 = new AstNode(AST_WIRE);
 		current_wire_rand = false;
 		current_wire_const = false;
-	} wire_type_token_list delay {
+	} wire_type_token_list {
 		$$ = astbuf3;
 	};
 
@@ -1240,7 +1240,7 @@ wire_decl:
 		}
 		if (astbuf2 && astbuf2->children.size() != 2)
 			frontend_verilog_yyerror("wire/reg/logic packed dimension must be of the form: [<expr>:<expr>], [<expr>+:<expr>], or [<expr>-:<expr>]");
-	} wire_name_list {
+	} delay wire_name_list {
 		delete astbuf1;
 		if (astbuf2 != NULL)
 			delete astbuf2;

--- a/tests/various/bug1614.ys
+++ b/tests/various/bug1614.ys
@@ -1,0 +1,5 @@
+read_verilog <<EOT
+module testcase;
+    wire [3:0] #1 a = 4'b0000;
+endmodule
+EOT


### PR DESCRIPTION
Fixes a minor bug in the verilog frontend that caused #1614. The previous grammar accepted syntax that both iverilog and verilator flagged as invalid. Testcase added as in the reported issue. Please review, I'm not sure whether my fix missed some part of the verilog spec and broke something else.

## Post-Patch
Testcase as in #1614 now parses successfully, syntax also accepted by iverilog and verilator.
```
[thasti@pc]$ cat delay.v
module testcase;
    wire [3:0] #1 a = 4'b0000;
endmodule

[thasti@pc]$ yosys delay.v
Parsing Verilog input from `/tmp/delay.v' to AST representation.
Time spent: 100% Parsing Verilog input from `/tmp/delay.v' to AST representation.
Generating RTLIL representation for module `\testcase'.
Successfully finished Verilog frontend.

[thasti@pc]$ iverilog /tmp/delay.v 
[no output]

[thasti@pc]$ verilator --lint-only /tmp/delay.v 
[no output]
```

## Pre-Patch 
Previously the following (incorrect) syntax was accepted by yosys (delay specified before range), which is illegal syntax according to iverilog and verilator.
```
[thasti@pc]$ cat delay.v
module testcase;
    wire #1 [3:0] a = 4'b0000;
endmodule

[thasti@pc]$ yosys delay.v
Parsing Verilog input from `/tmp/delay.v' to AST representation.
Generating RTLIL representation for module `\testcase'.
Successfully finished Verilog frontend. <<< Should not finish successfully!

[thasti@pc]$ iverilog /tmp/delay.v 
/tmp/delay.v:2: syntax error
/tmp/delay.v:2: error: invalid module item.

[thasti@pc]$ verilator --lint-only /tmp/delay.v 
%Error: /tmp/delay.v:2: syntax error, unexpected '[', expecting IDENTIFIER or do or final
    wire #1 [3:0] a = 4'b0000;
            ^
%Error: Exiting due to 1 error(s)
```