### PR TITLE
Respect \A_SIGNED for $shift

### DIFF
--- a/backends/btor/test_cells.sh
+++ b/backends/btor/test_cells.sh
@@ -6,7 +6,7 @@ rm -rf test_cells.tmp
 mkdir -p test_cells.tmp
 cd test_cells.tmp
 
-../../../yosys -p 'test_cell -n 5 -w test all /$alu /$fa /$lcu /$lut /$sop /$macc /$mul /$div /$mod /$divfloor /$modfloor'
+../../../yosys -p 'test_cell -n 5 -w test all /$alu /$fa /$lcu /$lut /$sop /$macc /$mul /$div /$mod /$divfloor /$modfloor /$shiftx'
 
 for fn in test_*.il; do
 	../../../yosys -p "
@@ -19,7 +19,7 @@ for fn in test_*.il; do
 		hierarchy -top main
 		write_btor ${fn%.il}.btor
 	"
-	boolectormc -kmax 1 --trace-gen --stop-first -v ${fn%.il}.btor > ${fn%.il}.out
+	btormc -kmax 1 --trace-gen --stop-first -v ${fn%.il}.btor > ${fn%.il}.out
 	if grep " SATISFIABLE" ${fn%.il}.out; then
 		echo "Check failed for ${fn%.il}."
 		exit 1

