### PR TITLE
Add support for QuickLogic devices

### DIFF
--- a/techlibs/quicklogic/Makefile.inc
+++ b/techlibs/quicklogic/Makefile.inc
@@ -1,0 +1,5 @@
+
+OBJS += techlibs/quicklogic/synth_quicklogic.o
+
+$(eval $(call add_share_file,share/quicklogic,techlibs/quicklogic/cells_map.v))
+$(eval $(call add_share_file,share/quicklogic,techlibs/quicklogic/cells_sim.v))

--- a/techlibs/quicklogic/cells_map.v
+++ b/techlibs/quicklogic/cells_map.v
@@ -1,63 +1,141 @@
-module \$_MUX_ (
-   input A,
-   input B,
-   input S,
-   output Y
-);
-    QLOGIC_MUX _TECHMAP_REPLACE_ (.A(A), .B(B), .S(S), .Y(Y));
+module \$lut (A, Y);
+    parameter WIDTH = 0;
+    parameter LUT = 0;
+
+    input [WIDTH-1:0] A;
+    output Y;
+
+    generate
+        if (WIDTH == 1)
+        begin
+            LUT1 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]));
+        end
+        else if (WIDTH == 2)
+        begin
+            LUT2 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]), .I1(A[1]));
+        end
+        else if (WIDTH == 3)
+        begin
+            LUT3 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]), .I1(A[1]), .I2(A[2]));
+        end
+        else if (WIDTH == 4)
+        begin
+            LUT4 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]), .I1(A[1]), .I2(A[2]), .I3(A[3]));
+        end
+        else
+        begin
+            wire _TECHMAP_FAIL_ = 1;
+        end
+    endgenerate
 endmodule
 
