### PR TITLE
cxxrtl.h: Fix incorrect CarryOut in alu when Bits % 32 != 0 && Invert == False

### DIFF
--- a/backends/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/cxxrtl.h
@@ -450,18 +450,13 @@ struct value : public expr_base<value<Bits>> {
 	std::pair<value<Bits>, bool /*CarryOut*/> alu(const value<Bits> &other) const {
 		value<Bits> result;
 		bool carry = CarryIn;
-		// Handle full chunks first
-		for (size_t n = 0; n < result.chunks - 1; n++) {
+		for (size_t n = 0; n < result.chunks; n++) {
 			result.data[n] = data[n] + (Invert ? ~other.data[n] : other.data[n]) + carry;
+			if (result.chunks - 1 == n) 
+				result.data[result.chunks - 1] &= result.msb_mask;
 			carry = (result.data[n] <  data[n]) ||
 			        (result.data[n] == data[n] && carry);
 		}
-		// Handle last chunk (mask before updating carry)
-		constexpr size_t last = result.chunks - 1;
-		result.data[last] = data[last] + (Invert ? ~other.data[last] : other.data[last]) + carry;
-		result.data[last] &= result.msb_mask;
-		carry = (result.data[last] <  data[last]) ||
-		        (result.data[last] == data[last] && carry);
 		return {result, carry};
 	}
 


### PR DESCRIPTION
This PR fixes the alu function in cxxrtl.h to return correct CarryOut when Bits % 32 != 0 && Invert == False, by updating carry after the last chunk is masked.
(CarryOut is currently only used by ucmp(), which always sets Invert = True, so this bug has not been triggered)