### PR TITLE
smtbmc and qbfsat: Add timeout option to set solver timeouts for Z3, Yices, and CVC4.

### DIFF
--- a/backends/smt2/smtbmc.py
+++ b/backends/smt2/smtbmc.py
@@ -1557,8 +1557,9 @@ else:  # not tempind, covermode
                 smt_assert(get_constr_expr(constr_asserts, i))
 
             print_msg("Solving for step %d.." % (last_check_step))
-            if smt_check_sat() != "sat":
-                print("%s No solution found!" % smt.timestamp())
+            status = smt_check_sat()
+            if status != "sat":
+                print("%s No solution found! (%s)" % (smt.timestamp(), status))
                 retstatus = "FAILED"
                 break
 

--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -121,6 +121,7 @@ class SmtIo:
         self.logic_bv = True
         self.logic_dt = False
         self.forall = False
+        self.timeout = 0
         self.produce_models = True
         self.smt2cache = [list()]
         self.p = None
@@ -135,6 +136,7 @@ class SmtIo:
             self.debug_file = opts.debug_file
             self.dummy_file = opts.dummy_file
             self.timeinfo = opts.timeinfo
+            self.timeout = opts.timeout
             self.unroll = opts.unroll
             self.noincr = opts.noincr
             self.info_stmts = opts.info_stmts
@@ -147,6 +149,7 @@ class SmtIo:
             self.debug_file = None
             self.dummy_file = None
             self.timeinfo = os.name != "nt"
+            self.timeout = 0
             self.unroll = False
             self.noincr = False
             self.info_stmts = list()
@@ -176,18 +179,28 @@ class SmtIo:
                 self.popen_vargs = ['yices-smt2'] + self.solver_opts
             else:
                 self.popen_vargs = ['yices-smt2', '--incremental'] + self.solver_opts
+            if self.timeout != 0:
+                self.popen_vargs.append('-t')
+                self.popen_vargs.append('%d' % self.timeout);
 
         if self.solver == "z3":
             self.popen_vargs = ['z3', '-smt2', '-in'] + self.solver_opts
+            if self.timeout != 0:
+                self.popen_vargs.append('-T:%d' % self.timeout);
 
         if self.solver == "cvc4":
             if self.noincr:
                 self.popen_vargs = ['cvc4', '--lang', 'smt2.6' if self.logic_dt else 'smt2'] + self.solver_opts
             else:
                 self.popen_vargs = ['cvc4', '--incremental', '--lang', 'smt2.6' if self.logic_dt else 'smt2'] + self.solver_opts
+            if self.timeout != 0:
+                self.popen_vargs.append('--tlimit=%d000' % self.timeout);
 
         if self.solver == "mathsat":
             self.popen_vargs = ['mathsat'] + self.solver_opts
+            if self.timeout != 0:
+                print('timeout option is not supported for mathsat.')
+                sys.exit(1)
 
         if self.solver == "boolector":
             if self.noincr:
@@ -195,6 +208,9 @@ class SmtIo:
             else:
                 self.popen_vargs = ['boolector', '--smt2', '-i'] + self.solver_opts
             self.unroll = True
+            if self.timeout != 0:
+                print('timeout option is not supported for boolector.')
+                sys.exit(1)
 
         if self.solver == "abc":
             if len(self.solver_opts) > 0:
@@ -204,6 +220,9 @@ class SmtIo:
             self.logic_ax = False
             self.unroll = True
             self.noincr = True
+            if self.timeout != 0:
+                print('timeout option is not supported for abc.')
+                sys.exit(1)
 
         if self.solver == "dummy":
             assert self.dummy_file is not None
@@ -448,6 +467,10 @@ class SmtIo:
             return
 
         fields = stmt.split()
+
+        if fields[1] == "yosys-smt2-timeout":
+            self.timeout = int(fields[2])
+            assert self.timeout > 0
 
         if fields[1] == "yosys-smt2-nomem":
             if self.logic is None:
@@ -710,7 +733,7 @@ class SmtIo:
 
         if self.forall:
             result = self.read()
-            while result not in ["sat", "unsat", "unknown"]:
+            while result not in ["sat", "unsat", "unknown", "timeout", "interrupted", ""]:
                 print("%s %s: %s" % (self.timestamp(), self.solver, result))
                 result = self.read()
         else:
@@ -721,7 +744,7 @@ class SmtIo:
             print("(check-sat)", file=self.debug_file)
             self.debug_file.flush()
 
-        if result not in ["sat", "unsat"]:
+        if result not in ["sat", "unsat", "unknown", "timeout", "interrupted"]:
             if result == "":
                 print("%s Unexpected EOF response from solver." % (self.timestamp()), flush=True)
             else:
@@ -931,7 +954,7 @@ class SmtIo:
 class SmtOpts:
     def __init__(self):
         self.shortopts = "s:S:v"
-        self.longopts = ["unroll", "noincr", "noprogress", "dump-smt2=", "logic=", "dummy=", "info=", "nocomments"]
+        self.longopts = ["unroll", "noincr", "noprogress", "timeout=", "dump-smt2=", "logic=", "dummy=", "info=", "nocomments"]
         self.solver = "yices"
         self.solver_opts = list()
         self.debug_print = False
@@ -940,6 +963,7 @@ class SmtOpts:
         self.unroll = False
         self.noincr = False
         self.timeinfo = os.name != "nt"
+        self.timeout = 0
         self.logic = None
         self.info_stmts = list()
         self.nocomments = False
@@ -949,6 +973,8 @@ class SmtOpts:
             self.solver = a
         elif o == "-S":
             self.solver_opts.append(a)
