### PR TITLE
[Draft] MIF file generator from Yosys INIT parameter for Intel memory cells

### DIFF
--- a/techlibs/intel/Makefile.inc
+++ b/techlibs/intel/Makefile.inc
@@ -1,5 +1,6 @@
 
 OBJS += techlibs/intel/synth_intel.o
+OBJS += techlibs/intel/intel_genmif.o
 
 $(eval $(call add_share_file,share/intel/common,techlibs/intel/common/m9k_bb.v))
 $(eval $(call add_share_file,share/intel/common,techlibs/intel/common/altpll_bb.v))
@@ -11,4 +12,3 @@ families := max10 arria10gx cyclonev cyclone10lp cycloneiv cycloneive
 $(foreach family,$(families), $(eval $(call add_share_file,share/intel/$(family),techlibs/intel/$(family)/cells_sim.v)))
 $(foreach family,$(families), $(eval $(call add_share_file,share/intel/$(family),techlibs/intel/$(family)/cells_map.v)))
 #$(eval $(call add_share_file,share/intel/cycloneive,techlibs/intel/cycloneive/arith_map.v))
-

--- a/techlibs/intel/intel_genmif.cc
+++ b/techlibs/intel/intel_genmif.cc
@@ -1,0 +1,127 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012 - 2020  Claire Wolf <claire@symbioticeda.com>
+ *  Copyright (C) 2012 - 2020  Diego H     <diego@symbioticeda.com>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/yosys.h"
+#include "kernel/sigtools.h"
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <iomanip>
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+void create_mif (std::string file_name, std::string contents, int depth, int width)
+{
+	std::ofstream f;
+	f.open(file_name+".mif");
+
+	if (f.fail()) {
+		log_error("File %s cannot be opened. Check W/R permissions/quota in CWD.\n", file_name.c_str());
+	}
+
+	f << stringf("-- Yosys generated MIF file.\n");
+	f << stringf("-- The generation of MIF files is still experimental.\n");
+	f << stringf("DEPTH = %d;\n", depth);
+	f << stringf("WIDTH = %d;\n", width);
+	f << stringf("ADDRESS_RADIX=UNS;\n");
+	f << stringf("DATA_RADIX=BIN;\n");
+	f << stringf("CONTENT BEGIN\n");
+	
+	// Formatting the data in 0 to depth size -1 fashion as location, and with chunks of width size.
+	for (unsigned long iline = 0; iline < contents.length(); iline += width) {
+		int didx = depth-1;
+		f << "\t" << std::setw(4) << didx << " : " << contents.substr(iline, width) << std::internal << ";" << std::endl;
+		depth--;
+	}
+
+	f << "END;" << std::endl;
+	f.close();
+}
+
+static void mifgen(Module *module)
+{
+	for (auto cell : module->selected_cells()) {
+		// Skip non-intel memory cells
+		if (!(cell->type.in(ID(altsyncram))))
+			continue;
+
+		// Get the values from init parameter. 
+		// If contents are don't care, means that memory is not initialized, 
+		// so init_type is removed, and init_file needs to be set as UNUSED.
+		if (cell->getParam(ID(init_file)).is_fully_undef()) {
+			cell->setParam(ID(init_file), RTLIL::Const("UNUSED"));
+			cell->unsetParam(ID(init_type));
+			log("Skipping memory %s: Memory content is left as don't care or is not initialised.\n", RTLIL::id2cstr(cell->name)); 
+			continue;
+		}
+		
+		log("Processing memory %s: The MIF files will be saved in CWD.\n", RTLIL::id2cstr(cell->name));
+	
+		// Name of the cell is used to save the MIF file using same name.
+		std::string mem_name = RTLIL::escape_id(RTLIL::id2cstr(cell->name));
+		std::string mif_param = RTLIL::id2cstr(mem_name+".mif");
+		// TODO: Check for when A and B ports are different size? (init_file layout).
+		int width_a = cell->getParam(ID(width_a)).as_int();
+		int depth_a = cell->getParam(ID(numwords_a)).as_int();
+		// INIT parameter as a single line string
+		Const init = cell->getParam(ID(init_file));
+		std::string init_content = init.as_string();
+
+		// Create the mif file
+		create_mif (RTLIL::id2cstr(mem_name), init_content, depth_a, width_a);
+		// Set the MIF file as a parameter for the current memory cell.
+		cell->setParam(ID(init_file), RTLIL::Const(mif_param));
+		cell->setParam(ID(init_type), RTLIL::Const("mif"));
+	}
+}
+
+struct IntelMifGen : public Pass {
+	IntelMifGen() : Pass("intel_genmif", "Generate Intel memory contents in MIF format") { }
+	void help() YS_OVERRIDE
+	{
+		log("\n");
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    intel_genmif\n");
+		log("\n");
+		log("Convert the Yosys INIT parameter, to a MIF file that Quartus can process.\n");
+		log("This pass also set the parameters \"init_file\" and \"init_type\" depending on\n");
+		log("whether the memory is not initialised (init_file=UNUSED) or if\n");
+		log("the memory is initialised by user contents (init_file=mif file generated).\n");
+		log("\n");
+	}
+
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	{
+		log_header(design, "Executing INTEL_GENMIF pass.\n");
+
+		size_t argidx;
+		for (argidx = 1; argidx < args.size(); argidx++) {
+			break;
+		}
+		extra_args(args, argidx, design);
+
+		for (auto module : design->selected_modules())
+			mifgen(module);
+	}
+} IntelMifGen;
+
+PRIVATE_NAMESPACE_END

