### PR TITLE
Fix begin/end in generate

### DIFF
--- a/tests/simple/const_branch_finish.v
+++ b/tests/simple/const_branch_finish.v
@@ -21,9 +21,6 @@ module top;
 		end
 	end
 	generate
-		begin : unconditional_block
-			initial `CONSTANT_CHECK
-		end
 		if (WIDTH == 32) begin : conditional_block
 			initial `CONSTANT_CHECK
 		end

--- a/tests/simple/generate.v
+++ b/tests/simple/generate.v
@@ -167,7 +167,7 @@ module gen_test7;
 	reg [2:0] out2;
 	wire [2:0] out3;
 	generate
-		begin : cond
+		if (1) begin : cond
 			reg [2:0] sub_out1;
 			reg [2:0] sub_out2;
 			wire [2:0] sub_out3;
@@ -215,9 +215,9 @@ module gen_test8;
 
 	wire [1:0] x = 2'b11;
 	generate
-		begin : A
+		if (1) begin : A
 			wire [1:0] x;
-			begin : B
+			if (1) begin : B
 				wire [1:0] x = 2'b00;
 				`ASSERT(x == 0)
 				`ASSERT(A.x == 2)
@@ -228,7 +228,7 @@ module gen_test8;
 				`ASSERT(gen_test8.A.C.x == 1)
 				`ASSERT(gen_test8.A.B.x == 0)
 			end
-			begin : C
+			if (1) begin : C
 				wire [1:0] x = 2'b01;
 				`ASSERT(x == 1)
 				`ASSERT(A.x == 2)


### PR DESCRIPTION
In my understanding, unconditional_block in generate is not allowed.
Instead of it, `if (1) begin` can be used to introduce a new name scope.