### PR TITLE
Cleanup use of hard-coded default parameters in light of #1945

### DIFF
--- a/passes/pmgen/ice40_dsp.cc
+++ b/passes/pmgen/ice40_dsp.cc
@@ -73,11 +73,11 @@ void create_ice40_dsp(ice40_dsp_pm &pm)
 
 	// SB_MAC16 Input Interface
 	SigSpec A = st.sigA;
-	A.extend_u0(16, st.mul->parameters.at(ID::A_SIGNED, State::S0).as_bool());
+	A.extend_u0(16, st.mul->getParam(ID::A_SIGNED).as_bool());
 	log_assert(GetSize(A) == 16);
 
 	SigSpec B = st.sigB;
-	B.extend_u0(16, st.mul->parameters.at(ID::B_SIGNED, State::S0).as_bool());
+	B.extend_u0(16, st.mul->getParam(ID::B_SIGNED).as_bool());
 	log_assert(GetSize(B) == 16);
 
 	SigSpec CD = st.sigCD;
@@ -248,8 +248,8 @@ void create_ice40_dsp(ice40_dsp_pm &pm)
 	cell->setParam(ID(BOTADDSUB_CARRYSELECT), Const(0, 2));
 
 	cell->setParam(ID(MODE_8x8), State::S0);
