### PR TITLE
flatten: accept processes

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1536,13 +1536,13 @@ void RTLIL::Module::cloneInto(RTLIL::Module *new_mod) const
 		new_mod->addWire(it.first, it.second);
 
 	for (auto &it : memories)
-		new_mod->memories[it.first] = new RTLIL::Memory(*it.second);
+		new_mod->addMemory(it.first, it.second);
 
 	for (auto &it : cells_)
 		new_mod->addCell(it.first, it.second);
 
 	for (auto &it : processes)
-		new_mod->processes[it.first] = it.second->clone();
+		new_mod->addProcess(it.first, it.second);
 
 	struct RewriteSigSpecWorker
 	{
@@ -1911,6 +1911,14 @@ RTLIL::Memory *RTLIL::Module::addMemory(RTLIL::IdString name, const RTLIL::Memor
 	mem->attributes = other->attributes;
 	memories[mem->name] = mem;
 	return mem;
+}
+
+RTLIL::Process *RTLIL::Module::addProcess(RTLIL::IdString name, const RTLIL::Process *other)
+{
+	RTLIL::Process *proc = other->clone();
+	proc->name = name;
+	processes[name] = proc;
+	return proc;
 }
 
 #define DEF_METHOD(_func, _y_size, _type) \

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1175,6 +1175,8 @@ public:
 
 	RTLIL::Memory *addMemory(RTLIL::IdString name, const RTLIL::Memory *other);
 
+	RTLIL::Process *addProcess(RTLIL::IdString name, const RTLIL::Process *other);
+
 	// The add* methods create a cell and return the created cell. All signals must exist in advance.
 
 	RTLIL::Cell* addNot (RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_y, bool is_signed = false, const std::string &src = "");


### PR DESCRIPTION
There is no reason not to do this (the code that accepts processes is actually as long as the code that would print the error message rejecting them), it makes the pass nicer to use, and it allows some interesting experiments with other passes like CXXRTL (turns out `-noproc -flatten` has 15% lower compile time, which I was only able to measure after doing this change).