### PR TITLE
cxxrtl: don't compute vital values in log_assert()

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -1839,7 +1839,8 @@ struct CxxrtlWorker {
 				topo_design.edge(cell_module, module);
 			}
 		}
-		log_assert(topo_design.sort());
+		bool no_loops = topo_design.sort();
+		log_assert(no_loops);
 		modules.insert(modules.end(), topo_design.sorted.begin(), topo_design.sorted.end());
 
 		if (split_intf) {


### PR DESCRIPTION
This breaks NDEBUG builds.

Fixes #2166.