### PR TITLE
smtbmc, smtio: Allow the solver to return other status messages than just "sat" and "unsat".

### DIFF
--- a/backends/smt2/smtbmc.py
+++ b/backends/smt2/smtbmc.py
@@ -1275,10 +1275,10 @@ def smt_pop():
     asserts_consequent_cache.pop()
     smt.write("(pop 1)")
 
-def smt_check_sat(expected=["sat", "unsat"]):
+def smt_check_sat():
     if asserts_cache_dirty:
         smt_forall_assert()
-    return smt.check_sat(expected=expected)
+    return smt.check_sat()
 
 if tempind:
     retstatus = "FAILED"
@@ -1373,7 +1373,7 @@ elif covermode:
             smt_push()
             smt_assert("(distinct (covers_%d s%d) #b%s)" % (coveridx, step, "0" * len(cover_desc)))
 
-            if smt_check_sat() == "unsat":
+            if smt_check_sat() != "sat":
                 smt_pop()
                 break
 
@@ -1387,7 +1387,7 @@ elif covermode:
                     smt_assert_antecedent("(|%s_t| s%d s%d)" % (topmod, i-1, i))
                     smt_assert_consequent(get_constr_expr(constr_assumes, i))
                 print_msg("Re-solving with appended steps..")
-                if smt_check_sat() == "unsat":
+                if smt_check_sat() != "sat":
                     print("%s Cannot appended steps without violating assumptions!" % smt.timestamp())
                     found_failed_assert = True
                     retstatus = "FAILED"
@@ -1483,7 +1483,7 @@ else:  # not tempind, covermode
                 else:
                     print_msg("Checking assumptions in steps %d to %d.." % (step, last_check_step))
 
-                if smt_check_sat() == "unsat":
+                if smt_check_sat() != "sat":
                     print("%s Assumptions are unsatisfiable!" % smt.timestamp())
                     retstatus = "PREUNSAT"
                     break
@@ -1510,7 +1510,7 @@ else:  # not tempind, covermode
                             smt_assert_antecedent("(|%s_t| s%d s%d)" % (topmod, i-1, i))
                             smt_assert_consequent(get_constr_expr(constr_assumes, i))
                         print_msg("Re-solving with appended steps..")
-                        if smt_check_sat() == "unsat":
+                        if smt_check_sat() != "sat":
                             print("%s Cannot append steps without violating assumptions!" % smt.timestamp())
                             retstatus = "FAILED"
                             break

--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -667,7 +667,7 @@ class SmtIo:
 
         return stmt
 
-    def check_sat(self, expected=["sat", "unsat", "unknown", "timeout", "interrupted"]):
+    def check_sat(self):
         if self.debug_print:
             print("> (check-sat)")
         if self.debug_file and not self.nocomments:
@@ -754,6 +754,7 @@ class SmtIo:
             print("(check-sat)", file=self.debug_file)
             self.debug_file.flush()
 
+        expected = ["sat", "unsat", "unknown", "timeout", "interrupted"]
         if result not in expected:
             if result == "":
                 print("%s Unexpected EOF response from solver." % (self.timestamp()), flush=True)


### PR DESCRIPTION
See also #2282 and YosysHQ/SymbiYosys#102.

This (re-)adds support for "unknown", "timeout", and "interrupted", but fixes the logic in smtbmc.py that caused the bug in YosysHQ/SymbiYosys#102 .  I think I inadvertently caused that bug with an incomplete patch in #2018 .  Mea culpa.

Now the nitpick about smtbmc output in https://github.com/Yosyshq/yosys/pull/2282#issuecomment-661281789 is resolved.  In fact, this also fixes similarly semantically incorrect output from SymbiYosys `make test_puzzles_primegen_primes_fail`:

Before:
```
cd docs/examples/puzzles && python3 ../../../sbysrc/sby.py -f primegen.sby primes_fail
SBY 21:32:29 [primegen_primes_fail] Removing directory 'primegen_primes_fail'.
SBY 21:32:29 [primegen_primes_fail] Copy 'primegen.sv' to 'primegen_primes_fail/src/primegen.sv'.
SBY 21:32:29 [primegen_primes_fail] engine_0: smtbmc --dumpsmt2 --progress --stbv z3
SBY 21:32:29 [primegen_primes_fail] base: starting process "cd primegen_primes_fail/src; yosys -ql ../model/design.log ../model/design.ys"
SBY 21:32:29 [primegen_primes_fail] base: finished (returncode=0)
SBY 21:32:29 [primegen_primes_fail] smt2_stbv: starting process "cd primegen_primes_fail/model; yosys -ql design_smt2_stbv.log design_smt2_stbv.ys"
SBY 21:32:29 [primegen_primes_fail] smt2_stbv: finished (returncode=0)
SBY 21:32:29 [primegen_primes_fail] engine_0: starting process "cd primegen_primes_fail; yosys-smtbmc -s z3 --presat -c --dump-smt2 engine_0/trace.smt2 -t 1  --append 0 --dump-vcd engine_0/trace%.vcd --dump-vlogtb engine_0/trace%_tb.v --dump-smtc engine_0/trace%.smtc model/design_smt2_stbv.smt2"
SBY 21:32:29 [primegen_primes_fail] engine_0: ##   0:00:00  Solver: z3
SBY 21:32:29 [primegen_primes_fail] engine_0: ##   0:00:00  Checking cover reachability in step 0..
SBY 21:33:05 [primegen_primes_fail] engine_0: ##   0:00:35  Unexpected response from solver: unknown
SBY 21:33:05 [primegen_primes_fail] engine_0: finished (returncode=1)
SBY 21:33:05 [primegen_primes_fail] engine_0: Status returned by engine: ERROR
SBY 21:33:05 [primegen_primes_fail] summary: Elapsed clock time [H:MM:SS (secs)]: 0:00:35 (35)
SBY 21:33:05 [primegen_primes_fail] summary: Elapsed process time [H:MM:SS (secs)]: 0:00:00 (0)
SBY 21:33:05 [primegen_primes_fail] summary: engine_0 (smtbmc --dumpsmt2 --progress --stbv z3) returned ERROR
SBY 21:33:05 [primegen_primes_fail] DONE (ERROR, rc=0)
```

(IMO this is semantically incorrect; it FAILed, not ERRORed).

Now:
```
cd docs/examples/puzzles && python3 ../../../sbysrc/sby.py -f primegen.sby primes_fail
SBY 21:38:14 [primegen_primes_fail] Removing directory 'primegen_primes_fail'.
SBY 21:38:14 [primegen_primes_fail] Copy 'primegen.sv' to 'primegen_primes_fail/src/primegen.sv'.
SBY 21:38:14 [primegen_primes_fail] engine_0: smtbmc --dumpsmt2 --progress --stbv z3
SBY 21:38:14 [primegen_primes_fail] base: starting process "cd primegen_primes_fail/src; yosys -ql ../model/design.log ../model/design.ys"
SBY 21:38:14 [primegen_primes_fail] base: finished (returncode=0)
SBY 21:38:14 [primegen_primes_fail] smt2_stbv: starting process "cd primegen_primes_fail/model; yosys -ql design_smt2_stbv.log design_smt2_stbv.ys"
SBY 21:38:14 [primegen_primes_fail] smt2_stbv: finished (returncode=0)
SBY 21:38:14 [primegen_primes_fail] engine_0: starting process "cd primegen_primes_fail; yosys-smtbmc -s z3 --presat -c --dump-smt2 engine_0/trace.smt2 -t 1  --append 0 --dump-vcd engine_0/trace%.vcd --dump-vlogtb engine_0/trace%_tb.v --dump-smtc engine_0/trace%.smtc model/design_smt2_stbv.smt2"
SBY 21:38:14 [primegen_primes_fail] engine_0: ##   0:00:00  Solver: z3
SBY 21:38:14 [primegen_primes_fail] engine_0: ##   0:00:00  Checking cover reachability in step 0..
SBY 21:38:49 [primegen_primes_fail] engine_0: ##   0:00:34  Unreached cover statement at primegen.sv:24.23-25.12.
SBY 21:38:49 [primegen_primes_fail] engine_0: ##   0:00:35  Status: failed
SBY 21:38:49 [primegen_primes_fail] engine_0: finished (returncode=1)
SBY 21:38:49 [primegen_primes_fail] engine_0: Status returned by engine: FAIL
SBY 21:38:49 [primegen_primes_fail] summary: Elapsed clock time [H:MM:SS (secs)]: 0:00:35 (35)
SBY 21:38:49 [primegen_primes_fail] summary: Elapsed process time [H:MM:SS (secs)]: 0:00:34 (34)
SBY 21:38:49 [primegen_primes_fail] summary: engine_0 (smtbmc --dumpsmt2 --progress --stbv z3) returned FAIL
SBY 21:38:49 [primegen_primes_fail] DONE (FAIL, rc=0)
```