### PR TITLE
opt_expr: improve single-bit $and/$or/$xor/$xnor cells; gate cells too

### DIFF
--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -543,13 +543,13 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 				}
 			}
 
-			if (detect_const_and && (found_zero || found_inv || (!keepdc && found_undef && consume_x))) {
+			if (detect_const_and && (found_zero || found_inv || (found_undef && consume_x))) {
 				cover("opt.opt_expr.const_and");
 				replace_cell(assign_map, module, cell, "const_and", ID::Y, RTLIL::State::S0);
 				goto next_cell;
 			}
 
-			if (detect_const_or && (found_one || found_inv || (!keepdc && found_undef && consume_x))) {
+			if (detect_const_or && (found_one || found_inv || (found_undef && consume_x))) {
 				cover("opt.opt_expr.const_or");
 				replace_cell(assign_map, module, cell, "const_or", ID::Y, RTLIL::State::S1);
 				goto next_cell;
@@ -1149,7 +1149,7 @@ skip_fine_alu:
 			goto next_cell;
 		}
 
-		if (!keepdc && consume_x)
+		if (consume_x)
 		{
 			bool identity_wrt_a = false;
 			bool identity_wrt_b = false;
@@ -2041,11 +2041,12 @@ struct OptExprPass : public Pass {
 			do {
 				do {
 					did_something = false;
-					replace_const_cells(design, module, false, mux_undef, mux_bool, do_fine, keepdc, clkinv);
+					replace_const_cells(design, module, false /* consume_x */, mux_undef, mux_bool, do_fine, keepdc, clkinv);
 					if (did_something)
 						design->scratchpad_set_bool("opt.did_something", true);
 				} while (did_something);
-				replace_const_cells(design, module, true, mux_undef, mux_bool, do_fine, keepdc, clkinv);
+				if (!keepdc)
+				    replace_const_cells(design, module, true /* consume_x */, mux_undef, mux_bool, do_fine, keepdc, clkinv);
 				if (did_something)
 					design->scratchpad_set_bool("opt.did_something", true);
 			} while (did_something);

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -543,13 +543,13 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 				}
 			}
 
-			if (detect_const_and && (found_zero || found_inv || (!keepdc && found_undef))) {
+			if (detect_const_and && (found_zero || found_inv || (!keepdc && found_undef && consume_x))) {
 				cover("opt.opt_expr.const_and");
 				replace_cell(assign_map, module, cell, "const_and", ID::Y, RTLIL::State::S0);
 				goto next_cell;
 			}
 
-			if (detect_const_or && (found_one || found_inv || (!keepdc && found_undef))) {
+			if (detect_const_or && (found_one || found_inv || (!keepdc && found_undef && consume_x))) {
 				cover("opt.opt_expr.const_or");
 				replace_cell(assign_map, module, cell, "const_or", ID::Y, RTLIL::State::S1);
 				goto next_cell;
@@ -927,7 +927,7 @@ skip_fine_alu:
 			if (input.match("**")) ACTION_DO_Y(x);
 			if (input.match("1*")) ACTION_DO_Y(x);
 			if (input.match("*1")) ACTION_DO_Y(x);
-			if (!keepdc) {
+			if (consume_x) {
 				if (input.match(" *")) ACTION_DO_Y(0);
 				if (input.match("* ")) ACTION_DO_Y(0);
 			}
@@ -946,7 +946,7 @@ skip_fine_alu:
 			if (input.match("**")) ACTION_DO_Y(x);
 			if (input.match("0*")) ACTION_DO_Y(x);
 			if (input.match("*0")) ACTION_DO_Y(x);
-			if (!keepdc) {
+			if (consume_x) {
 				if (input.match(" *")) ACTION_DO_Y(1);
 				if (input.match("* ")) ACTION_DO_Y(1);
 			}
@@ -963,7 +963,7 @@ skip_fine_alu:
 			if (input.match("01")) ACTION_DO_Y(1);
 			if (input.match("10")) ACTION_DO_Y(1);
 			if (input.match("11")) ACTION_DO_Y(0);
-			if (!keepdc) {
+			if (consume_x) {
 				if (input.match(" *")) ACTION_DO_Y(0);
 				if (input.match("* ")) ACTION_DO_Y(0);
 			}
@@ -1149,7 +1149,7 @@ skip_fine_alu:
 			goto next_cell;
 		}
 
-		if (!keepdc)
+		if (!keepdc && consume_x)
 		{
 			bool identity_wrt_a = false;
 			bool identity_wrt_b = false;

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -2046,7 +2046,7 @@ struct OptExprPass : public Pass {
 						design->scratchpad_set_bool("opt.did_something", true);
 				} while (did_something);
 				if (!keepdc)
-				    replace_const_cells(design, module, true /* consume_x */, mux_undef, mux_bool, do_fine, keepdc, clkinv);
+					replace_const_cells(design, module, true /* consume_x */, mux_undef, mux_bool, do_fine, keepdc, clkinv);
 				if (did_something)
 					design->scratchpad_set_bool("opt.did_something", true);
 			} while (did_something);

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -575,7 +575,8 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 				if (cell->type.in(ID($xnor), ID($_XNOR_))) {
 					cover("opt.opt_expr.const_xnor");
 					// For consistency since simplemap does $xnor -> $_XOR_ + $_NOT_
-					replace_cell(assign_map, module, cell, "const_xnor", ID::Y, RTLIL::State::S1);
+					int width = cell->getParam(ID::Y_WIDTH).as_int();
+					replace_cell(assign_map, module, cell, "const_xnor", ID::Y, SigSpec(RTLIL::State::S1, width));
 					goto next_cell;
 				}
 				log_abort();

--- a/tests/fsm/generate.py
+++ b/tests/fsm/generate.py
@@ -36,9 +36,11 @@ parser.add_argument('-S', '--seed',  type = int, help = 'seed for PRNG')
 parser.add_argument('-c', '--count', type = int, default = 50, help = 'number of test cases to generate')
 args = parser.parse_args()
 
-if args.seed is not None:
-    print("PRNG seed: %d" % args.seed)
-    random.seed(args.seed)
+seed = args.seed
+if seed is None:
+    seed = random.randrange(sys.maxsize)
+print("PRNG seed: %d" % seed)
+random.seed(seed)
 
 for idx in range(args.count):
     with open('temp/uut_%05d.v' % idx, 'w') as f:

--- a/tests/opt/bug1758.ys
+++ b/tests/opt/bug1758.ys
@@ -1,0 +1,21 @@
+read_verilog -noopt <<EOT
+module gold(input i, output o);
+assign o = 1'bx | i;
+endmodule
+EOT
+copy gold coarse
+copy gold fine
+
+cd coarse
+opt_expr
+select -assert-none c:*
+
+cd fine
+opt_expr
+select -assert-none c:*
+
+cd
+miter -equiv -flatten -make_assert -make_outputs coarse fine miter
+sat -verify -prove-asserts -show-ports miter
+miter -equiv -flatten -make_assert -make_outputs -ignore_gold_x gold coarse miter2
+sat -verify -prove-asserts -show-ports -enable_undef miter2

--- a/tests/opt/opt_expr_alu.ys
+++ b/tests/opt/opt_expr_alu.ys
@@ -59,9 +59,8 @@ EOT
 alumacc
 equiv_opt -assert opt_expr -fine
 design -load postopt
-select -assert-count 1 t:$pos
 select -assert-count 1 t:$not
-select -assert-none t:$pos t:$not %% t:* %D
+select -assert-none t:$not %% t:* %D
 
 
 design -reset

--- a/tests/opt/opt_expr_and.ys
+++ b/tests/opt/opt_expr_and.ys
@@ -1,65 +1,10 @@
-read_verilog <<EOT
-module top(input a, output [3:0] y);
-assign y[0] = a^1'b0;
-assign y[1] = 1'b1^a;
-assign y[2] = a~^1'b0;
-assign y[3] = 1'b1^~a;
-endmodule
-EOT
-design -save read
-select -assert-count 2 t:$xor
-select -assert-count 2 t:$xnor
-
-equiv_opt opt_expr
-design -load postopt
-select -assert-none t:$xor
-select -assert-none t:$xnor
-select -assert-count 2 t:$not
-
-
-design -load read
-simplemap
-equiv_opt opt_expr
-design -load postopt
-select -assert-none t:$_XOR_
-select -assert-none t:$_XNOR_ # NB: simplemap does $xnor -> $_XOR_+$_NOT_
-select -assert-count 3 t:$_NOT_
-
-
-design -reset
-read_verilog -icells <<EOT
-module top(input a, output [1:0] y);
-$_XNOR_ u0(.A(a), .B(1'b0), .Y(y[0]));
-$_XNOR_ u1(.A(1'b1), .B(a), .Y(y[1]));
-endmodule
-EOT
-select -assert-count 2 t:$_XNOR_
-equiv_opt opt_expr
-design -load postopt
-select -assert-none t:$_XNOR_ # NB: simplemap does $xnor -> $_XOR_+$_NOT_
-select -assert-count 1 t:$_NOT_
-
-
-design -reset
-read_verilog <<EOT
-module top(input a, output [1:0] w, x, y, z);
-assign w = a^1'b0;
-assign x = a^1'b1;
-assign y = a~^1'b0;
-assign z = a~^1'b1;
-endmodule
-EOT
-equiv_opt opt_expr
-
-
-# Single-bit $xor
-design -reset
+# Single-bit $and
 read_verilog -noopt <<EOT
 module gold(input i, output o);
-assign o = 1'bx ^ i;
+assign o = 1'bx & i;
 endmodule
 EOT
-select -assert-count 1 t:$xor
+select -assert-count 1 t:$and
 copy gold coarse
 copy gold fine
 copy gold coarse_keepdc
@@ -96,14 +41,14 @@ miter -equiv -flatten -make_assert -make_outputs coarse_keepdc fine_keepdc miter
 sat -verify -prove-asserts -show-ports -enable_undef miter4
 
 
-# Multi-bit $xor
+# Multi-bit $and
 design -reset
 read_verilog -noopt <<EOT
 module gold(input i, output [6:0] o);
-assign o = {1'bx, 1'b0, 1'b0, 1'b1, 1'bx, 1'b1, i} ^ {7{i}};
+assign o = {1'bx, 1'b0, 1'b0, 1'b1, 1'bx, 1'b1, i} & {7{i}};
 endmodule
 EOT
-select -assert-count 1 t:$xor
+select -assert-count 1 t:$and
 copy gold coarse
 copy gold fine
 copy gold coarse_keepdc
@@ -111,12 +56,12 @@ copy gold fine_keepdc
 
 cd coarse
 opt_expr -fine
-select -assert-count 1 t:$xor # FIXME: Should be zero
+select -assert-none c:*
 
 cd fine
 simplemap
 opt_expr
-select -assert-none t:$_XOR_
+select -assert-none c:*
 
 cd
 miter -equiv -flatten -make_assert -make_outputs -ignore_gold_x gold coarse miter
@@ -125,17 +70,16 @@ miter -equiv -flatten -make_assert -make_outputs coarse fine miter2
 sat -verify -prove-asserts -show-ports -enable_undef miter2
 
 cd coarse_keepdc
-opt_expr -keepdc -fine
-dump
-select -assert-count 2 t:$xor $ FIXME: Should be one
+opt_expr -fine -keepdc
+select -assert-count 1 c:*
 
 cd fine_keepdc
 simplemap
 opt_expr -keepdc
-select -assert-count t c:$_XOR_
+select -assert-count 2 c:*
 
 cd
 miter -equiv -flatten -make_assert -make_outputs gold coarse_keepdc miter3
-sat -verify -prove-asserts -show-ports -enable_undef -set-def in_i miter3
+sat -verify -prove-asserts -show-ports -enable_undef miter3
 miter -equiv -flatten -make_assert -make_outputs coarse_keepdc fine_keepdc miter4
 sat -verify -prove-asserts -show-ports -enable_undef miter4

--- a/tests/opt/opt_expr_consumex.ys
+++ b/tests/opt/opt_expr_consumex.ys
@@ -1,0 +1,35 @@
+read_verilog <<EOT
+module top(input a, b, output o);
+wire tmp;
+assign o = tmp | 1'bx;
+assign tmp = a & 1'b0;
+endmodule
+EOT
+design -save read
+select -assert-count 1 t:$and
+select -assert-count 1 t:$or
+
+
+opt_expr
+select -assert-none t:$and t:$or
+sat -verify -enable_undef -prove o 1'bx
+
+
+design -load read
+opt_expr -keepdc
+select -assert-none t:$and t:$or
+sat -verify -enable_undef -prove o 1'bx
+
+
+design -load read
+simplemap
+opt_expr -keepdc
+select -assert-none t:$_AND_ t:$_OR_
+sat -verify -enable_undef -prove o 1'bx
+
+
+design -load read
+simplemap
+opt_expr -keepdc
+select -assert-none t:$_AND_ t:$_OR_
+sat -verify -enable_undef -prove o 1'bx

--- a/tests/opt/opt_expr_or.ys
+++ b/tests/opt/opt_expr_or.ys
@@ -1,65 +1,10 @@
-read_verilog <<EOT
-module top(input a, output [3:0] y);
-assign y[0] = a^1'b0;
-assign y[1] = 1'b1^a;
-assign y[2] = a~^1'b0;
-assign y[3] = 1'b1^~a;
-endmodule
-EOT
-design -save read
-select -assert-count 2 t:$xor
-select -assert-count 2 t:$xnor
-
-equiv_opt opt_expr
-design -load postopt
-select -assert-none t:$xor
-select -assert-none t:$xnor
-select -assert-count 2 t:$not
-
-
-design -load read
-simplemap
-equiv_opt opt_expr
-design -load postopt
-select -assert-none t:$_XOR_
-select -assert-none t:$_XNOR_ # NB: simplemap does $xnor -> $_XOR_+$_NOT_
-select -assert-count 3 t:$_NOT_
-
-
-design -reset
-read_verilog -icells <<EOT
-module top(input a, output [1:0] y);
-$_XNOR_ u0(.A(a), .B(1'b0), .Y(y[0]));
-$_XNOR_ u1(.A(1'b1), .B(a), .Y(y[1]));
-endmodule
-EOT
-select -assert-count 2 t:$_XNOR_
-equiv_opt opt_expr
-design -load postopt
-select -assert-none t:$_XNOR_ # NB: simplemap does $xnor -> $_XOR_+$_NOT_
-select -assert-count 1 t:$_NOT_
-
-
-design -reset
-read_verilog <<EOT
-module top(input a, output [1:0] w, x, y, z);
-assign w = a^1'b0;
-assign x = a^1'b1;
-assign y = a~^1'b0;
-assign z = a~^1'b1;
-endmodule
-EOT
-equiv_opt opt_expr
-
-
-# Single-bit $xor
-design -reset
+# Single-bit $or
 read_verilog -noopt <<EOT
 module gold(input i, output o);
-assign o = 1'bx ^ i;
+assign o = 1'bx | i;
 endmodule
 EOT
-select -assert-count 1 t:$xor
+select -assert-count 1 t:$or
 copy gold coarse
 copy gold fine
 copy gold coarse_keepdc
@@ -96,14 +41,14 @@ miter -equiv -flatten -make_assert -make_outputs coarse_keepdc fine_keepdc miter
 sat -verify -prove-asserts -show-ports -enable_undef miter4
 
 
-# Multi-bit $xor
+# Multi-bit $or
 design -reset
 read_verilog -noopt <<EOT
 module gold(input i, output [6:0] o);
-assign o = {1'bx, 1'b0, 1'b0, 1'b1, 1'bx, 1'b1, i} ^ {7{i}};
+assign o = {1'bx, 1'b0, 1'b0, 1'b1, 1'bx, 1'b1, i} | {7{i}};
 endmodule
 EOT
-select -assert-count 1 t:$xor
+select -assert-count 1 t:$or
 copy gold coarse
 copy gold fine
 copy gold coarse_keepdc
@@ -111,12 +56,12 @@ copy gold fine_keepdc
 
 cd coarse
 opt_expr -fine
-select -assert-count 1 t:$xor # FIXME: Should be zero
+select -assert-none c:*
 
 cd fine
 simplemap
 opt_expr
-select -assert-none t:$_XOR_
+select -assert-none c:*
 
 cd
 miter -equiv -flatten -make_assert -make_outputs -ignore_gold_x gold coarse miter
@@ -125,17 +70,16 @@ miter -equiv -flatten -make_assert -make_outputs coarse fine miter2
 sat -verify -prove-asserts -show-ports -enable_undef miter2
 
 cd coarse_keepdc
-opt_expr -keepdc -fine
-dump
-select -assert-count 2 t:$xor $ FIXME: Should be one
+opt_expr -fine -keepdc
+select -assert-count 1 c:*
 
 cd fine_keepdc
 simplemap
 opt_expr -keepdc
-select -assert-count t c:$_XOR_
+select -assert-count 2 c:*
 
 cd
 miter -equiv -flatten -make_assert -make_outputs gold coarse_keepdc miter3
-sat -verify -prove-asserts -show-ports -enable_undef -set-def in_i miter3
+sat -verify -prove-asserts -show-ports -enable_undef miter3
 miter -equiv -flatten -make_assert -make_outputs coarse_keepdc fine_keepdc miter4
 sat -verify -prove-asserts -show-ports -enable_undef miter4

--- a/tests/opt/opt_expr_xnor.ys
+++ b/tests/opt/opt_expr_xnor.ys
@@ -80,6 +80,6 @@ select -assert-count t c:$_XOR_
 
 cd
 miter -equiv -flatten -make_assert -make_outputs gold coarse_keepdc miter3
-sat -verify -prove-asserts -show-ports -enable_undef -set-def in_i miter3
+sat -verify -prove-asserts -show-ports -enable_undef miter3
 miter -equiv -flatten -make_assert -make_outputs coarse_keepdc fine_keepdc miter4
 sat -verify -prove-asserts -show-ports -enable_undef miter4

--- a/tests/opt/opt_expr_xnor.ys
+++ b/tests/opt/opt_expr_xnor.ys
@@ -83,3 +83,49 @@ miter -equiv -flatten -make_assert -make_outputs gold coarse_keepdc miter3
 sat -verify -prove-asserts -show-ports -enable_undef miter3
 miter -equiv -flatten -make_assert -make_outputs coarse_keepdc fine_keepdc miter4
 sat -verify -prove-asserts -show-ports -enable_undef miter4
+
+
+# Single-bit $xnor extension
+design -reset
+read_verilog -noopt <<EOT
+module gold(input i, output [1:0] o, p, q);
+assign o =  i ~^ i;
+assign p =  1'b0 ~^ i;
+assign q =  1'b1 ~^ i;
+endmodule
+EOT
+select -assert-count 3 t:$xnor
+copy gold coarse
+copy gold fine
+copy gold coarse_keepdc
+copy gold fine_keepdc
+
+cd coarse
+opt_expr -fine
+select -assert-none t:$xnor
+
+cd fine
+simplemap
+opt_expr
+select -assert-none t:$_XNOR_
+
+cd
+miter -equiv -flatten -make_assert -make_outputs -ignore_gold_x gold coarse miter
+sat -verify -prove-asserts -show-ports -enable_undef miter
+miter -equiv -flatten -make_assert -make_outputs coarse fine miter2
+sat -verify -prove-asserts -show-ports -enable_undef miter2
+
+cd coarse_keepdc
+opt_expr -keepdc -fine
+select -assert-count 1 t:$xnor
+
+cd fine_keepdc
+simplemap
+opt_expr -keepdc
+select -assert-count 0 c:$_XNOR_
+
+cd
+miter -equiv -flatten -make_assert -make_outputs gold coarse_keepdc miter3
+sat -verify -prove-asserts -show-ports -enable_undef miter3
+miter -equiv -flatten -make_assert -make_outputs coarse_keepdc fine_keepdc miter4
+sat -verify -prove-asserts -show-ports -enable_undef miter4

--- a/tests/opt/opt_expr_xnor.ys
+++ b/tests/opt/opt_expr_xnor.ys
@@ -56,7 +56,7 @@ copy gold fine_keepdc
 
 cd coarse
 opt_expr -fine
-select -assert-count 1 t:$xnor # FIXME: Should be zero
+select -assert-none t:$xnor
 
 cd fine
 simplemap
@@ -71,12 +71,12 @@ sat -verify -prove-asserts -show-ports -enable_undef miter2
 
 cd coarse_keepdc
 opt_expr -keepdc -fine
-select -assert-count 2 t:$xnor $ FIXME: Should be one
+select -assert-count 1 t:$xnor
 
 cd fine_keepdc
 simplemap
 opt_expr -keepdc
-select -assert-count t c:$_XOR_
+select -assert-count 0 c:$_XOR_
 
 cd
 miter -equiv -flatten -make_assert -make_outputs gold coarse_keepdc miter3

--- a/tests/opt/opt_expr_xnor.ys
+++ b/tests/opt/opt_expr_xnor.ys
@@ -1,65 +1,10 @@
-read_verilog <<EOT
-module top(input a, output [3:0] y);
-assign y[0] = a^1'b0;
-assign y[1] = 1'b1^a;
-assign y[2] = a~^1'b0;
-assign y[3] = 1'b1^~a;
-endmodule
-EOT
-design -save read
-select -assert-count 2 t:$xor
-select -assert-count 2 t:$xnor
-
-equiv_opt opt_expr
-design -load postopt
-select -assert-none t:$xor
-select -assert-none t:$xnor
-select -assert-count 2 t:$not
-
-
-design -load read
-simplemap
-equiv_opt opt_expr
-design -load postopt
-select -assert-none t:$_XOR_
-select -assert-none t:$_XNOR_ # NB: simplemap does $xnor -> $_XOR_+$_NOT_
-select -assert-count 3 t:$_NOT_
-
-
-design -reset
-read_verilog -icells <<EOT
-module top(input a, output [1:0] y);
-$_XNOR_ u0(.A(a), .B(1'b0), .Y(y[0]));
-$_XNOR_ u1(.A(1'b1), .B(a), .Y(y[1]));
-endmodule
-EOT
-select -assert-count 2 t:$_XNOR_
-equiv_opt opt_expr
-design -load postopt
-select -assert-none t:$_XNOR_ # NB: simplemap does $xnor -> $_XOR_+$_NOT_
-select -assert-count 1 t:$_NOT_
-
-
-design -reset
-read_verilog <<EOT
-module top(input a, output [1:0] w, x, y, z);
-assign w = a^1'b0;
-assign x = a^1'b1;
-assign y = a~^1'b0;
-assign z = a~^1'b1;
-endmodule
-EOT
-equiv_opt opt_expr
-
-
-# Single-bit $xor
-design -reset
+# Single-bit $xnor
 read_verilog -noopt <<EOT
 module gold(input i, output o);
-assign o = 1'bx ^ i;
+assign o = 1'bx ~^ i;
 endmodule
 EOT
-select -assert-count 1 t:$xor
+select -assert-count 1 t:$xnor
 copy gold coarse
 copy gold fine
 copy gold coarse_keepdc
@@ -67,12 +12,12 @@ copy gold fine_keepdc
 
 cd coarse
 opt_expr
-select -assert-none c:*
+select -assert-none t:$xnor
 
 cd fine
 simplemap
 opt_expr
-select -assert-none c:*
+select -assert-none c:t$_XNOR_
 
 cd
 miter -equiv -flatten -make_assert -make_outputs -ignore_gold_x gold coarse miter
@@ -87,7 +32,7 @@ select -assert-count 1 c:*
 cd fine_keepdc
 simplemap
 opt_expr -keepdc
-select -assert-count 1 c:*
+select -assert-count 1 t:$_XOR_
 
 cd
 miter -equiv -flatten -make_assert -make_outputs gold coarse_keepdc miter3
@@ -96,14 +41,14 @@ miter -equiv -flatten -make_assert -make_outputs coarse_keepdc fine_keepdc miter
 sat -verify -prove-asserts -show-ports -enable_undef miter4
 
 
-# Multi-bit $xor
+# Multi-bit $xnor
 design -reset
 read_verilog -noopt <<EOT
 module gold(input i, output [6:0] o);
-assign o = {1'bx, 1'b0, 1'b0, 1'b1, 1'bx, 1'b1, i} ^ {7{i}};
+assign o = {1'bx, 1'b0, 1'b0, 1'b1, 1'bx, 1'b1, i} ~^ {7{i}};
 endmodule
 EOT
-select -assert-count 1 t:$xor
+select -assert-count 1 t:$xnor
 copy gold coarse
 copy gold fine
 copy gold coarse_keepdc
@@ -111,12 +56,12 @@ copy gold fine_keepdc
 
 cd coarse
 opt_expr -fine
-select -assert-count 1 t:$xor # FIXME: Should be zero
+select -assert-count 1 t:$xnor # FIXME: Should be zero
 
 cd fine
 simplemap
 opt_expr
-select -assert-none t:$_XOR_
+select -assert-none t:$_XNOR_
 
 cd
 miter -equiv -flatten -make_assert -make_outputs -ignore_gold_x gold coarse miter
@@ -126,8 +71,7 @@ sat -verify -prove-asserts -show-ports -enable_undef miter2
 
 cd coarse_keepdc
 opt_expr -keepdc -fine
-dump
-select -assert-count 2 t:$xor $ FIXME: Should be one
+select -assert-count 2 t:$xnor $ FIXME: Should be one
 
 cd fine_keepdc
 simplemap

--- a/tests/opt/opt_expr_xor.ys
+++ b/tests/opt/opt_expr_xor.ys
@@ -136,6 +136,6 @@ select -assert-count t c:$_XOR_
 
 cd
 miter -equiv -flatten -make_assert -make_outputs gold coarse_keepdc miter3
-sat -verify -prove-asserts -show-ports -enable_undef -set-def in_i miter3
+sat -verify -prove-asserts -show-ports -enable_undef miter3
 miter -equiv -flatten -make_assert -make_outputs coarse_keepdc fine_keepdc miter4
 sat -verify -prove-asserts -show-ports -enable_undef miter4

--- a/tests/opt/opt_expr_xor.ys
+++ b/tests/opt/opt_expr_xor.ys
@@ -111,7 +111,7 @@ copy gold fine_keepdc
 
 cd coarse
 opt_expr -fine
-select -assert-count 1 t:$xor # FIXME: Should be zero
+select -assert-count 0 t:$xor
 
 cd fine
 simplemap
@@ -126,13 +126,12 @@ sat -verify -prove-asserts -show-ports -enable_undef miter2
 
 cd coarse_keepdc
 opt_expr -keepdc -fine
-dump
-select -assert-count 2 t:$xor $ FIXME: Should be one
+select -assert-count 1 t:$xor
 
 cd fine_keepdc
 simplemap
 opt_expr -keepdc
-select -assert-count t c:$_XOR_
+select -assert-count 3 t:$_XOR_
 
 cd
 miter -equiv -flatten -make_assert -make_outputs gold coarse_keepdc miter3


### PR DESCRIPTION
Before this, `opt_expr -keepdc` wasn't always behaving correctly, and there were missed opportunities surrounding single-bit coarse cells `$and/$or/$xor/$xnor`.

Fixes #1758.

~The one remaining issue with `opt_expr` is that it won't optimise multi-bit coarse grained cells directly:~
```
read_verilog <<EOT
module top(input [1:0] i, output [1:0] o);
assign o = 2'b00 & i;
endmodule
EOT
opt_expr
```
~will show a 2-bit `$and` cell remaining. Instead, Yosys seems to rely on bit-blasting into fine-grained cells (`$_AND_`) and optimising there. I'll file this as a separate issue.~
EDIT: I'm wrong. I needed `opt_expr -fine`.