### PR TITLE
Clean up and parallelize testsuite

### DIFF
--- a/tests/arch/anlogic/run-test.sh
+++ b/tests/arch/anlogic/run-test.sh
@@ -1,20 +1,4 @@
 #!/usr/bin/env bash
-set -e
-{
-echo "all::"
-for x in *.ys; do
-	echo "all:: run-$x"
-	echo "run-$x:"
-	echo "	@echo 'Running $x..'"
-	echo "	@../../../yosys -ql ${x%.ys}.log -w 'Yosys has only limited support for tri-state logic at the moment.' $x"
-done
-for s in *.sh; do
-	if [ "$s" != "run-test.sh" ]; then
-		echo "all:: run-$s"
-		echo "run-$s:"
-		echo "	@echo 'Running $s..'"
-		echo "	@bash $s"
-	fi
-done
-} > run-test.mk
-exec ${MAKE:-make} -f run-test.mk
+set -eu
+source ../../gen-tests-makefile.sh
+run_tests --yosys-scripts --bash --yosys-args "-w 'Yosys has only limited support for tri-state logic at the moment.'"

--- a/tests/arch/ecp5/run-test.sh
+++ b/tests/arch/ecp5/run-test.sh
@@ -1,20 +1,4 @@
 #!/usr/bin/env bash
-set -e
-{
-echo "all::"
-for x in *.ys; do
-	echo "all:: run-$x"
-	echo "run-$x:"
-	echo "	@echo 'Running $x..'"
-	echo "	@../../../yosys -ql ${x%.ys}.log -w 'Yosys has only limited support for tri-state logic at the moment.' $x"
-done
-for s in *.sh; do
-	if [ "$s" != "run-test.sh" ]; then
-		echo "all:: run-$s"
-		echo "run-$s:"
-		echo "	@echo 'Running $s..'"
-		echo "	@bash $s"
-	fi
-done
-} > run-test.mk
-exec ${MAKE:-make} -f run-test.mk
+set -eu
+source ../../gen-tests-makefile.sh
+run_tests --yosys-scripts --bash --yosys-args "-w 'Yosys has only limited support for tri-state logic at the moment.'"

--- a/tests/arch/efinix/run-test.sh
+++ b/tests/arch/efinix/run-test.sh
@@ -1,20 +1,4 @@
 #!/usr/bin/env bash
-set -e
-{
-echo "all::"
-for x in *.ys; do
-	echo "all:: run-$x"
-	echo "run-$x:"
-	echo "	@echo 'Running $x..'"
-	echo "	@../../../yosys -ql ${x%.ys}.log -w 'Yosys has only limited support for tri-state logic at the moment.' $x"
-done
-for s in *.sh; do
-	if [ "$s" != "run-test.sh" ]; then
-		echo "all:: run-$s"
-		echo "run-$s:"
-		echo "	@echo 'Running $s..'"
-		echo "	@bash $s"
-	fi
-done
-} > run-test.mk
-exec ${MAKE:-make} -f run-test.mk
+set -eu
+source ../../gen-tests-makefile.sh
+run_tests --yosys-scripts --bash --yosys-args "-w 'Yosys has only limited support for tri-state logic at the moment.'"

--- a/tests/arch/gowin/run-test.sh
+++ b/tests/arch/gowin/run-test.sh
@@ -1,20 +1,4 @@
 #!/usr/bin/env bash
-set -e
-{
-echo "all::"
-for x in *.ys; do
-	echo "all:: run-$x"
-	echo "run-$x:"
-	echo "	@echo 'Running $x..'"
-	echo "	@../../../yosys -ql ${x%.ys}.log -w 'Yosys has only limited support for tri-state logic at the moment.' $x"
-done
-for s in *.sh; do
-	if [ "$s" != "run-test.sh" ]; then
-		echo "all:: run-$s"
-		echo "run-$s:"
-		echo "	@echo 'Running $s..'"
-		echo "	@bash $s"
-	fi
-done
-} > run-test.mk
-exec ${MAKE:-make} -f run-test.mk
+set -eu
+source ../../gen-tests-makefile.sh
+run_tests --yosys-scripts --bash --yosys-args "-w 'Yosys has only limited support for tri-state logic at the moment.'"

--- a/tests/arch/ice40/run-test.sh
+++ b/tests/arch/ice40/run-test.sh
@@ -1,20 +1,4 @@
 #!/usr/bin/env bash
