### PR TITLE
Regex support for GCC 4.8

### DIFF
--- a/backends/firrtl/firrtl.cc
+++ b/backends/firrtl/firrtl.cc
@@ -25,7 +25,6 @@
 #include "kernel/log.h"
 #include <algorithm>
 #include <string>
-#include <regex>
 #include <vector>
 #include <cmath>
 

--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -413,13 +413,13 @@ int main(int argc, char **argv)
 			scriptfile_tcl = true;
 			break;
 		case 'W':
-			log_warn_regexes.push_back(REGEX_COMPILE(optarg));
+			log_warn_regexes.push_back(YS_REGEX_COMPILE(optarg));
 			break;
 		case 'w':
-			log_nowarn_regexes.push_back(REGEX_COMPILE(optarg));
+			log_nowarn_regexes.push_back(YS_REGEX_COMPILE(optarg));
 			break;
 		case 'e':
-			log_werror_regexes.push_back(REGEX_COMPILE(optarg));
+			log_werror_regexes.push_back(YS_REGEX_COMPILE(optarg));
 			break;
 		case 'D':
 			vlog_defines.push_back(optarg);

--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -413,22 +413,13 @@ int main(int argc, char **argv)
 			scriptfile_tcl = true;
 			break;
 		case 'W':
-			log_warn_regexes.push_back(std::regex(optarg,
-					std::regex_constants::nosubs |
-					std::regex_constants::optimize |
-					std::regex_constants::egrep));
+			log_warn_regexes.push_back(REGEX_COMPILE(optarg));
 			break;
 		case 'w':
-			log_nowarn_regexes.push_back(std::regex(optarg,
-					std::regex_constants::nosubs |
-					std::regex_constants::optimize |
-					std::regex_constants::egrep));
+			log_nowarn_regexes.push_back(REGEX_COMPILE(optarg));
 			break;
 		case 'e':
-			log_werror_regexes.push_back(std::regex(optarg,
-					std::regex_constants::nosubs |
-					std::regex_constants::optimize |
-					std::regex_constants::egrep));
+			log_werror_regexes.push_back(REGEX_COMPILE(optarg));
 			break;
 		case 'D':
 			vlog_defines.push_back(optarg);

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -41,8 +41,8 @@ YOSYS_NAMESPACE_BEGIN
 std::vector<FILE*> log_files;
 std::vector<std::ostream*> log_streams;
 std::map<std::string, std::set<std::string>> log_hdump;
-std::vector<REGEX_TYPE> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
-std::vector<std::pair<REGEX_TYPE,LogExpectedItem>> log_expect_log, log_expect_warning, log_expect_error;
+std::vector<YS_REGEX_TYPE> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
+std::vector<std::pair<YS_REGEX_TYPE,LogExpectedItem>> log_expect_log, log_expect_warning, log_expect_error;
 std::set<std::string> log_warnings, log_experimentals, log_experimentals_ignored;
 int log_warnings_count = 0;
 int log_warnings_count_noexpect = 0;
