### PR TITLE
kernel: Design::remove(RTLIL::Module *) to check refcount_modules_

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -597,6 +597,7 @@ void RTLIL::Design::remove(RTLIL::Module *module)
 	}
 
 	log_assert(modules_.at(module->name) == module);
+	log_assert(refcount_modules_ == 0);
 	modules_.erase(module->name);
 	delete module;
 }

--- a/passes/cmds/design.cc
+++ b/passes/cmds/design.cc
@@ -340,7 +340,7 @@ struct DesignPass : public Pass {
 
 		if (reset_mode || !load_name.empty() || push_mode || pop_mode)
 		{
-			for (auto mod : design->modules())
+			for (auto mod : design->modules().to_vector())
 				design->remove(mod);
 
 			design->selection_stack.clear();


### PR DESCRIPTION
To prevent insertion during iteration; in line with `Design::add()`, `Module::{add,remove}()`, etc.

https://github.com/YosysHQ/yosys/pull/1862#discussion_r406340722