### PR TITLE
opt_expr: optimise $xor/$xnor/$_XOR_/$_XNOR_ -s with constant inputs

### DIFF
--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -502,7 +502,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 			SigBit sig_b = assign_map(cell->getPort(ID::B));
 			if (!sig_a.wire)
 				std::swap(sig_a, sig_b);
-			if (sig_b == State::S0 || sig_b == State::S1)
+			if (sig_b == State::S0 || sig_b == State::S1) {
 				if (cell->type.in(ID($xor), ID($_XOR_))) {
 					cover("opt.opt_expr.xor_buffer");
 					replace_cell(assign_map, module, cell, "xor_buffer", ID::Y, sig_b == State::S1 ? module->NotGate(NEW_ID, sig_a) : sig_a);
@@ -510,9 +510,11 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 				}
 				if (cell->type.in(ID($xnor), ID($_XNOR_))) {
 					cover("opt.opt_expr.xnor_buffer");
-					replace_cell(assign_map, module, cell, "xor_buffer", ID::Y, sig_b == State::S1 ? sig_a : module->NotGate(NEW_ID, sig_a));
+					replace_cell(assign_map, module, cell, "xnor_buffer", ID::Y, sig_b == State::S1 ? sig_a : module->NotGate(NEW_ID, sig_a));
 					goto next_cell;
 				}
+				log_abort();
+			}
 		}
 
 		if (cell->type.in(ID($reduce_and), ID($reduce_or), ID($reduce_bool), ID($reduce_xor), ID($reduce_xnor), ID($neg)) &&

--- a/tests/arch/anlogic/fsm.ys
+++ b/tests/arch/anlogic/fsm.ys
@@ -10,9 +10,6 @@ sat -verify -prove-asserts -show-public -set-at 1 in_reset 1 -seq 20 -prove-skip
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd fsm # Constrain all select calls below inside the top module
 
-select -assert-count 1 t:AL_MAP_LUT2
-select -assert-count 5 t:AL_MAP_LUT5
-select -assert-count 1 t:AL_MAP_LUT6
 select -assert-count 6 t:AL_MAP_SEQ
 
-select -assert-none t:AL_MAP_LUT2 t:AL_MAP_LUT5 t:AL_MAP_LUT6 t:AL_MAP_SEQ %% t:* %D
+select -assert-none t:AL_MAP_LUT* t:AL_MAP_SEQ %% t:* %D

--- a/tests/arch/efinix/fsm.ys
+++ b/tests/arch/efinix/fsm.ys
@@ -10,7 +10,6 @@ sat -verify -prove-asserts -show-public -set-at 1 in_reset 1 -seq 20 -prove-skip
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd fsm # Constrain all select calls below inside the top module
 
-select -assert-count 1  t:EFX_GBUFCE
-select -assert-count 6  t:EFX_FF
-select -assert-count 15 t:EFX_LUT4
+select -assert-count 1 t:EFX_GBUFCE
+select -assert-count 6 t:EFX_FF
 select -assert-none t:EFX_GBUFCE t:EFX_FF t:EFX_LUT4 %% t:* %D

--- a/tests/opt/opt_expr_xor.ys
+++ b/tests/opt/opt_expr_xor.ys
@@ -14,7 +14,7 @@ equiv_opt opt_expr
 design -load postopt
 select -assert-none t:$xor
 select -assert-none t:$xnor
-select -assert-count 2 t:$_NOT_
+select -assert-count 2 t:$not
 
 
 design -load read
@@ -38,3 +38,15 @@ equiv_opt opt_expr
 design -load postopt
 select -assert-none t:$_XNOR_ # NB: simplemap does $xnor -> $_XOR_+$_NOT_
 select -assert-count 1 t:$_NOT_
+
+
+design -reset
+read_verilog <<EOT
+module top(input a, output [1:0] w, x, y, z);
+assign w = a^1'b0;
+assign x = a^1'b1;
+assign y = a~^1'b0;
+assign z = a~^1'b1;
+endmodule
+EOT
+equiv_opt opt_expr

--- a/tests/opt/opt_expr_xor.ys
+++ b/tests/opt/opt_expr_xor.ys
@@ -1,0 +1,40 @@
+read_verilog <<EOT
+module top(input a, output [3:0] y);
+assign y[0] = a^1'b0;
+assign y[1] = 1'b1^a;
+assign y[2] = a~^1'b0;
+assign y[3] = 1'b1^~a;
+endmodule
+EOT
+design -save read
+select -assert-count 2 t:$xor
+select -assert-count 2 t:$xnor
+
+equiv_opt opt_expr
+design -load postopt
+select -assert-none t:$xor
+select -assert-none t:$xnor
+select -assert-count 2 t:$_NOT_
+
+
+design -load read
+simplemap
+equiv_opt opt_expr
+design -load postopt
+select -assert-none t:$_XOR_
+select -assert-none t:$_XNOR_ # NB: simplemap does $xnor -> $_XOR_+$_NOT_
+select -assert-count 3 t:$_NOT_
+
+
+design -reset
+read_verilog -icells <<EOT
+module top(input a, output [1:0] y);
+$_XNOR_ u0(.A(a), .B(1'b0), .Y(y[0]));
+$_XNOR_ u1(.A(1'b1), .B(a), .Y(y[1]));
+endmodule
+EOT
+select -assert-count 2 t:$_XNOR_
+equiv_opt opt_expr
+design -load postopt
+select -assert-none t:$_XNOR_ # NB: simplemap does $xnor -> $_XOR_+$_NOT_
+select -assert-count 1 t:$_NOT_


### PR DESCRIPTION
Interestingly, it seems that `opt_expr` will only optimise word-level `$and`/`$or` cells if they are one-bit wide:
https://github.com/YosysHQ/yosys/blob/f828cb5132b5d1a2c2d4d26ffaac6d492c7cc69e/passes/opt/opt_expr.cc#L443
https://github.com/YosysHQ/yosys/blob/f828cb5132b5d1a2c2d4d26ffaac6d492c7cc69e/passes/opt/opt_expr.cc#L449

Thus something like: `assign y = a & 2'b11` would not get optimised until simplemap breaks it down to gate-level/1-bit wide `$_AND_` cells.

In the case of `$xor`/`$xnor`/`$_XOR_`/`$_XNOR_` it seems that no optimisation was done at all, so this PR fixes that (but still only operates on 1-bit word cells).