### PR TITLE
kernel: guard include of signal.h more precisely

### DIFF
--- a/kernel/log.h
+++ b/kernel/log.h
@@ -55,7 +55,9 @@
 #else
 #  include <sys/time.h>
 #  include <sys/resource.h>
-#  include <signal.h>
+#  if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#    include <signal.h>
+#  endif
 #endif
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
Upgrading to WASI SDK 11.0 caused the WASM build to fail because WASM does not have signals.