### PR TITLE
Use flowmap instead of gate2lut in noabc modes

### DIFF
--- a/techlibs/common/synth.cc
+++ b/techlibs/common/synth.cc
@@ -78,6 +78,9 @@ struct SynthPass : public ScriptPass
 		log("    -abc9\n");
 		log("        use new ABC9 flow (EXPERIMENTAL)\n");
 		log("\n");
+		log("    -flowmap\n");
+		log("        use FlowMap LUT techmapping instead of ABC\n");
+		log("\n");
 		log("\n");
 		log("The following commands are executed by this synthesis command:\n");
 		help_script();
@@ -85,7 +88,7 @@ struct SynthPass : public ScriptPass
 	}
 
 	string top_module, fsm_opts, memory_opts, abc;
-	bool autotop, flatten, noalumacc, nofsm, noabc, noshare;
+	bool autotop, flatten, noalumacc, nofsm, noabc, noshare, flowmap;
 	int lut;
 
 	void clear_flags() YS_OVERRIDE
@@ -101,6 +104,7 @@ struct SynthPass : public ScriptPass
 		nofsm = false;
 		noabc = false;
 		noshare = false;
+		flowmap = false;
 		abc = "abc";
 	}
 
@@ -167,6 +171,10 @@ struct SynthPass : public ScriptPass
 				abc = "abc9";
 				continue;
 			}
+			if (args[argidx] == "-flowmap") {
+				flowmap = true;
+				continue;
+			}
 			break;
 		}
 		extra_args(args, argidx, design);
@@ -176,6 +184,8 @@ struct SynthPass : public ScriptPass
 
 		if (abc == "abc9" && !lut)
 			log_cmd_error("ABC9 flow only supported for FPGA synthesis (using '-lut' option)\n");
+		if (flowmap && !lut)
+			log_cmd_error("FlowMap is only supported for FPGA synthesis (using '-lut' option)\n");
 
 		log_header(design, "Executing SYNTH pass.\n");
 		log_push();
@@ -240,15 +250,20 @@ struct SynthPass : public ScriptPass
 			{
 				run("techmap -map +/gate2lut.v", "(if -noabc and -lut)");
 				run("clean; opt_lut", "           (if -noabc and -lut)");
+				run("flowmap -maxlut K", "        (if -flowmap and -lut)");
 			}
 			else if (noabc && lut)
 			{
 				run(stringf("techmap -map +/gate2lut.v -D LUT_WIDTH=%d", lut));
 				run("clean; opt_lut");
 			}
+			else if (flowmap)
+			{
+				run(stringf("flowmap -maxlut %d", lut));
+			}
 			run("opt -fast");
 
-			if (!noabc) {
+			if (!noabc && !flowmap) {
 		#ifdef YOSYS_ENABLE_ABC
 				if (help_mode)
 				{

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -96,6 +96,9 @@ struct SynthIce40Pass : public ScriptPass
 		log("    -abc9\n");
 		log("        use new ABC9 flow (EXPERIMENTAL)\n");
 		log("\n");
+        log("    -flowmap\n");
+        log("        use FlowMap LUT techmapping instead of abc (EXPERIMENTAL)\n");
+        log("\n");
 		log("\n");
 		log("The following commands are executed by this synthesis command:\n");
 		help_script();
@@ -103,7 +106,7 @@ struct SynthIce40Pass : public ScriptPass
 	}
 
 	string top_opt, blif_file, edif_file, json_file, device_opt;
-	bool nocarry, nodffe, nobram, dsp, flatten, retime, noabc, abc2, vpr, abc9;
+	bool nocarry, nodffe, nobram, dsp, flatten, retime, noabc, abc2, vpr, abc9, flowmap;
 	int min_ce_use;
 
 	void clear_flags() YS_OVERRIDE
@@ -123,6 +126,7 @@ struct SynthIce40Pass : public ScriptPass
 		abc2 = false;
 		vpr = false;
 		abc9 = false;
+        flowmap = false;
 		device_opt = "hx";
 	}
 
@@ -214,6 +218,10 @@ struct SynthIce40Pass : public ScriptPass
 				device_opt = args[++argidx];
 				continue;
 			}
+            if (args[argidx] == "-flowmap") {
+                flowmap = true;
+                continue;
+            }
 			break;
 		}
 		extra_args(args, argidx, design);
@@ -225,6 +233,13 @@ struct SynthIce40Pass : public ScriptPass
 
 		if (abc9 && retime)
 			log_cmd_error("-retime option not currently compatible with -abc9!\n");
+
+        if (abc9 && noabc)
+            log_cmd_error("-abc9 is incompatible with -noabc!\n");
+        if (abc9 && flowmap)
+            log_cmd_error("-abc9 is incompatible with -flowmap!\n");
+        if (flowmap && noabc)
+            log_cmd_error("-flowmap is incompatible with -noabc!\n");
 
 		log_header(design, "Executing SYNTH_ICE40 pass.\n");
 		log_push();
@@ -346,9 +361,12 @@ struct SynthIce40Pass : public ScriptPass
 				run("ice40_opt", "(only if -abc2)");
 			}
 			run("techmap -map +/ice40/latches_map.v");
-			if (noabc || help_mode) {
-				run("simplemap", "                               (only if -noabc)");
-				run("techmap -map +/gate2lut.v -D LUT_WIDTH=4", "(only if -noabc)");
+			if (noabc || flowmap || help_mode) {
+				run("simplemap", "                               (if -noabc or -flowmap)");
+                if (noabc || help_mode)
+				    run("techmap -map +/gate2lut.v -D LUT_WIDTH=4", "(only if -noabc)");
+                if (flowmap || help_mode)
+                    run("flowmap -maxlut 4", "(only if -flowmap)");
 			}
 			if (!noabc) {
 				if (abc9) {


### PR DESCRIPTION
This is more of a discussion point than a pull request.

The PR itself is simple: use the `flowmap` pass from #775 instead of `techmap -map +/gate2lut.v` for better synthesis quality when using `synth{,_ice40} -noabc`.

![firefox_2020-02-08_17-22-32](https://user-images.githubusercontent.com/1503707/74089297-a5c6ae80-4a97-11ea-9bc7-3ab86b68ceea.png)

But should we just remove `-noabc`, given that only iCE40 even exposes an option for it?
Or should we add `-noabc` option that uses `flowmap` to all flows, so that Yosys does not require ABC for FPGA synthesis?
What about CMOS synthesis, which currently *does* require ABC?