### PR TITLE
kernel: Module::makeblackbox() to clear connections too

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -767,6 +767,8 @@ void RTLIL::Module::makeblackbox()
 		delete it->second;
 	processes.clear();
 
+	connections_.clear();
+
 	remove(delwires);
 	set_bool_attribute(ID::blackbox);
 }


### PR DESCRIPTION
Not removing connections can lead to the equivalent of:
`assign 1'bx = 1'bx;`
(since wires have been deleted) which fires an assertion in `Module::check()`
