### PR TITLE
Use static constexpr instead of static const where possible.

### DIFF
--- a/libs/sha1/sha1.h
+++ b/libs/sha1/sha1.h
@@ -35,9 +35,9 @@ public:
     static std::string from_file(const std::string &filename);
 
 private:
-    static const unsigned int DIGEST_INTS = 5;  /* number of 32bit integers per SHA1 digest */
-    static const unsigned int BLOCK_INTS = 16;  /* number of 32bit integers per SHA1 block */
-    static const unsigned int BLOCK_BYTES = BLOCK_INTS * 4;
+    static constexpr unsigned int DIGEST_INTS = 5;  /* number of 32bit integers per SHA1 digest */
+    static constexpr unsigned int BLOCK_INTS = 16;  /* number of 32bit integers per SHA1 block */
+    static constexpr unsigned int BLOCK_BYTES = BLOCK_INTS * 4;
 
     uint32_t digest[DIGEST_INTS];
     std::string buffer;

--- a/libs/subcircuit/subcircuit.cc
+++ b/libs/subcircuit/subcircuit.cc
@@ -316,7 +316,7 @@ class SubCircuit::SolverWorker
 
 	// helper functions for handling permutations
 
-	static const int maxPermutationsLimit = 1000000;
+	static constexpr int maxPermutationsLimit = 1000000;
 
 	static int numberOfPermutations(const std::vector<std::string> &list)
 	{
@@ -1689,4 +1689,3 @@ void SubCircuit::Solver::clearConfig()
 {
 	worker->clearConfig();
 }
-


### PR DESCRIPTION
In particular inside class declarations, a static const
assignment is technically not a definition, while constexpr is.

Signed-off-by: Henner Zeller <h.zeller@acm.org>