### PR TITLE
kernel: Add `dict` support for rvalue references and C++11 move semantics.

### DIFF
--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -465,13 +465,43 @@ public:
 		return std::pair<iterator, bool>(iterator(this, i), true);
 	}
 
-	std::pair<iterator, bool> insert(K const &key, T &&rvalue)
+	std::pair<iterator, bool> emplace(K const &key, T const &value)
+	{
+		int hash = do_hash(key);
+		int i = do_lookup(key, hash);
+		if (i >= 0)
+			return std::pair<iterator, bool>(iterator(this, i), false);
+		i = do_insert(std::make_pair(key, value), hash);
+		return std::pair<iterator, bool>(iterator(this, i), true);
+	}
+
+	std::pair<iterator, bool> emplace(K const &key, T &&rvalue)
 	{
 		int hash = do_hash(key);
 		int i = do_lookup(key, hash);
 		if (i >= 0)
 			return std::pair<iterator, bool>(iterator(this, i), false);
 		i = do_insert(std::make_pair(key, std::forward<T>(rvalue)), hash);
+		return std::pair<iterator, bool>(iterator(this, i), true);
+	}
+
+	std::pair<iterator, bool> emplace(K &&rkey, T const &value)
+	{
+		int hash = do_hash(rkey);
+		int i = do_lookup(rkey, hash);
+		if (i >= 0)
+			return std::pair<iterator, bool>(iterator(this, i), false);
+		i = do_insert(std::make_pair(std::forward<K>(rkey), value), hash);
+		return std::pair<iterator, bool>(iterator(this, i), true);
+	}
+
+	std::pair<iterator, bool> emplace(K &&rkey, T &&rvalue)
+	{
+		int hash = do_hash(rkey);
+		int i = do_lookup(rkey, hash);
+		if (i >= 0)
+			return std::pair<iterator, bool>(iterator(this, i), false);
+		i = do_insert(std::make_pair(std::forward<K>(rkey), std::forward<T>(rvalue)), hash);
 		return std::pair<iterator, bool>(iterator(this, i), true);
 	}
 


### PR DESCRIPTION
This avoids an unnecessary copy of the `std::pair<K, T>` in the `entry_t` constructor when the inserted key/value pair is an rvalue and also always avoids an unnecessary `std::move()` into the `entries` member variable by instead constructing the `entry_t` in place with `emplace_back()`.

Inserting an rvalue into a `dict` is actually not super uncommon throughout the code base:
```
user@host:~/github/yosys$ find . -type f | xargs grep -n "\.insert(.*std::make_pair" | grep -v "^Binary file"
./techlibs/ice40/ice40_opt.cc:128:							new_attr.insert(std::make_pair(a.first, a.second));
./passes/hierarchy/submod.cc:187:						auto jt = new_wire->attributes.insert(std::make_pair(ID::init, Const(State::Sx, GetSize(sig)))).first;
./passes/pmgen/ice40_wrapcarry.cc:147:						carry->attributes.insert(std::make_pair(ID::src, src));
./passes/pmgen/ice40_wrapcarry.cc:148:						lut->attributes.insert(std::make_pair(ID::src, src));
./passes/techmap/shregmap.cc:143:					auto r = sigbit_chain_next.insert(std::make_pair(d_bit, cell));
./passes/techmap/shregmap.cc:157:						sigbit_chain_next.insert(std::make_pair(wire, cell));
./passes/techmap/abc9_ops.cc:50:			auto r = box_lookup.insert(std::make_pair(stringf("$__boxid%d", id), m->name));
./passes/techmap/abc9_ops.cc:143:		auto r = clk_to_mergeability.insert(std::make_pair(abc9_clock, clk_to_mergeability.size() + 1));
./passes/techmap/abc9_ops.cc:180:			replace.insert(std::make_pair(Q,D));
./passes/opt/opt_merge.cc:281:				auto r = sharemap.insert(std::make_pair(hash, cell));
./backends/aiger/xaiger.cc:225:					auto r YS_ATTRIBUTE(unused) = ff_bits.insert(std::make_pair(D, cell));
./frontends/aiger/aigerparse.cc:72:					auto r YS_ATTRIBUTE(unused) = sig2driver.insert(std::make_pair(it2.second, it.second));
```