### PR TITLE
tests: avoid using bash4's assoc arrays as macOS no likey

### DIFF
--- a/tests/arch/run-test.sh
+++ b/tests/arch/run-test.sh
@@ -2,14 +2,16 @@
 
 set -e
 
-declare -A defines=( ["ice40"]="ICE40_HX ICE40_LP ICE40_U" )
-
 echo "Running syntax check on arch sim models"
 for arch in ../../techlibs/*; do
 	find $arch -name cells_sim.v | while read path; do
 		arch_name=$(basename -- $arch)
-		if [ "${defines[$arch_name]}" ]; then
-			for def in ${defines[$arch_name]}; do
+		defines=""
+		if [ "$arch_name" == "ice40" ]; then
+			defines="ICE40_HX ICE40_LP ICE40_U"
+		fi
+		if [ ! -z "$defines" ]; then
+			for def in $defines; do
 				echo -n "Test $path -D$def ->"
 				iverilog -t null -I$arch -D$def $path
 				echo " ok"


### PR DESCRIPTION
Resolves https://github.com/YosysHQ/yosys/pull/1739#issuecomment-599516034