### PR TITLE
Fix bug in `add` command argument processing.

### DIFF
--- a/passes/cmds/add.cc
+++ b/passes/cmds/add.cc
@@ -150,7 +150,7 @@ struct AddPass : public Pass {
 			return;
 		}
 
-		extra_args(args, argidx, design);
+		extra_args(args, argidx, design, false);
 
 		for (auto module : design->modules())
 		{


### PR DESCRIPTION
This is the `add` command, not a `select` command, so extra arguments should not be treated as if they are arguments to a `select` command.