### PR TITLE
Generate only simple assignments in verilog backend

### DIFF
--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -35,7 +35,7 @@
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
-bool verbose, norename, noattr, attr2comment, noexpr, nodec, nohex, nostr, extmem, defparam, decimal, siminit, systemverilog;
+bool verbose, norename, noattr, attr2comment, noexpr, nodec, nohex, nostr, extmem, defparam, decimal, siminit, systemverilog, simple_lhs;
 int auto_name_counter, auto_name_offset, auto_name_digits, extmem_counter;
 std::map<RTLIL::IdString, int> auto_name_map;
 std::set<RTLIL::IdString> reg_wires;
@@ -1546,14 +1546,22 @@ void dump_cell(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 
 void dump_conn(std::ostream &f, std::string indent, const RTLIL::SigSpec &left, const RTLIL::SigSpec &right)
 {
-	int offset = 0;
-	for (auto &chunk : left.chunks()) {
+	if (simple_lhs) {
+		int offset = 0;
+		for (auto &chunk : left.chunks()) {
+			f << stringf("%s" "assign ", indent.c_str());
+			dump_sigspec(f, chunk);
+			f << stringf(" = ");
+			dump_sigspec(f, right.extract(offset, GetSize(chunk)));
+			f << stringf(";\n");
+			offset += GetSize(chunk);
+		}
+	} else {
 		f << stringf("%s" "assign ", indent.c_str());
-		dump_sigspec(f, chunk);
+		dump_sigspec(f, left);
 		f << stringf(" = ");
-		dump_sigspec(f, right.extract(offset, GetSize(chunk)));
+		dump_sigspec(f, right);
 		f << stringf(";\n");
-		offset += GetSize(chunk);
 	}
 }
 
@@ -1865,6 +1873,9 @@ struct VerilogBackend : public Backend {
 		log("        deactivates this feature and instead will write string constants\n");
 		log("        as binary numbers.\n");
 		log("\n");
+		log("    -simple-lhs\n");
+		log("        Connection assignments with simple left hand side without concatenations.\n");
+		log("\n");
 		log("    -extmem\n");
 		log("        instead of initializing memories using assignments to individual\n");
 		log("        elements, use the '$readmemh' function to read initialization data\n");
@@ -1912,6 +1923,7 @@ struct VerilogBackend : public Backend {
 		defparam = false;
 		decimal = false;
 		siminit = false;
+		simple_lhs = false;
 		auto_prefix = "";
 
 		bool blackboxes = false;
@@ -1982,6 +1994,10 @@ struct VerilogBackend : public Backend {
 			}
 			if (arg == "-selected") {
 				selected = true;
+				continue;
+			}
+			if (arg == "-simple-lhs") {
+				simple_lhs = true;
 				continue;
 			}
 			if (arg == "-v") {

--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -1546,11 +1546,15 @@ void dump_cell(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 
 void dump_conn(std::ostream &f, std::string indent, const RTLIL::SigSpec &left, const RTLIL::SigSpec &right)
 {
-	f << stringf("%s" "assign ", indent.c_str());
-	dump_sigspec(f, left);
-	f << stringf(" = ");
-	dump_sigspec(f, right);
-	f << stringf(";\n");
+	int offset = 0;
+	for (auto &chunk : left.chunks()) {
+		f << stringf("%s" "assign ", indent.c_str());
+		dump_sigspec(f, chunk);
+		f << stringf(" = ");
+		dump_sigspec(f, right.extract(offset, GetSize(chunk)));
+		f << stringf(";\n");
+		offset += GetSize(chunk);
+	}
 }
 
 void dump_proc_switch(std::ostream &f, std::string indent, RTLIL::SwitchRule *sw);


### PR DESCRIPTION
Yosys currently emits assigns with a concatenated expression on the LHS in form like:
assign {a,b} = {c,d,e};
this change generate instead (note that size is taken into consideration):
assign a = {c, d};
assign b = e;

This fixes issue #1286