### PR TITLE
Add -nomux switch to proc

### DIFF
--- a/passes/proc/proc.cc
+++ b/passes/proc/proc.cc
@@ -50,6 +50,9 @@ struct ProcPass : public Pass {
 		log("\n");
 		log("The following options are supported:\n");
 		log("\n");
+		log("    -nomux\n");
+		log("        Will omit the proc_mux pass.\n");
+		log("\n");
 		log("    -global_arst [!]<netname>\n");
 		log("        This option is passed through to proc_arst.\n");
 		log("\n");
@@ -62,6 +65,7 @@ struct ProcPass : public Pass {
 	{
 		std::string global_arst;
 		bool ifxmode = false;
+		bool nomux = false;
 
 		log_header(design, "Executing PROC pass (convert processes to netlists).\n");
 		log_push();
@@ -69,6 +73,10 @@ struct ProcPass : public Pass {
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
 		{
+			if (args[argidx] == "-nomux") {
+				nomux = true;
+				continue;
+			}
 			if (args[argidx] == "-global_arst" && argidx+1 < args.size()) {
 				global_arst = args[++argidx];
 				continue;
@@ -90,7 +98,8 @@ struct ProcPass : public Pass {
 			Pass::call(design, "proc_arst");
 		else
 			Pass::call(design, "proc_arst -global_arst " + global_arst);
-		Pass::call(design, ifxmode ? "proc_mux -ifx" : "proc_mux");
+		if (!nomux)
+			Pass::call(design, ifxmode ? "proc_mux -ifx" : "proc_mux");
 		Pass::call(design, "proc_dlatch");
 		Pass::call(design, "proc_dff");
 		Pass::call(design, "proc_clean");


### PR DESCRIPTION
Running `proc -nomux` will with this change omit the `proc_mux` pass.

This PR was prompted by nmigen/nmigen#479
