### PR TITLE
qbfsat: Make hole name recovery from source locations more robust.

### DIFF
--- a/passes/sat/qbfsat.cc
+++ b/passes/sat/qbfsat.cc
@@ -98,11 +98,8 @@ dict<std::string, std::string> get_hole_loc_name_map(RTLIL::Module *module, cons
 	for (auto cell : module->cells()) {
 		std::string cell_src = cell->get_src_attribute();
 		auto pos = sol.hole_to_value.find(cell_src);
-		if (pos != sol.hole_to_value.end()) {
-#ifndef NDEBUG
-			log_assert(cell->type.in("$anyconst", "$anyseq"));
-			log_assert(cell->getPort(ID::Y).is_wire());
-#endif
+		if (pos != sol.hole_to_value.end() && cell->type.in("$anyconst", "$anyseq")) {
+			log_assert(hole_loc_to_name.find(pos->first) == hole_loc_to_name.end());
 			hole_loc_to_name[pos->first] = cell->getPort(ID::Y).as_wire()->name.str();
 		}
 	}


### PR DESCRIPTION
This PR allows, for `$anyconst` "hole" specialization purposes, multiple cells to share the same source location as long as only one `$anyconst` or `$anyseq` has that location.

This may seem stupid: Exactly one cell should have any particular source location.  But if we do some transformations to the design in order to add the `$anyconst`, there is no natural source location, so they might get tagged with the location of another related cell.