### PR TITLE
Add codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,6 +23,9 @@ passes/opt/opt_lut.cc          @whitequark
 # requests automatically, but we add information for other
 # contributors here too, so we know who to ask to take a look.
 
+# synth_intel_alm
+techlibs/intel_alm/*           @ZirconiumX
+
 # pyosys
 misc/*.py                      @btut
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,25 @@
+## CODE NOTIFICATIONS
+# Register yourself here to be notified about modifications
+# for any files you have an interest in/know your way around.
+
+# Each line is a file pattern followed by one or more users.
+# Both github usernames and email addresses are supported.
+# Order is important; the last matching pattern takes the most
+# precedence. Previous matches will not be applied.
+
+
+# PATH (can use glob)          USERNAME(S)
+
+passes/cmds/scratchpad.cc      @nakengelhardt
+
+
+
+## External Contributors
+# Only users with write permission to the repository get review
+# requests automatically, but we add information for other
+# contributors here too, so we know who to ask to take a look.
+
+# pyosys
+misc/*.py                      @btut
+
+# firrtl backend

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,8 +11,8 @@
 # PATH (can use glob)          USERNAME(S)
 
 passes/cmds/scratchpad.cc      @nakengelhardt
-frontends/rpc/*                @whitequark
-backends/cxxrtl/*              @whitequark
+frontends/rpc/                 @whitequark
+backends/cxxrtl/               @whitequark
 passes/cmds/bugpoint.cc        @whitequark
 passes/techmap/flowmap.cc      @whitequark
 passes/opt/opt_lut.cc          @whitequark

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,10 +23,14 @@ passes/opt/opt_lut.cc          @whitequark
 # requests automatically, but we add information for other
 # contributors here too, so we know who to ask to take a look.
 
-# synth_intel_alm
-techlibs/intel_alm/*           @ZirconiumX
+techlibs/intel_alm/            @ZirconiumX
 
 # pyosys
 misc/*.py                      @btut
 
 # firrtl backend
+?
+
+passes/sat/qbfsat.cc           @boqwxp
+passes/cmds/exec.cc            @boqwxp
+passes/cmds/printattrs.cc      @boqwxp

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,14 +22,15 @@ passes/opt/opt_lut.cc          @whitequark
 # Only users with write permission to the repository get review
 # requests automatically, but we add information for other
 # contributors here too, so we know who to ask to take a look.
+# These still override previous lines, so be careful not to
+# accidentally disable any of the above rules.
 
 techlibs/intel_alm/            @ZirconiumX
 
 # pyosys
 misc/*.py                      @btut
 
-# firrtl backend
-?
+backends/firrtl                @ucbjrl @azidar
 
 passes/sat/qbfsat.cc           @boqwxp
 passes/cmds/exec.cc            @boqwxp

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,7 +11,11 @@
 # PATH (can use glob)          USERNAME(S)
 
 passes/cmds/scratchpad.cc      @nakengelhardt
-
+frontends/rpc/*                @whitequark
+backends/cxxrtl/*              @whitequark
+passes/cmds/bugpoint.cc        @whitequark
+passes/techmap/flowmap.cc      @whitequark
+passes/opt/opt_lut.cc          @whitequark
 
 
 ## External Contributors


### PR DESCRIPTION
No ownership implied; on a voluntary basis, add yourself to this file to have github request a review from you when a file of interest is changed. You can add commits to this PR, or leave a comment here or on slack with lines you'd like me to add.

We also write down who was responsible for major external contributions, but anyone without write access will not automatically get notified by github if I understand correctly. It's still a convenient place to keep this information.