-module \$_DFF_N_ (
-   input D,
-   input C,
-   output Q
-);
-    wire nC = ~ C;
-    QLOGIC_DFFE _TECHMAP_REPLACE_ (.S(1'b0), .D(D), .E(1'b1), .QCK(nC), .R(1'b0), .QZ(Q));
+module \$_MUX_ (A, B, S, Y);
+
+    parameter WIDTH = 0;
+
+    input [WIDTH-1:0] A, B;
+    input S;
+    output reg [WIDTH-1:0] Y;
+
+    generate
+        if (WIDTH == 1)
+        begin
+            mux2x0 _TECHMAP_REPLACE_ (.Q(Y[0]), .S(S), .A(A[0]), .B(B[0]));
+        end
+        else
+        begin
+            wire _TECHMAP_FAIL_ = 1;
+        end
+    endgenerate
 endmodule
 
-module \$_DFF_P_ (
-   input D,
-   input C,
-   output Q
-);
-    QLOGIC_DFFE _TECHMAP_REPLACE_ (.S(1'b0), .D(D), .E(1'b1), .QCK(C), .R(1'b0), .QZ(Q));
+module \$_NOT_ (A, Y);
+    input A;
+    output Y;
+    inv _TECHMAP_REPLACE_ (.Q(Y), .A(A));
 endmodule
 
-module \$_DFF_PN0_ (
-   input D,
-   input C,
-   input R,
-   output Q
-);
-    wire nR = ~ R;
-    QLOGIC_DFFE _TECHMAP_REPLACE_ (.S(1'b0), .D(D), .E(1'b1), .QCK(C), .R(nR), .QZ(Q));
+module \$_AND_ (A, B, Y);
+    input A;
+    input B;
+    output Y;
+    AND2I0 _TECHMAP_REPLACE_ (.Q(Q), .A(A), .B(B));
 endmodule
 
-module \$_DFF_PP0_ (
-   input D,
-   input C,
-   input R,
-   output Q
-);
-    QLOGIC_DFFE _TECHMAP_REPLACE_ (.S(1'b0), .D(D), .E(1'b1), .QCK(C), .R(R), .QZ(Q));
+module \$_DFF_N_ (D, Q, C);
+    input D;
+    input C;
+    output Q;
+    dff _TECHMAP_REPLACE_ (.Q(Q), .D(D), .CLK(~C));
 endmodule
 
-module \$__DFFE_PP0_ (
-   input D,
-   input C,
-   input E,
-   input R,
-   output Q
-);
-    wire nE = ~ E;
-    QLOGIC_DFFE _TECHMAP_REPLACE_ (.S(1'b0), .D(D), .E(nE), .QCK(C), .R(R), .QZ(Q));
+module \$_DFF_P_ (D, Q, C);
+    input D;
+    input C;
+    output Q;
+    dff _TECHMAP_REPLACE_ (.Q(Q), .D(D), .CLK(C));
 endmodule
 
-module \$_NOT_ (
-   input A,
-   output Y
-);
-    QLOGIC_NOT _TECHMAP_REPLACE_ (.A(A), .Y(Y));
+module \$_DFF_NN0_ (D, Q, C, R);
+    input D;
+    input C;
+    input R;
+    output Q;
+    dffc _TECHMAP_REPLACE_ (.Q(Q), .D(D), .CLK(~C), .CLR(~R));
 endmodule
 
+module \$_DFF_NN1_ (D, Q, C, R);
+    input D;
+    input C;
+    input R;
+    output Q;
+    dffp _TECHMAP_REPLACE_ (.Q(Q), .D(D), .CLK(~C), .PRE(~R));
+endmodule
+
+module \$_DFF_NP0_ (D, Q, C, R);
+    input D;
+    input C;
+    input R;
+    output Q;
+    dffc _TECHMAP_REPLACE_ (.Q(Q), .D(D), .CLK(~C), .CLR(R));
+endmodule
+
+module \$_DFF_NP1_ (D, Q, C, R);
+    input D;
+    input C;
+    input R;
+    output Q;
+    dffp _TECHMAP_REPLACE_ (.Q(Q), .D(D), .CLK(~C), .PRE(R));
+endmodule
+
+module \$_DFF_PN0_ (D, Q, C, R);
+    input D;
+    input C;
+    input R;
+    output Q;
+    dffc _TECHMAP_REPLACE_ (.Q(Q), .D(D), .CLK(C), .CLR(~R));
+endmodule
+
+module \$_DFF_PN1_ (D, Q, C, R);
+    input D;
+    input C;
+    input R;
+    output Q;
+    dffp _TECHMAP_REPLACE_ (.Q(Q), .D(D), .CLK(C), .PRE(~R));
+endmodule
+
+module \$_DFF_PP0_ (D, Q, C, R);
+    input D;
+    input C;
+    input R;
+    output Q;
+    dffc _TECHMAP_REPLACE_ (.Q(Q), .D(D), .CLK(C), .CLR(R));
+endmodule
+
+module \$_DFF_PP1_ (D, Q, C, R);
+    input D;
+    input C;
+    input R;
+    output Q;
+    dffp _TECHMAP_REPLACE_ (.Q(Q), .D(D), .CLK(C), .PRE(R));
+endmodule

--- a/techlibs/quicklogic/cells_map.v
+++ b/techlibs/quicklogic/cells_map.v
@@ -66,7 +66,9 @@ module \$_DFF_N_ (D, Q, C);
     input D;
     input C;
     output Q;
-    dff _TECHMAP_REPLACE_ (.Q(Q), .D(D), .CLK(~C));
+    wire C_INV;
+    inv clkinv (.Q(C_INV), .A(C));
+    dff tmpdff (.Q(Q), .D(D), .CLK(C_INV));
 endmodule
 
 module \$_DFF_P_ (D, Q, C);
@@ -81,7 +83,11 @@ module \$_DFF_NN0_ (D, Q, C, R);
     input C;
     input R;
     output Q;
-    dffc _TECHMAP_REPLACE_ (.Q(Q), .D(D), .CLK(~C), .CLR(~R));
+    wire C_INV;
+    inv clkinv (.Q(C_INV), .A(C));
+    wire R_INV;
+    inv clrinv (.Q(R_INV), .A(R));
+    dffc tmpdffc (.Q(Q), .D(D), .CLK(C_INV), .CLR(R_INV));
 endmodule
 
 module \$_DFF_NN1_ (D, Q, C, R);
@@ -89,7 +95,11 @@ module \$_DFF_NN1_ (D, Q, C, R);
     input C;
     input R;
     output Q;
-    dffp _TECHMAP_REPLACE_ (.Q(Q), .D(D), .CLK(~C), .PRE(~R));
+    wire C_INV;
+    inv clkinv (.Q(C_INV), .A(C));
+    wire R_INV;
+    inv preinv (.Q(R_INV), .A(R));
+    dffp tmpdffp (.Q(Q), .D(D), .CLK(C_INV), .PRE(R_INV));
 endmodule
 
 module \$_DFF_NP0_ (D, Q, C, R);
@@ -97,7 +107,9 @@ module \$_DFF_NP0_ (D, Q, C, R);
     input C;
     input R;
     output Q;
-    dffc _TECHMAP_REPLACE_ (.Q(Q), .D(D), .CLK(~C), .CLR(R));
+    wire C_INV;
+    inv clkinv (.Q(C_INV), .A(C));
+    dffc tmpdffc (.Q(Q), .D(D), .CLK(C_INV), .CLR(R));
 endmodule
 
 module \$_DFF_NP1_ (D, Q, C, R);
@@ -105,7 +117,9 @@ module \$_DFF_NP1_ (D, Q, C, R);
     input C;
     input R;
     output Q;
-    dffp _TECHMAP_REPLACE_ (.Q(Q), .D(D), .CLK(~C), .PRE(R));
+    wire C_INV;
+    inv clkinv (.Q(C_INV), .A(C));
+    dffp tmpdffp (.Q(Q), .D(D), .CLK(C_INV), .PRE(R));
 endmodule
 
 module \$_DFF_PN0_ (D, Q, C, R);
@@ -113,7 +127,9 @@ module \$_DFF_PN0_ (D, Q, C, R);
     input C;
     input R;
     output Q;
-    dffc _TECHMAP_REPLACE_ (.Q(Q), .D(D), .CLK(C), .CLR(~R));
+    wire R_INV;
+    inv preinv (.Q(R_INV), .A(R));
+    dffc tmpdffc (.Q(Q), .D(D), .CLK(C), .CLR(R_INV));
 endmodule
 
 module \$_DFF_PN1_ (D, Q, C, R);
@@ -121,7 +137,9 @@ module \$_DFF_PN1_ (D, Q, C, R);
     input C;
     input R;
     output Q;
-    dffp _TECHMAP_REPLACE_ (.Q(Q), .D(D), .CLK(C), .PRE(~R));
+    wire R_INV;
+    inv preinv (.Q(R_INV), .A(R));
+    dffp tmpdffp (.Q(Q), .D(D), .CLK(C), .PRE(R_INV));
 endmodule
 
 module \$_DFF_PP0_ (D, Q, C, R);

--- a/techlibs/quicklogic/cells_map.v
+++ b/techlibs/quicklogic/cells_map.v
@@ -194,3 +194,20 @@ module \$_DFFSR_PPP_ (D, Q, C, R, S);
     output Q;
     dffpc tmpdffpc (.Q(Q), .D(D), .CLK(C), .CLR(R), .PRE(S));
 endmodule
+
+module qlal4s3_mult_16x16_cell (
+    input [15:0] Amult,
+    input [15:0] Bmult,
+    input [1:0] Valid_mult,
+    input [31:0] Cmult);
+
+    wire [63:0] Cmult_w;
+    wire [31:0] Amult_w;
+    wire [31:0] Bmult_w;
+
+    assign Amult_w = {{16{Amult[15]}}, Amult};
+    assign Bmult_w = {{16{Bmult[15]}}, Bmult};
+    assign Cmult = Cmult_w[31:0];
+
+    qlal4s3_mult_32x32_cell I1 ( .Amult(Amult_w), .Bmult(Bmult_w), .Cmult(Cmult_w));
+endmodule

--- a/techlibs/quicklogic/cells_map.v
+++ b/techlibs/quicklogic/cells_map.v
@@ -1,0 +1,63 @@
+module \$_MUX_ (
+   input A,
+   input B,
+   input S,
+   output Y
+);
+    QLOGIC_MUX _TECHMAP_REPLACE_ (.A(A), .B(B), .S(S), .Y(Y));
+endmodule
+
+module \$_DFF_N_ (
+   input D,
+   input C,
+   output Q
+);
+    wire nC = ~ C;
+    QLOGIC_DFFE _TECHMAP_REPLACE_ (.S(1'b0), .D(D), .E(1'b1), .QCK(nC), .R(1'b0), .QZ(Q));
+endmodule
+
+module \$_DFF_P_ (
+   input D,
+   input C,
+   output Q
+);
+    QLOGIC_DFFE _TECHMAP_REPLACE_ (.S(1'b0), .D(D), .E(1'b1), .QCK(C), .R(1'b0), .QZ(Q));
+endmodule
+
+module \$_DFF_PN0_ (
+   input D,
+   input C,
+   input R,
+   output Q
+);
+    wire nR = ~ R;
+    QLOGIC_DFFE _TECHMAP_REPLACE_ (.S(1'b0), .D(D), .E(1'b1), .QCK(C), .R(nR), .QZ(Q));
+endmodule
+
+module \$_DFF_PP0_ (
+   input D,
+   input C,
+   input R,
+   output Q
+);
+    QLOGIC_DFFE _TECHMAP_REPLACE_ (.S(1'b0), .D(D), .E(1'b1), .QCK(C), .R(R), .QZ(Q));
+endmodule
+
+module \$__DFFE_PP0_ (
+   input D,
+   input C,
+   input E,
+   input R,
+   output Q
+);
+    wire nE = ~ E;
+    QLOGIC_DFFE _TECHMAP_REPLACE_ (.S(1'b0), .D(D), .E(nE), .QCK(C), .R(R), .QZ(Q));
+endmodule
+
+module \$_NOT_ (
+   input A,
+   output Y
+);
+    QLOGIC_NOT _TECHMAP_REPLACE_ (.A(A), .Y(Y));
+endmodule
+

--- a/techlibs/quicklogic/cells_map.v
+++ b/techlibs/quicklogic/cells_map.v
@@ -5,22 +5,39 @@ module \$lut (A, Y);
     input [WIDTH-1:0] A;
     output Y;
 
+    function [WIDTH ** 2 - 1:0] INIT_address_inverse;
+        input [WIDTH ** 2 - 1: 0] arr;
+        integer i;
+        integer n;
+        reg [WIDTH - 1:0] tmp;
+        reg [WIDTH - 1:0] tmp2;
+        tmp = 0;
+        tmp2 = 0;
+        for (i = 0; i < WIDTH ** 2; i++) begin
+            INIT_address_inverse[tmp2] = arr[tmp];
+            tmp = tmp + 1;
+            for (n = 0; n < WIDTH; n++) begin
+                tmp2[WIDTH - 1 - n] = tmp[n];
+            end
+        end
+    endfunction
+
     generate
         if (WIDTH == 1)
         begin
-            LUT1 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]));
+            LUT1 #(.INIT(INIT_address_inverse(LUT))) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]));
         end
         else if (WIDTH == 2)
         begin
-            LUT2 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]), .I1(A[1]));
+            LUT2 #(.INIT(INIT_address_inverse(LUT))) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]), .I1(A[1]));
         end
         else if (WIDTH == 3)
         begin
-            LUT3 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]), .I1(A[1]), .I2(A[2]));
+            LUT3 #(.INIT(INIT_address_inverse(LUT))) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]), .I1(A[1]), .I2(A[2]));
         end
         else if (WIDTH == 4)
         begin
-            LUT4 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]), .I1(A[1]), .I2(A[2]), .I3(A[3]));
+            LUT4 #(.INIT(INIT_address_inverse(LUT))) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]), .I1(A[1]), .I2(A[2]), .I3(A[3]));
         end
         else
         begin

