### PR TITLE
Add `printattrs` command to print attributes of currently selected objects.

### DIFF
--- a/passes/cmds/Makefile.inc
+++ b/passes/cmds/Makefile.inc
@@ -39,3 +39,4 @@ OBJS += passes/cmds/bugpoint.o
 endif
 OBJS += passes/cmds/scratchpad.o
 OBJS += passes/cmds/logger.o
+OBJS += passes/cmds/printattrs.o

--- a/passes/cmds/printattrs.cc
+++ b/passes/cmds/printattrs.cc
@@ -34,6 +34,16 @@ struct PrintAttrsPass : public Pass {
 		log("\n");
 		log("\n");
 	}
+
+	static void log_const(const RTLIL::IdString &s, const RTLIL::Const &x, const unsigned int indent) {
+		if (x.flags == RTLIL::CONST_FLAG_STRING)
+			log("%s(* %s=\"%s\" *)\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(s), x.decode_string().c_str());
+		else if (x.flags == RTLIL::CONST_FLAG_NONE)
+			log("%s(* %s=%s *)\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(s), x.as_string().c_str());
+		else
+			log_assert(x.flags == RTLIL::CONST_FLAG_STRING || x.flags == RTLIL::CONST_FLAG_NONE); //intended to fail
+	}
+
 	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
 	{
 		size_t argidx = 1;
@@ -42,29 +52,26 @@ struct PrintAttrsPass : public Pass {
 		unsigned int indent = 0;
 		for (auto mod : design->selected_modules())
 		{
-
 			if (design->selected_whole_module(mod)) {
 				log("%s%s\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(mod->name));
 				indent += 2;
 				for (auto &it : mod->attributes)
-					log("%s(* %s=\"%s\" %s *)\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(it.first), it.second.decode_string().c_str(), it.second.as_string().c_str());
+					log_const(it.first, it.second, indent);
 			}
 
 			for (auto cell : mod->selected_cells()) {
 				log("%s%s\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(cell->name));
 				indent += 2;
-				for (auto &it : cell->attributes) {
-					log("%s(* %s=\"%s\" %s *)\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(it.first), it.second.decode_string().c_str(), it.second.as_string().c_str());
-				}
+				for (auto &it : cell->attributes)
+					log_const(it.first, it.second, indent);
 				indent -= 2;
 			}
 
 			for (auto wire : mod->selected_wires()) {
 				log("%s%s\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(wire->name));
 				indent += 2;
-				for (auto &it : wire->attributes) {
-					log("%s(* %s=\"%s\" %s *)\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(it.first), it.second.decode_string().c_str(), it.second.as_string().c_str());
-				}
+				for (auto &it : wire->attributes)
+					log_const(it.first, it.second, indent);
 				indent -= 2;
 			}
 

--- a/passes/cmds/printattrs.cc
+++ b/passes/cmds/printattrs.cc
@@ -35,11 +35,17 @@ struct PrintAttrsPass : public Pass {
 		log("\n");
 	}
 
+	static std::string get_indent_str(const unsigned int indent) {
+		//Build the format string (e.g. "%4s")
+		std::string format_str = stringf("%%%ds", indent);
+		return stringf(format_str.c_str(), " "); //Use the format string with " " as %s 
+	}
+
 	static void log_const(const RTLIL::IdString &s, const RTLIL::Const &x, const unsigned int indent) {
 		if (x.flags == RTLIL::CONST_FLAG_STRING)
-			log("%s(* %s=\"%s\" *)\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(s), x.decode_string().c_str());
+			log("%s(* %s=\"%s\" *)\n", get_indent_str(indent).c_str(), log_id(s), x.decode_string().c_str());
 		else if (x.flags == RTLIL::CONST_FLAG_NONE)
-			log("%s(* %s=%s *)\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(s), x.as_string().c_str());
+			log("%s(* %s=%s *)\n", get_indent_str(indent).c_str(), log_id(s), x.as_string().c_str());
 		else
 			log_assert(x.flags == RTLIL::CONST_FLAG_STRING || x.flags == RTLIL::CONST_FLAG_NONE); //intended to fail
 	}
@@ -53,14 +59,14 @@ struct PrintAttrsPass : public Pass {
 		for (auto mod : design->selected_modules())
 		{
 			if (design->selected_whole_module(mod)) {
-				log("%s%s\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(mod->name));
+				log("%s%s\n", get_indent_str(indent).c_str(), log_id(mod->name));
 				indent += 2;
 				for (auto &it : mod->attributes)
 					log_const(it.first, it.second, indent);
 			}
 
 			for (auto cell : mod->selected_cells()) {
-				log("%s%s\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(cell->name));
+				log("%s%s\n", get_indent_str(indent).c_str(), log_id(cell->name));
 				indent += 2;
 				for (auto &it : cell->attributes)
 					log_const(it.first, it.second, indent);
@@ -68,7 +74,7 @@ struct PrintAttrsPass : public Pass {
 			}
 
 			for (auto wire : mod->selected_wires()) {
-				log("%s%s\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(wire->name));
+				log("%s%s\n", get_indent_str(indent).c_str(), log_id(wire->name));
 				indent += 2;
 				for (auto &it : wire->attributes)
 					log_const(it.first, it.second, indent);

--- a/passes/cmds/printattrs.cc
+++ b/passes/cmds/printattrs.cc
@@ -1,0 +1,79 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2020  Alberto Gonzalez <boqwxp@airmail.cc>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/yosys.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+struct PrintAttrsPass : public Pass {
+	PrintAttrsPass() : Pass("printattrs", "print attributes of selected objects") { }
+	void help() YS_OVERRIDE
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    printattrs [selection]\n");
+		log("\n");
+		log("Print all attributes of the selected objects.\n");
+		log("\n");
+		log("\n");
+	}
+	void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	{
+		size_t argidx = 1;
+		extra_args(args, argidx, design);
+
+		unsigned int indent = 0;
+		for (auto mod : design->selected_modules())
+		{
+
+			if (design->selected_whole_module(mod)) {
+				log("%s%s\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(mod->name));
+				indent += 2;
+				for (auto &it : mod->attributes)
+					log("%s(* %s=\"%s\" %s *)\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(it.first), it.second.decode_string().c_str(), it.second.as_string().c_str());
+			}
+
+			for (auto cell : mod->selected_cells()) {
+				log("%s%s\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(cell->name));
+				indent += 2;
+				for (auto &it : cell->attributes) {
+					log("%s(* %s=\"%s\" %s *)\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(it.first), it.second.decode_string().c_str(), it.second.as_string().c_str());
+				}
+				indent -= 2;
+			}
+
+			for (auto wire : mod->selected_wires()) {
+				log("%s%s\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(wire->name));
+				indent += 2;
+				for (auto &it : wire->attributes) {
+					log("%s(* %s=\"%s\" %s *)\n", stringf(stringf("%%%ds", indent).c_str(), " ").c_str(), log_id(it.first), it.second.decode_string().c_str(), it.second.as_string().c_str());
+				}
+				indent -= 2;
+			}
+
+			if (design->selected_whole_module(mod))
+				indent -= 2;
+		}
+
+		log("\n");
+	}
+} PrintAttrsPass;
+
+PRIVATE_NAMESPACE_END

--- a/passes/cmds/printattrs.cc
+++ b/passes/cmds/printattrs.cc
@@ -36,9 +36,7 @@ struct PrintAttrsPass : public Pass {
 	}
 
 	static std::string get_indent_str(const unsigned int indent) {
-		//Build the format string (e.g. "%4s")
-		std::string format_str = stringf("%%%ds", indent);
-		return stringf(format_str.c_str(), " "); //Use the format string with " " as %s 
+		return stringf("%*s", indent, "");
 	}
 
 	static void log_const(const RTLIL::IdString &s, const RTLIL::Const &x, const unsigned int indent) {

--- a/tests/various/printattr.ys
+++ b/tests/various/printattr.ys
@@ -1,0 +1,14 @@
+logger -expect log ".*cells_not_processed=[01]* .*" 1
+logger -expect log ".*src=.<<EOT:1\.1-9\.10. .*" 1
+read_verilog <<EOT
+module mux2(a, b, s, y);
+	input a, b, s;
+	output y;
+
+	wire s_n = ~s;
+	wire t0 = s & a;
+	wire t1 = s_n & b;
+	assign y = t0 | t1;
+endmodule
+EOT
+printattrs


### PR DESCRIPTION
AFAIK in general there is no way to know if an attribute is a string attribute, a bool attribute, or bit string attribute.  So the attribute value is printed first as `decode_string()` and then as `as_string()`, so all kinds of attribute values will be visible.