### PR TITLE
Removing cells_sim from GoWin bram techmap

### DIFF
--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -191,7 +191,7 @@ struct SynthGowinPass : public ScriptPass
 		if (!nobram && check_label("map_bram", "(skip if -nobram)"))
 		{
 			run("memory_bram -rules +/gowin/brams.txt");
-			run("techmap -map +/gowin/brams_map.v -map +/gowin/cells_sim.v");
+			run("techmap -map +/gowin/brams_map.v");
 		}
 
 		if (!nolutram && check_label("map_lutram", "(skip if -nolutram)"))


### PR DESCRIPTION
Answering @eddiehung reviews request, I'm fixing one of the comments: 
https://github.com/YosysHQ/yosys/commit/f9272fc56d7179f04a9f776bf056eedfc33dd358#r37144384

the other one: https://github.com/YosysHQ/yosys/commit/f9272fc56d7179f04a9f776bf056eedfc33dd358#r37144371
Makes perfect sense to remove `run("techmap -map +/techmap.v");` since is irrelevant, but `fine` synthesis seems to be replaced for `map_ffram` and `map_gates` in current head, so these lines does not exists in master anymore.