### PR TITLE
Implementation of  SV structs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,8 @@ from SystemVerilog:
 - enums are supported (including inside packages)
 	- but are currently not strongly typed
 
+- structs are supported
+
 - SystemVerilog interfaces (SVIs) are supported. Modports for specifying whether
   ports are inputs or outputs are supported.
 

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -171,6 +171,8 @@ std::string AST::type2str(AstNodeType type)
 	X(AST_PACKAGE)
 	X(AST_WIRETYPE)
 	X(AST_TYPEDEF)
+	X(AST_STRUCT)
+	X(AST_STRUCT_ITEM)
 #undef X
 	default:
 		log_abort();

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -143,7 +143,7 @@ namespace AST
 		AST_GENCASE,
 		AST_GENBLOCK,
 		AST_TECALL,
-		
+
 		AST_POSEDGE,
 		AST_NEGEDGE,
 		AST_EDGE,
@@ -156,7 +156,9 @@ namespace AST
 		AST_PACKAGE,
 
 		AST_WIRETYPE,
-		AST_TYPEDEF
+		AST_TYPEDEF,
+		AST_STRUCT,
+		AST_STRUCT_ITEM
 	};
 
 	struct AstSrcLocType {
@@ -306,6 +308,7 @@ namespace AST
 
 		// helpers for enum
 		void allocateDefaultEnumValues();
+		void annotateTypedEnums(AstNode *template_node);
 	};
 
 	// process an AST tree (ast must point to an AST_DESIGN node) and generate RTLIL code

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -991,6 +991,7 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 	case AST_MODPORT:
 	case AST_MODPORTMEMBER:
 	case AST_TYPEDEF:
+	case AST_STRUCT:
 		break;
 	case AST_INTERFACEPORT: {
 		// If a port in a module with unknown type is found, mark it with the attribute 'is_interface'

--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -262,7 +262,9 @@ static bool isUserType(std::string &s)
 "final"      { SV_KEYWORD(TOK_FINAL); }
 "logic"      { SV_KEYWORD(TOK_LOGIC); }
 "var"        { SV_KEYWORD(TOK_VAR); }
-"bit"        { SV_KEYWORD(TOK_REG); }
+"bit"        { SV_KEYWORD(TOK_LOGIC); }
+"int"        { SV_KEYWORD(TOK_INT); }
+"byte"       { SV_KEYWORD(TOK_BYTE); }
 
 "eventually"   { if (formal_mode) return TOK_EVENTUALLY; SV_KEYWORD(TOK_EVENTUALLY); }
 "s_eventually" { if (formal_mode) return TOK_EVENTUALLY; SV_KEYWORD(TOK_EVENTUALLY); }
@@ -276,11 +278,14 @@ static bool isUserType(std::string &s)
 "reg"     { return TOK_REG; }
 "integer" { return TOK_INTEGER; }
 "signed"  { return TOK_SIGNED; }
+"unsigned" { SV_KEYWORD(TOK_UNSIGNED); }
 "genvar"  { return TOK_GENVAR; }
 "real"    { return TOK_REAL; }
 
 "enum"    { SV_KEYWORD(TOK_ENUM); }
 "typedef" { SV_KEYWORD(TOK_TYPEDEF); }
+"struct" { SV_KEYWORD(TOK_STRUCT); }
+"packed" { SV_KEYWORD(TOK_PACKED); }
 
 [0-9][0-9_]* {
 	yylval->string = new std::string(yytext);

--- a/tests/svtypes/struct_simple.sv
+++ b/tests/svtypes/struct_simple.sv
@@ -1,0 +1,39 @@
+module top;
+	localparam BITS=8;
+
+	struct packed {
+		logic a;
+		logic[BITS-1:0] b;
+		byte c;
+		logic x, y;
+	} s;
+
+	struct packed signed { 
+		integer a;
+		logic[15:0] b;
+		logic[7:0] c;
+		bit [7:0] d;
+	} pack1;
+
+	assign s.a = '1;
+	assign s.b = '1;
+	assign s.c = 8'hAA;
+	assign s.x = '1;
+	logic[7:0] t;
+	assign t = s.b;
+	assign pack1.a = 42;
+	assign pack1.b = 16'hAAAA;
+	assign pack1.c = '1;
+	assign pack1.d = 8'h55;
+
+	always_comb assert(s.a == 1'b1);
+	always_comb assert(s.c == 8'hAA);
+	always_comb assert(s.x == 1'b1);
+	always_comb assert(t == 8'hFF);
+	always_comb assert(pack1.a == 42);
+	always_comb assert(pack1.b == 16'hAAAA);
+	always_comb assert(pack1.c == 8'hFF);
+	always_comb assert(pack1[15:8] == 8'hFF);
+	always_comb assert(pack1.d == 8'h55);
+
+endmodule

--- a/tests/svtypes/typedef_struct.sv
+++ b/tests/svtypes/typedef_struct.sv
@@ -1,0 +1,42 @@
+package p;
+
+typedef struct packed {
+	byte a;
+	byte b;
+} p_t;
+
+endpackage
+
+
+module top;
+
+	typedef logic[7:0] t_t;
+
+	typedef struct packed {
+		bit		a;
+		logic[7:0]	b;
+		t_t		t;
+	} s_t;
+
+	s_t s;
+	s_t s1;
+
+	p::p_t ps;
+
+	assign s.a = '1;
+	assign s.b = '1;
+	assign s.t = 8'h55;
+	assign s1 = s;
+	assign ps.a = 8'hAA;
+	assign ps.b = 8'h55;
+
+	always_comb begin
+		assert(s.a == 1'b1);
+		assert(s.b == 8'hFF);
+		assert(s.t == 8'h55);
+		assert(s1.t == 8'h55);
+		assert(ps.a == 8'hAA);
+		assert(ps.b == 8'h55);
+	end
+
+endmodule


### PR DESCRIPTION
This implements SV packed structures by generating a wire sized to hold all the members packed contiguously.  References to members are rewritten as range operations on that wire.