### PR TITLE
smtbmc: Fix return status handling.

### DIFF
--- a/backends/smt2/smtbmc.py
+++ b/backends/smt2/smtbmc.py
@@ -1511,7 +1511,7 @@ else:  # not tempind, covermode
                             smt_assert_consequent(get_constr_expr(constr_assumes, i))
                         print_msg("Re-solving with appended steps..")
                         if smt_check_sat() == "unsat":
-                            print("%s Cannot appended steps without violating assumptions!" % smt.timestamp())
+                            print("%s Cannot append steps without violating assumptions!" % smt.timestamp())
                             retstatus = "FAILED"
                             break
                     print_anyconsts(step)

--- a/backends/smt2/smtbmc.py
+++ b/backends/smt2/smtbmc.py
@@ -1548,7 +1548,7 @@ else:  # not tempind, covermode
                         break
 
                     smt_pop()
-                if not retstatus:
+                if retstatus == "FAILED" or retstatus == "PREUNSAT":
                     break
 
         else:  # gentrace
@@ -1568,7 +1568,7 @@ else:  # not tempind, covermode
 
         step += step_size
 
-    if gentrace and retstatus:
+    if gentrace and retstatus == "PASSED":
         print_anyconsts(0)
         write_trace(0, num_steps, '%')
 


### PR DESCRIPTION
It looks like `retstatus` was changed in 2ed2e9c3e but these lines were not updated.