### PR TITLE
Revert "intel_alm: direct M10K instantiation"

### DIFF
--- a/techlibs/intel_alm/Makefile.inc
+++ b/techlibs/intel_alm/Makefile.inc
@@ -15,9 +15,9 @@ $(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/ds
 $(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/mem_sim.v))
 
 # RAM
-$(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/bram_m10k.txt))
-$(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/bram_m20k.txt))
-$(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/bram_m20k_map.v))
+bramtypes := m10k m20k
+$(foreach bramtype, $(bramtypes), $(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/bram_$(bramtype).txt)))
+$(foreach bramtype, $(bramtypes), $(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/bram_$(bramtype)_map.v)))
 $(eval $(call add_share_file,share/intel_alm/common,techlibs/intel_alm/common/lutram_mlab.txt))
 
 # Miscellaneous

--- a/techlibs/intel_alm/common/bram_m10k.txt
+++ b/techlibs/intel_alm/common/bram_m10k.txt
@@ -1,4 +1,4 @@
-bram MISTRAL_M10K
+bram __MISTRAL_M10K_SDP
     init   0   # TODO: Re-enable when I figure out how BRAM init works
     abits 13   @D8192x1
     dbits  1   @D8192x1
@@ -27,7 +27,7 @@ bram MISTRAL_M10K
 endbram
 
 
-match MISTRAL_M10K
+match __MISTRAL_M10K_SDP
     min efficiency 5
     make_transp
 endmatch

--- a/techlibs/intel_alm/common/bram_m10k_map.v
+++ b/techlibs/intel_alm/common/bram_m10k_map.v
@@ -1,0 +1,31 @@
+module __MISTRAL_M10K_SDP(CLK1, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
+
+parameter CFG_ABITS = 10;
+parameter CFG_DBITS = 10;
+parameter CFG_ENABLE_A = 1;
+parameter CFG_ENABLE_B = 1;
+
+input CLK1;
+input [CFG_ABITS-1:0] A1ADDR, B1ADDR;
+input [CFG_DBITS-1:0] A1DATA;
+output [CFG_DBITS-1:0] B1DATA;
+input [CFG_ENABLE_A-1:0] A1EN, B1EN;
+
+altsyncram #(
+    .operation_mode("dual_port"),
+    .ram_block_type("m10k"),
+    .widthad_a(CFG_ABITS),
+    .width_a(CFG_DBITS),
+    .widthad_b(CFG_ABITS),
+    .width_b(CFG_DBITS),
+) _TECHMAP_REPLACE_ (
+    .address_a(A1ADDR),
+    .data_a(A1DATA),
+    .wren_a(A1EN),
+    .address_b(B1ADDR),
+    .q_b(B1DATA),
+    .clock0(CLK1),
+    .clock1(CLK1)
+);
+
+endmodule

--- a/techlibs/intel_alm/common/megafunction_bb.v
+++ b/techlibs/intel_alm/common/megafunction_bb.v
@@ -157,38 +157,3 @@ input [ay_scan_in_width-1:0] ay;
 output [result_a_width-1:0] resulta;
 
 endmodule
-
-(* blackbox *)
-module cyclonev_ram_block(portaaddr, portadatain, portawe, portbaddr, portbdataout, portbre, clk0);
-
-parameter operation_mode = "dual_port";
-parameter logical_ram_name = "";
-parameter port_a_address_width = 10;
-parameter port_a_data_width = 10;
-parameter port_a_logical_ram_depth = 1024;
-parameter port_a_logical_ram_width = 10;
-parameter port_a_first_address = 0;
-parameter port_a_last_address = 1023;
-parameter port_a_first_bit_number = 0;
-parameter port_b_address_width = 10;
-parameter port_b_data_width = 10;
-parameter port_b_logical_ram_depth = 1024;
-parameter port_b_logical_ram_width = 10;
-parameter port_b_first_address = 0;
-parameter port_b_last_address = 1023;
-parameter port_b_first_bit_number = 0;
-parameter port_b_address_clock = "clock0";
-parameter port_b_read_enable_clock = "clock0";
-parameter mem_init0 = "";
-parameter mem_init1 = "";
-parameter mem_init2 = "";
-parameter mem_init3 = "";
-parameter mem_init4 = "";
-
-input [port_a_address_width-1:0] portaaddr;
-input [port_b_address_width-1:0] portbaddr;
-input [port_a_data_width-1:0] portadatain;
-output [port_b_data_width-1:0] portbdataout;
-input clk0, portawe, portbre;
-
-endmodule

--- a/techlibs/intel_alm/common/mem_sim.v
+++ b/techlibs/intel_alm/common/mem_sim.v
@@ -68,37 +68,3 @@ always @(posedge CLK1)
 assign B1DATA = mem[B1ADDR];
 
 endmodule
-
-// The M10K
-// --------
-// TODO
-
-module MISTRAL_M10K(CLK1, A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN);
-
-parameter CFG_ABITS = 10;
-parameter CFG_DBITS = 10;
-
-input CLK1;
-input [CFG_ABITS-1:0] A1ADDR, B1ADDR;
-input [CFG_DBITS-1:0] A1DATA;
-input A1EN, B1EN;
-output reg [CFG_DBITS-1:0] B1DATA;
-
-reg [2**CFG_ABITS * CFG_DBITS - 1 : 0] mem = 0;
-
-specify
-    $setup(A1ADDR, posedge CLK1, 0);
-    $setup(A1DATA, posedge CLK1, 0);
-
-    if (B1EN) (posedge CLK1 => (B1DATA : A1DATA)) = 0;
-endspecify
-
-always @(posedge CLK1) begin
-    if (A1EN)
-        mem[(A1ADDR + 1) * CFG_DBITS - 1 : A1ADDR * CFG_DBITS] <= A1DATA;
-
-    if (B1EN)
-        B1DATA <= mem[(B1ADDR + 1) * CFG_DBITS - 1 : B1ADDR * CFG_DBITS];
-end
-
-endmodule

