### PR TITLE
cxxrtl: fix sshr sign-extension.

### DIFF
--- a/backends/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/cxxrtl.h
@@ -376,10 +376,12 @@ struct value : public expr_base<value<Bits>> {
 				: data[chunks - 1 - n] << (chunk::bits - shift_bits);
 		}
 		if (Signed && is_neg()) {
-			for (size_t n = chunks - shift_chunks; n < chunks; n++)
+			size_t top_chunk_idx  = (Bits - shift_bits) / chunk::bits;
+			size_t top_chunk_bits = (Bits - shift_bits) % chunk::bits;
+			for (size_t n = top_chunk_idx + 1; n < chunks; n++)
 				result.data[n] = chunk::mask;
 			if (shift_bits != 0)
-				result.data[chunks - shift_chunks] |= chunk::mask << (chunk::bits - shift_bits);
+				result.data[top_chunk_idx] |= chunk::mask << top_chunk_bits;
 		}
 		return result;
 	}


### PR DESCRIPTION
This fixes #2157

I think this covers all the cases now. It works by finding the most significant chunk after the shift, calculating the number of bits in that chunk, then masking the rest. In the edge case where a small shift lands right on a chunk boundary, it will mask off the whole chunk above - I think that's reasonable so it didn't seem worth adding a special case.

This won't guarantee masking all chunks above the new "valid" region (ie: if a small shift moves the value out of chunk[1] and completely into chunk[0], this won't mask chunk[1]). I wasn't sure whether that was required as the result will get sliced down immediately anyway?