### PR TITLE
deminout: prevent any constant assignment from demoting to input

### DIFF
--- a/passes/techmap/deminout.cc
+++ b/passes/techmap/deminout.cc
@@ -113,7 +113,7 @@ struct DeminoutPass : public Pass {
 						{
 							if (bits_numports[bit] > 1 || bits_inout.count(bit))
 								new_input = true, new_output = true;
-							if (bit == State::S0 || bit == State::S1)
+							if (!bit.wire)
 								new_output = true;
 							if (bits_written.count(bit)) {
 								new_output = true;


### PR DESCRIPTION
Before this patch,

```
module top(inout io);
assign io = 1'bx;
endmodule
```

would have the `io` pin demoted to input (same happens for `1'bz`,
but not for `1'b0` or `1'b1`), resulting in check failures later on.

Part of fix for #1841.