### PR TITLE
Add WASI platform support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CONFIG := clang
 # CONFIG := gcc-4.8
 # CONFIG := afl-gcc
 # CONFIG := emcc
+# CONFIG := wasi
 # CONFIG := mxe
 # CONFIG := msys2
 # CONFIG := msys2-64
@@ -32,7 +33,9 @@ ENABLE_NDEBUG := 0
 LINK_CURSES := 0
 LINK_TERMCAP := 0
 LINK_ABC := 0
-# Needed for environments that don't have proper thread support (i.e. emscripten)
+# Needed for environments that can't run executables (i.e. emscripten, wasm)
+DISABLE_SPAWN := 0
+# Needed for environments that don't have proper thread support (i.e. emscripten, wasm--for now)
 DISABLE_ABC_THREADS := 0
 
 # clang sanitizers
@@ -42,7 +45,7 @@ SANITIZER =
 # SANITIZER = undefined
 # SANITIZER = cfi
 
-PROGRAM_PREFIX := 
+PROGRAM_PREFIX :=
 
 OS := $(shell uname -s)
 PREFIX ?= /usr/local
@@ -253,6 +256,8 @@ LDFLAGS += $(EMCCFLAGS)
 LDLIBS =
 EXE = .js
 
+DISABLE_SPAWN := 1
+
 TARGETS := $(filter-out $(PROGRAM_PREFIX)yosys-config,$(TARGETS))
 EXTRA_TARGETS += yosysjs-$(YOSYS_VER).zip
 
