### PR TITLE
Split `flatten` from `techmap` and simplify it

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1884,6 +1884,18 @@ RTLIL::Cell *RTLIL::Module::addCell(RTLIL::IdString name, const RTLIL::Cell *oth
 	return cell;
 }
 
+RTLIL::Memory *RTLIL::Module::addMemory(RTLIL::IdString name, const RTLIL::Memory *other)
+{
+	RTLIL::Memory *mem = new RTLIL::Memory;
+	mem->name = name;
+	mem->width = other->width;
+	mem->start_offset = other->start_offset;
+	mem->size = other->size;
+	mem->attributes = other->attributes;
+	memories[mem->name] = mem;
+	return mem;
+}
+
 #define DEF_METHOD(_func, _y_size, _type) \
 	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_y, bool is_signed, const std::string &src) { \
 		RTLIL::Cell *cell = addCell(name, _type);           \

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1170,6 +1170,8 @@ public:
 	RTLIL::Cell *addCell(RTLIL::IdString name, RTLIL::IdString type);
 	RTLIL::Cell *addCell(RTLIL::IdString name, const RTLIL::Cell *other);
 
+	RTLIL::Memory *addMemory(RTLIL::IdString name, const RTLIL::Memory *other);
+
 	// The add* methods create a cell and return the created cell. All signals must exist in advance.
 
 	RTLIL::Cell* addNot (RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_y, bool is_signed = false, const std::string &src = "");

--- a/passes/techmap/Makefile.inc
+++ b/passes/techmap/Makefile.inc
@@ -1,4 +1,5 @@
 
+OBJS += passes/techmap/flatten.o
 OBJS += passes/techmap/techmap.o
 OBJS += passes/techmap/simplemap.o
 OBJS += passes/techmap/dfflibmap.o

--- a/passes/techmap/flatten.cc
+++ b/passes/techmap/flatten.cc
@@ -79,15 +79,9 @@ struct FlattenWorker
 		for (auto &it : tpl->memories) {
 			IdString m_name = it.first;
 			apply_prefix(cell->name, m_name);
-			RTLIL::Memory *m = new RTLIL::Memory;
-			m->name = m_name;
-			m->width = it.second->width;
-			m->start_offset = it.second->start_offset;
-			m->size = it.second->size;
-			m->attributes = it.second->attributes;
+			RTLIL::Memory *m = module->addMemory(m_name, it.second);
 			if (m->attributes.count(ID::src))
 				m->add_strpool_attribute(ID::src, extra_src_attrs);
-			module->memories[m->name] = m;
 			memory_renames[it.first] = m->name;
 			design->select(module, m);
 		}

--- a/passes/techmap/flatten.cc
+++ b/passes/techmap/flatten.cc
@@ -249,10 +249,8 @@ struct FlattenWorker
 		}
 	}
 
-	bool flatten_module(RTLIL::Design *design, RTLIL::Module *module, pool<RTLIL::Cell*> &handled_cells, bool in_recursion)
+	bool flatten_module(RTLIL::Design *design, RTLIL::Module *module, pool<RTLIL::Cell*> &handled_cells)
 	{
-		std::string mapmsg_prefix = in_recursion ? "Recursively mapping" : "Mapping";
-
 		if (!design->selected(module) || module->get_blackbox_attribute(ignore_wb))
 			return false;
 
@@ -346,7 +344,7 @@ struct FlattenWorker
 				mkdebug.off();
 			}
 
-			log_debug("%s %s.%s (%s) using %s.\n", mapmsg_prefix.c_str(), log_id(module), log_id(cell), log_id(cell->type), log_id(tpl));
+			log_debug("Flattening %s.%s (%s) using %s.\n", log_id(module), log_id(cell), log_id(cell->type), log_id(tpl));
 			flatten_module(design, module, cell, tpl);
 			did_something = true;
 		}
