### PR TITLE
Return correct modname when found in cache.

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -1511,6 +1511,7 @@ RTLIL::IdString AstModule::derive(RTLIL::Design *design, const dict<RTLIL::IdStr
 		}
 
 	} else {
+		modname = new_modname;
 		log("Found cached RTLIL representation for module `%s'.\n", modname.c_str());
 	}
 


### PR DESCRIPTION
Fixes  #2451 where otherwise equal submodules were showing different types.