### PR TITLE
Add missing [[noreturn]] to log_file_error()

### DIFF
--- a/kernel/log.h
+++ b/kernel/log.h
@@ -152,7 +152,7 @@ void log_file_info(const std::string &filename, int lineno, const char *format, 
 
 void log_warning_noprefix(const char *format, ...) YS_ATTRIBUTE(format(printf, 1, 2));
 [[noreturn]] void log_error(const char *format, ...) YS_ATTRIBUTE(format(printf, 1, 2));
-void log_file_error(const string &filename, int lineno, const char *format, ...) YS_ATTRIBUTE(format(printf, 3, 4));
+[[noreturn]] void log_file_error(const string &filename, int lineno, const char *format, ...) YS_ATTRIBUTE(format(printf, 3, 4));
 [[noreturn]] void log_cmd_error(const char *format, ...) YS_ATTRIBUTE(format(printf, 1, 2));
 
 #ifndef NDEBUG


### PR DESCRIPTION
Previously this was tagged only with `YS_ATTRIBUTE(noreturn)`, but not `YS_NORETURN`, so it got lost in #2173, resulting in warnings in `frontends/ast/simplify.cc`:

```
frontends/ast/simplify.cc:267:1: warning: function declared 'noreturn' should not return [-Winvalid-noreturn]
}
^
frontends/ast/simplify.cc:379:1: warning: function declared 'noreturn' should not return [-Winvalid-noreturn]
}
^
```