### PR TITLE
json: Change compat mode to directly emit ints <= 32 bits

### DIFF
--- a/backends/json/json.cc
+++ b/backends/json/json.cc
@@ -104,7 +104,7 @@ struct JsonWriter
 			if (state < 2)
 				str += " ";
 			f << get_string(str);
-		} else if (compat_int_mode && GetSize(value) == 32 && value.is_fully_def()) {
+		} else if (compat_int_mode && GetSize(value) <= 32 && value.is_fully_def()) {
 			if ((value.flags & RTLIL::ConstFlags::CONST_FLAG_SIGNED) != 0)
 				f << stringf("%d", value.as_int());
 			else
@@ -296,7 +296,7 @@ struct JsonBackend : public Backend {
 		log("        include AIG models for the different gate types\n");
 		log("\n");
 		log("    -compat-int\n");
-		log("        emit 32-bit fully-defined parameter values directly\n");
+		log("        emit 32-bit or smaller fully-defined parameter values directly\n");
 		log("        as JSON numbers (for compatibility with old parsers)\n");
 		log("\n");
 		log("\n");
@@ -540,7 +540,7 @@ struct JsonPass : public Pass {
 		log("        also include AIG models for the different gate types\n");
 		log("\n");
 		log("    -compat-int\n");
-		log("        emit 32-bit fully-defined parameter values directly\n");
+		log("        emit 32-bit or smaller fully-defined parameter values directly\n");
 		log("        as JSON numbers (for compatibility with old parsers)\n");
 		log("\n");
 		log("See 'help write_json' for a description of the JSON format used.\n");


### PR DESCRIPTION
This increases compatibility with certain older parsers in some cases that worked before commit 15fae357 but do not work with the current compat-int mode

The specific case that I encountered involved flip-flop cells with `INIT` attributes set to 0 (these attributes are created by the `dffinit` pass). For some reason that I didn't fully investigate (because it does not seem to cause any breakage), yosys seems to think that these attributes are 0 bits wide (e.g. `write_verilog` will output `.INIT({0{1'b0}})`). The code prior to commit 15fae357 would have output a 0 into the resulting JSON file, but the code that is currently in master will output an empty string (even with `-compat-int`).

By making `-compat-int` write attributes with <= 32 bits (rather than == 32 bits) as JSON numbers, the behavior should exactly match the pre-15fae357 behavior. 