### PR TITLE
Fix compilation for emcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,7 @@ EMCCFLAGS := -Os -Wno-warn-absolute-paths
 EMCCFLAGS += --memory-init-file 0 --embed-file share -s NO_EXIT_RUNTIME=1
 EMCCFLAGS += -s EXPORTED_FUNCTIONS="['_main','_run','_prompt','_errmsg']"
 EMCCFLAGS += -s TOTAL_MEMORY=134217728
+EMCCFLAGS += -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]'
 # https://github.com/kripken/emscripten/blob/master/src/settings.js
 CXXFLAGS += $(EMCCFLAGS)
 LDFLAGS += $(EMCCFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H -DABC_MEMALIGN=8"
 EMCCFLAGS := -Os -Wno-warn-absolute-paths
 EMCCFLAGS += --memory-init-file 0 --embed-file share -s NO_EXIT_RUNTIME=1
 EMCCFLAGS += -s EXPORTED_FUNCTIONS="['_main','_run','_prompt','_errmsg']"
-EMCCFLAGS += -s TOTAL_MEMORY=128*1024*1024
+EMCCFLAGS += -s TOTAL_MEMORY=134217728
 # https://github.com/kripken/emscripten/blob/master/src/settings.js
 CXXFLAGS += $(EMCCFLAGS)
 LDFLAGS += $(EMCCFLAGS)
@@ -895,6 +895,7 @@ config-emcc: clean
 	echo 'ENABLE_ABC := 0' >> Makefile.conf
 	echo 'ENABLE_PLUGINS := 0' >> Makefile.conf
 	echo 'ENABLE_READLINE := 0' >> Makefile.conf
+	echo 'ENABLE_ZLIB := 0' >> Makefile.conf
 
 config-mxe: clean
 	echo 'CONFIG := mxe' > Makefile.conf

--- a/frontends/rpc/Makefile.inc
+++ b/frontends/rpc/Makefile.inc
@@ -1,2 +1,3 @@
-
+ifneq ($(CONFIG),emcc)
 OBJS += frontends/rpc/rpc_frontend.o
+endif

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -695,7 +695,6 @@ void log_check_expected()
 			log_warn_regexes.clear();
 			log("Expected error pattern '%s' found !!!\n", item.second.pattern.c_str());
 			#ifdef EMSCRIPTEN
-				log_files = backup_log_files;
 				throw 0;
 			#elif defined(_MSC_VER)
 				_exit(0);

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -341,7 +341,11 @@ int run_command(const std::string &command, std::function<void(const std::string
 	if (!process_line)
 		return system(command.c_str());
 
+#ifdef EMSCRIPTEN
+	FILE *f = nullptr;
+#else
 	FILE *f = popen(command.c_str(), "r");
+#endif
 	if (f == nullptr)
 		return -1;
 


### PR DESCRIPTION
This fixes the following errors:

1. TOTAL_MEMORY no longer supports '128\*1024\*1024'.
2. Set ENABLE_ZLIB = 0 for emcc.
3. Disable rpc frontend because it uses unimplemented posix api.
4. Remove call to popen.
5. Allow YosysJS to call 'cccall'.