### PR TITLE
Signed and macro grammar update

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -745,7 +745,7 @@ module_body:
 module_body_stmt:
 	task_func_decl | specify_block | param_decl | localparam_decl | typedef_decl | defparam_decl | specparam_declaration | wire_decl | assign_stmt | cell_stmt |
 	enum_decl | struct_decl |
-	always_stmt | TOK_GENERATE module_gen_body TOK_ENDGENERATE | defattr | assert_property | checker_decl | ignored_specify_block;
+	always_stmt | TOK_GENERATE module_gen_body TOK_ENDGENERATE | defattr | assert_property | checker_decl | ignored_specify_block | /* empty statement */ ';';
 
 checker_decl:
 	TOK_CHECKER TOK_ID ';' {

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -1329,6 +1329,8 @@ ignspec_id:
 param_signed:
 	TOK_SIGNED {
 		astbuf1->is_signed = true;
+	} | TOK_UNSIGNED {
+		astbuf1->is_signed = false;
 	} | /* empty */;
 
 param_integer:
@@ -1339,14 +1341,14 @@ param_integer:
 		astbuf1->children.back()->children.push_back(AstNode::mkconst_int(31, true));
 		astbuf1->children.back()->children.push_back(AstNode::mkconst_int(0, true));
 		astbuf1->is_signed = true;
-	} | /* empty */;
+	}
 
 param_real:
 	TOK_REAL {
 		if (astbuf1->children.size() != 1)
 			frontend_verilog_yyerror("Parameter already declared as integer, cannot set to real.");
 		astbuf1->children.push_back(new AstNode(AST_REALVALUE));
-	} | /* empty */;
+	}
 
 param_range:
 	range {
@@ -1357,8 +1359,12 @@ param_range:
 		}
 	};
 
+param_integer_type: param_integer param_signed
+param_range_type: type_vec param_signed param_range
+param_implicit_type: param_signed param_range
+
 param_type:
-	param_signed param_integer param_real param_range |
+	param_integer_type | param_real | param_range_type | param_implicit_type |
 	hierarchical_type_id {
 		astbuf1->is_custom_type = true;
 		astbuf1->children.push_back(new AstNode(AST_WIRETYPE));

--- a/tests/various/signed.ys
+++ b/tests/various/signed.ys
@@ -1,0 +1,28 @@
+# SV LRM A2.2.1
+
+read_verilog -sv <<EOT
+module test_signed();
+parameter integer signed  a = 0;
+parameter integer unsigned  b = 0;
+
+endmodule
+EOT
+
+design -reset
+read_verilog -sv <<EOT
+module test_signed();
+parameter logic signed [7:0] a = 0;
+parameter logic unsigned [7:0] b = 0;
+
+endmodule
+EOT
+
+design -reset
+logger -expect error "syntax error, unexpected TOK_INTEGER" 1
+read_verilog -sv <<EOT
+module test_signed();
+parameter signed integer a = 0;
+parameter unsigned integer b = 0;
+
+endmodule
+EOT


### PR DESCRIPTION
This PR fixes some issues in `signed` and macro calls grammar