### PR TITLE
verilog: support attributes before (not after) task identifier (but 13 s/r conflicts)

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -2217,23 +2217,23 @@ behavioral_stmt:
 	defattr | assert | wire_decl | param_decl | localparam_decl | typedef_decl |
 	non_opt_delay behavioral_stmt |
 	simple_behavioral_stmt ';' | ';' |
-	hierarchical_id attr {
+	attr hierarchical_id {
 		AstNode *node = new AstNode(AST_TCALL);
-		node->str = *$1;
-		delete $1;
+		node->str = *$2;
+		delete $2;
 		ast_stack.back()->children.push_back(node);
 		ast_stack.push_back(node);
-		append_attr(node, $2);
+		append_attr(node, $1);
 	} opt_arg_list ';'{
 		ast_stack.pop_back();
 	} |
-	TOK_MSG_TASKS attr {
+	attr TOK_MSG_TASKS {
 		AstNode *node = new AstNode(AST_TCALL);
-		node->str = *$1;
-		delete $1;
+		node->str = *$2;
+		delete $2;
 		ast_stack.back()->children.push_back(node);
 		ast_stack.push_back(node);
-		append_attr(node, $2);
+		append_attr(node, $1);
 	} opt_arg_list ';'{
 		ast_stack.pop_back();
 	} |
@@ -2329,8 +2329,6 @@ behavioral_stmt:
 		case_type_stack.pop_back();
 		ast_stack.pop_back();
 	};
-
-	;
 
 unique_case_attr:
 	/* empty */ {

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -2216,7 +2216,7 @@ simple_behavioral_stmt:
 behavioral_stmt:
 	defattr | assert | wire_decl | param_decl | localparam_decl | typedef_decl |
 	non_opt_delay behavioral_stmt |
-	simple_behavioral_stmt ';' | ';' |
+	attr simple_behavioral_stmt ';' | ';' |
 	attr hierarchical_id {
 		AstNode *node = new AstNode(AST_TCALL);
 		node->str = *$2;

--- a/tests/verilog/task_attr.ys
+++ b/tests/verilog/task_attr.ys
@@ -1,0 +1,28 @@
+read_verilog <<EOT
+module top;
+    task foo;
+    endtask
+
+    always @*
+        (* foo *) foo;
+
+    initial
+        if (0) $info("bar");
+endmodule
+EOT
+# Since task enables are not an RTLIL object,
+#   any attributes on their AST get dropped
+select -assert-none a:* a:src %d
+
+
+logger -expect error "syntax error, unexpected ATTR_BEGIN" 1
+design -reset
+read_verilog <<EOT
+module top;
+    task foo;
+    endtask
+
+    always @*
+        foo (* foo *);
+endmodule
+EOT


### PR DESCRIPTION
Attributes go after the function identifier for function calls, but before the task identifier for task enable statements.

This fixes it, but introduces 13 shift-reduce conflicts. Can someone smarter than I help me figure out where the conflict is please?
EDIT: Actually, it goes further and breaks a task related test...

Potentially blocking #2044 which also has 13 shift-reduce conflicts when I try and add support for attributes for `simple_behavioural_stmt`.