### PR TITLE
synth_*: call 'opt -fast' after 'techmap'

### DIFF
--- a/techlibs/anlogic/synth_anlogic.cc
+++ b/techlibs/anlogic/synth_anlogic.cc
@@ -175,6 +175,7 @@ struct SynthAnlogicPass : public ScriptPass
 		if (check_label("map_gates"))
 		{
 			run("techmap -map +/techmap.v -map +/anlogic/arith_map.v");
+			run("opt -fast");
 			if (retime || help_mode)
 				run("abc -dff -D 1", "(only if -retime)");
 		}

--- a/techlibs/coolrunner2/synth_coolrunner2.cc
+++ b/techlibs/coolrunner2/synth_coolrunner2.cc
@@ -144,8 +144,8 @@ struct SynthCoolrunner2Pass : public ScriptPass
 		if (check_label("fine"))
 		{
 			run("opt -fast -full");
-			run("techmap");
-			run("techmap -map +/coolrunner2/cells_latch.v");
+			run("techmap -map +/techmap.v -map +/coolrunner2/cells_latch.v");
+			run("opt -fast");
 			run("dfflibmap -prepare -liberty +/coolrunner2/xc2_dff.lib");
 		}
 

--- a/techlibs/ecp5/synth_ecp5.cc
+++ b/techlibs/ecp5/synth_ecp5.cc
@@ -289,6 +289,7 @@ struct SynthEcp5Pass : public ScriptPass
 				run("techmap");
 			else
 				run("techmap -map +/techmap.v -map +/ecp5/arith_map.v");
+			run("opt -fast");
 			if (retime || help_mode)
 				run("abc -dff -D 1", "(only if -retime)");
 		}

--- a/techlibs/efinix/synth_efinix.cc
+++ b/techlibs/efinix/synth_efinix.cc
@@ -175,6 +175,7 @@ struct SynthEfinixPass : public ScriptPass
 		if (check_label("map_gates"))
 		{
 			run("techmap -map +/techmap.v -map +/efinix/arith_map.v");
+			run("opt -fast");
 			if (retime || help_mode)
 				run("abc -dff -D 1", "(only if -retime)");
 		}

--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -211,7 +211,7 @@ struct SynthGowinPass : public ScriptPass
 		if (check_label("map_gates"))
 		{
 			run("techmap -map +/techmap.v -map +/gowin/arith_map.v");
-			run("techmap -map +/techmap.v");
+			run("opt -fast");
 			if (retime || help_mode)
 				run("abc -dff -D 1", "(only if -retime)");
 			run("splitnets");

--- a/techlibs/greenpak4/synth_greenpak4.cc
+++ b/techlibs/greenpak4/synth_greenpak4.cc
@@ -160,8 +160,7 @@ struct SynthGreenPAK4Pass : public ScriptPass
 			run("opt -fast -mux_undef -undriven -fine");
 			run("memory_map");
 			run("opt -undriven -fine");
-			run("techmap");
-			run("techmap -map +/greenpak4/cells_latch.v");
+			run("techmap -map +/techmap.v -map +/greenpak4/cells_latch.v");
 			run("dfflibmap -prepare -liberty +/greenpak4/gp_dff.lib");
 			run("opt -fast");
 			if (retime || help_mode)

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -316,6 +316,7 @@ struct SynthIce40Pass : public ScriptPass
 				run("ice40_wrapcarry");
 				run("techmap -map +/techmap.v -map +/ice40/arith_map.v");
 			}
+			run("opt -fast");
 			if (retime || help_mode)
 				run("abc -dff -D 1", "(only if -retime)");
 			run("ice40_opt");

--- a/techlibs/sf2/synth_sf2.cc
+++ b/techlibs/sf2/synth_sf2.cc
@@ -180,6 +180,7 @@ struct SynthSf2Pass : public ScriptPass
 			run("memory_map");
 			run("opt -undriven -fine");
 			run("techmap -map +/techmap.v -map +/sf2/arith_map.v");
+			run("opt -fast");
 			if (retime || help_mode)
 				run("abc -dff -D 1", "(only if -retime)");
 		}


### PR DESCRIPTION
Necessary post-#1650-with-[fix](4c1d3a126d3978aeacbab623532c0ec9400b8959) at least on `tests/arch/anlogic/mux.ys`, which transforms:
![before](https://user-images.githubusercontent.com/6740044/73902758-a7039b80-484b-11ea-8822-031c7105160a.png)
into
![after](https://user-images.githubusercontent.com/6740044/73902649-55f3a780-484b-11ea-9536-18da39f03e89.png)
which leads to the "optimal" solution of 5xLUT6...
To be honest, I think only a `clean` was strictly necessary but I think there may be value in doing `opt -fast` as done in `synth_xilinx`.

Even though it wasn't necessary for other arches to get back to passing status, I've done the same change for them...