### PR TITLE
intel_alm: add additional ABC9 timings

### DIFF
--- a/techlibs/intel_alm/common/alm_sim.v
+++ b/techlibs/intel_alm/common/alm_sim.v
@@ -69,6 +69,14 @@
 
 `default_nettype none
 
+// Cyclone V LUT output timings (picoseconds):
+//
+//          CARRY   A    B    C   D   E    F   G
+//  COMBOUT    -  605  583  510 512   -   97 400 (LUT6)
+//  COMBOUT    -  602  583  457 510 302   93 483 (LUT7)
+//   SUMOUT  368 1342 1323  887 927   -  785   -
+// CARRYOUT   71 1082 1062  866 813   - 1198   -
+
 (* abc9_lut=2, lib_whitebox *)
 module MISTRAL_ALUT6(input A, B, C, D, E, F, output Q);
 
@@ -76,12 +84,12 @@ parameter [63:0] LUT = 64'h0000_0000_0000_0000;
 
 `ifdef cyclonev
 specify
-    (A => Q) = 602;
-    (B => Q) = 584;
+    (A => Q) = 605;
+    (B => Q) = 583;
     (C => Q) = 510;
-    (D => Q) = 510;
-    (E => Q) = 339;
-    (F => Q) = 94;
+    (D => Q) = 512;
+    (E => Q) = 400;
+    (F => Q) = 97;
 endspecify
 `endif
 `ifdef cyclone10gx
@@ -107,11 +115,11 @@ parameter [31:0] LUT = 32'h0000_0000;
 
 `ifdef cyclonev
 specify
-    (A => Q) = 584;
+    (A => Q) = 583;
     (B => Q) = 510;
-    (C => Q) = 510;
-    (D => Q) = 339;
-    (E => Q) = 94;
+    (C => Q) = 512;
+    (D => Q) = 400;
+    (E => Q) = 97;
 endspecify
 `endif
 `ifdef cyclone10gx
@@ -137,9 +145,9 @@ parameter [15:0] LUT = 16'h0000;
 `ifdef cyclonev
 specify
     (A => Q) = 510;
-    (B => Q) = 510;
-    (C => Q) = 339;
-    (D => Q) = 94;
+    (B => Q) = 512;
+    (C => Q) = 400;
+    (D => Q) = 97;
 endspecify
 `endif
 `ifdef cyclone10gx
@@ -164,8 +172,8 @@ parameter [7:0] LUT = 8'h00;
 `ifdef cyclonev
 specify
     (A => Q) = 510;
-    (B => Q) = 339;
-    (C => Q) = 94;
+    (B => Q) = 400;
+    (C => Q) = 97;
 endspecify
 `endif
 `ifdef cyclone10gx
@@ -188,8 +196,8 @@ parameter [3:0] LUT = 4'h0;
 
 `ifdef cyclonev
 specify
-    (A => Q) = 339;
-    (B => Q) = 94;
+    (A => Q) = 400;
+    (B => Q) = 97;
 endspecify
 `endif
 `ifdef cyclone10gx
@@ -209,7 +217,7 @@ module MISTRAL_NOT(input A, output Q);
 
 `ifdef cyclonev
 specify
-    (A => Q) = 94;
+    (A => Q) = 97;
 endspecify
 `endif
 `ifdef cyclone10gx
@@ -230,31 +238,33 @@ parameter LUT1 = 16'h0000;
 
 `ifdef cyclonev
 specify
-    (A => SO) = 1283;
-    (B => SO) = 1167;
-    (C => SO) = 866;
-    (D0 => SO) = 756;
-    (D1 => SO) = 756;
-    (CI => SO) = 355;
-    (A => CO) = 950;
-    (B => CO) = 1039;
-    (C => CO) = 820;
-    (D0 => CO) = 1006;
-    (D1 => CO) = 1006;
-    (CI => CO) = 23;
+    (A  => SO) = 1342;
+    (B  => SO) = 1323;
+    (C  => SO) = 927;
+    (D0 => SO) = 887;
+    (D1 => SO) = 785;
+    (CI => SO) = 368;
+
+    (A  => CO) = 1082;
+    (B  => CO) = 1062;
+    (C  => CO) = 813;
+    (D0 => CO) = 866;
+    (D1 => CO) = 1198;
+    (CI => CO) = 36; // Divided by 2 to account for there being two ALUT_ARITHs in an ALM)
 endspecify
 `endif
 `ifdef cyclone10gx
 specify
