### PR TITLE
Expose abc and data paths as globals for pyosys 

### DIFF
--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -366,6 +366,9 @@ extern std::map<std::string, void*> loaded_python_plugins;
 extern std::map<std::string, std::string> loaded_plugin_aliases;
 void load_plugin(std::string filename, std::vector<std::string> aliases);
 
+extern std::string yosys_share_dirname;
+extern std::string yosys_abc_executable;
+
 YOSYS_NAMESPACE_END
 
 #endif

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1470,16 +1470,7 @@ struct AbcPass : public Pass {
 		pi_map.clear();
 		po_map.clear();
 
-#ifdef ABCEXTERNAL
-		std::string exe_file;
-		if (std::getenv("ABC")) {
-			exe_file = std::getenv("ABC");
-		} else {
-			exe_file = ABCEXTERNAL;
-		}
-#else
-		std::string exe_file = proc_self_dirname() + proc_program_prefix() + "yosys-abc";
-#endif
+		std::string exe_file = yosys_abc_executable;
 		std::string script_file, liberty_file, constr_file, clk_str;
 		std::string delay_target, sop_inputs, sop_products, lutin_shared = "-S 1";
 		bool fast_mode = false, dff_mode = false, keepff = false, cleanup = true;
@@ -1493,13 +1484,6 @@ struct AbcPass : public Pass {
 		map_mux16 = false;
 		enabled_gates.clear();
 		cmos_cost = false;
-
-#ifdef _WIN32
-#ifndef ABCEXTERNAL
-		if (!check_file_exists(exe_file + ".exe") && check_file_exists(proc_self_dirname() + "..\\" + proc_program_prefix()+ "yosys-abc.exe"))
-			exe_file = proc_self_dirname() + "..\\" + proc_program_prefix() + "yosys-abc";
-#endif
-#endif
 
 		// get arguments from scratchpad first, then override by command arguments
 		std::string lut_arg, luts_arg, g_arg;

--- a/passes/techmap/abc9_exe.cc
+++ b/passes/techmap/abc9_exe.cc
@@ -379,11 +379,7 @@ struct Abc9ExePass : public Pass {
 	{
 		log_header(design, "Executing ABC9_EXE pass (technology mapping using ABC9).\n");
 
-#ifdef ABCEXTERNAL
-		std::string exe_file = ABCEXTERNAL;
-#else
-		std::string exe_file = proc_self_dirname() + proc_program_prefix()+ "yosys-abc";
-#endif
+		std::string exe_file = yosys_abc_executable;
 		std::string script_file, clk_str, box_file, lut_file;
 		std::string delay_target, lutin_shared = "-S 1", wire_delay;
 		std::string tempdir_name;
@@ -394,13 +390,6 @@ struct Abc9ExePass : public Pass {
 #if 0
 		cleanup = false;
 		show_tempdir = true;
-#endif
-
-#ifdef _WIN32
-#ifndef ABCEXTERNAL
-		if (!check_file_exists(exe_file + ".exe") && check_file_exists(proc_self_dirname() + "..\\" + proc_program_prefix() + "yosys-abc.exe"))
-			exe_file = proc_self_dirname() + "..\\" + proc_program_prefix() + "yosys-abc";
-#endif
 #endif
 
 		std::string lut_arg, luts_arg;


### PR DESCRIPTION
To be able to use and check pyosys builds without installing yosys itself (for CI) we need to override determined data share location and location from ABC, since those are calculated from python location and not from yosys itslef.
Even when installed as is, ABC executable was not able to be determined correctly. 
This is replacement for #2430 
