### PR TITLE
Closes #1762. Adds warnings for `select` arguments not matching any object and for `add` command when no modules selected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -716,6 +716,7 @@ test: $(TARGETS) $(EXTRA_TARGETS)
 	+cd tests/memories && bash run-test.sh $(ABCOPT) $(SEEDOPT)
 	+cd tests/bram && bash run-test.sh $(SEEDOPT)
 	+cd tests/various && bash run-test.sh
+	+cd tests/select && bash run-test.sh
 	+cd tests/sat && bash run-test.sh
 	+cd tests/svinterfaces && bash run-test.sh $(SEEDOPT)
 	+cd tests/svtypes && bash run-test.sh $(SEEDOPT)

--- a/passes/cmds/add.cc
+++ b/passes/cmds/add.cc
@@ -206,6 +206,7 @@ struct AddPass : public Pass {
 
 		extra_args(args, argidx, design);
 
+		bool selected_anything = false;
 		for (auto module : design->modules())
 		{
 			log_assert(module != nullptr);
@@ -214,11 +215,14 @@ struct AddPass : public Pass {
 			if (module->get_bool_attribute("\\blackbox"))
 				continue;
 
+			selected_anything = true;
 			if (is_formal_celltype(command))
 				add_formal(module, command, arg_name, enable_name);
 			else if (command == "wire")
 				add_wire(design, module, arg_name, arg_width, arg_flag_input, arg_flag_output, arg_flag_global);
 		}
+		if (!selected_anything)
+			log_warning("No modules selected, or only blackboxes.  Nothing was added.\n");
 	}
 } AddPass;
 

--- a/passes/cmds/select.cc
+++ b/passes/cmds/select.cc
@@ -625,7 +625,7 @@ static void select_filter_active_mod(RTLIL::Design *design, RTLIL::Selection &se
 	}
 }
 
-static void select_stmt(RTLIL::Design *design, std::string arg)
+static void select_stmt(RTLIL::Design *design, std::string arg, bool disable_empty_warning = false)
 {
 	std::string arg_mod, arg_memb;
 	std::unordered_map<std::string, bool> arg_mod_found;
@@ -913,12 +913,12 @@ static void select_stmt(RTLIL::Design *design, std::string arg)
 	select_filter_active_mod(design, work_stack.back());
 
 	for (auto &it : arg_mod_found) {
-		if (it.second == false) {
+		if (it.second == false && !disable_empty_warning) {
 			log_warning("Selection \"%s\" did not match any module.\n", it.first.c_str());
 		}
 	}
 	for (auto &it : arg_memb_found) {
-		if (it.second == false) {
+		if (it.second == false && !disable_empty_warning) {
 			log_warning("Selection \"%s\" did not match any object.\n", it.first.c_str());
 		}
 	}
@@ -1311,7 +1311,8 @@ struct SelectPass : public Pass {
 			}
 			if (arg.size() > 0 && arg[0] == '-')
 				log_cmd_error("Unknown option %s.\n", arg.c_str());
-			select_stmt(design, arg);
+			bool disable_empty_warning = count_mode || assert_none || assert_any || (assert_count != -1) || (assert_max != -1) || (assert_min != -1);
+			select_stmt(design, arg, disable_empty_warning);
 			sel_str += " " + arg;
 		}
 

--- a/passes/cmds/select.cc
+++ b/passes/cmds/select.cc
@@ -775,7 +775,8 @@ static void select_stmt(RTLIL::Design *design, std::string arg, bool disable_emp
 			arg_mod = arg.substr(0, pos);
 			if (!prefixed) arg_mod_found[arg_mod] = false;
 			arg_memb = arg.substr(pos+1);
-			if (!prefixed) arg_memb_found[arg_memb] = false;
+			bool arg_memb_prefixed = GetSize(arg_memb) >= 2 && isalpha(arg_memb[0]) && arg_memb[1] == ':';
+			if (!arg_memb_prefixed) arg_memb_found[arg_memb] = false;
 		}
 	}
 

--- a/passes/cmds/select.cc
+++ b/passes/cmds/select.cc
@@ -764,10 +764,7 @@ static void select_stmt(RTLIL::Design *design, std::string arg)
 	} else {
 		size_t pos = arg.find('/');
 		if (pos == std::string::npos) {
-			if (arg.find(':') == std::string::npos || arg.compare(0, 1, "A") == 0)
-				arg_mod = arg;
-			else
-				arg_mod = "*", arg_memb = arg;
+			arg_mod = arg;
 		} else {
 			arg_mod = arg.substr(0, pos);
 			arg_memb = arg.substr(pos+1);
@@ -787,6 +784,10 @@ static void select_stmt(RTLIL::Design *design, std::string arg)
 	{
 		if (arg_mod.compare(0, 2, "A:") == 0) {
 			if (!match_attr(mod->attributes, arg_mod.substr(2)))
+				continue;
+		} else
+		if (arg_mod.compare(0, 2, "N:") == 0) {
+			if (!match_ids(mod->name, arg_mod.substr(2)))
 				continue;
 		} else
 		if (!match_ids(mod->name, arg_mod))
@@ -1073,6 +1074,10 @@ struct SelectPass : public Pass {
 		log("    A:<pattern>, A:<pattern>=<pattern>\n");
 		log("        all modules with an attribute matching the given pattern\n");
 		log("        in addition to = also <, <=, >=, and > are supported\n");
+		log("\n");
+		log("    N:<pattern>\n");
+		log("        all modules with a name matching the given pattern\n");
+		log("        (i.e. 'N:' is optional as it is the default matching rule)\n");
 		log("\n");
 		log("An <obj_pattern> can be an object name, wildcard expression, or one of\n");
 		log("the following:\n");

--- a/tests/select/no_warn_assert.ys
+++ b/tests/select/no_warn_assert.ys
@@ -1,0 +1,2 @@
+logger -expect-no-warnings
+select -assert-count 0 top/t:ff4 top/w:d0 %co:+[d] %i

--- a/tests/select/no_warn_prefixed_arg_memb.ys
+++ b/tests/select/no_warn_prefixed_arg_memb.ys
@@ -1,0 +1,5 @@
+logger -expect-no-warnings
+read_verilog ../../examples/igloo2/example.v
+hierarchy
+proc
+select example/t:$add

--- a/tests/select/no_warn_prefixed_empty_select_arg.ys
+++ b/tests/select/no_warn_prefixed_empty_select_arg.ys
@@ -1,0 +1,3 @@
+logger -expect-no-warnings
+select n:foo/bar*
+select t:$assert

--- a/tests/select/run-test.sh
+++ b/tests/select/run-test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+for x in *.ys; do
+  echo "Running $x.."
+  ../../yosys -ql ${x%.ys}.log $x
+done

--- a/tests/select/warn_empty_select_arg.ys
+++ b/tests/select/warn_empty_select_arg.ys
@@ -1,0 +1,3 @@
+logger -expect warning "did not match any module." 1
+logger -expect warning "did not match any object." 1
+select foo/bar


### PR DESCRIPTION
See discussion in #1756 and #1762.

The changes to `add.cc` are pretty straightforward.  The changes to `select.cc` definitely require review and should probably be discussed.

First, is this implemented correctly?  I don't have a lot of experience with this part of the code base.
Second, are there bad performance implications?  I don't imagine there will be much impact, but maybe I'm wrong.
Third, is this the desired behavior?  Should `select` arguments that do not match anything generate an error instead of a warning?