### PR TITLE
write_verilog: dump $mem cell attributes

### DIFF
--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -1066,6 +1066,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 		//  initial begin
 		//    memid[0] = ...
 		//  end
+		dump_attributes(f, indent.c_str(), cell->attributes);
 		f << stringf("%s" "reg [%d:%d] %s [%d:%d];\n", indent.c_str(), width-1, 0, mem_id.c_str(), size+offset-1, offset);
 		if (use_init)
 		{


### PR DESCRIPTION
The Verilog backend already dumps attributes on RTLIL::Memory objects but not on `$mem` cells.