### PR TITLE
kernel: Cell::getParam() to throw exception again if not found

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -2619,16 +2619,15 @@ void RTLIL::Cell::setParam(RTLIL::IdString paramname, RTLIL::Const value)
 
 const RTLIL::Const &RTLIL::Cell::getParam(RTLIL::IdString paramname) const
 {
-	static const RTLIL::Const empty;
 	const auto &it = parameters.find(paramname);
 	if (it != parameters.end())
 		return it->second;
 	if (module && module->design) {
 		RTLIL::Module *m = module->design->module(type);
 		if (m)
-			return m->parameter_default_values.at(paramname, empty);
+			return m->parameter_default_values.at(paramname);
 	}
-	return empty;
+	throw std::out_of_range("Cell::getParam()");
 }
 
 void RTLIL::Cell::sort()

--- a/passes/pmgen/xilinx_dsp_cascade.pmg
+++ b/passes/pmgen/xilinx_dsp_cascade.pmg
@@ -188,7 +188,7 @@ arg next
 //       driven by the 'P' output of the previous DSP cell, and (c) has its
 //       'PCIN' port unused
 match nextP
-	select !param(nextP, \CREG).as_bool()
+	select !nextP->type.in(\DSP48E1) || !param(nextP, \CREG).as_bool()
 	select (nextP->type.in(\DSP48A, \DSP48A1) && port(nextP, \OPMODE, Const(0, 8)).extract(2,2) == Const::from_string("11")) || (nextP->type.in(\DSP48E1) && port(nextP, \OPMODE, Const(0, 7)).extract(4,3) == Const::from_string("011"))
 	select nusers(port(nextP, \C, SigSpec())) > 1
 	select nusers(port(nextP, \PCIN, SigSpec())) == 0

