### PR TITLE
xilinx: Fix attributes_test.ys

### DIFF
--- a/tests/arch/xilinx/attributes_test.ys
+++ b/tests/arch/xilinx/attributes_test.ys
@@ -16,8 +16,7 @@ select -assert-count 8 t:RAM32X1D
 # Set ram_style distributed to blockram memory; will be implemented as distributed
 design -reset
 read_verilog ../common/memory_attributes/attributes_test.v
-prep
-setattr -mod -set ram_style "distributed" block_ram
+setattr -set ram_style "distributed" block_ram/m:*
 synth_xilinx -top block_ram -noiopad
 cd block_ram # Constrain all select calls below inside the top module
 select -assert-count 32 t:RAM128X1D
@@ -25,8 +24,7 @@ select -assert-count 32 t:RAM128X1D
 # Set synthesis, logic_block to blockram memory; will be implemented as distributed
 design -reset
 read_verilog ../common/memory_attributes/attributes_test.v
-prep
-setattr -mod -set logic_block 1 block_ram
+setattr -set logic_block 1 block_ram/m:*
 synth_xilinx -top block_ram -noiopad
 cd block_ram # Constrain all select calls below inside the top module
 select -assert-count 0 t:RAMB18E1


### PR DESCRIPTION
This test pretty much passes by accident — the `prep` command runs
memory_collect without memory_dff first, which prevents merging read
register into the memory, and thus blocks block RAM inference for a
reason completely unrelated to the attribute.

The attribute setting didn't actually work because it was set on the
containing module instead of the actual memory.