### PR TITLE
log: Use `std::set` instead of `std::vector` for `log_expect_{error, warning, log}` to better express the intent that each element is unique.

### DIFF
--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -42,7 +42,7 @@ std::vector<FILE*> log_files;
 std::vector<std::ostream*> log_streams;
 std::map<std::string, std::set<std::string>> log_hdump;
 std::vector<YS_REGEX_TYPE> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
-std::vector<std::pair<YS_REGEX_TYPE,LogExpectedItem>> log_expect_log, log_expect_warning, log_expect_error;
+std::set<std::pair<YS_REGEX_TYPE,LogExpectedItem>> log_expect_log, log_expect_warning, log_expect_error;
 std::set<std::string> log_warnings, log_experimentals, log_experimentals_ignored;
 int log_warnings_count = 0;
 int log_warnings_count_noexpect = 0;

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -214,7 +214,7 @@ struct LogExpectedItem
 	std::string pattern;
 };
 
-extern std::vector<std::pair<YS_REGEX_TYPE,LogExpectedItem>> log_expect_log, log_expect_warning, log_expect_error;
+extern std::set<std::pair<YS_REGEX_TYPE,LogExpectedItem>> log_expect_log, log_expect_warning, log_expect_error;
 void log_check_expected();
 
 const char *log_signal(const RTLIL::SigSpec &sig, bool autoint = true);

--- a/passes/cmds/logger.cc
+++ b/passes/cmds/logger.cc
@@ -168,7 +168,7 @@ struct LoggerPass : public Pass {
 								break;
 							}
 						if (it == ie)
-							log_expect_error.emplace_back(YS_REGEX_COMPILE(pattern), LogExpectedItem(pattern, count));
+							log_expect_error.insert(YS_REGEX_COMPILE(pattern), LogExpectedItem(pattern, count));
 					}
 					else if (type=="warning") {
 						auto it = log_expect_warning.begin();
@@ -179,7 +179,7 @@ struct LoggerPass : public Pass {
 								break;
 							}
 						if (it == ie)
-							log_expect_warning.emplace_back(YS_REGEX_COMPILE(pattern), LogExpectedItem(pattern, count));
+							log_expect_warning.insert(YS_REGEX_COMPILE(pattern), LogExpectedItem(pattern, count));
 					}
 					else if (type=="log") {
 						auto it = log_expect_log.begin();
@@ -190,7 +190,7 @@ struct LoggerPass : public Pass {
 								break;
 							}
 						if (it == ie)
-							log_expect_log.emplace_back(YS_REGEX_COMPILE(pattern), LogExpectedItem(pattern, count));
+							log_expect_log.insert(YS_REGEX_COMPILE(pattern), LogExpectedItem(pattern, count));
 					}
 					else log_abort();
 				}


### PR DESCRIPTION
See https://github.com/YosysHQ/yosys/pull/2055#discussion_r425470742 .