### PR TITLE
Avoid switch fall-through warnings

### DIFF
--- a/backends/cxxrtl/cxxrtl.cc
+++ b/backends/cxxrtl/cxxrtl.cc
@@ -2346,16 +2346,22 @@ struct CxxrtlBackend : public Backend {
 			case 6:
 				worker.max_opt_level = true;
 				worker.run_proc_flatten = true;
+				YS_FALLTHROUGH
 			case 5:
 				worker.run_opt_clean_purge = true;
+				YS_FALLTHROUGH
 			case 4:
 				worker.localize_public = true;
+				YS_FALLTHROUGH
 			case 3:
 				worker.elide_public = true;
+				YS_FALLTHROUGH
 			case 2:
 				worker.localize_internal = true;
+				YS_FALLTHROUGH
 			case 1:
 				worker.elide_internal = true;
+				YS_FALLTHROUGH
 			case 0:
 				break;
 			default:

--- a/backends/cxxrtl/cxxrtl.cc
+++ b/backends/cxxrtl/cxxrtl.cc
@@ -1943,13 +1943,13 @@ struct CxxrtlWorker {
 						case RTLIL::STa:
 							break;
 
+						case RTLIL::STg:
+							log_cmd_error("Global clock is not supported.\n");
+
 						// Handling of init-type sync rules is delegated to the `proc_init` pass, so we can use the wire
 						// attribute regardless of input.
 						case RTLIL::STi:
 							log_assert(false);
-
-						case RTLIL::STg:
-							log_cmd_error("Global clock is not supported.\n");
 					}
 			}
 

--- a/backends/firrtl/firrtl.cc
+++ b/backends/firrtl/firrtl.cc
@@ -343,7 +343,7 @@ struct FirrtlWorker
 				switch (dir) {
 					case FD_INOUT:
 						log_warning("Instance port connection %s.%s is INOUT; treating as OUT\n", cell_type.c_str(), log_signal(it->second));
-						/* FALLTHRU */
+						YS_FALLTHROUGH
 					case FD_OUT:
 						sourceExpr = firstName;
 						sinkExpr = secondExpr;
@@ -351,7 +351,7 @@ struct FirrtlWorker
 						break;
 					case FD_NODIRECTION:
 						log_warning("Instance port connection %s.%s is NODIRECTION; treating as IN\n", cell_type.c_str(), log_signal(it->second));
-						/* FALLTHRU */
+						YS_FALLTHROUGH
 					case FD_IN:
 						sourceExpr = secondExpr;
 						sinkExpr = firstName;

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -923,7 +923,7 @@ void AstNode::detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *foun
 			}
 			break;
 		}
-		/* fall through */
+		YS_FALLTHROUGH
 
 	// everything should have been handled above -> print error if not.
 	default:
@@ -1019,7 +1019,7 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 		if (GetSize(children) >= 1 && children[0]->type == AST_CONSTANT) {
 			current_module->parameter_default_values[str] = children[0]->asParaConst();
 		}
-		/* fall through */
+		YS_FALLTHROUGH
 	case AST_LOCALPARAM:
 		if (flag_pwires)
 		{
@@ -1807,7 +1807,8 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 				is_signed = sign_hint;
 				return SigSpec(wire);
 			}
-		} /* fall through */
+		}
+		YS_FALLTHROUGH
 
 	// everything should have been handled above -> print error if not.
 	default:

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -91,7 +91,7 @@ std::string AstNode::process_format_str(const std::string &sformat, int next_arg
 				case 'D':
 					if (got_len)
 						goto unsupported_format;
-					/* fall through */
+					YS_FALLTHROUGH
 				case 'x':
 				case 'X':
 					if (next_arg >= GetSize(children))

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -155,6 +155,16 @@ extern Tcl_Obj *Tcl_ObjSetVar2(Tcl_Interp *interp, Tcl_Obj *part1Ptr, Tcl_Obj *p
 #  define YS_NORETURN
 #endif
 
+#if __cplusplus >= 201703L
+#  define YS_FALLTHROUGH [[fallthrough]];
+#elif defined(__GNUC__)
+#  define YS_FALLTHROUGH [[gnu::fallthrough]];
+#elif defined(__clang__)
+#  define YS_FALLTHROUGH [[clang::fallthrough]];
+#else
+#  define YS_FALLTHROUGH
+#endif
+
 YOSYS_NAMESPACE_BEGIN
 
 // Note: All headers included in hashlib.h must be included


### PR DESCRIPTION
Add a few comments and an unreachable `break` in cxxrtl to silence implicit fallthrough warnings. For some reason, the g++9 configuration on travis doesn't allow comments to [silence the warnings](https://travis-ci.org/github/YosysHQ/yosys/jobs/682632651#L661), even though this [should be enabled](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html) by `-Wextra`. Not that this is too big of a deal, but specifying the warning option explicitly might just fix it.