### PR TITLE
cxxrtl: fix two buggy split_by functions

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -474,14 +474,16 @@ std::vector<std::string> split_by(const std::string &str, const std::string &sep
 	std::vector<std::string> result;
 	size_t prev = 0;
 	while (true) {
-		size_t curr = str.find_first_of(sep, prev + 1);
-		if (curr > str.size())
-			curr = str.size();
-		if (curr > prev + 1)
-			result.push_back(str.substr(prev, curr - prev));
-		if (curr == str.size())
+		size_t curr = str.find_first_of(sep, prev);
+		if (curr == std::string::npos) {
+			std::string part = str.substr(prev);
+			if (!part.empty()) result.push_back(part);
 			break;
-		prev = curr;
+		} else {
+			std::string part = str.substr(prev, curr - prev);
+			if (!part.empty()) result.push_back(part);
+			prev = curr + 1;
+		}
 	}
 	return result;
 }

--- a/backends/cxxrtl/cxxrtl_vcd.h
+++ b/backends/cxxrtl/cxxrtl_vcd.h
@@ -136,14 +136,14 @@ class vcd_writer {
 		std::vector<std::string> hierarchy;
 		size_t prev = 0;
 		while (true) {
-			size_t curr = hier_name.find_first_of(' ', prev + 1);
-			if (curr > hier_name.size())
-				curr = hier_name.size();
-			if (curr > prev + 1)
-				hierarchy.push_back(hier_name.substr(prev, curr - prev));
-			if (curr == hier_name.size())
+			size_t curr = hier_name.find_first_of(' ', prev);
+			if (curr == std::string::npos) {
+				hierarchy.push_back(hier_name.substr(prev));
 				break;
-			prev = curr + 1;
+			} else {
+				hierarchy.push_back(hier_name.substr(prev, curr - prev));
+				prev = curr + 1;
+			}
 		}
 		return hierarchy;
 	}


### PR DESCRIPTION
(Something about the first binary search and the first correct binary search...)