-set -e
-{
-echo "all::"
-for x in *.ys; do
-	echo "all:: run-$x"
-	echo "run-$x:"
-	echo "	@echo 'Running $x..'"
-	echo "	@../../../yosys -ql ${x%.ys}.log -w 'Yosys has only limited support for tri-state logic at the moment.' $x"
-done
-for s in *.sh; do
-	if [ "$s" != "run-test.sh" ]; then
-		echo "all:: run-$s"
-		echo "run-$s:"
-		echo "	@echo 'Running $s..'"
-		echo "	@bash $s"
-	fi
-done
-} > run-test.mk
-exec ${MAKE:-make} -f run-test.mk
+set -eu
+source ../../gen-tests-makefile.sh
+run_tests --yosys-scripts --bash --yosys-args "-w 'Yosys has only limited support for tri-state logic at the moment.'"

--- a/tests/arch/intel_alm/run-test.sh
+++ b/tests/arch/intel_alm/run-test.sh
@@ -1,20 +1,4 @@
 #!/usr/bin/env bash
-set -e
-{
-echo "all::"
-for x in *.ys; do
-	echo "all:: run-$x"
-	echo "run-$x:"
-	echo "	@echo 'Running $x..'"
-	echo "	@../../../yosys -ql ${x%.ys}.log -w 'Yosys has only limited support for tri-state logic at the moment.' $x"
-done
-for s in *.sh; do
-	if [ "$s" != "run-test.sh" ]; then
-		echo "all:: run-$s"
-		echo "run-$s:"
-		echo "	@echo 'Running $s..'"
-		echo "	@bash $s"
-	fi
-done
-} > run-test.mk
-exec ${MAKE:-make} -f run-test.mk
+set -eu
+source ../../gen-tests-makefile.sh
+run_tests --yosys-scripts --bash --yosys-args "-w 'Yosys has only limited support for tri-state logic at the moment.'"

--- a/tests/arch/xilinx/run-test.sh
+++ b/tests/arch/xilinx/run-test.sh
@@ -1,20 +1,4 @@
 #!/usr/bin/env bash
-set -e
-{
-echo "all::"
-for x in *.ys; do
-	echo "all:: run-$x"
-	echo "run-$x:"
-	echo "	@echo 'Running $x..'"
-	echo "	@../../../yosys -ql ${x%.ys}.log -w 'Yosys has only limited support for tri-state logic at the moment.' $x"
-done
-for s in *.sh; do
-	if [ "$s" != "run-test.sh" ]; then
-		echo "all:: run-$s"
-		echo "run-$s:"
-		echo "	@echo 'Running $s..'"
-		echo "	@bash $s"
-	fi
-done
-} > run-test.mk
-exec ${MAKE:-make} -f run-test.mk
+set -eu
+source ../../gen-tests-makefile.sh
+run_tests --yosys-scripts --bash --yosys-args "-w 'Yosys has only limited support for tri-state logic at the moment.'"

--- a/tests/gen-tests-makefile.sh
+++ b/tests/gen-tests-makefile.sh
@@ -6,7 +6,7 @@ YOSYS_BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../ >/dev/null 2>&1 && pwd)
 generate_target() {
 	target_name=$1
 	test_command=$2
-	echo "all:: $target_name"
+	echo "all: $target_name"
 	echo ".PHONY: $target_name"
 	echo "$target_name:"
 	printf "\t@%s\n" "$test_command"
@@ -65,7 +65,7 @@ generate_tests() {
 	fi
 
 	echo ".PHONY: all"
-	echo "all::"
+	echo "all:"
 
 	if [[ $do_ys = true ]]; then
 		for x in *.ys; do

--- a/tests/gen-tests-makefile.sh
+++ b/tests/gen-tests-makefile.sh
@@ -1,0 +1,94 @@
+set -eu
+
+YOSYS_BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../ >/dev/null 2>&1 && pwd)"
+
+# $ generate_target target_name test_command
+generate_target() {
+	target_name=$1
+	test_command=$2
+	echo "all:: $target_name"
+	echo ".PHONY: $target_name"
+	echo "$target_name:"
+	printf "\t@%s\n" "$test_command"
+	printf "\t@echo 'Passed %s'\n" "$target_name"
+}
+
+# $ generate_ys_test ys_file [yosys_args]
+generate_ys_test() {
+	ys_file=$1
+	yosys_args=${2:-}
+	generate_target "$ys_file" "$YOSYS_BASEDIR/yosys -ql ${ys_file%.*}.log $yosys_args $ys_file"
+}
+
+# $ generate_bash_test bash_file
+generate_bash_test() {
+	bash_file=$1
+	generate_target "$bash_file" "bash -v $bash_file >${bash_file%.*}.log 2>&1"
+}
+
+# $ generate_tests [-y|--yosys-scripts] [-s|--prove-sv] [-b|--bash] [-a|--yosys-args yosys_args]
+generate_tests() {
+	do_ys=false
+	do_sv=false
+	do_sh=false
+	yosys_args=""
+
+	while [[ $# -gt 0 ]]; do
+		arg="$1"
+		case "$arg" in
+			-y|--yosys-scripts)
+				do_ys=true
+				shift
+				;;
+			-s|--prove-sv)
+				do_sv=true
+				shift
+				;;
+			-b|--bash)
+				do_sh=true
+				shift
+				;;
+			-a|--yosys-args)
+				yosys_args+="$2"
+				shift
+				shift
+				;;
+			*)
+				echo >&2 "Unknown argument: $1"
+				exit 1
+		esac
+	done
+
+	if [[ ! ( $do_ys = true || $do_sv = true || $do_sh = true ) ]]; then
+		echo >&2 "Error: No file types selected"
+		exit 1
+	fi
+
+	echo ".PHONY: all"
+	echo "all::"
+
+	if [[ $do_ys = true ]]; then
+		for x in *.ys; do
+			generate_ys_test "$x" "$yosys_args"
+		done
+	fi;
+	if [[ $do_sv = true ]]; then
+		for x in *.sv; do
+			if [ ! -f "${x%.sv}.ys"  ]; then
+				generate_ys_test "$x" "-p \"prep -top top; sat -verify -prove-asserts\" $yosys_args"
+			fi;
+		done
+	fi;
+	if [[ $do_sh == true ]]; then
+		for s in *.sh; do
+			if [ "$s" != "run-test.sh" ]; then
+				generate_bash_test "$s"
+			fi
+		done
+	fi
+}
+
+run_tests() {
+	generate_tests "$@" > run-test.mk
+	exec ${MAKE:-make} -f run-test.mk
+}