@@ -177,11 +177,11 @@ void logv(const char *format, va_list ap)
 
 			if (!linebuffer.empty() && linebuffer.back() == '\n') {
 				for (auto &re : log_warn_regexes)
-					if (REGEX_NS::regex_search(linebuffer, re))
+					if (YS_REGEX_NS::regex_search(linebuffer, re))
 						log_warning("Found log message matching -W regex:\n%s", str.c_str());
 
 				for (auto &item : log_expect_log)
-					if (REGEX_NS::regex_search(linebuffer, item.first))
+					if (YS_REGEX_NS::regex_search(linebuffer, item.first))
 						item.second.current_count++;
 
 				linebuffer.clear();
@@ -238,7 +238,7 @@ static void logv_warning_with_prefix(const char *prefix,
 	bool suppressed = false;
 
 	for (auto &re : log_nowarn_regexes)
-		if (REGEX_NS::regex_search(message, re))
+		if (YS_REGEX_NS::regex_search(message, re))
 			suppressed = true;
 
 	if (suppressed)
@@ -251,12 +251,12 @@ static void logv_warning_with_prefix(const char *prefix,
 		log_make_debug = 0;
 
 		for (auto &re : log_werror_regexes)
-			if (REGEX_NS::regex_search(message, re))
+			if (YS_REGEX_NS::regex_search(message, re))
 				log_error("%s",  message.c_str());
 
 		bool warning_match = false;
 		for (auto &item : log_expect_warning)
-			if (REGEX_NS::regex_search(message, item.first)) {
+			if (YS_REGEX_NS::regex_search(message, item.first)) {
 				item.second.current_count++;
 				warning_match = true;
 			}
@@ -349,7 +349,7 @@ static void logv_error_with_prefix(const char *prefix,
 		log_error_atexit();
 
 	for (auto &item : log_expect_error)
-		if (REGEX_NS::regex_search(log_last_error, item.first))
+		if (YS_REGEX_NS::regex_search(log_last_error, item.first))
 			item.second.current_count++;
 
 	if (check_expected_logs)

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -41,8 +41,8 @@ YOSYS_NAMESPACE_BEGIN
 std::vector<FILE*> log_files;
 std::vector<std::ostream*> log_streams;
 std::map<std::string, std::set<std::string>> log_hdump;
-std::vector<std::regex> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
-std::vector<std::pair<std::regex,LogExpectedItem>> log_expect_log, log_expect_warning, log_expect_error;
+std::vector<REGEX_TYPE> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
+std::vector<std::pair<REGEX_TYPE,LogExpectedItem>> log_expect_log, log_expect_warning, log_expect_error;
 std::set<std::string> log_warnings, log_experimentals, log_experimentals_ignored;
 int log_warnings_count = 0;
 int log_warnings_count_noexpect = 0;
@@ -177,11 +177,11 @@ void logv(const char *format, va_list ap)
 
 			if (!linebuffer.empty() && linebuffer.back() == '\n') {
 				for (auto &re : log_warn_regexes)
-					if (std::regex_search(linebuffer, re))
+					if (REGEX_NS::regex_search(linebuffer, re))
 						log_warning("Found log message matching -W regex:\n%s", str.c_str());
 
 				for (auto &item : log_expect_log)
-					if (std::regex_search(linebuffer, item.first))
+					if (REGEX_NS::regex_search(linebuffer, item.first))
 						item.second.current_count++;
 
 				linebuffer.clear();
@@ -238,7 +238,7 @@ static void logv_warning_with_prefix(const char *prefix,
 	bool suppressed = false;
 
 	for (auto &re : log_nowarn_regexes)
-		if (std::regex_search(message, re))
+		if (REGEX_NS::regex_search(message, re))
 			suppressed = true;
 
 	if (suppressed)
@@ -251,12 +251,12 @@ static void logv_warning_with_prefix(const char *prefix,
 		log_make_debug = 0;
 
 		for (auto &re : log_werror_regexes)
-			if (std::regex_search(message, re))
+			if (REGEX_NS::regex_search(message, re))
 				log_error("%s",  message.c_str());
 
 		bool warning_match = false;
 		for (auto &item : log_expect_warning)
-			if (std::regex_search(message, item.first)) {
+			if (REGEX_NS::regex_search(message, item.first)) {
 				item.second.current_count++;
 				warning_match = true;
 			}
@@ -349,7 +349,7 @@ static void logv_error_with_prefix(const char *prefix,
 		log_error_atexit();
 
 	for (auto &item : log_expect_error)
-		if (std::regex_search(log_last_error, item.first))
+		if (REGEX_NS::regex_search(log_last_error, item.first))
 			item.second.current_count++;
 
 	if (check_expected_logs)

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -26,7 +26,7 @@
 
 // In GCC 4.8 std::regex is not working correctlty, in order to make features
 // using regular expressions to work replacement regex library is used
-#if defined(__GNUC__) && ( __GNUC__ == 4 && __GNUC_MINOR__ <= 8)
+#if defined(__GNUC__) && !defined( __clang__) && ( __GNUC__ == 4 && __GNUC_MINOR__ <= 8)
 	#include <boost/xpressive/xpressive.hpp>
 	#define YS_REGEX_TYPE boost::xpressive::sregex
 	#define YS_REGEX_NS boost::xpressive

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -23,18 +23,21 @@
 #define LOG_H
 
 #include <time.h>
-#if defined(__GNUC__) && ( __GNUC__ == 4 && __GNUC_MINOR__ == 8)
+
+// In GCC 4.8 std::regex is not working correctlty, in order to make features
+// using regular expressions to work replacement regex library is used
+#if defined(__GNUC__) && ( __GNUC__ == 4 && __GNUC_MINOR__ <= 8)
 	#include <boost/xpressive/xpressive.hpp>
-	#define REGEX_TYPE boost::xpressive::sregex
-	#define REGEX_NS boost::xpressive
-	#define REGEX_COMPILE(param) boost::xpressive::sregex::compile(param, \
+	#define YS_REGEX_TYPE boost::xpressive::sregex
+	#define YS_REGEX_NS boost::xpressive
+	#define YS_REGEX_COMPILE(param) boost::xpressive::sregex::compile(param, \
 					boost::xpressive::regex_constants::nosubs | \
 					boost::xpressive::regex_constants::optimize)
 # else
 	#include <regex>
-	#define REGEX_TYPE std::regex
-	#define REGEX_NS std
-	#define REGEX_COMPILE(param) std::regex(param, \
+	#define YS_REGEX_TYPE std::regex
+	#define YS_REGEX_NS std
+	#define YS_REGEX_COMPILE(param) std::regex(param, \
 					std::regex_constants::nosubs | \
 					std::regex_constants::optimize | \
 					std::regex_constants::egrep)
@@ -64,7 +67,7 @@ struct log_cmd_error_exception { };
 extern std::vector<FILE*> log_files;
 extern std::vector<std::ostream*> log_streams;
 extern std::map<std::string, std::set<std::string>> log_hdump;
-extern std::vector<REGEX_TYPE> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
+extern std::vector<YS_REGEX_TYPE> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
 extern std::set<std::string> log_warnings, log_experimentals, log_experimentals_ignored;
 extern int log_warnings_count;
 extern int log_warnings_count_noexpect;
@@ -166,7 +169,7 @@ struct LogExpectedItem
 	std::string pattern;
 };
 
-extern std::vector<std::pair<REGEX_TYPE,LogExpectedItem>> log_expect_log, log_expect_warning, log_expect_error;
+extern std::vector<std::pair<YS_REGEX_TYPE,LogExpectedItem>> log_expect_log, log_expect_warning, log_expect_error;
 void log_check_expected();
 
 const char *log_signal(const RTLIL::SigSpec &sig, bool autoint = true);

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -23,7 +23,22 @@
 #define LOG_H
 
 #include <time.h>
-#include <regex>
+#if defined(__GNUC__) && ( __GNUC__ == 4 && __GNUC_MINOR__ == 8)
+	#include <boost/xpressive/xpressive.hpp>
+	#define REGEX_TYPE boost::xpressive::sregex
+	#define REGEX_NS boost::xpressive
+	#define REGEX_COMPILE(param) boost::xpressive::sregex::compile(param, \
+					boost::xpressive::regex_constants::nosubs | \
+					boost::xpressive::regex_constants::optimize)
+# else
+	#include <regex>
+	#define REGEX_TYPE std::regex
+	#define REGEX_NS std
+	#define REGEX_COMPILE(param) std::regex(param, \
+					std::regex_constants::nosubs | \
+					std::regex_constants::optimize | \
+					std::regex_constants::egrep)
+#endif
 
 #ifndef _WIN32
 #  include <sys/time.h>
@@ -49,7 +64,7 @@ struct log_cmd_error_exception { };
 extern std::vector<FILE*> log_files;
 extern std::vector<std::ostream*> log_streams;
 extern std::map<std::string, std::set<std::string>> log_hdump;
-extern std::vector<std::regex> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
+extern std::vector<REGEX_TYPE> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
 extern std::set<std::string> log_warnings, log_experimentals, log_experimentals_ignored;
 extern int log_warnings_count;
 extern int log_warnings_count_noexpect;
@@ -151,7 +166,7 @@ struct LogExpectedItem
 	std::string pattern;
 };
 
-extern std::vector<std::pair<std::regex,LogExpectedItem>> log_expect_log, log_expect_warning, log_expect_error;
+extern std::vector<std::pair<REGEX_TYPE,LogExpectedItem>> log_expect_log, log_expect_warning, log_expect_error;
 void log_check_expected();
 
 const char *log_signal(const RTLIL::SigSpec &sig, bool autoint = true);

--- a/passes/cmds/logger.cc
+++ b/passes/cmds/logger.cc
@@ -96,9 +96,9 @@ struct LoggerPass : public Pass {
 				if (pattern.front() == '\"' && pattern.back() == '\"') pattern = pattern.substr(1, pattern.size() - 2);		
 				try {
 					log("Added regex '%s' for warnings to warn list.\n", pattern.c_str());
-					log_warn_regexes.push_back(REGEX_COMPILE(pattern));
+					log_warn_regexes.push_back(YS_REGEX_COMPILE(pattern));
 				}
-				catch (const REGEX_NS::regex_error& e) {
+				catch (const YS_REGEX_NS::regex_error& e) {
 					log_cmd_error("Error in regex expression '%s' !\n", pattern.c_str());
 				}
 				continue;
@@ -108,9 +108,9 @@ struct LoggerPass : public Pass {
 				if (pattern.front() == '\"' && pattern.back() == '\"') pattern = pattern.substr(1, pattern.size() - 2);	
 				try {
 					log("Added regex '%s' for warnings to nowarn list.\n", pattern.c_str());
-					log_nowarn_regexes.push_back(REGEX_COMPILE(pattern));
+					log_nowarn_regexes.push_back(YS_REGEX_COMPILE(pattern));
 				}
-				catch (const REGEX_NS::regex_error& e) {
+				catch (const YS_REGEX_NS::regex_error& e) {
 					log_cmd_error("Error in regex expression '%s' !\n", pattern.c_str());
 				}
 				continue;
@@ -120,9 +120,9 @@ struct LoggerPass : public Pass {
 				if (pattern.front() == '\"' && pattern.back() == '\"') pattern = pattern.substr(1, pattern.size() - 2);	
 				try {
 					log("Added regex '%s' for warnings to werror list.\n", pattern.c_str());
-					log_werror_regexes.push_back(REGEX_COMPILE(pattern));
+					log_werror_regexes.push_back(YS_REGEX_COMPILE(pattern));
 				}
-				catch (const REGEX_NS::regex_error& e) {
+				catch (const YS_REGEX_NS::regex_error& e) {
 					log_cmd_error("Error in regex expression '%s' !\n", pattern.c_str());
 				}
 				continue;
@@ -159,13 +159,13 @@ struct LoggerPass : public Pass {
 				log("Added regex '%s' for warnings to expected %s list.\n", pattern.c_str(), type.c_str());
 				try {
 					if (type=="error")
-						log_expect_error.push_back(std::make_pair(REGEX_COMPILE(pattern), LogExpectedItem(pattern, count)));
+						log_expect_error.push_back(std::make_pair(YS_REGEX_COMPILE(pattern), LogExpectedItem(pattern, count)));
 					else if (type=="warning")
-						log_expect_warning.push_back(std::make_pair(REGEX_COMPILE(pattern), LogExpectedItem(pattern, count)));
+						log_expect_warning.push_back(std::make_pair(YS_REGEX_COMPILE(pattern), LogExpectedItem(pattern, count)));
 					else
-						log_expect_log.push_back(std::make_pair(REGEX_COMPILE(pattern), LogExpectedItem(pattern, count)));
+						log_expect_log.push_back(std::make_pair(YS_REGEX_COMPILE(pattern), LogExpectedItem(pattern, count)));
 				}
-				catch (const REGEX_NS::regex_error& e) {
+				catch (const YS_REGEX_NS::regex_error& e) {
 					log_cmd_error("Error in regex expression '%s' !\n", pattern.c_str());
 				}
 				continue;

--- a/passes/cmds/logger.cc
+++ b/passes/cmds/logger.cc
@@ -96,12 +96,9 @@ struct LoggerPass : public Pass {
 				if (pattern.front() == '\"' && pattern.back() == '\"') pattern = pattern.substr(1, pattern.size() - 2);		
 				try {
 					log("Added regex '%s' for warnings to warn list.\n", pattern.c_str());
-					log_warn_regexes.push_back(std::regex(pattern,
-						std::regex_constants::nosubs |
-						std::regex_constants::optimize |
-						std::regex_constants::egrep));
+					log_warn_regexes.push_back(REGEX_COMPILE(pattern));
 				}
-				catch (const std::regex_error& e) {
+				catch (const REGEX_NS::regex_error& e) {
 					log_cmd_error("Error in regex expression '%s' !\n", pattern.c_str());
 				}
 				continue;
@@ -111,12 +108,9 @@ struct LoggerPass : public Pass {
 				if (pattern.front() == '\"' && pattern.back() == '\"') pattern = pattern.substr(1, pattern.size() - 2);	
 				try {
 					log("Added regex '%s' for warnings to nowarn list.\n", pattern.c_str());
-					log_nowarn_regexes.push_back(std::regex(pattern,
-						std::regex_constants::nosubs |
-						std::regex_constants::optimize |
-						std::regex_constants::egrep));
+					log_nowarn_regexes.push_back(REGEX_COMPILE(pattern));
 				}
-				catch (const std::regex_error& e) {
+				catch (const REGEX_NS::regex_error& e) {
 					log_cmd_error("Error in regex expression '%s' !\n", pattern.c_str());
 				}
 				continue;
@@ -126,12 +120,9 @@ struct LoggerPass : public Pass {
 				if (pattern.front() == '\"' && pattern.back() == '\"') pattern = pattern.substr(1, pattern.size() - 2);	
 				try {
 					log("Added regex '%s' for warnings to werror list.\n", pattern.c_str());
-					log_werror_regexes.push_back(std::regex(pattern,
-						std::regex_constants::nosubs |
-						std::regex_constants::optimize |
-						std::regex_constants::egrep));
+					log_werror_regexes.push_back(REGEX_COMPILE(pattern));
 				}
-				catch (const std::regex_error& e) {
+				catch (const REGEX_NS::regex_error& e) {
 					log_cmd_error("Error in regex expression '%s' !\n", pattern.c_str());
 				}
 				continue;
@@ -168,22 +159,13 @@ struct LoggerPass : public Pass {
 				log("Added regex '%s' for warnings to expected %s list.\n", pattern.c_str(), type.c_str());
 				try {
 					if (type=="error")
-						log_expect_error.push_back(std::make_pair(std::regex(pattern,
-							std::regex_constants::nosubs |
-							std::regex_constants::optimize |
-							std::regex_constants::egrep), LogExpectedItem(pattern, count)));
+						log_expect_error.push_back(std::make_pair(REGEX_COMPILE(pattern), LogExpectedItem(pattern, count)));
 					else if (type=="warning")
-						log_expect_warning.push_back(std::make_pair(std::regex(pattern,
-							std::regex_constants::nosubs |
-							std::regex_constants::optimize |
-							std::regex_constants::egrep), LogExpectedItem(pattern, count)));
+						log_expect_warning.push_back(std::make_pair(REGEX_COMPILE(pattern), LogExpectedItem(pattern, count)));
 					else
-						log_expect_log.push_back(std::make_pair(std::regex(pattern,
-							std::regex_constants::nosubs |
-							std::regex_constants::optimize |
-							std::regex_constants::egrep), LogExpectedItem(pattern, count)));
+						log_expect_log.push_back(std::make_pair(REGEX_COMPILE(pattern), LogExpectedItem(pattern, count)));
 				}
-				catch (const std::regex_error& e) {
+				catch (const REGEX_NS::regex_error& e) {
 					log_cmd_error("Error in regex expression '%s' !\n", pattern.c_str());
 				}
 				continue;

--- a/tests/various/logger_error.ys
+++ b/tests/various/logger_error.ys
@@ -1,0 +1,6 @@
+logger -werror "is implicitly declared." -expect error "is implicitly declared." 1
+read_verilog << EOF
+module top(...);
+	assign b = w;
+endmodule
+EOF

--- a/tests/various/logger_nowarning.ys
+++ b/tests/various/logger_nowarning.ys
@@ -1,0 +1,6 @@
+logger -expect-no-warnings -nowarn "is implicitly declared."
+read_verilog << EOF
+module top(...);
+	assign b = w;
+endmodule
+EOF

--- a/tests/various/logger_warn.ys
+++ b/tests/various/logger_warn.ys
@@ -1,0 +1,6 @@
+logger -warn "Successfully finished Verilog frontend." -expect warning "Successfully finished Verilog frontend." 1
+read_verilog << EOF
+module top(...);
+	assign b = w;
+endmodule
+EOF

--- a/tests/various/logger_warning.ys
+++ b/tests/various/logger_warning.ys
@@ -1,0 +1,6 @@
+logger -expect warning "is implicitly declared." 2
+read_verilog << EOF
+module top(...);
+	assign b = w;
+endmodule
+EOF


### PR DESCRIPTION
Since std::regex does not work (it compiles) on gcc 4.8, there were few possible ways to go
 - boost::regex - it is 1:1 with std::regex but there is a big issue, in case boost is compiled on later gcc and linked with gcc 4.8 then linking will fail, also requires additional library to be linked
 - boost::xpressive - compatible but slightly different syntax for some parts, header only, so no additional library to link
