### PR TITLE
Fix constant args used with function ports split across declarations

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -3211,14 +3211,15 @@ skip_dynamic_range_lvalue_expansion:;
 				if (wire_cache.count(child->str))
 				{
 					wire = wire_cache.at(child->str);
-					if (wire->children.empty()) {
+					bool contains_value = wire->type == AST_LOCALPARAM;
+					if (wire->children.size() == contains_value) {
 						for (auto c : child->children)
 							wire->children.push_back(c->clone());
 					} else if (!child->children.empty()) {
 						while (child->simplify(true, false, false, stage, -1, false, false)) { }
-						if (GetSize(child->children) == GetSize(wire->children)) {
+						if (GetSize(child->children) == GetSize(wire->children) - contains_value) {
 							for (int i = 0; i < GetSize(child->children); i++)
-								if (*child->children.at(i) != *wire->children.at(i))
+								if (*child->children.at(i) != *wire->children.at(i + contains_value))
 									goto tcall_incompatible_wires;
 						} else {
 					tcall_incompatible_wires:

--- a/tests/various/const_arg_loop.v
+++ b/tests/various/const_arg_loop.v
@@ -23,6 +23,22 @@ module top;
 		end
 	endfunction
 
+	function automatic [31:0] operation3;
+		input [4:0] rounds;
+		input integer num;
+		reg [4:0] rounds;
+		integer i;
+		begin
+			begin : shadow
+				integer rounds;
+				rounds = 0;
+			end
+			for (i = 0; i < rounds; i = i + 1)
+				num = num * 2;
+			operation3 = num;
+		end
+	endfunction
+
 	wire [31:0] a;
 	assign a = 2;
 
@@ -34,11 +50,15 @@ module top;
 	wire [31:0] x2;
 	assign x2 = operation2(A, a);
 
+	wire [31:0] x3;
+	assign x3 = operation3(A, a);
+
 // `define VERIFY
 `ifdef VERIFY
     assert property (a == 2);
     assert property (A == 3);
     assert property (x1 == 16);
     assert property (x2 == 4);
+    assert property (x3 == 16);
 `endif
 endmodule


### PR DESCRIPTION
This fixes the issue I inadvertently introduced in #2299. Thanks to @mmicko for spotting and reporting this!