### PR TITLE
More rpc test fixes

### DIFF
--- a/tests/rpc/frontend.py
+++ b/tests/rpc/frontend.py
@@ -83,10 +83,11 @@ def main():
 
 	if args.mode == "unix-socket":
 		sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+		sock.settimeout(30)
 		sock.bind(args.path)
 		try:
-			ys_proc = subprocess.Popen(["../../yosys", "-ql", "unix.log", "-p", "connect_rpc -path {}; read_verilog design.v; hierarchy -top top; flatten; select -assert-count 1 t:$neg".format(args.path)])
 			sock.listen(1)
+			ys_proc = subprocess.Popen(["../../yosys", "-ql", "unix.log", "-p", "connect_rpc -path {}; read_verilog design.v; hierarchy -top top; flatten; select -assert-count 1 t:$neg".format(args.path)])
 			conn, addr = sock.accept()
 			file = conn.makefile("rw")
 			while True:


### PR DESCRIPTION
There was still another race condition in the RPC frontend test: if the yosys process executes `connect_rpc` before the python process gets to `sock.listen()` the connection would fail and the test would hang.

This executes `sock.listen()` before launching the yosys process. It also adds a 30 second timeout to the socket so that the test will eventually fail rather than hang.