### PR TITLE
Adds support for defining abc location at runtime

### DIFF
--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1471,7 +1471,12 @@ struct AbcPass : public Pass {
 		po_map.clear();
 
 #ifdef ABCEXTERNAL
-		std::string exe_file = ABCEXTERNAL;
+		std::string exe_file;
+		if (std::getenv("ABC")) {
+			exe_file = std::getenv("ABC");
+		} else {
+			exe_file = ABCEXTERNAL;
+		}
 #else
 		std::string exe_file = proc_self_dirname() + proc_program_prefix() + "yosys-abc";
 #endif


### PR DESCRIPTION
This patch adds support for defining the ABC location at runtime instead of at compile time. This is helpful in build systems like bazel which do not have stable locations for binaries or directories during the compilation phase.

This change should be backwards compatible with the existing behavior.