### PR TITLE
Use (and ignore) the expression provided to log_assert in NDEBUG builds

### DIFF
--- a/backends/ilang/ilang_backend.cc
+++ b/backends/ilang/ilang_backend.cc
@@ -362,9 +362,7 @@ void ILANG_BACKEND::dump_module(std::ostream &f, std::string indent, RTLIL::Modu
 
 void ILANG_BACKEND::dump_design(std::ostream &f, RTLIL::Design *design, bool only_selected, bool flag_m, bool flag_n)
 {
-#ifndef NDEBUG
 	int init_autoidx = autoidx;
-#endif
 
 	if (!flag_m) {
 		int count_selected_mods = 0;

--- a/frontends/aiger/aigerparse.cc
+++ b/frontends/aiger/aigerparse.cc
@@ -69,7 +69,7 @@ struct ConstEvalAig
 				continue;
 			for (auto &it2 : it.second->connections())
 				if (yosys_celltypes.cell_output(it.second->type, it2.first)) {
-					auto r YS_ATTRIBUTE(unused) = sig2driver.insert(std::make_pair(it2.second, it.second));
+					auto r = sig2driver.insert(std::make_pair(it2.second, it.second));
 					log_assert(r.second);
 				}
 		}
@@ -400,9 +400,9 @@ void AigerReader::parse_xaiger()
 	for (int c = f.get(); c != EOF; c = f.get()) {
 		// XAIGER extensions
 		if (c == 'm') {
-			uint32_t dataSize YS_ATTRIBUTE(unused) = parse_xaiger_literal(f);
+			uint32_t dataSize = parse_xaiger_literal(f);
 			uint32_t lutNum = parse_xaiger_literal(f);
-			uint32_t lutSize YS_ATTRIBUTE(unused) = parse_xaiger_literal(f);
+			uint32_t lutSize = parse_xaiger_literal(f);
 			log_debug("m: dataSize=%u lutNum=%u lutSize=%u\n", dataSize, lutNum, lutSize);
 			ConstEvalAig ce(module);
 			for (unsigned i = 0; i < lutNum; ++i) {
@@ -434,7 +434,7 @@ void AigerReader::parse_xaiger()
 					int gray = j ^ (j >> 1);
 					ce.set_incremental(input_sig, RTLIL::Const{gray, GetSize(input_sig)});
 					RTLIL::SigBit o(output_sig);
-					bool success YS_ATTRIBUTE(unused) = ce.eval(o);
+					bool success = ce.eval(o);
 					log_assert(success);
 					log_assert(o.wire == nullptr);
 					lut_mask[gray] = o.data;
@@ -446,7 +446,7 @@ void AigerReader::parse_xaiger()
 			}
 		}
 		else if (c == 'r') {
-			uint32_t dataSize YS_ATTRIBUTE(unused) = parse_xaiger_literal(f);
+			uint32_t dataSize = parse_xaiger_literal(f);
 			flopNum = parse_xaiger_literal(f);
 			log_debug("flopNum = %u\n", flopNum);
 			log_assert(dataSize == (flopNum+1) * sizeof(uint32_t));
@@ -455,7 +455,7 @@ void AigerReader::parse_xaiger()
 				mergeability.emplace_back(parse_xaiger_literal(f));
 		}
 		else if (c == 's') {
-			uint32_t dataSize YS_ATTRIBUTE(unused) = parse_xaiger_literal(f);
+			uint32_t dataSize = parse_xaiger_literal(f);
 			flopNum = parse_xaiger_literal(f);
 			log_assert(dataSize == (flopNum+1) * sizeof(uint32_t));
 			initial_state.reserve(flopNum);
@@ -469,15 +469,15 @@ void AigerReader::parse_xaiger()
 		}
 		else if (c == 'h') {
 			f.ignore(sizeof(uint32_t));
-			uint32_t version YS_ATTRIBUTE(unused) = parse_xaiger_literal(f);
+			uint32_t version = parse_xaiger_literal(f);
 			log_assert(version == 1);
-			uint32_t ciNum YS_ATTRIBUTE(unused) = parse_xaiger_literal(f);
+			uint32_t ciNum = parse_xaiger_literal(f);
 			log_debug("ciNum = %u\n", ciNum);
-			uint32_t coNum YS_ATTRIBUTE(unused) = parse_xaiger_literal(f);
+			uint32_t coNum = parse_xaiger_literal(f);
 			log_debug("coNum = %u\n", coNum);
 			piNum = parse_xaiger_literal(f);
 			log_debug("piNum = %u\n", piNum);
-			uint32_t poNum YS_ATTRIBUTE(unused) = parse_xaiger_literal(f);
+			uint32_t poNum = parse_xaiger_literal(f);
 			log_debug("poNum = %u\n", poNum);
 			uint32_t boxNum = parse_xaiger_literal(f);
 			log_debug("boxNum = %u\n", boxNum);

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -778,7 +778,7 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 				while (node->simplify(true, false, false, 1, -1, false, node->type == AST_PARAMETER || node->type == AST_LOCALPARAM))
 					did_something = true;
 			if (node->type == AST_ENUM) {
-				for (auto enode YS_ATTRIBUTE(unused) : node->children){
+				for (auto enode : node->children){
 					log_assert(enode->type==AST_ENUM_ITEM);
 					while (node->simplify(true, false, false, 1, -1, false, in_param))
 						did_something = true;

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -1882,7 +1882,7 @@ struct VerificExtNets
 				new_net = new Net(name.c_str());
 				nl->Add(new_net);
 
-				Net *n YS_ATTRIBUTE(unused) = route_up(new_net, port->IsOutput(), ca_nl, ca_net);
+				Net *n = route_up(new_net, port->IsOutput(), ca_nl, ca_net);
 				log_assert(n == ca_net);
 			}
 

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -157,11 +157,10 @@ void log_warning_noprefix(const char *format, ...) YS_ATTRIBUTE(format(printf, 1
 
 #ifndef NDEBUG
 static inline bool ys_debug(int n = 0) { if (log_force_debug) return true; log_debug_suppressed += n; return false; }
-#  define log_debug(...) do { if (ys_debug(1)) log(__VA_ARGS__); } while (0)
 #else
 static inline bool ys_debug(int = 0) { return false; }
-#  define log_debug(_fmt, ...) do { } while (0)
 #endif
+#  define log_debug(...) do { if (ys_debug(1)) log(__VA_ARGS__); } while (0)
 
 static inline void log_suppressed() {
 	if (log_debug_suppressed && !log_make_debug) {

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -370,7 +370,7 @@ static inline void log_dump_val_worker(char *v) { log("%s", v); }
 static inline void log_dump_val_worker(const char *v) { log("%s", v); }
 static inline void log_dump_val_worker(std::string v) { log("%s", v.c_str()); }
 static inline void log_dump_val_worker(PerformanceTimer p) { log("%f seconds", p.sec()); }
-static inline void log_dump_args_worker(const char *p YS_ATTRIBUTE(unused)) { log_assert(*p == 0); }
+static inline void log_dump_args_worker(const char *p) { log_assert(*p == 0); }
 void log_dump_val_worker(RTLIL::IdString v);
 void log_dump_val_worker(RTLIL::SigSpec v);
 void log_dump_val_worker(RTLIL::State v);

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -236,7 +236,7 @@ static inline void log_assert_worker(bool cond, const char *expr, const char *fi
 }
 #  define log_assert(_assert_expr_) YOSYS_NAMESPACE_PREFIX log_assert_worker(_assert_expr_, #_assert_expr_, __FILE__, __LINE__)
 #else
-#  define log_assert(_assert_expr_)
+#  define log_assert(_assert_expr_) do { if (0) { (void)(_assert_expr_); } } while(0)
 #endif
 
 #define log_abort() YOSYS_NAMESPACE_PREFIX log_error("Abort in %s:%d.\n", __FILE__, __LINE__)

--- a/kernel/macc.h
+++ b/kernel/macc.h
@@ -107,10 +107,8 @@ struct Macc
 		std::vector<RTLIL::State> config_bits = cell->getParam(ID::CONFIG).bits;
 		int config_cursor = 0;
 
-#ifndef NDEBUG
 		int config_width = cell->getParam(ID::CONFIG_WIDTH).as_int();
 		log_assert(GetSize(config_bits) >= config_width);
-#endif
 
 		int num_bits = 0;
 		if (config_bits[config_cursor++] == State::S1) num_bits |= 1;

--- a/kernel/modtools.h
+++ b/kernel/modtools.h
@@ -169,7 +169,7 @@ struct ModIndex : public RTLIL::Monitor
 		port_add(cell, port, sig);
 	}
 
-	void notify_connect(RTLIL::Module *mod YS_ATTRIBUTE(unused), const RTLIL::SigSig &sigsig) override
+	void notify_connect(RTLIL::Module *mod, const RTLIL::SigSig &sigsig) override
 	{
 		log_assert(module == mod);
 
@@ -214,13 +214,13 @@ struct ModIndex : public RTLIL::Monitor
 		}
 	}
 
-	void notify_connect(RTLIL::Module *mod YS_ATTRIBUTE(unused), const std::vector<RTLIL::SigSig>&) override
+	void notify_connect(RTLIL::Module *mod, const std::vector<RTLIL::SigSig>&) override
 	{
 		log_assert(module == mod);
 		auto_reload_module = true;
 	}
 
-	void notify_blackout(RTLIL::Module *mod YS_ATTRIBUTE(unused)) override
+	void notify_blackout(RTLIL::Module *mod) override
 	{
 		log_assert(module == mod);
 		auto_reload_module = true;

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -145,6 +145,14 @@ extern Tcl_Obj *Tcl_ObjSetVar2(Tcl_Interp *interp, Tcl_Obj *part1Ptr, Tcl_Obj *p
 #endif
 
 #if __cplusplus >= 201703L
+#  define YS_MAYBE_UNUSED [[maybe_unused]];
+#elif defined(__GNUC__) || defined(__clang__)
+#  define YS_MAYBE_UNUSED __attribute__((__unused__))
+#else
+#  define YS_MAYBE_UNUSED
+#endif
+
+#if __cplusplus >= 201703L
 #  define YS_FALLTHROUGH [[fallthrough]];
 #elif defined(__clang__)
 #  define YS_FALLTHROUGH [[clang::fallthrough]];

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -117,7 +117,7 @@ void replace_undriven(RTLIL::Module *module, const CellTypes &ct)
 }
 
 void replace_cell(SigMap &assign_map, RTLIL::Module *module, RTLIL::Cell *cell,
-		const std::string &info YS_ATTRIBUTE(unused), IdString out_port, RTLIL::SigSpec out_val)
+		const std::string &info, IdString out_port, RTLIL::SigSpec out_val)
 {
 	RTLIL::SigSpec Y = cell->getPort(out_port);
 	out_val.extend_u0(Y.size(), false);

--- a/passes/pmgen/pmgen.py
+++ b/passes/pmgen/pmgen.py
@@ -589,7 +589,7 @@ with open(outfile, "w") as f:
         if block["type"] in ("match", "code"):
             print("  // {}".format(block["src"]), file=f)
 
-        print("  void block_{}(int recursion YS_ATTRIBUTE(unused)) {{".format(index), file=f)
+        print("  void block_{}(int recursion YS_MAYBE_UNUSED) {{".format(index), file=f)
         current_pattern, current_subpattern = block["pattern"]
 
         if block["type"] == "final":
@@ -636,17 +636,17 @@ with open(outfile, "w") as f:
         for s in sorted(const_st):
             t = state_types[current_pattern][s]
             if t.endswith("*"):
-                print("    {} const &{} YS_ATTRIBUTE(unused) = st_{}.{};".format(t, s, current_pattern, s), file=f)
+                print("    {} const &{} YS_MAYBE_UNUSED = st_{}.{};".format(t, s, current_pattern, s), file=f)
             else:
-                print("    const {} &{} YS_ATTRIBUTE(unused) = st_{}.{};".format(t, s, current_pattern, s), file=f)
+                print("    const {} &{} YS_MAYBE_UNUSED = st_{}.{};".format(t, s, current_pattern, s), file=f)
 
         for s in sorted(nonconst_st):
             t = state_types[current_pattern][s]
-            print("    {} &{} YS_ATTRIBUTE(unused) = st_{}.{};".format(t, s, current_pattern, s), file=f)
+            print("    {} &{} YS_MAYBE_UNUSED = st_{}.{};".format(t, s, current_pattern, s), file=f)
 
         for u in sorted(udata_types[current_pattern].keys()):
             t = udata_types[current_pattern][u]
-            print("    {} &{} YS_ATTRIBUTE(unused) = ud_{}.{};".format(t, u, current_pattern, u), file=f)
+            print("    {} &{} YS_MAYBE_UNUSED = ud_{}.{};".format(t, u, current_pattern, u), file=f)
 
         if len(restore_st):
             print("", file=f)
@@ -676,7 +676,7 @@ with open(outfile, "w") as f:
 
             print("", file=f)
             print("rollback_label:", file=f)
-            print("    YS_ATTRIBUTE(unused);", file=f)
+            print("    YS_MAYBE_UNUSED;", file=f)
 
             if len(block["fcode"]):
                 print("#define accept do { accept_cnt++; on_accept(); } while(0)", file=f)
@@ -684,7 +684,7 @@ with open(outfile, "w") as f:
                 for line in block["fcode"]:
                     print("  " + line, file=f)
                 print("finish_label:", file=f)
-                print("    YS_ATTRIBUTE(unused);", file=f)
+                print("    YS_MAYBE_UNUSED;", file=f)
                 print("#undef accept", file=f)
                 print("#undef finish", file=f)
 
@@ -733,13 +733,13 @@ with open(outfile, "w") as f:
             valueidx = 1
             for item in block["setup"]:
                 if item[0] == "slice":
-                    print("        const int &{} YS_ATTRIBUTE(unused) = std::get<{}>(cells[_pmg_idx]);".format(item[1], valueidx), file=f)
+                    print("        const int &{} YS_MAYBE_UNUSED = std::get<{}>(cells[_pmg_idx]);".format(item[1], valueidx), file=f)
                     valueidx += 1
                 if item[0] == "choice":
-                    print("        const {} &{} YS_ATTRIBUTE(unused) = std::get<{}>(cells[_pmg_idx]);".format(item[1], item[2], valueidx), file=f)
+                    print("        const {} &{} YS_MAYBE_UNUSED = std::get<{}>(cells[_pmg_idx]);".format(item[1], item[2], valueidx), file=f)
                     valueidx += 1
                 if item[0] == "define":
-                    print("        const {} &{} YS_ATTRIBUTE(unused) = std::get<{}>(cells[_pmg_idx]);".format(item[1], item[2], valueidx), file=f)
+                    print("        const {} &{} YS_MAYBE_UNUSED = std::get<{}>(cells[_pmg_idx]);".format(item[1], item[2], valueidx), file=f)
                     valueidx += 1
             print("        if (blacklist_cells.count({})) continue;".format(block["cell"]), file=f)
             for expr in block["filter"]:

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -741,7 +741,7 @@ void prep_xaiger(RTLIL::Module *module, bool dff)
 	if (ys_debug(1))
 		toposort.analyze_loops = true;
 
-	bool no_loops YS_ATTRIBUTE(unused) = toposort.sort();
+	bool no_loops = toposort.sort();
 
 	if (ys_debug(1)) {
 		unsigned i = 0;
@@ -1453,7 +1453,7 @@ void reintegrate(RTLIL::Module *module, bool dff_mode)
 			for (auto driver_cell : bit_drivers.at(it.first))
 			for (auto user_cell : it.second)
 				toposort.edge(driver_cell, user_cell);
-	bool no_loops YS_ATTRIBUTE(unused) = toposort.sort();
+	bool no_loops = toposort.sort();
 	log_assert(no_loops);
 
 	for (auto ii = toposort.sorted.rbegin(); ii != toposort.sorted.rend(); ii++) {

--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -409,11 +409,11 @@ static void map_sr_to_arst(IdString from, IdString to)
 	if (!cell_mappings.count(from) || cell_mappings.count(to) > 0)
 		return;
 
-	char from_clk_pol YS_ATTRIBUTE(unused) = from[8];
+	char from_clk_pol = from[8];
 	char from_set_pol = from[9];
 	char from_clr_pol = from[10];
-	char to_clk_pol YS_ATTRIBUTE(unused) = to[6];
-	char to_rst_pol YS_ATTRIBUTE(unused) = to[7];
+	char to_clk_pol = to[6];
+	char to_rst_pol = to[7];
 	char to_rst_val = to[8];
 
 	log_assert(from_clk_pol == to_clk_pol);
@@ -455,9 +455,9 @@ static void map_adff_to_dff(IdString from, IdString to)
 	if (!cell_mappings.count(from) || cell_mappings.count(to) > 0)
 		return;
 
-	char from_clk_pol YS_ATTRIBUTE(unused) = from[6];
+	char from_clk_pol = from[6];
 	char from_rst_pol = from[7];
-	char to_clk_pol YS_ATTRIBUTE(unused) = to[6];
+	char to_clk_pol = to[6];
 
 	log_assert(from_clk_pol == to_clk_pol);
 

--- a/passes/tests/test_abcloop.cc
+++ b/passes/tests/test_abcloop.cc
@@ -132,7 +132,7 @@ static void test_abcloop()
 		SatGen satgen(ez.get(), &sigmap);
 
 		for (auto c : module->cells()) {
-			bool ok YS_ATTRIBUTE(unused) = satgen.importCell(c);
+			bool ok = satgen.importCell(c);
 			log_assert(ok);
 		}
 
@@ -182,7 +182,7 @@ static void test_abcloop()
 	SatGen satgen(ez.get(), &sigmap);
 
 	for (auto c : module->cells()) {
-		bool ok YS_ATTRIBUTE(unused) = satgen.importCell(c);
+		bool ok = satgen.importCell(c);
 		log_assert(ok);
 	}
 


### PR DESCRIPTION
This avoids warnings in NDEBUG builds emitted when a variable is only used in log_assert, but is always defined.

I've done this to avoid a warning introduced by commit 3c4e974, and fixed up the other places where this problem came up before.