### PR TITLE
xilinx: mark IOBUFDSE3 IOB pin as external

### DIFF
--- a/techlibs/xilinx/cells_xtra.py
+++ b/techlibs/xilinx/cells_xtra.py
@@ -376,7 +376,7 @@ CELLS = [
     Cell('IOBUFDS_DIFF_OUT', port_attrs={'IO': ['iopad_external_pin'], 'IOB': ['iopad_external_pin']}),
     Cell('IOBUFDS_DIFF_OUT_DCIEN', port_attrs={'IO': ['iopad_external_pin'], 'IOB': ['iopad_external_pin']}),
     Cell('IOBUFDS_DIFF_OUT_INTERMDISABLE', port_attrs={'IO': ['iopad_external_pin'], 'IOB': ['iopad_external_pin']}),
-    Cell('IOBUFDSE3', port_attrs={'IO': ['iopad_external_pin']}),
+    Cell('IOBUFDSE3', port_attrs={'IO': ['iopad_external_pin'], 'IOB': ['iopad_external_pin']}),
     # Output.
     # Cell('OBUF', port_attrs={'O': ['iopad_external_pin']}),
     Cell('OBUFDS', port_attrs={'O': ['iopad_external_pin'], 'OB': ['iopad_external_pin']}),

--- a/techlibs/xilinx/cells_xtra.v
+++ b/techlibs/xilinx/cells_xtra.v
@@ -7559,6 +7559,7 @@ module IOBUFDSE3 (...);
     output O;
     (* iopad_external_pin *)
     inout IO;
+    (* iopad_external_pin *)
     inout IOB;
     input DCITERMDISABLE;
     input I;


### PR DESCRIPTION
While using a Yosys-Vivado flow I've noticed an issue with how `IOB` in `IOBUFDSE3` was handled, this PR aims to fix this issue.