### PR TITLE
Use CXXFLAGS to enable pyosys specific code before generating wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -686,7 +686,7 @@ endif
 
 %.pyh: %.h
 	$(Q) mkdir -p $(dir $@)
-	$(P) cat $< | grep -E -v "#[ ]*(include|error)" | $(LD) -x c++ -o $@ -E -P -
+	$(P) cat $< | grep -E -v "#[ ]*(include|error)" | $(LD) $(CXXFLAGS) -x c++ -o $@ -E -P -
 
 ifeq ($(ENABLE_PYOSYS),1)
 $(PY_WRAPPER_FILE).cc: misc/$(PY_GEN_SCRIPT).py $(PY_WRAP_INCLUDES)


### PR DESCRIPTION
The .pyh files were generated without the CXXFLAGS. This meant that code
marked by the WITH_PYTHON flag was excluded. This is fixed by adding the
flag in the rule for .pyh files.