### PR TITLE
Adding error message for when size (width) of number literal is zero

### DIFF
--- a/frontends/verilog/const2ast.cc
+++ b/frontends/verilog/const2ast.cc
@@ -139,6 +139,10 @@ static void my_strtobin(std::vector<RTLIL::State> &data, const char *str, int le
 		data.resize(len_in_bits, msb);
 	}
 
+	if (len_in_bits == 0)
+		log_error("Illegal integer constant size of zero in %s:%d (IEEE 1800-2012, 5.7).\n",
+				current_filename.c_str(), get_line_num());
+
 	if (len > len_in_bits)
 		log_warning("Literal has a width of %d bit, but value requires %d bit. (%s:%d)\n",
 			len_in_bits, len, current_filename.c_str(), get_line_num());

--- a/frontends/verilog/const2ast.cc
+++ b/frontends/verilog/const2ast.cc
@@ -140,8 +140,7 @@ static void my_strtobin(std::vector<RTLIL::State> &data, const char *str, int le
 	}
 
 	if (len_in_bits == 0)
-		log_error("Illegal integer constant size of zero in %s:%d (IEEE 1800-2012, 5.7).\n",
-				current_filename.c_str(), get_line_num());
+		log_file_error(current_filename, get_line_num(), "Illegal integer constant size of zero (IEEE 1800-2012, 5.7).\n");
 
 	if (len > len_in_bits)
 		log_warning("Literal has a width of %d bit, but value requires %d bit. (%s:%d)\n",


### PR DESCRIPTION
The following PR aims to close #1808 . Given that this is a front-end specific change, and even if the change may look simple, please feel free to comment if doesn't looks good enough or should be applied at a different level.