### PR TITLE
backends/blif: Remove unused vector of strings

### DIFF
--- a/backends/blif/blif.cc
+++ b/backends/blif/blif.cc
@@ -118,8 +118,6 @@ struct BlifDumper
 		return str;
 	}
 
-	#define CSTR(x) (str(x).c_str())
-
 	const std::string str_init(RTLIL::SigBit sig)
 	{
 		sigmap.apply(sig);
@@ -166,7 +164,7 @@ struct BlifDumper
 	void dump()
 	{
 		f << stringf("\n");
-		f << stringf(".model %s\n", CSTR(module->name));
+		f << stringf(".model %s\n", module->name.c_str());
 
 		std::map<int, RTLIL::Wire*> inputs, outputs;
 
@@ -181,7 +179,7 @@ struct BlifDumper
 		for (auto &it : inputs) {
 			RTLIL::Wire *wire = it.second;
 			for (int i = 0; i < wire->width; i++)
-				f << stringf(" %s", CSTR(RTLIL::SigSpec(wire, i)));
+				f << stringf(" %s", RTLIL::SigSpec(wire, i).c_str());
 		}
 		f << stringf("\n");
 
@@ -189,7 +187,7 @@ struct BlifDumper
 		for (auto &it : outputs) {
 			RTLIL::Wire *wire = it.second;
 			for (int i = 0; i < wire->width; i++)
-				f << stringf(" %s", CSTR(RTLIL::SigSpec(wire, i)));
+				f << stringf(" %s", RTLIL::SigSpec(wire, i).c_str());
 		}
 		f << stringf("\n");
 
@@ -231,131 +229,131 @@ struct BlifDumper
 			if (config->unbuf_types.count(cell->type)) {
 				auto portnames = config->unbuf_types.at(cell->type);
 				f << stringf(".names %s %s\n1 1\n",
-						CSTR(cell->getPort(portnames.first)), CSTR(cell->getPort(portnames.second)));
+						cell->getPort(portnames.first).c_str(), cell->getPort(portnames.second).c_str());
 				continue;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_NOT_)) {
 				f << stringf(".names %s %s\n0 1\n",
-						CSTR(cell->getPort(ID::A)), CSTR(cell->getPort(ID::Y)));
+						cell->getPort(ID::A).c_str(), cell->getPort(ID::Y).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_AND_)) {
 				f << stringf(".names %s %s %s\n11 1\n",
-						CSTR(cell->getPort(ID::A)), CSTR(cell->getPort(ID::B)), CSTR(cell->getPort(ID::Y)));
+						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::Y).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_OR_)) {
 				f << stringf(".names %s %s %s\n1- 1\n-1 1\n",
-						CSTR(cell->getPort(ID::A)), CSTR(cell->getPort(ID::B)), CSTR(cell->getPort(ID::Y)));
+						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::Y).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_XOR_)) {
 				f << stringf(".names %s %s %s\n10 1\n01 1\n",
-						CSTR(cell->getPort(ID::A)), CSTR(cell->getPort(ID::B)), CSTR(cell->getPort(ID::Y)));
+						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::Y).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_NAND_)) {
 				f << stringf(".names %s %s %s\n0- 1\n-0 1\n",
-						CSTR(cell->getPort(ID::A)), CSTR(cell->getPort(ID::B)), CSTR(cell->getPort(ID::Y)));
+						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::Y).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_NOR_)) {
 				f << stringf(".names %s %s %s\n00 1\n",
-						CSTR(cell->getPort(ID::A)), CSTR(cell->getPort(ID::B)), CSTR(cell->getPort(ID::Y)));
+						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::Y).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_XNOR_)) {
 				f << stringf(".names %s %s %s\n11 1\n00 1\n",
-						CSTR(cell->getPort(ID::A)), CSTR(cell->getPort(ID::B)), CSTR(cell->getPort(ID::Y)));
+						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::Y).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_ANDNOT_)) {
 				f << stringf(".names %s %s %s\n10 1\n",
-						CSTR(cell->getPort(ID::A)), CSTR(cell->getPort(ID::B)), CSTR(cell->getPort(ID::Y)));
+						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::Y).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_ORNOT_)) {
 				f << stringf(".names %s %s %s\n1- 1\n-0 1\n",
-						CSTR(cell->getPort(ID::A)), CSTR(cell->getPort(ID::B)), CSTR(cell->getPort(ID::Y)));
+						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::Y).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_AOI3_)) {
 				f << stringf(".names %s %s %s %s\n-00 1\n0-0 1\n",
-						CSTR(cell->getPort(ID::A)), CSTR(cell->getPort(ID::B)), CSTR(cell->getPort(ID::C)), CSTR(cell->getPort(ID::Y)));
+						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::C).c_str(), cell->getPort(ID::Y).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_OAI3_)) {
 				f << stringf(".names %s %s %s %s\n00- 1\n--0 1\n",
-						CSTR(cell->getPort(ID::A)), CSTR(cell->getPort(ID::B)), CSTR(cell->getPort(ID::C)), CSTR(cell->getPort(ID::Y)));
+						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::C).c_str(), cell->getPort(ID::Y).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_AOI4_)) {
 				f << stringf(".names %s %s %s %s %s\n-0-0 1\n-00- 1\n0--0 1\n0-0- 1\n",
-						CSTR(cell->getPort(ID::A)), CSTR(cell->getPort(ID::B)),
-						CSTR(cell->getPort(ID::C)), CSTR(cell->getPort(ID::D)), CSTR(cell->getPort(ID::Y)));
+						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(),
+						cell->getPort(ID::C).c_str(), cell->getPort(ID::D).c_str(), cell->getPort(ID::Y).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_OAI4_)) {
 				f << stringf(".names %s %s %s %s %s\n00-- 1\n--00 1\n",
-						CSTR(cell->getPort(ID::A)), CSTR(cell->getPort(ID::B)),
-						CSTR(cell->getPort(ID::C)), CSTR(cell->getPort(ID::D)), CSTR(cell->getPort(ID::Y)));
+						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(),
+						cell->getPort(ID::C).c_str(), cell->getPort(ID::D).c_str(), cell->getPort(ID::Y).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_MUX_)) {
 				f << stringf(".names %s %s %s %s\n1-0 1\n-11 1\n",
-						CSTR(cell->getPort(ID::A)), CSTR(cell->getPort(ID::B)),
-						CSTR(cell->getPort(ID::S)), CSTR(cell->getPort(ID::Y)));
+						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(),
+						cell->getPort(ID::S).c_str(), cell->getPort(ID::Y).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_NMUX_)) {
 				f << stringf(".names %s %s %s %s\n0-0 1\n-01 1\n",
-						CSTR(cell->getPort(ID::A)), CSTR(cell->getPort(ID::B)),
-						CSTR(cell->getPort(ID::S)), CSTR(cell->getPort(ID::Y)));
+						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(),
+						cell->getPort(ID::S).c_str(), cell->getPort(ID::Y).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_FF_)) {
-				f << stringf(".latch %s %s%s\n", CSTR(cell->getPort(ID::D)), CSTR(cell->getPort(ID::Q)),
+				f << stringf(".latch %s %s%s\n", cell->getPort(ID::D).c_str(), cell->getPort(ID::Q).c_str(),
 						str_init(cell->getPort(ID::Q)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_DFF_N_)) {
-				f << stringf(".latch %s %s fe %s%s\n", CSTR(cell->getPort(ID::D)), CSTR(cell->getPort(ID::Q)),
-						CSTR(cell->getPort(ID::C)), str_init(cell->getPort(ID::Q)).c_str());
+				f << stringf(".latch %s %s fe %s%s\n", cell->getPort(ID::D).c_str(), cell->getPort(ID::Q).c_str(),
+						cell->getPort(ID::C).c_str(), str_init(cell->getPort(ID::Q)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_DFF_P_)) {
-				f << stringf(".latch %s %s re %s%s\n", CSTR(cell->getPort(ID::D)), CSTR(cell->getPort(ID::Q)),
-						CSTR(cell->getPort(ID::C)), str_init(cell->getPort(ID::Q)).c_str());
+				f << stringf(".latch %s %s re %s%s\n", cell->getPort(ID::D).c_str(), cell->getPort(ID::Q).c_str(),
+						cell->getPort(ID::C).c_str(), str_init(cell->getPort(ID::Q)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_DLATCH_N_)) {
-				f << stringf(".latch %s %s al %s%s\n", CSTR(cell->getPort(ID::D)), CSTR(cell->getPort(ID::Q)),
-						CSTR(cell->getPort(ID::E)), str_init(cell->getPort(ID::Q)).c_str());
+				f << stringf(".latch %s %s al %s%s\n", cell->getPort(ID::D).c_str(), cell->getPort(ID::Q).c_str(),
+						cell->getPort(ID::E).c_str(), str_init(cell->getPort(ID::Q)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_DLATCH_P_)) {
-				f << stringf(".latch %s %s ah %s%s\n", CSTR(cell->getPort(ID::D)), CSTR(cell->getPort(ID::Q)),
-						CSTR(cell->getPort(ID::E)), str_init(cell->getPort(ID::Q)).c_str());
+				f << stringf(".latch %s %s ah %s%s\n", cell->getPort(ID::D).c_str(), cell->getPort(ID::Q).c_str(),
+						cell->getPort(ID::E).c_str(), str_init(cell->getPort(ID::Q)).c_str());
 				goto internal_cell;
 			}
 
@@ -365,10 +363,10 @@ struct BlifDumper
 				auto width = cell->parameters.at(ID::WIDTH).as_int();
 				log_assert(inputs.size() == width);
 				for (int i = width-1; i >= 0; i--)
-					f << stringf(" %s", CSTR(inputs.extract(i, 1)));
+					f << stringf(" %s", inputs.extract(i, 1).c_str());
 				auto &output = cell->getPort(ID::Y);
 				log_assert(output.size() == 1);
-				f << stringf(" %s", CSTR(output));
+				f << stringf(" %s", output.c_str());
 				f << stringf("\n");
 				RTLIL::SigSpec mask = cell->parameters.at(ID::LUT);
 				for (int i = 0; i < (1 << width); i++)
@@ -391,10 +389,10 @@ struct BlifDumper
 					table.push_back(State::S0);
 				log_assert(inputs.size() == width);
 				for (int i = 0; i < width; i++)
-					f << stringf(" %s", CSTR(inputs.extract(i, 1)));
+					f << stringf(" %s", inputs.extract(i, 1).c_str());
 				auto &output = cell->getPort(ID::Y);
 				log_assert(output.size() == 1);
-				f << stringf(" %s", CSTR(output));
+				f << stringf(" %s", output.c_str());
 				f << stringf("\n");
 				for (int i = 0; i < depth; i++) {
 					for (int j = 0; j < width; j++) {
@@ -409,11 +407,11 @@ struct BlifDumper
 				goto internal_cell;
 			}
 
-			f << stringf(".%s %s", subckt_or_gate(cell->type.str()), CSTR(cell->type));
+			f << stringf(".%s %s", subckt_or_gate(cell->type.str()), cell->type.c_str());
 			for (auto &conn : cell->connections())
 			{
 				if (conn.second.size() == 1) {
-					f << stringf(" %s=%s", CSTR(conn.first), CSTR(conn.second[0]));
+					f << stringf(" %s=%s", conn.first.c_str(), conn.second[0].c_str());
 					continue;
 				}
 
@@ -422,20 +420,20 @@ struct BlifDumper
 
 				if (w == nullptr) {
 					for (int i = 0; i < GetSize(conn.second); i++)
-						f << stringf(" %s[%d]=%s", CSTR(conn.first), i, CSTR(conn.second[i]));
+						f << stringf(" %s[%d]=%s", conn.first.c_str(), i, conn.second[i].c_str());
 				} else {
 					for (int i = 0; i < std::min(GetSize(conn.second), GetSize(w)); i++) {
 						SigBit sig(w, i);
-						f << stringf(" %s[%d]=%s", CSTR(conn.first), sig.wire->upto ?
+						f << stringf(" %s[%d]=%s", conn.first.c_str(), sig.wire->upto ?
 								sig.wire->start_offset+sig.wire->width-sig.offset-1 :
-								sig.wire->start_offset+sig.offset, CSTR(conn.second[i]));
+								sig.wire->start_offset+sig.offset, conn.second[i].c_str());
 					}
 				}
 			}
 			f << stringf("\n");
 
 			if (config->cname_mode)
-				f << stringf(".cname %s\n", CSTR(cell->name));
+				f << stringf(".cname %s\n", cell->name.c_str());
 			if (config->attr_mode)
 				dump_params(".attr", cell->attributes);
 			if (config->param_mode)
@@ -444,7 +442,7 @@ struct BlifDumper
 			if (0) {
 		internal_cell:
 				if (config->iname_mode)
-					f << stringf(".cname %s\n", CSTR(cell->name));
+					f << stringf(".cname %s\n", cell->name.c_str());
 				if (config->iattr_mode)
 					dump_params(".attr", cell->attributes);
 			}
@@ -460,12 +458,12 @@ struct BlifDumper
 				continue;
 
 			if (config->conn_mode)
-				f << stringf(".conn %s %s\n", CSTR(rhs_bit), CSTR(lhs_bit));
+				f << stringf(".conn %s %s\n", rhs_bit.c_str(), lhs_bit.c_str());
 			else if (!config->buf_type.empty())
 				f << stringf(".%s %s %s=%s %s=%s\n", subckt_or_gate(config->buf_type), config->buf_type.c_str(),
-						config->buf_in.c_str(), CSTR(rhs_bit), config->buf_out.c_str(), CSTR(lhs_bit));
+						config->buf_in.c_str(), rhs_bit.c_str(), config->buf_out.c_str(), lhs_bit.c_str());
 			else
-				f << stringf(".names %s %s\n1 1\n", CSTR(rhs_bit), CSTR(lhs_bit));
+				f << stringf(".names %s %s\n1 1\n", rhs_bit.c_str(), lhs_bit.c_str());
 		}
 
 		f << stringf(".end\n");

--- a/backends/blif/blif.cc
+++ b/backends/blif/blif.cc
@@ -164,7 +164,7 @@ struct BlifDumper
 	void dump()
 	{
 		f << stringf("\n");
-		f << stringf(".model %s\n", module->name.c_str());
+		f << stringf(".model %s\n", str(module->name).c_str());
 
 		std::map<int, RTLIL::Wire*> inputs, outputs;
 
@@ -179,7 +179,7 @@ struct BlifDumper
 		for (auto &it : inputs) {
 			RTLIL::Wire *wire = it.second;
 			for (int i = 0; i < wire->width; i++)
-				f << stringf(" %s", RTLIL::SigSpec(wire, i).c_str());
+				f << stringf(" %s", str(RTLIL::SigSpec(wire, i)).c_str());
 		}
 		f << stringf("\n");
 
@@ -187,7 +187,7 @@ struct BlifDumper
 		for (auto &it : outputs) {
 			RTLIL::Wire *wire = it.second;
 			for (int i = 0; i < wire->width; i++)
-				f << stringf(" %s", RTLIL::SigSpec(wire, i).c_str());
+				f << stringf(" %s", str(RTLIL::SigSpec(wire, i)).c_str());
 		}
 		f << stringf("\n");
 
@@ -229,131 +229,131 @@ struct BlifDumper
 			if (config->unbuf_types.count(cell->type)) {
 				auto portnames = config->unbuf_types.at(cell->type);
 				f << stringf(".names %s %s\n1 1\n",
-						cell->getPort(portnames.first).c_str(), cell->getPort(portnames.second).c_str());
+						str(cell->getPort(portnames.first)).c_str(), str(cell->getPort(portnames.second)).c_str());
 				continue;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_NOT_)) {
 				f << stringf(".names %s %s\n0 1\n",
-						cell->getPort(ID::A).c_str(), cell->getPort(ID::Y).c_str());
+						str(cell->getPort(ID::A)).c_str(), str(cell->getPort(ID::Y)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_AND_)) {
 				f << stringf(".names %s %s %s\n11 1\n",
-						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::Y).c_str());
+						str(cell->getPort(ID::A)).c_str(), str(cell->getPort(ID::B)).c_str(), str(cell->getPort(ID::Y)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_OR_)) {
 				f << stringf(".names %s %s %s\n1- 1\n-1 1\n",
-						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::Y).c_str());
+						str(cell->getPort(ID::A)).c_str(), str(cell->getPort(ID::B)).c_str(), str(cell->getPort(ID::Y)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_XOR_)) {
 				f << stringf(".names %s %s %s\n10 1\n01 1\n",
-						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::Y).c_str());
+						str(cell->getPort(ID::A)).c_str(), str(cell->getPort(ID::B)).c_str(), str(cell->getPort(ID::Y)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_NAND_)) {
 				f << stringf(".names %s %s %s\n0- 1\n-0 1\n",
-						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::Y).c_str());
+						str(cell->getPort(ID::A)).c_str(), str(cell->getPort(ID::B)).c_str(), str(cell->getPort(ID::Y)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_NOR_)) {
 				f << stringf(".names %s %s %s\n00 1\n",
-						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::Y).c_str());
+						str(cell->getPort(ID::A)).c_str(), str(cell->getPort(ID::B)).c_str(), str(cell->getPort(ID::Y)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_XNOR_)) {
 				f << stringf(".names %s %s %s\n11 1\n00 1\n",
-						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::Y).c_str());
+						str(cell->getPort(ID::A)).c_str(), str(cell->getPort(ID::B)).c_str(), str(cell->getPort(ID::Y)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_ANDNOT_)) {
 				f << stringf(".names %s %s %s\n10 1\n",
-						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::Y).c_str());
+						str(cell->getPort(ID::A)).c_str(), str(cell->getPort(ID::B)).c_str(), str(cell->getPort(ID::Y)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_ORNOT_)) {
 				f << stringf(".names %s %s %s\n1- 1\n-0 1\n",
-						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::Y).c_str());
+						str(cell->getPort(ID::A)).c_str(), str(cell->getPort(ID::B)).c_str(), str(cell->getPort(ID::Y)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_AOI3_)) {
 				f << stringf(".names %s %s %s %s\n-00 1\n0-0 1\n",
-						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::C).c_str(), cell->getPort(ID::Y).c_str());
+						str(cell->getPort(ID::A)).c_str(), str(cell->getPort(ID::B)).c_str(), str(cell->getPort(ID::C)).c_str(), str(cell->getPort(ID::Y)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_OAI3_)) {
 				f << stringf(".names %s %s %s %s\n00- 1\n--0 1\n",
-						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(), cell->getPort(ID::C).c_str(), cell->getPort(ID::Y).c_str());
+						str(cell->getPort(ID::A)).c_str(), str(cell->getPort(ID::B)).c_str(), str(cell->getPort(ID::C)).c_str(), str(cell->getPort(ID::Y)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_AOI4_)) {
 				f << stringf(".names %s %s %s %s %s\n-0-0 1\n-00- 1\n0--0 1\n0-0- 1\n",
-						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(),
-						cell->getPort(ID::C).c_str(), cell->getPort(ID::D).c_str(), cell->getPort(ID::Y).c_str());
+						str(cell->getPort(ID::A)).c_str(), str(cell->getPort(ID::B)).c_str(),
+						str(cell->getPort(ID::C)).c_str(), str(cell->getPort(ID::D)).c_str(), str(cell->getPort(ID::Y)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_OAI4_)) {
 				f << stringf(".names %s %s %s %s %s\n00-- 1\n--00 1\n",
-						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(),
-						cell->getPort(ID::C).c_str(), cell->getPort(ID::D).c_str(), cell->getPort(ID::Y).c_str());
+						str(cell->getPort(ID::A)).c_str(), str(cell->getPort(ID::B)).c_str(),
+						str(cell->getPort(ID::C)).c_str(), str(cell->getPort(ID::D)).c_str(), str(cell->getPort(ID::Y)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_MUX_)) {
 				f << stringf(".names %s %s %s %s\n1-0 1\n-11 1\n",
-						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(),
-						cell->getPort(ID::S).c_str(), cell->getPort(ID::Y).c_str());
+						str(cell->getPort(ID::A)).c_str(), str(cell->getPort(ID::B)).c_str(),
+						str(cell->getPort(ID::S)).c_str(), str(cell->getPort(ID::Y)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_NMUX_)) {
 				f << stringf(".names %s %s %s %s\n0-0 1\n-01 1\n",
-						cell->getPort(ID::A).c_str(), cell->getPort(ID::B).c_str(),
-						cell->getPort(ID::S).c_str(), cell->getPort(ID::Y).c_str());
+						str(cell->getPort(ID::A)).c_str(), str(cell->getPort(ID::B)).c_str(),
+						str(cell->getPort(ID::S)).c_str(), str(cell->getPort(ID::Y)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_FF_)) {
-				f << stringf(".latch %s %s%s\n", cell->getPort(ID::D).c_str(), cell->getPort(ID::Q).c_str(),
+				f << stringf(".latch %s %s%s\n", str(cell->getPort(ID::D)).c_str(), str(cell->getPort(ID::Q)).c_str(),
 						str_init(cell->getPort(ID::Q)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_DFF_N_)) {
-				f << stringf(".latch %s %s fe %s%s\n", cell->getPort(ID::D).c_str(), cell->getPort(ID::Q).c_str(),
-						cell->getPort(ID::C).c_str(), str_init(cell->getPort(ID::Q)).c_str());
+				f << stringf(".latch %s %s fe %s%s\n", str(cell->getPort(ID::D)).c_str(), str(cell->getPort(ID::Q)).c_str(),
+						str(cell->getPort(ID::C)).c_str(), str_init(cell->getPort(ID::Q)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_DFF_P_)) {
-				f << stringf(".latch %s %s re %s%s\n", cell->getPort(ID::D).c_str(), cell->getPort(ID::Q).c_str(),
-						cell->getPort(ID::C).c_str(), str_init(cell->getPort(ID::Q)).c_str());
+				f << stringf(".latch %s %s re %s%s\n", str(cell->getPort(ID::D)).c_str(), str(cell->getPort(ID::Q)).c_str(),
+						str(cell->getPort(ID::C)).c_str(), str_init(cell->getPort(ID::Q)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_DLATCH_N_)) {
-				f << stringf(".latch %s %s al %s%s\n", cell->getPort(ID::D).c_str(), cell->getPort(ID::Q).c_str(),
-						cell->getPort(ID::E).c_str(), str_init(cell->getPort(ID::Q)).c_str());
+				f << stringf(".latch %s %s al %s%s\n", str(cell->getPort(ID::D)).c_str(), str(cell->getPort(ID::Q)).c_str(),
+						str(cell->getPort(ID::E)).c_str(), str_init(cell->getPort(ID::Q)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_DLATCH_P_)) {
-				f << stringf(".latch %s %s ah %s%s\n", cell->getPort(ID::D).c_str(), cell->getPort(ID::Q).c_str(),
-						cell->getPort(ID::E).c_str(), str_init(cell->getPort(ID::Q)).c_str());
+				f << stringf(".latch %s %s ah %s%s\n", str(cell->getPort(ID::D)).c_str(), str(cell->getPort(ID::Q)).c_str(),
+						str(cell->getPort(ID::E)).c_str(), str_init(cell->getPort(ID::Q)).c_str());
 				goto internal_cell;
 			}
 
@@ -363,10 +363,10 @@ struct BlifDumper
 				auto width = cell->parameters.at(ID::WIDTH).as_int();
 				log_assert(inputs.size() == width);
 				for (int i = width-1; i >= 0; i--)
-					f << stringf(" %s", inputs.extract(i, 1).c_str());
+					f << stringf(" %s", str(inputs.extract(i, 1)).c_str());
 				auto &output = cell->getPort(ID::Y);
 				log_assert(output.size() == 1);
-				f << stringf(" %s", output.c_str());
+				f << stringf(" %s", str(output).c_str());
 				f << stringf("\n");
 				RTLIL::SigSpec mask = cell->parameters.at(ID::LUT);
 				for (int i = 0; i < (1 << width); i++)
@@ -389,10 +389,10 @@ struct BlifDumper
 					table.push_back(State::S0);
 				log_assert(inputs.size() == width);
 				for (int i = 0; i < width; i++)
-					f << stringf(" %s", inputs.extract(i, 1).c_str());
+					f << stringf(" %s", str(inputs.extract(i, 1)).c_str());
 				auto &output = cell->getPort(ID::Y);
 				log_assert(output.size() == 1);
-				f << stringf(" %s", output.c_str());
+				f << stringf(" %s", str(output).c_str());
 				f << stringf("\n");
 				for (int i = 0; i < depth; i++) {
 					for (int j = 0; j < width; j++) {
@@ -407,11 +407,11 @@ struct BlifDumper
 				goto internal_cell;
 			}
 
-			f << stringf(".%s %s", subckt_or_gate(cell->type.str()), cell->type.c_str());
+			f << stringf(".%s %s", subckt_or_gate(cell->type.str()), str(cell->type).c_str());
 			for (auto &conn : cell->connections())
 			{
 				if (conn.second.size() == 1) {
-					f << stringf(" %s=%s", conn.first.c_str(), conn.second[0].c_str());
+					f << stringf(" %s=%s", str(conn.first).c_str(), str(conn.second[0]).c_str());
 					continue;
 				}
 
@@ -420,20 +420,20 @@ struct BlifDumper
 
 				if (w == nullptr) {
 					for (int i = 0; i < GetSize(conn.second); i++)
-						f << stringf(" %s[%d]=%s", conn.first.c_str(), i, conn.second[i].c_str());
+						f << stringf(" %s[%d]=%s", str(conn.first).c_str(), i, str(conn.second[i]).c_str());
 				} else {
 					for (int i = 0; i < std::min(GetSize(conn.second), GetSize(w)); i++) {
 						SigBit sig(w, i);
-						f << stringf(" %s[%d]=%s", conn.first.c_str(), sig.wire->upto ?
+						f << stringf(" %s[%d]=%s", str(conn.first).c_str(), sig.wire->upto ?
 								sig.wire->start_offset+sig.wire->width-sig.offset-1 :
-								sig.wire->start_offset+sig.offset, conn.second[i].c_str());
+								sig.wire->start_offset+sig.offset, str(conn.second[i]).c_str());
 					}
 				}
 			}
 			f << stringf("\n");
 
 			if (config->cname_mode)
-				f << stringf(".cname %s\n", cell->name.c_str());
+				f << stringf(".cname %s\n", str(cell->name).c_str());
 			if (config->attr_mode)
 				dump_params(".attr", cell->attributes);
 			if (config->param_mode)
@@ -442,7 +442,7 @@ struct BlifDumper
 			if (0) {
 		internal_cell:
 				if (config->iname_mode)
-					f << stringf(".cname %s\n", cell->name.c_str());
+					f << stringf(".cname %s\n", str(cell->name).c_str());
 				if (config->iattr_mode)
 					dump_params(".attr", cell->attributes);
 			}
@@ -458,12 +458,12 @@ struct BlifDumper
 				continue;
 
 			if (config->conn_mode)
-				f << stringf(".conn %s %s\n", rhs_bit.c_str(), lhs_bit.c_str());
+				f << stringf(".conn %s %s\n", str(rhs_bit).c_str(), str(lhs_bit).c_str());
 			else if (!config->buf_type.empty())
 				f << stringf(".%s %s %s=%s %s=%s\n", subckt_or_gate(config->buf_type), config->buf_type.c_str(),
-						config->buf_in.c_str(), rhs_bit.c_str(), config->buf_out.c_str(), lhs_bit.c_str());
+						config->buf_in.c_str(), str(rhs_bit).c_str(), config->buf_out.c_str(), str(lhs_bit).c_str());
 			else
-				f << stringf(".names %s %s\n1 1\n", rhs_bit.c_str(), lhs_bit.c_str());
+				f << stringf(".names %s %s\n1 1\n", str(rhs_bit).c_str(), str(lhs_bit).c_str());
 		}
 
 		f << stringf(".end\n");


### PR DESCRIPTION
For reasons that are unclear to me, this was being used to store every
result of `cstr` before returning them. The vector was never accessed otherwise,
resulting in a huge unnecessary memory sink when emitting to BLIF.

On local tests, this saves an extraordinary amount of memory (and subsequently time) during BLIF emission:
an 87MB BLIF output previously required 1GB of resident memory, and now requires virtually none.