### PR TITLE
Get yosys building on Visual Studio

### DIFF
--- a/frontends/verilog/preproc.cc
+++ b/frontends/verilog/preproc.cc
@@ -591,7 +591,7 @@ read_define_args()
 
 		default:
 			// The only FSM states are 0-2 and we dealt with 2 at the start of the loop.
-			__builtin_unreachable();
+			log_assert(false);
 		}
 	}
 

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -1481,7 +1481,7 @@ enum_name_decl:
 		delete $1;
 		SET_AST_NODE_LOC(node, @1, @1);
 		delete node->children[0];
-		node->children[0] = $2 ?: new AstNode(AST_NONE);
+		node->children[0] = $2 ? $2 : new AstNode(AST_NONE);
 		astbuf2->children.push_back(node);
 	}
 	;

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -117,11 +117,11 @@ extern Tcl_Obj *Tcl_ObjSetVar2(Tcl_Interp *interp, Tcl_Obj *part1Ptr, Tcl_Obj *p
 #    define PATH_MAX MAX_PATH
 #    define isatty _isatty
 #    define fileno _fileno
-#  else
-//   mingw includes `wingdi.h` which defines a TRANSPARENT macro
-//   that conflicts with X(TRANSPARENT) entry in kernel/constids.inc
-#    undef TRANSPARENT
 #  endif
+
+// mingw and msvc include `wingdi.h` which defines a TRANSPARENT macro
+// that conflicts with X(TRANSPARENT) entry in kernel/constids.inc
+#  undef TRANSPARENT
 #endif
 
 #ifndef PATH_MAX

--- a/passes/techmap/extract_counter.cc
+++ b/passes/techmap/extract_counter.cc
@@ -795,11 +795,11 @@ struct ExtractCounterPass : public Pass {
 		pool<RTLIL::IdString> _parallel_cells;
 		CounterExtractionSettings settings
 		{
-			.parallel_cells = _parallel_cells,
-			.maxwidth = 64,
-			.minwidth = 2,
-			.allow_arst = true,
-			.allowed_dirs = 0,
+			_parallel_cells,    // parallel_cells
+			64,                 // maxwidth
+			2,                  // minwidth
+			true,               // allow_arst
+			0,                  // allowed_dirs
 		};
 
 		size_t argidx;


### PR DESCRIPTION
These patches will make yosys build on MSVC 15 2017:

- The TRANSPARENT patch is similar to the one in the [mingw_fix branch](https://github.com/YosysHQ/yosys/tree/mingw_fix)
- The `__builtin_unreachable` patch can probably be generalized to a header to a `#define YOSYS_UNREACHABLE`, but since this is the only usage of `__builtin_unreachable`, I just did the change there.