### PR TITLE
ilang_parser: reject negative literals in constant position

### DIFF
--- a/frontends/ilang/ilang_lexer.l
+++ b/frontends/ilang/ilang_lexer.l
@@ -91,8 +91,10 @@ USING_YOSYS_NAMESPACE
 [0-9]+'[01xzm-]*	{ rtlil_frontend_ilang_yylval.string = strdup(yytext); return TOK_VALUE; }
 -?[0-9]+		{
 	char *end = nullptr;
+	errno = 0;
 	long value = strtol(yytext, &end, 10);
-	if (end != yytext + strlen(yytext))
+	log_assert(end == yytext + strlen(yytext));
+	if (errno == ERANGE)
 		return TOK_INVALID; // literal out of range of long
 	if (value < INT_MIN || value > INT_MAX)
 		return TOK_INVALID; // literal out of range of int (relevant mostly for LP64 platforms)

--- a/frontends/ilang/ilang_parser.y
+++ b/frontends/ilang/ilang_parser.y
@@ -421,6 +421,8 @@ constant:
 		free($1);
 	} |
 	TOK_INT {
+		if ($1 < 0)
+			rtlil_frontend_ilang_yyerror("negative literal");
 		$$ = new RTLIL::Const($1, 32);
 	} |
 	TOK_STRING {


### PR DESCRIPTION
Consider this IL code:

    module \foo
      attribute \init -2147483647
      wire width 64 \-2**31+1
    end

Before this commit, it would not roundtrip through the IL backend:

    module \foo
      attribute \init 32'10000000000000000000000000000001
      wire width 64 \-2**31+1
    end

Neither would it result in Verilog output with a negative number:

    module foo();
      (* init = 32'd2147483649 *)
      wire [63:0] \-2**31+1 ;
    endmodule

To avoid ambiguity, prohibit these entirely. This PR also includes a fix for an out-of-range check that previously would have never fired.