### PR TITLE
splitnets: skip modules with processes

### DIFF
--- a/passes/cmds/splitnets.cc
+++ b/passes/cmds/splitnets.cc
@@ -141,6 +141,9 @@ struct SplitnetsPass : public Pass {
 
 		for (auto module : design->selected_modules())
 		{
+			if (module->has_processes_warn())
+				continue;
+
 			SplitnetsWorker worker;
 
 			if (flag_ports)


### PR DESCRIPTION
This is similar to some other utility passes.

This is very useful for the cxxrtl backend (which calls splitnets internally) because that backend works just fine on modules with processes. In particular a situation where some modules have processes (and should be skipped) and some modules do not (and will be processed) is normal for that backend, and calling splitnets in that situation is beneficial.