### PR TITLE
Fix the truth table for $_SR_* cells.

### DIFF
--- a/techlibs/common/gen_fine_ffs.py
+++ b/techlibs/common/gen_fine_ffs.py
@@ -8,15 +8,14 @@ TEMPLATES = [
 //-
 //- Truth table:    S R | Q
 //-                -----+---
-//-                 {S:0|1} {R:0|1} | x
-//-                 {S:0|1} {R:1|0} | 1
-//-                 {S:1|0} {R:0|1} | 0
-//-                 {S:1|0} {R:1|0} | y
+//-                 - {R:0|1} | 0
+//-                 {S:0|1} - | 1
+//-                 - - | q
 //-
 module \$_SR_{S:N|P}{R:N|P}_ (S, R, Q);
 input S, R;
 output reg Q;
-always @({S:neg|pos}edge S, {R:neg|pos}edge R) begin
+always @* begin
 	if (R == {R:0|1})
 		Q <= 0;
 	else if (S == {S:0|1})

--- a/techlibs/common/simcells.v
+++ b/techlibs/common/simcells.v
@@ -469,15 +469,14 @@ endmodule
 //-
 //- Truth table:    S R | Q
 //-                -----+---
-//-                 0 0 | x
-//-                 0 1 | 1
-//-                 1 0 | 0
-//-                 1 1 | y
+//-                 - 0 | 0
+//-                 0 - | 1
+//-                 - - | q
 //-
 module \$_SR_NN_ (S, R, Q);
 input S, R;
 output reg Q;
-always @(negedge S, negedge R) begin
+always @* begin
 	if (R == 0)
 		Q <= 0;
 	else if (S == 0)
@@ -493,15 +492,14 @@ endmodule
 //-
 //- Truth table:    S R | Q
 //-                -----+---
-//-                 0 1 | x
-//-                 0 0 | 1
-//-                 1 1 | 0
-//-                 1 0 | y
+//-                 - 1 | 0
+//-                 0 - | 1
+//-                 - - | q
 //-
 module \$_SR_NP_ (S, R, Q);
 input S, R;
 output reg Q;
-always @(negedge S, posedge R) begin
+always @* begin
 	if (R == 1)
 		Q <= 0;
 	else if (S == 0)
@@ -517,15 +515,14 @@ endmodule
 //-
 //- Truth table:    S R | Q
 //-                -----+---
-//-                 1 0 | x
-//-                 1 1 | 1
-//-                 0 0 | 0
-//-                 0 1 | y
+//-                 - 0 | 0
+//-                 1 - | 1
+//-                 - - | q
 //-
 module \$_SR_PN_ (S, R, Q);
 input S, R;
 output reg Q;
-always @(posedge S, negedge R) begin
+always @* begin
 	if (R == 0)
 		Q <= 0;
 	else if (S == 1)
@@ -541,15 +538,14 @@ endmodule
 //-
 //- Truth table:    S R | Q
 //-                -----+---
-//-                 1 1 | x
-//-                 1 0 | 1
-//-                 0 1 | 0
-//-                 0 0 | y
+//-                 - 1 | 0
+//-                 1 - | 1
+//-                 - - | q
 //-
 module \$_SR_PP_ (S, R, Q);
 input S, R;
 output reg Q;
-always @(posedge S, posedge R) begin
+always @* begin
 	if (R == 1)
 		Q <= 0;
 	else if (S == 1)

--- a/techlibs/common/simlib.v
+++ b/techlibs/common/simlib.v
@@ -1633,7 +1633,7 @@ wire [WIDTH-1:0] pos_clr = CLR_POLARITY ? CLR : ~CLR;
 genvar i;
 generate
 	for (i = 0; i < WIDTH; i = i+1) begin:bitslices
-		always @(posedge pos_set[i], posedge pos_clr[i])
+		always @*
 			if (pos_clr[i])
 				Q[i] <= 0;
 			else if (pos_set[i])


### PR DESCRIPTION
This brings the documented behavior for these cells in line with
$_DFFSR_* and $_DLATCHSR_*, which is that R has priority over S.
The models were already reflecting that behavior.

Also get rid of sim-synth mismatch in the models while we're at it.