### PR TITLE
intel_alm: ABC9 sequential optimisations

### DIFF
--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -294,7 +294,7 @@ struct Abc9Pass : public ScriptPass
 			run("design -load $abc9_map");
 			run("proc");
 			run("wbflip");
-			run("techmap -wb -map %$abc9 -map +/techmap.v");
+			run("techmap -wb -map %$abc9 -map +/techmap.v A:abc9_flop");
 			run("opt");
 			if (dff_mode || help_mode) {
 				if (!help_mode)

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -294,7 +294,7 @@ struct Abc9Pass : public ScriptPass
 			run("design -load $abc9_map");
 			run("proc");
 			run("wbflip");
-			run("techmap");
+			run("techmap -wb -map %$abc9 -map +/techmap.v");
 			run("opt");
 			if (dff_mode || help_mode) {
 				if (!help_mode)

--- a/techlibs/intel_alm/Makefile.inc
+++ b/techlibs/intel_alm/Makefile.inc
@@ -2,6 +2,9 @@
 OBJS += techlibs/intel_alm/synth_intel_alm.o
 
 # Techmap
+$(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/abc9_map.v))
+$(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/abc9_unmap.v))
+$(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/abc9_model.v))
 $(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/alm_map.v))
 $(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/alm_sim.v))
 $(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/arith_alm_map.v))

