### PR TITLE
Module name scope support

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1597,6 +1597,13 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 	if (type == AST_IDENTIFIER) {
 		if (current_scope.count(str) == 0) {
 			AstNode *current_scope_ast = (current_ast_mod == nullptr) ? current_ast : current_ast_mod;
+			const std::string& mod_scope = current_scope_ast->str;
+			if (str[0] == '\\' && str.substr(0, mod_scope.size()) == mod_scope) {
+				std::string new_str = "\\" + str.substr(mod_scope.size() + 1);
+				if (current_scope.count(new_str)) {
+					str = new_str;
+				}
+			}
 			for (auto node : current_scope_ast->children) {
 				//log("looking at mod scope child %s\n", type2str(node->type).c_str());
 				switch (node->type) {

--- a/tests/simple/generate.v
+++ b/tests/simple/generate.v
@@ -223,6 +223,10 @@ module gen_test8;
 				`ASSERT(A.x == 2)
 				`ASSERT(A.C.x == 1)
 				`ASSERT(A.B.x == 0)
+				`ASSERT(gen_test8.x == 3)
+				`ASSERT(gen_test8.A.x == 2)
+				`ASSERT(gen_test8.A.C.x == 1)
+				`ASSERT(gen_test8.A.B.x == 0)
 			end
 			begin : C
 				wire [1:0] x = 2'b01;
@@ -230,12 +234,20 @@ module gen_test8;
 				`ASSERT(A.x == 2)
 				`ASSERT(A.C.x == 1)
 				`ASSERT(A.B.x == 0)
+				`ASSERT(gen_test8.x == 3)
+				`ASSERT(gen_test8.A.x == 2)
+				`ASSERT(gen_test8.A.C.x == 1)
+				`ASSERT(gen_test8.A.B.x == 0)
 			end
 			assign x = B.x ^ 2'b11 ^ C.x;
 			`ASSERT(x == 2)
 			`ASSERT(A.x == 2)
 			`ASSERT(A.C.x == 1)
 			`ASSERT(A.B.x == 0)
+			`ASSERT(gen_test8.x == 3)
+			`ASSERT(gen_test8.A.x == 2)
+			`ASSERT(gen_test8.A.C.x == 1)
+			`ASSERT(gen_test8.A.B.x == 0)
 		end
 	endgenerate
 
@@ -243,4 +255,8 @@ module gen_test8;
 	`ASSERT(A.x == 2)
 	`ASSERT(A.C.x == 1)
 	`ASSERT(A.B.x == 0)
+	`ASSERT(gen_test8.x == 3)
+	`ASSERT(gen_test8.A.x == 2)
+	`ASSERT(gen_test8.A.C.x == 1)
+	`ASSERT(gen_test8.A.B.x == 0)
 endmodule


### PR DESCRIPTION
In certain contexts, using the name of the module as a scope prefix is needed to refer to a data declaration which has been shadowed in the local scope. These "name hierarchy" roots are described in Section 12.5 of IEEE 1364-2005.

I'm not sure that this is a great method of getting these wires to properly resolve. I also considered attempting to resolve the autowires as part of `genRTLIL`, but I'm not familiar with that code. Any feedback you may have is greatly appreciated!