### PR TITLE
write_cxxrtl: ignore disconnected module ports

### DIFF
--- a/backends/cxxrtl/cxxrtl.cc
+++ b/backends/cxxrtl/cxxrtl.cc
@@ -970,6 +970,8 @@ struct CxxrtlWorker {
 						continue;
 				}
 				if (cell->output(conn.first)) {
+					if (conn.second.empty())
+						continue; // ignore disconnected ports
 					f << indent;
 					dump_sigspec_lhs(conn.second);
 					f << " = " << mangle(cell) << "." << mangle_wire_name(conn.first) << ".curr;\n";


### PR DESCRIPTION
E.g. port `q` in `submod x(.p(p), .q());`.

Fixes #1920.