-    (A => SO) = 644;
-    (B => SO) = 477;
-    (C => SO) = 416;
+    (A  => SO) = 644;
+    (B  => SO) = 477;
+    (C  => SO) = 416;
     (D0 => SO) = 380;
     (D1 => SO) = 431;
     (CI => SO) = 276;
-    (A => CO) = 525;
-    (B => CO) = 433;
-    (C => CO) = 712;
+
+    (A  => CO) = 525;
+    (B  => CO) = 433;
+    (C  => CO) = 712;
     (D0 => CO) = 653;
     (D1 => CO) = 593;
     (CI => CO) = 16;

--- a/techlibs/intel_alm/common/dff_sim.v
+++ b/techlibs/intel_alm/common/dff_sim.v
@@ -54,43 +54,44 @@
 //
 // Note: the DFFEAS primitive is mostly emulated; it does not reflect what the hardware implements.
 
-`ifdef cyclonev
-`define SYNCPATH 262
-`define SYNCSETUP 522
-`define COMBPATH 0
-`endif
-`ifdef cyclone10gx
-`define SYNCPATH 219
-`define SYNCSETUP 268
-`define COMBPATH 0
-`endif
-
-// fallback for when a family isn't detected (e.g. when techmapping for equivalence)
-`ifndef SYNCPATH
-`define SYNCPATH 0
-`define SYNCSETUP 0
-`define COMBPATH 0
-`endif
-
 (* abc9_box, lib_whitebox *)
 module MISTRAL_FF(
     input DATAIN, CLK, ACLR, ENA, SCLR, SLOAD, SDATA,
     output reg Q
 );
 
+`ifdef cyclonev
 specify