--- a/tests/memories/run-test.sh
+++ b/tests/memories/run-test.sh
@@ -9,12 +9,12 @@ while getopts "A:S:" opt
 do
     case "$opt" in
 	A) abcopt="-A $OPTARG" ;;
-	S) seed="-S $OPTARG" ;;
+	S) seed="$OPTARG" ;;
     esac
 done
 shift "$((OPTIND-1))"
 
-bash ../tools/autotest.sh $abcopt $seed -G *.v
+${MAKE:-make} -f ../tools/autotest.mk SEED="$seed" EXTRA_FLAGS="$abcopt" *.v
 
 for f in `egrep -l 'expect-(wr-ports|rd-ports|rd-clk)' *.v`; do
 	echo -n "Testing expectations for $f .."

--- a/tests/opt/.gitignore
+++ b/tests/opt/.gitignore
@@ -1,1 +1,2 @@
 *.log
+run-test.mk

--- a/tests/opt/run-test.sh
+++ b/tests/opt/run-test.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-set -e
-for x in *.ys; do
-  echo "Running $x.."
-  ../../yosys -ql ${x%.ys}.log $x
-done
+set -eu
+source ../gen-tests-makefile.sh
+run_tests --yosys-scripts

--- a/tests/sat/.gitignore
+++ b/tests/sat/.gitignore
@@ -1,1 +1,2 @@
 *.log
+run-test.mk

--- a/tests/sat/run-test.sh
+++ b/tests/sat/run-test.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-set -e
-for x in *.ys; do
-	echo "Running $x.."
-	../../yosys -ql ${x%.ys}.log $x
-done
+#!/usr/bin/env bash
+set -eu
+source ../gen-tests-makefile.sh
+run_tests --yosys-scripts

--- a/tests/simple/run-test.sh
+++ b/tests/simple/run-test.sh
@@ -17,5 +17,4 @@ if ! command -v iverilog > /dev/null ; then
   exit 1
 fi
 
-shopt -s nullglob
 exec ${MAKE:-make} -f ../tools/autotest.mk $seed *.{sv,v}

--- a/tests/svtypes/run-test.sh
+++ b/tests/svtypes/run-test.sh
@@ -1,20 +1,4 @@
 #!/usr/bin/env bash
-set -e
-{
-echo "all::"
-for x in *.ys; do
-	echo "all:: run-$x"
-	echo "run-$x:"
-	echo "	@echo 'Running $x..'"
-	echo "	@../../yosys -ql ${x%.ys}.log $x"
-done
-for x in *.sv; do
-	if [ ! -f "${x%.sv}.ys"  ]; then
-		echo "all:: check-$x"
-		echo "check-$x:"
-		echo "	@echo 'Checking $x..'"
-		echo "	@../../yosys -ql ${x%.sv}.log -p \"prep -top top; sat -verify -prove-asserts\" $x"
-	fi
-done
-} > run-test.mk
-exec ${MAKE:-make} -f run-test.mk
+set -eu
+source ../gen-tests-makefile.sh
+run_tests --yosys-scripts --prove-sv

