### PR TITLE
abc9: improve (* keep *) handling

### DIFF
--- a/backends/aiger/xaiger.cc
+++ b/backends/aiger/xaiger.cc
@@ -224,8 +224,6 @@ struct XAigerWriter
 					alias_map[Q] = D;
 					auto r YS_ATTRIBUTE(unused) = ff_bits.insert(std::make_pair(D, cell));
 					log_assert(r.second);
-					if (input_bits.erase(Q))
-						log_assert(Q.wire->attributes.count(ID::keep));
 					continue;
 				}
 
@@ -379,11 +377,6 @@ struct XAigerWriter
 							alias_map[O] = b;
 						ci_bits.emplace_back(b);
 						undriven_bits.erase(O);
-						// If PI and CI, then must be a (* keep *) wire
-						if (input_bits.erase(O)) {
-							log_assert(output_bits.count(O));
-							log_assert(O.wire->get_bool_attribute(ID::keep));
-						}
 					}
 			}
 
@@ -468,8 +461,8 @@ struct XAigerWriter
 		for (const auto &bit : output_bits) {
 			ordered_outputs[bit] = aig_o++;
 			int aig;
-			// Unlike bit2aig() which checks aig_map first, for
-			//   inout/keep bits, since aig_map will point to
+			// Unlike bit2aig() which checks aig_map first for
+			//   inout/scc bits, since aig_map will point to
 			//   the PI, first attempt to find the NOT/AND driver
 			//   before resorting to an aig_map lookup (which
 			//   could be another PO)

--- a/backends/aiger/xaiger.cc
+++ b/backends/aiger/xaiger.cc
@@ -174,11 +174,12 @@ struct XAigerWriter
 				undriven_bits.insert(bit);
 				unused_bits.insert(bit);
 
-				bool keep = wire->get_bool_attribute(ID::keep);
-				if (wire->port_input || keep)
+				bool scc = wire->attributes.count(ID(abc9_scc));
+				if (wire->port_input || scc)
 					input_bits.insert(bit);
 
-				if (wire->port_output || keep) {
+				bool keep = wire->get_bool_attribute(ID::keep);
+				if (wire->port_output || keep || scc) {
 					if (bit != wirebit)
 						alias_map[wirebit] = bit;
 					output_bits.insert(wirebit);

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1553,6 +1553,11 @@ struct AbcPass : public Pass {
 		show_tempdir = design->scratchpad_get_bool("abc.showtmp", show_tempdir);
 		markgroups = design->scratchpad_get_bool("abc.markgroups", markgroups);
 
+		if (design->scratchpad_get_bool("abc.debug")) {
+			cleanup = false;
+			show_tempdir = true;
+		}
+
 		size_t argidx, g_argidx;
 		bool g_arg_from_cmd = false;
 		char pwd [PATH_MAX];

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -110,14 +110,13 @@ void mark_scc(RTLIL::Module *module)
 			if (c.second.is_fully_const()) continue;
 			if (cell->output(c.first)) {
 				SigBit b = c.second.as_bit();
+				// TODO: Don't be as heavy handed as to
+				//       mark the entire wire as part of the scc
 				Wire *w = b.wire;
-				w->set_bool_attribute(ID::keep);
-				w->attributes[ID(abc9_scc_id)] = id.as_int();
+				w->set_bool_attribute(ID(abc9_scc));
 			}
 		}
 	}
-
-	module->fixup_ports();
 }
 
 void prep_dff(RTLIL::Module *module)
@@ -967,10 +966,8 @@ void reintegrate(RTLIL::Module *module)
 		RTLIL::Wire *mapped_wire = mapped_mod->wire(port);
 		RTLIL::Wire *wire = module->wire(port);
 		log_assert(wire);
-		if (wire->attributes.erase(ID(abc9_scc_id))) {
-			auto r YS_ATTRIBUTE(unused) = wire->attributes.erase(ID::keep);
-			log_assert(r);
-		}
+		wire->attributes.erase(ID(abc9_scc));
+
 		RTLIL::Wire *remap_wire = module->wire(remap_name(port));
 		RTLIL::SigSpec signal(wire, 0, GetSize(remap_wire));
 		log_assert(GetSize(signal) >= GetSize(remap_wire));


### PR DESCRIPTION
Currently, `(* keep *)`-ed wires are transformed into primary inputs and primary outputs.
That appears to be overly onerous (and is not what `abc` does) so only transform them into primary outputs.