### PR TITLE
Verilog frontend: add location information to parsed constants

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -2618,6 +2618,7 @@ basic_expr:
 		bits->str = *$1;
 		SET_AST_NODE_LOC(bits, @1, @1);
 		AstNode *val = const2ast(*$2, case_type_stack.size() == 0 ? 0 : case_type_stack.back(), !lib_mode);
+		SET_AST_NODE_LOC(val, @2, @2);
 		if (val == NULL)
 			log_error("Value conversion failed: `%s'\n", $2->c_str());
 		$$ = new AstNode(AST_TO_BITS, bits, val);
@@ -2626,6 +2627,7 @@ basic_expr:
 	} |
 	integral_number {
 		$$ = const2ast(*$1, case_type_stack.size() == 0 ? 0 : case_type_stack.back(), !lib_mode);
+		SET_AST_NODE_LOC($$, @1, @1);
 		if ($$ == NULL)
 			log_error("Value conversion failed: `%s'\n", $1->c_str());
 		delete $1;
@@ -2644,6 +2646,7 @@ basic_expr:
 	} |
 	TOK_STRING {
 		$$ = AstNode::mkconst_str(*$1);
+		SET_AST_NODE_LOC($$, @1, @1);
 		delete $1;
 	} |
 	hierarchical_id attr {


### PR DESCRIPTION
See #1855.

The example to `read_verilog -dump_ast1`:
```
module top(input a, output reg q);
	always @*
		if (1'b1)
			q = !a;
endmodule
```

now gives:
```
    AST_MODULE <<stdin>:1.1-5.10> [0x218ae70] str='\top'
      AST_WIRE <<stdin>:1.18-1.19> [0x218b680] str='\a' input port=1
      AST_WIRE <<stdin>:1.32-1.33> [0x218b7c0] str='\q' output reg port=2
      AST_ALWAYS <<stdin>:2.2-4.11> [0x218b900]
        AST_BLOCK <<stdin>:2.11-4.11> [0x218ba40]
          AST_CASE <<stdin>:3.3-4.11> [0x2186ce0]
            AST_REDUCE_BOOL <<stdin>:0.0-0.0> [0x218c320]
              AST_CONSTANT <<stdin>:3.7-3.11> [0x2164c60] bits='1'(1) range=[0:0] int=1
            AST_COND <<stdin>:3.7-3.11> [0x218c080]
              AST_CONSTANT <<stdin>:0.0-0.0> [0x218bf30] bits='1'(1) range=[0:0] int=1
              AST_BLOCK <<stdin>:4.4-4.11> [0x2189e10]
                AST_ASSIGN_EQ <<stdin>:4.4-4.10> [0x218cc30]
                  AST_IDENTIFIER <<stdin>:4.4-4.5> [0x218c470] str='\q'
                  AST_LOGIC_NOT <<stdin>:4.8-4.10> [0x218c710]
                    AST_IDENTIFIER <<stdin>:4.9-4.10> [0x218c5c0] str='\a'
```

This is based on #1896 because I was already on it and it was more convenient for me to use the stdin reading to iterate on this and make sure everything worked properly.