### PR TITLE
Add support for non-power-of-two mem chunks in verific importer

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -1265,13 +1265,18 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::se
 			int numchunks = int(inst->OutputSize()) / memory->width;
 			int chunksbits = ceil_log2(numchunks);
 
-			if ((numchunks * memory->width) != int(inst->OutputSize()) || (numchunks & (numchunks - 1)) != 0)
+			if ((numchunks * memory->width) != int(inst->OutputSize()))
 				log_error("Import of asymmetric memories of this type is not supported yet: %s %s\n", inst->Name(), inst->GetInput()->Name());
 
 			for (int i = 0; i < numchunks; i++)
 			{
 				RTLIL::SigSpec addr = {operatorInput1(inst), RTLIL::Const(i, chunksbits)};
 				RTLIL::SigSpec data = operatorOutput(inst).extract(i * memory->width, memory->width);
+
+				if ((numchunks & (numchunks - 1)) != 0) {
+					addr = module->Mul(NEW_ID, operatorInput1(inst), RTLIL::Const(numchunks));
+					addr = module->Add(NEW_ID, addr, RTLIL::Const(i));
+				}
 
 				RTLIL::Cell *cell = module->addCell(numchunks == 1 ? inst_name :
 						RTLIL::IdString(stringf("%s_%d", inst_name.c_str(), i)), ID($memrd));
@@ -1295,13 +1300,18 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::se
 			int numchunks = int(inst->Input2Size()) / memory->width;
 			int chunksbits = ceil_log2(numchunks);
 
-			if ((numchunks * memory->width) != int(inst->Input2Size()) || (numchunks & (numchunks - 1)) != 0)
+			if ((numchunks * memory->width) != int(inst->Input2Size()))
 				log_error("Import of asymmetric memories of this type is not supported yet: %s %s\n", inst->Name(), inst->GetOutput()->Name());
 
 			for (int i = 0; i < numchunks; i++)
 			{
 				RTLIL::SigSpec addr = {operatorInput1(inst), RTLIL::Const(i, chunksbits)};
 				RTLIL::SigSpec data = operatorInput2(inst).extract(i * memory->width, memory->width);
+
+				if ((numchunks & (numchunks - 1)) != 0) {
+					addr = module->Mul(NEW_ID, operatorInput1(inst), RTLIL::Const(numchunks));
+					addr = module->Add(NEW_ID, addr, RTLIL::Const(i));
+				}
 
 				RTLIL::Cell *cell = module->addCell(numchunks == 1 ? inst_name :
 						RTLIL::IdString(stringf("%s_%d", inst_name.c_str(), i)), ID($memwr));


### PR DESCRIPTION
Test case:

```
module test (
	input  logic clock,        
	input  logic reset,
	input  logic [0:0] A,
	input  logic [1:0] B,
	input  logic [2:0] C,
	input  logic [15:0] din,
	output logic [15:0] dout
);
	logic [15:0] mem [0:1][0:3][0:5];

	always @(posedge clock) begin
		if (reset) begin
			for (int I = 0; I < 2; I++)
			for (int K = 0; K < 4; K++)
				mem[I][K] <= '{default:0};
		end else begin
			dout <= mem[A][B][C];
			mem[A][B][C] <= din;
		end
	end
endmodule
```