### PR TITLE
make rpc frontend unix socket test less fragile

### DIFF
--- a/tests/rpc/frontend.py
+++ b/tests/rpc/frontend.py
@@ -31,7 +31,7 @@ end
 
 import json
 import argparse
-import sys, socket, os
+import sys, socket, os, subprocess
 try:
 	import msvcrt, win32pipe, win32file
 except ImportError:
@@ -85,6 +85,7 @@ def main():
 		sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 		sock.bind(args.path)
 		try:
+			ys_proc = subprocess.Popen(["../../yosys", "-ql", "unix.log", "-p", "connect_rpc -path {}; read_verilog design.v; hierarchy -top top; flatten; select -assert-count 1 t:$neg".format(args.path)])
 			sock.listen(1)
 			conn, addr = sock.accept()
 			file = conn.makefile("rw")
@@ -93,7 +94,11 @@ def main():
 				if not input: break
 				file.write(call(input) + "\n")
 				file.flush()
+			ys_proc.wait(timeout=10)
+			if ys_proc.returncode:
+				raise subprocess.CalledProcessError(ys_proc.returncode, ys_proc.args)
 		finally:
+			ys_proc.kill()
 			sock.close()
 			os.unlink(args.path)
 

--- a/tests/rpc/run-test.sh
+++ b/tests/rpc/run-test.sh
@@ -4,3 +4,4 @@ for x in *.ys; do
   echo "Running $x.."
   ../../yosys -ql ${x%.ys}.log $x
 done
+python3 frontend.py unix-socket frontend.sock

--- a/tests/rpc/unix.ys
+++ b/tests/rpc/unix.ys
@@ -1,6 +1,0 @@
-!python3 frontend.py unix-socket frontend.sock & sleep 0.1
-connect_rpc -path frontend.sock
-read_verilog design.v
-hierarchy -top top
-flatten
-select -assert-count 1 t:$neg


### PR DESCRIPTION
The unix socket test of the rpc frontend relies on the command `python3 frontend.py unix-socket frontend.sock` creating the named socket within 0.1 seconds. However, the speed of the test environment isn't really something we want to test here. Waiting longer is also undesirable as it artificially increases the execution time of the test. Moreover, when the script does not execute fast enough, the test leaves behind a running python process and an open socket. (If the test is run a second time it then succeeds by using the instance from the previous run...)

To remedy this problem, this PR puts the python script in charge for the unix-socket test case. Yosys is launched by the python script after the socket is established. In case of any exception both the socket and the yosys process are cleaned up. However it's still possible for the whole thing to hang if readline() doesn't return, not sure if that case needs to be considered.