### PR TITLE
qbfsat: Add support for CVC4.

### DIFF
--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -172,7 +172,7 @@ class SmtIo:
             self.unroll = False
 
         if self.solver == "yices":
-            if self.noincr:
+            if self.noincr or self.forall:
                 self.popen_vargs = ['yices-smt2'] + self.solver_opts
             else:
                 self.popen_vargs = ['yices-smt2', '--incremental'] + self.solver_opts
@@ -232,16 +232,20 @@ class SmtIo:
             if self.logic_uf: self.logic += "UF"
             if self.logic_bv: self.logic += "BV"
             if self.logic_dt: self.logic = "ALL"
+            if self.solver == "yices" and self.forall: self.logic = "BV"
 
         self.setup_done = True
 
-        for stmt in self.info_stmts:
-            self.write(stmt)
+        if self.forall and self.solver == "yices":
+            self.write("(set-option :yices-ef-max-iters 1000000000)")
 
         if self.produce_models:
             self.write("(set-option :produce-models true)")
 
         self.write("(set-logic %s)" % self.logic)
+
+        for stmt in self.info_stmts:
+            self.write(stmt)
 
     def timestamp(self):
         secs = int(time() - self.start_time)

--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -236,6 +236,9 @@ class SmtIo:
 
         self.setup_done = True
 
+        for stmt in self.info_stmts:
+            self.write(stmt)
+
         if self.forall and self.solver == "yices":
             self.write("(set-option :yices-ef-max-iters 1000000000)")
 
@@ -243,9 +246,6 @@ class SmtIo:
             self.write("(set-option :produce-models true)")
 
         self.write("(set-logic %s)" % self.logic)
-
-        for stmt in self.info_stmts:
-            self.write(stmt)
 
     def timestamp(self):
         secs = int(time() - self.start_time)

--- a/passes/sat/qbfsat.cc
+++ b/passes/sat/qbfsat.cc
@@ -41,7 +41,7 @@ struct QbfSolveOptions {
 	bool specialize, specialize_from_file, write_solution, nocleanup, dump_final_smt2, assume_outputs, assume_neg;
 	bool nooptimize, nobisection;
 	bool sat, unsat, show_smtbmc;
-	enum Solver{Z3, Yices} solver;
+	enum Solver{Z3, Yices, CVC4} solver;
 	std::string specialize_soln_file;
 	std::string write_soln_soln_file;
 	std::string dump_final_smt2_file;
@@ -57,6 +57,8 @@ std::string get_solver_name(const QbfSolveOptions &opt) {
 		return "z3";
 	else if (opt.solver == opt.Solver::Yices)
 		return "yices";
+	else if (opt.solver == opt.Solver::CVC4)
+		return "cvc4";
 	else
 		log_cmd_error("unknown solver specified.\n");
 	return "";
@@ -504,6 +506,8 @@ QbfSolveOptions parse_args(const std::vector<std::string> &args) {
 					opt.solver = opt.Solver::Z3;
 				else if (args[opt.argidx+1] == "yices")
 					opt.solver = opt.Solver::Yices;
+				else if (args[opt.argidx+1] == "cvc4")
+					opt.solver = opt.Solver::CVC4;
 				else
 					log_cmd_error("Unknown solver \"%s\".\n", args[opt.argidx+1].c_str());
 				opt.argidx++;
@@ -619,7 +623,7 @@ struct QbfSatPass : public Pass {
 		log("        quantified bitvector problems.\n");
 		log("\n");
 		log("    -solver <solver>\n");
-		log("        Use a particular solver. Choose one of: \"z3\", \"yices\".\n");
+		log("        Use a particular solver. Choose one of: \"z3\", \"yices\", and \"cvc4\".\n");
 		log("\n");
 		log("    -sat\n");
 		log("        Generate an error if the solver does not return \"sat\".\n");


### PR DESCRIPTION
Overview:
----
This PR adds support for using [CVC4](https://github.com/CVC4/CVC4) as a solver for `qbfsat`.

I have not been able to get acceptable performance from CVC4; even Z3 seems to be faster.  It does seem to have very low memory usage, but I'm not sure how meaningful that is if I can never get a solution for even fairly small problems.  [The example](https://github.com/boqwxp/yosys-examples/blob/master/example1/example.smt2) that Yices solves in less than 6 minutes still was not solved by CVC4 after 200 minutes on my machine.

But it is possible to use it, it takes very little additional effort, and there are lots of knobs to fiddle with, so maybe it would work better for someone else who knows just how to tune those knobs.

Depends:
----
- [x] PR #1996 
- [x] PR #2015 
- [x] PR #2016