### PR TITLE
verilog: error if no direction given for task arguments, default to input in SV mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -780,6 +780,7 @@ test: $(TARGETS) $(EXTRA_TARGETS)
 	+cd tests/arch/intel_alm && bash run-test.sh $(SEEDOPT)
 	+cd tests/rpc && bash run-test.sh
 	+cd tests/memfile && bash run-test.sh
+	+cd tests/verilog && bash run-test.sh
 	@echo ""
 	@echo "  Passed \"make test\"."
 	@echo ""

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -853,7 +853,11 @@ task_func_port:
 		}
 		if (astbuf2 && astbuf2->children.size() != 2)
 			frontend_verilog_yyerror("task/function argument range must be of the form: [<expr>:<expr>], [<expr>+:<expr>], or [<expr>-:<expr>]");
-	} wire_name | wire_name;
+	} wire_name |
+	{
+		if (!astbuf1)
+			frontend_verilog_yyerror("Non-ANSI style task/function arguments not currently supported");
+	} wire_name;
 
 task_func_body:
 	task_func_body behavioral_stmt |

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -855,8 +855,16 @@ task_func_port:
 			frontend_verilog_yyerror("task/function argument range must be of the form: [<expr>:<expr>], [<expr>+:<expr>], or [<expr>-:<expr>]");
 	} wire_name |
 	{
-		if (!astbuf1)
-			frontend_verilog_yyerror("Non-ANSI style task/function arguments not currently supported");
+		if (!astbuf1) {
+			if (!sv_mode)
+				frontend_verilog_yyerror("task/function argument direction missing");
+			albuf = new dict<IdString, AstNode*>;
+			astbuf1 = new AstNode(AST_WIRE);
+			current_wire_rand = false;
+			current_wire_const = false;
+			astbuf1->is_input = true;
+			astbuf2 = NULL;
+		}
 	} wire_name;
 
 task_func_body:

--- a/tests/verilog/.gitignore
+++ b/tests/verilog/.gitignore
@@ -1,0 +1,3 @@
+/*.log
+/*.out
+/run-test.mk

--- a/tests/verilog/bug2042-sv.ys
+++ b/tests/verilog/bug2042-sv.ys
@@ -21,6 +21,31 @@ sat -verify -prove-asserts
 
 
 design -reset
+read_verilog -sv <<EOT
+module Task_Test_Top
+(
+input a,
+output b, c
+);
+
+    task SomeTaskName(x, output y, z);
+       y = ~x;
+       z = x;
+    endtask
+
+    always @*
+        SomeTaskName(a, b, c);
+
+    assert property (b == ~a);
+    assert property (c == a);
+
+endmodule
+EOT
+proc
+sat -verify -prove-asserts
+
+
+design -reset
 logger -expect error "syntax error, unexpected TOK_ENDTASK, expecting ';'" 1
 read_verilog -sv <<EOT
 module Task_Test_Top

--- a/tests/verilog/bug2042-sv.ys
+++ b/tests/verilog/bug2042-sv.ys
@@ -1,0 +1,34 @@
+read_verilog -sv <<EOT
+module Task_Test_Top
+(
+input a,
+output b
+);
+
+    task SomeTaskName(a);
+       b = ~a;
+    endtask
+
+    always @*
+        SomeTaskName(a);
+
+    assert property (b == ~a);
+
+endmodule
+EOT
+proc
+sat -verify -prove-asserts
+
+
+design -reset
+logger -expect error "syntax error, unexpected TOK_ENDTASK, expecting ';'" 1
+read_verilog -sv <<EOT
+module Task_Test_Top
+(
+);
+
+    task SomeTaskName(a)
+    endtask
+
+endmodule
+EOT

--- a/tests/verilog/bug2042.ys
+++ b/tests/verilog/bug2042.ys
@@ -1,4 +1,4 @@
-logger -expect error "Non-ANSI style task/function arguments not currently supported" 1
+logger -expect error "task/function argument direction missing" 1
 read_verilog <<EOT
 module Task_Test_Top
 (
@@ -9,4 +9,3 @@ module Task_Test_Top
 
 endmodule
 EOT
-

--- a/tests/verilog/bug2042.ys
+++ b/tests/verilog/bug2042.ys
@@ -1,0 +1,12 @@
+logger -expect error "Non-ANSI style task/function arguments not currently supported" 1
+read_verilog <<EOT
+module Task_Test_Top
+(
+);
+
+    task SomeTaskName(a)
+    endtask
+
+endmodule
+EOT
+

--- a/tests/verilog/run-test.sh
+++ b/tests/verilog/run-test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+{
+echo "all::"
+for x in *.ys; do
+	echo "all:: run-$x"
+	echo "run-$x:"
+	echo "	@echo 'Running $x..'"
+	echo "	@../../yosys -ql ${x%.ys}.log $x"
+done
+for s in *.sh; do
+	if [ "$s" != "run-test.sh" ]; then
+		echo "all:: run-$s"
+		echo "run-$s:"
+		echo "	@echo 'Running $s..'"
+		echo "	@bash $s"
+	fi
+done
+} > run-test.mk
+exec ${MAKE:-make} -f run-test.mk


### PR DESCRIPTION
Fixes #2042.

~Supporting this is left as a future enhancement.~