### PR TITLE
log: Use `dict` instead of `std::vector<std::pair>` for `log_expect_{error, warning, log}` to better express the intent that each element is unique.

### DIFF
--- a/kernel/log.h
+++ b/kernel/log.h
@@ -202,19 +202,16 @@ void log_flush();
 
 struct LogExpectedItem
 {
-	LogExpectedItem(std::string pattern, int expected) :
-		expected_count(expected),
-		current_count(0),
-		pattern(pattern)
-	{
-	}
+	LogExpectedItem(const YS_REGEX_TYPE &pat, int expected) :
+			pattern(pat), expected_count(expected), current_count(0) {}
+	LogExpectedItem() : expected_count(0), current_count(0) {}
 
+	YS_REGEX_TYPE pattern;
 	int expected_count;
 	int current_count;
-	std::string pattern;
 };
 
-extern std::vector<std::pair<YS_REGEX_TYPE,LogExpectedItem>> log_expect_log, log_expect_warning, log_expect_error;
+extern dict<std::string, LogExpectedItem> log_expect_log, log_expect_warning, log_expect_error;
 void log_check_expected();
 
 const char *log_signal(const RTLIL::SigSpec &sig, bool autoint = true);

--- a/passes/cmds/logger.cc
+++ b/passes/cmds/logger.cc
@@ -159,39 +159,12 @@ struct LoggerPass : public Pass {
 					log_cmd_error("Expected error message occurrences must be 1 !\n");
 				log("Added regex '%s' for warnings to expected %s list.\n", pattern.c_str(), type.c_str());
 				try {
-					if (type=="error") {
-						auto it = log_expect_error.begin();
-						auto ie = log_expect_error.end();
-						for (; it != ie; it++)
-							if (it->second.pattern == pattern) {
-								it->second.expected_count = count;
-								break;
-							}
-						if (it == ie)
-							log_expect_error.emplace_back(YS_REGEX_COMPILE(pattern), LogExpectedItem(pattern, count));
-					}
-					else if (type=="warning") {
-						auto it = log_expect_warning.begin();
-						auto ie = log_expect_warning.end();
-						for (; it != ie; it++)
-							if (it->second.pattern == pattern) {
-								it->second.expected_count = count;
-								break;
-							}
-						if (it == ie)
-							log_expect_warning.emplace_back(YS_REGEX_COMPILE(pattern), LogExpectedItem(pattern, count));
-					}
-					else if (type=="log") {
-						auto it = log_expect_log.begin();
-						auto ie = log_expect_log.end();
-						for (; it != ie; it++)
-							if (it->second.pattern == pattern) {
-								it->second.expected_count = count;
-								break;
-							}
-						if (it == ie)
-							log_expect_log.emplace_back(YS_REGEX_COMPILE(pattern), LogExpectedItem(pattern, count));
-					}
+					if (type == "error")
+						log_expect_error[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
+					else if (type == "warning")
+						log_expect_warning[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
+					else if (type == "log")
+						log_expect_log[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
 					else log_abort();
 				}
 				catch (const YS_REGEX_NS::regex_error& e) {


### PR DESCRIPTION
This refactors the `logger_expect_*` data structures to use the (`std::string`) regex pattern as the key to a `dict`, and to put the compiled `YS_REGEX_TYPE` into the value type `LogExpectedItem`.  This eliminates the need for the code added in #2055 and better expresses the intent: There should only be one entry per regex.