### PR TITLE
cxxrtl: provide a way to perform unobtrusive power-on reset

### DIFF
--- a/backends/cxxrtl/cxxrtl_capi.cc
+++ b/backends/cxxrtl/cxxrtl_capi.cc
@@ -43,6 +43,10 @@ void cxxrtl_destroy(cxxrtl_handle handle) {
 	delete handle;
 }
 
+void cxxrtl_reset(cxxrtl_handle handle) {
+	handle->module->reset();
+}
+
 int cxxrtl_eval(cxxrtl_handle handle) {
 	return handle->module->eval();
 }

--- a/backends/cxxrtl/cxxrtl_capi.h
+++ b/backends/cxxrtl/cxxrtl_capi.h
@@ -55,6 +55,14 @@ cxxrtl_handle cxxrtl_create(cxxrtl_toplevel design);
 // Release all resources used by a design and its handle.
 void cxxrtl_destroy(cxxrtl_handle handle);
 
+// Reinitialize the design, replacing the internal state with the reset values while preserving
+// black boxes.
+//
+// This operation is essentially equivalent to a power-on reset. Values, wires, and memories are
+// returned to their reset state while preserving the state of black boxes and keeping all of
+// the interior pointers obtained with e.g. `cxxrtl_get` valid.
+void cxxrtl_reset(cxxrtl_handle handle);
+
 // Evaluate the design, propagating changes on inputs to the `next` value of internal state and
 // output wires.
 //


### PR DESCRIPTION
Although it is always possible to destroy and recreate the design to simulate a power-on reset, this has two drawbacks:
  * Black boxes are also destroyed and recreated, which causes them to reacquire their resources, which might be costly and/or erase important state.
  * Pointers into the design are invalidated and have to be acquired again, which is costly and might be very inconvenient if they are captured elsewhere (especially through the C API).