### PR TITLE
opt_expr: Add more $alu optimizations.

### DIFF
--- a/tests/opt/opt_expr_alu.ys
+++ b/tests/opt/opt_expr_alu.ys
@@ -5,7 +5,7 @@ endmodule
 EOT
 
 alumacc
-equiv_opt opt_expr -fine
+equiv_opt -assert opt_expr -fine
 design -load postopt
 select -assert-count 1 t:$pos
 select -assert-count none t:$pos t:* %D
@@ -30,7 +30,7 @@ assign y = {a,1'b1} - 1'b1;
 endmodule
 EOT
 
-equiv_opt opt_expr -fine
+equiv_opt -assert opt_expr -fine
 design -load postopt
 select -assert-count 1 t:$pos
 select -assert-count none t:$pos t:* %D
@@ -43,7 +43,7 @@ assign y = {a,3'b101} - 1'b1;
 endmodule
 EOT
 
-equiv_opt opt_expr -fine
+equiv_opt -assert opt_expr -fine
 design -load postopt
 select -assert-count 1 t:$pos
 select -assert-count none t:$pos t:* %D
@@ -57,7 +57,55 @@ endmodule
 EOT
 
 alumacc
-equiv_opt opt_expr -fine
+equiv_opt -assert opt_expr -fine
 design -load postopt
 select -assert-count 1 t:$pos
 select -assert-count none t:$pos t:* %D
+
+
+design -reset
+read_verilog <<EOT
+module test(input [1:0] a, output [3:0] y);
+assign y = -{a[1], 2'b10, a[0]};
+endmodule
+EOT
+
+alumacc
+equiv_opt -assert opt -fine
+design -load postopt
+select -assert-count 1 t:$alu
+select -assert-count 1 t:$alu r:Y_WIDTH=3 %i
+select -assert-count 1 t:$not
+select -assert-count none t:$alu t:$not t:* %D %D
+
+
+design -reset
+read_verilog <<EOT
+module test(input [3:0] a, input [2:0] b, output [5:0] y);
+assign y = {a[3:2], 1'b1, a[1:0]} + {b[2], 2'b11, b[1:0]};
+endmodule
+EOT
+
+alumacc
+equiv_opt -assert opt -fine
+design -load postopt
+dump
+select -assert-count 2 t:$alu
+select -assert-count 1 t:$alu r:Y_WIDTH=2 %i
+select -assert-count 1 t:$alu r:Y_WIDTH=3 %i
+select -assert-count none t:$alu t:* %D
+
+
+design -reset
+read_verilog <<EOT
+module test(input [3:0] a, input [3:0] b, output [5:0] y);
+assign y = {a[3:2], 1'b0, a[1:0]} + {b[3:2], 1'b0, b[1:0]};
+endmodule
+EOT
+
+alumacc
+equiv_opt -assert opt -fine
+design -load postopt
+select -assert-count 2 t:$alu
+select -assert-count 2 t:$alu r:Y_WIDTH=3 %i
+select -assert-count none t:$alu t:* %D


### PR DESCRIPTION
Detect the places in the $alu where the carry bit is constant (due to
const A[i] == B[i] ^ BI) and split it into smaller $alu at these points.

Also, make the existing const-carry detection for low bits more generic
(now handles cases where both BI and CI are constant, but not equal to
one another).

Fixes #1912.