### PR TITLE
Fix solver output parsing for exists-forall optimization 

### DIFF
--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -704,7 +704,9 @@ class SmtIo:
                     if msg is not None:
                         print("%s waiting for solver (%s)" % (self.timestamp(), msg), flush=True)
 
-        result = self.read()
+        result = ""
+        while result not in ["sat", "unsat", "unknown"]:
+            result = self.read()
 
         if self.debug_file:
             print("(set-info :status %s)" % result, file=self.debug_file)

--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -704,8 +704,12 @@ class SmtIo:
                     if msg is not None:
                         print("%s waiting for solver (%s)" % (self.timestamp(), msg), flush=True)
 
-        result = ""
-        while result not in ["sat", "unsat", "unknown"]:
+        if self.forall:
+            result = self.read()
+            while result not in ["sat", "unsat", "unknown"]:
+                print("%s %s: %s" % (self.timestamp(), self.solver, result))
+                result = self.read()
+        else:
             result = self.read()
 
         if self.debug_file:


### PR DESCRIPTION
This assumes the only desired output from the solver will be "sat", "unsat", or "unknown".