### PR TITLE
[NFCI] Deduplicate builtin FF cell types list

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -47,6 +47,53 @@ int RTLIL::IdString::last_created_idx_ptr_;
 
 dict<std::string, std::string> RTLIL::constpad;
 
+const pool<IdString> &RTLIL::builtin_ff_cell_types() {
+	static const pool<IdString> res = {
+		ID($sr),
+		ID($ff),
+		ID($dff),
+		ID($dffe),
+		ID($dffsr),
+		ID($adff),
+		ID($dlatch),
+		ID($dlatchsr),
+		ID($_DFFE_NN_),
+		ID($_DFFE_NP_),
+		ID($_DFFE_PN_),
+		ID($_DFFE_PP_),
+		ID($_DFFSR_NNN_),
+		ID($_DFFSR_NNP_),
+		ID($_DFFSR_NPN_),
+		ID($_DFFSR_NPP_),
+		ID($_DFFSR_PNN_),
+		ID($_DFFSR_PNP_),
+		ID($_DFFSR_PPN_),
+		ID($_DFFSR_PPP_),
+		ID($_DFF_NN0_),
+		ID($_DFF_NN1_),
+		ID($_DFF_NP0_),
+		ID($_DFF_NP1_),
+		ID($_DFF_N_),
+		ID($_DFF_PN0_),
+		ID($_DFF_PN1_),
+		ID($_DFF_PP0_),
+		ID($_DFF_PP1_),
+		ID($_DFF_P_),
+		ID($_DLATCHSR_NNN_),
+		ID($_DLATCHSR_NNP_),
+		ID($_DLATCHSR_NPN_),
+		ID($_DLATCHSR_NPP_),
+		ID($_DLATCHSR_PNN_),
+		ID($_DLATCHSR_PNP_),
+		ID($_DLATCHSR_PPN_),
+		ID($_DLATCHSR_PPP_),
+		ID($_DLATCH_N_),
+		ID($_DLATCH_P_),
+		ID($_FF_),
+	};
+	return res;
+}
+
 RTLIL::Const::Const()
 {
 	flags = RTLIL::CONST_FLAG_NONE;

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -383,6 +383,8 @@ namespace RTLIL
 
 	extern dict<std::string, std::string> constpad;
 
+	const pool<IdString> &builtin_ff_cell_types();
+
 	static inline std::string escape_id(const std::string &str) {
 		if (str.size() > 0 && str[0] != '\\' && str[0] != '$')
 			return "\\" + str;

--- a/passes/cmds/check.cc
+++ b/passes/cmds/check.cc
@@ -98,49 +98,6 @@ struct CheckPass : public Pass {
 
 		log_header(design, "Executing CHECK pass (checking for obvious problems).\n");
 
-		pool<IdString> fftypes;
-		fftypes.insert(ID($sr));
-		fftypes.insert(ID($ff));
-		fftypes.insert(ID($dff));
-		fftypes.insert(ID($dffe));
-		fftypes.insert(ID($dffsr));
-		fftypes.insert(ID($adff));
-		fftypes.insert(ID($dlatch));
-		fftypes.insert(ID($dlatchsr));
-		fftypes.insert(ID($_DFFE_NN_));
-		fftypes.insert(ID($_DFFE_NP_));
-		fftypes.insert(ID($_DFFE_PN_));
-		fftypes.insert(ID($_DFFE_PP_));
-		fftypes.insert(ID($_DFFSR_NNN_));
-		fftypes.insert(ID($_DFFSR_NNP_));
-		fftypes.insert(ID($_DFFSR_NPN_));
-		fftypes.insert(ID($_DFFSR_NPP_));
-		fftypes.insert(ID($_DFFSR_PNN_));
-		fftypes.insert(ID($_DFFSR_PNP_));
-		fftypes.insert(ID($_DFFSR_PPN_));
-		fftypes.insert(ID($_DFFSR_PPP_));
-		fftypes.insert(ID($_DFF_NN0_));
-		fftypes.insert(ID($_DFF_NN1_));
-		fftypes.insert(ID($_DFF_NP0_));
-		fftypes.insert(ID($_DFF_NP1_));
-		fftypes.insert(ID($_DFF_N_));
-		fftypes.insert(ID($_DFF_PN0_));
-		fftypes.insert(ID($_DFF_PN1_));
-		fftypes.insert(ID($_DFF_PP0_));
-		fftypes.insert(ID($_DFF_PP1_));
-		fftypes.insert(ID($_DFF_P_));
-		fftypes.insert(ID($_DLATCHSR_NNN_));
-		fftypes.insert(ID($_DLATCHSR_NNP_));
-		fftypes.insert(ID($_DLATCHSR_NPN_));
-		fftypes.insert(ID($_DLATCHSR_NPP_));
-		fftypes.insert(ID($_DLATCHSR_PNN_));
-		fftypes.insert(ID($_DLATCHSR_PNP_));
-		fftypes.insert(ID($_DLATCHSR_PPN_));
-		fftypes.insert(ID($_DLATCHSR_PPP_));
-		fftypes.insert(ID($_DLATCH_N_));
-		fftypes.insert(ID($_DLATCH_P_));
-		fftypes.insert(ID($_FF_));
-
 		for (auto module : design->selected_whole_modules_warn())
 		{
 			if (module->has_processes_warn())
@@ -242,7 +199,7 @@ struct CheckPass : public Pass {
 			{
 				for (auto cell : module->cells())
 				{
-					if (fftypes.count(cell->type) == 0)
+					if (RTLIL::builtin_ff_cell_types().count(cell->type) == 0)
 						continue;
 
 					for (auto bit : sigmap(cell->getPort(ID::Q)))

--- a/passes/cmds/setundef.cc
+++ b/passes/cmds/setundef.cc
@@ -359,34 +359,9 @@ struct SetundefPass : public Pass {
 				pool<SigBit> ffbits;
 				pool<Wire*> initwires;
 
-				pool<IdString> fftypes;
-				fftypes.insert(ID($dff));
-				fftypes.insert(ID($dffe));
-				fftypes.insert(ID($dffsr));
-				fftypes.insert(ID($adff));
-
-				std::vector<char> list_np = {'N', 'P'}, list_01 = {'0', '1'};
-
-				for (auto c1 : list_np)
-					fftypes.insert(stringf("$_DFF_%c_", c1));
-
-				for (auto c1 : list_np)
-				for (auto c2 : list_np)
-					fftypes.insert(stringf("$_DFFE_%c%c_", c1, c2));
-
-				for (auto c1 : list_np)
-				for (auto c2 : list_np)
-				for (auto c3 : list_01)
-					fftypes.insert(stringf("$_DFF_%c%c%c_", c1, c2, c3));
-
-				for (auto c1 : list_np)
-				for (auto c2 : list_np)
-				for (auto c3 : list_np)
-					fftypes.insert(stringf("$_DFFSR_%c%c%c_", c1, c2, c3));
-
 				for (auto cell : module->cells())
 				{
-					if (!fftypes.count(cell->type))
+					if (!RTLIL::builtin_ff_cell_types().count(cell->type))
 						continue;
 
 					for (auto bit : sigmap(cell->getPort(ID::Q)))

--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -118,9 +118,7 @@ struct OptMergeWorker
 		for (auto &it : *conn) {
 			RTLIL::SigSpec sig;
 			if (cell->output(it.first)) {
-				if (it.first == ID::Q && (cell->type.begins_with("$dff") || cell->type.begins_with("$dlatch") ||
-							cell->type.begins_with("$_DFF") || cell->type.begins_with("$_DLATCH") || cell->type.begins_with("$_SR_") ||
-							cell->type.in(ID($adff), ID($sr), ID($ff), ID($_FF_)))) {
+				if (it.first == ID::Q && RTLIL::builtin_ff_cell_types().count(cell->type)) {
 					// For the 'Q' output of state elements,
 					//   use its (* init *) attribute value
 					for (const auto &b : dff_init_map(it.second))


### PR DESCRIPTION
A few passes included the same list of FF cell types.  Make it a global
const instead.

The zinit pass also seems to include a list like that, but given that
it seems to be completely broken at the time (see #1568 discussion),
I'm going to pretend I didn't see that.