### PR TITLE
intel_alm: better map wide but shallow multiplies

### DIFF
--- a/techlibs/intel_alm/synth_intel_alm.cc
+++ b/techlibs/intel_alm/synth_intel_alm.cc
@@ -214,10 +214,14 @@ struct SynthIntelALMPass : public ScriptPass {
 				run("techmap -map +/mul2dsp.v [...]", "(unless -nodsp)");
 			} else if (!nodsp) {
 				// Cyclone V supports 9x9 multiplication, Cyclone 10 GX does not.
-				run("techmap -map +/mul2dsp.v -D DSP_A_MAXWIDTH=27 -D DSP_B_MAXWIDTH=27  -D DSP_A_MINWIDTH=19 -D DSP_B_MINWIDTH=19 -D DSP_NAME=__MUL27X27");
+				run("techmap -map +/mul2dsp.v -D DSP_A_MAXWIDTH=27 -D DSP_B_MAXWIDTH=27  -D DSP_A_MINWIDTH=19 -D DSP_B_MINWIDTH=4 -D DSP_NAME=__MUL27X27");
+				run("chtype -set $mul t:$__soft_mul");
+				run("techmap -map +/mul2dsp.v -D DSP_A_MAXWIDTH=27 -D DSP_B_MAXWIDTH=27  -D DSP_A_MINWIDTH=4 -D DSP_B_MINWIDTH=19 -D DSP_NAME=__MUL27X27");
 				run("chtype -set $mul t:$__soft_mul");
 				if (family_opt == "cyclonev") {
-					run("techmap -map +/mul2dsp.v -D DSP_A_MAXWIDTH=18 -D DSP_B_MAXWIDTH=18  -D DSP_A_MINWIDTH=10 -D DSP_B_MINWIDTH=10 -D DSP_NAME=__MUL18X18");
+					run("techmap -map +/mul2dsp.v -D DSP_A_MAXWIDTH=18 -D DSP_B_MAXWIDTH=18  -D DSP_A_MINWIDTH=10 -D DSP_B_MINWIDTH=4 -D DSP_NAME=__MUL18X18");
+					run("chtype -set $mul t:$__soft_mul");
+					run("techmap -map +/mul2dsp.v -D DSP_A_MAXWIDTH=18 -D DSP_B_MAXWIDTH=18  -D DSP_A_MINWIDTH=4 -D DSP_B_MINWIDTH=10 -D DSP_NAME=__MUL18X18");
 					run("chtype -set $mul t:$__soft_mul");
 					run("techmap -map +/mul2dsp.v -D DSP_A_MAXWIDTH=9 -D DSP_B_MAXWIDTH=9  -D DSP_A_MINWIDTH=4 -D DSP_B_MINWIDTH=4 -D DSP_NAME=__MUL9X9");
 					run("chtype -set $mul t:$__soft_mul");


### PR DESCRIPTION
Before, M-bit x N-bit (with M large and N small) would be built out of MISTRAL_MUL9X9 cells, which obviously gets inefficient for large M. By loosening one of the bounds at a time, synth_intel_alm can better map these kinds of multiplies. (e.g. a 20x4 multiply was mapped out of 4 9x9 multipliers, using 1 1/3rd DSP blocks, and is now mapped out of 2 18x18 multipliers, using only 1 DSP block).