### PR TITLE
qbfsat: Add `-solver` option and allow choice of Z3 or Yices, making Yices the default.

### DIFF
--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -172,7 +172,7 @@ class SmtIo:
             self.unroll = False
 
         if self.solver == "yices":
-            if self.noincr:
+            if self.noincr or self.forall:
                 self.popen_vargs = ['yices-smt2'] + self.solver_opts
             else:
                 self.popen_vargs = ['yices-smt2', '--incremental'] + self.solver_opts
@@ -232,16 +232,20 @@ class SmtIo:
             if self.logic_uf: self.logic += "UF"
             if self.logic_bv: self.logic += "BV"
             if self.logic_dt: self.logic = "ALL"
+            if self.solver == "yices" and self.forall: self.logic = "BV"
 
         self.setup_done = True
 
-        for stmt in self.info_stmts:
-            self.write(stmt)
+        if self.forall and self.solver == "yices":
+            self.write("(set-option :yices-ef-max-iters 1000000000)")
 
         if self.produce_models:
             self.write("(set-option :produce-models true)")
 
         self.write("(set-logic %s)" % self.logic)
+
+        for stmt in self.info_stmts:
+            self.write(stmt)
 
     def timestamp(self):
         secs = int(time() - self.start_time)

--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -236,6 +236,9 @@ class SmtIo:
 
         self.setup_done = True
 
+        for stmt in self.info_stmts:
+            self.write(stmt)
+
         if self.forall and self.solver == "yices":
             self.write("(set-option :yices-ef-max-iters 1000000000)")
 
@@ -243,9 +246,6 @@ class SmtIo:
             self.write("(set-option :produce-models true)")
 
         self.write("(set-logic %s)" % self.logic)
-
-        for stmt in self.info_stmts:
-            self.write(stmt)
 
     def timestamp(self):
         secs = int(time() - self.start_time)


### PR DESCRIPTION
Overview:
----
This PR adds support for using Yices in exists-forall mode to `yosys-smtbmc` and `qbfsat`.  This requires some tweaks like ensuring the logic specification is only `BV` and appears before any uses of operators or types from that logic.

This PR also makes Yices the default solver, replacing Z3.  This is because I have [found](https://github.com/boqwxp/yosys-examples/tree/master/example1) that Yices is *much* faster than Z3.  In this example, Yices found a solution to a bisection iteration problem in ~6m on my machine (~3m when linking Yices with `libtcmalloc`), using no more than 400MB of memory.  Z3, on the other hand, took approximately the same amount of time to gobble up 8GB of memory and fail.  While this is only one data point, it agrees with my experience that Yices is (often by far) the most performant exists-forall `BV` solver.

Depends:
----
- [x] [Yices](https://github.com/SRI-CSL/yices2) >= git commit 186434ba7212ecc436729152e212a30c08c65b06
- [x] PR #1996 
- [x] PR #2015 