### PR TITLE
Support 2D bit arrays in structures. Optimise array indexing.

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -383,43 +383,9 @@ static AstNode *node_int(int ival)
 	return AstNode::mkconst_int(ival, true);
 }
 
-static AstNode *node_uint(uint ival)
-{
-	return AstNode::mkconst_int(ival, false);
-}
-
-static unsigned int power_of_two(int n)
-{
-	// iff n is a power of two then return the power, else return 0
-	// caller must ensure n > 1
-	log_assert(n > 1);
-	if (n & (n - 1)) {
-		// not a power of 2
-		return 0;
-	}
-	// brute force the shift
-	for (unsigned int i = 1; i < 32; i++) {
-		n >>= 1;
-		if (n & 1) {
-			return i;
-		}
-	}
-	return 0;
-}
-
 static AstNode *multiply_by_const(AstNode *expr_node, int stride)
 {
-	// the stride is very likely a power of 2, e.g. 8 for bytes
-	// and so could be optimised with a shift
-	AstNode *node;
-	unsigned int shift;
-	if ((shift = power_of_two(stride)) > 0) {
-		node = new AstNode(AST_SHIFT_LEFT, expr_node, node_uint(shift));
-	}
-	else {
-		node = new AstNode(AST_MUL, expr_node, node_int(stride));
-	}
-	return node;
+	return new AstNode(AST_MUL, expr_node, node_int(stride));
 }
 
 static AstNode *offset_indexed_range(int offset, int stride, AstNode *left_expr, AstNode *right_expr)

--- a/tests/svtypes/struct_array.sv
+++ b/tests/svtypes/struct_array.sv
@@ -1,9 +1,9 @@
 // test for array indexing in structures
 
 module top;
-	
+
 	struct packed {
-		bit [7:0] [7:0] a;	// 8 element packed array of bytes
+		bit [5:0] [7:0] a;	// 6 element packed array of bytes
 		bit [15:0] b;		// filler for non-zero offset
 	} s;
 
@@ -13,13 +13,30 @@ module top;
 		s.a[2:1] = 16'h1234;
 		s.a[5] = 8'h42;
 
-		s.a[7] = '1;
-		s.a[7][1:0] = '0;
-
 		s.b = '1;
 		s.b[1:0] = '0;
 	end
 
-	always_comb assert(s==80'hFC00_4200_0012_3400_FFFC);
+	always_comb assert(s==64'h4200_0012_3400_FFFC);
+
+	struct packed {
+		bit [7:0] [7:0] a;	// 8 element packed array of bytes
+		bit [15:0] b;		// filler for non-zero offset
+	} s2;
+
+	initial begin
+		s2 = '0;
+
+		s2.a[2:1] = 16'h1234;
+		s2.a[5] = 8'h42;
+
+		s2.a[7] = '1;
+		s2.a[7][1:0] = '0;
+
+		s2.b = '1;
+		s2.b[1:0] = '0;
+	end
+
+	always_comb assert(s2==80'hFC00_4200_0012_3400_FFFC);
 
 endmodule

--- a/tests/svtypes/struct_array.sv
+++ b/tests/svtypes/struct_array.sv
@@ -3,7 +3,7 @@
 module top;
 	
 	struct packed {
-		bit [5:0] [7:0] a;	// 6 element packed array of bytes
+		bit [7:0] [7:0] a;	// 8 element packed array of bytes
 		bit [15:0] b;		// filler for non-zero offset
 	} s;
 
@@ -13,10 +13,13 @@ module top;
 		s.a[2:1] = 16'h1234;
 		s.a[5] = 8'h42;
 
+		s.a[7] = '1;
+		s.a[7][1:0] = '0;
+
 		s.b = '1;
 		s.b[1:0] = '0;
 	end
 
-	always_comb assert(s==64'h4200_0012_3400_FFFC);
+	always_comb assert(s==80'hFC00_4200_0012_3400_FFFC);
 
 endmodule


### PR DESCRIPTION
Support bit slicing of array elements in structs or unions e.g.

    s.a[i][p:q]

Array indexing when the array stride is a power of two is now done with a shift rather than a multiply.