### PR TITLE
opt_clean: remove (* init *) regardless of -purge, remove (* init *) when consistent with sigmap, clean to behave identically

### DIFF
--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -473,7 +473,7 @@ bool rmunused_module_init(RTLIL::Module *module, bool verbose)
 					goto next_wire;
 
 				if (mapped_wire_bit != init[i]) {
-					log_warning("Initial value conflict for wire '%s' and value '%s'.\n", log_signal(wire_bit), log_signal(mapped_wire_bit));
+					log_warning("Initial value conflict for %s resolving to %s but with init %s.\n", log_signal(wire_bit), log_signal(mapped_wire_bit), log_signal(init[i]));
 					goto next_wire;
 				}
 			}

--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -412,7 +412,7 @@ bool rmunused_module_signals(RTLIL::Module *module, bool purge_mode, bool verbos
 	return !del_wires_queue.empty();
 }
 
-bool rmunused_module_init(RTLIL::Module *module, bool purge_mode, bool verbose)
+bool rmunused_module_init(RTLIL::Module *module, bool verbose)
 {
 	bool did_something = false;
 	CellTypes fftypes;
@@ -445,9 +445,6 @@ bool rmunused_module_init(RTLIL::Module *module, bool purge_mode, bool verbose)
 
 	for (auto wire : module->wires())
 	{
-		if (!purge_mode && wire->name[0] == '\\')
-			continue;
-
 		if (wire->attributes.count(ID::init) == 0)
 			continue;
 
@@ -464,11 +461,22 @@ bool rmunused_module_init(RTLIL::Module *module, bool purge_mode, bool verbose)
 			if (wire_bit == mapped_wire_bit)
 				goto next_wire;
 
-			if (qbits.count(sigmap(SigBit(wire, i))) == 0)
-				goto next_wire;
+			if (mapped_wire_bit.wire) {
+				if (qbits.count(mapped_wire_bit) == 0)
+					goto next_wire;
 
-			if (qbits.at(sigmap(SigBit(wire, i))) != init[i])
-				goto next_wire;
+				if (qbits.at(mapped_wire_bit) != init[i])
+					goto next_wire;
+			}
+			else {
+				if (mapped_wire_bit == State::Sx || mapped_wire_bit == State::Sz)
+					goto next_wire;
+
+				if (mapped_wire_bit != init[i]) {
+					log_warning("Initial value conflict for wire '%s' and value '%s'.\n", log_signal(wire_bit), log_signal(mapped_wire_bit));
+					goto next_wire;
+				}
+			}
 		}
 
 		if (verbose)
@@ -512,7 +520,7 @@ void rmunused_module(RTLIL::Module *module, bool purge_mode, bool verbose, bool 
 	rmunused_module_cells(module, verbose);
 	while (rmunused_module_signals(module, purge_mode, verbose)) { }
 
-	if (rminit && rmunused_module_init(module, purge_mode, verbose))
+	if (rminit && rmunused_module_init(module, verbose))
 		while (rmunused_module_signals(module, purge_mode, verbose)) { }
 }
 

--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -611,8 +611,7 @@ struct CleanPass : public Pass {
 			}
 			break;
 		}
-		if (argidx < args.size())
-			extra_args(args, argidx, design);
+		extra_args(args, argidx, design);
 
 		keep_cache.reset(design);
 
@@ -627,7 +626,7 @@ struct CleanPass : public Pass {
 		for (auto module : design->selected_whole_modules()) {
 			if (module->has_processes())
 				continue;
-			rmunused_module(module, purge_mode, ys_debug(), false);
+			rmunused_module(module, purge_mode, ys_debug(), true);
 		}
 
 		log_suppressed();

--- a/tests/opt/opt_clean_init.ys
+++ b/tests/opt/opt_clean_init.ys
@@ -1,0 +1,13 @@
+logger -expect warning "Initial value conflict for wire '\\y' and value '1'0'" 1
+logger -expect-no-warnings
+read_verilog <<EOT
+module top;
+(* init=1'b0 *) wire w = 1'b0;
+(* init=1'bx *) wire x = 1'b0;
+(* init=1'b1 *) wire y = 1'b0;
+(* init=1'b0 *) wire z = 1'bx;
+endmodule
+EOT
+clean
+select -assert-count 1 a:init
+select -assert-count 1 w:y a:init %i

--- a/tests/opt/opt_clean_init.ys
+++ b/tests/opt/opt_clean_init.ys
@@ -1,4 +1,4 @@
-logger -expect warning "Initial value conflict for wire '\\y' and value '1'0'" 1
+logger -expect warning "Initial value conflict for \\y resolving to 1'0 but with init 1'1" 1
 logger -expect-no-warnings
 read_verilog <<EOT
 module top;


### PR DESCRIPTION
* Remove `(* init *)` on public signals regardless of `-purge` option -- since we're not removing signals, we're just removing redundant information
* Remove `(* init *)` when consistent with the sigmap (constant) result, see testcase
* `clean` was not behaving identically to `opt_clean` as per documentation, since it didn't invoke this `init` removal