### PR TITLE
verific: recover wiretype/enum attr as part of import_attributes()

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -149,7 +149,7 @@ RTLIL::IdString VerificImporter::new_verific_id(Verific::DesignObj *obj)
 	return s;
 }
 
-void VerificImporter::import_attributes(dict<RTLIL::IdString, RTLIL::Const> &attributes, DesignObj *obj)
+void VerificImporter::import_attributes(dict<RTLIL::IdString, RTLIL::Const> &attributes, DesignObj *obj, Netlist *nl)
 {
 	MapIter mi;
 	Att *attr;
@@ -162,6 +162,35 @@ void VerificImporter::import_attributes(dict<RTLIL::IdString, RTLIL::Const> &att
 		if (attr->Key()[0] == ' ' || attr->Value() == nullptr)
 			continue;
 		attributes[RTLIL::escape_id(attr->Key())] = RTLIL::Const(std::string(attr->Value()));
+	}
+
+	if (nl) {
+		auto type_range = nl->GetTypeRange(obj->Name());
+		if (!type_range)
+			return;
+		if (!type_range->IsTypeEnum())
+			return;
+		attributes.emplace(ID::wiretype, RTLIL::escape_id(type_range->GetTypeName()));
+
+		MapIter mi;
+		const char *k, *v;
+		FOREACH_MAP_ITEM(type_range->GetEnumIdMap(), mi, &k, &v) {
+			// Expect <decimal>'b<binary>
+			auto p = strchr(v, '\'');
+			if (p) {
+				if (*(p+1) != 'b')
+					p = nullptr;
+				else
+					for (auto q = p+2; *q != '\0'; q++)
+						if (*q != '0' && *q != '1') {
+							p = nullptr;
+							break;
+						}
+			}
+			if (p == nullptr)
+				log_error("Expected TypeRange value '%s' to be of form <decimal>'b<binary>.\n", v);
+			attributes.emplace(stringf("\\enum_value_%s", p+2), RTLIL::escape_id(k));
+		}
 	}
 }
 
@@ -845,7 +874,7 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::se
 			log("  importing port %s.\n", port->Name());
 
 		RTLIL::Wire *wire = module->addWire(RTLIL::escape_id(port->Name()));
-		import_attributes(wire->attributes, port);
+		import_attributes(wire->attributes, port, nl);
 
 		wire->port_id = nl->IndexOf(port) + 1;
 
@@ -872,7 +901,7 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::se
 
 		RTLIL::Wire *wire = module->addWire(RTLIL::escape_id(portbus->Name()), portbus->Size());
 		wire->start_offset = min(portbus->LeftIndex(), portbus->RightIndex());
-		import_attributes(wire->attributes, portbus);
+		import_attributes(wire->attributes, portbus, nl);
 
 		if (portbus->GetDir() == DIR_INOUT || portbus->GetDir() == DIR_IN)
 			wire->port_input = true;
@@ -1021,7 +1050,7 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::se
 			log("  importing net %s as %s.\n", net->Name(), log_id(wire_name));
 
 		RTLIL::Wire *wire = module->addWire(wire_name);
-		import_attributes(wire->attributes, net);
+		import_attributes(wire->attributes, net, nl);
 
 		net_map[net] = wire;
 	}
@@ -1046,7 +1075,7 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::se
 
 			RTLIL::Wire *wire = module->addWire(wire_name, netbus->Size());
 			wire->start_offset = min(netbus->LeftIndex(), netbus->RightIndex());
-			import_attributes(wire->attributes, netbus);
+			import_attributes(wire->attributes, netbus, nl);
 
 			RTLIL::Const initval = Const(State::Sx, GetSize(wire));
 			bool initval_valid = false;

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -172,7 +172,10 @@ void VerificImporter::import_attributes(dict<RTLIL::IdString, RTLIL::Const> &att
 			return;
 		if (nl->IsFromVhdl() && strcmp(type_range->GetTypeName(), "STD_LOGIC") == 0)
 			return;
-		attributes.emplace(ID::wiretype, RTLIL::escape_id(type_range->GetTypeName()));
+		auto type_name = type_range->GetTypeName();
+		if (!type_name)
+			return;
+		attributes.emplace(ID::wiretype, RTLIL::escape_id(type_name));
 
 		MapIter mi;
 		const char *k, *v;

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -1153,30 +1153,6 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::se
 	for (auto net : anyseq_nets)
 		module->connect(net_map_at(net), module->Anyseq(new_verific_id(net)));
 
-	char *id_name;
-	TypeRange *type_range;
-	FOREACH_MAP_ITEM(nl->GetTypeRangeTable(), mi, &id_name, &type_range)
-	{
-		if (!type_range)
-			continue;
-		if (!type_range->IsTypeEnum())
-			continue;
-		auto wire = module->wire(RTLIL::escape_id(id_name));
-		if (!wire) {
-			if (net->IsUserDeclared())
-				log_warning("Unable to find imported net '%s'.\n", net->Name());
-			continue;
-		}
-		wire->set_string_attribute(ID::wiretype, type_range->GetTypeName());
-
-		MapIter mj;
-		char *k, *v;
-		FOREACH_MAP_ITEM(type_range->GetEnumIdMap(), mj, &k, &v) {
-			IdString key = stringf("\\enum_value_%s", v);
-			wire->set_string_attribute(key, k);
-		}
-	}
-
 	pool<Instance*, hash_ptr_ops> sva_asserts;
 	pool<Instance*, hash_ptr_ops> sva_assumes;
 	pool<Instance*, hash_ptr_ops> sva_covers;

--- a/frontends/verific/verific.h
+++ b/frontends/verific/verific.h
@@ -79,7 +79,7 @@ struct VerificImporter
 	RTLIL::SigBit net_map_at(Verific::Net *net);
 
 	RTLIL::IdString new_verific_id(Verific::DesignObj *obj);
-	void import_attributes(dict<RTLIL::IdString, RTLIL::Const> &attributes, Verific::DesignObj *obj);
+	void import_attributes(dict<RTLIL::IdString, RTLIL::Const> &attributes, Verific::DesignObj *obj, Verific::Netlist  *nl = nullptr);
 
 	RTLIL::SigSpec operatorInput(Verific::Instance *inst);
 	RTLIL::SigSpec operatorInput1(Verific::Instance *inst);


### PR DESCRIPTION
Supersedes #1986 

Test at YosysHQ/yosys-tests#90