### PR TITLE
refixed parsing of constant with comment between size and value

### DIFF
--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -113,8 +113,10 @@ extern int frontend_verilog_yylex(YYSTYPE *yylval_param, YYLTYPE *yyloc_param);
 %x SYNOPSYS_TRANSLATE_OFF
 %x SYNOPSYS_FLAGS
 %x IMPORT_DPI
+%x BASED_CONST
 
 %%
+	int comment_caller;
 
 <INITIAL,SYNOPSYS_TRANSLATE_OFF>"`file_push "[^\n]* {
 	fn_stack.push_back(current_filename);
@@ -273,9 +275,21 @@ extern int frontend_verilog_yylex(YYSTYPE *yylval_param, YYLTYPE *yyloc_param);
 	return TOK_CONSTVAL;
 }
 
-[0-9]*[ \t]*\'[sS]?[bodhBODH]?[ \t\r\n]*[0-9a-fA-FzxZX?_]+ {
+\'[01zxZX] {
 	yylval->string = new std::string(yytext);
-	return TOK_CONSTVAL;
+	return TOK_UNBASED_UNSIZED_CONSTVAL;
+}
+
+\'[sS]?[bodhBODH] {
+	BEGIN(BASED_CONST);
+	yylval->string = new std::string(yytext);
+	return TOK_BASE;
+}
+
+<BASED_CONST>[0-9a-fA-FzxZX?][0-9a-fA-FzxZX?_]* {
+	BEGIN(0);
+	yylval->string = new std::string(yytext);
+	return TOK_BASED_CONSTVAL;
 }
 
 [0-9][0-9_]*\.[0-9][0-9_]*([eE][-+]?[0-9_]+)? {
@@ -478,16 +492,17 @@ import[ \t\r\n]+\"(DPI|DPI-C)\"[ \t\r\n]+function[ \t\r\n]+ {
 	return TOK_SPECIFY_AND;
 }
 
-"/*" { BEGIN(COMMENT); }
+<INITIAL,BASED_CONST>"/*" { comment_caller=YY_START; BEGIN(COMMENT); }
 <COMMENT>.    /* ignore comment body */
 <COMMENT>\n   /* ignore comment body */
-<COMMENT>"*/" { BEGIN(0); }
+<COMMENT>"*/" { BEGIN(comment_caller); }
 
-[ \t\r\n]		/* ignore whitespaces */
-\\[\r\n]		/* ignore continuation sequence */
-"//"[^\r\n]*		/* ignore one-line comments */
+<INITIAL,BASED_CONST>[ \t\r\n]		/* ignore whitespaces */
+<INITIAL,BASED_CONST>\\[\r\n]		/* ignore continuation sequence */
+<INITIAL,BASED_CONST>"//"[^\r\n]*	/* ignore one-line comments */
 
-. { return *yytext; }
+<INITIAL>. { return *yytext; }
+<*>. { BEGIN(0); return *yytext; }
 
 %%
 

--- a/tests/various/bug1745.ys
+++ b/tests/various/bug1745.ys
@@ -1,0 +1,8 @@
+logger -expect error "syntax error, unexpected TOK_CONSTVAL" 1
+read_verilog <<EOT
+module inverter(input a, output y);
+
+   assign y = (a == 1'b0? 1'b1 : 1'b0);
+   
+endmodule // inverter
+EOT

--- a/tests/various/constcomment.ys
+++ b/tests/various/constcomment.ys
@@ -1,0 +1,16 @@
+read_verilog <<EOT
+module top1;
+        localparam a = 8 /*foo*/ 'h ab;
+        localparam b = 8 'h /*foo*/ cd;
+        generate
+                if (a != 8'b10101011) $error("a incorrect!");
+                if (b != 8'b11001101) $error("b incorrect!");
+        endgenerate
+endmodule
+EOT
+logger -expect error "syntax error, unexpected TOK_BASE" 1
+read_verilog <<EOT
+module top2;
+	localparam a = 12'h4 /*foo*/'b0;
+endmodule
+EOT


### PR DESCRIPTION
The code to handle comments between size and value in constants by arbitrarily concatenating two TOK_CONSTVAL which was introduced in ee8ad72fd950e1ee204e5c97155a50b8b1445dec has three problems:

* It accepts invalid code; e.g. the expression `12'h4 /*foo*/'b0` is accepted as the hexadecimal constant `12'h4b0` despite being syntactically incorrect
* It generates misleading diagnostics; e.g. the expression `a == 1'b0? 1'b1 : 1'b0`
  yields the diagnostic "Digit larger than 1 used in in base-2 constant" (issue #1745)
* It is incomplete - It does not accept any spaces between the comment and the `'`, and no comments between the base and the digits even though spaces are allowed there.

This PR fixes all three problems by making the three parts of a based constant (size, base, digits) into three separate tokens, allowing the linear whitespace (including comments) between them to be treated as normal inter-token whitespace.