--- a/techlibs/intel/synth_intel.cc
+++ b/techlibs/intel/synth_intel.cc
@@ -193,6 +193,7 @@ struct SynthIntelPass : public ScriptPass {
 				    help_mode) {
 				run("memory_bram -rules +/intel/common/brams_m9k.txt", "(if applicable for family)");
 				run("techmap -map +/intel/common/brams_map_m9k.v", "(if applicable for family)");
+				run("intel_genmif");
 			} else {
 				log_warning("BRAM mapping is not currently supported for %s.\n", family_opt.c_str());
 			}


### PR DESCRIPTION
Since Quartus requires either an hex file or a mif file, to be created as part of the synhtesized memories, for all families, this PR takes the Yosys `INIT` parameter and converts it to a Quartus MIF file.
A `PicoSoC` example has been used to test this pass as shown [here](https://twitter.com/dhdezr73/status/1175991636955938816).  Also, as a quick example, consider this module:
```verilog
`default_nettype none
`define _MEM_INIT_
module ram #(parameter DW=8, AW=10)
   (input  wire [DW-1:0]  i_din,
    input  wire [AW-1:0]  i_wain, i_rain,
    output logic [DW-1:0] o_dout,
    input  wire           i_clk, i_en);

`ifdef _ZERO_INIT_
   var logic [DW-1:0]     array [(2**AW)-1:0] /* synthesis syn_ramstyle = "MLAB"*/ = '{default:0};
`endif

`ifdef _MEM_INIT_
   logic [DW-1:0]     array [(2**AW)-1:0] /* synthesis syn_ramstyle = "MLAB"*/;
   initial $readmemh("f0.hex", array);
`endif

   always_ff @(posedge i_clk) begin
      if (i_en) array[i_wain] <= i_din;
   end

   always_ff @(posedge i_clk) o_dout <= array[i_rain];
endmodule // ram
```
with `f0.hex` as:
```
1FF
1DE
1AD
100
1FF
1DE
1AD
100
1FF
1DE
1AD
100
1FF
1DE
1AD
100
1FF
1DE
1AD
100
1FF
1DE
1AD
100
```
Both Quartus and MIFGen creates a MIF file with the same contents (left Yosys, right Quartus).
![image](https://user-images.githubusercontent.com/10665129/80445532-27311e80-88da-11ea-806d-09f69d044352.png)

I'm creating this PR as a draft, because there is still some work needed in the testing side, and some other improvements that might be needed to cover all Intel memory blocks. This might be of interest to @ZirconiumX .