### PR TITLE
Improve ABC repository management in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -669,7 +669,8 @@ ifneq ($(ABCREV),default)
 	$(Q) if ( cd abc 2> /dev/null && ! git diff-index --quiet HEAD; ); then \
 		echo 'REEBE: NOP pbagnvaf ybpny zbqvsvpngvbaf! Frg NOPERI=qrsnhyg va Lbflf Znxrsvyr!' | tr 'A-Za-z' 'N-ZA-Mn-za-m'; false; \
 	fi
-	$(Q) if test "`cd abc 2> /dev/null && git rev-parse --short HEAD`" != "$(ABCREV)"; then \
+# set a variable so the test fails if git fails to run - when comparing outputs directly, empty string would match empty string
+	$(Q) if ! (cd abc && rev="`git rev-parse $(ABCREV)`" && test "`git rev-parse HEAD`" == "$$rev"); then \
 		test $(ABCPULL) -ne 0 || { echo 'REEBE: NOP abg hc gb qngr naq NOPCHYY frg gb 0 va Znxrsvyr!' | tr 'A-Za-z' 'N-ZA-Mn-za-m'; exit 1; }; \
 		echo "Pulling ABC from $(ABCURL):"; set -x; \
 		test -d abc || git clone $(ABCURL) abc; \
@@ -930,6 +931,9 @@ echo-yosys-ver:
 
 echo-git-rev:
 	@echo "$(GIT_REV)"
+
+echo-abc-rev:
+	@echo "$(ABCREV)"
 
 -include libs/*/*.d
 -include frontends/*/*.d


### PR DESCRIPTION
The output of `rev-parse --short` may be abbreviated differently from ABCREV (e.g. `ed90ce20` vs `ed90ce2`), so simply comparing the strings to check whether the correct revision is checked out will always fail. Passing both HEAD and ABCREV through `rev-parse` and then comparing the full hashes fixes that.

Packaging scripts might want to avoid sources being downloaded during build, which is ensured by `ABCPULL=0`. However, unless `ABCREV=default` is used (which is also not ideal) the correct ABC commit needs to be checked out before building. The newly added `echo-abc-rev` target can be used by packaging scripts to do just that, such that a subsequent build with `ABCPULL=0` succeeds.

This is a followup to #1666, which was reverted because of multiple issues. The commit in this PR includes fixes for the ones that apply.