### PR TITLE
abc: use YosysHQ/abc instead of upstream berkeley-abc/abc

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,7 @@ Yosys 0.9 .. Yosys 0.9-dev
 
  * Various
     - Added "write_xaiger" backend
-    - Added "abc9" pass for timing-aware techmapping (experimental, FPGA only, no FFs)
+    - Added "abc9" pass for timing-aware techmapping (experimental, FPGA only)
     - Added "synth_xilinx -abc9" (experimental)
     - Added "synth_ice40 -abc9" (experimental)
     - Added "synth -abc9" (experimental)
@@ -58,7 +58,6 @@ Yosys 0.9 .. Yosys 0.9-dev
     - Added support for SystemVerilog wildcard port connections (.*)
     - Added "xilinx_dffopt" pass
     - Added "scratchpad" pass
-    - Added "abc9 -dff"
     - Added "synth_xilinx -dff"
     - Improved support of $readmem[hb] Memory Content File inclusion
     - Added "opt_lut_ins" pass
@@ -66,6 +65,7 @@ Yosys 0.9 .. Yosys 0.9-dev
     - Removed "dffsr2dff" (use opt_rmdff instead)
     - Added "design -delete"
     - Added "select -unset"
+    - Use YosysHQ/abc instead of upstream berkeley-abc/abc
 
 Yosys 0.8 .. Yosys 0.9
 ----------------------

--- a/Makefile
+++ b/Makefile
@@ -133,9 +133,9 @@ bumpversion:
 # is just a symlink to your actual ABC working directory, as 'make mrproper'
 # will remove the 'abc' directory and you do not want to accidentally
 # delete your work on ABC..
-ABCREV = ed90ce2
+ABCREV = d14acd8
 ABCPULL = 1
-ABCURL ?= https://github.com/berkeley-abc/abc
+ABCURL ?= https://github.com/YosysHQ/abc
 ABCMKARGS = CC="$(CXX)" CXX="$(CXX)" ABC_USE_LIBSTDCXX=1
 
 # set ABCEXTERNAL = <abc-command> to use an external ABC instance

--- a/manual/CHAPTER_Auxprogs.tex
+++ b/manual/CHAPTER_Auxprogs.tex
@@ -19,7 +19,8 @@ for details.
 
 \section{yosys-abc}
 
-This is a unmodified copy of ABC \citeweblink{ABC}. Not all versions of Yosys
-work with all versions of ABC. So Yosys comes with its own yosys-abc to avoid
+This is a fork of ABC \citeweblink{ABC} with a small set of custom modifications
+that have not yet been accepted upstream. Not all versions of Yosys work with
+all versions of ABC. So Yosys comes with its own yosys-abc to avoid
 compatibility issues between the two.
 


### PR DESCRIPTION
Enabling modifications.

Currently, the only modification is YosysHQ/abc#1 which is a proposed fix for Yosys' `abc9 -dff` operating on multi clock designs.