### PR TITLE
greenpak4: Add final clean -purge

### DIFF
--- a/techlibs/greenpak4/synth_greenpak4.cc
+++ b/techlibs/greenpak4/synth_greenpak4.cc
@@ -188,7 +188,7 @@ struct SynthGreenPAK4Pass : public ScriptPass
 			run("attrmvcp -attr src -attr LOC -driven t:GP_IBUF n:*");
 			run("techmap -map +/greenpak4/cells_map.v");
 			run("greenpak4_dffinv");
-			run("clean");
+			run("clean -purge");
 		}
 
 		if (check_label("check"))


### PR DESCRIPTION
gp4par does not like netnames that have bits set to constant values ("0" or "1"). get rid of them with a final `clean -purge`