### PR TITLE
minisat: add missing include guard for WASI

### DIFF
--- a/libs/minisat/00_PATCH_wasm.patch
+++ b/libs/minisat/00_PATCH_wasm.patch
@@ -32,3 +32,15 @@
  #endif
 +#endif
  }
+--- System.cc
++++ System.cc
+@@ -24,7 +24,9 @@
+ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************************************************/
+
++#if !defined(__wasm)
+ #include <signal.h>
++#endif
+ #include <stdio.h>
+
+ #include "System.h"

--- a/libs/minisat/System.cc
+++ b/libs/minisat/System.cc
@@ -24,7 +24,9 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
+#if !defined(__wasm)
 #include <signal.h>
+#endif
 #include <stdio.h>
 
 #include "System.h"


### PR DESCRIPTION
Including signal.h used to be allowed in WASI by mistake, but it's an error since SDK 11.