### PR TITLE
MacOS has even stricter stack limits in catalina.

### DIFF
--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -39,7 +39,7 @@ if os.name == "posix":
         smtio_stacksize = 128 * 1024 * 1024
         if os.uname().sysname == "Darwin":
             # MacOS has rather conservative stack limits
-            smtio_stacksize = 16 * 1024 * 1024
+            smtio_stacksize = 16 * 1024 * 512
         if current_rlimit_stack[1] != resource.RLIM_INFINITY:
             smtio_stacksize = min(smtio_stacksize, current_rlimit_stack[1])
         if current_rlimit_stack[0] < smtio_stacksize:

--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -39,7 +39,7 @@ if os.name == "posix":
         smtio_stacksize = 128 * 1024 * 1024
         if os.uname().sysname == "Darwin":
             # MacOS has rather conservative stack limits
-            smtio_stacksize = 16 * 1024 * 512
+            smtio_stacksize = 8 * 1024 * 1024
         if current_rlimit_stack[1] != resource.RLIM_INFINITY:
             smtio_stacksize = min(smtio_stacksize, current_rlimit_stack[1])
         if current_rlimit_stack[0] < smtio_stacksize:


### PR DESCRIPTION
Invoking sby in macOS Catalina fails because of bizarre stack limits in Catalina.

See related issue here: https://github.com/YosysHQ/yosys/issues/692

Invoking sby in Catalina fails with:

```
SBY 13:58:00 [adder3_formal] engine_0: Traceback (most recent call last):
SBY 13:58:00 [adder3_formal] engine_0: File "/usr/local/bin/yosys-smtbmc", line 22, in <module>
SBY 13:58:00 [adder3_formal] engine_0: from smtio import SmtIo, SmtOpts, MkVcd
SBY 13:58:00 [adder3_formal] engine_0: File "/usr/local/Cellar/yosys/0.9_2/bin/../share/yosys/python3/smtio.py", line 46, in <module>
SBY 13:58:00 [adder3_formal] engine_0: resource.setrlimit(resource.RLIMIT_STACK, (smtio_stacksize, current_rlimit_stack[1]))
SBY 13:58:00 [adder3_formal] engine_0: ValueError: current limit exceeds maximum limit
SBY 13:58:00 [adder3_formal] engine_0: finished (returncode=1)
SBY 13:58:00 [adder3_formal] ERROR: engine_0: Engine terminated without status.
SBY 13:58:00 [adder3_formal] DONE (ERROR, rc=16)
```