### PR TITLE
Fixing implicit declaration of nets in dynamic_part_select test

### DIFF
--- a/tests/various/dynamic_part_select/forloop_select.v
+++ b/tests/various/dynamic_part_select/forloop_select.v
@@ -3,12 +3,12 @@ module forloop_select #(parameter WIDTH=16, SELW=4, CTRLW=$clog2(WIDTH), DINW=2*
    (input wire             clk,
     input wire [CTRLW-1:0] ctrl,
     input wire [DINW-1:0]  din,
-    input wire 		   en,
+    input wire             en,
     output reg [WIDTH-1:0] dout);
-   
-   reg [SELW:0] 	   sel;
+
+   reg [SELW:0]            sel;
    localparam SLICE = WIDTH/(SELW**2);
-   
+
    always @(posedge clk)
      begin
         if (en) begin
@@ -17,4 +17,3 @@ module forloop_select #(parameter WIDTH=16, SELW=4, CTRLW=$clog2(WIDTH), DINW=2*
         end
      end
 endmodule
-

--- a/tests/various/dynamic_part_select/forloop_select.v
+++ b/tests/various/dynamic_part_select/forloop_select.v
@@ -1,8 +1,9 @@
+`default_nettype none
 module forloop_select #(parameter WIDTH=16, SELW=4, CTRLW=$clog2(WIDTH), DINW=2**SELW)
-   (input                  clk,
-    input [CTRLW-1:0] 	   ctrl,
-    input [DINW-1:0] 	   din,
-    input                  en,
+   (input wire             clk,
+    input wire [CTRLW-1:0] ctrl,
+    input wire [DINW-1:0]  din,
+    input wire 		   en,
     output reg [WIDTH-1:0] dout);
    
    reg [SELW:0] 	   sel;

--- a/tests/various/dynamic_part_select/forloop_select_gate.v
+++ b/tests/various/dynamic_part_select/forloop_select_gate.v
@@ -1,8 +1,9 @@
+`default_nettype none
 module forloop_select_gate (clk, ctrl, din, en, dout);
-      input clk;
-      input [3:0] ctrl;
-      input [15:0] din;
-      input en;
+      input wire clk;
+      input wire [3:0] ctrl;
+      input wire [15:0] din;
+      input wire en;
       output reg [15:0] dout;
       reg [4:0] sel;
       always @(posedge clk)

--- a/tests/various/dynamic_part_select/multiple_blocking.v
+++ b/tests/various/dynamic_part_select/multiple_blocking.v
@@ -1,8 +1,9 @@
+`default_nettype none
 module multiple_blocking #(parameter WIDTH=32, SELW=1, CTRLW=$clog2(WIDTH), DINW=2**SELW)
-   (input                  clk,
-    input [CTRLW-1:0] 	   ctrl,
-    input [DINW-1:0] 	   din,
-    input [SELW-1:0] 	   sel,
+   (input wire             clk,
+    input wire [CTRLW-1:0] ctrl,
+    input wire [DINW-1:0]  din,
+    input wire [SELW-1:0]  sel,
     output reg [WIDTH-1:0] dout);
    
    localparam SLICE = WIDTH/(SELW**2);

--- a/tests/various/dynamic_part_select/multiple_blocking_gate.v
+++ b/tests/various/dynamic_part_select/multiple_blocking_gate.v
@@ -1,4 +1,4 @@
-`default_nettype wire
+`default_nettype none
 module multiple_blocking_gate (clk, ctrl, din, sel, dout);
    input wire clk;
    input wire [4:0] ctrl;

--- a/tests/various/dynamic_part_select/multiple_blocking_gate.v
+++ b/tests/various/dynamic_part_select/multiple_blocking_gate.v
@@ -1,8 +1,9 @@
+`default_nettype wire
 module multiple_blocking_gate (clk, ctrl, din, sel, dout);
-   input clk;
-   input [4:0] ctrl;
-   input [1:0] din;
-   input [0:0] sel;
+   input wire clk;
+   input wire [4:0] ctrl;
+   input wire [1:0] din;
+   input wire [0:0] sel;
    output reg [31:0] dout;
    reg [5:0] 	     a;
    reg [0:0] 	     b;

--- a/tests/various/dynamic_part_select/nonblocking.v
+++ b/tests/various/dynamic_part_select/nonblocking.v
@@ -1,8 +1,9 @@
+`default_nettype none
 module nonblocking #(parameter WIDTH=32, SELW=1, CTRLW=$clog2(WIDTH), DINW=2**SELW)
-   (input                  clk,
-    input [CTRLW-1:0] 	   ctrl,
-    input [DINW-1:0] 	   din,
-    input [SELW-1:0] 	   sel,
+   (input wire             clk,
+    input wire [CTRLW-1:0] ctrl,
+    input wire [DINW-1:0]  din,
+    input wire [SELW-1:0]  sel,
     output reg [WIDTH-1:0] dout);
    
    localparam SLICE = WIDTH/(SELW**2);

--- a/tests/various/dynamic_part_select/nonblocking_gate.v
+++ b/tests/various/dynamic_part_select/nonblocking_gate.v
@@ -1,8 +1,9 @@
+`default_nettype none
 module nonblocking_gate (clk, ctrl, din, sel, dout);
-   input clk;
-   input [4:0] ctrl;
-   input [1:0] din;
-   input [0:0] sel;
+   input wire clk;
+   input wire [4:0] ctrl;
+   input wire [1:0] din;
+   input wire [0:0] sel;
    output reg [31:0] dout;
    always @(posedge clk)
      begin

