### PR TITLE
Frontend: allow reading file input from stdin, like a REPL heredoc mode

### DIFF
--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -479,27 +479,27 @@ void Frontend::extra_args(std::istream *&f, std::string &filename, std::vector<s
 	{
 		std::string arg = args[argidx];
 
-		if (arg.compare(0, 1, "-") == 0 && arg != "-")
+		if (arg.compare(0, 1, "-") == 0)
 			cmd_error(args, argidx, "Unknown option or option in arguments.");
 		if (f != NULL)
 			cmd_error(args, argidx, "Extra filename argument in direct file mode.");
 
-		filename = (arg == "-")? "<stdin>" : arg;
+		filename = arg;
 		//Accommodate heredocs with EOT marker spaced out from "<<", e.g. "<< EOT" vs. "<<EOT"
 		if (filename == "<<" && argidx+1 < args.size())
 			filename += args[++argidx];
-		if (filename.compare(0, 2, "<<") == 0 || filename == "<stdin>") {
-			if (Frontend::current_script_file == NULL && filename != "<stdin>")
-				log_error("Unexpected here document '%s' outside of script!\n", filename.c_str());
+		if (filename.compare(0, 2, "<<") == 0) {
 			if (filename.size() <= 2)
 				log_error("Missing EOT marker in here document!\n");
-			std::string eot_marker = filename == "<stdin>"? "EOT" : filename.substr(2); //"EOT" hardcoded as EOT marker when reading from stdin
+			std::string eot_marker = filename.substr(2);
+			if (Frontend::current_script_file == nullptr)
+				filename = "<stdin>";
 			last_here_document.clear();
 			while (1) {
 				std::string buffer;
 				char block[4096];
 				while (1) {
-					if (fgets(block, 4096, filename == "<stdin>"? stdin : Frontend::current_script_file) == NULL)
+					if (fgets(block, 4096, Frontend::current_script_file == nullptr? stdin : Frontend::current_script_file) == nullptr)
 						log_error("Unexpected end of file in here document '%s'!\n", filename.c_str());
 					buffer += block;
 					if (buffer.size() > 0 && (buffer[buffer.size() - 1] == '\n' || buffer[buffer.size() - 1] == '\r'))

--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -479,26 +479,27 @@ void Frontend::extra_args(std::istream *&f, std::string &filename, std::vector<s
 	{
 		std::string arg = args[argidx];
 
-		if (arg.compare(0, 1, "-") == 0)
+		if (arg.compare(0, 1, "-") == 0 && arg != "-")
 			cmd_error(args, argidx, "Unknown option or option in arguments.");
 		if (f != NULL)
 			cmd_error(args, argidx, "Extra filename argument in direct file mode.");
 
-		filename = arg;
+		filename = (arg == "-")? "<stdin>" : arg;
+		//Accommodate heredocs with EOT marker spaced out from "<<", e.g. "<< EOT" vs. "<<EOT"
 		if (filename == "<<" && argidx+1 < args.size())
 			filename += args[++argidx];
-		if (filename.compare(0, 2, "<<") == 0) {
-			if (Frontend::current_script_file == NULL)
+		if (filename.compare(0, 2, "<<") == 0 || filename == "<stdin>") {
+			if (Frontend::current_script_file == NULL && filename != "<stdin>")
 				log_error("Unexpected here document '%s' outside of script!\n", filename.c_str());
 			if (filename.size() <= 2)
 				log_error("Missing EOT marker in here document!\n");
-			std::string eot_marker = filename.substr(2);
+			std::string eot_marker = filename == "<stdin>"? "EOT" : filename.substr(2); //"EOT" hardcoded as EOT marker when reading from stdin
 			last_here_document.clear();
 			while (1) {
 				std::string buffer;
 				char block[4096];
 				while (1) {
-					if (fgets(block, 4096, Frontend::current_script_file) == NULL)
+					if (fgets(block, 4096, filename == "<stdin>"? stdin : Frontend::current_script_file) == NULL)
 						log_error("Unexpected end of file in here document '%s'!\n", filename.c_str());
 					buffer += block;
 					if (buffer.size() > 0 && (buffer[buffer.size() - 1] == '\n' || buffer[buffer.size() - 1] == '\r'))


### PR DESCRIPTION
When using the REPL, there is no convenient way to specify a design.  One can call `read_verilog`, `read_blif`, etc., but the Verilog or BLIF, etc. must exist in some file.

This PR enables recognition of "-" as a filename for `Frontend` passes, and when that is given, it reads from stdin just like it would read from a script file with a heredoc.  This means one can do something like the following:

```
yosys> read_verilog -dump_ast1 -
module top(input a, output reg q);
	always @*
		if (1'b1)
			q = !a;
endmodule
EOT
1. Executing Verilog-2005 frontend: <stdin>
Parsing Verilog input from `<stdin>' to AST representation.
Generating RTLIL representation for module `\top'.
Dumping AST before simplification:
    AST_MODULE <<stdin>:1.1-5.10> [0x1da4420] str='\top'
      AST_WIRE <<stdin>:1.18-1.19> [0x1da4c30] str='\a' input port=1
      AST_WIRE <<stdin>:1.32-1.33> [0x1da4d70] str='\q' output reg port=2
      AST_ALWAYS <<stdin>:2.2-4.11> [0x1da4eb0]
        AST_BLOCK <<stdin>:2.11-4.11> [0x1da4ff0]
          AST_CASE <<stdin>:3.3-4.11> [0x1da0290]
            AST_REDUCE_BOOL <<stdin>:0.0-0.0> [0x1da5630]
              AST_CONSTANT <<stdin>:0.0-0.0> [0x1d7ec60] bits='1'(1) range=[0:0] int=1
            AST_COND <<stdin>:3.7-3.11> [0x1da33c0]
              AST_CONSTANT <<stdin>:0.0-0.0> [0x1da5780] bits='1'(1) range=[0:0] int=1
              AST_BLOCK <<stdin>:4.4-4.11> [0x1da3540]
                AST_ASSIGN_EQ <<stdin>:4.4-4.10> [0x1da5cc0]
                  AST_IDENTIFIER <<stdin>:4.4-4.5> [0x1da54e0] str='\q'
                  AST_LOGIC_NOT <<stdin>:4.8-4.10> [0x1da5b70]
                    AST_IDENTIFIER <<stdin>:4.9-4.10> [0x1da5a20] str='\a'
--- END OF AST DUMP ---
Successfully finished Verilog frontend.

yosys> ls

1 modules:
  top
```

One deficiency of the current implementation:  The end marker is hardcoded as "EOT".  Ideally this somehow would be optionally specified by the user.