### PR TITLE
Preserve 'signed'-ness of a verilog wire through RTLIL

### DIFF
--- a/backends/ilang/ilang_backend.cc
+++ b/backends/ilang/ilang_backend.cc
@@ -131,6 +131,8 @@ void ILANG_BACKEND::dump_wire(std::ostream &f, std::string indent, const RTLIL::
 		f << stringf("output %d ", wire->port_id);
 	if (wire->port_input && wire->port_output)
 		f << stringf("inout %d ", wire->port_id);
+	if (wire->is_signed)
+		f << stringf("signed ");
 	f << stringf("%s\n", wire->name.c_str());
 }
 

--- a/backends/json/json.cc
+++ b/backends/json/json.cc
@@ -160,6 +160,8 @@ struct JsonWriter
 				f << stringf("          \"offset\": %d,\n", w->start_offset);
 			if (w->upto)
 				f << stringf("          \"upto\": 1,\n");
+			if (w->is_signed)
+				f << stringf("          \"signed\": %d,\n", w->is_signed);
 			f << stringf("          \"bits\": %s\n", get_bits(w).c_str());
 			f << stringf("        }");
 			first = false;
@@ -227,6 +229,8 @@ struct JsonWriter
 				f << stringf("          \"offset\": %d,\n", w->start_offset);
 			if (w->upto)
 				f << stringf("          \"upto\": 1,\n");
+			if (w->is_signed)
+				f << stringf("          \"signed\": %d,\n", w->is_signed);
 			f << stringf("          \"attributes\": {");
 			write_parameters(w->attributes);
 			f << stringf("\n          }\n");

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -1058,6 +1058,7 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 			wire->port_input = is_input;
 			wire->port_output = is_output;
 			wire->upto = range_swapped;
+			wire->is_signed = is_signed;
 
 			for (auto &attr : attributes) {
 				if (attr.second->type != AST_CONSTANT)

--- a/frontends/ilang/ilang_parser.y
+++ b/frontends/ilang/ilang_parser.y
@@ -192,6 +192,9 @@ wire_options:
 	wire_options TOK_UPTO {
 		current_wire->upto = true;
 	} |
+	wire_options TOK_SIGNED {
+		current_wire->is_signed = true;
+	} |
 	wire_options TOK_OFFSET TOK_INT {
 		current_wire->start_offset = $3;
 	} |

--- a/frontends/json/jsonparse.cc
+++ b/frontends/json/jsonparse.cc
@@ -309,6 +309,12 @@ void json_import(Design *design, string &modname, JsonNode *node)
 					port_wire->upto = val->data_number != 0;
 			}
 
+			if (port_node->data_dict.count("signed") != 0) {
+				JsonNode *val = port_node->data_dict.at("signed");
+				if (val->type == 'N')
+					port_wire->is_signed = val->data_number != 0;
+			}
+
 			if (port_node->data_dict.count("offset") != 0) {
 				JsonNode *val = port_node->data_dict.at("offset");
 				if (val->type == 'N')
@@ -573,4 +579,3 @@ struct JsonFrontend : public Frontend {
 } JsonFrontend;
 
 YOSYS_NAMESPACE_END
-

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1862,6 +1862,7 @@ RTLIL::Wire *RTLIL::Module::addWire(RTLIL::IdString name, const RTLIL::Wire *oth
 	wire->port_input = other->port_input;
 	wire->port_output = other->port_output;
 	wire->upto = other->upto;
+	wire->is_signed = other->is_signed;
 	wire->attributes = other->attributes;
 	return wire;
 }
@@ -2445,6 +2446,7 @@ RTLIL::Wire::Wire()
 	port_input = false;
 	port_output = false;
 	upto = false;
+	is_signed = false;
 
 #ifdef WITH_PYTHON
 	RTLIL::Wire::get_all_wires()->insert(std::pair<unsigned int, RTLIL::Wire*>(hashidx_, this));

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1353,7 +1353,7 @@ public:
 	RTLIL::Module *module;
 	RTLIL::IdString name;
 	int width, start_offset, port_id;
-	bool port_input, port_output, upto;
+	bool port_input, port_output, upto, is_signed;
 
 #ifdef WITH_PYTHON
 	static std::map<unsigned int, RTLIL::Wire*> *get_all_wires(void);


### PR DESCRIPTION
As per suggestion made in https://github.com/YosysHQ/yosys/pull/1987, now:

`RTLIL::Wire` now holds an is_signed field.
`signed` is exported via JSON backend, and read in via JSON frontend
Also exported via dump_rtlil command, and read back via ilang_parser

I am sure I missed a few other places, and would love to add a test somewhere. Please feel free to advise!
