### PR TITLE
Allow localparams in constant functions

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -4488,6 +4488,18 @@ AstNode *AstNode::eval_const_function(AstNode *fcall)
 
 		log_assert(variables.count(str) != 0);
 
+		if (stmt->type == AST_LOCALPARAM)
+		{
+			while (stmt->simplify(true, false, false, 1, -1, false, true)) { }
+
+			if (!backup_scope.count(stmt->str))
+				backup_scope[stmt->str] = current_scope[stmt->str];
+			current_scope[stmt->str] = stmt;
+
+			block->children.erase(block->children.begin());
+			continue;
+		}
+
 		if (stmt->type == AST_ASSIGN_EQ)
 		{
 			if (stmt->children.at(0)->type == AST_IDENTIFIER && stmt->children.at(0)->children.size() != 0 &&

--- a/tests/various/const_func_block_var.v
+++ b/tests/various/const_func_block_var.v
@@ -1,15 +1,18 @@
 module top(out);
 	function integer operation;
 		input integer num;
+		localparam incr = 1;
+		localparam mult = 1;
 		begin
 			operation = 0;
 			begin : op_i
 				integer i;
-				for (i = 0; i < 2; i = i + 1)
+				for (i = 0; i * mult < 2; i = i + incr)
 				begin : op_j
 					integer j;
-					for (j = i; j < i * 2; j = j + 1)
-						num = num + 1;
+					localparam other_mult = 2;
+					for (j = i; j < i * other_mult; j = j + incr)
+						num = num + incr;
 				end
 				num = num * 2;
 			end


### PR DESCRIPTION
Note that this change and the addition of sub-block declaration support in #2300 do not properly handle shadowing. Rather that complicate this PR, I will introduce some form of stack for `backup_scope` within `eval_const_function` in a later PR.