### PR TITLE
cxxrtl: fix attribute syntax, minor fixes

### DIFF
--- a/backends/cxxrtl/cxxrtl.cc
+++ b/backends/cxxrtl/cxxrtl.cc
@@ -212,7 +212,7 @@ bool is_ff_cell(RTLIL::IdString type)
 
 bool is_internal_cell(RTLIL::IdString type)
 {
-	return type[0] == '$' && !type.begins_with("$paramod\\");
+	return type[0] == '$' && !type.begins_with("$paramod");
 }
 
 bool is_cxxrtl_blackbox_cell(const RTLIL::Cell *cell)

--- a/backends/cxxrtl/cxxrtl.cc
+++ b/backends/cxxrtl/cxxrtl.cc
@@ -726,12 +726,13 @@ struct CxxrtlWorker {
 
 	void dump_const_init(const RTLIL::Const &data, int width, int offset = 0, bool fixed_width = false)
 	{
+		const int CHUNK_SIZE = 32;
 		f << "{";
 		while (width > 0) {
-			const int CHUNK_SIZE = 32;
-			uint32_t chunk = data.extract(offset, width > CHUNK_SIZE ? CHUNK_SIZE : width).as_int();
+			int chunk_width = min(width, CHUNK_SIZE);
+			uint32_t chunk = data.extract(offset, chunk_width).as_int();
 			if (fixed_width)
-				f << stringf("0x%08xu", chunk);
+				f << stringf("0x%.*xu", chunk_width / 4, chunk);
 			else
 				f << stringf("%#xu", chunk);
 			if (width > CHUNK_SIZE)


### PR DESCRIPTION
I did not realize that an attribute named `pass.attr` needs escaping in Verilog (mostly because Yosys gladly accepts it). Because of that the Yosys convention is `pass_attr`, and this PR updates CXX to use that convention.