### PR TITLE
sim: Fix handling of constant-connected cell inputs at startup

### DIFF
--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -128,8 +128,12 @@ struct SimInstance
 
 			for (auto &port : cell->connections()) {
 				if (cell->input(port.first))
-					for (auto bit : sigmap(port.second))
+					for (auto bit : sigmap(port.second)) {
 						upd_cells[bit].insert(cell);
+						// Make sure cell inputs connected to constants are updated in the first cycle
+						if (bit.wire == nullptr)
+							dirty_bits.insert(bit);
+					}
 			}
 
 			if (cell->type.in(ID($dff))) {

--- a/tests/various/sim_const.ys
+++ b/tests/various/sim_const.ys
@@ -1,0 +1,13 @@
+read_verilog <<EOT
+
+module top(input clk, output reg [1:0] q);
+	wire [1:0] x = 2'b10;
+	always @(posedge clk)
+		q <= x & 2'b11;
+endmodule
+EOT
+
+proc
+sim -clock clk -n 1 -w top
+select -assert-count 1 a:init=2'b10 top/q %i
+


### PR DESCRIPTION
From https://www.reddit.com/r/yosys/comments/g57t8d/using_sim_to_get_initial_state_for_smtlib2_and/