### PR TITLE
Use c_str(), not str() for IdString/std::string == and != operators

### DIFF
--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -296,8 +296,8 @@ namespace RTLIL
 
 		// The methods below are just convenience functions for better compatibility with std::string.
 
-		bool operator==(const std::string &rhs) const { return str() == rhs; }
-		bool operator!=(const std::string &rhs) const { return str() != rhs; }
+		bool operator==(const std::string &rhs) const { return c_str() == rhs; }
+		bool operator!=(const std::string &rhs) const { return c_str() != rhs; }
 
 		bool operator==(const char *rhs) const { return strcmp(c_str(), rhs) == 0; }
 		bool operator!=(const char *rhs) const { return strcmp(c_str(), rhs) != 0; }


### PR DESCRIPTION
These operators work by fetching the string from the global string
table and then comparing with the std::string that was passed in as
rhs.

Using str() means that we create a std::string (strlen; malloc;
memcpy), compare for equality (another memcmp if they have the same
length) and then finally free the string.

Using c_str() means that we pass the const char* straight to
std::string's equality operator. This ends up as a call to
std::string::compare (the const char* flavour), which is essentially
strcmp.