### PR TITLE
Fix Verilator sim warnings: 1 BLKSEQ and 3 WIDTH

### DIFF
--- a/techlibs/ice40/cells_sim.v
+++ b/techlibs/ice40/cells_sim.v
@@ -2508,7 +2508,7 @@ module SB_SPRAM256KA (
 
 	always @(negedge POWEROFF) begin
 		for (i = 0; i <= 16383; i = i+1)
-			mem[i] = 'bx;
+			mem[i] = 16'bx;
 	end
 
 	always @(posedge CLOCK, posedge off) begin
@@ -2516,17 +2516,17 @@ module SB_SPRAM256KA (
 			DATAOUT <= 0;
 		end else
 		if (STANDBY) begin
-			DATAOUT <= 'bx;
+			DATAOUT <= 16'bx;
 		end else
 		if (CHIPSELECT) begin
 			if (!WREN) begin
 				DATAOUT <= mem[ADDRESS];
 			end else begin
-				if (MASKWREN[0]) mem[ADDRESS][ 3: 0] = DATAIN[ 3: 0];
-				if (MASKWREN[1]) mem[ADDRESS][ 7: 4] = DATAIN[ 7: 4];
-				if (MASKWREN[2]) mem[ADDRESS][11: 8] = DATAIN[11: 8];
-				if (MASKWREN[3]) mem[ADDRESS][15:12] = DATAIN[15:12];
-				DATAOUT <= 'bx;
+				if (MASKWREN[0]) mem[ADDRESS][ 3: 0] <= DATAIN[ 3: 0];
+				if (MASKWREN[1]) mem[ADDRESS][ 7: 4] <= DATAIN[ 7: 4];
+				if (MASKWREN[2]) mem[ADDRESS][11: 8] <= DATAIN[11: 8];
+				if (MASKWREN[3]) mem[ADDRESS][15:12] <= DATAIN[15:12];
+				DATAOUT <= 16'bx;
 			end
 		end
 	end


### PR DESCRIPTION
Sylvain "tnt" Munaut suggested I create this PR to solve a few warnings from Verilator in an ice40 simulation file when I asked about them. -Thanks!