### PR TITLE
Remove EXPLICIT_CARRY logic.

### DIFF
--- a/techlibs/xilinx/cells_sim.v
+++ b/techlibs/xilinx/cells_sim.v
@@ -455,29 +455,6 @@ module CARRY8(
   assign CO[7] = S[7] ? CO[6] : DI[7];
 endmodule
 
-`ifdef _EXPLICIT_CARRY
-
-module CARRY0(output CO_CHAIN, CO_FABRIC, O, input CI, CI_INIT, DI, S);
-  parameter CYINIT_FABRIC = 0;
-  wire CI_COMBINE;
-  if(CYINIT_FABRIC) begin
-    assign CI_COMBINE = CI_INIT;
-  end else begin
-    assign CI_COMBINE = CI;
-  end
-  assign CO_CHAIN = S ? CI_COMBINE : DI;
-  assign CO_FABRIC = S ? CI_COMBINE : DI;
-  assign O = S ^ CI_COMBINE;
-endmodule
-
-module CARRY(output CO_CHAIN, CO_FABRIC, O, input CI, DI, S);
-  assign CO_CHAIN = S ? CI : DI;
-  assign CO_FABRIC = S ? CI : DI;
-  assign O = S ^ CI;
-endmodule
-
-`endif
-
 module ORCY (output O, input CI, I);
   assign O = CI | I;
 endmodule

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -77,10 +77,6 @@ struct SynthXilinxPass : public ScriptPass
 		log("        write the design to the specified BLIF file. writing of an output file\n");
 		log("        is omitted if this parameter is not specified.\n");
 		log("\n");
-		log("    -vpr\n");
-		log("        generate an output netlist (and BLIF file) suitable for VPR\n");
-		log("        (this feature is experimental and incomplete)\n");
-		log("\n");
 		log("    -ise\n");
 		log("        generate an output netlist suitable for ISE\n");
 		log("\n");
@@ -142,7 +138,7 @@ struct SynthXilinxPass : public ScriptPass
 	}
 
 	std::string top_opt, edif_file, blif_file, family;
-	bool flatten, retime, vpr, ise, noiopad, noclkbuf, nobram, nolutram, nosrl, nocarry, nowidelut, nodsp, uram;
+	bool flatten, retime, ise, noiopad, noclkbuf, nobram, nolutram, nosrl, nocarry, nowidelut, nodsp, uram;
 	bool abc9, dff;
 	bool flatten_before_abc;
 	int widemux;
@@ -157,7 +153,6 @@ struct SynthXilinxPass : public ScriptPass
 		family = "xc7";
 		flatten = false;
 		retime = false;
-		vpr = false;
 		ise = false;
 		noiopad = false;
 		noclkbuf = false;
@@ -227,10 +222,6 @@ struct SynthXilinxPass : public ScriptPass
 			}
 			if (args[argidx] == "-nowidelut") {
 				nowidelut = true;
-				continue;
-			}
-			if (args[argidx] == "-vpr") {
-				vpr = true;
 				continue;
 			}
 			if (args[argidx] == "-ise") {
@@ -352,8 +343,6 @@ struct SynthXilinxPass : public ScriptPass
 
 		if (check_label("begin")) {
 			std::string read_args;
-			if (vpr)
-				read_args += " -D_EXPLICIT_CARRY";
 			read_args += " -lib -specify +/xilinx/cells_sim.v";
 			run("read_verilog" + read_args);
 
@@ -577,8 +566,6 @@ struct SynthXilinxPass : public ScriptPass
 				techmap_args += stringf(" -D MIN_MUX_INPUTS=%d -map +/xilinx/mux_map.v", widemux);
 			if (!nocarry) {
 				techmap_args += " -map +/xilinx/arith_map.v";
-				if (vpr)
-					techmap_args += " -D _EXPLICIT_CARRY";
 			}
 			run("techmap " + techmap_args);
 			run("opt -fast");


### PR DESCRIPTION
The symbiflow-arch-defs tool chain no longer needs the EXPLICIT_CARRY within yosys itself.