--- a/techlibs/intel_alm/common/abc9_map.v
+++ b/techlibs/intel_alm/common/abc9_map.v
@@ -11,7 +11,7 @@ parameter _TECHMAP_CONSTMSK_ACLR_ = 1'b0;
 
 // If the async-clear is constant, we assume it's disabled.
 if (_TECHMAP_CONSTMSK_ACLR_ != 1'b0)
-    MISTRAL_FF_SYNCONLY _TECHMAP_REPLACE_ (.DATAIN(DATAIN), .CLK(CLK), .ENA(ENA), .SCLR(SCLR), .SLOAD(SLOAD), .SDATA(SDATA), .Q(Q));
+    $__MISTRAL_FF_SYNCONLY _TECHMAP_REPLACE_ (.DATAIN(DATAIN), .CLK(CLK), .ENA(ENA), .SCLR(SCLR), .SLOAD(SLOAD), .SDATA(SDATA), .Q(Q));
 else
     wire _TECHMAP_FAIL_ = 1;
 

--- a/techlibs/intel_alm/common/abc9_map.v
+++ b/techlibs/intel_alm/common/abc9_map.v
@@ -1,0 +1,18 @@
+// This file exists to map purely-synchronous flops to ABC9 flops, while 
+// mapping flops with asynchronous-clear as boxes, this is because ABC9 
+// doesn't support asynchronous-clear flops in sequential synthesis.
+
+module MISTRAL_FF(
+    input DATAIN, CLK, ACLR, ENA, SCLR, SLOAD, SDATA,
+    output reg Q
+);
+
+parameter _TECHMAP_CONSTMSK_ACLR_ = 1'b0;
+
+// If the async-clear is constant, we assume it's disabled.
+if (_TECHMAP_CONSTMSK_ACLR_ != 1'b0)
+    MISTRAL_FF_SYNCONLY _TECHMAP_REPLACE_ (.DATAIN(DATAIN), .CLK(CLK), .ENA(ENA), .SCLR(SCLR), .SLOAD(SLOAD), .SDATA(SDATA), .Q(Q));
+else
+    wire _TECHMAP_FAIL_ = 1;
+
+endmodule

--- a/techlibs/intel_alm/common/abc9_model.v
+++ b/techlibs/intel_alm/common/abc9_model.v
@@ -18,7 +18,7 @@
 
 // This is a purely-synchronous flop, that ABC9 can use for sequential synthesis.
 (* abc9_flop, lib_whitebox *)
-module MISTRAL_FF_SYNCONLY(
+module $__MISTRAL_FF_SYNCONLY (
     input DATAIN, CLK, ENA, SCLR, SLOAD, SDATA,
     output reg Q
 );

--- a/techlibs/intel_alm/common/abc9_model.v
+++ b/techlibs/intel_alm/common/abc9_model.v
@@ -1,21 +1,3 @@
-`ifdef cyclonev
-`define SYNCPATH 262
-`define SYNCSETUP 522
-`define COMBPATH 0
-`endif
-`ifdef cyclone10gx
-`define SYNCPATH 219
-`define SYNCSETUP 268
-`define COMBPATH 0
-`endif
-
-// fallback for when a family isn't detected (e.g. when techmapping for equivalence)
-`ifndef SYNCPATH
-`define SYNCPATH 0
-`define SYNCSETUP 0
-`define COMBPATH 0
-`endif
-
 // This is a purely-synchronous flop, that ABC9 can use for sequential synthesis.
 (* abc9_flop, lib_whitebox *)
 module $__MISTRAL_FF_SYNCONLY (
@@ -23,33 +5,6 @@ module $__MISTRAL_FF_SYNCONLY (
     output reg Q
 );
 
-specify
-    if (ENA) (posedge CLK => (Q : DATAIN)) = `SYNCPATH;
-    if (ENA) (posedge CLK => (Q : SCLR)) = `SYNCPATH;
-    if (ENA) (posedge CLK => (Q : SLOAD)) = `SYNCPATH;
-    if (ENA) (posedge CLK => (Q : SDATA)) = `SYNCPATH;
-
-    $setup(DATAIN, posedge CLK, `SYNCSETUP);
-    $setup(ENA, posedge CLK, `SYNCSETUP);
-    $setup(SCLR, posedge CLK, `SYNCSETUP);
-    $setup(SLOAD, posedge CLK, `SYNCSETUP);
-    $setup(SDATA, posedge CLK, `SYNCSETUP);
-endspecify
-
-initial begin
-    // Altera flops initialise to zero.
-	Q = 0;
-end
-
-always @(posedge CLK) begin
-    // Clock-enable
-	if (ENA) begin
-        // Synchronous clear
-        if (SCLR) Q <= 0;
-        // Synchronous load
-        else if (SLOAD) Q <= SDATA;
-        else Q <= DATAIN;
-    end
-end
+MISTRAL_FF ff (.DATAIN(DATAIN), .CLK(CLK), .ENA(ENA), .ACLR(1'b1), .SCLR(SCLR), .SLOAD(SLOAD), .SDATA(SDATA), .Q(Q));
 
 endmodule

--- a/techlibs/intel_alm/common/abc9_model.v
+++ b/techlibs/intel_alm/common/abc9_model.v
@@ -1,0 +1,55 @@
+`ifdef cyclonev
+`define SYNCPATH 262
+`define SYNCSETUP 522
+`define COMBPATH 0
+`endif
+`ifdef cyclone10gx
+`define SYNCPATH 219
+`define SYNCSETUP 268
+`define COMBPATH 0
+`endif
+
+// fallback for when a family isn't detected (e.g. when techmapping for equivalence)
+`ifndef SYNCPATH
+`define SYNCPATH 0
+`define SYNCSETUP 0
+`define COMBPATH 0
+`endif
+
+// This is a purely-synchronous flop, that ABC9 can use for sequential synthesis.
+(* abc9_flop, lib_whitebox *)
+module MISTRAL_FF_SYNCONLY(
+    input DATAIN, CLK, ENA, SCLR, SLOAD, SDATA,
+    output reg Q
+);
+
+specify
+    if (ENA) (posedge CLK => (Q : DATAIN)) = `SYNCPATH;
+    if (ENA) (posedge CLK => (Q : SCLR)) = `SYNCPATH;
+    if (ENA) (posedge CLK => (Q : SLOAD)) = `SYNCPATH;
+    if (ENA) (posedge CLK => (Q : SDATA)) = `SYNCPATH;
+
+    $setup(DATAIN, posedge CLK, `SYNCSETUP);
+    $setup(ENA, posedge CLK, `SYNCSETUP);
+    $setup(SCLR, posedge CLK, `SYNCSETUP);
+    $setup(SLOAD, posedge CLK, `SYNCSETUP);
+    $setup(SDATA, posedge CLK, `SYNCSETUP);
+endspecify
+
+initial begin
+    // Altera flops initialise to zero.
+	Q = 0;
+end
+
+always @(posedge CLK) begin
+    // Clock-enable
+	if (ENA) begin
+        // Synchronous clear
+        if (SCLR) Q <= 0;
+        // Synchronous load
+        else if (SLOAD) Q <= SDATA;
+        else Q <= DATAIN;
+    end
+end
+
+endmodule

--- a/techlibs/intel_alm/common/abc9_unmap.v
+++ b/techlibs/intel_alm/common/abc9_unmap.v
@@ -1,7 +1,7 @@
 // After performing sequential synthesis, map the synchronous flops back to
 // standard MISTRAL_FF flops.
 
-module MISTRAL_FF_SYNCONLY(
+module $__MISTRAL_FF_SYNCONLY (
     input DATAIN, CLK, ENA, SCLR, SLOAD, SDATA,
     output reg Q
 );

--- a/techlibs/intel_alm/common/abc9_unmap.v
+++ b/techlibs/intel_alm/common/abc9_unmap.v
@@ -1,0 +1,11 @@
+// After performing sequential synthesis, map the synchronous flops back to
+// standard MISTRAL_FF flops.
+
+module MISTRAL_FF_SYNCONLY(
+    input DATAIN, CLK, ENA, SCLR, SLOAD, SDATA,
+    output reg Q
+);
+
+MISTRAL_FF _TECHMAP_REPLACE_ (.DATAIN(DATAIN), .CLK(CLK), .ACLR(1'b1), .ENA(ENA), .SCLR(SCLR), .SLOAD(SLOAD), .SDATA(SDATA), .Q(Q));
+
+endmodule

--- a/techlibs/intel_alm/common/dff_sim.v
+++ b/techlibs/intel_alm/common/dff_sim.v
@@ -90,7 +90,7 @@ specify
     $setup(SLOAD, posedge CLK, `SYNCSETUP);
     $setup(SDATA, posedge CLK, `SYNCSETUP);
 
-    (ACLR => Q) = `COMBPATH;
+    if (!ACLR) (ACLR => Q) = `COMBPATH;
 endspecify
 
 initial begin

--- a/techlibs/intel_alm/common/dff_sim.v
+++ b/techlibs/intel_alm/common/dff_sim.v
@@ -79,10 +79,9 @@ module MISTRAL_FF(
 );
 
 specify
-    if (ENA) (posedge CLK => (Q : DATAIN)) = `SYNCPATH;
-    if (ENA) (posedge CLK => (Q : SCLR)) = `SYNCPATH;
-    if (ENA) (posedge CLK => (Q : SLOAD)) = `SYNCPATH;
-    if (ENA) (posedge CLK => (Q : SDATA)) = `SYNCPATH;
+    if (ENA && ACLR !== 1'b0 && !SCLR && !SLOAD) (posedge CLK => (Q : DATAIN)) = `SYNCPATH;
+    if (ENA && SCLR) (posedge CLK => (Q : 1'b0)) = `SYNCPATH;
+    if (ENA && !SCLR && SLOAD) (posedge CLK => (Q : SDATA)) = `SYNCPATH;
 
     $setup(DATAIN, posedge CLK, `SYNCSETUP);
     $setup(ENA, posedge CLK, `SYNCSETUP);
@@ -90,7 +89,7 @@ specify
     $setup(SLOAD, posedge CLK, `SYNCSETUP);
     $setup(SDATA, posedge CLK, `SYNCSETUP);
 
-    if (!ACLR) (ACLR => Q) = `COMBPATH;
+    if (ACLR === 1'b0) (ACLR => Q) = `COMBPATH;
 endspecify
 
 initial begin

--- a/techlibs/intel_alm/common/mem_sim.v
+++ b/techlibs/intel_alm/common/mem_sim.v
@@ -48,9 +48,19 @@
 // the following model because it's very difficult to trigger this in practice
 // as clock cycles will be much longer than any potential blip of 'x, so the
 // model can be treated as always returning a defined result.
+
+(* abc9_box, lib_whitebox *)
 module MISTRAL_MLAB(input [4:0] A1ADDR, input A1DATA, A1EN, CLK1, input [4:0] B1ADDR, output B1DATA);
 
 reg [31:0] mem = 32'b0;
+
+// TODO
+specify
+    $setup(A1ADDR, posedge CLK1, 0);
+    $setup(A1DATA, posedge CLK1, 0);
+
+    (B1ADDR *> B1DATA) = 0;
+endspecify
 
 always @(posedge CLK1)
     if (A1EN) mem[A1ADDR] <= A1DATA;

--- a/techlibs/intel_alm/synth_intel_alm.cc
+++ b/techlibs/intel_alm/synth_intel_alm.cc
@@ -173,7 +173,7 @@ struct SynthIntelALMPass : public ScriptPass {
 			run(stringf("read_verilog -specify -lib -D %s +/intel_alm/common/alm_sim.v", family_opt.c_str()));
 			run(stringf("read_verilog -specify -lib -D %s +/intel_alm/common/dff_sim.v", family_opt.c_str()));
 			run(stringf("read_verilog -specify -lib -D %s +/intel_alm/common/mem_sim.v", family_opt.c_str()));
-			run(stringf("read_verilog -specify -lib -D %s +/intel_alm/common/abc9_model.v", family_opt.c_str()));
+			run(stringf("read_verilog -specify -lib -D %s -icells +/intel_alm/common/abc9_model.v", family_opt.c_str()));
 
 			// Misc and common cells
 			run("read_verilog -lib +/intel/common/altpll_bb.v");

--- a/techlibs/intel_alm/synth_intel_alm.cc
+++ b/techlibs/intel_alm/synth_intel_alm.cc
@@ -38,19 +38,25 @@ struct SynthIntelALMPass : public ScriptPass {
 		log("This command runs synthesis for ALM-based Intel FPGAs.\n");
 		log("\n");
 		log("    -top <module>\n");
-		log("        use the specified module as top module (default='top')\n");
+		log("        use the specified module as top module\n");
 		log("\n");
 		log("    -family <family>\n");
 		log("        target one of:\n");
 		log("        \"cyclonev\"    - Cyclone V (default)\n");
 		log("        \"cyclone10gx\" - Cyclone 10GX\n");
 		log("\n");
-		log("    -quartus\n");
-		log("        output a netlist using Quartus cells instead of MISTRAL_* cells\n");
-		log("\n");
 		log("    -vqm <file>\n");
 		log("        write the design to the specified Verilog Quartus Mapping File. Writing of an\n");
 		log("        output file is omitted if this parameter is not specified. Implies -quartus.\n");
+		log("\n");
+		log("    -noflatten\n");
+		log("        do not flatten design before synthesis; useful for per-module area statistics\n");
+		log("\n");
+		log("    -quartus\n");
+		log("        output a netlist using Quartus cells instead of MISTRAL_* cells\n");
+		log("\n");
+		log("    -dff\n");
+		log("        pass DFFs to ABC to perform sequential logic optimisations (EXPERIMENTAL)\n");
 		log("\n");
 		log("    -run <from_label>:<to_label>\n");
 		log("        only run the commands between the labels (see below). an empty\n");
@@ -63,16 +69,13 @@ struct SynthIntelALMPass : public ScriptPass {
 		log("    -nobram\n");
 		log("        do not use block RAM cells in output netlist\n");
 		log("\n");
-		log("    -noflatten\n");
-		log("        do not flatten design before synthesis\n");
-		log("\n");
 		log("The following commands are executed by this synthesis command:\n");
 		help_script();
 		log("\n");
 	}
 
 	string top_opt, family_opt, bram_type, vout_file;
-	bool flatten, quartus, nolutram, nobram;
+	bool flatten, quartus, nolutram, nobram, dff;
 
 	void clear_flags() YS_OVERRIDE
 	{
@@ -84,6 +87,7 @@ struct SynthIntelALMPass : public ScriptPass {
 		quartus = false;
 		nolutram = false;
 		nobram = false;
+		dff = false;
 	}
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
@@ -130,6 +134,10 @@ struct SynthIntelALMPass : public ScriptPass {
 				flatten = false;
 				continue;
 			}
+			if (args[argidx] == "-dff") {
+				dff = true;
+				continue;
+			}
 			break;
 		}
 		extra_args(args, argidx, design);
@@ -165,6 +173,7 @@ struct SynthIntelALMPass : public ScriptPass {
 			run(stringf("read_verilog -specify -lib -D %s +/intel_alm/common/alm_sim.v", family_opt.c_str()));
 			run(stringf("read_verilog -specify -lib -D %s +/intel_alm/common/dff_sim.v", family_opt.c_str()));
 			run(stringf("read_verilog -specify -lib -D %s +/intel_alm/common/mem_sim.v", family_opt.c_str()));
+			run(stringf("read_verilog -specify -lib -D %s +/intel_alm/common/abc9_model.v", family_opt.c_str()));
 
 			// Misc and common cells
 			run("read_verilog -lib +/intel/common/altpll_bb.v");
@@ -209,7 +218,9 @@ struct SynthIntelALMPass : public ScriptPass {
 		}
 
 		if (check_label("map_luts")) {
-			run("abc9 -maxlut 6 -W 200");
+			run("techmap -map +/intel_alm/common/abc9_map.v");
+			run(stringf("abc9 %s -maxlut 6 -W 200", help_mode ? "[-dff]" : dff ? "-dff" : ""));
+			run("techmap -map +/intel_alm/common/abc9_unmap.v");
 			run("techmap -map +/intel_alm/common/alm_map.v");
 			run("opt -fast");
 			run("autoname");

--- a/tests/arch/intel_alm/fsm.ys
+++ b/tests/arch/intel_alm/fsm.ys
@@ -13,7 +13,8 @@ cd fsm # Constrain all select calls below inside the top module
 
 select -assert-count 6 t:MISTRAL_FF
 select -assert-max 2 t:MISTRAL_ALUT2 # Clang returns 2, GCC returns 1
+select -assert-count 1 t:MISTRAL_ALUT3
 select -assert-max 1 t:MISTRAL_ALUT4 # Clang returns 0, GCC returns 1
 select -assert-max 5 t:MISTRAL_ALUT5 # Clang returns 5, GCC returns 4
 select -assert-max 2 t:MISTRAL_ALUT6 # Clang returns 1, GCC returns 2
-select -assert-none t:MISTRAL_FF t:MISTRAL_ALUT2 t:MISTRAL_ALUT4 t:MISTRAL_ALUT5 t:MISTRAL_ALUT6 %% t:* %D
+select -assert-none t:MISTRAL_FF t:MISTRAL_ALUT2 t:MISTRAL_ALUT3 t:MISTRAL_ALUT4 t:MISTRAL_ALUT5 t:MISTRAL_ALUT6 %% t:* %D

--- a/tests/arch/intel_alm/fsm.ys
+++ b/tests/arch/intel_alm/fsm.ys
@@ -13,7 +13,7 @@ cd fsm # Constrain all select calls below inside the top module
 
 select -assert-count 6 t:MISTRAL_FF
 select -assert-max 2 t:MISTRAL_ALUT2 # Clang returns 2, GCC returns 1
-select -assert-count 1 t:MISTRAL_ALUT3
-select -assert-count 5 t:MISTRAL_ALUT5
-select -assert-count 2 t:MISTRAL_ALUT6
-select -assert-none t:MISTRAL_FF t:MISTRAL_ALUT2 t:MISTRAL_ALUT3 t:MISTRAL_ALUT5 t:MISTRAL_ALUT6 %% t:* %D
+select -assert-max 1 t:MISTRAL_ALUT4 # Clang returns 0, GCC returns 1
+select -assert-max 5 t:MISTRAL_ALUT5 # Clang returns 5, GCC returns 4
+select -assert-max 2 t:MISTRAL_ALUT6 # Clang returns 1, GCC returns 2
+select -assert-none t:MISTRAL_FF t:MISTRAL_ALUT2 t:MISTRAL_ALUT4 t:MISTRAL_ALUT5 t:MISTRAL_ALUT6 %% t:* %D


### PR DESCRIPTION
This plugs in #1926 for `synth_intel_alm`. The benefits are [modest](https://gist.github.com/ZirconiumX/a9b2c4bc7f5be27962415d698e5495cf) but might be worth it to somebody.

Some small mapping files are used to distinguish between flops with asynchronous clear (which should be `(* abc9_box *)`) and those without (which can be passed to ABC9 as `(* abc9_flop *)`).

This lead to some cleanup; flops and LUTRAM are a bit better specified, and I also reorganised the help to put more useful options near the top.

cc @mwkmwkmwk @eddiehung 