### PR TITLE
verilog_backend: in non-SV mode, add a trigger for `always @*`

### DIFF
--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -1718,6 +1718,8 @@ void dump_process(std::ostream &f, std::string indent, RTLIL::Process *proc, boo
 	}
 
 	f << stringf("%s" "always%s begin\n", indent.c_str(), systemverilog ? "_comb" : " @*");
+	if (!systemverilog)
+		f << indent + "  " << "if (" << id("\\initial") << ") begin end\n";
 	dump_case_body(f, indent, &proc->root_case, true);
 
 	std::string backup_indent = indent;
@@ -1849,6 +1851,9 @@ void dump_module(std::ostream &f, std::string indent, RTLIL::Module *module)
 		}
 	}
 	f << stringf(");\n");
+
+	if (!systemverilog && !module->processes.empty())
+		f << indent + "  " << "reg " << id("\\initial") << " = 0;\n";
 
 	for (auto w : module->wires())
 		dump_wire(f, indent + "  ", w);

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -1050,6 +1050,8 @@ void run_backend(std::string filename, std::string command, RTLIL::Design *desig
 	if (command == "auto") {
 		if (filename.size() > 2 && filename.compare(filename.size()-2, std::string::npos, ".v") == 0)
 			command = "verilog";
+		else if (filename.size() > 3 && filename.compare(filename.size()-3, std::string::npos, ".sv") == 0)
+			command = "verilog -sv";
 		else if (filename.size() > 3 && filename.compare(filename.size()-3, std::string::npos, ".il") == 0)
 			command = "ilang";
 		else if (filename.size() > 3 && filename.compare(filename.size()-3, std::string::npos, ".cc") == 0)


### PR DESCRIPTION
This PR depends on and includes #2272. It only affects translation of RTLIL processes (for which there is limited support).

Due to the event-driven nature of Verilog, processes like

    reg x;
    always @*
        x <= 1;

may never execute. This can be fixed in SystemVerilog code by using `always_comb` instead of `always @*`, but in Verilog-2001 the options are limited. This PR implements the following workaround:

    reg init = 0;
    reg x;
    always @* begin
        if (init) begin end
        x <= 1;
    end