--- a/tests/techmap/mem_simple_4x1_runtest.sh
+++ b/tests/techmap/mem_simple_4x1_runtest.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ev
+set -e
 
 ../../yosys -b 'verilog -noattr' -o mem_simple_4x1_synth.v -p 'proc; opt; memory -nomap; techmap -map mem_simple_4x1_map.v;; techmap; opt; abc;; stat' mem_simple_4x1_uut.v
 

--- a/tests/techmap/recursive_runtest.sh
+++ b/tests/techmap/recursive_runtest.sh
@@ -1,3 +1,3 @@
-set -ev
+set -e
 
 ../../yosys -p 'hierarchy -top top; techmap -map recursive_map.v -max_iter 1; select -assert-count 2 t:sub; select -assert-count 2 t:bar' recursive.v

--- a/tests/techmap/run-test.sh
+++ b/tests/techmap/run-test.sh
@@ -1,20 +1,4 @@
 #!/usr/bin/env bash
-set -e
-{
-echo "all::"
-for x in *.ys; do
-	echo "all:: run-$x"
-	echo "run-$x:"
-	echo "	@echo 'Running $x..'"
-	echo "	@../../yosys -ql ${x%.ys}.log -e 'select out of bounds' $x"
-done
-for s in *.sh; do
-	if [ "$s" != "run-test.sh" ]; then
-		echo "all:: run-$s"
-		echo "run-$s:"
-		echo "	@echo 'Running $s..'"
-		echo "	@bash $s > ${s%.sh}.log 2>&1"
-	fi
-done
-} > run-test.mk
-exec ${MAKE:-make} -f run-test.mk
+set -eu
+source ../gen-tests-makefile.sh
+run_tests --yosys-scripts --bash --yosys-args "-e 'select out of bounds'"

--- a/tests/various/run-test.sh
+++ b/tests/various/run-test.sh
@@ -1,20 +1,4 @@
 #!/usr/bin/env bash
-set -e
-{
-echo "all::"
-for x in *.ys; do
-	echo "all:: run-$x"
-	echo "run-$x:"
-	echo "	@echo 'Running $x..'"
-	echo "	@../../yosys -ql ${x%.ys}.log $x"
-done
-for s in *.sh; do
-	if [ "$s" != "run-test.sh" ]; then
-		echo "all:: run-$s"
-		echo "run-$s:"
-		echo "	@echo 'Running $s..'"
-		echo "	@bash $s"
-	fi
-done
-} > run-test.mk
-exec ${MAKE:-make} -f run-test.mk
+set -eu
+source ../gen-tests-makefile.sh
+run_tests --yosys-scripts --bash

--- a/tests/verilog/run-test.sh
+++ b/tests/verilog/run-test.sh
@@ -1,20 +1,4 @@
 #!/usr/bin/env bash
-set -e
-{
-echo "all::"
-for x in *.ys; do
-	echo "all:: run-$x"
-	echo "run-$x:"
-	echo "	@echo 'Running $x..'"
-	echo "	@../../yosys -ql ${x%.ys}.log $x"
-done
-for s in *.sh; do
-	if [ "$s" != "run-test.sh" ]; then
-		echo "all:: run-$s"
-		echo "run-$s:"
-		echo "	@echo 'Running $s..'"
-		echo "	@bash $s"
-	fi
-done
-} > run-test.mk
-exec ${MAKE:-make} -f run-test.mk
+set -eu
+source ../gen-tests-makefile.sh
+run_tests --yosys-scripts --bash


### PR DESCRIPTION
- Factor out creating a Makefile from the `*.ys`/`*.v`/`*.sh` in the working directory to reduce redundancy in `run-test.sh` files
- Convert several tests to use Makefiles supporting `-j` for concurrency

Here are some crude timing benchmarks. First, on my i7-3520M (quad core) laptop:

.               | `make -j4 test` (before) | `make -j4 test` (after) | `make -j1`
--------------- | ------------------------ | ----------------------- | ----------
Wall time       | 899 s                    | 544 s                   | 1070 s
usr+sys time    | 1253 s                   | 1515 s                  | 1069 s
= concurrency   | 1.39                     | 2.78                    | 1.00

Resulting in a concurrency boost of **+100%** and a runtime change of **-39%**. I'm pretty sure the increase in total processor time is due to (increased) thermal throttling, so the measured effect on runtime is probably lower than it could be.

On my i7-4790 (8-core) desktop:

.               | `make -j8 test` (before) | `make -j8 test` (after) | `make -j1`
--------------- | ------------------------ | ----------------------- | ----------
Wall time       | 648 s                    | 328 s                   | 796 s
usr+sys time    | 975 s                    | 1282 s                  | 797 s
= concurrency   | 1.50                     | 3.91                    | 1.00

Which is a concurrency boost of **+161%** and a runtime change of **-49%**.
 