### PR TITLE
Add rewrite_filename for sim -vcd argument.

### DIFF
--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -810,7 +810,9 @@ struct SimPass : public Pass {
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++) {
 			if (args[argidx] == "-vcd" && argidx+1 < args.size()) {
-				worker.vcdfile.open(args[++argidx].c_str());
+				std::string vcd_filename = args[++argidx];
+				rewrite_filename(vcd_filename);
+				worker.vcdfile.open(vcd_filename.c_str());
 				continue;
 			}
 			if (args[argidx] == "-n" && argidx+1 < args.size()) {


### PR DESCRIPTION
I've added a call to `rewrite_filename` on a local copy of the argument value passed with `-vcd` to the `sim` pass. I kept having an issue with my build scripts where it wouldn't generate the vcd file, but worked fine if I did it by hand. Turns out it was quotes on the filename string, which `rewrite_filename` tidies up, among other things.