### PR TITLE
Makefile: Add disabled-by-default ENABLE_SCCACHE config option.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,8 @@ ENABLE_GPROF := 0
 ENABLE_DEBUG := 0
 ENABLE_NDEBUG := 0
 ENABLE_CCACHE := 0
+# sccache is not always a drop-in replacement for ccache in practice
+ENABLE_SCCACHE := 0
 LINK_CURSES := 0
 LINK_TERMCAP := 0
 LINK_ABC := 0
@@ -530,6 +532,10 @@ endif
 
 ifeq ($(ENABLE_CCACHE),1)
 CXX := ccache $(CXX)
+else
+ifeq ($(ENABLE_SCCACHE),1)
+CXX := sccache $(CXX)
+endif
 endif
 
 define add_share_file
@@ -1019,4 +1025,3 @@ echo-abc-rev:
 
 .PHONY: all top-all abc test install install-abc manual clean mrproper qtcreator coverage vcxsrc mxebin
 .PHONY: config-clean config-clang config-gcc config-gcc-static config-gcc-4.8 config-afl-gcc config-gprof config-sudo
-

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ bumpversion:
 # is just a symlink to your actual ABC working directory, as 'make mrproper'
 # will remove the 'abc' directory and you do not want to accidentally
 # delete your work on ABC..
-ABCREV = 341db25
+ABCREV = 4f5f73d
 ABCPULL = 1
 ABCURL ?= https://github.com/YosysHQ/abc
 ABCMKARGS = CC="$(CXX)" CXX="$(CXX)" ABC_USE_LIBSTDCXX=1


### PR DESCRIPTION
[`sccache`](https://github.com/mozilla/sccache) is a `ccache`-like tool that supports distributed compilation and more languages. While it can be used as a `ccache`-replacement, I've found a few edge cases where symlinking `sccache` to `ccache` can choke. This includes on Windows where the symlink just plain doesn't work, and incompatibility with mixed C/C++ projects on all systems (`yosys` is unaffected by the latter).

Considering edge cases, along with using a completely separate cache and its extra distributed compilation capabilities, I think it's reasonable to add an `ENABLE_SCCACHE` option disabled by default. Like `ENABLE_EDITLINE` and `ENABLE_READLINE`, this option is mutually-exclusive with `ENABLE_CCACHE`; the former takes priority.

Two caveats:
* I can't speak for `ccache`, but `abc` doesn't currently play all that nice with `sccache`, even though the build succeeds. I filed a PR to fix this [upstream](https://github.com/berkeley-abc/abc/pull/108), and will get it into the YosysHQ fork once it's accepted.
* Compiler configs that requires special `CC` Makefile var handling in `ABCMKARGS` do not have `ccache`/`sccache` support yet. My feeling is that this should be fixed as part of #2011; this mostly affects Windows anyway and not the "typical" case of *nix.

