### PR TITLE
Explain how to do out-of-tree builds in README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ SANITIZER =
 # SANITIZER = undefined
 # SANITIZER = cfi
 
-PROGRAM_PREFIX := 
+PROGRAM_PREFIX :=
 
 OS := $(shell uname -s)
 PREFIX ?= /usr/local
@@ -584,10 +584,10 @@ include $(YOSYS_SRC)/techlibs/*/Makefile.inc
 
 else
 
-include frontends/verilog/Makefile.inc
-include frontends/ilang/Makefile.inc
-include frontends/ast/Makefile.inc
-include frontends/blif/Makefile.inc
+include $(YOSYS_SRC)/frontends/verilog/Makefile.inc
+include $(YOSYS_SRC)/frontends/ilang/Makefile.inc
+include $(YOSYS_SRC)/frontends/ast/Makefile.inc
+include $(YOSYS_SRC)/frontends/blif/Makefile.inc
 
 OBJS += passes/hierarchy/hierarchy.o
 OBJS += passes/cmds/select.o
@@ -597,14 +597,14 @@ OBJS += passes/cmds/cover.o
 OBJS += passes/cmds/design.o
 OBJS += passes/cmds/plugin.o
 
-include passes/proc/Makefile.inc
-include passes/opt/Makefile.inc
-include passes/techmap/Makefile.inc
+include $(YOSYS_SRC)/passes/proc/Makefile.inc
+include $(YOSYS_SRC)/passes/opt/Makefile.inc
+include $(YOSYS_SRC)/passes/techmap/Makefile.inc
 
-include backends/verilog/Makefile.inc
-include backends/ilang/Makefile.inc
+include $(YOSYS_SRC)/backends/verilog/Makefile.inc
+include $(YOSYS_SRC)/backends/ilang/Makefile.inc
 
-include techlibs/common/Makefile.inc
+include $(YOSYS_SRC)/techlibs/common/Makefile.inc
 
 endif
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ Tests are located in the tests subdirectory and can be executed using the test t
 
 	$ make test
 
+To use a separate (out-of-tree) build directory, provide a path to the Makefile.
+
+	$ mkdir build; cd build
+	$ make -f ../Makefile
+
+Out-of-tree builds require a clean source tree.
+
 Getting Started
 ===============
 
@@ -388,7 +395,7 @@ Verilog Attributes and non-standard features
 
 - The cell attribute ``wildcard_port_conns`` represents wildcard port
   connections (SystemVerilog ``.*``). These are resolved to concrete
-  connections to matching wires in ``hierarchy``.  
+  connections to matching wires in ``hierarchy``.
 
 - In addition to the ``(* ... *)`` attribute syntax, Yosys supports
   the non-standard ``{* ... *}`` attribute syntax to set default attributes

--- a/techlibs/ecp5/Makefile.inc
+++ b/techlibs/ecp5/Makefile.inc
@@ -2,6 +2,15 @@
 OBJS += techlibs/ecp5/synth_ecp5.o techlibs/ecp5/ecp5_ffinit.o \
         techlibs/ecp5/ecp5_gsr.o
 
+GENFILES += techlibs/ecp5/bram_init_1_2_4.vh
+GENFILES += techlibs/ecp5/bram_init_9_18_36.vh
+GENFILES += techlibs/ecp5/bram_conn_1.vh
+GENFILES += techlibs/ecp5/bram_conn_2.vh
+GENFILES += techlibs/ecp5/bram_conn_4.vh
+GENFILES += techlibs/ecp5/bram_conn_9.vh
+GENFILES += techlibs/ecp5/bram_conn_18.vh
+GENFILES += techlibs/ecp5/bram_conn_36.vh
+
 $(eval $(call add_share_file,share/ecp5,techlibs/ecp5/cells_ff.vh))
 $(eval $(call add_share_file,share/ecp5,techlibs/ecp5/cells_io.vh))
 $(eval $(call add_share_file,share/ecp5,techlibs/ecp5/cells_map.v))

--- a/techlibs/gowin/Makefile.inc
+++ b/techlibs/gowin/Makefile.inc
@@ -2,6 +2,7 @@
 OBJS += techlibs/gowin/synth_gowin.o
 OBJS += techlibs/gowin/determine_init.o
 
+GENFILES += techlibs/gowin/bram_init_16.vh
 
 $(eval $(call add_share_file,share/gowin,techlibs/gowin/cells_map.v))
 $(eval $(call add_share_file,share/gowin,techlibs/gowin/cells_sim.v))
@@ -10,8 +11,6 @@ $(eval $(call add_share_file,share/gowin,techlibs/gowin/brams_map.v))
 $(eval $(call add_share_file,share/gowin,techlibs/gowin/brams.txt))
 $(eval $(call add_share_file,share/gowin,techlibs/gowin/lutrams_map.v))
 $(eval $(call add_share_file,share/gowin,techlibs/gowin/lutrams.txt))
-
-
 
 $(eval $(call add_share_file,share/gowin,techlibs/gowin/brams_init3.vh))
 


### PR DESCRIPTION
All this time I thought Yosys can't be built out of tree, but it turns out it can be, it's just really cleverly hidden. (As far as I can find, even though support for this was added in 2015, but no Yosys-related resource explained how to actually use it at any point. I had to reverse-engineer it from the Makefiles.)