--- a/techlibs/intel_alm/common/quartus_rename.v
+++ b/techlibs/intel_alm/common/quartus_rename.v
@@ -123,51 +123,6 @@ module MISTRAL_MLAB(input [4:0] A1ADDR, input A1DATA, A1EN, CLK1, input [4:0] B1
 endmodule
 
 
-module MISTRAL_M10K(A1ADDR, A1DATA, A1EN, CLK1, B1ADDR, B1DATA, B1EN);
-
-parameter CFG_ABITS = 10;
-parameter CFG_DBITS = 10;
-
-input [CFG_ABITS-1:0] A1ADDR, B1ADDR;
-input [CFG_DBITS-1:0] A1DATA;
-input CLK1, A1EN, B1EN;
-output [CFG_DBITS-1:0] B1DATA;
-
-// Much like the MLAB, the M10K has mem_init[01234] parameters which would let
-// you initialise the RAM cell via hex literals. If they were implemented.
-
-cyclonev_ram_block #(
-    .operation_mode("dual_port"),
-    .logical_ram_name("MISTRAL_M10K"),
-    .port_a_address_width(CFG_ABITS),
-    .port_a_data_width(CFG_DBITS),
-    .port_a_logical_ram_depth(2**CFG_ABITS),
-    .port_a_logical_ram_width(CFG_DBITS),
-    .port_a_first_address(0),
-    .port_a_last_address(2**CFG_DBITS - 1),
-    .port_a_first_bit_number(0),
-    .port_b_address_width(CFG_ABITS),
-    .port_b_data_width(CFG_DBITS),
-    .port_b_logical_ram_depth(2**CFG_ABITS),
-    .port_b_logical_ram_width(CFG_DBITS),
-    .port_b_first_address(0),
-    .port_b_last_address(2**CFG_DBITS - 1),
-    .port_b_first_bit_number(0),
-    .port_b_address_clock("clock0"),
-    .port_b_read_enable_clock("clock0")
-) _TECHMAP_REPLACE_ (
-    .portaaddr(A1ADDR),
-    .portadatain(A1DATA),
-    .portawe(A1EN),
-    .portbaddr(B1ADDR),
-    .portbdataout(B1DATA),
-    .portbre(B1EN),
-    .clk0(CLK1)
-);
-
-endmodule
-
-
 module MISTRAL_MUL27X27(input [26:0] A, B, output [53:0] Y);
 
 `MAC #(.ax_width(27), .ay_scan_in_width(27), .result_a_width(54), .operation_mode("M27x27")) _TECHMAP_REPLACE_ (.ax(A), .ay(B), .resulta(Y));

--- a/techlibs/intel_alm/synth_intel_alm.cc
+++ b/techlibs/intel_alm/synth_intel_alm.cc
@@ -235,8 +235,7 @@ struct SynthIntelALMPass : public ScriptPass {
 
 		if (!nobram && check_label("map_bram", "(skip if -nobram)")) {
 			run(stringf("memory_bram -rules +/intel_alm/common/bram_%s.txt", bram_type.c_str()));
-			if (help_mode || bram_type != "m10k")
-				run(stringf("techmap -map +/intel_alm/common/bram_%s_map.v", bram_type.c_str()));
+			run(stringf("techmap -map +/intel_alm/common/bram_%s_map.v", bram_type.c_str()));
 		}
 
 		if (!nolutram && check_label("map_lutram", "(skip if -nolutram)")) {

--- a/tests/arch/intel_alm/blockram.ys
+++ b/tests/arch/intel_alm/blockram.ys
@@ -1,6 +1,0 @@
-read_verilog ../common/blockram.v
-chparam -set ADDRESS_WIDTH 10 -set DATA_WIDTH 10 sync_ram_sdp
-synth_intel_alm -family cyclonev
-cd sync_ram_sdp
-select -assert-count 1 t:MISTRAL_M10K
-select -assert-none t:MISTRAL_M10K %% t:* %D


### PR DESCRIPTION
So, the M10K PR broke the Quartus backend in two ways, one trivial, one substantially less so.

- the `port_[ab]_last_address` parameters to `cyclonev_ram_block` use `CFG_DBITS` instead of `CFG_ABITS`; this means Quartus can fail to infer the RAM size and then gives up. This by itself is just a single character fix and a regression test to avoid breaking it again.
- all the RAM cells have the same logical RAM name, which worked fine in my own testing until I ran it with a different codebase and it broke horribly because Quartus does *not* like RAMs of different geometries having the same logical RAM name.

The problem is that Yosys does not have a way to assign a unique identifier to a cell parameter - even just the cell name would work, I believe. I've been wondering if it would be better to put it in `techmap` (which is already very complicated), or in `chparam`.

While I come up with an acceptable way to solve the logical RAM name problem, the PR should be reverted as to limit the breakage in master.