### PR TITLE
cxxrtl: fix rzext()

### DIFF
--- a/backends/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/cxxrtl.h
@@ -165,8 +165,8 @@ struct value : public expr_base<value<Bits>> {
 			carry = (shift_bits == 0) ? 0
 				: data[n] >> (chunk::bits - shift_bits);
 		}
-		if (carry != 0)
-			result.data[result.chunks - 1] = carry;
+		if (shift_chunks + chunks < result.chunks)
+			result.data[shift_chunks + chunks] = carry;
 		return result;
 	}
 


### PR DESCRIPTION
This was a correctness issue, but one of the consequences is that it resulted in jumps in generated machine code where there should have been none. As a side effect of fixing the bug, Minerva SoC became 10% faster.