### PR TITLE
anlogic: Use dfflegalize.

### DIFF
--- a/techlibs/anlogic/cells_map.v
+++ b/techlibs/anlogic/cells_map.v
@@ -1,31 +1,17 @@
-module  \$_DFF_N_ (input D, C, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'bx), .SRMUX("SR"), .SRMODE("SYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(~C), .ce(1'b1), .sr(1'b0)); endmodule
-module  \$_DFF_P_ (input D, C, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'bx), .SRMUX("SR"), .SRMODE("SYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C),  .ce(1'b1), .sr(1'b0)); endmodule
+module  \$_DFFE_PN0P_ (input D, C, R, E, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'b0), .SRMUX("INV"), .SRMODE("ASYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C) ,.ce(E), .sr(R)); wire _TECHMAP_REMOVEINIT_Q_ = 1'b1; endmodule
+module  \$_DFFE_PN1P_ (input D, C, R, E, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'b1), .SRMUX("INV"), .SRMODE("ASYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .ce(E), .sr(R)); wire _TECHMAP_REMOVEINIT_Q_ = 1'b1; endmodule
+module  \$_DFFE_PP0P_ (input D, C, R, E, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'b0), .SRMUX("SR"),  .SRMODE("ASYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .ce(E), .sr(R)); wire _TECHMAP_REMOVEINIT_Q_ = 1'b1; endmodule
+module  \$_DFFE_PP1P_ (input D, C, R, E, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'b1), .SRMUX("SR"), . SRMODE("ASYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .ce(E), .sr(R)); wire _TECHMAP_REMOVEINIT_Q_ = 1'b1; endmodule
 
-module  \$_DFFE_NN_ (input D, C, E, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'bx), .SRMUX("SR"), .SRMODE("SYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(~C), .ce(E), .sr(1'b0)); endmodule
-module  \$_DFFE_NP_ (input D, C, E, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'bx), .SRMUX("SR"), .SRMODE("SYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(~C), .ce(E), .sr(1'b0)); endmodule
-module  \$_DFFE_PN_ (input D, C, E, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'bx), .SRMUX("SR"), .SRMODE("SYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C),  .ce(E), .sr(1'b0)); endmodule
-module  \$_DFFE_PP_ (input D, C, E, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'bx), .SRMUX("SR"), .SRMODE("SYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C),  .ce(E), .sr(1'b0)); endmodule
+module  \$_SDFFE_PN0P_ (input D, C, R, E, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'b0), .SRMUX("INV"), .SRMODE("SYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C) ,.ce(E), .sr(R)); wire _TECHMAP_REMOVEINIT_Q_ = 1'b1; endmodule
+module  \$_SDFFE_PN1P_ (input D, C, R, E, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'b1), .SRMUX("INV"), .SRMODE("SYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .ce(E), .sr(R)); wire _TECHMAP_REMOVEINIT_Q_ = 1'b1; endmodule
+module  \$_SDFFE_PP0P_ (input D, C, R, E, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'b0), .SRMUX("SR"),  .SRMODE("SYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .ce(E), .sr(R)); wire _TECHMAP_REMOVEINIT_Q_ = 1'b1; endmodule
+module  \$_SDFFE_PP1P_ (input D, C, R, E, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'b1), .SRMUX("SR"), . SRMODE("SYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .ce(E), .sr(R)); wire _TECHMAP_REMOVEINIT_Q_ = 1'b1; endmodule
 
-module  \$_DFF_NN0_ (input D, C, R, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'b0), .SRMUX("INV"), .SRMODE("ASYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(~C), .ce(1'b1), .sr(R)); endmodule
-module  \$_DFF_NN1_ (input D, C, R, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'b1), .SRMUX("INV"), .SRMODE("ASYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(~C), .ce(1'b1), .sr(R)); endmodule
-module  \$_DFF_NP0_ (input D, C, R, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'b0), .SRMUX("SR"),  .SRMODE("ASYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(~C), .ce(1'b1), .sr(R)); endmodule
-module  \$_DFF_NP1_ (input D, C, R, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'b1), .SRMUX("SR"),  .SRMODE("ASYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(~C), .ce(1'b1), .sr(R)); endmodule
-module  \$_DFF_PN0_ (input D, C, R, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'b0), .SRMUX("INV"), .SRMODE("ASYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C) , .ce(1'b1), .sr(R)); endmodule
-module  \$_DFF_PN1_ (input D, C, R, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'b1), .SRMUX("INV"), .SRMODE("ASYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C),  .ce(1'b1), .sr(R)); endmodule
-module  \$_DFF_PP0_ (input D, C, R, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'b0), .SRMUX("SR"),  .SRMODE("ASYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C),  .ce(1'b1), .sr(R)); endmodule
-module  \$_DFF_PP1_ (input D, C, R, output Q); AL_MAP_SEQ #(.DFFMODE("FF"), .REGSET(1'b1), .SRMUX("SR"), . SRMODE("ASYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C),  .ce(1'b1), .sr(R)); endmodule
-
-module \$_DLATCH_N_ (E, D, Q);
-  wire [1023:0] _TECHMAP_DO_ = "simplemap; opt";
-  input E, D;
-  output Q = !E ? D : Q;
-endmodule
-
-module \$_DLATCH_P_ (E, D, Q);
-  wire [1023:0] _TECHMAP_DO_ = "simplemap; opt";
-  input E, D;
-  output Q = E ? D : Q;
-endmodule
+module  \$_DLATCH_NN0_ (input D, R, E, output Q); AL_MAP_SEQ #(.DFFMODE("LATCH"), .REGSET(1'b0), .SRMUX("INV"), .SRMODE("ASYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(E) ,.ce(1'b1), .sr(R)); wire _TECHMAP_REMOVEINIT_Q_ = 1'b1; endmodule
+module  \$_DLATCH_NN1_ (input D, R, E, output Q); AL_MAP_SEQ #(.DFFMODE("LATCH"), .REGSET(1'b1), .SRMUX("INV"), .SRMODE("ASYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(E), .ce(1'b1), .sr(R)); wire _TECHMAP_REMOVEINIT_Q_ = 1'b1; endmodule
+module  \$_DLATCH_NP0_ (input D, R, E, output Q); AL_MAP_SEQ #(.DFFMODE("LATCH"), .REGSET(1'b0), .SRMUX("SR"),  .SRMODE("ASYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(E), .ce(1'b1), .sr(R)); wire _TECHMAP_REMOVEINIT_Q_ = 1'b1; endmodule
+module  \$_DLATCH_NP1_ (input D, R, E, output Q); AL_MAP_SEQ #(.DFFMODE("LATCH"), .REGSET(1'b1), .SRMUX("SR"), . SRMODE("ASYNC")) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(E), .ce(1'b1), .sr(R)); wire _TECHMAP_REMOVEINIT_Q_ = 1'b1; endmodule
 
 `ifndef NO_LUT
 module \$lut (A, Y);

--- a/techlibs/anlogic/cells_sim.v
+++ b/techlibs/anlogic/cells_sim.v
@@ -10,9 +10,6 @@ module AL_MAP_SEQ (
 	parameter SRMUX = "SR"; //SR/INV
 	parameter SRMODE = "SYNC"; //SYNC/ASYNC
 
-	wire clk_ce;
-	assign clk_ce = ce ? clk : 1'b0;
-
 	wire srmux;
 	generate
 		case (SRMUX)
@@ -20,7 +17,7 @@ module AL_MAP_SEQ (
 			"INV": assign srmux = ~sr;
 			default: assign srmux = sr;
 		endcase
-	endgenerate	
+	endgenerate
 
 	wire regset;
 	generate
@@ -34,43 +31,45 @@ module AL_MAP_SEQ (
 	initial q = regset;
 
 	generate
-   		if (DFFMODE == "FF") 
+		if (DFFMODE == "FF")
 		begin
-			if (SRMODE == "ASYNC") 
+			if (SRMODE == "ASYNC")
 			begin
-				always @(posedge clk_ce, posedge srmux)
+				always @(posedge clk, posedge srmux)
 					if (srmux)
 						q <= regset;
-					else 
-						q <= d;	
-			end 
+					else if (ce)
+						q <= d;
+			end
 			else
 			begin
-				always @(posedge clk_ce)
+				always @(posedge clk)
 					if (srmux)
 						q <= regset;
-					else 
-						q <= d;	
+					else if (ce)
+						q <= d;
 			end
 		end
 		else
 		begin
 			// DFFMODE == "LATCH"
-			if (SRMODE == "ASYNC") 
+			if (SRMODE == "ASYNC")
 			begin
-				always @(clk_ce, srmux)
+				always @*
 					if (srmux)
 						q <= regset;
-					else 
-						q <= d;	
-			end 
+					else if (~clk & ce)
+						q <= d;
+			end
 			else
 			begin
-				always @(clk_ce)
-					if (srmux)
-						q <= regset;
-					else 
-						q <= d;	
+				always @*
+					if (~clk) begin
+						if (srmux)
+							q <= regset;
+						else if (ce)
+							q <= d;
+					end
 			end
 		end
     endgenerate

--- a/techlibs/anlogic/synth_anlogic.cc
+++ b/techlibs/anlogic/synth_anlogic.cc
@@ -182,8 +182,8 @@ struct SynthAnlogicPass : public ScriptPass
 
 		if (check_label("map_ffs"))
 		{
+			run("dfflegalize -cell $_DFFE_P??P_ r -cell $_SDFFE_P??P_ r -cell $_DLATCH_N??_ r");
 			run("techmap -D NO_LUT -map +/anlogic/cells_map.v");
-			run("dffinit -strinit SET RESET -ff AL_MAP_SEQ q REGSET -noreinit");
 			run("opt_expr -mux_undef");
 			run("simplemap");
 		}

--- a/tests/arch/anlogic/latches.ys
+++ b/tests/arch/anlogic/latches.ys
@@ -3,31 +3,33 @@ design -save read
 
 hierarchy -top latchp
 proc
-# Can't run any sort of equivalence check because latches are blown to LUTs
-synth_anlogic
+equiv_opt -assert -multiclock -map +/anlogic/cells_sim.v synth_anlogic
+design -load postopt
 cd latchp # Constrain all select calls below inside the top module
-select -assert-count 1 t:AL_MAP_LUT3
 
-select -assert-none t:AL_MAP_LUT3 %% t:* %D
+select -assert-count 1 t:AL_MAP_SEQ
+select -assert-count 1 t:AL_MAP_LUT1
+select -assert-none t:AL_MAP_SEQ t:AL_MAP_LUT1 %% t:* %D
 
 
 design -load read
 hierarchy -top latchn
 proc
-# Can't run any sort of equivalence check because latches are blown to LUTs
-synth_anlogic
+equiv_opt -assert -multiclock -map +/anlogic/cells_sim.v synth_anlogic
+design -load postopt
 cd latchn # Constrain all select calls below inside the top module
-select -assert-count 1 t:AL_MAP_LUT3
 
-select -assert-none t:AL_MAP_LUT3 %% t:* %D
+select -assert-count 1 t:AL_MAP_SEQ
+select -assert-none t:AL_MAP_SEQ %% t:* %D
 
 
 design -load read
 hierarchy -top latchsr
 proc
-# Can't run any sort of equivalence check because latches are blown to LUTs
-synth_anlogic
+equiv_opt -assert -multiclock -map +/anlogic/cells_sim.v synth_anlogic
+design -load postopt
 cd latchsr # Constrain all select calls below inside the top module
-select -assert-count 1 t:AL_MAP_LUT5
 
-select -assert-none t:AL_MAP_LUT5 %% t:* %D
+select -assert-count 1 t:AL_MAP_SEQ
+select -assert-count 2 t:AL_MAP_LUT3
+select -assert-none t:AL_MAP_SEQ t:AL_MAP_LUT3 %% t:* %D


### PR DESCRIPTION
Notes:

1. This fixes the sim library to something sane (with proper clock gating and latch model). Hopefully this actually matches the hardware.  If not, the corresponding functionality needs to be disabled, because there's just no hope for it.
2. This adds support for mapping DFFs with both async reset and enable, with sync reset (and maybe enable), and proper latch support.  The new DFF types are not actually emitted yet — this will be done in the future `opt_dff` pass.