--- a/techlibs/ecp5/ecp5_gsr.cc
+++ b/techlibs/ecp5/ecp5_gsr.cc
@@ -81,7 +81,7 @@ struct Ecp5GsrPass : public Pass {
 
 			for (auto cell : module->selected_cells())
 			{
-				if (cell->getParam(ID(GSR)).decode_string() != "AUTO")
+				if (!cell->hasParam(ID(GSR)) || cell->getParam(ID(GSR)).decode_string() != "AUTO")
 					continue;
 				
 				bool gsren = found_gsr;

--- a/techlibs/xilinx/xilinx_dffopt.cc
+++ b/techlibs/xilinx/xilinx_dffopt.cc
@@ -292,17 +292,20 @@ unmap:
 				LutData final_lut;
 				if (worthy_post_r) {
 					final_lut = lut_d_post_r;
-					log("  Merging R LUT for %s/%s (%d -> %d)\n", log_id(cell), log_id(sig_Q.wire), GetSize(lut_d.second), GetSize(final_lut.second));
 				} else if (worthy_post_s) {
 					final_lut = lut_d_post_s;
-					log("  Merging S LUT for %s/%s (%d -> %d)\n", log_id(cell), log_id(sig_Q.wire), GetSize(lut_d.second), GetSize(final_lut.second));
 				} else if (worthy_post_ce) {
 					final_lut = lut_d_post_ce;
-					log("  Merging CE LUT for %s/%s (%d -> %d)\n", log_id(cell), log_id(sig_Q.wire), GetSize(lut_d.second), GetSize(final_lut.second));
 				} else {
 					// Nothing to do here.
 					continue;
 				}
+
+				std::string ports;
+				if (worthy_post_r) ports += " + R";
+				if (worthy_post_s) ports += " + S";
+				if (worthy_post_ce) ports += " + CE";
+				log("  Merging D%s LUTs for %s/%s (%d -> %d)\n", ports.c_str(), log_id(cell), log_id(sig_Q.wire), GetSize(lut_d.second), GetSize(final_lut.second));
 
 				// Okay, we're doing it.  Unmap ports.
 				if (worthy_post_r) {

--- a/tests/arch/ice40/ice40_dsp.ys
+++ b/tests/arch/ice40/ice40_dsp.ys
@@ -8,4 +8,5 @@ assign o4 = a * b;
 SB_MAC16 m3 (.A(a), .B(b), .O(o5));
 endmodule
 EOT
+read_verilog -lib +/ice40/cells_sim.v
 ice40_dsp

--- a/tests/arch/xilinx/xilinx_dffopt.ys
+++ b/tests/arch/xilinx/xilinx_dffopt.ys
@@ -18,17 +18,17 @@ FDRE ff (.D(tmp[0]), .CE(tmp[1]), .R(tmp[2]), .Q(o[0]));
 endmodule
 
 EOT
-
+read_verilog -lib +/xilinx/cells_sim.v
 design -save t0
 
 equiv_opt -blacklist xilinx_dffopt_blacklist.txt -assert -map +/xilinx/cells_sim.v xilinx_dffopt
 design -load postopt
 clean
 
+cd t0
 select -assert-count 1 t:FDRE
 select -assert-count 1 t:LUT6
-select -assert-count 3 t:LUT2
-select -assert-none t:FDRE t:LUT6 t:LUT2 %% t:* %D
+select -assert-none t:FDRE t:LUT6 %% t:* %D
 
 design -load t0
 
@@ -36,9 +36,10 @@ equiv_opt -blacklist xilinx_dffopt_blacklist.txt -assert -map +/xilinx/cells_sim
 design -load postopt
 clean
 
+cd t0
 select -assert-count 1 t:FDRE
 select -assert-count 1 t:LUT4
-select -assert-count 3 t:LUT2
+select -assert-count 1 t:LUT2
 select -assert-none t:FDRE t:LUT4 t:LUT2 %% t:* %D
 
 design -reset
@@ -65,16 +66,17 @@ endmodule
 
 EOT
 
+read_verilog -lib +/xilinx/cells_sim.v
 design -save t0
 
 equiv_opt -blacklist xilinx_dffopt_blacklist.txt -assert -map +/xilinx/cells_sim.v xilinx_dffopt
 design -load postopt
 clean
 
+cd t0
 select -assert-count 1 t:FDSE
 select -assert-count 1 t:LUT6
-select -assert-count 3 t:LUT2
-select -assert-none t:FDSE t:LUT6 t:LUT2 %% t:* %D
+select -assert-none t:FDSE t:LUT6 %% t:* %D
 
 design -load t0
 
@@ -82,9 +84,10 @@ equiv_opt -blacklist xilinx_dffopt_blacklist.txt -assert -map +/xilinx/cells_sim
 design -load postopt
 clean
 
+cd t0
 select -assert-count 1 t:FDSE
 select -assert-count 1 t:LUT4
-select -assert-count 3 t:LUT2
+select -assert-count 1 t:LUT2
 select -assert-none t:FDSE t:LUT4 t:LUT2 %% t:* %D
 
 design -reset
@@ -111,15 +114,17 @@ endmodule
 
 EOT
 
+read_verilog -lib +/xilinx/cells_sim.v
 design -save t0
 
 equiv_opt -async2sync -blacklist xilinx_dffopt_blacklist.txt -assert -map +/xilinx/cells_sim.v xilinx_dffopt
 design -load postopt
 clean
 
+cd t0
 select -assert-count 1 t:FDCE
 select -assert-count 1 t:LUT4
-select -assert-count 3 t:LUT2
+select -assert-count 1 t:LUT2
 select -assert-none t:FDCE t:LUT4 t:LUT2 %% t:* %D
 
 design -reset
@@ -145,16 +150,17 @@ endmodule
 
 EOT
 
+read_verilog -lib +/xilinx/cells_sim.v
 design -save t0
 
 equiv_opt -blacklist xilinx_dffopt_blacklist.txt -assert -map +/xilinx/cells_sim.v xilinx_dffopt
 design -load postopt
 clean
 
+cd t0
 select -assert-count 1 t:FDSE
 select -assert-count 1 t:LUT5
-select -assert-count 2 t:LUT2
-select -assert-none t:FDSE t:LUT5 t:LUT2 %% t:* %D
+select -assert-none t:FDSE t:LUT5 %% t:* %D
 
 design -load t0
 
@@ -162,6 +168,7 @@ equiv_opt -blacklist xilinx_dffopt_blacklist.txt -assert -map +/xilinx/cells_sim
 design -load postopt
 clean
 
+cd t0
 select -assert-count 1 t:FDSE
 select -assert-count 2 t:LUT2
 select -assert-none t:FDSE t:LUT2 %% t:* %D
@@ -191,16 +198,17 @@ endmodule
 
 EOT
 
+read_verilog -lib +/xilinx/cells_sim.v
 design -save t0
 
 equiv_opt -blacklist xilinx_dffopt_blacklist.txt -assert -map +/xilinx/cells_sim.v xilinx_dffopt
 design -load postopt
 clean
 
+cd t0
 select -assert-count 1 t:FDRSE
 select -assert-count 1 t:LUT6
-select -assert-count 4 t:LUT2
-select -assert-none t:FDRSE t:LUT6 t:LUT2 %% t:* %D
+select -assert-none t:FDRSE t:LUT6 %% t:* %D
 
 design -load t0
 
@@ -208,9 +216,10 @@ equiv_opt -blacklist xilinx_dffopt_blacklist.txt -assert -map +/xilinx/cells_sim
 design -load postopt
 clean
 
+cd t0
 select -assert-count 1 t:FDRSE
 select -assert-count 1 t:LUT4
-select -assert-count 4 t:LUT2
+select -assert-count 1 t:LUT2
 select -assert-none t:FDRSE t:LUT4 t:LUT2 %% t:* %D
 
 design -reset

--- a/tests/arch/xilinx/xilinx_dsp.ys
+++ b/tests/arch/xilinx/xilinx_dsp.ys
@@ -8,4 +8,5 @@ assign o4 = a * b;
 DSP48E1 m3 (.A(a), .B(b), .P(o5));
 endmodule
 EOT
+read_verilog -lib +/xilinx/cells_sim.v
 xilinx_dsp


### PR DESCRIPTION
As it did before #1945.
Would not expect this to be reachable for the end-user, but makes debugging a little easier for developers who may have fat fingers.