### PR TITLE
pyosys: Use C++11 override keyword for bindings

### DIFF
--- a/misc/py_wrap_generator.py
+++ b/misc/py_wrap_generator.py
@@ -1414,7 +1414,7 @@ class WFunction:
 			text += ", "
 		if len(self.args) > 0:
 			text = text[:-2]
-		text += ") YS_OVERRIDE;\n"
+		text += ") override;\n"
 		return text
 
 	def gen_decl_hash_py(self):


### PR DESCRIPTION
7191dd16 dropped the `YS_OVERRIDE` macro, but it was still being generated by the python bindings generator, resulting in errors like these when compiled with `ENABLE_PYOSYS=1`:

```
kernel/python_wrappers.cc:350:21: error: expected ‘;’ at end of member declaration
  350 |   virtual void help() YS_OVERRIDE;
      |                     ^
      |                      ;
kernel/python_wrappers.cc:350:23: error: ‘YS_OVERRIDE’ does not name a type
  350 |   virtual void help() YS_OVERRIDE;
      |                       ^~~~~~~~~~~
```