### PR TITLE
Add dependency to verilog_lexer.cc

### DIFF
--- a/frontends/verilog/Makefile.inc
+++ b/frontends/verilog/Makefile.inc
@@ -10,7 +10,7 @@ frontends/verilog/verilog_parser.tab.cc: frontends/verilog/verilog_parser.y
 
 frontends/verilog/verilog_parser.tab.hh: frontends/verilog/verilog_parser.tab.cc
 
-frontends/verilog/verilog_lexer.cc: frontends/verilog/verilog_lexer.l
+frontends/verilog/verilog_lexer.cc: frontends/verilog/verilog_lexer.l frontends/verilog/verilog_parser.tab.cc
 	$(Q) mkdir -p $(dir $@)
 	$(P) flex -o frontends/verilog/verilog_lexer.cc $<
 


### PR DESCRIPTION
This solves issue when verilog_parser.y is changes, since implicitly it depends of verilog_parser.tab.cc and verilog_parser.tab.h