### PR TITLE
intel_alm: increase abc9 -W

### DIFF
--- a/techlibs/intel_alm/synth_intel_alm.cc
+++ b/techlibs/intel_alm/synth_intel_alm.cc
@@ -258,7 +258,7 @@ struct SynthIntelALMPass : public ScriptPass {
 
 		if (check_label("map_luts")) {
 			run("techmap -map +/intel_alm/common/abc9_map.v");
-			run(stringf("abc9 %s -maxlut 6 -W 200", help_mode ? "[-dff]" : dff ? "-dff" : ""));
+			run(stringf("abc9 %s -maxlut 6 -W 600", help_mode ? "[-dff]" : dff ? "-dff" : ""));
 			run("techmap -map +/intel_alm/common/abc9_unmap.v");
 			run("techmap -map +/intel_alm/common/alm_map.v");
 			run("opt -fast");

--- a/tests/arch/intel_alm/mux.ys
+++ b/tests/arch/intel_alm/mux.ys
@@ -47,9 +47,9 @@ proc
 equiv_opt -assert -map +/intel_alm/common/alm_sim.v synth_intel_alm -family cyclonev # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux8 # Constrain all select calls below inside the top module
-select -assert-count 3 t:MISTRAL_ALUT5
-select -assert-count 1 t:MISTRAL_ALUT6
-select -assert-none t:MISTRAL_ALUT5 t:MISTRAL_ALUT6 %% t:* %D
+select -assert-count 1 t:MISTRAL_ALUT3
+select -assert-count 2 t:MISTRAL_ALUT6
+select -assert-none t:MISTRAL_ALUT3 t:MISTRAL_ALUT6 %% t:* %D
 
 
 design -load read
@@ -69,9 +69,9 @@ proc
 equiv_opt -assert -map +/intel_alm/common/alm_sim.v synth_intel_alm -family cyclonev # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux16 # Constrain all select calls below inside the top module
-select -assert-count 2 t:MISTRAL_ALUT5
-select -assert-count 4 t:MISTRAL_ALUT6
-select -assert-none t:MISTRAL_ALUT5 t:MISTRAL_ALUT6 %% t:* %D
+select -assert-count 1 t:MISTRAL_ALUT3
+select -assert-count 5 t:MISTRAL_ALUT6
+select -assert-none t:MISTRAL_ALUT3 t:MISTRAL_ALUT6 %% t:* %D
 
 
 design -load read


### PR DESCRIPTION
This turns the weird Cyclone V MUX8 mapping into the "two MUX4s into a MUX2" mapping you'd expect.