### PR TITLE
Verilog frontend: add source location in more parser rules

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -1924,11 +1924,13 @@ always_events:
 always_event:
 	TOK_POSEDGE expr {
 		AstNode *node = new AstNode(AST_POSEDGE);
+		SET_AST_NODE_LOC(node, @1, @1);
 		ast_stack.back()->children.push_back(node);
 		node->children.push_back($2);
 	} |
 	TOK_NEGEDGE expr {
 		AstNode *node = new AstNode(AST_NEGEDGE);
+		SET_AST_NODE_LOC(node, @1, @1);
 		ast_stack.back()->children.push_back(node);
 		node->children.push_back($2);
 	} |

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -2246,6 +2246,7 @@ behavioral_stmt:
 		exitTypeScope();
 		if ($4 != NULL && $8 != NULL && *$4 != *$8)
 			frontend_verilog_yyerror("Begin label (%s) and end label (%s) don't match.", $4->c_str()+1, $8->c_str()+1);
+		SET_AST_NODE_LOC(ast_stack.back(), @2, @8);
 		delete $4;
 		delete $8;
 		ast_stack.pop_back();


### PR DESCRIPTION
See #1855.

Before this PR:
```
yosys> read_verilog -dump_ast1 <<EOT
module foo(input clk);

always @(posedge clk) begin:foo
    reg bar;
    bar <= ~bar;
end
endmodule
EOT
1. Executing Verilog-2005 frontend: <stdin>
Parsing Verilog input from `<stdin>' to AST representation.
Generating RTLIL representation for module `\foo'.
Dumping AST before simplification:
    AST_MODULE <<stdin>:1.1-7.10> [0x598402ff9670] str='\foo'
      AST_WIRE <<stdin>:1.18-1.21> [0x598402ff2d00] str='\clk' input port=1
      AST_ALWAYS <<stdin>:3.1-6.4> [0x598402ff2e40]
        AST_POSEDGE <<stdin>:0.0-0.0> [0x598402ff6cf0]
          AST_IDENTIFIER <<stdin>:3.18-3.21> [0x598402ff6bb0] str='\clk'
        AST_BLOCK <<stdin>:3.22-6.4> [0x598402ff6e30]
          AST_BLOCK <<stdin>:0.0-0.0> [0x598402ff3850] str='\foo'
            AST_WIRE <<stdin>:4.9-4.12> [0x598402ff7560] str='\bar' reg
            AST_ASSIGN_LE <<stdin>:5.5-5.16> [0x598402ff7aa0]
              AST_IDENTIFIER <<stdin>:5.5-5.8> [0x598402ff76b0] str='\bar'
              AST_BIT_NOT <<stdin>:5.12-5.16> [0x598402ff7950]
                AST_IDENTIFIER <<stdin>:5.13-5.16> [0x598402ff7800] str='\bar'
--- END OF AST DUMP ---
Successfully finished Verilog frontend.
```


After this PR:
```
yosys> read_verilog -dump_ast1 <<EOT
module foo(input clk);

always @(posedge clk) begin:foo
    reg bar;
    bar <= ~bar;
end
endmodule
EOT
1. Executing Verilog-2005 frontend: <stdin>
Parsing Verilog input from `<stdin>' to AST representation.
Generating RTLIL representation for module `\foo'.
Dumping AST before simplification:
    AST_MODULE <<stdin>:1.1-7.10> [0x5a47605b2820] str='\foo'
      AST_WIRE <<stdin>:1.18-1.21> [0x5a47605abeb0] str='\clk' input port=1
      AST_ALWAYS <<stdin>:3.1-6.4> [0x5a47605abff0]
        AST_POSEDGE <<stdin>:3.10-3.17> [0x5a47605afea0]
          AST_IDENTIFIER <<stdin>:3.18-3.21> [0x5a47605afd60] str='\clk'
        AST_BLOCK <<stdin>:3.22-6.4> [0x5a47605affe0]
          AST_BLOCK <<stdin>:3.23-6.4> [0x5a47605b05c0] str='\foo'
            AST_WIRE <<stdin>:4.9-4.12> [0x5a47605b0860] str='\bar' reg
            AST_ASSIGN_LE <<stdin>:5.5-5.16> [0x5a47605b1170]
              AST_IDENTIFIER <<stdin>:5.5-5.8> [0x5a47605b09b0] str='\bar'
              AST_BIT_NOT <<stdin>:5.12-5.16> [0x5a47605b0c50]
                AST_IDENTIFIER <<stdin>:5.13-5.16> [0x5a47605b0b00] str='\bar'
--- END OF AST DUMP ---
Successfully finished Verilog frontend.
```