### PR TITLE
Rewrite multirange arrays sizes [n] as [n-1:0]

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -210,14 +210,23 @@ static AstNode *checkRange(AstNode *type_node, AstNode *range_node)
 	return range_node;
 }
 
-static void rewriteAsMemoryNode(AstNode *node, AstNode *rangeNode)
+static void rewriteRange(AstNode *rangeNode)
 {
-	node->type = AST_MEMORY;
 	if (rangeNode->type == AST_RANGE && rangeNode->children.size() == 1) {
 		// SV array size [n], rewrite as [n-1:0]
 		rangeNode->children[0] = new AstNode(AST_SUB, rangeNode->children[0], AstNode::mkconst_int(1, true));
 		rangeNode->children.push_back(AstNode::mkconst_int(0, false));
 	}
+}
+
+static void rewriteAsMemoryNode(AstNode *node, AstNode *rangeNode)
+{
+	node->type = AST_MEMORY;
+	if (rangeNode->type == AST_MULTIRANGE) {
+		for (auto *itr : rangeNode->children)
+			rewriteRange(itr);
+	} else
+		rewriteRange(rangeNode);
 	node->children.push_back(rangeNode);
 }
 

--- a/tests/svtypes/multirange_array.sv
+++ b/tests/svtypes/multirange_array.sv
@@ -1,0 +1,16 @@
+// test for multirange arrays
+
+`define STRINGIFY(x) `"x`"
+`define STATIC_ASSERT(x) if(!(x)) $error({"assert failed: ", `STRINGIFY(x)})
+
+module top;
+
+	logic a [3];
+	logic b [3][5];
+	logic c [3][5][7];
+
+	`STATIC_ASSERT($bits(a) == 3);
+	`STATIC_ASSERT($bits(b) == 15);
+	`STATIC_ASSERT($bits(c) == 105);
+
+endmodule


### PR DESCRIPTION
This PR fixes multirange arrays size in cases when dimension is specified as size (not as a range)