### PR TITLE
Fix .editorconfig to not break abc

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,8 @@ indent_style = tab
 indent_size = tab
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[abc/**]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false


### PR DESCRIPTION
abc has lots of trailing spaces and a different convention for indents.