### PR TITLE
intel_alm: DSP inference

### DIFF
--- a/techlibs/intel_alm/Makefile.inc
+++ b/techlibs/intel_alm/Makefile.inc
@@ -10,6 +10,8 @@ $(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/al
 $(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/arith_alm_map.v))
 $(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/dff_map.v))
 $(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/dff_sim.v))
+$(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/dsp_sim.v))
+$(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/dsp_map.v))
 $(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/mem_sim.v))
 
 # RAM

--- a/techlibs/intel_alm/common/dsp_map.v
+++ b/techlibs/intel_alm/common/dsp_map.v
@@ -1,0 +1,49 @@
+module __MUL27X27(A, B, Y);
+
+parameter A_SIGNED = 1;
+parameter B_SIGNED = 1;
+parameter A_WIDTH = 27;
+parameter B_WIDTH = 27;
+parameter Y_WIDTH = 54;
+
+input [A_WIDTH-1:0] A;
+input [B_WIDTH-1:0] B;
+output [Y_WIDTH-1:0] Y;
+
+MISTRAL_MUL27X27 _TECHMAP_REPLACE_ (.A(A), .B(B), .Y(Y));
+
+endmodule
+
+
+module __MUL18X18(A, B, Y);
+
+parameter A_SIGNED = 1;
+parameter B_SIGNED = 1;
+parameter A_WIDTH = 18;
+parameter B_WIDTH = 18;
+parameter Y_WIDTH = 36;
+
+input [A_WIDTH-1:0] A;
+input [B_WIDTH-1:0] B;
+output [Y_WIDTH-1:0] Y;
+
+MISTRAL_MUL18X18 _TECHMAP_REPLACE_ (.A(A), .B(B), .Y(Y));
+
+endmodule
+
+
+module __MUL9X9(A, B, Y);
+
+parameter A_SIGNED = 1;
+parameter B_SIGNED = 1;
+parameter A_WIDTH = 9;
+parameter B_WIDTH = 9;
+parameter Y_WIDTH = 18;
+
+input [A_WIDTH-1:0] A;
+input [B_WIDTH-1:0] B;
+output [Y_WIDTH-1:0] Y;
+
+MISTRAL_MUL9X9 _TECHMAP_REPLACE_ (.A(A), .B(B), .Y(Y));
+
+endmodule

--- a/techlibs/intel_alm/common/dsp_sim.v
+++ b/techlibs/intel_alm/common/dsp_sim.v
@@ -1,0 +1,35 @@
+(* abc9_box *)
+module MISTRAL_MUL27x27(input [26:0] A, input [26:0] B, output [53:0] Y);
+
+specify
+    (A *> Y) = 4057;
+    (B *> Y) = 4057;
+endspecify
+
+assign Y = $signed(A) * $signed(B);
+
+endmodule
+
+(* abc9_box *)
+module MISTRAL_MUL18X18(input [17:0] A, input [17:0] B, output [35:0] Y);
+
+specify
+    (A *> Y) = 4057;
+    (B *> Y) = 4057;
+endspecify
+
+assign Y = $signed(A) * $signed(B);
+
+endmodule
+
+(* abc9_box *)
+module MISTRAL_MUL9X9(input [8:0] A, input [8:0] B, output [17:0] Y);
+
+specify
+    (A *> Y) = 4057;
+    (B *> Y) = 4057;
+endspecify
+
+assign Y = $signed(A) * $signed(B);
+
+endmodule

--- a/techlibs/intel_alm/common/megafunction_bb.v
+++ b/techlibs/intel_alm/common/megafunction_bb.v
@@ -129,3 +129,31 @@ output [data_width-1:0] portbdataout;
 input ena0, clk0, clk1;
 
 endmodule
