### PR TITLE
select: do not select inside black-/white- boxes unless '=' prefix used

### DIFF
--- a/passes/cmds/select.cc
+++ b/passes/cmds/select.cc
@@ -1113,8 +1113,8 @@ struct SelectPass : public Pass {
 		log("    <obj_pattern>\n");
 		log("        select the specified object(s) from the current module\n");
 		log("\n");
-		log("Prefix the following patterns with '=' if the pattern should match black-/\n");
-		log("white-box modules and their contents.\n");
+		log("By default, patterns will not match black/white-box modules or their");
+		log("contents. To include such objects, prefix the pattern with '='.\n");
 		log("\n");
 		log("A <mod_pattern> can be a module name, wildcard expression (*, ?, [..])\n");
 		log("matching module names, or one of the following:\n");

--- a/passes/cmds/select.cc
+++ b/passes/cmds/select.cc
@@ -761,10 +761,10 @@ static void select_stmt(RTLIL::Design *design, std::string arg, bool disable_emp
 		return;
 	}
 
-	bool select_blackboxes = true;
+	bool select_blackboxes = false;
 	if (arg.substr(0, 1) == "=") {
 		arg = arg.substr(1);
-		select_blackboxes = false;
+		select_blackboxes = true;
 	}
 
 	if (!design->selected_active_module.empty()) {
@@ -1113,6 +1113,9 @@ struct SelectPass : public Pass {
 		log("    <obj_pattern>\n");
 		log("        select the specified object(s) from the current module\n");
 		log("\n");
+		log("Prefix the following patterns with '=' if the pattern should match black-/\n");
+		log("white-box modules and their contents.\n");
+		log("\n");
 		log("A <mod_pattern> can be a module name, wildcard expression (*, ?, [..])\n");
 		log("matching module names, or one of the following:\n");
 		log("\n");
@@ -1123,9 +1126,6 @@ struct SelectPass : public Pass {
 		log("    N:<pattern>\n");
 		log("        all modules with a name matching the given pattern\n");
 		log("        (i.e. 'N:' is optional as it is the default matching rule)\n");
-		log("\n");
-		log("Prefix the pattern with '=' if the pattern should not match blackbox\n");
-		log("modules and their content.\n");
 		log("\n");
 		log("An <obj_pattern> can be an object name, wildcard expression, or one of\n");
 		log("the following:\n");

--- a/passes/cmds/select.cc
+++ b/passes/cmds/select.cc
@@ -809,6 +809,9 @@ static void select_stmt(RTLIL::Design *design, std::string arg, bool disable_emp
 			continue;
 		}
 
+		if (mod->get_blackbox_attribute())
+			continue;
+
 		if (arg_memb.compare(0, 2, "w:") == 0) {
 			for (auto wire : mod->wires())
 				if (match_ids(wire->name, arg_memb.substr(2)))

--- a/tests/select/blackboxes.ys
+++ b/tests/select/blackboxes.ys
@@ -16,6 +16,13 @@ module wb(input a, b, output o);
 assign o = a ^ b;
 endmodule
 EOT
+clean
 
 select -assert-count 1 c:*
 select -assert-none t:* t:$and %d
+select -assert-count 3 w:*
+select -assert-count 4 *
+
+select -assert-count 3 =c:*
+select -assert-count 10 =w:*
+select -assert-count 13 =*

--- a/tests/select/blackboxes.ys
+++ b/tests/select/blackboxes.ys
@@ -1,0 +1,21 @@
+read_verilog -specify <<EOT
+module top(input a, b, output o);
+assign o = a & b;
+endmodule
+
+(* blackbox *)
+module bb(input a, b, output o);
+assign o = a | b;
+specify
+	(a => o) = 1;
+endspecify
+endmodule
+
+(* whitebox *)
+module wb(input a, b, output o);
+assign o = a ^ b;
+endmodule
+EOT
+
+select -assert-count 1 c:*
+select -assert-none t:* t:$and %d


### PR DESCRIPTION
Without which `select c:*` will select specify cells inside blackboxes, or anything inside a whitebox.