### PR TITLE
Adds support for defining the YOSYS_DATDIR location at runtime

### DIFF
--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -848,6 +848,8 @@ std::string proc_share_dirname()
 	if (check_file_exists(proc_share_path, true))
 		return proc_share_path;
 #    ifdef YOSYS_DATDIR
+	if (std::getenv("YOSYS_DATDIR"))
+		return std::getenv("YOSYS_DATDIR");
 	proc_share_path = YOSYS_DATDIR "/";
 	if (check_file_exists(proc_share_path, true))
 		return proc_share_path;


### PR DESCRIPTION
This is helpful in build systems like Bazel which do not have stable locations for binaries or directories during the compilation phase.

This change should be backwards compatible with the existing behavior.

This change was split from https://github.com/YosysHQ/yosys/pull/2416 where @whitequark was concerned about the dynamic toolchain location YOSYS_DATDIR, and wanted to leave it to a maintainer to decide whether or not to merge. 

Currently this change sets the value via an env variable, but it could also be set as a command line flag if the maintainers view that as better functionality for the codebase.

### Previous Conversation 

https://github.com/YosysHQ/yosys/pull/2416#discussion_r513857756