-	cell->setParam(ID::A_SIGNED, st.mul->parameters.at(ID::A_SIGNED, State::S0).as_bool());
-	cell->setParam(ID::B_SIGNED, st.mul->parameters.at(ID::B_SIGNED, State::S0).as_bool());
+	cell->setParam(ID::A_SIGNED, st.mul->getParam(ID::A_SIGNED).as_bool());
+	cell->setParam(ID::B_SIGNED, st.mul->getParam(ID::B_SIGNED).as_bool());
 
 	if (st.ffO) {
 		if (st.o_lo)

--- a/passes/pmgen/ice40_dsp.pmg
+++ b/passes/pmgen/ice40_dsp.pmg
@@ -65,7 +65,7 @@ code sigA sigB sigH
 endcode
 
 code argQ ffA ffAholdmux ffArstmux ffAholdpol ffArstpol sigA clock clock_pol
-	if (mul->type != \SB_MAC16 || !param(mul, \A_REG, State::S0).as_bool()) {
+	if (mul->type != \SB_MAC16 || !param(mul, \A_REG).as_bool()) {
 		argQ = sigA;
 		subpattern(in_dffe);
 		if (dff) {
@@ -86,7 +86,7 @@ code argQ ffA ffAholdmux ffArstmux ffAholdpol ffArstpol sigA clock clock_pol
 endcode
 
 code argQ ffB ffBholdmux ffBrstmux ffBholdpol ffBrstpol sigB clock clock_pol
-	if (mul->type != \SB_MAC16 || !param(mul, \B_REG, State::S0).as_bool()) {
+	if (mul->type != \SB_MAC16 || !param(mul, \B_REG).as_bool()) {
 		argQ = sigB;
 		subpattern(in_dffe);
 		if (dff) {
@@ -109,7 +109,7 @@ endcode
 code argD ffFJKG sigH clock clock_pol
 	if (nusers(sigH) == 2 &&
 			(mul->type != \SB_MAC16 ||
-			 (!param(mul, \TOP_8x8_MULT_REG, State::S0).as_bool() && !param(mul, \BOT_8x8_MULT_REG, State::S0).as_bool() && !param(mul, \PIPELINE_16x16_MULT_REG1, State::S0).as_bool() && !param(mul, \PIPELINE_16x16_MULT_REG1, State::S0).as_bool()))) {
+			 (!param(mul, \TOP_8x8_MULT_REG).as_bool() && !param(mul, \BOT_8x8_MULT_REG).as_bool() && !param(mul, \PIPELINE_16x16_MULT_REG1).as_bool() && !param(mul, \PIPELINE_16x16_MULT_REG1).as_bool()))) {
 		argD = sigH;
 		subpattern(out_dffe);
 		if (dff) {
@@ -148,7 +148,7 @@ endcode
 
 code argD ffH sigH sigO clock clock_pol
 	if (ffFJKG && nusers(sigH) == 2 &&
-			(mul->type != \SB_MAC16 || !param(mul, \PIPELINE_16x16_MULT_REG2, State::S0).as_bool())) {
+			(mul->type != \SB_MAC16 || !param(mul, \PIPELINE_16x16_MULT_REG2).as_bool())) {
 		argD = sigH;
 		subpattern(out_dffe);
 		if (dff) {
@@ -179,7 +179,7 @@ reject_ffH:		;
 endcode
 
 match add
-	if mul->type != \SB_MAC16 || (param(mul, \TOPOUTPUT_SELECT, State::S0).as_int() == 3 && param(mul, \BOTOUTPUT_SELECT, State::S0).as_int() == 3)
+	if mul->type != \SB_MAC16 || (param(mul, \TOPOUTPUT_SELECT).as_int() == 3 && param(mul, \BOTOUTPUT_SELECT).as_int() == 3)
 
 	select add->type.in($add)
 	choice <IdString> AB {\A, \B}
@@ -205,7 +205,7 @@ code sigCD sigO cd_signed
 		if ((actual_acc_width > actual_mul_width) && (natural_mul_width > actual_mul_width))
 			reject;
 		// If accumulator, check adder width and signedness
-		if (sigCD == sigH && (actual_acc_width != actual_mul_width) && (param(mul, \A_SIGNED, State::S0).as_bool() != param(add, \A_SIGNED).as_bool()))
+		if (sigCD == sigH && (actual_acc_width != actual_mul_width) && (param(mul, \A_SIGNED).as_bool() != param(add, \A_SIGNED).as_bool()))
 			reject;
 
 		sigO = port(add, \Y);
@@ -229,7 +229,7 @@ endcode
 code argD ffO ffOholdmux ffOrstmux ffOholdpol ffOrstpol sigO sigCD clock clock_pol cd_signed o_lo
 	if (mul->type != \SB_MAC16 ||
 			// Ensure that register is not already used
-			((param(mul, \TOPOUTPUT_SELECT, 0).as_int() != 1 && param(mul, \BOTOUTPUT_SELECT, 0).as_int() != 1) &&
+			((param(mul, \TOPOUTPUT_SELECT).as_int() != 1 && param(mul, \BOTOUTPUT_SELECT).as_int() != 1) &&
 			 // Ensure that OLOADTOP/OLOADBOT is unused or zero
 			 (port(mul, \OLOADTOP, State::S0).is_fully_zero() && port(mul, \OLOADBOT, State::S0).is_fully_zero()))) {
 
@@ -280,7 +280,7 @@ endcode
 
 code argQ ffCD ffCDholdmux ffCDholdpol ffCDrstpol sigCD clock clock_pol
 	if (!sigCD.empty() && sigCD != sigO &&
-			(mul->type != \SB_MAC16 || (!param(mul, \C_REG, State::S0).as_bool() && !param(mul, \D_REG, State::S0).as_bool()))) {
+			(mul->type != \SB_MAC16 || (!param(mul, \C_REG).as_bool() && !param(mul, \D_REG).as_bool()))) {
 		argQ = sigCD;
 		subpattern(in_dffe);
 		if (dff) {
@@ -532,7 +532,7 @@ endcode
 
 match ff
 	select ff->type.in($dff)
-	// DSP48E1 does not support clock inversion
+	// SB_MAC16 does not support clock inversion
 	select param(ff, \CLK_POLARITY).as_bool()
 
 	slice offset GetSize(port(ff, \D))

--- a/passes/pmgen/xilinx_dsp.pmg
+++ b/passes/pmgen/xilinx_dsp.pmg
@@ -95,7 +95,7 @@ code sigA sigB sigC sigD sigM clock
 	sigD = port(dsp, \D, SigSpec());
 
 	SigSpec P = port(dsp, \P);
-	if (param(dsp, \USE_MULT, Const("MULTIPLY")).decode_string() == "MULTIPLY") {
+	if (param(dsp, \USE_MULT).decode_string() == "MULTIPLY") {
 		// Only care about those bits that are used
 		int i;
 		for (i = GetSize(P)-1; i >= 0; i--)
@@ -120,7 +120,7 @@ endcode
 //      reset functionality, using a subpattern discussed above)
 //     If matched, treat 'A' input as input of ADREG
 code argQ ffAD ffADcemux ffADrstmux ffADcepol ffADrstpol sigA clock
-	if (param(dsp, \ADREG, 1).as_int() == 0) {
+	if (param(dsp, \ADREG).as_int() == 0) {
 		argQ = sigA;
 		subpattern(in_dffe);
 		if (dff) {
@@ -144,7 +144,7 @@ endcode
 match preAdd
 	if sigD.empty() || sigD.is_fully_zero()
 	// Ensure that preAdder not already used
-	if param(dsp, \USE_DPORT, Const("FALSE")).decode_string() == "FALSE"
+	if param(dsp, \USE_DPORT).decode_string() == "FALSE"
 	if port(dsp, \INMODE, Const(0, 5)).is_fully_zero()
 
 	select preAdd->type.in($add)
@@ -176,7 +176,7 @@ code argQ ffAD ffADcemux ffADrstmux ffADcepol ffADrstpol sigA clock ffA2 ffA2cem
 	// Only search for ffA2 if there was a pre-adder
 	//   (otherwise ffA2 would have been matched as ffAD)
 	if (preAdd) {
-		if (param(dsp, \AREG, 1).as_int() == 0) {
+		if (param(dsp, \AREG).as_int() == 0) {
 			argQ = sigA;
 			subpattern(in_dffe);
 			if (dff) {
@@ -237,7 +237,7 @@ endcode
 // (5) Match 'B' input for B2REG
 //     If B2REG, then match 'B' input for B1REG
 code argQ ffB2 ffB2cemux ffB2rstmux ffB2cepol ffBrstpol sigB clock ffB1 ffB1cemux ffB1rstmux ffB1cepol
-	if (param(dsp, \BREG, 1).as_int() == 0) {
+	if (param(dsp, \BREG).as_int() == 0) {
 		argQ = sigB;
 		subpattern(in_dffe);
 		if (dff) {
@@ -287,7 +287,7 @@ endcode
 
 // (6) Match 'D' input for DREG
 code argQ ffD ffDcemux ffDrstmux ffDcepol ffDrstpol sigD clock
-	if (param(dsp, \DREG, 1).as_int() == 0) {
+	if (param(dsp, \DREG).as_int() == 0) {
 		argQ = sigD;
 		subpattern(in_dffe);
 		if (dff) {
@@ -308,7 +308,7 @@ endcode
 
 // (7) Match 'P' output that exclusively drives an MREG
 code argD ffM ffMcemux ffMrstmux ffMcepol ffMrstpol sigM sigP clock
-	if (param(dsp, \MREG, 1).as_int() == 0 && nusers(sigM) == 2) {
+	if (param(dsp, \MREG).as_int() == 0 && nusers(sigM) == 2) {
 		argD = sigM;
 		subpattern(out_dffe);
 		if (dff) {
@@ -363,7 +363,7 @@ endcode
 
 // (9) Match 'P' output that exclusively drives a PREG
 code argD ffP ffPcemux ffPrstmux ffPcepol ffPrstpol sigP clock
-	if (param(dsp, \PREG, 1).as_int() == 0) {
+	if (param(dsp, \PREG).as_int() == 0) {
 		int users = 2;
 		// If ffMcemux and no postAdd new-value net must have three users: ffMcemux, ffM and ffPcemux
 		if (ffMcemux && !postAdd) users++;
@@ -424,7 +424,7 @@ endcode
 //      to implement this function
 match overflow
 	if ffP
-	if param(dsp, \USE_PATTERN_DETECT, Const("NO_PATDET")).decode_string() == "NO_PATDET"
+	if param(dsp, \USE_PATTERN_DETECT).decode_string() == "NO_PATDET"
 	select overflow->type.in($ge)
 	select GetSize(port(overflow, \Y)) <= 48
 	select port(overflow, \B).is_fully_const()

--- a/passes/pmgen/xilinx_dsp_CREG.pmg
+++ b/passes/pmgen/xilinx_dsp_CREG.pmg
@@ -42,7 +42,7 @@ udata <bool> dffcepol dffrstpol
 //     and (b) uses the 'C' port
 match dsp
 	select dsp->type.in(\DSP48A, \DSP48A1, \DSP48E1)
-	select param(dsp, \CREG, 1).as_int() == 0
+	select param(dsp, \CREG).as_int() == 0
 	select nusers(port(dsp, \C, SigSpec())) > 1
 endmatch
 
@@ -61,7 +61,7 @@ code sigC sigP clock
 
 	SigSpec P = port(dsp, \P);
 	if (!dsp->type.in(\DSP48E1) ||
- param(dsp, \USE_MULT, Const("MULTIPLY")).decode_string() == "MULTIPLY") {
+            param(dsp, \USE_MULT).decode_string() == "MULTIPLY") {
 		// Only care about those bits that are used
 		int i;
 		for (i = GetSize(P)-1; i >= 0; i--)

--- a/passes/pmgen/xilinx_dsp_cascade.pmg
+++ b/passes/pmgen/xilinx_dsp_cascade.pmg
@@ -188,7 +188,7 @@ arg next
 //       driven by the 'P' output of the previous DSP cell, and (c) has its
 //       'PCIN' port unused
 match nextP
-	select !param(nextP, \CREG, State::S1).as_bool()
+	select !param(nextP, \CREG).as_bool()
 	select (nextP->type.in(\DSP48A, \DSP48A1) && port(nextP, \OPMODE, Const(0, 8)).extract(2,2) == Const::from_string("11")) || (nextP->type.in(\DSP48E1) && port(nextP, \OPMODE, Const(0, 7)).extract(4,3) == Const::from_string("011"))
 	select nusers(port(nextP, \C, SigSpec())) > 1
 	select nusers(port(nextP, \PCIN, SigSpec())) == 0
@@ -201,7 +201,7 @@ endmatch
 match nextP_shift17
 	if !nextP
 	select nextP_shift17->type.in(\DSP48E1)
-	select !param(nextP_shift17, \CREG, State::S1).as_bool()
+	select !param(nextP_shift17, \CREG).as_bool()
 	select port(nextP_shift17, \OPMODE, Const(0, 7)).extract(4,3) == Const::from_string("011")
 	select nusers(port(nextP_shift17, \C, SigSpec())) > 1
 	select nusers(port(nextP_shift17, \PCIN, SigSpec())) == 0
@@ -242,10 +242,10 @@ code argQ clock AREG
 	if (next && next->type.in(\DSP48E1)) {
 		Cell *prev = std::get<0>(chain.back());
 
-		if (param(next, \A_INPUT, Const("DIRECT")).decode_string() == "DIRECT" &&
+		if (param(next, \A_INPUT).decode_string() == "DIRECT" &&
 				port(next, \ACIN, SigSpec()).is_fully_zero() &&
 				nusers(port(prev, \ACOUT, SigSpec())) <= 1) {
-			if (param(prev, \AREG, 2) == 0) {
+			if (param(prev, \AREG) == 0) {
 				if (port(prev, \A) == port(next, \A))
 					AREG = 0;
 			}
@@ -259,9 +259,9 @@ code argQ clock AREG
 					if (dffrstmux && port(dffrstmux, \S) != port(prev, \RSTA, State::S0))
 						goto reject_AREG;
 					IdString CEA;
-					if (param(prev, \AREG, 2) == 1)
+					if (param(prev, \AREG) == 1)
 						CEA = \CEA2;
-					else if (param(prev, \AREG, 2) == 2)
+					else if (param(prev, \AREG) == 2)
 						CEA = \CEA1;
 					else log_abort();
 					if (!dffcemux && port(prev, CEA, State::S0) != State::S1)
@@ -282,11 +282,11 @@ code argQ clock BREG
 	BREG = -1;
 	if (next) {
 		Cell *prev = std::get<0>(chain.back());
-		if (param(next, \B_INPUT, Const("DIRECT")).decode_string() == "DIRECT" &&
+		if ((next->type != \DSP48E1 || param(next, \B_INPUT).decode_string() == "DIRECT") &&
 				port(next, \BCIN, SigSpec()).is_fully_zero() &&
 				nusers(port(prev, \BCOUT, SigSpec())) <= 1) {
-			if ((next->type.in(\DSP48A, \DSP48A1) && param(prev, \B0REG, 0) == 0 && param(prev, \B1REG, 1) == 0) ||
-				(next->type.in(\DSP48E1) && param(prev, \BREG, 2) == 0)) {
+			if ((next->type.in(\DSP48A, \DSP48A1) && param(prev, \B0REG) == 0 && param(prev, \B1REG) == 0) ||
+				(next->type.in(\DSP48E1) && param(prev, \BREG) == 0)) {
 				if (port(prev, \B) == port(next, \B))
 					BREG = 0;
 			}
@@ -303,9 +303,9 @@ code argQ clock BREG
 					if (next->type.in(\DSP48A, \DSP48A1))
 						CEB = \CEB;
 					else if (next->type.in(\DSP48E1)) {
-						if (param(prev, \BREG, 2) == 1)
+						if (param(prev, \BREG) == 1)
 							CEB = \CEB2;
-						else if (param(prev, \BREG, 2) == 2)
+						else if (param(prev, \BREG) == 2)
 							CEB = \CEB1;
 						else log_abort();
 					}
@@ -315,7 +315,7 @@ code argQ clock BREG
 					if (dffcemux && port(dffcemux, \S) != port(prev, CEB, State::S0))
 						goto reject_BREG;
 					if (dffD == unextend(port(prev, \B))) {
-						if (next->type.in(\DSP48A, \DSP48A1) && param(prev, \B0REG, 0) != 0)
+						if (next->type.in(\DSP48A, \DSP48A1) && param(prev, \B0REG) != 0)
 							goto reject_BREG;
 						BREG = 1;
 					}

--- a/passes/pmgen/xilinx_srl.cc
+++ b/passes/pmgen/xilinx_srl.cc
@@ -48,7 +48,7 @@ void run_fixed(xilinx_srl_pm &pm)
 				initval.append(State::Sx);
 		}
 		else if (cell->type.in(ID(FDRE), ID(FDRE_1))) {
-			if (cell->parameters.at(ID::INIT, State::S0).as_bool())
+			if (cell->getParam(ID::INIT).as_bool())
 				initval.append(State::S1);
 			else
 				initval.append(State::S0);
@@ -71,7 +71,7 @@ void run_fixed(xilinx_srl_pm &pm)
 		else if (first_cell->type.in(ID($_DFF_N_), ID($_DFFE_NN_), ID($_DFFE_NP_), ID(FDRE_1)))
 			c->setParam(ID(CLKPOL), 0);
 		else if (first_cell->type.in(ID(FDRE))) {
-			if (!first_cell->parameters.at(ID(IS_C_INVERTED), State::S0).as_bool())
+			if (!first_cell->getParam(ID(IS_C_INVERTED)).as_bool())
 				c->setParam(ID(CLKPOL), 1);
 			else
 				c->setParam(ID(CLKPOL), 0);

--- a/passes/pmgen/xilinx_srl.pmg
+++ b/passes/pmgen/xilinx_srl.pmg
@@ -13,8 +13,8 @@ endcode
 match first
 	select first->type.in($_DFF_N_, $_DFF_P_, $_DFFE_NN_, $_DFFE_NP_, $_DFFE_PN_, $_DFFE_PP_, \FDRE, \FDRE_1)
 	select !first->has_keep_attr()
-	select !first->type.in(\FDRE) || !param(first, \IS_R_INVERTED, State::S0).as_bool()
-	select !first->type.in(\FDRE) || !param(first, \IS_D_INVERTED, State::S0).as_bool()
+	select !first->type.in(\FDRE) || !param(first, \IS_R_INVERTED).as_bool()
+	select !first->type.in(\FDRE) || !param(first, \IS_D_INVERTED).as_bool()
 	select !first->type.in(\FDRE, \FDRE_1) || port(first, \R, State::S0).is_fully_zero()
 	filter !non_first_cells.count(first)
 generate
@@ -84,8 +84,8 @@ arg en_port
 match first
 	select first->type.in($_DFF_N_, $_DFF_P_, $_DFFE_NN_, $_DFFE_NP_, $_DFFE_PN_, $_DFFE_PP_, \FDRE, \FDRE_1)
 	select !first->has_keep_attr()
-	select !first->type.in(\FDRE) || !param(first, \IS_R_INVERTED, State::S0).as_bool()
-	select !first->type.in(\FDRE) || !param(first, \IS_D_INVERTED, State::S0).as_bool()
+	select !first->type.in(\FDRE) || !param(first, \IS_R_INVERTED).as_bool()
+	select !first->type.in(\FDRE) || !param(first, \IS_D_INVERTED).as_bool()
 	select !first->type.in(\FDRE, \FDRE_1) || port(first, \R, State::S0).is_fully_zero()
 endmatch
 
@@ -111,9 +111,9 @@ match next
 	index <SigBit> port(next, \Q) === port(first, \D)
 	filter port(next, clk_port) == port(first, clk_port)
 	filter en_port == IdString() || port(next, en_port) == port(first, en_port)
-	filter !first->type.in(\FDRE) || param(next, \IS_C_INVERTED, State::S0).as_bool() == param(first, \IS_C_INVERTED, State::S0).as_bool()
-	filter !first->type.in(\FDRE) || param(next, \IS_D_INVERTED, State::S0).as_bool() == param(first, \IS_D_INVERTED, State::S0).as_bool()
-	filter !first->type.in(\FDRE) || param(next, \IS_R_INVERTED, State::S0).as_bool() == param(first, \IS_R_INVERTED, State::S0).as_bool()
+	filter !first->type.in(\FDRE) || param(next, \IS_C_INVERTED).as_bool() == param(first, \IS_C_INVERTED).as_bool()
+	filter !first->type.in(\FDRE) || param(next, \IS_D_INVERTED).as_bool() == param(first, \IS_D_INVERTED).as_bool()
+	filter !first->type.in(\FDRE) || param(next, \IS_R_INVERTED).as_bool() == param(first, \IS_R_INVERTED).as_bool()
 	filter !first->type.in(\FDRE, \FDRE_1) || port(next, \R, State::S0).is_fully_zero()
 endmatch
 
@@ -138,9 +138,9 @@ match next
 	index <SigBit> port(next, \Q) === port(chain.back(), \D)
 	filter port(next, clk_port) == port(first, clk_port)
 	filter en_port == IdString() || port(next, en_port) == port(first, en_port)
-	filter !first->type.in(\FDRE) || param(next, \IS_C_INVERTED, State::S0).as_bool() == param(first, \IS_C_INVERTED, State::S0).as_bool()
-	filter !first->type.in(\FDRE) || param(next, \IS_D_INVERTED, State::S0).as_bool() == param(first, \IS_D_INVERTED, State::S0).as_bool()
-	filter !first->type.in(\FDRE) || param(next, \IS_R_INVERTED, State::S0).as_bool() == param(first, \IS_R_INVERTED, State::S0).as_bool()
+	filter !first->type.in(\FDRE) || param(next, \IS_C_INVERTED).as_bool() == param(first, \IS_C_INVERTED).as_bool()
+	filter !first->type.in(\FDRE) || param(next, \IS_D_INVERTED).as_bool() == param(first, \IS_D_INVERTED).as_bool()
+	filter !first->type.in(\FDRE) || param(next, \IS_R_INVERTED).as_bool() == param(first, \IS_R_INVERTED).as_bool()
 	filter !first->type.in(\FDRE, \FDRE_1) || port(next, \R, State::S0).is_fully_zero()
 generate
 	Cell *cell = module->addCell(NEW_ID, chain.back()->type);

--- a/techlibs/ecp5/ecp5_ffinit.cc
+++ b/techlibs/ecp5/ecp5_ffinit.cc
@@ -106,9 +106,7 @@ struct Ecp5FfinitPass : public Pass {
 				SigBit bit_d = sigmap(sig_d[0]);
 				SigBit bit_q = sigmap(sig_q[0]);
 
-				std::string regset = "RESET";
-				if (cell->hasParam(ID(REGSET)))
-					regset = cell->getParam(ID(REGSET)).decode_string();
+				std::string regset = cell->getParam(ID(REGSET)).decode_string();
 				State resetState;
 				if (regset == "SET")
 					resetState = State::S1;
@@ -135,9 +133,7 @@ struct Ecp5FfinitPass : public Pass {
 				}
 
 				if (GetSize(sig_lsr) >= 1 && sig_lsr[0] != State::S0) {
-					std::string srmode = "LSR_OVER_CE";
-					if (cell->hasParam(ID(SRMODE)))
-						srmode = cell->getParam(ID(SRMODE)).decode_string();
+					std::string srmode = cell->getParam(ID(SRMODE)).decode_string();
 					if (srmode == "ASYNC") {
 						log("Async reset value %c for FF cell %s inconsistent with init value %c.\n",
 							resetState != State::S0 ? '1' : '0', log_id(cell), val != State::S0 ? '1' : '0');
@@ -154,9 +150,7 @@ struct Ecp5FfinitPass : public Pass {
 						cell->setPort(ID(LSR), State::S0);
 
 						if(cell->hasPort(ID(CE))) {
-							std::string cemux = "CE";
-							if (cell->hasParam(ID(CEMUX)))
-								cemux = cell->getParam(ID(CEMUX)).decode_string();
+							std::string cemux = cell->getParam(ID(CEMUX)).decode_string();
 							SigSpec sig_ce = cell->getPort(ID(CE));
 							if (GetSize(sig_ce) >= 1) {
 								SigBit bit_ce = sigmap(sig_ce[0]);

--- a/techlibs/ecp5/ecp5_gsr.cc
+++ b/techlibs/ecp5/ecp5_gsr.cc
@@ -81,7 +81,7 @@ struct Ecp5GsrPass : public Pass {
 
 			for (auto cell : module->selected_cells())
 			{
-				if (!cell->hasParam(ID(GSR)) || cell->getParam(ID(GSR)).decode_string() != "AUTO")
+				if (cell->getParam(ID(GSR)).decode_string() != "AUTO")
 					continue;
 				
 				bool gsren = found_gsr;
@@ -114,9 +114,9 @@ struct Ecp5GsrPass : public Pass {
 			{
 				if (cell->type != ID(TRELLIS_FF))
 					continue;
-				if (!cell->hasParam(ID(GSR)) || cell->getParam(ID(GSR)).decode_string() != "ENABLED")
+				if (cell->getParam(ID(GSR)).decode_string() != "ENABLED")
 					continue;
-				if (!cell->hasParam(ID(SRMODE)) || cell->getParam(ID(SRMODE)).decode_string() != "ASYNC")
+				if (cell->getParam(ID(SRMODE)).decode_string() != "ASYNC")
 					continue;
 				SigSpec sig_lsr = cell->getPort(ID(LSR));
 				if (GetSize(sig_lsr) < 1)


### PR DESCRIPTION
Courtesy of functionality enabled in #1945. Means that default parameter values are held in one place only: `<arch>/cells_sim.v`.