### PR TITLE
Suppress output of Makefile.conf when printing source versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,10 @@ define newline
 endef
 
 ifneq ($(wildcard Makefile.conf),)
+# don't echo Makefile.conf contents when invoked to print source versions
+ifeq ($(findstring echo-,$(MAKECMDGOALS)),)
 $(info $(subst $$--$$,$(newline),$(shell sed 's,^,[Makefile.conf] ,; s,$$,$$--$$,;' < Makefile.conf | tr -d '\n' | sed 's,\$$--\$$$$,,')))
+endif
 include Makefile.conf
 endif
 


### PR DESCRIPTION
The make targets echo-yosys-ver, echo-git-ver and echo-abc-rev can be used to programmatically extract contents of make variables for external scripts. Unfortunately, when a Makefile.conf exists, its contents would also be echoed, making the output almost unusable. This patch selectively disables this functionality for these special targets.