### PR TITLE
cxxrtl: Gas gas gas! I'm gonna step on the gas! Tonight I'll fly!

### DIFF
--- a/backends/cxxrtl/cxxrtl.cc
+++ b/backends/cxxrtl/cxxrtl.cc
@@ -1971,9 +1971,9 @@ struct CxxrtlWorker {
 
 			if (!feedback_wires.empty()) {
 				has_feedback_arcs = true;
-				log("Module `%s' contains feedback arcs through wires:\n", module->name.c_str());
+				log("Module `%s' contains feedback arcs through wires:\n", log_id(module));
 				for (auto wire : feedback_wires)
-					log("  %s\n", wire->name.c_str());
+					log("  %s\n", log_id(wire));
 			}
 
 			for (auto wire : module->wires()) {
@@ -2002,9 +2002,9 @@ struct CxxrtlWorker {
 			}
 			if (!buffered_wires.empty()) {
 				has_buffered_wires = true;
-				log("Module `%s' contains buffered combinatorial wires:\n", module->name.c_str());
+				log("Module `%s' contains buffered combinatorial wires:\n", log_id(module));
 				for (auto wire : buffered_wires)
-					log("  %s\n", wire->name.c_str());
+					log("  %s\n", log_id(wire));
 			}
 
 			eval_converges[module] = feedback_wires.empty() && buffered_wires.empty();

--- a/backends/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/cxxrtl.h
@@ -717,15 +717,16 @@ struct module {
 	module(const module &) = delete;
 	module &operator=(const module &) = delete;
 
-	virtual void eval() = 0;
+	virtual bool eval() = 0;
 	virtual bool commit() = 0;
 
 	size_t step() {
 		size_t deltas = 0;
+		bool converged = false;
 		do {
-			eval();
+			converged = eval();
 			deltas++;
-		} while (commit());
+		} while (commit() && !converged);
 		return deltas;
 	}
 };


### PR DESCRIPTION
This PR improves performance of the CXXRTL simulations by approximately 2.6× uniformly across different pass pipelines on a single representative design (Minerva SRAM SoC with black box UART). Moreover, if the design is fully flattened, it is able to achieve 1 delta cycle per clock edge by optimally scheduling all of the logic in the design, including the black box.

The following is a totally non-scientific estimate of the speedup provided by this PR. It was collected on an idle Dell XPS13 9360 laptop with Intel Core i7-7500U CPU, Linux 4.19.0-8, and clang++ 7.0.1-8 by running the Minerva SRAM SoC for 1 million cycles. Each evaluation step invokes the `poll()` syscall (and very few of them also `write()`), which are excluded from the measurements (i.e. only user time is counted). [Reproduce my results!](https://github.com/YosysHQ/yosys/files/4516222/cxxrtl-toymark.zip)

These numbers are not intended to quantify any specific aspect of CXXRTL (much less serve as a comparison with other tools), but rather give an approximate sense of the kind of performance one might expect when simulating a small but practical SoC.

| passes          | before   | after    | speedup |
|-----------------|----------|----------|---------|
|  none           | 22 kCPS  | 55 kCPS  |  +150%  |
| `proc`          | 32 kCPS  | 90 kCPS  |  +180%  |
| `proc; flatten` | 280 kCPS | 730 kCPS |  +160%  |

I would also like to thank @jfng for his contribution to this work.