### PR TITLE
Validate parameters only when they are used

### DIFF
--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -765,11 +765,13 @@ struct HierarchyPass : public Pass {
 			top_mod = design->module(top_name);
 
 			dict<RTLIL::IdString, RTLIL::Const> top_parameters;
-			for (auto &para : parameters) {
-				SigSpec sig_value;
-				if (!RTLIL::SigSpec::parse(sig_value, NULL, para.second))
-					log_cmd_error("Can't decode value '%s'!\n", para.second.c_str());
-				top_parameters[RTLIL::escape_id(para.first)] = sig_value.as_const();
+			if ((top_mod == nullptr && design->module(abstract_id)) || top_mod != nullptr) {
+				for (auto &para : parameters) {
+					SigSpec sig_value;
+					if (!RTLIL::SigSpec::parse(sig_value, NULL, para.second))
+						log_cmd_error("Can't decode value '%s'!\n", para.second.c_str());
+					top_parameters[RTLIL::escape_id(para.first)] = sig_value.as_const();
+				}
 			}
 
 			if (top_mod == nullptr && design->module(abstract_id))


### PR DESCRIPTION
This solves problem on hierarchy pass where string parameters are properly handled by Verific but validation for "our" parameters does not support strings and fails here. In Verific case this dict (top_parameters) is not used anyway, so with this additional if statement we are just doing conversion if this is going to be used at all.