--- a/techlibs/quicklogic/cells_map.v
+++ b/techlibs/quicklogic/cells_map.v
@@ -29,15 +29,15 @@ module \$lut (A, Y);
         end
         else if (WIDTH == 2)
         begin
-            LUT2 #(.INIT(INIT_address_inverse(LUT))) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]), .I1(A[1]));
+            LUT2 #(.INIT(INIT_address_inverse(LUT))) _TECHMAP_REPLACE_ (.O(Y), .I0(A[1]), .I1(A[0]));
         end
         else if (WIDTH == 3)
         begin
-            LUT3 #(.INIT(INIT_address_inverse(LUT))) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]), .I1(A[1]), .I2(A[2]));
+            LUT3 #(.INIT(INIT_address_inverse(LUT))) _TECHMAP_REPLACE_ (.O(Y), .I0(A[2]), .I1(A[1]), .I2(A[0]));
         end
         else if (WIDTH == 4)
         begin
-            LUT4 #(.INIT(INIT_address_inverse(LUT))) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]), .I1(A[1]), .I2(A[2]), .I3(A[3]));
+            LUT4 #(.INIT(INIT_address_inverse(LUT))) _TECHMAP_REPLACE_ (.O(Y), .I0(A[3]), .I1(A[2]), .I2(A[1]), .I3(A[0]));
         end
         else
         begin
@@ -76,7 +76,7 @@ module \$_AND_ (A, B, Y);
     input A;
     input B;
     output Y;
-    AND2I0 _TECHMAP_REPLACE_ (.Q(Q), .A(A), .B(B));
+    AND2I0 _TECHMAP_REPLACE_ (.Q(Y), .A(A), .B(B));
 endmodule
 
 module \$_DFF_N_ (D, Q, C);

--- a/techlibs/quicklogic/cells_map.v
+++ b/techlibs/quicklogic/cells_map.v
@@ -195,6 +195,108 @@ module \$_DFFSR_PPP_ (D, Q, C, R, S);
     dffpc tmpdffpc (.Q(Q), .D(D), .CLK(C), .CLR(R), .PRE(S));
 endmodule
 
