### PR TITLE
write_cxxrtl: enable separate compilation

### DIFF
--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -1984,7 +1984,7 @@ struct VerilogBackend : public Backend {
 		extra_args(f, filename, args, argidx);
 		if (extmem)
 		{
-			if (filename.empty())
+			if (filename == "<stdout>")
 				log_cmd_error("Option -extmem must be used with a filename.\n");
 			extmem_prefix = filename.substr(0, filename.rfind('.'));
 		}


### PR DESCRIPTION
This PR makes it possible to use several cxxrtl-generated files in one application, as well as compiling cxxrtl-generated code as a separate compilation unit.