### PR TITLE
dfflegalize: Add special support for const-D latches.

### DIFF
--- a/passes/techmap/dfflegalize.cc
+++ b/passes/techmap/dfflegalize.cc
@@ -659,6 +659,24 @@ flip_dqisr:;
 					// This init value is not supported at all...
 					if (supported_dlatch & flip_initmask(initmask))
 						goto flip_dqi;
+
+					if ((sig_d == State::S0 && (supported_adff0 & initmask)) ||
+							(sig_d == State::S1 && (supported_adff1 & initmask)) ||
+							(sig_d == State::S0 && (supported_adff1 & flip_initmask(initmask))) ||
+							(sig_d == State::S1 && (supported_adff0 & flip_initmask(initmask)))
+					) {
+						// Special case: const-D dlatch can be converted into adff with const clock.
+						ff_type = (sig_d == State::S0) ? FF_ADFF0 : FF_ADFF1;
+						if (ff_neg & NEG_E) {
+							ff_neg &= ~NEG_E;
+							ff_neg |= NEG_R;
+						}
+						sig_r = sig_e;
+						sig_d = State::Sx;
+						sig_c = State::S1;
+						continue;
+					}
+
 					if (!supported_dlatch)
 						reason = "dlatch are not supported";
 					else

--- a/tests/techmap/dfflegalize_dlatch_const.ys
+++ b/tests/techmap/dfflegalize_dlatch_const.ys
@@ -1,0 +1,53 @@
+read_verilog -icells <<EOT
+
+module dlatch(input E, D, (* init = 8'hf0 *) output [7:0] Q);
+$_DLATCH_P_ ff0 (.E(E), .D(1'b0), .Q(Q[0]));
+$_DLATCH_N_ ff1 (.E(E), .D(1'b0), .Q(Q[1]));
+$_DLATCH_P_ ff2 (.E(E), .D(1'b1), .Q(Q[2]));
+$_DLATCH_N_ ff3 (.E(E), .D(1'b1), .Q(Q[3]));
+$_DLATCH_P_ ff4 (.E(E), .D(1'b0), .Q(Q[4]));
+$_DLATCH_N_ ff5 (.E(E), .D(1'b0), .Q(Q[5]));
+$_DLATCH_P_ ff6 (.E(E), .D(1'b1), .Q(Q[6]));
+$_DLATCH_N_ ff7 (.E(E), .D(1'b1), .Q(Q[7]));
+endmodule
+
+EOT
+
+design -save orig
+equiv_opt -assert -multiclock -map +/simcells.v dfflegalize -cell $_DFF_PP0_ 01
+equiv_opt -assert -multiclock -map +/simcells.v dfflegalize -cell $_DFF_PP?_ 0
+equiv_opt -assert -multiclock -map +/simcells.v dfflegalize -cell $_DFFSRE_PPPP_ 0
+equiv_opt -assert -multiclock -map +/simcells.v dfflegalize -cell $_DFFSRE_PPPP_ 1
+
+# Convert everything to ADFFs.
+
+design -load orig
+dfflegalize -cell $_DFF_PP0_ 01
+
+select -assert-count 12 t:$_NOT_
+select -assert-count 8 t:$_DFF_PP0_
+select -assert-none t:$_DFF_PP0_ t:$_NOT_ %% %n t:* %i
+
+design -load orig
+dfflegalize -cell $_DFF_PP?_ 0
+
+select -assert-count 12 t:$_NOT_
+select -assert-count 4 t:$_DFF_PP0_
+select -assert-count 4 t:$_DFF_PP1_
+select -assert-none t:$_DFF_PP0_ t:$_DFF_PP1_ t:$_NOT_ %% %n t:* %i
+
+# Convert everything to DFFSREs.
+
+design -load orig
+dfflegalize -cell $_DFFSRE_PPPP_ 0
+
+select -assert-count 12 t:$_NOT_
+select -assert-count 8 t:$_DFFSRE_PPPP_
+select -assert-none t:$_DFFSRE_PPPP_ t:$_NOT_ %% %n t:* %i
+
+design -load orig
+dfflegalize -cell $_DFFSRE_PPPP_ 1
+
+select -assert-count 12 t:$_NOT_
+select -assert-count 8 t:$_DFFSRE_PPPP_
+select -assert-none t:$_DFFSRE_PPPP_ t:$_NOT_ %% %n t:* %i


### PR DESCRIPTION
Those can be created by `opt_dff` when optimizing `$adff` with const
clock, or with D == Q.  Make dfflegalize do the opposite transform
when such dlatches would be otherwise unimplementable.