### PR TITLE
Remove yosys libdir from LDFLAGS (and fix a typo)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,6 @@ YOSYS_SRC := $(dir $(firstword $(MAKEFILE_LIST)))
 VPATH := $(YOSYS_SRC)
 
 CXXFLAGS := $(CXXFLAGS) -Wall -Wextra -ggdb -I. -I"$(YOSYS_SRC)" -MD -D_YOSYS_ -fPIC -I$(PREFIX)/include
-LDFLAGS := $(LDFLAGS) -L$(LIBDIR)
 LDLIBS := $(LDLIBS) -lstdc++ -lm
 PLUGIN_LDFLAGS :=
 
@@ -371,7 +370,7 @@ BOOST_PYTHON_LIB ?= $(shell \
 endif
 
 ifeq ($(BOOST_PYTHON_LIB),)
-$(error BOOST_PYTHON_LIB could not be detected. Please define manualy)
+$(error BOOST_PYTHON_LIB could not be detected. Please define manually)
 endif
 
 ifeq ($(OS), Darwin)


### PR DESCRIPTION
`$(LIBDIR)` is only created at install, so at best contains an older version of libyosys; and yosys is not linked against older versions of itself, so there is no reason to add it to linker flags. If no previous install with `ENABLE_LIBYOSYS := 1` was done, the directory doesn't exist at all and leads to a warning at build:
```
ld: warning: directory not found for option '-L/usr/local/lib/yosys'
```