### PR TITLE
cxxrtl: don't overwrite buffered inputs

### DIFF
--- a/backends/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/cxxrtl.h
@@ -659,7 +659,7 @@ struct wire {
 	value<Bits> next;
 
 	wire() = default;
-	constexpr wire(const value<Bits> &init) : curr(init), next(init) {}
+	explicit constexpr wire(const value<Bits> &init) : curr(init), next(init) {}
 	template<typename... Init>
 	explicit constexpr wire(Init ...init) : curr{init...}, next{init...} {}
 


### PR DESCRIPTION
Before this commit, a cell's input was always assigned like:

    p_cell.p_input = (value...);

If `p_input` is buffered (e.g. if the design is built at -O0), this is not correct. (In practice, this breaks clocking.) Unfortunately, the incorrect design was compiled without diagnostics because `wire<>` was move-assignable and also implicitly constructible from `value<>`.

After this commit, cell inputs are no longer incorrectly assumed to always be unbuffered, and wires are not assignable from values.