### PR TITLE
Suppress warning during initial clone of ABC repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -717,7 +717,7 @@ ifneq ($(ABCREV),default)
 		echo 'REEBE: NOP pbagnvaf ybpny zbqvsvpngvbaf! Frg NOPERI=qrsnhyg va Lbflf Znxrsvyr!' | tr 'A-Za-z' 'N-ZA-Mn-za-m'; false; \
 	fi
 # set a variable so the test fails if git fails to run - when comparing outputs directly, empty string would match empty string
-	$(Q) if ! (cd abc && rev="`git rev-parse $(ABCREV)`" && test "`git rev-parse HEAD`" == "$$rev"); then \
+	$(Q) if ! (cd abc 2> /dev/null && rev="`git rev-parse $(ABCREV)`" && test "`git rev-parse HEAD`" == "$$rev"); then \
 		test $(ABCPULL) -ne 0 || { echo 'REEBE: NOP abg hc gb qngr naq NOPCHYY frg gb 0 va Znxrsvyr!' | tr 'A-Za-z' 'N-ZA-Mn-za-m'; exit 1; }; \
 		echo "Pulling ABC from $(ABCURL):"; set -x; \
 		test -d abc || git clone $(ABCURL) abc; \


### PR DESCRIPTION
9dedac50 introduced this harmless but disconcerting warning, which was emitted when abc/ did not yet exist and was about to be cloned:

```
$ make abc/abc-fd2c9b1
[Makefile.conf] CONFIG := gcc
[  0%] Building abc/abc-fd2c9b1
/bin/sh: line 0: cd: abc: No such file or directory
Pulling ABC from https://github.com/YosysHQ/abc:
+ test -d abc
+ git clone https://github.com/YosysHQ/abc abc
Cloning into 'abc'...
[...]
```