### PR TITLE
verilog: allow attributes on behavioural statements (including null statement)

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -2230,7 +2230,6 @@ behavioral_stmt:
 	non_opt_delay behavioral_stmt |
 	attr simple_behavioral_stmt ';' |
 	attr ';' {
-		log_file_warning(current_filename, get_line_num(), "Attribute(s) attached to null statement. Ignoring.\n");
 		free_attr($1);
 	} |
 	attr hierarchical_id {
@@ -2534,7 +2533,6 @@ module_gen_body:
 gen_stmt_or_module_body_stmt:
 	gen_stmt | module_body_stmt |
 	attr ';' {
-		log_file_warning(current_filename, get_line_num(), "Attribute(s) attached to null statement. Ignoring.\n");
 		free_attr($1);
 	};
 

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -2228,7 +2228,11 @@ simple_behavioral_stmt:
 behavioral_stmt:
 	defattr | assert | wire_decl | param_decl | localparam_decl | typedef_decl |
 	non_opt_delay behavioral_stmt |
-	attr simple_behavioral_stmt ';' | ';' |
+	attr simple_behavioral_stmt ';' |
+	attr ';' {
+		log_file_warning(current_filename, get_line_num(), "Attribute(s) attached to null statement. Ignoring.\n");
+		free_attr($1);
+	} |
 	attr hierarchical_id {
 		AstNode *node = new AstNode(AST_TCALL);
 		node->str = *$2;

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -2203,32 +2203,36 @@ assert_property:
 	};
 
 simple_behavioral_stmt:
-	lvalue '=' delay expr {
-		AstNode *node = new AstNode(AST_ASSIGN_EQ, $1, $4);
+	attr lvalue '=' delay expr {
+		AstNode *node = new AstNode(AST_ASSIGN_EQ, $2, $5);
 		ast_stack.back()->children.push_back(node);
-		SET_AST_NODE_LOC(node, @1, @4);
+		SET_AST_NODE_LOC(node, @2, @5);
+		append_attr(node, $1);
 	} |
-	lvalue TOK_INCREMENT {
-		AstNode *node = new AstNode(AST_ASSIGN_EQ, $1, new AstNode(AST_ADD, $1->clone(), AstNode::mkconst_int(1, true)));
+	attr lvalue TOK_INCREMENT {
+		AstNode *node = new AstNode(AST_ASSIGN_EQ, $2, new AstNode(AST_ADD, $2->clone(), AstNode::mkconst_int(1, true)));
 		ast_stack.back()->children.push_back(node);
-		SET_AST_NODE_LOC(node, @1, @2);
+		SET_AST_NODE_LOC(node, @2, @3);
+		append_attr(node, $1);
 	} |
-	lvalue TOK_DECREMENT {
-		AstNode *node = new AstNode(AST_ASSIGN_EQ, $1, new AstNode(AST_SUB, $1->clone(), AstNode::mkconst_int(1, true)));
+	attr lvalue TOK_DECREMENT {
+		AstNode *node = new AstNode(AST_ASSIGN_EQ, $2, new AstNode(AST_SUB, $2->clone(), AstNode::mkconst_int(1, true)));
 		ast_stack.back()->children.push_back(node);
-		SET_AST_NODE_LOC(node, @1, @2);
+		SET_AST_NODE_LOC(node, @2, @3);
+		append_attr(node, $1);
 	} |
-	lvalue OP_LE delay expr {
-		AstNode *node = new AstNode(AST_ASSIGN_LE, $1, $4);
+	attr lvalue OP_LE delay expr {
+		AstNode *node = new AstNode(AST_ASSIGN_LE, $2, $5);
 		ast_stack.back()->children.push_back(node);
-		SET_AST_NODE_LOC(node, @1, @4);
+		SET_AST_NODE_LOC(node, @2, @5);
+		append_attr(node, $1);
 	};
 
 // this production creates the obligatory if-else shift/reduce conflict
 behavioral_stmt:
 	defattr | assert | wire_decl | param_decl | localparam_decl | typedef_decl |
 	non_opt_delay behavioral_stmt |
-	attr simple_behavioral_stmt ';' |
+	simple_behavioral_stmt ';' |
 	attr ';' {
 		free_attr($1);
 	} |

--- a/tests/verilog/bug2037.ys
+++ b/tests/verilog/bug2037.ys
@@ -41,3 +41,18 @@ module test ();
 endmodule
 EOT
 select -assert-none a:*
+
+
+design -reset
+read_verilog <<EOT
+module test ();
+	localparam y = 1;
+	reg x = 1'b0;
+	always @(*) begin
+		if (y)
+			(* foo *) x <= 1'b1;
+		else
+			(* bar *) x = 1'b0;
+	end
+endmodule
+EOT

--- a/tests/verilog/bug2037.ys
+++ b/tests/verilog/bug2037.ys
@@ -7,3 +7,37 @@ module test ();
 		if (y) (* foo *) ;
 endmodule
 EOT
+
+
+design -reset
+logger -expect warning "Attribute\(s\) attached to null statement\. Ignoring\." 3 # cumulative
+logger -expect-no-warnings
+read_verilog <<EOT
+module test ();
+	localparam y = 1;
+	always @(*)
+		if (y) (* foo *) ; else (* bar *) ;
+endmodule
+EOT
+
+
+design -reset
+logger -expect warning "Attribute\(s\) attached to null statement\. Ignoring\." 4 # cumulative
+logger -expect-no-warnings
+read_verilog <<EOT
+module test ();
+	localparam y = 1;
+    generate if (y) (* foo *) ; endgenerate
+endmodule
+EOT
+
+
+design -reset
+logger -expect warning "Attribute\(s\) attached to null statement\. Ignoring\." 6 # cumulative
+logger -expect-no-warnings
+read_verilog <<EOT
+module test ();
+	localparam y = 1;
+    generate if (y) (* foo *) ; else (* bar *); endgenerate
+endmodule
+EOT

--- a/tests/verilog/bug2037.ys
+++ b/tests/verilog/bug2037.ys
@@ -1,4 +1,3 @@
-logger -expect warning "Attribute\(s\) attached to null statement\. Ignoring\." 1
 logger -expect-no-warnings
 read_verilog <<EOT
 module test ();
@@ -7,10 +6,10 @@ module test ();
 		if (y) (* foo *) ;
 endmodule
 EOT
+select -assert-none a:* a:src %d
 
 
 design -reset
-logger -expect warning "Attribute\(s\) attached to null statement\. Ignoring\." 3 # cumulative
 logger -expect-no-warnings
 read_verilog <<EOT
 module test ();
@@ -19,10 +18,10 @@ module test ();
 		if (y) (* foo *) ; else (* bar *) ;
 endmodule
 EOT
+select -assert-none a:* a:src %d
 
 
 design -reset
-logger -expect warning "Attribute\(s\) attached to null statement\. Ignoring\." 4 # cumulative
 logger -expect-no-warnings
 read_verilog <<EOT
 module test ();
@@ -30,10 +29,10 @@ module test ();
     generate if (y) (* foo *) ; endgenerate
 endmodule
 EOT
+select -assert-none a:*
 
 
 design -reset
-logger -expect warning "Attribute\(s\) attached to null statement\. Ignoring\." 6 # cumulative
 logger -expect-no-warnings
 read_verilog <<EOT
 module test ();
@@ -41,3 +40,4 @@ module test ();
     generate if (y) (* foo *) ; else (* bar *); endgenerate
 endmodule
 EOT
+select -assert-none a:*

--- a/tests/verilog/bug2037.ys
+++ b/tests/verilog/bug2037.ys
@@ -1,0 +1,9 @@
+logger -expect warning "Attribute\(s\) attached to null statement\. Ignoring\." 1
+logger -expect-no-warnings
+read_verilog <<EOT
+module test ();
+	localparam y = 1;
+	always @(*)
+		if (y) (* foo *) ;
+endmodule
+EOT


### PR DESCRIPTION
Fixes #2037. 

To support the null statement I had to remove the `gen_stmt_or_null` rule as modifying it to allow attributes created a shift/reduce conflict.