### PR TITLE
hashlib, rtlil: Add `operator+()` and `operator+=()` to `dict` iterators

### DIFF
--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -363,7 +363,7 @@ public:
 	public:
 		const_iterator() { }
 		const_iterator operator++() { index--; return *this; }
-		const_iterator operator+=(int amt) { index -= amt; if(index < 0) index = -1; return *this; }
+		const_iterator operator+=(int amt) { index -= amt; return *this; }
 		bool operator<(const const_iterator &other) const { return index > other.index; }
 		bool operator==(const const_iterator &other) const { return index == other.index; }
 		bool operator!=(const const_iterator &other) const { return index != other.index; }
@@ -381,7 +381,7 @@ public:
 	public:
 		iterator() { }
 		iterator operator++() { index--; return *this; }
-		iterator operator+=(int amt) { index -= amt; if(index < 0) index = -1; return *this; }
+		iterator operator+=(int amt) { index -= amt; return *this; }
 		bool operator<(const iterator &other) const { return index > other.index; }
 		bool operator==(const iterator &other) const { return index == other.index; }
 		bool operator!=(const iterator &other) const { return index != other.index; }

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -363,6 +363,7 @@ public:
 	public:
 		const_iterator() { }
 		const_iterator operator++() { index--; return *this; }
+		const_iterator operator+=(int amt) { index -= amt; if(index < 0) index = -1; return *this; }
 		bool operator<(const const_iterator &other) const { return index > other.index; }
 		bool operator==(const const_iterator &other) const { return index == other.index; }
 		bool operator!=(const const_iterator &other) const { return index != other.index; }
@@ -380,6 +381,7 @@ public:
 	public:
 		iterator() { }
 		iterator operator++() { index--; return *this; }
+		iterator operator+=(int amt) { index -= amt; if(index < 0) index = -1; return *this; }
 		bool operator<(const iterator &other) const { return index > other.index; }
 		bool operator==(const iterator &other) const { return index == other.index; }
 		bool operator!=(const iterator &other) const { return index != other.index; }

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -554,6 +554,29 @@ namespace RTLIL
 			return *this;
 		}
 
+		inline ObjIterator<T>& operator+=(int amt) {
+			log_assert(list_p != nullptr);
+			it += amt;
+			if (it == list_p->end()) {
+				(*refcount_p)--;
+				list_p = nullptr;
+				refcount_p = nullptr;
+			}
+			return *this;
+		}
+
+		inline ObjIterator<T> operator+(int amt) {
+			log_assert(list_p != nullptr);
+			ObjIterator<T> new_obj(*this);
+			new_obj.it += amt;
+			if (new_obj.it == list_p->end()) {
+				(*(new_obj.refcount_p))--;
+				new_obj.list_p = nullptr;
+				new_obj.refcount_p = nullptr;
+			}
+			return new_obj;
+		}
+
 		inline const ObjIterator<T> operator++(int) {
 			ObjIterator<T> result(*this);
 			++(*this);


### PR DESCRIPTION
Currently, with `dict` iterators like you'd get from e.g. `module->cells().begin()`, you can increment them: `module->cells().begin()++` but you can't offset from them: `module->cells().begin() + 5`.  This PR changes that.

Specifically, this PR adds `operator+=()` to `dict<>::iterator` and `dict<>::const_iterator` and adds `operator+()` and `operator+=()` to `ObjIterator`. 

This PR is used in PR #2172 in which it helps to reduce memory usage by obviating the need for a `dict<int, Cell *>` mapping node numbers to cells with: `RTLIL::Cell *cell = *(module->cells().begin() += i);`  Note that one can use `operator+=()` on any temporary object to improve efficiency vs. `operator+()`, which makes a copy of the iterator object.