### PR TITLE
intel_alm: fix typo in MISTRAL_MUL27X27 cell name

### DIFF
--- a/techlibs/intel_alm/common/dsp_sim.v
+++ b/techlibs/intel_alm/common/dsp_sim.v
@@ -1,5 +1,5 @@
 (* abc9_box *)
-module MISTRAL_MUL27x27(input [26:0] A, input [26:0] B, output [53:0] Y);
+module MISTRAL_MUL27X27(input [26:0] A, input [26:0] B, output [53:0] Y);
 
 // TODO: Cyclone 10 GX timings; the below are for Cyclone V
 specify


### PR DESCRIPTION
This escaped code review and broke things unintentionally.