### PR TITLE
Clean up pseudo-private member usage in `passes/cmds/design.cc`.

### DIFF
--- a/passes/cmds/design.cc
+++ b/passes/cmds/design.cc
@@ -200,7 +200,7 @@ struct DesignPass : public Pass {
 					continue;
 				}
 				if (sel.selected_module(mod->name))
-					log_cmd_error("Module %s is only partly selected.\n", RTLIL::id2cstr(mod->name));
+					log_cmd_error("Module %s is only partly selected.\n", log_id(mod->name));
 			}
 
 			if (import_mode) {


### PR DESCRIPTION
Mostly straightforward.

The interesting parts are things like (orig. line 233):
```
			if (copy_to_design->modules_.count(prefix))
				delete copy_to_design->modules_.at(prefix);
```
changing to:
```
			if (copy_to_design->module(prefix) != nullptr)
				copy_to_design->remove(copy_to_design->module(prefix));
```

The `if` condition is a standard change.  But the mechanics change from `delete`ing it to `remove()`ing it.  `remove()` does `delete` it, too, but it also erases the entry in `modules_` (which should have been done before, no?) and notifies any monitors.

Similarly, the lines changed to e.g:
```
						RTLIL::Module *t = fmod->clone();
						t->name = trg_name;
						t->design = copy_to_design;
						t->attributes.erase("\\top");
						copy_to_design->add(t);
```
now use the proper `add()` method rather than brute forcing it into `modules_` directly.