### PR TITLE
Enable ENABLE_LIBYOSYS when ENABLE_PYOSYS is set (closes #1813)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ ifneq ($(wildcard Makefile.conf),)
 include Makefile.conf
 endif
 
+ifeq ($(ENABLE_PYOSYS),1)
+ENABLE_LIBYOSYS := 1
+endif
+
 BINDIR := $(PREFIX)/bin
 LIBDIR := $(PREFIX)/lib
 DATDIR := $(PREFIX)/share/yosys


### PR DESCRIPTION
Since for pyosys libyosys is mandatory, this makes it more user friendly.
This closes issue  #1813