### PR TITLE
write_verilog: emit intermediate wire for constant values in sensitivity list

### DIFF
--- a/tests/verilog/const_arst.ys
+++ b/tests/verilog/const_arst.ys
@@ -1,0 +1,24 @@
+read_verilog <<EOT
+module test (
+	input clk, d,
+	output reg q
+);
+wire nop = 1'h0;
+always @(posedge clk, posedge nop) begin
+	if (nop) q <= 1'b0;
+	else q <= d;
+end
+endmodule
+EOT
+prep -top test
+write_verilog const_arst.v
+design -stash gold
+read_verilog const_arst.v
+prep -top test
+design -stash gate
+design -copy-from gold -as gold A:top
+design -copy-from gate -as gate A:top
+miter -equiv -flatten -make_assert gold gate miter
+prep -top miter
+clk2fflogic
+sat -set-init-zero -tempinduct -prove-asserts -verify

--- a/tests/verilog/const_sr.ys
+++ b/tests/verilog/const_sr.ys
@@ -1,0 +1,25 @@
+read_verilog <<EOT
+module test (
+	input clk, rst, d,
+	output reg q
+);
+wire nop = 1'h0;
+always @(posedge clk, posedge nop, posedge rst) begin
+	if (rst) q <= 1'b0;
+	else if (nop) q <= 1'b1;
+	else q <= d;
+end
+endmodule
+EOT
+prep -top test
+write_verilog const_sr.v
+design -stash gold
+read_verilog const_sr.v
+prep -top test
+design -stash gate
+design -copy-from gold -as gold A:top
+design -copy-from gate -as gate A:top
+miter -equiv -flatten -make_assert gold gate miter
+prep -top miter
+clk2fflogic
+sat -set-init-zero -tempinduct -prove-asserts -verify


### PR DESCRIPTION
While `posedge 1'b0` in a sensitivity list is technically standard-compliant verilog, it is not supported by many verilog frontends (including our own: `read_verilog` errors and `verific -sv` delivers wrong results...) To avoid these issues,  this makes `write_verilog` assign the constant value to a wire and use the wire in the sensitivity list.