### PR TITLE
Fixes for building Fedora distro RPMs of yosys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -608,6 +608,11 @@ $(eval $(call add_include_file,backends/cxxrtl/cxxrtl_vcd_capi.cc))
 $(eval $(call add_include_file,backends/cxxrtl/cxxrtl_vcd_capi.h))
 
 OBJS += kernel/driver.o kernel/register.o kernel/rtlil.o kernel/log.o kernel/calc.o kernel/yosys.o
+ifeq ($(ENABLE_ABC),1)
+ifneq ($(ABCEXTERNAL),)
+kernel/yosys.o: CXXFLAGS += -DABCEXTERNAL='"$(ABCEXTERNAL)"'
+endif
+endif
 OBJS += kernel/cellaigs.o kernel/celledges.o kernel/satgen.o kernel/mem.o
 
 kernel/log.o: CXXFLAGS += -DYOSYS_SRC='"$(YOSYS_SRC)"'

--- a/passes/sat/freduce.cc
+++ b/passes/sat/freduce.cc
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <algorithm>
+#include <limits>
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN


### PR DESCRIPTION
I co-maintain yosys in the Fedora distribution, and the following two patches help get the latest upstream to build correctly in that environment:

- an additional `#include` is needed to build `passes/sat/freduce.cc` with the upcoming `gcc-11` toolchain
- we need to pass `-DABCEXTERNAL` into `kernel/yosys.cc` to have the latter actually do something productive in that situation

Thanks for considering!