### PR TITLE
expose pass fix

### DIFF
--- a/passes/sat/expose.cc
+++ b/passes/sat/expose.cc
@@ -281,11 +281,15 @@ struct ExposePass : public Pass {
 				flag_dff = true;
 				continue;
 			}
-			if (args[argidx] == "-cut" && !flag_input) {
+			if (args[argidx] == "-cut") {
+				if (flag_input)
+					log_cmd_error("Options -cut and -input are mutually exclusive.\n");
 				flag_cut = true;
 				continue;
 			}
-			if (args[argidx] == "-input" && !flag_cut) {
+			if (args[argidx] == "-input") {
+				if (flag_cut)
+					log_cmd_error("Options -cut and -input are mutually exclusive.\n");
 				flag_input = true;
 				continue;
 			}

--- a/passes/sat/expose.cc
+++ b/passes/sat/expose.cc
@@ -479,21 +479,15 @@ struct ExposePass : public Pass {
 					}
 				}
 			}
-			for (auto &wm : wire_map)
-			{
-				if (flag_input) {
-						RTLIL::Wire *in_wire = module->addWire(wm.second, GetSize(wm.first));
-						out_to_in_map.add(wm.first, in_wire);
-				}
-				if (flag_cut) {
-						RTLIL::Wire *in_wire = add_new_wire(module, wm.second, wm.first->width);
-						in_wire->port_input = true;
-						out_to_in_map.add(sigmap(wm.first), in_wire);
-				}
-			}
 
 			if (flag_input)
 			{
+				for (auto &wm : wire_map)
+				{
+					RTLIL::Wire *in_wire = module->addWire(wm.second, GetSize(wm.first));
+					out_to_in_map.add(wm.first, in_wire);
+				}
+
 				for (auto cell : module->cells()) {
 					if (!ct.cell_known(cell->type))
 						continue;
@@ -508,6 +502,13 @@ struct ExposePass : public Pass {
 
 			if (flag_cut)
 			{
+				for (auto &wm : wire_map)
+				{
+					RTLIL::Wire *in_wire = add_new_wire(module, wm.second, wm.first->width);
+					in_wire->port_input = true;
+					out_to_in_map.add(sigmap(wm.first), in_wire);
+				}
+
 				for (auto cell : module->cells()) {
 					if (!ct.cell_known(cell->type))
 						continue;


### PR DESCRIPTION
After change https://github.com/YosysHQ/yosys/commit/696660351f657a42ec5d4785d8ab547e0b568c94 expose pass was broken due to assertion caused by reference counter (code was adding new wires while looping trough them, which is not allowed). 

This change, adds new all new wires after loop have been finished.