### PR TITLE
memory_dff: Fix needlessly duplicating enable bits.

### DIFF
--- a/passes/memory/memory_dff.cc
+++ b/passes/memory/memory_dff.cc
@@ -46,8 +46,15 @@ struct MemoryDffWorker
 	{
 		sigmap.apply(sig);
 
+		dict<SigBit, SigBit> cache;
+
 		for (auto &bit : sig)
 		{
+			if (cache.count(bit)) {
+				bit = cache[bit];
+				continue;
+			}
+
 			if (bit.wire == NULL)
 				continue;
 
@@ -103,6 +110,7 @@ struct MemoryDffWorker
 						d = module->Mux(NEW_ID, rbit, d, cell->getPort(ID::SRST));
 				}
 
+				cache[bit] = d;
 				bit = d;
 				clk = this_clk;
 				clk_polarity = this_clk_polarity;

--- a/tests/arch/ecp5/bug2409.ys
+++ b/tests/arch/ecp5/bug2409.ys
@@ -1,0 +1,24 @@
+read_verilog <<EOT
+module t (...);
+
+input CLK;
+input [10:0] A;
+input WE;
+input C;
+input [7:0] DI;
+output reg [7:0] DO;
+
+reg [7:0] mem[2047:0];
+
+always @(posedge CLK) begin
+	if (C)
+		if (WE)
+			mem[A] <= DI;
+	DO <= mem[A];
+end
+
+endmodule
+EOT
+
+synth_ecp5
+select -assert-count 1 t:DP16KD


### PR DESCRIPTION
When the register being merged into the EN signal happens to be a $sdff,
the current code creates a new $mux for every bit, even if they happen
to be identical (as is usually the case), preventing proper grouping
further down the flow.  Fix this by adding a simple cache.

Fixes #2409.