### PR TITLE
xilinx: Fix srl regression.

### DIFF
--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -652,13 +652,13 @@ struct SynthXilinxPass : public ScriptPass
 			}
 			run("clean");
 
+			if (help_mode || !abc9)
+				run("techmap -map +/xilinx/ff_map.v", "(only if not '-abc9')");
 			// This shregmap call infers fixed length shift registers after abc
 			//   has performed any necessary retiming
 			if (!nosrl || help_mode)
 				run("xilinx_srl -fixed -minlen 3", "(skip if '-nosrl')");
 			std::string techmap_args = "-map +/xilinx/lut_map.v -map +/xilinx/cells_map.v";
-			if (help_mode || !abc9)
-				techmap_args += stringf(" -map +/xilinx/ff_map.v");
 			techmap_args += " -D LUT_WIDTH=" + lut_size_s;
 			run("techmap " + techmap_args);
 			if (help_mode)

--- a/tests/arch/xilinx/nosrl.ys
+++ b/tests/arch/xilinx/nosrl.ys
@@ -1,0 +1,41 @@
+read_verilog <<EOT
+
+module xilinx_srl_static_test(input i, clk, output [1:0] q);
+reg head = 1'b0;
+reg [3:0] shift1 = 4'b0000;
+reg [3:0] shift2 = 4'b0000;
+
+always @(posedge clk) begin
+    head <= i;
+    shift1 <= {shift1[2:0], head};
+    shift2 <= {shift2[2:0], head};
+end
+
+assign q = {shift2[3], shift1[3]};
+endmodule
+
+EOT
+
+design -save read
+
+hierarchy -top xilinx_srl_static_test
+proc
+#equiv_opt -assert -map +/xilinx/cells_sim.v synth_xilinx -noiopad # equivalency check
+equiv_opt -map +/xilinx/cells_sim.v synth_xilinx -noiopad # equivalency check
+design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
+cd xilinx_srl_static_test # Constrain all select calls below inside the top module
+stat
+select -assert-count 1 t:BUFG
+select -assert-count 1 t:SRL16E
+select -assert-none t:BUFG t:SRL16E %% t:* %D
+
+design -load read
+hierarchy -top xilinx_srl_static_test
+proc
+equiv_opt -assert -map +/xilinx/cells_sim.v synth_xilinx -nosrl -noiopad # equivalency check
+design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
+cd xilinx_srl_static_test # Constrain all select calls below inside the top module
+stat
+select -assert-count 1 t:BUFG
+select -assert-count 5 t:FDRE
+select -assert-none t:BUFG t:FDRE %% t:* %D


### PR DESCRIPTION
Of standard yosys cells, xilinx_srl only works on $_DFF_?_ and
$_DFFE_?P_, which get upgraded to $_SDFFE_?P?P_ by dfflegalize at the
point where xilinx_srl is called for non-abc9.  Fix this by running
ff_map.v first, resulting in FDRE cells, which are handled correctly.