### PR TITLE
ice40: Fix SPRAM model to keep data stable if chipselect is low

### DIFF
--- a/techlibs/ice40/cells_sim.v
+++ b/techlibs/ice40/cells_sim.v
@@ -2350,16 +2350,19 @@ module SB_SPRAM256KA (
 		if (off) begin
 			DATAOUT <= 0;
 		end else
-		if (CHIPSELECT && !STANDBY && !WREN) begin
-			DATAOUT <= mem[ADDRESS];
-		end else begin
-			if (CHIPSELECT && !STANDBY && WREN) begin
+		if (STANDBY) begin
+			DATAOUT <= 'bx;
+		end else
+		if (CHIPSELECT) begin
+			if (!WREN) begin
+				DATAOUT <= mem[ADDRESS];
+			end else begin
 				if (MASKWREN[0]) mem[ADDRESS][ 3: 0] = DATAIN[ 3: 0];
 				if (MASKWREN[1]) mem[ADDRESS][ 7: 4] = DATAIN[ 7: 4];
 				if (MASKWREN[2]) mem[ADDRESS][11: 8] = DATAIN[11: 8];
 				if (MASKWREN[3]) mem[ADDRESS][15:12] = DATAIN[15:12];
+				DATAOUT <= 'bx;
 			end
-			DATAOUT <= 'bx;
 		end
 	end
 `endif


### PR DESCRIPTION
According to the official simulation model, and also cross-checked
on real hardware, the data output of the SPRAM when chipselect is
low is kept stable. It doesn't go undefined.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>