### PR TITLE
intel_alm: fix DFFE matching

### DIFF
--- a/techlibs/intel_alm/synth_intel_alm.cc
+++ b/techlibs/intel_alm/synth_intel_alm.cc
@@ -199,7 +199,7 @@ struct SynthIntelALMPass : public ScriptPass {
 		}
 
 		if (check_label("map_ffs")) {
-			run("dff2dffe -direct-match $_DFF_*");
+			run("dff2dffe");
 			// As mentioned in common/dff_sim.v, Intel flops power up to zero,
 			// so use `zinit` to add inverters where needed.
 			run("zinit");

--- a/tests/arch/intel_alm/dffs.ys
+++ b/tests/arch/intel_alm/dffs.ys
@@ -17,6 +17,5 @@ equiv_opt -async2sync -assert -map +/intel_alm/common/alm_sim.v -map +/intel_alm
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd dffe # Constrain all select calls below inside the top module
 select -assert-count 1 t:MISTRAL_FF
-select -assert-count 1 t:MISTRAL_ALUT3
 
-select -assert-none t:MISTRAL_FF t:MISTRAL_ALUT3 %% t:* %D
+select -assert-none t:MISTRAL_FF %% t:* %D

--- a/tests/arch/intel_alm/fsm.ys
+++ b/tests/arch/intel_alm/fsm.ys
@@ -13,6 +13,7 @@ cd fsm # Constrain all select calls below inside the top module
 
 select -assert-count 6 t:MISTRAL_FF
 select -assert-max 2 t:MISTRAL_ALUT2 # Clang returns 2, GCC returns 1
+select -assert-count 1 t:MISTRAL_ALUT3
 select -assert-count 5 t:MISTRAL_ALUT5
-select -assert-count 1 t:MISTRAL_ALUT6
-select -assert-none t:MISTRAL_FF t:MISTRAL_ALUT2 t:MISTRAL_ALUT5 t:MISTRAL_ALUT6 %% t:* %D
+select -assert-count 2 t:MISTRAL_ALUT6
+select -assert-none t:MISTRAL_FF t:MISTRAL_ALUT2 t:MISTRAL_ALUT3 t:MISTRAL_ALUT5 t:MISTRAL_ALUT6 %% t:* %D


### PR DESCRIPTION
While working on M10K direct instantiation, I discovered an embarrassing bug where the `dff2dffe` pass was doing nothing because it's pattern matching against `$_DFF_*` before `techmap` executes; the fix is simply to be less specific.

This one-line patch reduces the area of VexRiscV by about 15%.

cc @mwkmwkmwk 