+module \$_DLATCH_P_ (E, D, Q);
+    input E;
+    input D;
+    output reg Q;
+    LUT3 #(.INIT(8'b11100010)) latchimpl (.O(Q), .I2(D), .I1(E), .I0(Q));
+endmodule
+
+module \$_DLATCH_N_ (E, D, Q);
+    input E;
+    input D;
+    output reg Q;
+    LUT3 #(.INIT(8'b10111000)) latchimpl (.O(Q), .I2(D), .I1(E), .I0(Q));
+endmodule
+
+module \$_DLATCHSR_NNN_ (E, S, R, D, Q);
+    input E;
+    input S;
+    input R;
+    input D;
+    output Q;
+    wire SEDQ;
+    LUT4 #(.INIT(16'b101011001111111)) sedqlut (.O(SEDQ), .I3(S), .I2(E), .I1(D), .I0(Q));
+    LUT2 #(.INIT(4'b1000)) sedr (.O(Q), .I1(R), .I0(SEDQ));
+endmodule
+
+module \$_DLATCHSR_NNP_ (E, S, R, D, Q);
+    input E;
+    input S;
+    input R;
+    input D;
+    output Q;
+    wire SEDQ;
+    LUT4 #(.INIT(16'b101011001111111)) sedqlut (.O(SEDQ), .I3(S), .I2(E), .I1(D), .I0(Q));
+    LUT2 #(.INIT(4'b0010)) sedr (.O(Q), .I1(R), .I0(SEDQ));
+endmodule
+
+module \$_DLATCHSR_NPN_ (E, S, R, D, Q);
+    input E;
+    input S;
+    input R;
+    input D;
+    output Q;
+    wire SEDQ;
+    LUT4 #(.INIT(16'b111111111010110)) sedqlut (.O(SEDQ), .I3(S), .I2(E), .I1(D), .I0(Q));
+    LUT2 #(.INIT(4'b1000)) sedr (.O(Q), .I1(R), .I0(SEDQ));
+endmodule
+
+module \$_DLATCHSR_NPP_ (E, S, R, D, Q);
+    input E;
+    input S;
+    input R;
+    input D;
+    output Q;
+    wire SEDQ;
+    LUT4 #(.INIT(16'b111111111010110)) sedqlut (.O(SEDQ), .I3(S), .I2(E), .I1(D), .I0(Q));
+    LUT2 #(.INIT(4'b0010)) sedr (.O(Q), .I1(R), .I0(SEDQ));
+endmodule
+
+module \$_DLATCHSR_PNN_ (E, S, R, D, Q);
+    input E;
+    input S;
+    input R;
+    input D;
+    output Q;
+    wire SEDQ;
+    LUT4 #(.INIT(16'b110010101111111)) sedqlut (.O(SEDQ), .I3(S), .I2(E), .I1(D), .I0(Q));
+    LUT2 #(.INIT(4'b1000)) sedr (.O(Q), .I1(R), .I0(SEDQ));
+endmodule
+
+module \$_DLATCHSR_PNP_ (E, S, R, D, Q);
+    input E;
+    input S;
+    input R;
+    input D;
+    output Q;
+    wire SEDQ;
+    LUT4 #(.INIT(16'b110010101111111)) sedqlut (.O(SEDQ), .I3(S), .I2(E), .I1(D), .I0(Q));
+    LUT2 #(.INIT(4'b0010)) sedr (.O(Q), .I1(R), .I0(SEDQ));
+endmodule
+
+module \$_DLATCHSR_PPN_ (E, S, R, D, Q);
+    input E;
+    input S;
+    input R;
+    input D;
+    output Q;
+    wire SEDQ;
+    LUT4 #(.INIT(16'b111111111100101)) sedqlut (.O(SEDQ), .I3(S), .I2(E), .I1(D), .I0(Q));
+    LUT2 #(.INIT(4'b1000)) sedr (.O(Q), .I1(R), .I0(SEDQ));
+endmodule
+
+module \$_DLATCHSR_PPP_ (E, S, R, D, Q);
+    input E;
+    input S;
+    input R;
+    input D;
+    output Q;
+    wire SEDQ;
+    LUT4 #(.INIT(16'b11111111110010)) sedqlut (.O(SEDQ), .I3(S), .I2(E), .I1(D), .I0(Q));
+    LUT2 #(.INIT(4'b0010)) sedr (.O(Q), .I1(R), .I0(SEDQ));
+endmodule
+
 module qlal4s3_mult_16x16_cell (
     input [15:0] Amult,
     input [15:0] Bmult,

--- a/techlibs/quicklogic/cells_map.v
+++ b/techlibs/quicklogic/cells_map.v
@@ -174,3 +174,23 @@ module \$_DFF_PP1_ (D, Q, C, R);
     output Q;
     dffp _TECHMAP_REPLACE_ (.Q(Q), .D(D), .CLK(C), .PRE(R));
 endmodule
+
+module \$_DFFSR_NPP_ (D, Q, C, R, S);
+    input D;
+    input C;
+    input R;
+    input S;
+    output Q;
+    wire C_INV;
+    inv clkinv (.Q(C_INV), .A(C));
+    dffpc tmpdffpc (.Q(Q), .D(D), .CLK(C_INV), .CLR(R), .PRE(S));
+endmodule
+
+module \$_DFFSR_PPP_ (D, Q, C, R, S);
+    input D;
+    input C;
+    input R;
+    input S;
+    output Q;
+    dffpc tmpdffpc (.Q(Q), .D(D), .CLK(C), .CLR(R), .PRE(S));
+endmodule

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -278,6 +278,25 @@ module ram8k_2x1_cell_macro (
     input [3:0] RMB);
 
 endmodule /* ram8k_2x1_cell_macro */
+
+(* blackbox *)
+module qlal4s3_32x32_mult_cell (
+    input [31:0] Amult,
+    input [31:0] Bmult,
+    input [1:0] Valid_mult,
+    output [63:0] Cmult);
+
+endmodule /* qlal4s3_32x32_mult_cell */
+
+(* blackbox *)
+module qlal4s3_16x16_mult_cell (
+    input [15:0] Amult,
+    input [15:0] Bmult,
+    input [1:0] Valid_mult,
+    output [31:0] Cmult);
+
+endmodule /* qlal4s3_16x16_mult_cell */
+
 // module DFFSEC(output Q, input D, CLR, EN, CLK, N_11);
 //     parameter [0:0] INIT = 1'b0;
 //     // TODO implement

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -7,36 +7,26 @@ endmodule
 //               TZ        TSL TAB
 module LUT2(output O, input I0, I1);
     parameter [3:0] INIT = 0;
-    wire [1:0] s1 = I0 ? INIT[3:2] : INIT[1:0];
-    assign O = I1 ? s1[1] : s1[0];
+    assign O = INIT[{I1, I0}];
 endmodule
 
-// O: TZ
+// O:  TZ
 // I0: TA1 TA2 TB1 TB2
 // I1: TSL
 // I2: TAB
 module LUT3(output O, input I0, I1, I2);
     parameter [7:0] INIT = 0;
-    wire [3:0] s2 = I0 ? INIT[7:4] : INIT[3:0];
-    wire [1:0] s1 = I1 ? s2[3:2] : s2[1:0];
-    assign O = I2 ? s1[1] : s1[0];
-    // TODO: This is not a valid in-sight implementation for QL - to be
-    // discussed with the client
+    assign O = INIT[{I2, I1, I0}];
 endmodule
 
-// O: CZ
+// O:  CZ
 // I0: TA1 TA2 TB1 TB2 BA1 BA2 BB1 BB2
 // I1: TSL BSL
 // I2: TAB BAB
 // I3: TBS
 module LUT4(output O, input I0, I1, I2, I3);
     parameter [15:0] INIT = 0;
-    wire [7:0] s3 = I0 ? INIT[15:8] : INIT[7:0];
-    wire [3:0] s2 = I1 ? s3[7:4] : s3[3:0];
-    wire [1:0] s1 = I2 ? s2[3:2] : s2[1:0];
-    assign O = I3 ? s1[1] : s1[0];
-    // TODO: This is not a valid in-sight implementation for QL - to be
-    // discussed with the client
+    assign O = INIT[{I3, I2, I1, I0}];
 endmodule
 
 //               FZ       FS

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -166,8 +166,8 @@ module outpad(output P, input A);
     assign P = A;
 endmodule
 
-module ckpad(output Q, input P);
-    assign Q = P;
+module ckpad(output CLK, input P);
+    assign CLK = P;
 endmodule
 
 // module DFFSEC(output Q, input D, CLR, EN, CLK, N_11);

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -45,7 +45,7 @@ module inv(output Q, input A);
 endmodule
 
 //               QZ      QDI  QCK
-module dff(output Q, input D, CLK);
+module dff(output reg Q, input D, CLK);
     parameter [0:0] INIT = 1'b0;
     initial Q = INIT;
     always @(posedge CLK) begin
@@ -54,7 +54,7 @@ module dff(output Q, input D, CLK);
 endmodule
 
 //                QZ      QDI  QCK  QRT
-module dffc(output Q, input D, CLK, CLR);
+module dffc(output reg Q, input D, CLK, CLR);
     parameter [0:0] INIT = 1'b0;
     initial Q = INIT;
     always @(posedge CLK, posedge CLR) begin
@@ -66,7 +66,7 @@ module dffc(output Q, input D, CLK, CLR);
 endmodule
 
 //                QZ      QDI  QCK  QST
-module dffp(output Q, input D, CLK, PRE);
+module dffp(output reg Q, input D, CLK, PRE);
     parameter [0:0] INIT = 1'b0;
     initial Q = INIT;
     always @(posedge CLK, posedge PRE) begin
@@ -78,7 +78,7 @@ module dffp(output Q, input D, CLK, PRE);
 endmodule
 
 //                 QZ      QDI  QCK  QRT  QST
-module dffpc(output Q, input D, CLK, CLR, PRE);
+module dffpc(output reg Q, input D, CLK, CLR, PRE);
     parameter [0:0] INIT = 1'b0;
     initial Q = INIT;
     always @(posedge CLK, posedge CLR, posedge PRE) begin
@@ -92,7 +92,7 @@ module dffpc(output Q, input D, CLK, CLR, PRE);
 endmodule
 
 //                QZ      QDI  QCK QEN
-module dffe(output Q, input D, CLK, EN);
+module dffe(output reg Q, input D, CLK, EN);
     parameter [0:0] INIT = 1'b0;
     initial Q = INIT;
     always @(posedge CLK) begin
@@ -102,7 +102,7 @@ module dffe(output Q, input D, CLK, EN);
 endmodule
 
 //                 QZ      QDI  QCK QEN  QRT
-module dffec(output Q, input D, CLK, EN, CLR);
+module dffec(output reg Q, input D, CLK, EN, CLR);
     parameter [0:0] INIT = 1'b0;
     initial Q = INIT;
     always @(posedge CLK, posedge CLR) begin
@@ -114,7 +114,7 @@ module dffec(output Q, input D, CLK, EN, CLR);
 endmodule
 
 //                  QZ      QDI  QCK QEN  QRT  QST
-module dffepc(output Q, input D, CLK, EN, CLR, PRE);
+module dffepc(output reg Q, input D, CLK, EN, CLR, PRE);
     parameter [0:0] INIT = 1'b0;
     initial Q = INIT;
     always @(posedge CLK, posedge CLR, posedge PRE) begin

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -7,8 +7,8 @@ endmodule
 //               TZ        TSL TAB
 module LUT2(output O, input I0, I1);
     parameter [3:0] INIT = 0;
-    wire [1:0] s1 = I1 ? INIT[3:2] : INIT[1:0];
-    assign O = I0 ? s1[1] : s1[0];
+    wire [1:0] s1 = I0 ? INIT[3:2] : INIT[1:0];
+    assign O = I1 ? s1[1] : s1[0];
 endmodule
 
 // O: TZ
@@ -17,9 +17,9 @@ endmodule
 // I2: TAB
 module LUT3(output O, input I0, I1, I2);
     parameter [7:0] INIT = 0;
-    wire [3:0] s2 = I2 ? INIT[7:4] : INIT[3:0];
+    wire [3:0] s2 = I0 ? INIT[7:4] : INIT[3:0];
     wire [1:0] s1 = I1 ? s2[3:2] : s2[1:0];
-    assign O = I0 ? s1[1] : s1[0];
+    assign O = I2 ? s1[1] : s1[0];
     // TODO: This is not a valid in-sight implementation for QL - to be
     // discussed with the client
 endmodule
@@ -31,10 +31,10 @@ endmodule
 // I3: TBS
 module LUT4(output O, input I0, I1, I2, I3);
     parameter [15:0] INIT = 0;
-    wire [7:0] s3 = I3 ? INIT[15:8] : INIT[7:0];
-    wire [3:0] s2 = I2 ? s3[7:4] : s3[3:0];
-    wire [1:0] s1 = I1 ? s2[3:2] : s2[1:0];
-    assign O = I0 ? s1[1] : s1[0];
+    wire [7:0] s3 = I0 ? INIT[15:8] : INIT[7:0];
+    wire [3:0] s2 = I1 ? s3[7:4] : s3[3:0];
+    wire [1:0] s1 = I2 ? s2[3:2] : s2[1:0];
+    assign O = I3 ? s1[1] : s1[0];
     // TODO: This is not a valid in-sight implementation for QL - to be
     // discussed with the client
 endmodule

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -121,6 +121,18 @@ module dffepc(output reg Q, input D, CLK, EN, CLR, PRE);
     end
 endmodule
 
+//                 QZ        QDI    QCK  QRT
+module dffsc(output reg Q, input D, CLK, CLR);
+    parameter [0:0] INIT = 1'b0;
+    initial Q = INIT;
+    always @(posedge CLK, posedge CLR) begin
+        if (CLR)
+            Q <= 1'b0;
+        else
+            Q <= D;
+    end
+endmodule
+
 //                  FZ       FS F2 (F1 TO 0)
 module AND2I0(output Q, input A, B);
     assign Q = A ? B : 0;

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -166,8 +166,8 @@ module outpad(output P, input A);
     assign P = A;
 endmodule
 
-module ckpad(output CLK, input P);
-    assign CLK = P;
+module ckpad(output Q, input P);
+    assign Q = P;
 endmodule
 
 // module DFFSEC(output Q, input D, CLR, EN, CLK, N_11);

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -241,13 +241,43 @@ input   Sys_PKfb_ClkS,
 input   FB_BusyS,
 input   WB_CLKS);
 
