### PR TITLE
Fix generate scoping issues

### DIFF
--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -250,7 +250,7 @@ namespace AST
 		// it also sets the id2ast pointers so that identifier lookups are fast in genRTLIL()
 		bool simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage, int width_hint, bool sign_hint, bool in_param);
 		AstNode *readmem(bool is_readmemh, std::string mem_filename, AstNode *memory, int start_addr, int finish_addr, bool unconditional_init);
-		void expand_genblock(std::string index_var, std::string prefix, std::map<std::string, std::string> &name_map);
+		void expand_genblock(std::string index_var, std::string prefix, std::map<std::string, std::string> &name_map, bool original_scope = true);
 		void replace_ids(const std::string &prefix, const std::map<std::string, std::string> &rules);
 		void mem2reg_as_needed_pass1(dict<AstNode*, pool<std::string>> &mem2reg_places,
 				dict<AstNode*, uint32_t> &mem2reg_flags, dict<AstNode*, uint32_t> &proc_flags, uint32_t &status_flags);

--- a/tests/simple/generate.v
+++ b/tests/simple/generate.v
@@ -159,3 +159,88 @@ generate
     end
 endgenerate
 endmodule
+
+// ------------------------------------------
+
+module gen_test7;
+	reg [2:0] out1;
+	reg [2:0] out2;
+	wire [2:0] out3;
+	generate
+		begin : cond
+			reg [2:0] sub_out1;
+			reg [2:0] sub_out2;
+			wire [2:0] sub_out3;
+			initial begin : init
+				reg signed [31:0] x;
+				x = 2 ** 2;
+				out1 = x;
+				sub_out1 = x;
+			end
+			always @* begin : proc
+				reg signed [31:0] x;
+				x = 2 ** 1;
+				out2 = x;
+				sub_out2 = x;
+			end
+			genvar x;
+			for (x = 0; x < 3; x = x + 1) begin
+				assign out3[x] = 1;
+				assign sub_out3[x] = 1;
+			end
+		end
+	endgenerate
+
+// `define VERIFY
+`ifdef VERIFY
+	assert property (out1 == 4);
+	assert property (out2 == 2);
+	assert property (out3 == 7);
+	assert property (cond.sub_out1 == 4);
+	assert property (cond.sub_out2 == 2);
+	assert property (cond.sub_out3 == 7);
+`endif
+endmodule
+
+// ------------------------------------------
+
+module gen_test8;
+
+// `define VERIFY
+`ifdef VERIFY
+	`define ASSERT(expr) assert property (expr);
+`else
+	`define ASSERT(expr)
+`endif
+
+	wire [1:0] x = 2'b11;
+	generate
+		begin : A
+			wire [1:0] x;
+			begin : B
+				wire [1:0] x = 2'b00;
+				`ASSERT(x == 0)
+				`ASSERT(A.x == 2)
+				`ASSERT(A.C.x == 1)
+				`ASSERT(A.B.x == 0)
+			end
+			begin : C
+				wire [1:0] x = 2'b01;
+				`ASSERT(x == 1)
+				`ASSERT(A.x == 2)
+				`ASSERT(A.C.x == 1)
+				`ASSERT(A.B.x == 0)
+			end
+			assign x = B.x ^ 2'b11 ^ C.x;
+			`ASSERT(x == 2)
+			`ASSERT(A.x == 2)
+			`ASSERT(A.C.x == 1)
+			`ASSERT(A.B.x == 0)
+		end
+	endgenerate
+
+	`ASSERT(x == 3)
+	`ASSERT(A.x == 2)
+	`ASSERT(A.C.x == 1)
+	`ASSERT(A.B.x == 0)
+endmodule


### PR DESCRIPTION
- expand_genblock defers prefixing of items within named sub-blocks
- Allow partially-qualified references to local scopes
- Handle shadowing within generate blocks
- Resolve generate scope references within tasks and functions
- Apply generate scoping to genvars
- Resolves #2214, resolves #1456

I'm very excited to finally have these issues resolved. I've done my best to adhere to the surrounding style and structure. Any feedback is greatly appreciated!