### PR TITLE
kernel: share a single CellTypes within a pass

### DIFF
--- a/kernel/modtools.h
+++ b/kernel/modtools.h
@@ -380,22 +380,15 @@ struct ModWalker
 		}
 	}
 
-	ModWalker() : design(NULL), module(NULL)
+	ModWalker(RTLIL::Design *design) : design(design), module(NULL)
 	{
+            ct.setup(design);
 	}
 
-	ModWalker(RTLIL::Design *design, RTLIL::Module *module, CellTypes *filter_ct = NULL)
+	void setup(RTLIL::Module *module, CellTypes *filter_ct = NULL)
 	{
-		setup(design, module, filter_ct);
-	}
-
-	void setup(RTLIL::Design *design, RTLIL::Module *module, CellTypes *filter_ct = NULL)
-	{
-		this->design = design;
 		this->module = module;
 
-		ct.clear();
-		ct.setup(design);
 		sigmap.set(module);
 
 		signal_drivers.clear();

--- a/passes/memory/memory_share.cc
+++ b/passes/memory/memory_share.cc
@@ -666,7 +666,6 @@ struct MemoryShareWorker
 	// -------------
 
 	MemoryShareWorker(RTLIL::Design *design) : design(design), modwalker(design) {}
-	}
 
 	void operator()(RTLIL::Module* module)
 	{

--- a/passes/memory/memory_share.cc
+++ b/passes/memory/memory_share.cc
@@ -665,9 +665,7 @@ struct MemoryShareWorker
 	// Setup and run
 	// -------------
 
-	MemoryShareWorker(RTLIL::Design *design) :
-			design(design), modwalker(design)
-	{
+	MemoryShareWorker(RTLIL::Design *design) : design(design), modwalker(design) {}
 	}
 
 	void operator()(RTLIL::Module* module)
@@ -764,7 +762,6 @@ struct MemorySharePass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE {
 		log_header(design, "Executing MEMORY_SHARE pass (consolidating $memrd/$memwr cells).\n");
 		extra_args(args, 1, design);
-
 		MemoryShareWorker msw(design);
 
 		for (auto module : design->selected_modules())

--- a/passes/memory/memory_share.cc
+++ b/passes/memory/memory_share.cc
@@ -670,12 +670,12 @@ struct MemoryShareWorker
 
 	void operator()(RTLIL::Module* module)
 	{
+		std::map<std::string, std::pair<std::vector<RTLIL::Cell*>, std::vector<RTLIL::Cell*>>> memindex;
+
 		this->module = module;
 		sigmap.set(module);
 		sig_to_mux.clear();
 		conditions_logic_cache.clear();
-
-		std::map<std::string, std::pair<std::vector<RTLIL::Cell*>, std::vector<RTLIL::Cell*>>> memindex;
 
 		sigmap_xmux = sigmap;
 		for (auto cell : module->cells())

--- a/passes/memory/memory_share.cc
+++ b/passes/memory/memory_share.cc
@@ -665,9 +665,18 @@ struct MemoryShareWorker
 	// Setup and run
 	// -------------
 
-	MemoryShareWorker(RTLIL::Design *design, RTLIL::Module *module) :
-			design(design), module(module), sigmap(module)
+	MemoryShareWorker(RTLIL::Design *design) :
+			design(design), modwalker(design)
 	{
+	}
+
+	void operator()(RTLIL::Module* module)
+	{
+		this->module = module;
+		sigmap.set(module);
+		sig_to_mux.clear();
+		conditions_logic_cache.clear();
+
 		std::map<std::string, std::pair<std::vector<RTLIL::Cell*>, std::vector<RTLIL::Cell*>>> memindex;
 
 		sigmap_xmux = sigmap;
@@ -717,7 +726,7 @@ struct MemoryShareWorker
 		cone_ct.cell_types.erase("$shift");
 		cone_ct.cell_types.erase("$shiftx");
 
-		modwalker.setup(design, module, &cone_ct);
+		modwalker.setup(module, &cone_ct);
 
 		for (auto &it : memindex)
 			consolidate_wr_using_sat(it.first, it.second.second);
@@ -755,8 +764,11 @@ struct MemorySharePass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE {
 		log_header(design, "Executing MEMORY_SHARE pass (consolidating $memrd/$memwr cells).\n");
 		extra_args(args, 1, design);
+
+		MemoryShareWorker msw(design);
+
 		for (auto module : design->selected_modules())
-			MemoryShareWorker(design, module);
+			msw(module);
 	}
 } MemorySharePass;
 

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -31,9 +31,8 @@ PRIVATE_NAMESPACE_BEGIN
 
 bool did_something;
 
-void replace_undriven(RTLIL::Design *design, RTLIL::Module *module)
+void replace_undriven(RTLIL::Module *module, const CellTypes& ct)
 {
-	CellTypes ct(design);
 	SigMap sigmap(module);
 	SigPool driven_signals;
 	SigPool used_signals;
@@ -1737,13 +1736,14 @@ struct OptExprPass : public Pass {
 		}
 		extra_args(args, argidx, design);
 
+		CellTypes ct(design);
 		for (auto module : design->selected_modules())
 		{
 			log("Optimizing module %s.\n", log_id(module));
 
 			if (undriven) {
 				did_something = false;
-				replace_undriven(design, module);
+				replace_undriven(module, ct);
 				if (did_something)
 					design->scratchpad_set_bool("opt.did_something", true);
 			}

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -31,7 +31,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 bool did_something;
 
-void replace_undriven(RTLIL::Module *module, const CellTypes& ct)
+void replace_undriven(RTLIL::Module *module, const CellTypes &ct)
 {
 	SigMap sigmap(module);
 	SigPool driven_signals;

--- a/passes/opt/share.cc
+++ b/passes/opt/share.cc
@@ -1156,6 +1156,10 @@ struct ShareWorker
 		topo_cell_drivers.clear();
 		topo_bit_drivers.clear();
 		exclusive_ctrls.clear();
+		terminal_bits.clear();
+		shareable_cells.clear();
+		forbidden_controls_cache.clear();
+		activation_patterns_cache.clear();
 
 		find_terminal_bits();
 		find_shareable_cells();

--- a/passes/opt/share.cc
+++ b/passes/opt/share.cc
@@ -1148,11 +1148,10 @@ struct ShareWorker
 	#endif
 
 		limit = config.limit;
-
 		modwalker.setup(module);
 
 		cells_to_remove.clear();
-		recursion_state.clear();;
+		recursion_state.clear();
 		topo_cell_drivers.clear();
 		topo_bit_drivers.clear();
 		exclusive_ctrls.clear();


### PR DESCRIPTION
Profiling showed that `CellTypes` was being created for each module in the design when inside `share`  and `memory_share`; rewrite to avoid doing that because constructing one can be expensive...