### PR TITLE
Bump ABCREV to receive fix for #1675

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ bumpversion:
 # is just a symlink to your actual ABC working directory, as 'make mrproper'
 # will remove the 'abc' directory and you do not want to accidentally
 # delete your work on ABC..
-ABCREV = 71f2b40
+ABCREV = ed90ce2
 ABCPULL = 1
 ABCURL ?= https://github.com/berkeley-abc/abc
 ABCMKARGS = CC="$(CXX)" CXX="$(CXX)" ABC_USE_LIBSTDCXX=1


### PR DESCRIPTION
Fixes #1675 by pulling in upstream fix.

Specific ABC testcase provided in #1675 now passes with `yosys-abc`, and the result also passes ABC's own combinational equivalence check `cec`.