### PR TITLE
ast, rpc: record original name of $paramod\* as \hdlname attribute

### DIFF
--- a/backends/firrtl/firrtl.cc
+++ b/backends/firrtl/firrtl.cc
@@ -306,17 +306,8 @@ struct FirrtlWorker
 		// If this is a parameterized module, its parent module is encoded in the cell type
 		if (cell->type.begins_with("$paramod"))
 		{
-			std::string::iterator it;
-			for (it = cell_type.begin(); it < cell_type.end(); it++)
-			{
-				switch (*it) {
-					case '\\': /* FALL_THROUGH */
-					case '=': /* FALL_THROUGH */
-					case '\'': /* FALL_THROUGH */
-					case '$': instanceOf.append("_"); break;
-					default: instanceOf.append(1, *it); break;
-				}
-			}
+			log_assert(cell->has_attribute(ID::hdlname));
+			instanceOf = cell->get_string_attribute(ID::hdlname);
 		}
 		else
 		{

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -1565,6 +1565,9 @@ std::string AstModule::derive_common(RTLIL::Design *design, const dict<RTLIL::Id
 	rewritten.reserve(GetSize(parameters));
 
 	AstNode *new_ast = ast->clone();
+	if (!new_ast->attributes.count(ID::hdlname))
+		new_ast->attributes[ID::hdlname] = AstNode::mkconst_str(stripped_name);
+
 	para_counter = 0;
 	for (auto child : new_ast->children) {
 		if (child->type != AST_PARAMETER)

--- a/frontends/rpc/rpc_frontend.cc
+++ b/frontends/rpc/rpc_frontend.cc
@@ -217,6 +217,8 @@ struct RpcModule : RTLIL::Module {
 				module.second->name = mangled_name;
 				module.second->design = design;
 				module.second->attributes.erase(ID::top);
+				if (!module.second->has_attribute(ID::hdlname))
+					module.second->set_string_attribute(ID::hdlname, module.first.str());
 				design->modules_[mangled_name] = module.second;
 				derived_design->modules_.erase(module.first);
 			}


### PR DESCRIPTION
The `$paramod` name mangling is not invertible (the `\` character, which separates the module name from the parameters, is valid in the module name itself), which does not stop people from trying to invert it.

This commit makes it easy to invert the name mangling by storing the original name explicitly in the `\hdlname` attribute, and fixes the firrtl backend to use the newly introduced attribute.

**Unresolved question:** is `\hdlname` the appropriate attribute here? Currently it's only used in the `unique` pass, and I think the intent is the same, but I'd rather double check.