+
+(* blackbox *)
+module cyclonev_mac(ax, ay, resulta);
+
+parameter ax_width = 9;
+parameter ay_scan_in_width = 9;
+parameter result_a_width = 18;
+parameter operation_mode = "M9x9";
+
+input [ax_width-1:0] ax;
+input [ay_scan_in_width-1:0] ay;
+output [result_a_width-1:0] resulta;
+
+endmodule
+
+(* blackbox *)
+module cyclone10gx_mac(ax, ay, resulta);
+
+parameter ax_width = 18;
+parameter ay_scan_in_width = 18;
+parameter result_a_width = 36;
+parameter operation_mode = "M18X18_FULL";
+
+input [ax_width-1:0] ax;
+input [ay_scan_in_width-1:0] ay;
+output [result_a_width-1:0] resulta;
+
+endmodule

--- a/techlibs/intel_alm/common/quartus_rename.v
+++ b/techlibs/intel_alm/common/quartus_rename.v
@@ -1,9 +1,11 @@
 `ifdef cyclonev
 `define LCELL cyclonev_lcell_comb
+`define MAC cyclonev_mac
 `define MLAB cyclonev_mlab_cell
 `endif
 `ifdef cyclone10gx
 `define LCELL cyclone10gx_lcell_comb
+`define MAC cyclone10gx_mac
 `define MLAB cyclone10gx_mlab_cell
 `endif
 
@@ -117,5 +119,26 @@ module MISTRAL_MLAB(input [4:0] A1ADDR, input A1DATA, A1EN, CLK1, input [4:0] B1
     .ena0(A1EN),
     .clk0(CLK1)
 );
+
+endmodule
+
+
+module MISTRAL_MUL27X27(input [26:0] A, B, output [53:0] Y);
+
+`MAC #(.ax_width(27), .ay_scan_in_width(27), .result_a_width(54), .operation_mode("M27x27")) _TECHMAP_REPLACE_ (.ax(A), .ay(B), .resulta(Y));
+
+endmodule
+
+
+module MISTRAL_MUL18X18(input [17:0] A, B, output [35:0] Y);
+
+`MAC #(.ax_width(18), .ay_scan_in_width(18), .result_a_width(36), .operation_mode("M18x18_FULL")) _TECHMAP_REPLACE_ (.ax(B), .ay(A), .resulta(Y));
+
+endmodule
+
+
+module MISTRAL_MUL9X9(input [8:0] A, B, output [17:0] Y);
+
+`MAC #(.ax_width(9), .ay_scan_in_width(9), .result_a_width(18), .operation_mode("M9x9")) _TECHMAP_REPLACE_ (.ax(A), .ay(B), .resulta(Y));
 
 endmodule

--- a/tests/arch/intel_alm/mul.ys
+++ b/tests/arch/intel_alm/mul.ys
@@ -1,0 +1,23 @@
+read_verilog ../common/mul.v
+hierarchy -top top
+proc
+equiv_opt -assert -map +/intel_alm/common/dsp_sim.v synth_intel_alm -family cyclonev # equivalency check
+design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
+cd top # Constrain all select calls below inside the top module
+
+stat
+
+select -assert-count 1 t:MISTRAL_MUL9X9
+select -assert-none t:MISTRAL_MUL9X9 %% t:* %D
+
+design -reset
+read_verilog ../common/mul.v
+hierarchy -top top
+proc
+equiv_opt -assert -map +/intel_alm/common/dsp_sim.v synth_intel_alm -family cyclone10gx # equivalency check
+design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
+cd top # Constrain all select calls below inside the top module
+
+# Cyclone 10 GX does not have 9x9 multipliers, so we use 18x18.
+select -assert-count 1 t:MISTRAL_MUL18X18
+select -assert-none t:MISTRAL_MUL18X18 %% t:* %D


### PR DESCRIPTION
This adds basic support for the multiply-accumulate slices within the Cyclone V, using `mul2dsp.v` to map them. They're rather unusual in that a slice can be three 9x9 multipliers, two 18x18 multipliers or a 27x27 multiplier.  Ideally this would have a Yosys pass to attempt to pack adders and flops into the cell, but this works fine as a minimum viable product.

cc @mwkmwkmwk 