-endmodule /* qlal4s3b_cell_macro*/
+endmodule /* qlal4s3b_cell_macro */
 
 (* blackbox *)
 module gclkbuff (input A, output Z);
 
 endmodule
 
+(* blackbox *)
+module ram8k_2x1_cell_macro (
+    input [10:0] A1_0,
+    input [10:0] A1_1,
+    input [10:0] A2_0,
+    input [10:0] A2_1,
+    input CLK1_0 /* synthesis syn_isclock=1 */,
+    input CLK1_1 /* synthesis syn_isclock=1 */,
+    output Almost_Empty_0, Almost_Empty_1, Almost_Full_0, Almost_Full_1,
+    input ASYNC_FLUSH_0, ASYNC_FLUSH_1,CLK2_0, CLK2_1, ASYNC_FLUSH_S0, ASYNC_FLUSH_S1, CLK1EN_0, CLK1EN_1, CLK1S_0, CLK1S_1,CLK2EN_0,CLK2EN_1, CLK2S_0, CLK2S_1, CONCAT_EN_0, CONCAT_EN_1, CS1_0, CS1_1,CS2_0, CS2_1, DIR_0, DIR_1, FIFO_EN_0, FIFO_EN_1, P1_0, P1_1, P2_0,P2_1, PIPELINE_RD_0, PIPELINE_RD_1,
+    output [3:0] POP_FLAG_0,
+    output [3:0] POP_FLAG_1,
+    output [3:0] PUSH_FLAG_0,
+    output [3:0] PUSH_FLAG_1,
+    output [17:0] RD_0,
+    output [17:0] RD_1,
+    input  SYNC_FIFO_0, SYNC_FIFO_1,
+    input [17:0] WD_0,
+    input [17:0] WD_1,
+    input [1:0] WEN1_0,
+    input [1:0] WEN1_1,
+    input [1:0] WIDTH_SELECT1_0,
+    input [1:0] WIDTH_SELECT1_1,
+    input [1:0] WIDTH_SELECT2_0,
+    input [1:0] WIDTH_SELECT2_1,
+    input SD,DS,LS,SD_RB1,LS_RB1,DS_RB1,RMEA,RMEB,TEST1A,TEST1B,
+    input [3:0] RMA,
+    input [3:0] RMB);
+
+endmodule /* ram8k_2x1_cell_macro */
 // module DFFSEC(output Q, input D, CLR, EN, CLK, N_11);
 //     parameter [0:0] INIT = 1'b0;
 //     // TODO implement

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -269,11 +269,6 @@ input   WB_CLKS);
 endmodule /* qlal4s3b_cell_macro */
 
 (* blackbox *)
-module bipad (input A, input EN, inout P, output Q);
-
-endmodule
-
-(* blackbox *)
 module gclkbuff (input A, output Z);
 
 endmodule

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -1,25 +1,179 @@
-module QLOGIC_MUX(
-    input A,
-    input B,
-    input S,
-    output Y
-);
-    assign Y = S ? A : B;
+//                FZ        FS
+module LUT1(output O, input I0);
+    parameter [1:0] INIT = 0;
+    assign O = I0 ? INIT[1] : INIT[0];
 endmodule
 
-module QLOGIC_DFFE(input S, input D, input E, input QCK, input R, output reg QZ);
+//               TZ        TSL TAB
+module LUT2(output O, input I0, I1);
+    parameter [3:0] INIT = 0;
+    wire [1:0] s1 = I1 ? INIT[3:2] : INIT[1:0];
+    assign O = I0 ? s1[1] : s1[0];
+endmodule
+
+// O: TZ
+// I0: TA1 TA2 TB1 TB2
+// I1: TSL
+// I2: TAB
+module LUT3(output O, input I0, I1, I2);
+    parameter [7:0] INIT = 0;
+    wire [3:0] s2 = I2 ? INIT[7:4] : INIT[3:0];
+    wire [1:0] s1 = I1 ? s2[3:2] : s2[1:0];
+    assign O = I0 ? s1[1] : s1[0];
+    // TODO: This is not a valid in-sight implementation for QL - to be
+    // discussed with the client
+endmodule
+
+// O: CZ
+// I0: TA1 TA2 TB1 TB2 BA1 BA2 BB1 BB2
+// I1: TSL BSL
+// I2: TAB BAB
+// I3: TBS
+module LUT4(output O, input I0, I1, I2, I3);
+    parameter [15:0] INIT = 0;
+    wire [7:0] s3 = I3 ? INIT[15:8] : INIT[7:0];
+    wire [3:0] s2 = I2 ? s3[7:4] : s3[3:0];
+    wire [1:0] s1 = I1 ? s2[3:2] : s2[1:0];
+    assign O = I0 ? s1[1] : s1[0];
+    // TODO: This is not a valid in-sight implementation for QL - to be
+    // discussed with the client
+endmodule
+
+//               FZ       FS
+module inv(output Q, input A);
+    assign Q = A ? 0 : 1;
+endmodule
+
+//               QZ      QDI  QCK
+module dff(output Q, input D, CLK);
     parameter [0:0] INIT = 1'b0;
-    initial QZ = INIT;
-    always @(posedge QCK) begin
-        if (S)
-           QZ <= 1'b1;
-        else if (E)
-           QZ <= D;
-        else if (R)
-           QZ <= 0;
+    initial Q = INIT;
+    always @(posedge CLK) begin
+        Q <= D;
     end
 endmodule
 
-module QLOGIC_NOT(input A, output Y);
-    assign Y = ~A;
+//                QZ      QDI  QCK  QRT
+module dffc(output Q, input D, CLK, CLR);
+    parameter [0:0] INIT = 1'b0;
+    initial Q = INIT;
+    always @(posedge CLK, posedge CLR) begin
+        if (CLR)
+            Q <= 1'b0;
+        else
+            Q <= D;
+    end
 endmodule
