### PR TITLE
Update verific API version check

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -53,7 +53,7 @@ USING_YOSYS_NAMESPACE
 #  error "Only Symbiotic EDA flavored Verific is supported. Please contact office@symbioticeda.com for commercial support for Yosys+Verific."
 #endif
 
-#if SYMBIOTIC_VERIFIC_API_VERSION < 1
+#if SYMBIOTIC_VERIFIC_API_VERSION < 202006
 #  error "Please update your version of Symbiotic EDA flavored Verific."
 #endif
 


### PR DESCRIPTION
Verific updated with new API version number (yyyyMM format), now we check for latest version to be used.
This resolves issue #2144