### PR TITLE
ice40: Map unmapped 'mince' DFFs to gate level

### DIFF
--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -345,6 +345,7 @@ struct SynthIce40Pass : public ScriptPass
 			if (min_ce_use >= 0) {
 				run("opt_merge");
 				run(stringf("dff2dffe -unmap-mince %d", min_ce_use));
+				run("simplemap t:$dff");
 			}
 			run("techmap -D NO_LUT -D NO_ADDER -map +/ice40/cells_map.v");
 			run("opt_expr -mux_undef");

--- a/tests/various/ice40_mince_abc9.ys
+++ b/tests/various/ice40_mince_abc9.ys
@@ -1,0 +1,17 @@
+read_verilog <<EOT
+
+module top(input clk, ce, input [2:0] a, b, output reg [2:0] q);
+
+	reg [2:0] aa, bb;
+
+	always @(posedge clk) begin
+		if (ce) begin
+			aa <= a;
+		end
+		bb <= b;
+		q <= aa + bb;
+	end
+endmodule
+EOT
+
+synth_ice40 -abc9 -dffe_min_ce_use 4


### PR DESCRIPTION
Otherwise, they are not mapped to `SB_DFF` before ABC, which causes a 'no loops' failure in `abc9` (and would also mean that required times etc were wrong).

cc @smunaut 