### PR TITLE
support using previously declared types/localparams/parameters in package

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -441,6 +441,29 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 		}
 	}
 
+	// create name resolution entries for all objects with names
+	if (type == AST_PACKAGE) {
+		//add names to package scope
+		for (size_t i = 0; i < children.size(); i++) {
+			AstNode *node = children[i];
+			// these nodes appear at the top level in a package and can define names
+			if (node->type == AST_PARAMETER || node->type == AST_LOCALPARAM || node->type == AST_TYPEDEF) {
+				current_scope[node->str] = node;
+			}
+			if (node->type == AST_ENUM) {
+				current_scope[node->str] = node;
+				for (auto enode : node->children) {
+					log_assert(enode->type==AST_ENUM_ITEM);
+					if (current_scope.count(enode->str) == 0)
+						current_scope[enode->str] = enode;
+					else
+						log_file_error(filename, location.first_line, "enum item %s already exists in package\n", enode->str.c_str());
+				}
+			}
+		}
+	}
+
+
 	auto backup_current_block = current_block;
 	auto backup_current_block_child = current_block_child;
 	auto backup_current_top_block = current_top_block;

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -521,7 +521,8 @@ package_body:
 
 package_body_stmt:
 	typedef_decl |
-	localparam_decl;
+	localparam_decl |
+	param_decl;
 
 interface:
 	TOK_INTERFACE {

--- a/tests/svtypes/typedef_package.sv
+++ b/tests/svtypes/typedef_package.sv
@@ -1,6 +1,9 @@
 package pkg;
 	typedef logic [7:0] uint8_t;
-	typedef enum logic [7:0] {bb=8'hBB} enum8_t;
+	typedef enum logic [7:0] {bb=8'hBB, cc=8'hCC} enum8_t;
+
+	localparam uint8_t PCONST = cc;
+	parameter uint8_t PCONST_COPY = PCONST;
 endpackage
 
 module top;
@@ -8,7 +11,9 @@ module top;
 	(* keep *) pkg::uint8_t a = 8'hAA;
 	(* keep *) pkg::enum8_t b_enum = pkg::bb;
 
-	always @* assert(a == 8'hAA);
-	always @* assert(b_enum == 8'hBB);
+	always_comb assert(a == 8'hAA);
+	always_comb assert(b_enum == 8'hBB);
+	always_comb assert(pkg::PCONST == pkg::cc);
+	always_comb assert(pkg::PCONST_COPY == pkg::cc);
 
 endmodule


### PR DESCRIPTION
This commit adds support for using previously declared typedefs, enum values, and localparams/parameters within the same package. It also adds syntax support for parameters in systemverilog packages.

(parameters in systemverilog packages can't actually be overridden, so
allowing parameters in addition to localparams doesn't actually add any
new functionality, but it's useful to be able to use the parameter
keyword also within packages, especially for existing code)