### PR TITLE
deminout: Don't demote inouts with unused bits

### DIFF
--- a/passes/techmap/deminout.cc
+++ b/passes/techmap/deminout.cc
@@ -121,8 +121,7 @@ struct DeminoutPass : public Pass {
 									goto tribuf_bit;
 							} else {
 						tribuf_bit:
-								if (bits_used.count(bit))
-									new_input = true;
+								new_input = true;
 							}
 						}
 

--- a/tests/various/deminout_unused.ys
+++ b/tests/various/deminout_unused.ys
@@ -1,0 +1,14 @@
+read_verilog <<EOT
+module top(input clk, inout [7:0] x);
+
+reg [3:0] ctr;
+always @(posedge clk) ctr <= ctr + 1'b1;
+
+assign x[7:4] = ctr;
+endmodule
+EOT
+proc
+tribuf
+deminout
+select -assert-count 1 i:x o:x %i
+


### PR DESCRIPTION
Previously, `deminout` was converting `inout` ports with unused bits to outputs with those bits driving 'x', which doesn't seem like a sound transformation to me as those unused bits should be high-z.

example case:
```verilog
module top(input clk, inout [7:0] x);

reg [3:0] ctr;
always @(posedge clk) ctr <= ctr + 1'b1;

assign x[7:4] = ctr;
endmodule
````
```
yosys -p "synth_ecp5; dump" tri.v
``` 