### PR TITLE
Link with libatomic always

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ YOSYS_SRC := $(dir $(firstword $(MAKEFILE_LIST)))
 VPATH := $(YOSYS_SRC)
 
 CXXFLAGS := $(CXXFLAGS) -Wall -Wextra -ggdb -I. -I"$(YOSYS_SRC)" -MD -D_YOSYS_ -fPIC -I$(PREFIX)/include
-LDLIBS := $(LDLIBS) -lstdc++ -lm
+LDLIBS := $(LDLIBS) -lstdc++ -lm -latomic
 PLUGIN_LDFLAGS :=
 
 PKG_CONFIG ?= pkg-config


### PR DESCRIPTION
libatomic must be linked explicitly under Android. Hence, we always link to it.
This change has been tested with:
 - Ubuntu 18.04 LTS + GCC 8.4.0
 - Android 9.0 + clang 10.0.1

Signed-off-by: Mohamed A. Bamakhrama <mohamed@alumni.tum.de>