### PR TITLE
fsm_extract: Initialize celltypes with full design.

### DIFF
--- a/passes/fsm/fsm_extract.cc
+++ b/passes/fsm/fsm_extract.cc
@@ -422,11 +422,7 @@ struct FsmExtractPass : public Pass {
 		log_header(design, "Executing FSM_EXTRACT pass (extracting FSM from design).\n");
 		extra_args(args, 1, design);
 
-		CellTypes ct;
-		ct.setup_internals();
-		ct.setup_internals_mem();
-		ct.setup_stdcells();
-		ct.setup_stdcells_mem();
+		CellTypes ct(design);
 
 		for (auto &mod_it : design->modules_)
 		{

--- a/tests/various/bug1781.ys
+++ b/tests/various/bug1781.ys
@@ -1,0 +1,33 @@
+read_verilog <<EOT
+
+module top(input clk, input rst);
+
+reg [1:0] state;
+
+always @(posedge clk, posedge rst) begin
+	if (rst)
+		state <= 0;
+	else
+		case (state)
+			2'b00: state <= 2'b01;
+			2'b01: state <= 2'b10;
+			2'b10: state <= 2'b00;
+		endcase
+end
+
+sub sub_i(.i(state == 0));
+
+endmodule
+
+
+(* blackbox, keep *)
+module sub(input i);
+endmodule
+
+EOT
+
+proc
+fsm
+
+# Make sure there is a driver
+select -assert-any t:sub %ci %a w:* %i %ci c:* %i


### PR DESCRIPTION
Fixes #1781.