### PR TITLE
synth_intel_alm: VQM support

### DIFF
--- a/techlibs/intel_alm/common/quartus_rename.v
+++ b/techlibs/intel_alm/common/quartus_rename.v
@@ -12,12 +12,8 @@ MISTRAL_ALUT2 #(.LUT(4'b0000)) _TECHMAP_REPLACE_ (.A(1'b1), .B(1'b1), .Q(Q));
 endmodule
 
 
-module MISTRAL_FF(input D, CLK, ACn, ALD, AD, EN, output reg Q);
+module MISTRAL_FF(input DATAIN, CLK, ACLR, ENA, SCLR, SLOAD, SDATA, output reg Q);
 
-parameter INIT = 1'b0;
-
-localparam [1023:0] INIT_STR = (INIT !== 1'b1) ? "low" : "high";
-
-dffeas #(.power_up(INIT_STR), .is_wysiwyg("true")) _TECHMAP_REPLACE_ (.d(D), .clk(CLK), .clrn(ACn), .aload(ALD), .asdata(AD), .ena(EN), .q(Q));
+dffeas #(.power_up("low"), .is_wysiwyg("true")) _TECHMAP_REPLACE_ (.d(DATAIN), .clk(CLK), .clrn(ACLR), .ena(ENA), .sclr(SCLR), .sload(SLOAD), .asdata(SDATA), .q(Q));
 
 endmodule

--- a/techlibs/intel_alm/synth_intel_alm.cc
+++ b/techlibs/intel_alm/synth_intel_alm.cc
@@ -223,6 +223,7 @@ struct SynthIntelALMPass : public ScriptPass {
 
 		if (check_label("quartus")) {
 			if (quartus || help_mode) {
+				run("setundef -zero");
 				run("hilomap -singleton -hicell __MISTRAL_VCC Q -locell __MISTRAL_GND Q");
 				run("techmap -map +/intel_alm/common/quartus_rename.v");
 				run(stringf("techmap -map +/intel_alm/%s/quartus_rename.v", family_opt.c_str()));


### PR DESCRIPTION
This is enough for Quartus to accept `synth_intel_alm -vqm` output, and compile attosoc to run on real hardware.

The lack of initialisable BRAM is annoying, but for attosoc it's small enough that implementing in flops isn't a big deal.

I would *love* to add tests for this, but testing with `synth_intel_alm -quartus` would be blocked on #1498, which doesn't seem to be going anywhere.