+
+//                QZ      QDI  QCK  QST
+module dffp(output Q, input D, CLK, PRE);
+    parameter [0:0] INIT = 1'b0;
+    initial Q = INIT;
+    always @(posedge CLK, posedge PRE) begin
+        if (PRE)
+            Q <= 1'b1;
+        else
+            Q <= D;
+    end
+endmodule
+
+//                 QZ      QDI  QCK  QRT  QST
+module dffpc(output Q, input D, CLK, CLR, PRE);
+    parameter [0:0] INIT = 1'b0;
+    initial Q = INIT;
+    always @(posedge CLK, posedge CLR, posedge PRE) begin
+        if (CLR)
+            Q <= 1'b0;
+        else if (PRE)
+            Q <= 1'b1;
+        else
+            Q <= D;
+    end
+endmodule
+
+//                QZ      QDI  QCK QEN
+module dffe(output Q, input D, CLK, EN);
+    parameter [0:0] INIT = 1'b0;
+    initial Q = INIT;
+    always @(posedge CLK) begin
+        if (EN)
+            Q <= D;
+    end
+endmodule
+
+//                 QZ      QDI  QCK QEN  QRT
+module dffec(output Q, input D, CLK, EN, CLR);
+    parameter [0:0] INIT = 1'b0;
+    initial Q = INIT;
+    always @(posedge CLK, posedge CLR) begin
+        if (CLR)
+            Q <= 1'b0;
+        else if (EN)
+            Q <= D;
+    end
+endmodule
+
+//                  QZ      QDI  QCK QEN  QRT  QST
+module dffepc(output Q, input D, CLK, EN, CLR, PRE);
+    parameter [0:0] INIT = 1'b0;
+    initial Q = INIT;
+    always @(posedge CLK, posedge CLR, posedge PRE) begin
+        if (CLR)
+            Q <= 1'b0;
+        else if (PRE)
+            Q <= 1'b1;
+        else if (EN)
+            Q <= D;
+    end
+endmodule
+
+//                  FZ       FS F2 (F1 TO 0)
+module AND2I0(output Q, input A, B);
+    assign Q = A ? B : 0;
+endmodule
+
+//                  FZ       FS F1 F2
+module mux2x0(output Q, input S, A, B);
+    assign Q = S ? B : A;
+endmodule
+
+//                  TZ       TSL TABTA1TA2TB1TB2 
+module mux4x0(output Q, input S0, S1, A, B, C, D);
+    assign Q = S1 ? (S0 ? D : C) : (S0 ? B : A);
+endmodule
+
+// S0 BSL TSL
+// S1 BAB TAB
+// S2 TBS
+// A TA1
+// B TA2
+// C TB1
+// D TB2
+// E BA1
+// F BA2
+// G BB1
+// H BB2
+// Q CZ
+module mux8x0(output Q, input S0, S1, S2, A, B, C, D, E, F, G, H);
+    assign Q = S2 ? (S1 ? (S0 ? H : G) : (S0 ? F : E)) : (S1 ? (S0 ? D : C) : (S0 ? B : A));
+endmodule
+
+// module DFFSEC(output Q, input D, CLR, EN, CLK, N_11);
+//     parameter [0:0] INIT = 1'b0;
+//     // TODO implement
+// endmodule
+// 
+// module DFFSEP(output Q, input D, CLR, EN, CLK, N_11);
+//     parameter [0:0] INIT = 1'b0;
+//     // TODO implement
+// endmodule
+// 
+// module DFFSLE_APC(output Q, input D, CLR, EN, CLK, N_11);
+//     parameter [0:0] INIT = 1'b0;
+//     // TODO implement
+// endmodule
+// 
+// module DFFSEC_APC(output Q, input D, CLR, EN, CLK, N_11);
+//     parameter [0:0] INIT = 1'b0;
+//     // TODO implement
+// endmodule

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -170,6 +170,84 @@ module ckpad(output Q, input P);
     assign Q = P;
 endmodule
 
+// BLACK BOXES
+
+(* blackbox *)
+module qlal4s3b_cell_macro(
+input	WB_CLK,
+input	WBs_ACK,
+input	[31:0]WBs_RD_DAT,
+output	[3:0]WBs_BYTE_STB,
+output	WBs_CYC,
+output	WBs_WE,
+output	WBs_RD,
+output	WBs_STB,
+output	[16:0]WBs_ADR,
+input	[3:0]SDMA_Req,
+input	[3:0]SDMA_Sreq,
+output	[3:0]SDMA_Done,
+output	[3:0]SDMA_Active,
+input	[3:0]FB_msg_out,
+input	[7:0]FB_Int_Clr,
+output	FB_Start,
+input	FB_Busy,
+output	WB_RST,
+output	Sys_PKfb_Rst,
+output	Sys_Clk0,
+output	Sys_Clk0_Rst,
+output	Sys_Clk1,
+output	Sys_Clk1_Rst,
+output	Sys_Pclk,
+output	Sys_Pclk_Rst,
+input	Sys_PKfb_Clk,
+input	[31:0]FB_PKfbData,
+output	[31:0]WBs_WR_DAT,
+input	[3:0]FB_PKfbPush,
+input	FB_PKfbSOF,
+input	FB_PKfbEOF,
+output	[7:0]Sensor_Int,
+output	FB_PKfbOverflow,
+output	[23:0]TimeStamp,
+input	Sys_PSel,
+input	[15:0]SPIm_Paddr,
+input	SPIm_PEnable,
+input	SPIm_PWrite,
+input	[31:0]SPIm_PWdata,
+output	SPIm_PReady,
+output	SPIm_PSlvErr,
+output	[31:0]SPIm_Prdata,
+input	[15:0]Device_ID,
+input	[13:0]FBIO_In_En,
+input	[13:0]FBIO_Out,
+input	[13:0]FBIO_Out_En,
+output	[13:0]FBIO_In,
+inout 	[13:0]SFBIO,
+input   Device_ID_6S,
+input   Device_ID_4S,
+input   SPIm_PWdata_26S,
+input   SPIm_PWdata_24S,
+input   SPIm_PWdata_14S,
+input   SPIm_PWdata_11S,
+input   SPIm_PWdata_0S,
+input   SPIm_Paddr_8S,
+input   SPIm_Paddr_6S,
+input   FB_PKfbPush_1S,
+input   FB_PKfbData_31S,
+input   FB_PKfbData_21S,
+input   FB_PKfbData_19S,
+input   FB_PKfbData_9S,
+input   FB_PKfbData_6S,
+input   Sys_PKfb_ClkS,
+input   FB_BusyS,
+input   WB_CLKS);
+
+endmodule /* qlal4s3b_cell_macro*/
+
+(* blackbox *)
+module gclkbuff (input A, output Z);
+
+endmodule
+
 // module DFFSEC(output Q, input D, CLR, EN, CLK, N_11);
 //     parameter [0:0] INIT = 1'b0;
 //     // TODO implement

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -179,6 +179,14 @@ module ckpad(output Q, input P);
     assign Q = P;
 endmodule
 
+module logic_0(output a);
+    assign a = 0;
+endmodule
+
+module logic_1(output a);
+    assign a = 1;
+endmodule
+
 // BLACK BOXES
 
 (* blackbox *)

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -180,6 +180,7 @@ endmodule
 // BLACK BOXES
 
 (* blackbox *)
