### PR TITLE
Fix GitHub misidentifying *.v files as Coq

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.v linguist-language=Verilog


### PR DESCRIPTION
This actually does confuse real people looking at language statistics in this repo...