### PR TITLE
test_cell: don't generate directional shifts with \B_SIGNED=1

### DIFF
--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -264,6 +264,10 @@ static void create_gold_module(RTLIL::Design *design, RTLIL::IdString cell_type,
 		cell->setPort(ID::Y, wire);
 	}
 
+	if (cell_type.in(ID($shl), ID($shr), ID($sshl), ID($sshr))) {
+		cell->parameters[ID::B_SIGNED] = false;
+	}
+
 	if (muxdiv && cell_type.in(ID($div), ID($mod), ID($divfloor), ID($modfloor))) {
 		auto b_not_zero = module->ReduceBool(NEW_ID, cell->getPort(ID::B));
 		auto div_out = module->addWire(NEW_ID, GetSize(cell->getPort(ID::Y)));


### PR DESCRIPTION
This was made an explicit error in e97e33d, "kernel: require \B_SIGNED=0 on $shl, $sshl, $shr, $sshr.".