### PR TITLE
opt_expr: Remove -clkinv option, make it the default.

### DIFF
--- a/passes/opt/opt.cc
+++ b/passes/opt/opt.cc
@@ -37,7 +37,7 @@ struct OptPass : public Pass {
 		log("a series of trivial optimizations and cleanups. This pass executes the other\n");
 		log("passes in the following order:\n");
 		log("\n");
-		log("    opt_expr [-mux_undef] [-mux_bool] [-undriven] [-clkinv] [-fine] [-full] [-keepdc]\n");
+		log("    opt_expr [-mux_undef] [-mux_bool] [-undriven] [-noclkinv] [-fine] [-full] [-keepdc]\n");
 		log("    opt_merge [-share_all] -nomux\n");
 		log("\n");
 		log("    do\n");
@@ -47,13 +47,13 @@ struct OptPass : public Pass {
 		log("        opt_share  (-full only)\n");
 		log("        opt_rmdff [-keepdc] [-sat]  (except when called with -noff)\n");
 		log("        opt_clean [-purge]\n");
-		log("        opt_expr [-mux_undef] [-mux_bool] [-undriven] [-clkinv] [-fine] [-full] [-keepdc]\n");
+		log("        opt_expr [-mux_undef] [-mux_bool] [-undriven] [-noclkinv] [-fine] [-full] [-keepdc]\n");
 		log("    while <changed design>\n");
 		log("\n");
 		log("When called with -fast the following script is used instead:\n");
 		log("\n");
 		log("    do\n");
-		log("        opt_expr [-mux_undef] [-mux_bool] [-undriven] [-clkinv] [-fine] [-full] [-keepdc]\n");
+		log("        opt_expr [-mux_undef] [-mux_bool] [-undriven] [-noclkinv] [-fine] [-full] [-keepdc]\n");
 		log("        opt_merge [-share_all]\n");
 		log("        opt_rmdff [-keepdc] [-sat]  (except when called with -noff)\n");
 		log("        opt_clean [-purge]\n");
@@ -96,8 +96,8 @@ struct OptPass : public Pass {
 				opt_expr_args += " -undriven";
 				continue;
 			}
-			if (args[argidx] == "-clkinv") {
-				opt_expr_args += " -clkinv";
+			if (args[argidx] == "-noclkinv") {
+				opt_expr_args += " -noclkinv";
 				continue;
 			}
 			if (args[argidx] == "-fine") {

--- a/techlibs/greenpak4/synth_greenpak4.cc
+++ b/techlibs/greenpak4/synth_greenpak4.cc
@@ -162,7 +162,7 @@ struct SynthGreenPAK4Pass : public ScriptPass
 			run("opt -undriven -fine");
 			run("techmap -map +/techmap.v -map +/greenpak4/cells_latch.v");
 			run("dfflibmap -prepare -liberty +/greenpak4/gp_dff.lib");
-			run("opt -fast");
+			run("opt -fast -noclkinv -noff");
 			if (retime || help_mode)
 				run("abc -dff -D 1", "(only if -retime)");
 		}

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -590,7 +590,7 @@ struct SynthXilinxPass : public ScriptPass
 		}
 
 		if (check_label("map_luts")) {
-			run("opt_expr -mux_undef");
+			run("opt_expr -mux_undef -noclkinv");
 			if (flatten_before_abc)
 				run("flatten");
 			if (help_mode)

--- a/tests/arch/xilinx/latches.ys
+++ b/tests/arch/xilinx/latches.ys
@@ -18,9 +18,8 @@ equiv_opt -async2sync -assert -map +/xilinx/cells_sim.v synth_xilinx -noiopad # 
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd latchn # Constrain all select calls below inside the top module
 select -assert-count 1 t:LDCE
-select -assert-count 1 t:INV
 
-select -assert-none t:LDCE t:INV %% t:* %D
+select -assert-none t:LDCE %% t:* %D
 
 
 design -load read


### PR DESCRIPTION
Adds -noclkinv option just in case the old behavior was actually useful
to someone.