### PR TITLE
Recognize `$anyconst` and `$anyseq` cell types as flags for an exists-forall problem

### DIFF
--- a/backends/smt2/smt2.cc
+++ b/backends/smt2/smt2.cc
@@ -1532,7 +1532,7 @@ struct Smt2Backend : public Backend {
 
 		for (auto module : sorted_modules)
 			for (auto cell : module->cells())
-				if (cell->type.in("$allconst", "$allseq"))
+				if (cell->type.in("$anyconst", "$anyseq", "$allconst", "$allseq"))
 					goto found_forall;
 		if (0) {
 	found_forall:


### PR DESCRIPTION
Maybe I don't properly understand the difference between `$anyconst` and `$anyseq` vs. `$allconst` and `$allseq`, but according to [this](https://symbiyosys.readthedocs.io/en/latest/verilog.html#unconstrained-variables) they should all be valid ways to declare an existentially-quantified variable for an exists-forall problem.

Yet, `backends/smt2/smt2.cc` only sets `forallmode = true` and emits the (necessary for proper interpretation by `yosys-smtbmc`) `; yosys-smt2-forall` directive if it detects `$allconst` or `$allseq`.  So, an exists-forall problem using only `$anyconst` and `$anyseq` won't properly be detected and elaborated.

If I'm wrong, I'm very interested to read why--and this should probably also go in #1740.