### PR TITLE
verilog: allow null gen-if then block

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -2533,7 +2533,12 @@ gen_stmt:
 		ast_stack.back()->children.push_back(node);
 		ast_stack.push_back(node);
 		ast_stack.back()->children.push_back($3);
-	} gen_stmt_block opt_gen_else {
+		AstNode *block = new AstNode(AST_GENBLOCK);
+		ast_stack.back()->children.push_back(block);
+		ast_stack.push_back(block);
+	} gen_stmt_or_null {
+		ast_stack.pop_back();
+	} opt_gen_else {
 		SET_AST_NODE_LOC(ast_stack.back(), @1, @7);
 		ast_stack.pop_back();
 	} |

--- a/tests/various/gen_if_null.v
+++ b/tests/various/gen_if_null.v
@@ -1,0 +1,13 @@
+module test(x, y, z);
+	localparam OFF = 0;
+	generate
+		if (OFF) ;
+		else input x;
+		if (!OFF) input y;
+		else ;
+		if (OFF) ;
+		else ;
+		if (OFF) ;
+		input z;
+	endgenerate
+endmodule

--- a/tests/various/gen_if_null.ys
+++ b/tests/various/gen_if_null.ys
@@ -1,0 +1,4 @@
+read_verilog gen_if_null.v
+select -assert-count 1 test/x
+select -assert-count 1 test/y
+select -assert-count 1 test/z


### PR DESCRIPTION
This addresses #2021. This wraps the then block of gen-ifs in an implicit block, similar to the strategy employed for procedural if statements. I am not sure if my strategy for "asserting" which branch is taken via the port bindings is reasonable. I am eager to receive any feedback you may have!