### PR TITLE
sim -vcd: add date, version, and option for timescale

### DIFF
--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -22,7 +22,6 @@
 #include "kernel/celltypes.h"
 
 #include <ctime>
-#include <iomanip>
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
@@ -649,10 +648,12 @@ struct SimWorker : SimShared
 			return;
 
 		vcdfile << stringf("$version %s $end\n", yosys_version_str);
-		vcdfile << stringf("$date ");
+
 		std::time_t t = std::time(nullptr);
-		vcdfile << std::put_time(std::localtime(&t), "%c %Z");
-		vcdfile << stringf(" $end\n");
+		char mbstr[255];
+		if (std::strftime(mbstr, sizeof(mbstr), "%c", std::localtime(&t))) {
+			vcdfile << stringf("$date ") << mbstr << stringf(" $end\n");
+		}
 
 		if (!timescale.empty())
 			vcdfile << stringf("$timescale %s $end\n", timescale.c_str());

--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -21,6 +21,9 @@
 #include "kernel/sigtools.h"
 #include "kernel/celltypes.h"
 
+#include <ctime>
+#include <iomanip>
+
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 


### PR DESCRIPTION
Fixes #2401.

The Verilog standard is very vague on which parts of the header are mandatory in a VCD file:

> The VCD file starts with header information giving the date, the version number of the simulator used for the simulation, and the timescale used. Next, the file contains definitions of the scope and type of variables being dumped, followed by the actual value changes at each simulation time increment. Only the variables that change value during a time increment are listed.

Similar present tense statements are used to describe mandatory as well as clearly optional elements. Either way, some VCD viewers require a timescale to be present to function correctly.

This adds an option to the `sim` pass to insert a timescale. It also always inserts yosys version and current local date and time, just in case, although I am not aware of any viewer that does anything with these fields.