### PR TITLE
Add ScriptPass::run_nocheck and use for abc9

### DIFF
--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -400,6 +400,18 @@ void ScriptPass::run(std::string command, std::string info)
 	}
 }
 
+void ScriptPass::run_nocheck(std::string command, std::string info)
+{
+	if (active_design == nullptr) {
+		if (info.empty())
+			log("        %s\n", command.c_str());
+		else
+			log("        %s    %s\n", command.c_str(), info.c_str());
+	} else {
+		Pass::call(active_design, command);
+	}
+}
+
 void ScriptPass::run_script(RTLIL::Design *design, std::string run_from, std::string run_to)
 {
 	help_mode = false;

--- a/kernel/register.h
+++ b/kernel/register.h
@@ -84,6 +84,7 @@ struct ScriptPass : Pass
 
 	bool check_label(std::string label, std::string info = std::string());
 	void run(std::string command, std::string info = std::string());
+	void run_nocheck(std::string command, std::string info = std::string());
 	void run_script(RTLIL::Design *design, std::string run_from = std::string(), std::string run_to = std::string());
 	void help_script();
 };

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -332,9 +332,9 @@ struct Abc9Pass : public ScriptPass
 					tempdir_name = make_temp_dir(tempdir_name);
 
 					if (!lut_mode)
-						run(stringf("abc9_ops -write_lut %s/input.lut", tempdir_name.c_str()));
-					run(stringf("abc9_ops -write_box %s/input.box", tempdir_name.c_str()));
-					run(stringf("write_xaiger -map %s/input.sym %s/input.xaig", tempdir_name.c_str(), tempdir_name.c_str()));
+						run_nocheck(stringf("abc9_ops -write_lut %s/input.lut", tempdir_name.c_str()));
+					run_nocheck(stringf("abc9_ops -write_box %s/input.box", tempdir_name.c_str()));
+					run_nocheck(stringf("write_xaiger -map %s/input.sym %s/input.xaig", tempdir_name.c_str(), tempdir_name.c_str()));
 
 					int num_outputs = active_design->scratchpad_get_int("write_xaiger.num_outputs");
 
@@ -350,9 +350,9 @@ struct Abc9Pass : public ScriptPass
 						if (!lut_mode)
 							abc9_exe_cmd += stringf(" -lut %s/input.lut", tempdir_name.c_str());
 						abc9_exe_cmd += stringf(" -box %s/input.box", tempdir_name.c_str());
-						run(abc9_exe_cmd);
-						run(stringf("read_aiger -xaiger -wideports -module_name %s$abc9 -map %s/input.sym %s/output.aig", log_id(mod), tempdir_name.c_str(), tempdir_name.c_str()));
-						run("abc9_ops -reintegrate");
+						run_nocheck(abc9_exe_cmd);
+						run_nocheck(stringf("read_aiger -xaiger -wideports -module_name %s$abc9 -map %s/input.sym %s/output.aig", log_id(mod), tempdir_name.c_str(), tempdir_name.c_str()));
+						run_nocheck("abc9_ops -reintegrate");
 					}
 					else
 						log("Don't call ABC as there is nothing to map.\n");
@@ -361,7 +361,7 @@ struct Abc9Pass : public ScriptPass
 						log("Removing temp directory.\n");
 						remove_directory(tempdir_name);
 					}
-
+					mod->check();
 					active_design->selection().selected_modules.clear();
 					log_pop();
 				}


### PR DESCRIPTION
Found that abc9 had significantly regressed when dealing with large "noflatten" designs while trying to build a large place and route benchmark; this turns out to be due to excessive Design::check calls after every step. To compensate the removed whole-design checks I've added a single Module::check after each module is processed.

This trivial example demonstrates the problem well:

```verilog
module xorx #(parameter [31:0] b = 0) (input [31:0] a, output [31:0] y);
	assign y = a ^ b;
endmodule

module top(input [31:0] a, output [31:0] y);
	localparam N = 2000;
	wire [31:0] s[0:N];
	generate
		genvar i;
		for (i = 0; i < N; i = i + 1'b1) begin
			xorx #(.b(i)) xor_i(.a(s[i]), .y(s[i+1]));
		end
	endgenerate
	assign s[0] = a;
	assign y = s[N];
endmodule
```

`synth_xilinx` (old ABC) takes 3m30s; `synth_xilinx -abc9` without this patch takes over 20 minutes (hasn't completed at the time of writing); `synth_xilinx -abc9` with this patch takes 3m48s.