### PR TITLE
Prevent CXXFLAGS from leaking to abc Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -661,6 +661,10 @@ ifeq ($(LINK_ABC),1)
 OBJS += $(PROGRAM_PREFIX)yosys-libabc.a
 endif
 
+# prevent the CXXFLAGS set by this Makefile from reaching abc/Makefile,
+# especially the -MD flag which will break the build when CXX is clang
+unexport CXXFLAGS
+
 top-all: $(TARGETS) $(EXTRA_TARGETS)
 	@echo ""
 	@echo "  Build successful."


### PR DESCRIPTION
Under certain circumstances¹, the CXXFLAGS assigned by the main `Makefile` can leak down to `abc/Makefile`.  This causes them to be passed along to `abc/depends.sh` when depending C++ code (such as `abc/src/sat/glucose/AbcGlucose.cpp`).  With `gcc` this seems work cause no problems, but when the compiler is `clang` this causes an issue because `clang` is unhappy with getting both `-MM` (which is from `abc/depends.sh`) and `-MD` (which is from `Makefile`) at the same time, and outputs preprocessed C code instead of dependency rules.

By unexporting CXXFLAGS, the leak is plugged and the build completes normally with `clang`.

¹ This happens when the environment variable CXXFLAGS is set to something in the environment where the top level `make` command is run.  The fact that CXXFLAGS was set in the environment causes `make` to re-export the value of `$(CXXFLAGS)` that it sets to the environment where it can be picked up by the sub make process.  Note that the flags which break the build do not come from the environment variable, but the environment variable must be set for them to be exported.  This is a quirk of how variable export works in `make`.