### PR TITLE
xilinx/ecp5: disable abc9's "&mfs" optimisation

### DIFF
--- a/passes/techmap/abc9_exe.cc
+++ b/passes/techmap/abc9_exe.cc
@@ -219,6 +219,10 @@ void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe
 	for (size_t pos = abc9_script.find("{R}"); pos != std::string::npos; pos = abc9_script.find("{R}", pos))
 		abc9_script = abc9_script.substr(0, pos) + R + abc9_script.substr(pos+3);
 
+	if (design->scratchpad_get_bool("abc9.nomfs"))
+		for (size_t pos = abc9_script.find("&mfs"); pos != std::string::npos; pos = abc9_script.find("&mfs", pos))
+			abc9_script = abc9_script.erase(pos, strlen("&mfs"));
+
 	abc9_script += stringf("; &ps -l; &write -n %s/output.aig", tempdir_name.c_str());
 	if (design->scratchpad_get_bool("abc9.verify")) {
 		if (dff_mode)

--- a/techlibs/ecp5/synth_ecp5.cc
+++ b/techlibs/ecp5/synth_ecp5.cc
@@ -324,6 +324,8 @@ struct SynthEcp5Pass : public ScriptPass
 
 			if (abc9) {
 				run("read_verilog -icells -lib -specify +/abc9_model.v +/ecp5/abc9_model.v");
+				if (!help_mode && !active_design->scratchpad.count("abc9.nomfs"))
+					active_design->scratchpad_set_bool("abc9.nomfs", true);
 				if (nowidelut)
 					run("abc9 -maxlut 4 -W 200");
 				else

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -613,6 +613,8 @@ struct SynthXilinxPass : public ScriptPass
 				if (family != "xc7")
 					log_warning("'synth_xilinx -abc9' not currently supported for the '%s' family, "
 							"will use timing for 'xc7' instead.\n", family.c_str());
+				if (!help_mode && !active_design->scratchpad.count("abc9.nomfs"))
+					active_design->scratchpad_set_bool("abc9.nomfs", true);
 				std::string techmap_args = "-map +/xilinx/abc9_map.v -max_iter 1";
 				if (dff_mode)
 					techmap_args += " -D DFF_MODE";


### PR DESCRIPTION
Because it can sometimes fire an assertion, e.g. #1962; fixes #1962 

Can be explicitly enabled with:
`scratchpad -set abc9.nomfs 0`
before:
`synth_{ecp5,xilinx} -abc9`