### PR TITLE
rtlil: remove dotted identifiers

### DIFF
--- a/frontends/rtlil/rtlil_lexer.l
+++ b/frontends/rtlil/rtlil_lexer.l
@@ -86,7 +86,6 @@ USING_YOSYS_NAMESPACE
 
 "\\"[^ \t\r\n]+		{ rtlil_frontend_yylval.string = strdup(yytext); return TOK_ID; }
 "$"[^ \t\r\n]+		{ rtlil_frontend_yylval.string = strdup(yytext); return TOK_ID; }
-"."[0-9]+		{ rtlil_frontend_yylval.string = strdup(yytext); return TOK_ID; }
 
 [0-9]+'[01xzm-]*	{ rtlil_frontend_yylval.string = strdup(yytext); return TOK_VALUE; }
 -?[0-9]+		{


### PR DESCRIPTION
No one knows where they came from and they never did anything useful.