### PR TITLE
kernel: Trap in `log_error()` when a debugger is attached

### DIFF
--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -354,6 +354,9 @@ static void logv_error_with_prefix(const char *prefix,
 
 	if (check_expected_logs)
 		log_check_expected();
+
+	YS_DEBUGTRAP_IF_DEBUGGING;
+
 #ifdef EMSCRIPTEN
 	log_files = backup_log_files;
 	throw 0;
@@ -673,7 +676,7 @@ void log_check_expected()
 		}
 		if (item.second.current_count != item.second.expected_count) {
 			log_warn_regexes.clear();
-			log_error("Expected warning pattern '%s' found %d time(s), instead of %d time(s) !\n", 
+			log_error("Expected warning pattern '%s' found %d time(s), instead of %d time(s) !\n",
 				item.second.pattern.c_str(), item.second.current_count, item.second.expected_count);
 		}
 	}
@@ -700,7 +703,7 @@ void log_check_expected()
 				_exit(0);
 			#else
 				_Exit(0);
-			#endif			
+			#endif
 		} else {
 			display_error_log_msg = false;
 			log_warn_regexes.clear();


### PR DESCRIPTION
The workflow of debugging fatal pass errors in Yosys is flawed in three ways:
 1. Running Yosys under a debugger is sufficient for the debugger to catch some fatal errors (segfaults, aborts, STL exceptions) but not others (`log_error()`, `log_cmd_error()`). This is neither obvious nor easy to remember.
 2. To catch Yosys-specific fatal errors, it is necessary to set a breakpoint at `logv_error_with_prefix()`, or at least, `logv_error()`. This is neither obvious nor easy to remember, and GDB's autocomplete takes many seconds to suggest function names due to the large amount of symbols in Yosys.
 3. If a breakpoint is not set and Yosys encounters with such a fatal error, the process terminates. When debugging a crash that takes a long time to reproduce (or a nondeterministic crash) this can waste a significant amount of time.

To solve this problem, add a macro `YS_DEBUGTRAP` that acts as a hard breakpoint (if available), and a macro `YS_DEBUGTRAP_IF_DEBUGGING` that acts as a hard breakpoint only if debugger is present.

Then, use `YS_DEBUGTRAP_IF_DEBUGGING` in `logv_error_with_prefix()` to obviate the need for a breakpoint on nearly every platform.

<hr>

This PR is a complete rewrite of #1938 that makes it much simpler and also fully portable. I believe it addresses all of the use cases requested by @boqwxp. Currently, `YS_DEBUGTRAP` is not used anywhere in Yosys; it could be used for debugging, but we could also use it e.g. to request the compiler to trip after a certain pass, [like Swift does](https://github.com/apple/swift/blob/master/lib/SILOptimizer/PassManager/PassManager.cpp#L339).

This PR has been tested on Linux glibc and Windows MinGW. It should build and work on any Win32 platform and on any POSIX platform, regardless of the compiler and architecture, since it only relies on the most basic primitives provided by either. I did not try it on MSVC since the code seems obviously correct to me, but I will do so (and any other reasonable platform) on request.

I admit that the manipulations with `signal()` I do on *nix platforms look weird. However, not only are all the alternatives much worse...
 1. `ptrace()` interface differs between Linux and BSDs and `ptrace(PTRACE_TRACEME)` can fail for a lot of reasons, such as "having a security policy preventing ptrace from running" or "being run under strace" or "process called PTRACE_TRACEME already" with no way to distinguish those;
 2. reading from `/proc/self/status` to get tracer PID is just gross, but also Linux-specific, wouldn't necessarily work in a container, and would misidentify strace as a debugger.

... but also the solution I implemented is nearly perfect because it is guaranteed by POSIX to do nothing when not debugged, does not disturb strace (which records a trap and moves on), and is virtually certain to trap on a real debugger (both gdb and lldb do trap here).

The only downside of it I can think of is that it's not MT-safe. (`raise` is guaranteed to deliver `SIGTRAP` to the current thread, unlike the usual, but there is no way to ignore a signal just on one thread.) So in theory, something else could race with this code for changing the SIGTRAP handler. It seems profoundly unlikely though.