### PR TITLE
License: bump year and add title

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,6 @@
-Copyright (C) 2012 - 2019  Clifford Wolf <clifford@clifford.at>
+ISC License
+
+Copyright (C) 2012 - 2020  Clifford Wolf <clifford@clifford.at>
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ```
 yosys -- Yosys Open SYnthesis Suite
 
-Copyright (C) 2012 - 2019  Clifford Wolf <clifford@clifford.at>
+Copyright (C) 2012 - 2020  Clifford Wolf <clifford@clifford.at>
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -129,7 +129,7 @@ void yosys_banner()
 	log(" |                                                                            |\n");
 	log(" |  yosys -- Yosys Open SYnthesis Suite                                       |\n");
 	log(" |                                                                            |\n");
-	log(" |  Copyright (C) 2012 - 2019  Clifford Wolf <clifford@clifford.at>           |\n");
+	log(" |  Copyright (C) 2012 - 2020  Clifford Wolf <clifford@clifford.at>           |\n");
 	log(" |                                                                            |\n");
 	log(" |  Permission to use, copy, modify, and/or distribute this software for any  |\n");
 	log(" |  purpose with or without fee is hereby granted, provided that the above    |\n");


### PR DESCRIPTION
The title is not legally mandated, but it's convenient for human consumption, and is included in the template text of this license, as recommended by [OSI](https://opensource.org/licenses/isc-license), [SPDX](https://spdx.org/licenses/ISC.html#licenseText), [choosealicense.com](https://choosealicense.com/licenses/isc/), and others.

***Note**: This PR is part of my personal project to improve the consistency and visibility of the ISC license in open source projects. See https://github.com/github/choosealicense.com/issues/377 for more details.*"