### PR TITLE
[RFC] Add conditional-insert operator to pool/dict

### DIFF
--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -435,6 +435,14 @@ public:
 			insert(*first);
 	}
 
+	template<class InputIterator, class Predicate>
+	void insert_if(InputIterator first, InputIterator last, Predicate pred)
+	{
+		for (; first != last; ++first)
+			if (pred(*first))
+				insert(*first);
+	}
+
 	std::pair<iterator, bool> insert(const K &key)
 	{
 		int hash = do_hash(key);
@@ -849,6 +857,14 @@ public:
 	{
 		for (; first != last; ++first)
 			insert(*first);
+	}
+
+	template<class InputIterator, class Predicate>
+	void insert_if(InputIterator first, InputIterator last, Predicate pred)
+	{
+		for (; first != last; ++first)
+			if (pred(*first))
+				insert(*first);
 	}
 
 	std::pair<iterator, bool> insert(const K &value)


### PR DESCRIPTION
While trying to reformat `flowmap`, I kept finding instances of:
```cpp
for (auto item : source_pool)
    if (condition)
        dest_pool.insert(item);
```
This PR lets you now do:
```cpp
dest_pool.insert_if(source_pool.begin(), source_pool.end(), [](/* ... */){ return condition; });
```
which I think is a bit terser. This could be further extended to:
```cpp
dest_pool.insert_if(source_pool, [](/* ... */){ return condition; });
```
by internally calling `begin`/`end`, but I wanted to see if this appealed to others first.

Another candidate to add is possibly `dict::insert_each` or something like it for this pattern:
```cpp
for (auto key : source)
    dest_dict[key].insert(item);
```
becoming:
```cpp
dest_dict.insert_each(source.begin(), source.end(), item);
```

I wanted to see what others thought of this first though.