### PR TITLE
flatten: preserve original object names

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,9 @@ Verilog Attributes and non-standard features
   that have ports with a width that depends on a parameter.
 
 - The ``hdlname`` attribute is used by some passes to document the original
-  (HDL) name of a module when renaming a module.
+  (HDL) name of a module when renaming a module. It should contain a single
+  name, or, when describing a hierarchical name in a flattened design, multiple
+  names separated by a single space character.
 
 - The ``keep`` attribute on cells and wires is used to mark objects that should
   never be removed by the optimizer. This is used for example for cells that

--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -508,7 +508,7 @@ std::string get_hdl_name(T *object)
 	if (object->has_attribute(ID::hdlname))
 		return object->get_string_attribute(ID::hdlname);
 	else
-		return object->name.str();
+		return object->name.str().substr(1);
 }
 
 struct CxxrtlWorker {

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -339,6 +339,22 @@ pool<string> RTLIL::AttrObject::get_strpool_attribute(RTLIL::IdString id) const
 	return data;
 }
 
+void RTLIL::AttrObject::set_hdlname_attribute(const vector<string> &hierarchy)
+{
+	string attrval;
+	for (const auto &ident : hierarchy) {
+		if (!attrval.empty())
+			attrval += " ";
+		attrval += ident;
+	}
+	set_string_attribute(ID::hdlname, attrval);
+}
+
+vector<string> RTLIL::AttrObject::get_hdlname_attribute() const
+{
+	return split_tokens(get_string_attribute(ID::hdlname), " ");
+}
+
 bool RTLIL::Selection::selected_module(RTLIL::IdString mod_name) const
 {
 	if (full_selection)

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -319,7 +319,7 @@ void RTLIL::AttrObject::set_strpool_attribute(RTLIL::IdString id, const pool<str
 			attrval += "|";
 		attrval += s;
 	}
-	attributes[id] = RTLIL::Const(attrval);
+	set_string_attribute(id, attrval);
 }
 
 void RTLIL::AttrObject::add_strpool_attribute(RTLIL::IdString id, const pool<string> &data)
@@ -334,7 +334,7 @@ pool<string> RTLIL::AttrObject::get_strpool_attribute(RTLIL::IdString id) const
 {
 	pool<string> data;
 	if (attributes.count(id) != 0)
-		for (auto s : split_tokens(attributes.at(id).decode_string(), "|"))
+		for (auto s : split_tokens(get_string_attribute(id), "|"))
 			data.insert(s);
 	return data;
 }

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -682,6 +682,9 @@ struct RTLIL::AttrObject
 	std::string get_src_attribute() const {
 		return get_string_attribute(ID::src);
 	}
+
+	void set_hdlname_attribute(const vector<string> &hierarchy);
+	vector<string> get_hdlname_attribute() const;
 };
 
 struct RTLIL::SigChunk

--- a/manual/CHAPTER_Overview.tex
+++ b/manual/CHAPTER_Overview.tex
@@ -193,6 +193,13 @@ Violating these rules results in a runtime error.
 
 All RTLIL identifiers are case sensitive.
 
+Some transformations, such as flattening, may have to change identifiers provided by the user
+to avoid name collisions. When that happens, attribute ``{\tt hdlname}`` is attached to the object
+with the changed identifier. This attribute contains one name (if emitted directly by the frontend,
+or is a result of disambiguation) or multiple names separated by spaces (if a result of flattening).
+All names specified in the ``{\tt hdlname}`` attribute are public and do not include the leading
+``\textbackslash``.
+
 \subsection{RTLIL::Design and RTLIL::Module}
 
 The RTLIL::Design object is basically just a container for RTLIL::Module objects. In addition to

--- a/passes/techmap/flatten.cc
+++ b/passes/techmap/flatten.cc
@@ -32,8 +32,12 @@ IdString concat_name(RTLIL::Cell *cell, IdString object_name)
 {
 	if (object_name[0] == '\\')
 		return stringf("%s.%s", cell->name.c_str(), object_name.c_str() + 1);
-	else
-		return stringf("$flatten%s.%s", cell->name.c_str(), object_name.c_str());
+	else {
+		std::string object_name_str = object_name.str();
+		if (object_name_str.substr(0, 8) == "$flatten")
+			object_name_str.erase(0, 8);
+		return stringf("$flatten%s.%s", cell->name.c_str(), object_name_str.c_str());
+	}
 }
 
 template<class T>


### PR DESCRIPTION
This PR depends on #2120.

This PR adjusts `flatten` to track the exact original name in the `hdlname` attribute, and describes the semantics of that attribute in the manual.

This addition lays the groundwork for robust end-to-end tracking of public names, from frontend to bitstream. I would like to see a future where tooling can find out where every bit of every register ended up without ever having to guess, even though registers could have a name that contains dots, have been removed, duplicated, renamed to avoid conflicts, or split.