### PR TITLE
dffinit: Avoid setting init parameter to zero-length value.

### DIFF
--- a/passes/techmap/dffinit.cc
+++ b/passes/techmap/dffinit.cc
@@ -154,9 +154,11 @@ struct DffinitPass : public Pass {
 							value = Const(low_string);
 					}
 
-					log("Setting %s.%s.%s (port=%s, net=%s) to %s.\n", log_id(module), log_id(cell), log_id(it.second),
-							log_id(it.first), log_signal(sig), log_signal(value));
-					cell->setParam(it.second, value);
+					if (value.size() != 0) {
+						log("Setting %s.%s.%s (port=%s, net=%s) to %s.\n", log_id(module), log_id(cell), log_id(it.second),
+								log_id(it.first), log_signal(sig), log_signal(value));
+						cell->setParam(it.second, value);
+					}
 				}
 			}
 

--- a/tests/techmap/dffinit.ys
+++ b/tests/techmap/dffinit.ys
@@ -1,0 +1,25 @@
+read_verilog <<EOT
+
+module ff(...);
+input d;
+output q;
+
+endmodule
+
+module top(...);
+input d;
+output q1;
+(* init = 1'b1 *)
+output q2;
+
+ff my_ff1(.d(d), .q(q1));
+ff my_ff2(.d(d), .q(q2));
+
+endmodule
+
+EOT
+
+dffinit -ff ff q init
+select -assert-count 2 t:ff
+select -assert-count 1 t:ff r:init %i
+select -assert-count 1 t:ff r:init=1'b1 %i


### PR DESCRIPTION
Fixes #1704.