### PR TITLE
dfflegalize: Gather init values from all wires.

### DIFF
--- a/passes/techmap/dfflegalize.cc
+++ b/passes/techmap/dfflegalize.cc
@@ -1296,7 +1296,7 @@ unrecognized:
 			sigmap.set(module);
 			initbits.clear();
 
-			for (auto wire : module->selected_wires())
+			for (auto wire : module->wires())
 			{
 				if (wire->attributes.count(ID::init) == 0)
 					continue;


### PR DESCRIPTION
Skipping non-selected wires is unsound in an obvious way.