### PR TITLE
clean: remove unused wires even with (* init *) on

### DIFF
--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -323,13 +323,17 @@ bool rmunused_module_signals(RTLIL::Module *module, bool purge_mode, bool verbos
 			initval.bits.resize(GetSize(wire), State::Sx);
 		if (initval.is_fully_undef())
 			wire->attributes.erase(ID::init);
+		Const used_initval = initval;
+		for (auto i = 0; i < GetSize(wire); i++)
+			if (used_initval[i] != State::Sx && !raw_used_signals.check(s1[i]) && !used_signals.check(s2[i]))
+				used_initval[i] = State::Sx;
 
 		if (GetSize(wire) == 0) {
 			// delete zero-width wires, unless they are module ports
 			if (wire->port_id == 0)
 				goto delete_this_wire;
 		} else
-		if (wire->port_id != 0 || wire->get_bool_attribute(ID::keep) || !initval.is_fully_undef()) {
+		if (wire->port_id != 0 || wire->get_bool_attribute(ID::keep) || !used_initval.is_fully_undef()) {
 			// do not delete anything with "keep" or module ports or initialized wires
 		} else
 		if (!purge_mode && check_public_name(wire->name) && (raw_used_signals.check_any(s1) || used_signals.check_any(s2) || s1 != s2)) {

--- a/tests/opt/opt_clean_init.ys
+++ b/tests/opt/opt_clean_init.ys
@@ -11,3 +11,32 @@ EOT
 clean
 select -assert-count 1 a:init
 select -assert-count 1 w:y a:init %i
+
+
+design -reset
+read_verilog <<EOT
+module top(input clk, d, output q);
+(* init=1'b0 *) wire private0;
+reg private1 = 1'b1;
+always @(posedge clk)
+    private1 <= d;
+assign q = private1;
+endmodule
+EOT
+proc
+rename -hide w:private*
+clean
+select -assert-count 1 a:init=1'b1
+select -assert-count 0 a:init=1'b0
+
+
+design -reset
+read_verilog <<EOT
+module top;
+(* init=1'b0 *) wire private;
+wire public = private;
+endmodule
+EOT
+rename -hide w:private
+clean
+select -assert-none w:*


### PR DESCRIPTION
`(* init *)` is not guaranteed to be attached to a DFF cell's Q port. Thus when that DFF gets blown away (e.g. by `abc9 -dff`) then it would desirable to also remove unused wires -- even with `(* init *)` on -- that get left behind.