### PR TITLE
rtlil: add AttrObject::{get,set}_string_attribute, AttrObject::has_attribute

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -289,6 +289,23 @@ bool RTLIL::AttrObject::get_bool_attribute(RTLIL::IdString id) const
 	return it->second.as_bool();
 }
 
+void RTLIL::AttrObject::set_string_attribute(RTLIL::IdString id, string value)
+{
+	if (value.empty())
+		attributes.erase(id);
+	else
+		attributes[id] = value;
+}
+
+string RTLIL::AttrObject::get_string_attribute(RTLIL::IdString id) const
+{
+	std::string value;
+	const auto it = attributes.find(id);
+	if (it != attributes.end())
+		value = it->second.decode_string();
+	return value;
+}
+
 void RTLIL::AttrObject::set_strpool_attribute(RTLIL::IdString id, const pool<string> &data)
 {
 	string attrval;
@@ -315,23 +332,6 @@ pool<string> RTLIL::AttrObject::get_strpool_attribute(RTLIL::IdString id) const
 		for (auto s : split_tokens(attributes.at(id).decode_string(), "|"))
 			data.insert(s);
 	return data;
-}
-
-void RTLIL::AttrObject::set_src_attribute(const std::string &src)
-{
-	if (src.empty())
-		attributes.erase(ID::src);
-	else
-		attributes[ID::src] = src;
-}
-
-std::string RTLIL::AttrObject::get_src_attribute() const
-{
-	std::string src;
-	const auto it = attributes.find(ID::src);
-	if (it != attributes.end())
-		src = it->second.decode_string();
-	return src;
 }
 
 bool RTLIL::Selection::selected_module(RTLIL::IdString mod_name) const

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -273,6 +273,11 @@ bool RTLIL::Const::is_fully_undef() const
 	return true;
 }
 
+bool RTLIL::AttrObject::has_attribute(RTLIL::IdString id) const
+{
+	return attributes.count(id);
+}
+
 void RTLIL::AttrObject::set_bool_attribute(RTLIL::IdString id, bool value)
 {
 	if (value)

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -656,6 +656,8 @@ struct RTLIL::AttrObject
 {
 	dict<RTLIL::IdString, RTLIL::Const> attributes;
 
+	bool has_attribute(RTLIL::IdString id) const;
+
 	void set_bool_attribute(RTLIL::IdString id, bool value=true);
 	bool get_bool_attribute(RTLIL::IdString id) const;
 

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -663,12 +663,19 @@ struct RTLIL::AttrObject
 		return get_bool_attribute(ID::blackbox) || (!ignore_wb && get_bool_attribute(ID::whitebox));
 	}
 
+	void set_string_attribute(RTLIL::IdString id, string value);
+	string get_string_attribute(RTLIL::IdString id) const;
+
 	void set_strpool_attribute(RTLIL::IdString id, const pool<string> &data);
 	void add_strpool_attribute(RTLIL::IdString id, const pool<string> &data);
 	pool<string> get_strpool_attribute(RTLIL::IdString id) const;
 
-	void set_src_attribute(const std::string &src);
-	std::string get_src_attribute() const;
+	void set_src_attribute(const std::string &src) {
+		set_string_attribute(ID::src, src);
+	}
+	std::string get_src_attribute() const {
+		return get_string_attribute(ID::src);
+	}
 };
 
 struct RTLIL::SigChunk


### PR DESCRIPTION
Cxxrtl is going to use a few string attributes, so I decided to factor these functions out. I also think that `has_attribute(ID::X)` reads nicer than `attributes.count(ID::X)`.