### PR TITLE
`rm -rf abc/` during clean see #1028

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -860,6 +860,7 @@ manual: $(TARGETS) $(EXTRA_TARGETS)
 	cd manual && bash manual.sh
 
 clean:
+	rm -rf abc/
 	rm -rf share
 	rm -rf kernel/*.pyh
 	if test -d manual; then cd manual && sh clean.sh; fi


### PR DESCRIPTION
This addresses problem seen in https://github.com/YosysHQ/yosys/issues/1028

Note the `abc/` directory is already in [.gitignore](https://github.com/YosysHQ/yosys/blob/master/.gitignore#L19) and is not in the current repo (but apparently has a hidden git clone to fetch it, specifically version fd2c9b1c).

I had added a `mkdir -p abc` to avoid a `/bin/sh: 1: cd: can't cd to abc` warning during `make`:

```
...snip...
[ 88%] Building techlibs/gowin/synth_gowin.o
[ 88%] Building techlibs/gowin/determine_init.o
[ 89%] Building techlibs/sf2/synth_sf2.o
[ 89%] Building techlibs/sf2/sf2_iobs.o
[100%] Building yosys
[100%] Building yosys-config
[100%] Building abc/abc-fd2c9b1
/bin/sh: 1: cd: can't cd to abc
Pulling ABC from https://github.com/YosysHQ/abc:
+ test -d abc
+ git clone https://github.com/YosysHQ/abc abc
Cloning into 'abc'...
remote: Enumerating objects: 35, done.
remote: Counting objects: 100% (35/35), done.
remote: Compressing objects: 100% (27/27), done.
remote: Total 58254 (delta 20), reused 13 (delta 8), pack-reused 58219
Receiving objects: 100% (58254/58254), 41.51 MiB | 738.00 KiB/s, done.
Resolving deltas: 100% (49774/49774), done.
Checking out files: 100% (1750/1750), done.
+ cd abc
+ make DEP= clean
make[1]: Entering directory '/mnt/c/workspace/yosys-clean/abc'
Using CC=gcc
Using CXX=g++
Using AR=ar
Using LD=g++
Compiling with CUDD
Using libreadline
Using pthreads
Found GCC_VERSION 7
Found GCC_MAJOR>=5
Using CFLAGS=-Wall -Wno-unused-function -Wno-write-strings -Wno-sign-compare -DLIN64 -DSIZEOF_VOID_P=8 -DSIZEOF_LONG=8 -DSIZEOF_INT=4 -DABC_USE_CUDD=1 -DABC_USE_READLINE  -DABC_USE_PTHREADS -Wno-unused-but-set-variable
`` Cleaning up...
removed 'arch_flags'
make[1]: Leaving directory '/mnt/c/workspace/yosys-clean/abc'
+ git fetch https://github.com/YosysHQ/abc
From https://github.com/YosysHQ/abc
 * branch              HEAD       -> FETCH_HEAD
+ git checkout fd2c9b1
Note: checking out 'fd2c9b1'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at fd2c9b1c Remove ABC_NO_RLIMIT macro, use defined(__wasm) instead.
[ 95%] ABC: Using CC=clang
[ 95%] ABC: Using CXX=clang
[ 95%] ABC: Using AR=ar
...snip...
```
however that caused problems of its own, so I left it to just remove the abc directory (and the hidden .files there)