### PR TITLE
cxxrtl: disambiguate values/wires and their aliases in debug info

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -1646,7 +1646,7 @@ struct CxxrtlWorker {
 				} else if (debug_alias_wires.count(wire)) {
 					// Alias of a member wire
 					f << indent << "items.emplace(path + " << escape_cxx_string(get_hdl_name(wire));
-					f << ", debug_item(" << mangle(debug_alias_wires[wire]) << "));\n";
+					f << ", debug_item(debug_alias(), " << mangle(debug_alias_wires[wire]) << "));\n";
 					count_alias_wires++;
 				} else if (!localized_wires.count(wire)) {
 					// Member wire

--- a/backends/cxxrtl/cxxrtl_capi.h
+++ b/backends/cxxrtl/cxxrtl_capi.h
@@ -89,7 +89,14 @@ enum cxxrtl_type {
 	// always NULL.
 	CXXRTL_MEMORY = 2,
 
-	// More object types will be added in the future, but the existing ones will never change.
+	// Aliases correspond to netlist nodes driven by another node such that their value is always
+	// exactly equal, or driven by a constant value.
+	//
+	// Aliases can be inspected via the `curr` pointer. They cannot be modified, and the `next`
+	// pointer is always NULL.
+	CXXRTL_ALIAS = 3,
+
+	// More object types may be added in the future, but the existing ones will never change.
 };
 
 // Description of a simulated object.
@@ -123,7 +130,7 @@ struct cxxrtl_object {
 	uint32_t *curr;
 	uint32_t *next;
 
-	// More description fields will be added in the future, but the existing ones will never change.
+	// More description fields may be added in the future, but the existing ones will never change.
 };
 
 // Retrieve description of a simulated object.


### PR DESCRIPTION
With this change, it is easier to see which signals carry state (only `wire<>`s appear as `reg` in VCD files) and to construct a minimal checkpoint (`CXXRTL_WIRE` debug items represent the canonical smallest set of state required to fully reconstruct the simulation).

Fixes #2137.