### PR TITLE
kernel: Trap in `log_error()` when a debugger is attached.

### DIFF
--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -354,6 +354,9 @@ static void logv_error_with_prefix(const char *prefix,
 
 	if (check_expected_logs)
 		log_check_expected();
+
+	YS_DEBUGTRAP; //trap into debugger if one is attached
+
 #ifdef EMSCRIPTEN
 	log_files = backup_log_files;
 	throw 0;

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -53,6 +53,8 @@
 #ifndef _WIN32
 #  include <sys/time.h>
 #  include <sys/resource.h>
+#  include <sys/ptrace.h>
+#  include <signal.h>
 #endif
 
 #if defined(_MSC_VER)
@@ -68,6 +70,22 @@ YOSYS_NAMESPACE_BEGIN
 #define S__LINE__sub2(x) #x
 #define S__LINE__sub1(x) S__LINE__sub2(x)
 #define S__LINE__ S__LINE__sub1(__LINE__)
+
+#if defined(_MSC_VER)
+# define YS_DEBUGTRAP __debugbreak()
+#elif defined(__unix__)
+# if defined(__clang__)
+#  if defined(__builtin_debugtrap)
+#   define YS_DEBUGTRAP __builtin_debugtrap()
+#  else
+#   define YS_DEBUGTRAP do{if(ptrace(PTRACE_TRACEME, 0, nullptr, 0) == -1){ raise(SIGTRAP); }} while(0);
+#  endif
+# else
+#  define YS_DEBUGTRAP do{if(ptrace(PTRACE_TRACEME, 0, nullptr, 0) == -1){ raise(SIGTRAP); }} while(0);
+# endif
+#else
+# define YS_DEBUGTRAP do{} while(0);
+#endif
 
 struct log_cmd_error_exception { };
 


### PR DESCRIPTION
This PR adds a multi-platform debug break facility to enable `log_error()` to instead issue a debug trap instead of simply exiting.
However, when no debugger is attached, the behavior remains unchanged.

See: https://stackoverflow.com/questions/3596781/how-to-detect-if-the-current-process-is-being-run-by-gdb (baseip's answer)
and: https://github.com/scottt/debugbreak

Note that the debugbreak code above upon which this is partially based is licensed under BSD 2-clause.  I think that should be compatible with the ISC license in the rest of Yosys, but I may be wrong.

This has only been tested on Linux so far.  Testing on Windows with MSVC and MingW should be done before this is merged.