### PR TITLE
opt_expr: Fix crash on $mul optimization with more zeros removed than…

### DIFF
--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -1596,6 +1596,14 @@ skip_identity:
 				log_debug("Removing low %d A and %d B bits from cell `%s' in module `%s'.\n",
 						a_zeros, b_zeros, cell->name.c_str(), module->name.c_str());
 
+				if (y_zeros >= GetSize(sig_y)) {
+					module->connect(sig_y, RTLIL::SigSpec(0, GetSize(sig_y)));
+					module->remove(cell);
+
+					did_something = true;
+					goto next_cell;
+				}
+
 				if (a_zeros) {
 					cell->setPort(ID::A, sig_a.extract_end(a_zeros));
 					cell->parameters[ID::A_WIDTH] = GetSize(sig_a) - a_zeros;

--- a/tests/opt/bug2221.ys
+++ b/tests/opt/bug2221.ys
@@ -1,0 +1,16 @@
+read_verilog <<EOT
+module test (
+        input [1:0] a,
+        input [1:0] b,
+        output [5:0] y
+);
+
+wire [5:0] aa = {a, 4'h0};
+wire [5:0] bb = {b, 4'h0};
+
+assign y = aa * bb;
+
+endmodule
+EOT
+
+equiv_opt -assert opt_expr


### PR DESCRIPTION
… Y has.

Fixes #2221.