@@ -273,6 +278,35 @@ yosysjs-$(YOSYS_VER).zip: yosys.js yosys.wasm viz.js misc/yosysjs/*
 
 yosys.html: misc/yosys.html
 	$(P) cp misc/yosys.html yosys.html
+
+else ifeq ($(CONFIG),wasi)
+ifeq ($(WASI_SDK),)
+CXX = clang++
+LD = clang++
+AR = llvm-ar
+RANLIB = llvm-ranlib
+WASIFLAGS := -target wasm32-wasi --sysroot $(WASI_SYSROOT) $(WASIFLAGS)
+else
+CXX = $(WASI_SDK)/bin/clang++
+LD = $(WASI_SDK)/bin/clang++
+AR = $(WASI_SDK)/bin/ar
+RANLIB = $(WASI_SDK)/bin/ranlib
+WASIFLAGS := --sysroot $(WASI_SDK)/share/wasi-sysroot $(WASIFLAGS)
+endif
+CXXFLAGS := $(WASIFLAGS) -std=c++11 -Os $(filter-out -fPIC,$(CXXFLAGS))
+LDFLAGS := $(WASIFLAGS) -Wl,-z,stack-size=1048576 $(filter-out -rdynamic,$(LDFLAGS))
+LDLIBS := $(filter-out -lrt,$(LDLIBS))
+ABCMKARGS += AR="$(AR)" RANLIB="$(RANLIB)"
+ABCMKARGS += ARCHFLAGS="$(WASIFLAGS) -DABC_USE_STDINT_H -DABC_NO_DYNAMIC_LINKING"
+ABCMKARGS += OPTFLAGS="-Os"
+EXE = .wasm
+
+DISABLE_SPAWN := 1
+
+ifeq ($(ENABLE_ABC),1)
+LINK_ABC := 1
+DISABLE_ABC_THREADS := 1
+endif
 
 else ifeq ($(CONFIG),mxe)
 PKG_CONFIG = /usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-pkg-config
@@ -394,6 +428,10 @@ endif
 
 ifeq ($(DISABLE_ABC_THREADS),1)
 ABCMKARGS += "ABC_USE_NO_PTHREADS=1"
+endif
+
+ifeq ($(DISABLE_SPAWN),1)
+CXXFLAGS += -DYOSYS_DISABLE_SPAWN
 endif
 
 ifeq ($(ENABLE_PLUGINS),1)
@@ -905,6 +943,14 @@ config-afl-gcc: clean
 
 config-emcc: clean
 	echo 'CONFIG := emcc' > Makefile.conf
+	echo 'ENABLE_TCL := 0' >> Makefile.conf
+	echo 'ENABLE_ABC := 0' >> Makefile.conf
+	echo 'ENABLE_PLUGINS := 0' >> Makefile.conf
+	echo 'ENABLE_READLINE := 0' >> Makefile.conf
+	echo 'ENABLE_ZLIB := 0' >> Makefile.conf
+
+config-wasi: clean
+	echo 'CONFIG := wasi' > Makefile.conf
 	echo 'ENABLE_TCL := 0' >> Makefile.conf
 	echo 'ENABLE_ABC := 0' >> Makefile.conf
 	echo 'ENABLE_PLUGINS := 0' >> Makefile.conf

--- a/frontends/rpc/Makefile.inc
+++ b/frontends/rpc/Makefile.inc
@@ -1,3 +1,3 @@
-ifneq ($(CONFIG),emcc)
+ifeq ($(DISABLE_SPAWN),0)
 OBJS += frontends/rpc/rpc_frontend.o
 endif

--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -238,6 +238,7 @@ void Pass::call(RTLIL::Design *design, std::string command)
 		return;
 
 	if (tok[0] == '!') {
+#if !defined(YOSYS_DISABLE_SPAWN)
 		cmd_buf = command.substr(command.find('!') + 1);
 		while (!cmd_buf.empty() && (cmd_buf.back() == ' ' || cmd_buf.back() == '\t' ||
 				cmd_buf.back() == '\r' || cmd_buf.back() == '\n'))
@@ -247,6 +248,9 @@ void Pass::call(RTLIL::Design *design, std::string command)
 		if (retCode != 0)
 			log_cmd_error("Shell command returned error code %d.\n", retCode);
 		return;
+#else
+		log_cmd_error("Shell is not available.\n");
+#endif
 	}
 
 	while (!tok.empty()) {

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -264,7 +264,9 @@ int readsome(std::istream &f, char *s, int n);
 std::string next_token(std::string &text, const char *sep = " \t\r\n", bool long_strings = false);
 std::vector<std::string> split_tokens(const std::string &text, const char *sep = " \t\r\n");
 bool patmatch(const char *pattern, const char *string);
+#if !defined(YOSYS_DISABLE_SPAWN)
 int run_command(const std::string &command, std::function<void(const std::string&)> process_line = std::function<void(const std::string&)>());
+#endif
 std::string make_temp_file(std::string template_str = "/tmp/yosys_XXXXXX");
 std::string make_temp_dir(std::string template_str = "/tmp/yosys_XXXXXX");
 bool check_file_exists(std::string filename, bool is_exec = false);

--- a/libs/ezsat/ezminisat.cc
+++ b/libs/ezsat/ezminisat.cc
@@ -29,11 +29,12 @@
 
 #include <limits.h>
 #include <stdint.h>
-#include <csignal>
 #include <cinttypes>
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__wasm)
+#  include <csignal>
 #  include <unistd.h>
+#  define HAS_ALARM
 #endif
 
 #include "../minisat/Solver.h"
@@ -84,7 +85,7 @@ bool ezMiniSAT::eliminated(int idx)
 }
 #endif
 
-#ifndef _WIN32
+#if defined(HAS_ALARM)
 ezMiniSAT *ezMiniSAT::alarmHandlerThis = NULL;
 clock_t ezMiniSAT::alarmHandlerTimeout = 0;
 
@@ -183,7 +184,7 @@ contradiction:
 #endif
 	}
 
-#ifndef _WIN32
+#if defined(HAS_ALARM)
 	struct sigaction sig_action;
 	struct sigaction old_sig_action;
 	int old_alarm_timeout = 0;
@@ -202,7 +203,7 @@ contradiction:
 
 	bool foundSolution = minisatSolver->solve(assumps);
 
-#ifndef _WIN32
+#if defined(HAS_ALARM)
 	if (solverTimeout > 0) {
 		if (alarmHandlerTimeout == 0)
 			solverTimoutStatus = true;

--- a/libs/minisat/00_PATCH_wasm.patch
+++ b/libs/minisat/00_PATCH_wasm.patch
@@ -1,0 +1,34 @@
+--- System.cc
++++ System.cc
+@@ -101,7 +101,7 @@ double Minisat::memUsedPeak(bool) { return 0; }
+ #endif
+
+
+-#if !defined(_MSC_VER) && !defined(__MINGW32__)
++#if !defined(_MSC_VER) && !defined(__MINGW32__) && !defined(__wasm)
+ void Minisat::limitMemory(uint64_t max_mem_mb)
+ {
+ // FIXME: OpenBSD does not support RLIMIT_AS. Not sure how well RLIMIT_DATA works instead.
+@@ -133,7 +133,7 @@ void Minisat::limitMemory(uint64_t /*max_mem_mb*/)
+ #endif
+
+
+-#if !defined(_MSC_VER) && !defined(__MINGW32__)
++#if !defined(_MSC_VER) && !defined(__MINGW32__) && !defined(__wasm)
+ void Minisat::limitTime(uint32_t max_cpu_time)
+ {
+     if (max_cpu_time != 0){
+@@ -156,9 +156,13 @@ void Minisat::limitTime(uint32_t /*max_cpu_time*/)
+
+ void Minisat::sigTerm(void handler(int))
+ {
++#if defined(__wasm)
++    (void)handler;
++#else
+     signal(SIGINT, handler);
+     signal(SIGTERM,handler);
+ #ifdef SIGXCPU
+     signal(SIGXCPU,handler);
+ #endif
++#endif
+ }

--- a/libs/minisat/00_UPDATE.sh
+++ b/libs/minisat/00_UPDATE.sh
@@ -16,4 +16,4 @@ patch -p0 < 00_PATCH_mkLit_default_arg.patch
 patch -p0 < 00_PATCH_remove_zlib.patch
 patch -p0 < 00_PATCH_no_fpu_control.patch
 patch -p0 < 00_PATCH_typofixes.patch
-
+patch -p0 < 00_PATCH_wasm.patch

--- a/libs/minisat/System.cc
+++ b/libs/minisat/System.cc
@@ -101,7 +101,7 @@ double Minisat::memUsedPeak(bool) { return 0; }
 #endif
 
 
-#if !defined(_MSC_VER) && !defined(__MINGW32__)
+#if !defined(_MSC_VER) && !defined(__MINGW32__) && !defined(__wasm)
 void Minisat::limitMemory(uint64_t max_mem_mb)
 {
 // FIXME: OpenBSD does not support RLIMIT_AS. Not sure how well RLIMIT_DATA works instead.
@@ -133,7 +133,7 @@ void Minisat::limitMemory(uint64_t /*max_mem_mb*/)
 #endif
 
 
-#if !defined(_MSC_VER) && !defined(__MINGW32__)
+#if !defined(_MSC_VER) && !defined(__MINGW32__) && !defined(__wasm)
 void Minisat::limitTime(uint32_t max_cpu_time)
 {
     if (max_cpu_time != 0){
@@ -156,9 +156,13 @@ void Minisat::limitTime(uint32_t /*max_cpu_time*/)
 
 void Minisat::sigTerm(void handler(int))
 {
+#if defined(__wasm)
+    (void)handler;
+#else
     signal(SIGINT, handler);
     signal(SIGTERM,handler);
 #ifdef SIGXCPU
     signal(SIGXCPU,handler);
+#endif
 #endif
 }

--- a/passes/cmds/Makefile.inc
+++ b/passes/cmds/Makefile.inc
@@ -1,5 +1,7 @@
 
+ifeq ($(DISABLE_SPAWN),0)
 OBJS += passes/cmds/exec.o
+endif
 OBJS += passes/cmds/add.o
 OBJS += passes/cmds/delete.o
 OBJS += passes/cmds/design.o
@@ -32,6 +34,8 @@ OBJS += passes/cmds/chformal.o
 OBJS += passes/cmds/chtype.o
 OBJS += passes/cmds/blackbox.o
 OBJS += passes/cmds/ltp.o
+ifeq ($(DISABLE_SPAWN),0)
 OBJS += passes/cmds/bugpoint.o
+endif
 OBJS += passes/cmds/scratchpad.o
 OBJS += passes/cmds/logger.o

--- a/passes/cmds/cover.cc
+++ b/passes/cmds/cover.cc
@@ -101,8 +101,8 @@ struct CoverPass : public Pass {
 				const std::string &filename = args[++argidx];
 				FILE *f = nullptr;
 				if (args[argidx-1] == "-d") {
-			#ifdef _WIN32
-					log_cmd_error("The 'cover -d' option is not supported on win32.\n");
+			#if defined(_WIN32) || defined(__wasm)
+					log_cmd_error("The 'cover -d' option is not supported on this platform.\n");
 			#else
 					char filename_buffer[4096];
 					snprintf(filename_buffer, 4096, "%s/yosys_cover_%d_XXXXXX.txt", filename.c_str(), getpid());

--- a/passes/cmds/show.cc
+++ b/passes/cmds/show.cc
@@ -682,7 +682,7 @@ struct ShowPass : public Pass {
 		std::vector<std::pair<std::string, RTLIL::Selection>> color_selections;
 		std::vector<std::pair<std::string, RTLIL::Selection>> label_selections;
 
-#if defined(EMSCRIPTEN) || defined(_WIN32)
+#if defined(_WIN32) || defined(YOSYS_DISABLE_SPAWN)
 		std::string format = "dot";
 		std::string prefix = "show";
 #else
@@ -849,10 +849,15 @@ struct ShowPass : public Pass {
 			std::string cmd = stringf(DOT_CMD, format.c_str(), dot_file.c_str(), out_file.c_str(), out_file.c_str(), out_file.c_str());
 			#undef DOT_CMD
 			log("Exec: %s\n", cmd.c_str());
-			if (run_command(cmd) != 0)
-				log_cmd_error("Shell command failed!\n");
+			#if !defined(YOSYS_DISABLE_SPAWN)
+				if (run_command(cmd) != 0)
+					log_cmd_error("Shell command failed!\n");
+			#endif
 		}
 
+		#if defined(YOSYS_DISABLE_SPAWN)
+			log_assert(viewer_exe.empty() && !format.empty());
+		#else
 		if (!viewer_exe.empty()) {
 			#ifdef _WIN32
 				// system()/cmd.exe does not understand single quotes nor
@@ -876,6 +881,7 @@ struct ShowPass : public Pass {
 			if (run_command(cmd) != 0)
 				log_cmd_error("Shell command failed!\n");
 		}
+		#endif
 
 		if (flag_pause) {
 		#ifdef YOSYS_ENABLE_READLINE

--- a/passes/sat/Makefile.inc
+++ b/passes/sat/Makefile.inc
@@ -13,5 +13,6 @@ OBJS += passes/sat/fmcombine.o
 OBJS += passes/sat/mutate.o
 OBJS += passes/sat/cutpoint.o
 OBJS += passes/sat/fminit.o
+ifeq ($(DISABLE_SPAWN),0)
 OBJS += passes/sat/qbfsat.o
-
+endif

--- a/passes/techmap/Makefile.inc
+++ b/passes/techmap/Makefile.inc
@@ -57,7 +57,7 @@ passes/techmap/techmap.inc: techlibs/common/techmap.v
 
 passes/techmap/techmap.o: passes/techmap/techmap.inc
 
-ifneq ($(CONFIG),emcc)
+ifeq ($(DISABLE_SPAWN),0)
 TARGETS += $(PROGRAM_PREFIX)yosys-filterlib$(EXE)
 EXTRA_OBJS += passes/techmap/filterlib.o
 

--- a/passes/techmap/abc9_exe.cc
+++ b/passes/techmap/abc9_exe.cc
@@ -420,11 +420,15 @@ struct Abc9ExePass : public Pass {
 		}
 
 		size_t argidx;
+#if defined(__wasm)
+		const char *pwd = ".";
+#else
 		char pwd [PATH_MAX];
 		if (!getcwd(pwd, sizeof(pwd))) {
 			log_cmd_error("getcwd failed: %s\n", strerror(errno));
 			log_abort();
 		}
+#endif
 		for (argidx = 1; argidx < args.size(); argidx++) {
 			std::string arg = args[argidx];
 			if (arg == "-exe" && argidx+1 < args.size()) {


### PR DESCRIPTION
See PR #1483 for a previous attempt (for some reason I can't reopen that PR).

<hr>

This PR includes the following significant changes:
  * Patching ezsat and minisat to disable resource limiting code on WASM/WASI, since the POSIX functions they use are unavailable.
  * Adding a new definition, `YOSYS_DISABLE_SPAWN`, present if platform does not support spawning subprocesses (i.e. Emscripten or WASI). This definition hides the definition of `run_command()`.
  * Adding a new Makefile flag, `DISABLE_SPAWN`, present in the same condition. This flag disables all passes that require spawning subprocesses for their function. It replaces ad-hoc checks of `$(CONFIG)`.

<hr>

This PR cannot be merged yet. Unresolved issues:
  - [x] https://github.com/YosysHQ/yosys/pull/1946 required for merging PR
  - [x] https://github.com/YosysHQ/abc/pull/2 required for `ENABLE_ABC:=1` build
  - [x] https://github.com/YosysHQ/abc/pull/3 required for `ENABLE_ABC:=1` build
  - [x] https://github.com/YosysHQ/abc/pull/5 required for `ENABLE_ABC:=1` build
  - [ ] What, if anything, do we do about C++ exceptions?

<hr>

In practice, WASI Yosys works quite well. I can synthesize medium sized iCE40 designs with the linked ABC just fine, and in reasonable time as well (within an order of magnitude even without LTO). Compiling Yosys itself from WASM to native code can take quite a while in the maximal configuration, but, fortunately, the native code is easily cached.

I am using [WASI SDK](https://github.com/WebAssembly/wasi-sdk/releases), [wasmtime](https://github.com/bytecodealliance/wasmtime), patched `abc`, and the following Yosys configuration:

```make
CONFIG := wasi

WASI_SDK := $(CURDIR)/wasi-sdk-10.0

ENABLE_TCL := 0
ENABLE_ABC := 1
ENABLE_GLOB := 0
ENABLE_PLUGINS := 0
ENABLE_READLINE := 0
ENABLE_EDITLINE := 0
ENABLE_VERIFIC := 0
ENABLE_COVER := 0
ENABLE_LIBYOSYS := 0
ENABLE_PROTOBUF := 0
ENABLE_ZLIB := 0

SMALL := 0

CXXFLAGS += -flto
LDFLAGS += -flto

ABCREV := default
```