--- a/tests/various/dynamic_part_select/original.v
+++ b/tests/various/dynamic_part_select/original.v
@@ -1,8 +1,9 @@
+`default_nettype none
 module original #(parameter WIDTH=32, SELW=1, CTRLW=$clog2(WIDTH), DINW=2**SELW)
-   (input                  clk,
-    input [CTRLW-1:0] 	   ctrl,
-    input [DINW-1:0] 	   din,
-    input [SELW-1:0] 	   sel,
+   (input wire             clk,
+    input wire [CTRLW-1:0] ctrl,
+    input wire [DINW-1:0]  din,
+    input wire [SELW-1:0]  sel,
     output reg [WIDTH-1:0] dout);
    localparam SLICE = WIDTH/(SELW**2);
    always @(posedge clk)

--- a/tests/various/dynamic_part_select/original_gate.v
+++ b/tests/various/dynamic_part_select/original_gate.v
@@ -1,8 +1,9 @@
+`default_nettype none
 module original_gate (clk, ctrl, din, sel, dout);
-   input clk;
-   input [4:0] ctrl;
-   input [1:0] din;
-   input [0:0] sel;
+   input wire clk;
+   input wire [4:0] ctrl;
+   input wire [1:0] din;
+   input wire [0:0] sel;
    output reg [31:0] dout;
    always @(posedge clk)
      case (({(ctrl)*(sel)})+(0))

--- a/tests/various/dynamic_part_select/reset_test.v
+++ b/tests/various/dynamic_part_select/reset_test.v
@@ -1,8 +1,10 @@
+`default_nettype none
 module reset_test  #(parameter WIDTH=32, SELW=1, CTRLW=$clog2(WIDTH), DINW=2**SELW)
-   (input                  clk,
-    input [CTRLW-1:0] 	   ctrl,
-    input [DINW-1:0] 	   din,
-    input [SELW-1:0] 	   sel,
+   (input wire             clk,
+    input wire             reset,
+    input wire [CTRLW-1:0] ctrl,
+    input wire [DINW-1:0]  din,
+    input wire [SELW-1:0]  sel,
     output reg [WIDTH-1:0] dout);
    
    reg [SELW:0] 		   i;
@@ -16,8 +18,6 @@ module reset_test  #(parameter WIDTH=32, SELW=1, CTRLW=$clog2(WIDTH), DINW=2**SE
             dout[i*rval+:SLICE] <= 32'hDEAD;
          end
       end
-      //else begin
       dout[ctrl*sel+:SLICE] <= din;
-      //end
    end
 endmodule

--- a/tests/various/dynamic_part_select/reset_test_gate.v
+++ b/tests/various/dynamic_part_select/reset_test_gate.v
@@ -1,8 +1,10 @@
-module reset_test_gate (clk, ctrl, din, sel, dout);
-   input clk;
-   input [4:0] ctrl;
-   input [1:0] din;
-   input [0:0] sel;
+`default_nettype none
+module reset_test_gate (clk, reset, ctrl, din, sel, dout);
+   input wire clk;
+   input wire reset;
+   input wire [4:0] ctrl;
+   input wire [1:0] din;
+   input wire [0:0] sel;
    output reg [31:0] dout;
    reg [1:0] 	     i;
    wire [0:0] 	     rval;

--- a/tests/various/dynamic_part_select/reversed.v
+++ b/tests/various/dynamic_part_select/reversed.v
@@ -1,8 +1,9 @@
+`default_nettype none
 module reversed #(parameter WIDTH=32, SELW=4, CTRLW=$clog2(WIDTH), DINW=2**SELW)
-   (input                  clk,
-    input [CTRLW-1:0] 	   ctrl,
-    input [DINW-1:0] 	   din,
-    input [SELW-1:0] 	   sel,
+   (input wire             clk,
+    input wire [CTRLW-1:0] ctrl,
+    input wire [DINW-1:0]  din,
+    input wire [SELW-1:0]  sel,
     output reg [WIDTH-1:0] dout);
    
    localparam SLICE = WIDTH/(SELW**2);

--- a/tests/various/dynamic_part_select/reversed_gate.v
+++ b/tests/various/dynamic_part_select/reversed_gate.v
@@ -3,7 +3,7 @@ module reversed_gate (clk, ctrl, din, sel, dout);
    input wire clk;
    input wire [4:0] ctrl;
    input wire [15:0] din;
-   input wire [3:0] 	sel;
+   input wire [3:0]  sel;
    output reg [31:0] dout;
    always @(posedge clk)
      case ((({(32)-((ctrl)*(sel))})+(1))-(2))

--- a/tests/various/dynamic_part_select/reversed_gate.v
+++ b/tests/various/dynamic_part_select/reversed_gate.v
@@ -1,8 +1,9 @@
+`default_nettype none
 module reversed_gate (clk, ctrl, din, sel, dout);
-   input clk;
-   input [4:0] ctrl;
-   input [15:0] din;
-   input [3:0] 	sel;
+   input wire clk;
+   input wire [4:0] ctrl;
+   input wire [15:0] din;
+   input wire [3:0] 	sel;
    output reg [31:0] dout;
    always @(posedge clk)
      case ((({(32)-((ctrl)*(sel))})+(1))-(2))


### PR DESCRIPTION
@eddiehung noticed implicit reset declaration in `reset_test.v`, fixing that and setting the default net type to none for the rest of files.