+(* keep *)
 module qlal4s3b_cell_macro(
 input	WB_CLK,
 input	WBs_ACK,

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -158,6 +158,18 @@ module mux8x0(output Q, input S0, S1, S2, A, B, C, D, E, F, G, H);
     assign Q = S2 ? (S1 ? (S0 ? H : G) : (S0 ? F : E)) : (S1 ? (S0 ? D : C) : (S0 ? B : A));
 endmodule
 
+module inpad(output Q, input P);
+    assign Q = P;
+endmodule
+
+module outpad(output P, input A);
+    assign P = A;
+endmodule
+
+module ckpad(output Q, input P);
+    assign Q = P;
+endmodule
+
 // module DFFSEC(output Q, input D, CLR, EN, CLK, N_11);
 //     parameter [0:0] INIT = 1'b0;
 //     // TODO implement

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -181,6 +181,11 @@ module ckpad(output Q, input P);
     assign Q = P;
 endmodule
 
+module bipad(input A, input EN, output Q, inout P);
+    assign Q = P;
+    assign P = EN ? A : 1'bz;
+endmodule
+
 module logic_0(output a);
     assign a = 0;
 endmodule

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -292,7 +292,7 @@ module ram8k_2x1_cell_macro (
 endmodule /* ram8k_2x1_cell_macro */
 
 (* blackbox *)
-module qlal4s3_32x32_mult_cell (
+module qlal4s3_mult_32x32_cell (
     input [31:0] Amult,
     input [31:0] Bmult,
     input [1:0] Valid_mult,
@@ -301,7 +301,7 @@ module qlal4s3_32x32_mult_cell (
 endmodule /* qlal4s3_32x32_mult_cell */
 
 (* blackbox *)
-module qlal4s3_16x16_mult_cell (
+module qlal4s3_mult_16x16_cell (
     input [15:0] Amult,
     input [15:0] Bmult,
     input [1:0] Valid_mult,

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -1,0 +1,25 @@
+module QLOGIC_MUX(
+    input A,
+    input B,
+    input S,
+    output Y
+);
+    assign Y = S ? A : B;
+endmodule
+
+module QLOGIC_DFFE(input S, input D, input E, input QCK, input R, output reg QZ);
+    parameter [0:0] INIT = 1'b0;
+    initial QZ = INIT;
+    always @(posedge QCK) begin
+        if (S)
+           QZ <= 1'b1;
+        else if (E)
+           QZ <= D;
+        else if (R)
+           QZ <= 0;
+    end
+endmodule
+
+module QLOGIC_NOT(input A, output Y);
+    assign Y = ~A;
+endmodule

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -44,6 +44,10 @@ module inv(output Q, input A);
     assign Q = A ? 0 : 1;
 endmodule
 
+module buff(output Q, input A);
+    assign Q = A;
+endmodule
+
 //               QZ      QDI  QCK
 module dff(output reg Q, input D, CLK);
     parameter [0:0] INIT = 1'b0;
@@ -134,6 +138,11 @@ endmodule
 
 //                  FZ       FS F1 F2
 module mux2x0(output Q, input S, A, B);
+    assign Q = S ? B : A;
+endmodule
+
+//                  FZ       FS F1 F2
+module mux2x1(output Q, input S, A, B);
     assign Q = S ? B : A;
 endmodule
 

--- a/techlibs/quicklogic/cells_sim.v
+++ b/techlibs/quicklogic/cells_sim.v
@@ -251,6 +251,11 @@ input   WB_CLKS);
 endmodule /* qlal4s3b_cell_macro */
 
 (* blackbox *)
+module bipad (input A, input EN, inout P, output Q);
+
+endmodule
+
+(* blackbox *)
 module gclkbuff (input A, output Z);
 
 endmodule

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -104,6 +104,7 @@ struct SynthQuickLogicPass : public ScriptPass
     void script() YS_OVERRIDE
     {
         if (check_label("begin")) {
+            run("read_verilog -lib +/quicklogic/cells_sim.v");
             run(stringf("hierarchy -check %s", top_opt.c_str()));
         }
 

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -1,0 +1,137 @@
+#include "kernel/register.h"
+#include "kernel/celltypes.h"
+#include "kernel/rtlil.h"
+#include "kernel/log.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+struct SynthQuickLogicPass : public ScriptPass
+{
+    SynthQuickLogicPass() : ScriptPass("synth_quicklogic", "Synthesis for QuickLogic FPGAs") { }
+
+    void help() YS_OVERRIDE
+    {
+        log("\n");
+        log("   synth_quicklogic [options]\n");
+        log("This command runs synthesis for QuickLogic FPGAs\n");
+        log("\n");
+        log("    -top <module>\n");
+        log("         use the specified module as top module\n");
+        log("\n");
+        log("    -exe <command>\n");
+#ifdef ABCEXTERNAL
+        log("        use the specified command instead of \"" ABCEXTERNAL "\" to execute ABC.\n");
+#else
+        log("        use the specified command instead of \"<yosys-bindir>/yosys-abc\" to execute ABC.\n");
+#endif
+        log("        This can e.g. be used to call a specific version of ABC or a wrapper.\n");
+        log("\n");
+        log("    -edif <file>\n");
+        log("        write the design to the specified edif file. writing of an output file\n");
+        log("        is omitted if this parameter is not specified.\n");
+        log("\n");
+        log("    -blif <file>\n");
+        log("        write the design to the specified BLIF file. writing of an output file\n");
+        log("        is omitted if this parameter is not specified.\n");
+        log("\n");
+        help_script();
+        log("\n");
+    }
+
+    std::string top_opt = "-auto-top";
+    std::string edif_file = "";
+    std::string blif_file = "";
+    std::string exe_file = "";
+    bool flatten = false;
+
+    void clear_flags() YS_OVERRIDE
+    {
+        top_opt = "-auto-top";
+#ifdef ABCEXTERNAL
+        exe_file = ABCEXTERNAL;
+#else
+        exe_file = proc_self_dirname() + "yosys-abc";
+#endif
+        flatten = false;
+        edif_file.clear();
+        blif_file.clear();
+    }
+
+    void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+    {
+        std::string run_from, run_to;
+        clear_flags();
+
+        size_t argidx;
+        for (argidx = 1; argidx < args.size(); argidx++)
+        {
+            if (args[argidx] == "-top" && argidx+1 < args.size()) {
+                top_opt = "-top " + args[++argidx];
+                continue;
+            }
+            if (args[argidx] == "-edif" && argidx+1 < args.size()) {
+                edif_file = args[++argidx];
+                continue;
+            }
+            if (args[argidx] == "-blif" && argidx+1 < args.size()) {
+                blif_file = args[++argidx];
+                continue;
+            }
+            if (args[argidx] == "-flatten") {
+                flatten = true;
+                continue;
+            }
+            if (args[argidx] == "-exe" && argidx+1 < args.size()) {
+                exe_file = args[++argidx];
+                continue;
+            }
+            break;
+        }
+        extra_args(args, argidx, design);
+
+        if (!design->full_selection())
+            log_cmd_error("This command only operates on fully selected designs!\n");
+
+        log_header(design, "Executing SYNTH_QUICKLOGIC pass.\n");
+        log_push();
+
+        run_script(design, run_from, run_to);
+
+        log_pop();
+    }
+
+    void script() YS_OVERRIDE
+    {
+        if (check_label("begin")) {
+            run(stringf("hierarchy -check %s", top_opt.c_str()));
+        }
+
+        if (check_label("prepare")) {
+            run("proc");
+            if (flatten || help_mode)
+                run("flatten", "(with '-flatten')");
+            run("opt");
+            run("check");
+            run("techmap");
+            run("abc -script +collapse;,muxes;,");
+            run("lut2mux");
+            run("proc");
+            run("opt");
+            run("dff2dffe");
+            run("techmap -map +/quicklogic/cells_map.v");
+        }
+
+        if (check_label("edif")) {
+            if (!edif_file.empty() || help_mode)
+                run(stringf("write_edif -pvector bra %s", edif_file.c_str()));
+        }
+
+        if (check_label("blif")) {
+            if (!blif_file.empty() || help_mode)
+                run(stringf("write_blif %s", blif_file.c_str()));
+        }
+    }
+} SynthQuickLogicPass;
+
+PRIVATE_NAMESPACE_END

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -124,7 +124,10 @@ struct SynthQuickLogicPass : public ScriptPass
             run("proc");
             run("opt");
             run("techmap -map +/quicklogic/cells_map.v");
-            run("iopadmap -bits -outpad outpad A:P -inpad inpad Q:P");
+            run("select -set clock_inputs */t:dff* %x:+[CLK] */t:dff* %d");
+            run("select -set invclock_inputs */t:dff* %x:+[CLK] */t:dff* %d %n");
+            run("iopadmap -bits -inpad ckpad CLK:P @clock_inputs");
+            run("iopadmap -bits -outpad outpad A:P -inpad inpad Q:P @invclock_inputs");
             run("techmap -map +/quicklogic/cells_map.v");
         }
 

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -128,7 +128,8 @@ struct SynthQuickLogicPass : public ScriptPass
             run("select -set invclock_inputs */t:dff* %x:+[CLK,CLR,PRE] */t:dff* %d %n");
             run("iopadmap -bits -inpad ckpad Q:P @clock_inputs");
             run("iopadmap -bits -outpad outpad A:P -inpad inpad Q:P @invclock_inputs");
-            run("splitnets -ports");
+            run("splitnets -ports -format ()");
+            run("hilomap -hicell logic_1 a -locell logic_0 a -singleton");
             run("techmap -map +/quicklogic/cells_map.v");
         }
 

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -124,6 +124,8 @@ struct SynthQuickLogicPass : public ScriptPass
             run("proc");
             run("opt");
             run("techmap -map +/quicklogic/cells_map.v");
+            run("iopadmap -bits -outpad outpad A:P -inpad inpad Q:P");
+            run("techmap -map +/quicklogic/cells_map.v");
         }
 
         if (check_label("edif")) {

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -130,7 +130,7 @@ struct SynthQuickLogicPass : public ScriptPass
 
         if (check_label("edif")) {
             if (!edif_file.empty() || help_mode)
-                run(stringf("write_edif -pvector bra %s", edif_file.c_str()));
+                run(stringf("write_edif -nogndvcc -attrprop -pvector par %s", edif_file.c_str()));
         }
 
         if (check_label("blif")) {

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -126,7 +126,7 @@ struct SynthQuickLogicPass : public ScriptPass
             run("techmap -map +/quicklogic/cells_map.v");
             run("select -set clock_inputs */t:dff* %x:+[CLK] */t:dff* %d");
             run("select -set invclock_inputs */t:dff* %x:+[CLK] */t:dff* %d %n");
-            run("iopadmap -bits -inpad ckpad CLK:P @clock_inputs");
+            run("iopadmap -bits -inpad ckpad Q:P @clock_inputs");
             run("iopadmap -bits -outpad outpad A:P -inpad inpad Q:P @invclock_inputs");
             run("splitnets -ports");
             run("techmap -map +/quicklogic/cells_map.v");

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -108,7 +108,7 @@ struct SynthQuickLogicPass : public ScriptPass
     {
         if (check_label("begin")) {
             run("read_verilog -lib +/quicklogic/cells_sim.v");
-            run(stringf("hierarchy -check %s", top_opt.c_str()));
+            run(stringf("hierarchy -check"));
         }
 
         if (check_label("prepare")) {

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -116,6 +116,7 @@ struct SynthQuickLogicPass : public ScriptPass
             run("proc");
             if (flatten || help_mode)
                 run("flatten", "(with '-flatten')");
+            run("tribuf -logic");
             run("opt_expr");
             run("proc");
             run("opt_clean");
@@ -141,6 +142,7 @@ struct SynthQuickLogicPass : public ScriptPass
             run("select -set invclock_inputs */t:dff* %x:+[CLK,CLR,PRE] */t:dff* %d %n");
             run("iopadmap -bits -inpad ckpad Q:P @clock_inputs");
             run("iopadmap -bits -outpad outpad A:P -inpad inpad Q:P @invclock_inputs");
+            run("iopadmap -bits -tinoutpad bipad EN:Q:A:P");
             if (this->currmodule.size() > 0)
                 run("select -clear");
             run("splitnets -ports -format ()");

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -35,6 +35,9 @@ struct SynthQuickLogicPass : public ScriptPass
         log("        write the design to the specified BLIF file. writing of an output file\n");
         log("        is omitted if this parameter is not specified.\n");
         log("\n");
+        log("    -flatten\n");
+        log("        flatten design before synthesis\n");
+        log("\n");
         help_script();
         log("\n");
     }
@@ -112,14 +115,14 @@ struct SynthQuickLogicPass : public ScriptPass
             run("proc");
             if (flatten || help_mode)
                 run("flatten", "(with '-flatten')");
-            run("opt");
+            run("opt_expr");
+            run("opt_clean");
             run("check");
+            run("opt");
             run("techmap");
-            run("abc -script +collapse;,muxes;,");
-            run("lut2mux");
+            run("abc -lut 1:4");
             run("proc");
             run("opt");
-            run("dff2dffe");
             run("techmap -map +/quicklogic/cells_map.v");
         }
 

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -124,8 +124,8 @@ struct SynthQuickLogicPass : public ScriptPass
             run("proc");
             run("opt");
             run("techmap -map +/quicklogic/cells_map.v");
-            run("select -set clock_inputs */t:dff* %x:+[CLK] */t:dff* %d");
-            run("select -set invclock_inputs */t:dff* %x:+[CLK] */t:dff* %d %n");
+            run("select -set clock_inputs */t:dff* %x:+[CLK,CLR,PRE] */t:dff* %d");
+            run("select -set invclock_inputs */t:dff* %x:+[CLK,CLR,PRE] */t:dff* %d %n");
             run("iopadmap -bits -inpad ckpad Q:P @clock_inputs");
             run("iopadmap -bits -outpad outpad A:P -inpad inpad Q:P @invclock_inputs");
             run("splitnets -ports");

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -128,6 +128,7 @@ struct SynthQuickLogicPass : public ScriptPass
             run("select -set invclock_inputs */t:dff* %x:+[CLK] */t:dff* %d %n");
             run("iopadmap -bits -inpad ckpad CLK:P @clock_inputs");
             run("iopadmap -bits -outpad outpad A:P -inpad inpad Q:P @invclock_inputs");
+            run("splitnets -ports");
             run("techmap -map +/quicklogic/cells_map.v");
         }
 

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -108,7 +108,7 @@ struct SynthQuickLogicPass : public ScriptPass
     {
         if (check_label("begin")) {
             run("read_verilog -lib +/quicklogic/cells_sim.v");
-            run(stringf("hierarchy -check"));
+            run(stringf("hierarchy -check %s", top_opt.c_str()));
         }
 
         if (check_label("prepare")) {
@@ -134,13 +134,14 @@ struct SynthQuickLogicPass : public ScriptPass
         }
 
         if (check_label("edif")) {
-            if (!edif_file.empty() || help_mode)
-                run(stringf("write_edif -nogndvcc -attrprop -pvector par %s", edif_file.c_str()));
+            if (!edif_file.empty() || help_mode) {
+                    run(stringf("write_edif -nogndvcc -attrprop -pvector par %s %s", top_opt.c_str(), edif_file.c_str()));
+            }
         }
 
         if (check_label("blif")) {
             if (!blif_file.empty() || help_mode)
-                run(stringf("write_blif %s", blif_file.c_str()));
+                run(stringf("write_blif %s %s", top_opt.c_str(), blif_file.c_str()));
         }
     }
 } SynthQuickLogicPass;

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -116,14 +116,23 @@ struct SynthQuickLogicPass : public ScriptPass
             if (flatten || help_mode)
                 run("flatten", "(with '-flatten')");
             run("opt_expr");
+            run("proc");
             run("opt_clean");
+            run("proc");
             run("check");
             run("opt");
+            run("proc");
             run("techmap");
             run("abc -lut 1:4");
+            run("opt_clean");
             run("proc");
-            run("opt");
             run("techmap -map +/quicklogic/cells_map.v");
+            run("clean");
+            run("opt");
+            run("check");
+            run("peepopt");
+            run("opt_clean -purge");
+            run("clean -purge");
             run("select -set clock_inputs */t:dff* %x:+[CLK,CLR,PRE] */t:dff* %d");
             run("select -set invclock_inputs */t:dff* %x:+[CLK,CLR,PRE] */t:dff* %d %n");
             run("iopadmap -bits -inpad ckpad Q:P @clock_inputs");
@@ -131,6 +140,8 @@ struct SynthQuickLogicPass : public ScriptPass
             run("splitnets -ports -format ()");
             run("hilomap -hicell logic_1 a -locell logic_0 a -singleton");
             run("techmap -map +/quicklogic/cells_map.v");
+            run("clean -purge");
+            run("opt");
         }
 
         if (check_label("edif")) {


### PR DESCRIPTION
This PR adds support for the following QuickLogic devices:

* EOS-S3 (https://www.quicklogic.com/products/eos-s3/)
* PolarPro 3E (https://www.quicklogic.com/products/fpga/fpgas-sram/#polarpro3e)

CC @mithro 