### PR TITLE
Fix SYNTHESIS always being defined in Verilog frontend

### DIFF
--- a/frontends/verilog/preproc.cc
+++ b/frontends/verilog/preproc.cc
@@ -321,7 +321,6 @@ struct define_body_t
 define_map_t::define_map_t()
 {
 	add("YOSYS", "1");
-	add(formal_mode ? "FORMAL" : "SYNTHESIS", "1");
 }
 
 // We must define this destructor here (rather than relying on the default), because we need to

--- a/frontends/verilog/verilog_frontend.cc
+++ b/frontends/verilog/verilog_frontend.cc
@@ -446,6 +446,9 @@ struct VerilogFrontend : public Frontend {
 			}
 			break;
 		}
+
+		defines_map.add(formal_mode ? "FORMAL" : "SYNTHESIS", "1");
+
 		extra_args(f, filename, args, argidx);
 
 		log_header(design, "Executing Verilog-2005 frontend: %s\n", filename.c_str());


### PR DESCRIPTION
This patch fixes a bug where the verilog macro SYNTHESIS is always defined when using read_verilog even when the -formal option is used.

The bug occured as the define_map_t constructor in frontends/verilog/preproc.cc set one of the two macros, dependent on the formal_mode global variable. In VerilogFrontend::execute() in frontends/verilog/verilog_frontend.cc the object defines_map is created before the options to read_verilog have been parsed. This means that formal_mode has not been set correctly yet, so SYNTHESIS is always defined.

This is fixed by defining the verilog macros in execute(), after the read_verilog options have been parsed, instead of in the define_map_t constructor.