### PR TITLE
Support packed arrays in struct/union.

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -1554,10 +1554,10 @@ member_name_list:
 member_name: TOK_ID {
 			astbuf1->str = $1->substr(1);
 			delete $1;
-			auto member_node = astbuf1->clone();
-			SET_AST_NODE_LOC(member_node, @1, @1);
-			astbuf2->children.push_back(member_node);
-		}
+			astbuf3 = astbuf1->clone();
+			SET_AST_NODE_LOC(astbuf3, @1, @1);
+			astbuf2->children.push_back(astbuf3);
+		} range { if ($3) astbuf3->children.push_back($3); }
 	;
 
 struct_member_type: { astbuf1 = new AstNode(AST_STRUCT_ITEM); } member_type_token
@@ -1595,7 +1595,7 @@ member_type_token:
 	;
 
 member_type: type_atom type_signing
-	| type_vec type_signing range	{ if ($3) astbuf1->children.push_back($3); }
+	| type_vec type_signing range_or_multirange	{ if ($3) astbuf1->children.push_back($3); }
 	;
 
 struct_var_list: struct_var

--- a/tests/svtypes/struct_array.sv
+++ b/tests/svtypes/struct_array.sv
@@ -1,0 +1,22 @@
+// test for array indexing in structures
+
+module top;
+	
+	struct packed {
+		bit [5:0] [7:0] a;	// 6 element packed array of bytes
+		bit [15:0] b;		// filler for non-zero offset
+	} s;
+
+	initial begin
+		s = '0;
+
+		s.a[2:1] = 16'h1234;
+		s.a[5] = 8'h42;
+
+		s.b = '1;
+		s.b[1:0] = '0;
+	end
+
+	always_comb assert(s==64'h4200_0012_3400_FFFC);
+
+endmodule


### PR DESCRIPTION
Allow packed arrays of the form

    bit [5:0] [63:0] a;         // 6 elements each 64 bits in size

in packed struct/union.