--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -750,21 +750,19 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 		f << stringf(" = ");
 		if (cell->getParam(ID::B_SIGNED).as_bool())
 		{
-			f << stringf("$signed(");
-			dump_sigspec(f, cell->getPort(ID::B));
-			f << stringf(")");
+			dump_cell_expr_port(f, cell, "B", true);
 			f << stringf(" < 0 ? ");
-			dump_sigspec(f, cell->getPort(ID::A));
+			dump_cell_expr_port(f, cell, "A", true);
 			f << stringf(" << - ");
 			dump_sigspec(f, cell->getPort(ID::B));
 			f << stringf(" : ");
-			dump_sigspec(f, cell->getPort(ID::A));
+			dump_cell_expr_port(f, cell, "A", true);
 			f << stringf(" >> ");
 			dump_sigspec(f, cell->getPort(ID::B));
 		}
 		else
 		{
-			dump_sigspec(f, cell->getPort(ID::A));
+			dump_cell_expr_port(f, cell, "A", true);
 			f << stringf(" >> ");
 			dump_sigspec(f, cell->getPort(ID::B));
 		}

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1035,7 +1035,11 @@ namespace {
 			}
 
 			if (cell->type.in(ID($shift), ID($shiftx))) {
-				param_bool(ID::A_SIGNED);
+				if (cell->type == ID($shiftx)) {
+					param_bool(ID::A_SIGNED, /*expected=*/false);
+				} else {
+					param_bool(ID::A_SIGNED);
+				}
 				param_bool(ID::B_SIGNED);
 				port(ID::A, param(ID::A_WIDTH));
 				port(ID::B, param(ID::B_WIDTH));

--- a/kernel/satgen.cc
+++ b/kernel/satgen.cc
@@ -522,7 +522,7 @@ bool SatGen::importCell(RTLIL::Cell *cell, int timestep)
 
 		int extend_bit = ez->CONST_FALSE;
 
-		if (!cell->type.in(ID($shift), ID($shiftx)) && cell->parameters[ID::A_SIGNED].as_bool())
+		if (cell->parameters[ID::A_SIGNED].as_bool())
 			extend_bit = a.back();
 
 		while (y.size() < a.size())
@@ -555,7 +555,7 @@ bool SatGen::importCell(RTLIL::Cell *cell, int timestep)
 			std::vector<int> undef_a_shifted;
 
 			extend_bit = cell->type == ID($shiftx) ? ez->CONST_TRUE : ez->CONST_FALSE;
-			if (!cell->type.in(ID($shift), ID($shiftx)) && cell->parameters[ID::A_SIGNED].as_bool())
+			if (cell->parameters[ID::A_SIGNED].as_bool())
 				extend_bit = undef_a.back();
 
 			while (undef_y.size() < undef_a.size())

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -264,6 +264,10 @@ static void create_gold_module(RTLIL::Design *design, RTLIL::IdString cell_type,
 		cell->setPort(ID::Y, wire);
 	}
 
+	if (cell_type.in(ID($shiftx))) {
+		cell->parameters[ID::A_SIGNED] = false;
+	}
+
 	if (cell_type.in(ID($shl), ID($shr), ID($sshl), ID($sshr))) {
 		cell->parameters[ID::B_SIGNED] = false;
 	}

--- a/techlibs/common/simlib.v
+++ b/techlibs/common/simlib.v
@@ -480,10 +480,18 @@ input [B_WIDTH-1:0] B;
 output [Y_WIDTH-1:0] Y;
 
 generate
-	if (B_SIGNED) begin:BLOCK1
-		assign Y = $signed(B) < 0 ? A << -B : A >> B;
-	end else begin:BLOCK2
-		assign Y = A >> B;
+	if (A_SIGNED) begin:BLOCK1
+		if (B_SIGNED) begin:BLOCK2
+			assign Y = $signed(B) < 0 ? $signed(A) << -B : $signed(A) >> B;
+		end else begin:BLOCK3
+			assign Y = $signed(A) >> B;
+		end
+	end else begin:BLOCK4
+		if (B_SIGNED) begin:BLOCK5
+			assign Y = $signed(B) < 0 ? A << -B : A >> B;
+		end else begin:BLOCK6
+			assign Y = A >> B;
+		end
 	end
 endgenerate
 

--- a/techlibs/common/techmap.v
+++ b/techlibs/common/techmap.v
@@ -141,6 +141,7 @@ module _90_shift_shiftx (A, B, Y);
 	parameter [B_WIDTH-1:0] _TECHMAP_CONSTVAL_B_ = 0;
 
 	localparam extbit = _TECHMAP_CELLTYPE_ == "$shift" ? 1'b0 : 1'bx;
+	wire a_padding = _TECHMAP_CELLTYPE_ == "$shiftx" ? extbit : (A_SIGNED ? A[A_WIDTH-1] : 1'b0);
 
 	generate
 `ifndef NO_LSB_FIRST_SHIFT_SHIFTX
@@ -160,7 +161,7 @@ module _90_shift_shiftx (A, B, Y);
 			localparam entries = (A_WIDTH+Y_WIDTH-1)/Y_WIDTH2;
 			localparam len = Y_WIDTH2 * ((entries+1)/2);
 			wire [len-1:0] AA;
-			wire [(A_WIDTH+Y_WIDTH2+Y_WIDTH-1)-1:0] Apad = {{(Y_WIDTH2+Y_WIDTH-1){extbit}}, A};
+			wire [(A_WIDTH+Y_WIDTH2+Y_WIDTH-1)-1:0] Apad = {{(Y_WIDTH2+Y_WIDTH-1){a_padding}}, A};
 			genvar i;
 			for (i = 0; i < A_WIDTH; i=i+Y_WIDTH2*2)
 				assign AA[i/2 +: Y_WIDTH2] = B[CLOG2_Y_WIDTH] ? Apad[i+Y_WIDTH2 +: Y_WIDTH2] : Apad[i +: Y_WIDTH2];
@@ -187,7 +188,8 @@ module _90_shift_shiftx (A, B, Y);
 			always @* begin
 				overflow = 0;
 				buffer = {WIDTH{extbit}};
-				buffer[`MAX(A_WIDTH, Y_WIDTH)-1:0] = A;
+				buffer[Y_WIDTH-1:0] = {Y_WIDTH{a_padding}};
+				buffer[A_WIDTH-1:0] = A;
 
 				if (B_WIDTH > BB_WIDTH) begin
 					if (B_SIGNED) begin


### PR DESCRIPTION
This reflects the behaviour of `$shr`/`$shl`, which sign-extend their A operands to the size of their output, then do a logical shift (shift in 0-bits).

Fixes #2196, replaces #2217.