-    if (ENA && ACLR !== 1'b0 && !SCLR && !SLOAD) (posedge CLK => (Q : DATAIN)) = `SYNCPATH;
-    if (ENA && SCLR) (posedge CLK => (Q : 1'b0)) = `SYNCPATH;
-    if (ENA && !SCLR && SLOAD) (posedge CLK => (Q : SDATA)) = `SYNCPATH;
+    if (ENA && ACLR !== 1'b0 && !SCLR && !SLOAD) (posedge CLK => (Q : DATAIN)) = 731;
+    if (ENA && SCLR) (posedge CLK => (Q : 1'b0)) = 890;
+    if (ENA && !SCLR && SLOAD) (posedge CLK => (Q : SDATA)) = 618;
 
-    $setup(DATAIN, posedge CLK, `SYNCSETUP);
-    $setup(ENA, posedge CLK, `SYNCSETUP);
-    $setup(SCLR, posedge CLK, `SYNCSETUP);
-    $setup(SLOAD, posedge CLK, `SYNCSETUP);
-    $setup(SDATA, posedge CLK, `SYNCSETUP);
+    $setup(DATAIN, posedge CLK, /* -196 */ 0);
+    $setup(ENA, posedge CLK, /* -196 */ 0);
+    $setup(SCLR, posedge CLK, /* -196 */ 0);
+    $setup(SLOAD, posedge CLK, /* -196 */ 0);
+    $setup(SDATA, posedge CLK, /* -196 */ 0);
 
-    if (ACLR === 1'b0) (ACLR => Q) = `COMBPATH;
+    if (ACLR === 1'b0) (ACLR => Q) = 282;
 endspecify
+`endif
+`ifdef cyclone10gx
+specify
+    // TODO (long-term): investigate these numbers.
+    // It seems relying on the Quartus Timing Analyzer was not the best idea; it's too fiddly.
+    if (ENA && ACLR !== 1'b0 && !SCLR && !SLOAD) (posedge CLK => (Q : DATAIN)) = 219;
+    if (ENA && SCLR) (posedge CLK => (Q : 1'b0)) = 219;
+    if (ENA && !SCLR && SLOAD) (posedge CLK => (Q : SDATA)) = 219;
+
+    $setup(DATAIN, posedge CLK, 268);
+    $setup(ENA, posedge CLK, 268);
+    $setup(SCLR, posedge CLK, 268);
+    $setup(SLOAD, posedge CLK, 268);
+    $setup(SDATA, posedge CLK, 268);
+
+    if (ACLR === 1'b0) (ACLR => Q) = 0;
+endspecify
+`endif
 
 initial begin
     // Altera flops initialise to zero.

--- a/techlibs/intel_alm/common/dsp_sim.v
+++ b/techlibs/intel_alm/common/dsp_sim.v
@@ -1,9 +1,10 @@
 (* abc9_box *)
 module MISTRAL_MUL27x27(input [26:0] A, input [26:0] B, output [53:0] Y);
 
+// TODO: Cyclone 10 GX timings; the below are for Cyclone V
 specify
-    (A *> Y) = 4057;
-    (B *> Y) = 4057;
+    (A *> Y) = 3732;
+    (B *> Y) = 3928;
 endspecify
 
 assign Y = $signed(A) * $signed(B);
@@ -13,9 +14,10 @@ endmodule
 (* abc9_box *)
 module MISTRAL_MUL18X18(input [17:0] A, input [17:0] B, output [35:0] Y);
 
+// TODO: Cyclone 10 GX timings; the below are for Cyclone V
 specify
-    (A *> Y) = 4057;
-    (B *> Y) = 4057;
+    (A *> Y) = 3180;
+    (B *> Y) = 3982;
 endspecify
 
 assign Y = $signed(A) * $signed(B);
@@ -25,9 +27,10 @@ endmodule
 (* abc9_box *)
 module MISTRAL_MUL9X9(input [8:0] A, input [8:0] B, output [17:0] Y);
 
+// TODO: Cyclone 10 GX timings; the below are for Cyclone V
 specify
-    (A *> Y) = 4057;
-    (B *> Y) = 4057;
+    (A *> Y) = 2818;
+    (B *> Y) = 3051;
 endspecify
 
 assign Y = $signed(A) * $signed(B);

--- a/techlibs/intel_alm/common/mem_sim.v
+++ b/techlibs/intel_alm/common/mem_sim.v
@@ -54,12 +54,17 @@ module MISTRAL_MLAB(input [4:0] A1ADDR, input A1DATA, A1EN, CLK1, input [4:0] B1
 
 reg [31:0] mem = 32'b0;
 
-// TODO
+// TODO: Cyclone 10 GX timings; the below timings are for Cyclone V
 specify
-    $setup(A1ADDR, posedge CLK1, 0);
-    $setup(A1DATA, posedge CLK1, 0);
+    $setup(A1ADDR, posedge CLK1, 86);
+    $setup(A1DATA, posedge CLK1, 86);
+    $setup(A1EN, posedge CLK1, 86);
 
-    (B1ADDR *> B1DATA) = 0;
+    (B1ADDR[0] => B1DATA) = 487;
+    (B1ADDR[1] => B1DATA) = 475;
+    (B1ADDR[2] => B1DATA) = 382;
+    (B1ADDR[3] => B1DATA) = 284;
+    (B1ADDR[4] => B1DATA) = 96;
 endspecify
 
 always @(posedge CLK1)

--- a/tests/arch/intel_alm/mux.ys
+++ b/tests/arch/intel_alm/mux.ys
@@ -47,10 +47,9 @@ proc
 equiv_opt -assert -map +/intel_alm/common/alm_sim.v synth_intel_alm -family cyclonev # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux8 # Constrain all select calls below inside the top module
-select -assert-count 1 t:MISTRAL_ALUT3
-select -assert-count 1 t:MISTRAL_ALUT5
-select -assert-count 2 t:MISTRAL_ALUT6
-select -assert-none t:MISTRAL_ALUT3 t:MISTRAL_ALUT5 t:MISTRAL_ALUT6 %% t:* %D
+select -assert-count 3 t:MISTRAL_ALUT5
+select -assert-count 1 t:MISTRAL_ALUT6
+select -assert-none t:MISTRAL_ALUT5 t:MISTRAL_ALUT6 %% t:* %D
 
 
 design -load read
@@ -70,10 +69,9 @@ proc
 equiv_opt -assert -map +/intel_alm/common/alm_sim.v synth_intel_alm -family cyclonev # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux16 # Constrain all select calls below inside the top module
-select -assert-count 1 t:MISTRAL_ALUT3
 select -assert-count 2 t:MISTRAL_ALUT5
 select -assert-count 4 t:MISTRAL_ALUT6
-select -assert-none t:MISTRAL_ALUT3 t:MISTRAL_ALUT5 t:MISTRAL_ALUT6 %% t:* %D
+select -assert-none t:MISTRAL_ALUT5 t:MISTRAL_ALUT6 %% t:* %D
 
 
 design -load read


### PR DESCRIPTION
These timings come from the Quartus DMF dumps, so they should more accurately reflect the timings of actual hardware, compared to the timings scavenged from the Quartus Timing Analyzer which may include other factors like fanout.