### PR TITLE
fsm_extract: avoid calling log_signal to determine wire name

### DIFF
--- a/passes/fsm/fsm_extract.cc
+++ b/passes/fsm/fsm_extract.cc
@@ -394,7 +394,7 @@ static void extract_fsm(RTLIL::Wire *wire)
 		RTLIL::Cell *cell = module->cells_.at(cellport.first);
 		RTLIL::SigSpec port_sig = assign_map(cell->getPort(cellport.second));
 		RTLIL::SigSpec unconn_sig = port_sig.extract(ctrl_out);
-		RTLIL::Wire *unconn_wire = module->addWire(stringf("$fsm_unconnect$%s$%d", log_signal(unconn_sig), autoidx++), unconn_sig.size());
+		RTLIL::Wire *unconn_wire = module->addWire(stringf("$fsm_unconnect$%d", autoidx++), unconn_sig.size());
 		port_sig.replace(unconn_sig, RTLIL::SigSpec(unconn_wire), &cell->connections_[cellport.second]);
 	}
 }


### PR DESCRIPTION
log_signal can result in a string with spaces (when bit selection is
involved), which breaks the rule of IdString not containing whitespace.
Instead, remove the sigspec from the name entirely — given that the
resulting wire will have no users, it will be removed later anyway,
so its name doesn't really matter.

Fixes #2118