### PR TITLE
splitnets: Cleanup and efficiency improvements

### DIFF
--- a/passes/cmds/splitnets.cc
+++ b/passes/cmds/splitnets.cc
@@ -59,9 +59,13 @@ struct SplitnetsWorker
 		new_wire->port_id = wire->port_id ? wire->port_id + offset : 0;
 		new_wire->port_input = wire->port_input;
 		new_wire->port_output = wire->port_output;
+		new_wire->start_offset = wire->start_offset + offset;
 
 		if (wire->attributes.count(ID::src))
 			new_wire->attributes[ID::src] = wire->attributes.at(ID::src);
+
+		if (wire->attributes.count(ID::hdlname))
+			new_wire->attributes[ID::hdlname] = wire->attributes.at(ID::hdlname);
 
 		if (wire->attributes.count(ID::keep))
 			new_wire->attributes[ID::keep] = wire->attributes.at(ID::keep);

--- a/passes/cmds/splitnets.cc
+++ b/passes/cmds/splitnets.cc
@@ -174,12 +174,12 @@ struct SplitnetsPass : public Pass {
 
 				std::map<RTLIL::Wire*, std::set<int>> split_wires_at;
 
-				for (auto &c : module->cells_)
-				for (auto &p : c.second->connections())
+				for (auto c : module->cells())
+				for (auto &p : c->connections())
 				{
-					if (!ct.cell_known(c.second->type))
+					if (!ct.cell_known(c->type))
 						continue;
-					if (!ct.cell_output(c.second->type, p.first))
+					if (!ct.cell_output(c->type, p.first))
 						continue;
 
 					RTLIL::SigSpec sig = p.second;
@@ -206,9 +206,8 @@ struct SplitnetsPass : public Pass {
 			}
 			else
 			{
-				for (auto &w : module->wires_) {
-					RTLIL::Wire *wire = w.second;
-					if (wire->width > 1 && (wire->port_id == 0 || flag_ports) && design->selected(module, w.second))
+				for (auto wire : module->wires()) {
+					if (wire->width > 1 && (wire->port_id == 0 || flag_ports) && design->selected(module, wire))
 						worker.splitmap[wire] = std::vector<RTLIL::SigBit>();
 				}
 

--- a/passes/cmds/splitnets.cc
+++ b/passes/cmds/splitnets.cc
@@ -61,20 +61,24 @@ struct SplitnetsWorker
 		new_wire->port_output = wire->port_output;
 		new_wire->start_offset = wire->start_offset + offset;
 
-		if (wire->attributes.count(ID::src))
-			new_wire->attributes[ID::src] = wire->attributes.at(ID::src);
+		auto it = wire->attributes.find(ID::src);
+		if (it != wire->attributes.end())
+			new_wire->attributes.emplace(ID::src, it->second);
 
-		if (wire->attributes.count(ID::hdlname))
-			new_wire->attributes[ID::hdlname] = wire->attributes.at(ID::hdlname);
+		it = wire->attributes.find(ID::hdlname);
+		if (it != wire->attributes.end())
+			new_wire->attributes.emplace(ID::hdlname, it->second);
 
-		if (wire->attributes.count(ID::keep))
-			new_wire->attributes[ID::keep] = wire->attributes.at(ID::keep);
+		it = wire->attributes.find(ID::keep);
+		if (it != wire->attributes.end())
+			new_wire->attributes.emplace(ID::keep, it->second);
 
-		if (wire->attributes.count(ID::init)) {
-			Const old_init = wire->attributes.at(ID::init), new_init;
+		it = wire->attributes.find(ID::init);
+		if (it != wire->attributes.end()) {
+			Const old_init = it->second, new_init;
 			for (int i = offset; i < offset+width; i++)
 				new_init.bits.push_back(i < GetSize(old_init) ? old_init.bits.at(i) : State::Sx);
-			new_wire->attributes[ID::init] = new_init;
+			new_wire->attributes.emplace(ID::init, new_init);
 		}
 
 		std::vector<RTLIL::SigBit> sigvec = RTLIL::SigSpec(new_wire).to_sigbit_vector();


### PR DESCRIPTION
This PR consists of two commits.  The first replaces code like:

```
if (wire->attributes.count(ID::src))
    new_wire->attributes[ID::src] = wire->attributes.at(ID::src);
```

with:

```
auto it = wire->attributes.find(ID::src);
if (it != wire->attributes.end())
    new_wire->attributes.emplace(ID::src, it->second);
```

The second replaces `for` loops over the pseudo-private members `wires_` and `cells_` with loops over `wires()` and `cells()`.

Depends:
----
- [x] PR #2142 