### PR TITLE
synth_intel_alm: Use dfflegalize.

### DIFF
--- a/techlibs/intel_alm/common/dff_map.v
+++ b/techlibs/intel_alm/common/dff_map.v
@@ -1,124 +1,13 @@
 `default_nettype none
 
-// D flip-flops
-module \$_DFF_P_ (input D, C, output Q);
-parameter _TECHMAP_WIREINIT_Q_ = 1'b0;
-if (_TECHMAP_WIREINIT_Q_ !== 1'b1) begin
+// D flip-flop with async reset and enable
+module \$_DFFE_PN0P_ (input D, C, R, E, output Q);
     wire _TECHMAP_REMOVEINIT_Q_ = 1'b1;
-    MISTRAL_FF _TECHMAP_REPLACE_(.DATAIN(D), .CLK(C), .ACLR(1'b1), .ENA(1'b1), .SCLR(1'b0), .SLOAD(1'b0), .SDATA(1'b0), .Q(Q));
-end else $error("Cannot implement a flip-flop that initialises to one");
+    MISTRAL_FF _TECHMAP_REPLACE_(.DATAIN(D), .CLK(C), .ACLR(R), .ENA(E), .SCLR(1'b0), .SLOAD(1'b0), .SDATA(1'b0), .Q(Q));
 endmodule
 
-module \$_DFF_N_ (input D, C, output Q);
-parameter _TECHMAP_WIREINIT_Q_ = 1'b0;
-if (_TECHMAP_WIREINIT_Q_ !== 1'b1) begin
+// D flip-flop with sync reset and enable (enable has priority)
+module \$_SDFFCE_PP0P_ (input D, C, R, E, output Q);
     wire _TECHMAP_REMOVEINIT_Q_ = 1'b1;
-    MISTRAL_FF _TECHMAP_REPLACE_(.DATAIN(D), .CLK(~C), .ACLR(1'b1), .ENA(1'b1), .SCLR(1'b0), .SLOAD(1'b0), .SDATA(1'b0), .Q(Q));
-end else $error("Cannot implement a flip-flop that initialises to one");
-endmodule
-
-// D flip-flops with reset
-module \$_DFF_PP0_ (input D, C, R, output Q);
-parameter _TECHMAP_WIREINIT_Q_ = 1'b0;
-if (_TECHMAP_WIREINIT_Q_ !== 1'b1) begin
-    wire _TECHMAP_REMOVEINIT_Q_ = 1'b1;
-    MISTRAL_FF _TECHMAP_REPLACE_(.DATAIN(D), .CLK(C), .ACLR(~R), .ENA(1'b1), .SCLR(1'b0), .SLOAD(1'b0), .SDATA(1'b0), .Q(Q));
-end else $error("Cannot implement a flip-flop with reset that initialises to one");
-endmodule
-
-module \$_DFF_PN0_ (input D, C, R, output Q);
-parameter _TECHMAP_WIREINIT_Q_ = 1'b0;
-if (_TECHMAP_WIREINIT_Q_ !== 1'b1) begin
-    wire _TECHMAP_REMOVEINIT_Q_ = 1'b1;
-    MISTRAL_FF _TECHMAP_REPLACE_(.DATAIN(D), .CLK(C), .ACLR(R), .ENA(1'b1), .SCLR(1'b0), .SLOAD(1'b0), .SDATA(1'b0), .Q(Q));
-end else $error("Cannot implement a flip-flop with reset that initialises to one");
-endmodule
-
-module \$_DFF_NP0_ (input D, C, R, output Q);
-parameter _TECHMAP_WIREINIT_Q_ = 1'b0;
-if (_TECHMAP_WIREINIT_Q_ !== 1'b1) begin
-    wire _TECHMAP_REMOVEINIT_Q_ = 1'b1;
-    MISTRAL_FF _TECHMAP_REPLACE_(.DATAIN(D), .CLK(~C), .ACLR(~R), .ENA(1'b1), .SCLR(1'b0), .SLOAD(1'b0), .SDATA(1'b0), .Q(Q));
-end else $error("Cannot implement a flip-flop with reset that initialises to one");
-endmodule
-
-module \$_DFF_NN0_ (input D, C, R, output Q);
-parameter _TECHMAP_WIREINIT_Q_ = 1'b0;
-if (_TECHMAP_WIREINIT_Q_ !== 1'b1) begin
-    wire _TECHMAP_REMOVEINIT_Q_ = 1'b1;
-    MISTRAL_FF _TECHMAP_REPLACE_(.DATAIN(D), .CLK(~C), .ACLR(R), .ENA(1'b1), .SCLR(1'b0), .SLOAD(1'b0), .SDATA(1'b0), .Q(Q));
-end else $error("Cannot implement a flip-flop with reset that initialises to one");
-endmodule
-
-// D flip-flops with set
-module \$_DFF_PP1_ (input D, C, R, output Q);
-parameter _TECHMAP_WIREINIT_Q_ = 1'b1;
-if (_TECHMAP_WIREINIT_Q_ !== 1'b0) begin
-    wire _TECHMAP_REMOVEINIT_Q_ = 1'b1;
-    wire Q_tmp;
-    MISTRAL_FF _TECHMAP_REPLACE_(.DATAIN(~D), .CLK(C), .ACLR(~R), .ENA(1'b1), .SCLR(1'b0), .SLOAD(1'b0), .SDATA(1'b0), .Q(Q_tmp));
-    assign Q = ~Q_tmp;
-end else $error("Cannot implement a flip-flop with set that initialises to zero");
-endmodule
-
-module \$_DFF_PN1_ (input D, C, R, output Q);
-parameter _TECHMAP_WIREINIT_Q_ = 1'b1;
-if (_TECHMAP_WIREINIT_Q_ !== 1'b0) begin
-    wire _TECHMAP_REMOVEINIT_Q_ = 1'b1;
-    wire Q_tmp;
-    MISTRAL_FF _TECHMAP_REPLACE_(.DATAIN(~D), .CLK(C), .ACLR(R), .ENA(1'b1), .SCLR(1'b0), .SLOAD(1'b0), .SDATA(1'b0), .Q(Q_tmp));
-end else $error("Cannot implement a flip-flop with set that initialises to zero");
-endmodule
-
-module \$_DFF_NP1_ (input D, C, R, output Q);
-parameter _TECHMAP_WIREINIT_Q_ = 1'b1;
-if (_TECHMAP_WIREINIT_Q_ !== 1'b0) begin
-    wire _TECHMAP_REMOVEINIT_Q_ = 1'b1;
-    wire Q_tmp;
-    MISTRAL_FF _TECHMAP_REPLACE_(.DATAIN(~D), .CLK(~C), .ACLR(~R), .ENA(1'b1), .SCLR(1'b0), .SLOAD(1'b0), .SDATA(1'b0), .Q(Q_tmp));
-    assign Q = ~Q_tmp;
-end else $error("Cannot implement a flip-flop with set that initialises to zero");
-endmodule
-
-module \$_DFF_NN1_ (input D, C, R, output Q);
-parameter _TECHMAP_WIREINIT_Q_ = 1'b1;
-if (_TECHMAP_WIREINIT_Q_ !== 1'b0) begin
-    wire _TECHMAP_REMOVEINIT_Q_ = 1'b1;
-    wire Q_tmp;
-    MISTRAL_FF _TECHMAP_REPLACE_(.DATAIN(~D), .CLK(~C), .ACLR(R), .ENA(1'b1), .SCLR(1'b0), .SLOAD(1'b0), .SDATA(1'b0), .Q(Q_tmp));
-    assign Q = ~Q_tmp;
-end else $error("Cannot implement a flip-flop with set that initialises to zero");
-endmodule
-
-// D flip-flops with clock enable
-module \$_DFFE_PP_ (input D, C, E, output Q);
-parameter _TECHMAP_WIREINIT_Q_ = 1'b0;
-if (_TECHMAP_WIREINIT_Q_ !== 1'b1) begin
-    wire _TECHMAP_REMOVEINIT_Q_ = 1'b1;
-    MISTRAL_FF _TECHMAP_REPLACE_(.DATAIN(D), .CLK(C), .ACLR(1'b1), .ENA(E), .SCLR(1'b0), .SLOAD(1'b0), .SDATA(1'b0), .Q(Q));
-end else $error("Cannot implement a flip-flop with enable that initialises to one");
-endmodule
-
-module \$_DFFE_PN_ (input D, C, E, output Q);
-parameter _TECHMAP_WIREINIT_Q_ = 1'b0;
-if (_TECHMAP_WIREINIT_Q_ !== 1'b1) begin
-    wire _TECHMAP_REMOVEINIT_Q_ = 1'b1;
-    MISTRAL_FF _TECHMAP_REPLACE_(.DATAIN(D), .CLK(C), .ACLR(1'b1), .ENA(~E), .SCLR(1'b0), .SLOAD(1'b0), .SDATA(1'b0), .Q(Q));
-end else $error("Cannot implement a flip-flop with enable that initialises to one");
-endmodule
-
-module \$_DFFE_NP_ (input D, C, E, output Q);
-parameter _TECHMAP_WIREINIT_Q_ = 1'b0;
-if (_TECHMAP_WIREINIT_Q_ !== 1'b1) begin
-    wire _TECHMAP_REMOVEINIT_Q_ = 1'b1;
-    MISTRAL_FF _TECHMAP_REPLACE_(.DATAIN(D), .CLK(~C), .ACLR(1'b1), .ENA(E), .SCLR(1'b0), .SLOAD(1'b0), .SDATA(1'b0), .Q(Q));
-end else $error("Cannot implement a flip-flop with enable that initialises to one");
-endmodule
-
-module \$_DFFE_NN_ (input D, C, E, output Q);
-parameter _TECHMAP_WIREINIT_Q_ = 1'b0;
-if (_TECHMAP_WIREINIT_Q_ !== 1'b1) begin
-    wire _TECHMAP_REMOVEINIT_Q_ = 1'b1;
-    MISTRAL_FF _TECHMAP_REPLACE_(.DATAIN(D), .CLK(~C), .ACLR(1'b1), .ENA(~E), .SCLR(1'b0), .SLOAD(1'b0), .SDATA(1'b0), .Q(Q));
-end else $error("Cannot implement a flip-flop with enable that initialises to one");
+    MISTRAL_FF _TECHMAP_REPLACE_(.DATAIN(D), .CLK(C), .ACLR(1'b1), .ENA(E), .SCLR(R), .SLOAD(1'b0), .SDATA(1'b0), .Q(Q));
 endmodule

--- a/techlibs/intel_alm/synth_intel_alm.cc
+++ b/techlibs/intel_alm/synth_intel_alm.cc
@@ -208,11 +208,10 @@ struct SynthIntelALMPass : public ScriptPass {
 		}
 
 		if (check_label("map_ffs")) {
+			run("techmap");
 			run("dff2dffe");
-			// As mentioned in common/dff_sim.v, Intel flops power up to zero,
-			// so use `zinit` to add inverters where needed.
-			run("zinit");
-			run("techmap -map +/techmap.v -map +/intel_alm/common/dff_map.v");
+			run("dfflegalize -cell $_DFFE_PN0P_ 0 -cell $_SDFFCE_PP0P_ 0");
+			run("techmap -map +/intel_alm/common/dff_map.v");
 			run("opt -full -undriven -mux_undef");
 			run("clean -purge");
 		}

--- a/tests/arch/intel_alm/fsm.ys
+++ b/tests/arch/intel_alm/fsm.ys
@@ -15,6 +15,6 @@ select -assert-count 6 t:MISTRAL_FF
 select -assert-max 2 t:MISTRAL_ALUT2 # Clang returns 2, GCC returns 1
 select -assert-count 1 t:MISTRAL_ALUT3
 select -assert-max 1 t:MISTRAL_ALUT4 # Clang returns 0, GCC returns 1
-select -assert-max 5 t:MISTRAL_ALUT5 # Clang returns 5, GCC returns 4
+select -assert-max 6 t:MISTRAL_ALUT5 # Clang returns 5, GCC returns 4
 select -assert-max 2 t:MISTRAL_ALUT6 # Clang returns 1, GCC returns 2
 select -assert-none t:MISTRAL_FF t:MISTRAL_ALUT2 t:MISTRAL_ALUT3 t:MISTRAL_ALUT4 t:MISTRAL_ALUT5 t:MISTRAL_ALUT6 %% t:* %D


### PR DESCRIPTION
Bonus: adds support for mapping flops with async reset + enable, as well as flops with sync reset (and maybe enable), though that's not properly utilized yet (pending `opt_dff` changes).

CC: @Ravenslofty (github doesn't allow me to add you as a reviewer properly).