### PR TITLE
Restrict RTLIL::IdString to not contain whitespace or control chars

### DIFF
--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -150,9 +150,6 @@ namespace RTLIL
 			if (!p[0])
 				return 0;
 
-			log_assert(p[0] == '$' || p[0] == '\\');
-			log_assert(p[1] != 0);
-
 			auto it = global_id_index_.find((char*)p);
 			if (it != global_id_index_.end()) {
 		#ifndef YOSYS_NO_IDS_REFCNT
@@ -164,6 +161,11 @@ namespace RTLIL
 		#endif
 				return it->second;
 			}
+
+			log_assert(p[0] == '$' || p[0] == '\\');
+			log_assert(p[1] != 0);
+			for (const char *c = p; *c; c++)
+				log_assert((unsigned)*c > (unsigned)' ');
 
 		#ifndef YOSYS_NO_IDS_REFCNT
 			if (global_free_idx_list_.empty()) {

--- a/manual/CHAPTER_Overview.tex
+++ b/manual/CHAPTER_Overview.tex
@@ -184,9 +184,12 @@ may hold important information for Yosys developers can be used without
 disturbing external tools. For example the Verilog backend assigns names in the form {\tt \_{\it integer}\_}.
 \end{itemize}
 
-In order to avoid programming errors, the RTLIL data structures check if all
-identifiers start with either a backslash or a dollar sign and generate a
-runtime error if this rule is violated.
+Whitespace and control characters (any character with an ASCII code 32 or less) are not allowed
+in RTLIL identifiers; most frontends and backends cannot support these characters in identifiers.
+
+In order to avoid programming errors, the RTLIL data structures check if all identifiers start
+with either a backslash or a dollar sign, and contain no whitespace or control characters.
+Violating these rules results in a runtime error.
 
 All RTLIL identifiers are case sensitive.
 


### PR DESCRIPTION
This is an existing invariant (most backends can't cope with these) but one that was not checked or documented.