@@ -408,13 +406,13 @@ struct FlattenPass : public Pass {
 			worker.flatten_do_list.insert(top_mod->name);
 			while (!worker.flatten_do_list.empty()) {
 				auto mod = design->module(*worker.flatten_do_list.begin());
-				while (worker.flatten_module(design, mod, handled_cells, false)) { }
+				while (worker.flatten_module(design, mod, handled_cells)) { }
 				worker.flatten_done_list.insert(mod->name);
 				worker.flatten_do_list.erase(mod->name);
 			}
 		} else {
 			for (auto mod : design->modules().to_vector())
-				while (worker.flatten_module(design, mod, handled_cells, false)) { }
+				while (worker.flatten_module(design, mod, handled_cells)) { }
 		}
 
 		log_suppressed();

--- a/passes/techmap/flatten.cc
+++ b/passes/techmap/flatten.cc
@@ -52,7 +52,6 @@ void apply_prefix(IdString prefix, RTLIL::SigSpec &sig, RTLIL::Module *module)
 struct FlattenWorker
 {
 	dict<std::pair<IdString, dict<IdString, RTLIL::Const>>, RTLIL::Module*> cache;
-	dict<Module*, SigMap> sigmaps;
 
 	pool<IdString> flatten_do_list;
 	pool<IdString> flatten_done_list;
@@ -122,6 +121,8 @@ struct FlattenWorker
 			design->select(module, w);
 		}
 
+		SigMap sigmap(module);
+
 		SigMap tpl_sigmap(tpl);
 		pool<SigBit> tpl_written_bits;
 
@@ -185,10 +186,7 @@ struct FlattenWorker
 
 			// connect internal and external wires
 
-			if (sigmaps.count(module) == 0)
-				sigmaps[module].set(module);
-
-			if (sigmaps.at(module)(c.first).has_const())
+			if (sigmap(c.first).has_const())
 				log_error("Mismatch in directionality for cell port %s.%s.%s: %s <= %s\n",
 					log_id(module), log_id(cell), log_id(it.first), log_signal(c.first), log_signal(c.second));
 
@@ -257,8 +255,6 @@ struct FlattenWorker
 		bool log_continue = false;
 		bool did_something = false;
 		LogMakeDebugHdl mkdebug;
-
-		SigMap sigmap(module);
 
 		for (auto cell : module->selected_cells())
 		{

--- a/passes/techmap/flatten.cc
+++ b/passes/techmap/flatten.cc
@@ -261,7 +261,7 @@ struct FlattenWorker
 				continue;
 
 			if (cell->get_bool_attribute(ID::keep_hierarchy) || tpl->get_bool_attribute(ID::keep_hierarchy)) {
-				log("Keeping %s.%s (found keep_hierarchy property).\n", log_id(module), log_id(cell));
+				log("Keeping %s.%s (found keep_hierarchy attribute).\n", log_id(module), log_id(cell));
 				used_modules.insert(tpl);
 				continue;
 			}

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -174,15 +174,9 @@ struct TechmapWorker
 		for (auto &it : tpl->memories) {
 			IdString m_name = it.first;
 			apply_prefix(cell->name, m_name);
-			RTLIL::Memory *m = new RTLIL::Memory;
-			m->name = m_name;
-			m->width = it.second->width;
-			m->start_offset = it.second->start_offset;
-			m->size = it.second->size;
-			m->attributes = it.second->attributes;
+			RTLIL::Memory *m = module->addMemory(m_name, it.second);
 			if (m->attributes.count(ID::src))
 				m->add_strpool_attribute(ID::src, extra_src_attrs);
-			module->memories[m->name] = m;
 			memory_renames[it.first] = m->name;
 			design->select(module, m);
 		}


### PR DESCRIPTION
Although the two passes started out very similar, they diverged over time and now have little in common. Moreover, `techmap` is extremely complex while `flatten` does not have to be, and this complexity interferes with improving `flatten`.

This is a fairly large PR, and it is best reviewed commit by commit: it starts by copying the techmap code wholesale and then simplifying it to make it easier to convince yourself that the changes are indeed correct. It can also be helpful to append `?w=1` to the URL to omit whitespace changes from the output.

The only actual improvement to `flatten` in this PR is using topological order, but it sets the stage for adding support for `hdlname` and processes (without `proc`).