### PR TITLE
abc9: -dff improvements

### DIFF
--- a/frontends/aiger/aigerparse.cc
+++ b/frontends/aiger/aigerparse.cc
@@ -775,7 +775,6 @@ void AigerReader::post_process()
 		}
 	}
 
-	dict<int, Wire*> mergeability_to_clock;
 	for (uint32_t i = 0; i < flopNum; i++) {
 		RTLIL::Wire *d = outputs[outputs.size() - flopNum + i];
 		log_assert(d);
@@ -895,7 +894,9 @@ void AigerReader::post_process()
 			}
 			else if (type == "box") {
 				RTLIL::Cell* cell = module->cell(stringf("$box%d", variable));
-				if (cell) // ABC could have optimised this box away
+				if (!cell)
+					log_debug("Box %d (%s) no longer exists.\n", variable, log_id(escaped_s));
+				else
 					module->rename(cell, escaped_s);
 			}
 			else
@@ -907,6 +908,8 @@ void AigerReader::post_process()
 		auto name = wp.first;
 		int min = wp.second.first;
 		int max = wp.second.second;
+		if (min == 0 && max == 0)
+			continue;
 
 		RTLIL::Wire *wire = module->wire(name);
 		if (wire)

--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -323,13 +323,17 @@ bool rmunused_module_signals(RTLIL::Module *module, bool purge_mode, bool verbos
 			initval.bits.resize(GetSize(wire), State::Sx);
 		if (initval.is_fully_undef())
 			wire->attributes.erase(ID::init);
+		Const used_initval = initval;
+		for (auto i = 0; i < GetSize(wire); i++)
+			if (used_initval[i] != State::Sx && !raw_used_signals.check(s1[i]) && !used_signals.check(s2[i]))
+				used_initval[i] = State::Sx;
 
 		if (GetSize(wire) == 0) {
 			// delete zero-width wires, unless they are module ports
 			if (wire->port_id == 0)
 				goto delete_this_wire;
 		} else
-		if (wire->port_id != 0 || wire->get_bool_attribute(ID::keep) || !initval.is_fully_undef()) {
+		if (wire->port_id != 0 || wire->get_bool_attribute(ID::keep) || !used_initval.is_fully_undef()) {
 			// do not delete anything with "keep" or module ports or initialized wires
 		} else
 		if (!purge_mode && check_public_name(wire->name) && (raw_used_signals.check_any(s1) || used_signals.check_any(s2) || s1 != s2)) {

--- a/tests/arch/xilinx/abc9_dff.ys
+++ b/tests/arch/xilinx/abc9_dff.ys
@@ -82,4 +82,38 @@ select -assert-count 1 t:FDPE
 select -assert-count 2 t:INV
 select -assert-count 0 t:FD* t:INV %% t:* %D
 
+
+design -reset
+read_verilog <<EOT
+module top(input clk, input d, output q);
+reg r;
+always @(posedge clk) begin
+r <= d;
+end
+assign q = ~r;
+endmodule
+EOT
+proc
+equiv_opt -assert -multiclock -map +/xilinx/cells_sim.v synth_xilinx -abc9 -dff -noiopad -noclkbuf
+design -load postopt
+select -assert-count 1 t:FDRE %co w:r %i
+
+
+design -reset
+read_verilog <<EOT
+module top(input clk, input a, b, output reg q1, output q2);
+reg r;
+always @(posedge clk) begin
+    q1 <= a | b;
+    r <= ~(~a & ~b);
+end
+assign q2 = r;
+endmodule
+EOT
+proc
+equiv_opt -assert -multiclock -map +/xilinx/cells_sim.v synth_xilinx -abc9 -dff -noiopad -noclkbuf
+design -load postopt
+select -assert-count 1 t:FDRE %co %a w:r %i
+
+
 logger -expect-no-warnings

--- a/tests/arch/xilinx/abc9_dff.ys
+++ b/tests/arch/xilinx/abc9_dff.ys
@@ -116,4 +116,19 @@ design -load postopt
 select -assert-count 1 t:FDRE %co %a w:r %i
 
 
+design -reset
+read_verilog <<EOT
+module top(input clk, input a, b, output o);
+reg r1, r2;
+always @(posedge clk) begin
+    r1 <= a | b;
+    r2 <= ~(~a & ~b);
+end
+assign o = r1 | r2;
+endmodule
+EOT
+proc
+equiv_opt -assert -multiclock -map +/xilinx/cells_sim.v synth_xilinx -abc9 -dff -noiopad -noclkbuf
+
+
 logger -expect-no-warnings

--- a/tests/opt/opt_clean_init.ys
+++ b/tests/opt/opt_clean_init.ys
@@ -11,3 +11,32 @@ EOT
 clean
 select -assert-count 1 a:init
 select -assert-count 1 w:y a:init %i
+
+
+design -reset
+read_verilog <<EOT
+module top(input clk, d, output q);
+(* init=1'b0 *) wire private0;
+reg private1 = 1'b1;
+always @(posedge clk)
+    private1 <= d;
+assign q = private1;
+endmodule
+EOT
+proc
+rename -hide w:private*
+clean
+select -assert-count 1 a:init=1'b1
+select -assert-count 0 a:init=1'b0
+
+
+design -reset
+read_verilog <<EOT
+module top;
+(* init=1'b0 *) wire private;
+wire public = private;
+endmodule
+EOT
+rename -hide w:private
+clean
+select -assert-none w:*


### PR DESCRIPTION
I noticed that `abc9 -dff` could leave behind some `(* init *)` attributes, which should be fixed by:
* Re-attaching the `$_DFF_[NP]_.Q` signal to the replaced flop, so that the original `(* init *)` attribute is linked and can be removed (also has the nice side effect of preserving public signals on flop outputs)
* Left-over `(* init *)` attributes for unused flops removed by ABC9 are queued to be fixed by #2076 (dependency)