### PR TITLE
dfflegalize: Fix decision tree for adffe.

### DIFF
--- a/passes/techmap/dfflegalize.cc
+++ b/passes/techmap/dfflegalize.cc
@@ -418,7 +418,8 @@ unmap_enable:
 					ff_type = has_set ? FF_ADFFE1 : FF_ADFFE0;
 					break;
 				}
-				if (supported_dffsr & initmask) {
+				if (supported_cells[has_en ? FF_DFFSRE : FF_DFFSR] & initmask) {
+adff_to_dffsr:
 					// Throw in a set/reset, retry in DFFSR/DFFSRE branch.
 					if (has_set) {
 						sig_s = sig_r;
@@ -440,6 +441,9 @@ unmap_enable:
 					// Unmap enable.
 					ff_type = has_set ? FF_ADFF1 : FF_ADFF0;
 					goto unmap_enable;
+				}
+				if (supported_dffsr & initmask) {
+					goto adff_to_dffsr;
 				}
 				log_assert(!((has_set ? supported_adff1 : supported_adff0) & initmask));
 				// Alright, so this particular combination of initval and


### PR DESCRIPTION
When an adffe is being legalized, and is not natively supported,
prioritize unmapping to adff over converting to dffsre if dffsre is not
natively supported itself.

Fixes #2361.