### PR TITLE
opt_expr: improve performance on $alu and $sub

### DIFF
--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -682,9 +682,6 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 				RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 				RTLIL::SigSpec sig_co = cell->getPort(ID(CO));
 
-				if (sig_ci.wire || sig_bi.wire)
-					goto next_cell;
-
 				bool sub = (sig_ci == State::S1 && sig_bi == State::S1);
 
 				// If not a subtraction, yet there is a carry or B is inverted

--- a/tests/opt/opt_expr_alu.ys
+++ b/tests/opt/opt_expr_alu.ys
@@ -1,0 +1,63 @@
+read_verilog <<EOT
+module test(input a, output [1:0] y);
+assign y = {a,1'b0} + 1'b1;
+endmodule
+EOT
+
+alumacc
+equiv_opt opt_expr -fine
+design -load postopt
+select -assert-count 1 t:$pos
+select -assert-count none t:$pos t:* %D
+
+
+design -reset
+read_verilog <<EOT
+module test(input a, output [1:0] y);
+assign y = {a,1'b1} + 1'b1;
+endmodule
+EOT
+
+alumacc
+select -assert-count 1 t:$alu
+select -assert-count none t:$alu t:* %D
+
+
+design -reset
+read_verilog <<EOT
+module test(input a, output [1:0] y);
+assign y = {a,1'b1} - 1'b1;
+endmodule
+EOT
+
+equiv_opt opt_expr -fine
+design -load postopt
+select -assert-count 1 t:$pos
+select -assert-count none t:$pos t:* %D
+
+
+design -reset
+read_verilog <<EOT
+module test(input a, output [3:0] y);
+assign y = {a,3'b101} - 1'b1;
+endmodule
+EOT
+
+equiv_opt opt_expr -fine
+design -load postopt
+select -assert-count 1 t:$pos
+select -assert-count none t:$pos t:* %D
+
+
+design -reset
+read_verilog <<EOT
+module test(input a, output [3:0] y);
+assign y = {a,3'b101} - 1'b1;
+endmodule
+EOT
+
+alumacc
+equiv_opt opt_expr -fine
+design -load postopt
+select -assert-count 1 t:$pos
+select -assert-count none t:$pos t:* %D


### PR DESCRIPTION
In particular:
* `$alu` cells (implementing `$add` or `$sub` functionality only) where an input is empty or all zero -- this duplicates the same functionality as for `$add` and `$sub`
* `$sub` cells with least-significant bits equal to `1'b1` -- e.g. the expression `{a,1'b1}-1'b1` can be safely optimised to `{a,1'b0}`.