+        elif o == "--timeout":
+            self.timeout = int(a)
         elif o == "-v":
             self.debug_print = True
         elif o == "--unroll":
@@ -979,6 +1005,9 @@ class SmtOpts:
 
     -S <opt>
         pass <opt> as command line argument to the solver
+
+    --timeout <value>
+        set the solver timeout to the specified value (in seconds).
 
     --logic <smt2_logic>
         use the specified SMT2 logic (e.g. QF_AUFBV)

--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -172,7 +172,7 @@ class SmtIo:
             self.unroll = False
 
         if self.solver == "yices":
-            if self.noincr:
+            if self.noincr or self.forall:
                 self.popen_vargs = ['yices-smt2'] + self.solver_opts
             else:
                 self.popen_vargs = ['yices-smt2', '--incremental'] + self.solver_opts
@@ -232,16 +232,20 @@ class SmtIo:
             if self.logic_uf: self.logic += "UF"
             if self.logic_bv: self.logic += "BV"
             if self.logic_dt: self.logic = "ALL"
+            if self.solver == "yices" and self.forall: self.logic = "BV"
 
         self.setup_done = True
 
-        for stmt in self.info_stmts:
-            self.write(stmt)
+        if self.forall and self.solver == "yices":
+            self.write("(set-option :yices-ef-max-iters 1000000000)")
 
         if self.produce_models:
             self.write("(set-option :produce-models true)")
 
         self.write("(set-logic %s)" % self.logic)
+
+        for stmt in self.info_stmts:
+            self.write(stmt)
 
     def timestamp(self):
         secs = int(time() - self.start_time)

--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -236,6 +236,9 @@ class SmtIo:
 
         self.setup_done = True
 
+        for stmt in self.info_stmts:
+            self.write(stmt)
+
         if self.forall and self.solver == "yices":
             self.write("(set-option :yices-ef-max-iters 1000000000)")
 
@@ -243,9 +246,6 @@ class SmtIo:
             self.write("(set-option :produce-models true)")
 
         self.write("(set-logic %s)" % self.logic)
-
-        for stmt in self.info_stmts:
-            self.write(stmt)
 
     def timestamp(self):
         secs = int(time() - self.start_time)

--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -468,10 +468,6 @@ class SmtIo:
 
         fields = stmt.split()
 
-        if fields[1] == "yosys-smt2-timeout":
-            self.timeout = int(fields[2])
-            assert self.timeout > 0
-
         if fields[1] == "yosys-smt2-nomem":
             if self.logic is None:
                 self.logic_ax = False

--- a/passes/sat/qbfsat.cc
+++ b/passes/sat/qbfsat.cc
@@ -41,7 +41,7 @@ struct QbfSolveOptions {
 	bool specialize, specialize_from_file, write_solution, nocleanup, dump_final_smt2, assume_outputs, assume_neg;
 	bool nooptimize, nobisection;
 	bool sat, unsat, show_smtbmc;
-	enum Solver{Z3, Yices} solver;
+	enum Solver{Z3, Yices, CVC4} solver;
 	std::string specialize_soln_file;
 	std::string write_soln_soln_file;
 	std::string dump_final_smt2_file;
@@ -57,6 +57,8 @@ std::string get_solver_name(const QbfSolveOptions &opt) {
 		return "z3";
 	else if (opt.solver == opt.Solver::Yices)
 		return "yices";
+	else if (opt.solver == opt.Solver::CVC4)
+		return "cvc4";
 	else
 		log_cmd_error("unknown solver specified.\n");
 	return "";
@@ -504,6 +506,8 @@ QbfSolveOptions parse_args(const std::vector<std::string> &args) {
 					opt.solver = opt.Solver::Z3;
 				else if (args[opt.argidx+1] == "yices")
 					opt.solver = opt.Solver::Yices;
+				else if (args[opt.argidx+1] == "cvc4")
+					opt.solver = opt.Solver::CVC4;
 				else
 					log_cmd_error("Unknown solver \"%s\".\n", args[opt.argidx+1].c_str());
 				opt.argidx++;
@@ -619,7 +623,7 @@ struct QbfSatPass : public Pass {
 		log("        quantified bitvector problems.\n");
 		log("\n");
 		log("    -solver <solver>\n");
-		log("        Use a particular solver. Choose one of: \"z3\", \"yices\".\n");
+		log("        Use a particular solver. Choose one of: \"z3\", \"yices\", and \"cvc4\".\n");
 		log("\n");
 		log("    -sat\n");
 		log("        Generate an error if the solver does not return \"sat\".\n");


### PR DESCRIPTION
Overview:
----
This PR adds support to `yosys-smtbmc` and `qbfsat` for setting solver timeouts.

This is mostly straightforward, ~but `yices-smt2` currently has [a bug](https://github.com/SRI-CSL/yices2/issues/210) that renders the proper command line argument mechanism for specifying a timeout ineffective.~

~The draft PR includes an additional commit to what is intended to merge that works around this issue by using the `timeout` program.  Obviously this is not portable and this workaround commit will be removed once the Yices issue is fixed.  Until then, the commit exists to help test Yosys and `yosys-smtbmc` behavior and the PR will remain as a draft.~

**Update**: Yices has been fixed and the workaround commit has been removed.  This PR is now ready for review.

Depends:
----
- [x] ~Fix for [Yices issue #210](https://github.com/SRI-CSL/yices2/issues/210)~ Yices >= git commit dc13a01fb366741b1b9221126b3ad8934e704aad
- [x] PR #1996 
- [x] PR #2015 
- [x] PR #2016
- [x] PR #2017 