### PR TITLE
kernel: Add `pool` support for rvalue references and C++11 move semantics.

### DIFF
--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -745,11 +745,24 @@ protected:
 	int do_insert(const K &value, int &hash)
 	{
 		if (hashtable.empty()) {
-			entries.push_back(entry_t(value, -1));
+			entries.emplace_back(value, -1);
 			do_rehash();
 			hash = do_hash(value);
 		} else {
-			entries.push_back(entry_t(value, hashtable[hash]));
+			entries.emplace_back(value, hashtable[hash]);
+			hashtable[hash] = entries.size() - 1;
+		}
+		return entries.size() - 1;
+	}
+
+	int do_insert(K &&value, int &hash)
+	{
+		if (hashtable.empty()) {
+			entries.emplace_back(std::forward<K>(value), -1);
+			do_rehash();
+			hash = do_hash(value);
+		} else {
+			entries.emplace_back(std::forward<K>(value), hashtable[hash]);
 			hashtable[hash] = entries.size() - 1;
 		}
 		return entries.size() - 1;
@@ -844,6 +857,16 @@ public:
 		if (i >= 0)
 			return std::pair<iterator, bool>(iterator(this, i), false);
 		i = do_insert(value, hash);
+		return std::pair<iterator, bool>(iterator(this, i), true);
+	}
+
+	std::pair<iterator, bool> insert(K &&value)
+	{
+		int hash = do_hash(value);
+		int i = do_lookup(value, hash);
+		if (i >= 0)
+			return std::pair<iterator, bool>(iterator(this, i), false);
+		i = do_insert(std::forward<K>(value), hash);
 		return std::pair<iterator, bool>(iterator(this, i), true);
 	}
 

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -871,6 +871,12 @@ public:
 		return std::pair<iterator, bool>(iterator(this, i), true);
 	}
 
+	template<typename... Args>
+	std::pair<iterator, bool> emplace(Args&&... args)
+	{
+		return insert(K(std::forward<Args>(args)...));
+	}
+
 	int erase(const K &key)
 	{
 		int hash = do_hash(key);

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -642,6 +642,7 @@ protected:
 
 		entry_t() { }
 		entry_t(const K &udata, int next) : udata(udata), next(next) { }
+		entry_t(K &&udata, int next) : udata(std::move(udata)), next(next) { }
 	};
 
 	std::vector<int> hashtable;

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -756,14 +756,14 @@ protected:
 		return entries.size() - 1;
 	}
 
-	int do_insert(K &&value, int &hash)
+	int do_insert(K &&rvalue, int &hash)
 	{
 		if (hashtable.empty()) {
-			entries.emplace_back(std::forward<K>(value), -1);
+			entries.emplace_back(std::forward<K>(rvalue), -1);
 			do_rehash();
-			hash = do_hash(value);
+			hash = do_hash(rvalue);
 		} else {
-			entries.emplace_back(std::forward<K>(value), hashtable[hash]);
+			entries.emplace_back(std::forward<K>(rvalue), hashtable[hash]);
 			hashtable[hash] = entries.size() - 1;
 		}
 		return entries.size() - 1;
@@ -861,13 +861,13 @@ public:
 		return std::pair<iterator, bool>(iterator(this, i), true);
 	}
 
-	std::pair<iterator, bool> insert(K &&value)
+	std::pair<iterator, bool> insert(K &&rvalue)
 	{
-		int hash = do_hash(value);
-		int i = do_lookup(value, hash);
+		int hash = do_hash(rvalue);
+		int i = do_lookup(rvalue, hash);
 		if (i >= 0)
 			return std::pair<iterator, bool>(iterator(this, i), false);
-		i = do_insert(std::forward<K>(value), hash);
+		i = do_insert(std::forward<K>(rvalue), hash);
 		return std::pair<iterator, bool>(iterator(this, i), true);
 	}
 


### PR DESCRIPTION
This is similar to the recent changes to `dict`.

This always avoids a `std::move` by `emplace_back()`ing `entry_t`s in-place, and avoids making a copy when `insert()` is given an rvalue reference by `std::forward<>()`ing and `std::move()`ing it into the `udata` member of `entry_t`.