### PR TITLE
intel_alm: work around a Quartus ICE

### DIFF
--- a/tests/arch/intel_alm/quartus_ice.ys
+++ b/tests/arch/intel_alm/quartus_ice.ys
@@ -1,0 +1,12 @@
+read_verilog <<EOT
+// Verilog has syntax for raw identifiers, where you start it with \ and end it with a space.
+// This test crashes Quartus due to it parsing \a[10] as a wire slice and not a raw identifier.
+module top();
+  (* keep *) wire [31:0] \a[10] ;
+  (* keep *) wire b;
+  assign b = \a[10] [31];
+endmodule
+EOT
+
+synth_intel_alm -family cyclonev -quartus
+select -assert-none w:*[* w:*]*


### PR DESCRIPTION
After knowing about this bug for [ten months](https://pastebin.com/iFbMHsiL) this morning I finally spent time (>12 hours of `bugpoint`) trying to diagnose what the hell was going on. It turns out that Quartus also appears to suffer something like #1676, and when presented with a raw identifier that contains `[]` parses uses of it as a slice access.

I also took the opportunity to add a few comments around here too about VQM and the various workarounds used for it.