### PR TITLE
CXXRTL: implement zero-cost full coverage debug information through the magic✨ of outlining🪄🎀🧹

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -2038,6 +2038,7 @@ struct CxxrtlWorker {
 				f << indent << "}\n";
 				f << "\n";
 			}
+			f << indent << "CXXRTL_EXTREMELY_COLD\n";
 			f << indent << "void " << mangle(module) << "::debug_info(debug_items &items, std::string path) {\n";
 			dump_debug_info_method(module);
 			f << indent << "}\n";

--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -211,7 +211,7 @@ bool is_ff_cell(RTLIL::IdString type)
 
 bool is_internal_cell(RTLIL::IdString type)
 {
-	return type[0] == '$' && !type.begins_with("$paramod");
+	return !type.isPublic() && !type.begins_with("$paramod");
 }
 
 bool is_cxxrtl_blackbox_cell(const RTLIL::Cell *cell)
@@ -1665,7 +1665,7 @@ struct CxxrtlWorker {
 		inc_indent();
 			f << indent << "assert(path.empty() || path[path.size() - 1] == ' ');\n";
 			for (auto wire : module->wires()) {
-				if (wire->name[0] != '\\')
+				if (!wire->name.isPublic())
 					continue;
 				if (module->get_bool_attribute(ID(cxxrtl_blackbox)) && (wire->port_id == 0))
 					continue;
@@ -1743,7 +1743,7 @@ struct CxxrtlWorker {
 			}
 			if (!module->get_bool_attribute(ID(cxxrtl_blackbox))) {
 				for (auto &memory_it : module->memories) {
-					if (memory_it.first[0] != '\\')
+					if (!memory_it.first.isPublic())
 						continue;
 					f << indent << "items.add(path + " << escape_cxx_string(get_hdl_name(memory_it.second));
 					f << ", debug_item(" << mangle(memory_it.second) << ", ";
@@ -2338,7 +2338,7 @@ struct CxxrtlWorker {
 				// Note that the information collected here can't be used for optimizing the netlist: debug information queries
 				// are pure and run on a design in a stable state, which allows assumptions that do not otherwise hold.
 				for (auto wire : module->wires()) {
-					if (wire->name[0] != '\\')
+					if (!wire->name.isPublic())
 						continue;
 					if (!unbuffered_wires[wire])
 						continue;

--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -1157,8 +1157,8 @@ struct CxxrtlWorker {
 				}
 				// The generated code has two bounds checks; one in an assertion, and another that guards the read.
 				// This is done so that the code does not invoke undefined behavior under any conditions, but nevertheless
-				// loudly crashes if an illegal condition is encountered. The assert may be turned off with -DNDEBUG not
-				// just for release builds, but also to make sure the simulator (which is presumably embedded in some
+				// loudly crashes if an illegal condition is encountered. The assert may be turned off with -DCXXRTL_NDEBUG
+				// not only for release builds, but also to make sure the simulator (which is presumably embedded in some
 				// larger program) will never crash the code that calls into it.
 				//
 				// If assertions are disabled, out of bounds reads are defined to return zero.

--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -911,7 +911,16 @@ struct CxxrtlWorker {
 		if (for_debug && !is_connect_outlined(conn))
 			return;
 
-		f << indent << "// connection\n";
+		std::vector<RTLIL::IdString> inlined_cells;
+		collect_sigspec_rhs(conn.second, inlined_cells);
+		if (for_debug || inlined_cells.empty()) {
+			f << indent << "// connection\n";
+		} else {
+			f << indent << "// cells";
+			for (auto inlined_cell : inlined_cells)
+				f << " " << inlined_cell.str();
+			f << "\n";
+		}
 		f << indent;
 		dump_sigspec_lhs(conn.first, for_debug);
 		f << " = ";

--- a/backends/cxxrtl/cxxrtl_capi.cc
+++ b/backends/cxxrtl/cxxrtl_capi.cc
@@ -86,3 +86,7 @@ void cxxrtl_enum(cxxrtl_handle handle, void *data,
 	for (auto &it : handle->objects.table)
 		callback(data, it.first.c_str(), static_cast<cxxrtl_object*>(&it.second[0]), it.second.size());
 }
+
+void cxxrtl_outline_eval(cxxrtl_outline outline) {
+	outline->eval();
+}

--- a/backends/cxxrtl/cxxrtl_capi.h
+++ b/backends/cxxrtl/cxxrtl_capi.h
@@ -128,6 +128,18 @@ enum cxxrtl_type {
 	// pointer is always NULL.
 	CXXRTL_ALIAS = 3,
 
+	// Outlines correspond to netlist nodes that were optimized in a way that makes them inaccessible
+	// outside of a module's `eval()` function. At the highest debug information level, every inlined
+	// node has a corresponding outline object.
+	//
+	// Outlines can be inspected via the `curr` pointer and can never be modified; the `next` pointer
+	// is always NULL. Unlike all other objects, the bits of an outline object are meaningful only
+	// after a call to `cxxrtl_outline_eval` and until any subsequent modification to the netlist.
+	// Observing this requirement is the responsibility of the caller; it is not enforced.
+	//
+	// Outlines always correspond to combinatorial netlist nodes that are not ports.
+	CXXRTL_OUTLINE = 4,
+
 	// More object types may be added in the future, but the existing ones will never change.
 };
 
@@ -171,8 +183,8 @@ enum cxxrtl_flag {
 
 	// Node has bits that are driven by a combinatorial cell or another node.
 	//
-	// This flag can be set on objects of type `CXXRTL_VALUE` and `CXXRTL_WIRE`. It may be combined
-	// with `CXXRTL_DRIVEN_SYNC` and `CXXRTL_UNDRIVEN`, as well as other flags.
+	// This flag can be set on objects of type `CXXRTL_VALUE`, `CXXRTL_WIRE`, and `CXXRTL_OUTLINE`.
+	// It may be combined with `CXXRTL_DRIVEN_SYNC` and `CXXRTL_UNDRIVEN`, as well as other flags.
 	//
 	// This flag is set on objects that have bits connected to the output of a combinatorial cell,
 	// or directly to another node. For designs without combinatorial loops, writing to such bits
@@ -193,8 +205,8 @@ enum cxxrtl_flag {
 
 // Description of a simulated object.
 //
-// The `data` array can be accessed directly to inspect and, if applicable, modify the bits
-// stored in the object.
+// The `curr` and `next` arrays can be accessed directly to inspect and, if applicable, modify
+// the bits stored in the object.
 struct cxxrtl_object {
 	// Type of the object.
 	//
@@ -230,6 +242,12 @@ struct cxxrtl_object {
 	// that cannot be modified, or cannot be modified in a race-free way, `next` is NULL.
 	uint32_t *curr;
 	uint32_t *next;
+
+	// Opaque reference to an outline. Only meaningful for outline objects.
+	//
+	// See the documentation of `cxxrtl_outline` for details. When creating a `cxxrtl_object`, set
+	// this field to NULL.
+	struct _cxxrtl_outline *outline;
 
 	// More description fields may be added in the future, but the existing ones will never change.
 };
@@ -271,6 +289,20 @@ inline struct cxxrtl_object *cxxrtl_get(cxxrtl_handle handle, const char *name) 
 void cxxrtl_enum(cxxrtl_handle handle, void *data,
                  void (*callback)(void *data, const char *name,
                                   struct cxxrtl_object *object, size_t parts));
+
+// Opaque reference to an outline.
+//
+// An outline is a group of outline objects that are evaluated simultaneously. The identity of
+// an outline can be compared to determine whether any two objects belong to the same outline.
+typedef struct _cxxrtl_outline *cxxrtl_outline;
+
+// Evaluate an outline.
+//
+// After evaluating an outline, the bits of every outline object contained in it are consistent
+// with the current state of the netlist. In general, any further modification to the netlist
+// causes every outline object to become stale, after which the corresponding outline must be
+// re-evaluated, otherwise the bits read from that object are meaningless.
+void cxxrtl_outline_eval(cxxrtl_outline outline);
 
 #ifdef __cplusplus
 }

--- a/backends/cxxrtl/cxxrtl_vcd.h
+++ b/backends/cxxrtl/cxxrtl_vcd.h
@@ -28,10 +28,13 @@ class vcd_writer {
 		size_t ident;
 		size_t width;
 		chunk_t *curr;
-		size_t prev_off;
+		size_t cache_offset;
+		debug_outline *outline;
+		bool *outline_warm;
 	};
 
 	std::vector<std::string> current_scope;
+	std::map<debug_outline*, bool> outlines;
 	std::vector<variable> variables;
 	std::vector<chunk_t> cache;
 	std::map<chunk_t*, size_t> aliases;
@@ -112,16 +115,22 @@ class vcd_writer {
 		buffer += '\n';
 	}
 
-	const variable &register_variable(size_t width, chunk_t *curr, bool constant = false) {
+	void reset_outlines() {
+		for (auto &outline_it : outlines)
+			outline_it.second = /*warm=*/(outline_it.first == nullptr);
+	}
+
+	variable &register_variable(size_t width, chunk_t *curr, bool constant = false, debug_outline *outline = nullptr) {
 		if (aliases.count(curr)) {
 			return variables[aliases[curr]];
 		} else {
+			auto outline_it = outlines.emplace(outline, /*warm=*/(outline == nullptr)).first;
 			const size_t chunks = (width + (sizeof(chunk_t) * 8 - 1)) / (sizeof(chunk_t) * 8);
 			aliases[curr] = variables.size();
 			if (constant) {
-				variables.emplace_back(variable { variables.size(), width, curr, (size_t)-1 });
+				variables.emplace_back(variable { variables.size(), width, curr, (size_t)-1, outline_it->first, &outline_it->second });
 			} else {
-				variables.emplace_back(variable { variables.size(), width, curr, cache.size() });
+				variables.emplace_back(variable { variables.size(), width, curr, cache.size(), outline_it->first, &outline_it->second });
 				cache.insert(cache.end(), &curr[0], &curr[chunks]);
 			}
 			return variables.back();
@@ -129,13 +138,17 @@ class vcd_writer {
 	}
 
 	bool test_variable(const variable &var) {
-		if (var.prev_off == (size_t)-1)
+		if (var.cache_offset == (size_t)-1)
 			return false; // constant
+		if (!*var.outline_warm) {
+			var.outline->eval();
+			*var.outline_warm = true;
+		}
 		const size_t chunks = (var.width + (sizeof(chunk_t) * 8 - 1)) / (sizeof(chunk_t) * 8);
-		if (std::equal(&var.curr[0], &var.curr[chunks], &cache[var.prev_off])) {
+		if (std::equal(&var.curr[0], &var.curr[chunks], &cache[var.cache_offset])) {
 			return false;
 		} else {
-			std::copy(&var.curr[0], &var.curr[chunks], &cache[var.prev_off]);
+			std::copy(&var.curr[0], &var.curr[chunks], &cache[var.cache_offset]);
 			return true;
 		}
 	}
@@ -197,6 +210,10 @@ public:
 				emit_var(register_variable(item.width, item.curr),
 				         "wire", name, item.lsb_at, multipart);
 				break;
+			case debug_item::OUTLINE:
+				emit_var(register_variable(item.width, item.curr, /*constant=*/false, item.outline),
+				         "wire", name, item.lsb_at, multipart);
+				break;
 		}
 	}
 
@@ -228,6 +245,7 @@ public:
 			emit_scope({});
 			emit_enddefinitions();
 		}
+		reset_outlines();
 		emit_time(timestamp);
 		for (auto var : variables)
 			if (test_variable(var) || first_sample) {

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -376,7 +376,7 @@ namespace RTLIL
 		bool in(const std::string &rhs) const { return *this == rhs; }
 		bool in(const pool<IdString> &rhs) const { return rhs.count(*this) != 0; }
 
-		bool isPublic() { return begins_with("\\"); }
+		bool isPublic() const { return begins_with("\\"); }
 	};
 
 	namespace ID {


### PR DESCRIPTION
This PR significantly improves almost every aspect of CXXRTL's performance. Most importantly, it eliminates the tradeoff between debug information coverage (which directly translates to available VCD traces and so on), runtime throughput, and compilation latency.

That's right: CXXRTL no longer has the `-Og` (optimize for debug coverage) option because it is now able to provide **100% debug coverage for every net in the source HDL at all times regardless of optimization settings**.

That's not all though. This PR also improves compilation latency, runtime throughput at 100% coverage, VCD writing performance, and VCD file size. On the benchmark I'm using (1M cycles of Minerva with UART blackbox), this changeset makes CXXRTL set up for full coverage **compile ~30% faster, run ~40% faster without being probed, run ~55% faster while writing every trace (except memories) to VCD, and the resulting VCD file is ~65% smaller!** Conversely, it makes CXXRTL set up for rapid iteration at partial coverage **compile ~20% faster, run at the same speed, and fit 7% more traces into a VCD file of the same size!** Sorcery, isn't it?

Here's the benchmark results (arranged in the ugliest table Markdown has ever rendered), before this changeset:

| scenario         | options   | compile time | no-probe run time | full VCD run time | VCD size | net coverage | 
|------------------|-----------|--------------|-------------------|-------------------|----------|--------------|
| full coverage    | `-O4 -g1` | ~12.1s | ~1.74s | ~24.0s | ~1784M | **100%** (1816/1816) |
| max performance  | `-O6 -g1` | ~8.2s  | **~1.05s** | ~5.5s | ~275M | 44% (800/1816) |

And here's the benchmark results for the same design after the changeset:

| scenario         | options   | compile time | no-probe run time | full VCD run time | VCD size | net coverage | 
|------------------|-----------|--------------|-------------------|-------------------|----------|--------------|
| max performance *and* full coverage | `-O6 -g3` | ~8.2s  | **~1.05s** | ~10.3s | ~597M | **100%** (1816/1816) |
| fast compilation | `-O6 -g2` | ~6.5s  | **~1.05s** | ~6.0s | ~275M | 47% (861/1816) |

<sub>Specific numbers included for entertainment purposes only. Your mileage may vary. I was more concerned about refining the instrumentation and avoiding pathological C++ compiler edge cases than improving performance, anyway.</sub>

I've experimented with DWARF-like "zero cost" debug information for RTL simulators for several months at this point, and during that time I've been calling it "zero cost" with the air quotes: while some of my solutions technically did achieve that goal, the cost was simply shifted elsewhere and increased enough to prohibit any practical use. However, this one seems like it can be called "zero cost" without reservations, since it is a strict improvement in every important aspect.

<hr>

So how does this all work? First, some context.

Until now, CXXRTL could not effectively provide full coverage because its compilation model requires close cooperation with a C++ compiler that is limited in its ability to reason about CXXRTL's algorithms. The final machine code has the best performance when the generated C++ code sticks to manipulating temporaries and locals. Storing many intermediate computation results into memory presents a significant obstacle to the optimizer.

Aside from interfering with the machine code compiler, many nets that appear in a typical HDL project serve no useful function yet require resources to keep track of. At the same time, these nets can be important for debugging. Consider, for example, unused signals on a high fanout bus. Even if the arbiters and decoders are designed in a way that lets the simulator discard those signals, they are still useful in VCD traces by confirming that the bus isn't stuck in some obscure state.

The solution is simple but surprisingly effective: generate two separate code paths that share the same state. The "performance" code path simulates only the nets that are required for the design to function, and stores in memory only the values of the registers; any intermediates remain just that--intermediates--even if they correspond to a net in the HDL source. The "coverage" code path is the opposite: it uses the stored design state to reconstruct every intermediate that corresponds to a user-defined net, and does nothing else.

For the most part, the goal of an RTL simulator is to be as fast as possible. No one will look at the vast majority of the cycles, so there's no real need to calculate and record the values of redundant nets, either. On the other hand, handling the small amount of cycles that *do* require attention is more important than anything else. These two observations determined the approach I took in this PR.

My earlier attempts at "zero cost" debug information relied on fine-grained representations of netlists to do the minimum amount of necessary work to evaluate any requested signal, under the hypothesis that 'only paying for what you use' is valuable in the context of an RTL simulator. Unfortunately, these fine-grained representations resulted in intractable compile times, and the coordination logic had enough overhead to make full trace dumps several times slower than just evaluating everything eagerly. After discussing the prototype with a few fellow FPGA designers, I understood that any solution, no matter how elegant conceptually, must justify its existence by being faster than just rebuilding the design with a different set of flags when something breaks. Eventually, I concluded that providing true "zero cost" debug information is not viable and focused on improving the experience with only partial coverage.

However, CXXRTL still had a major reason to provide full coverage in at least some capacity: nMigen. My goal of integrating CXXRTL into nMigen transparently required the former to provide access to any net, since breaking existing nMigen testbenches would not be very transparent. That's how `-Og` came into existence: it trades off however much performance is necessary to get full coverage because anything less than full coverage would be useless.

At this point, CXXRTL could be configured in one of the two modes: either more performance than coverage, or more coverage than performance. Since they are functionally identical in every way except for a few scheduler tweaks, eventually I realized I could just put both in the same build artifact, in the same namespace, with the same entry point, sharing the same class hierarchy and design state, with the option to switch between them at any time.

Knowing the highly asymmetric use patterns of RTL simulators, I decided to adapt the high coverage mode to be especially suited to the one workload every designer I talked to expressed a strong preference for: full VCD dumps. Rather than being configurable or fine-grained, it would always come with storage for every user-defined net (that is otherwise optimized to an inaccessible intermediate), and provide a single function that reconstructs the values of all of those nets. Conversely, it would feature no caching, or any other runtime logic, or even any way to affect the state of the design. Only nets driven by fully combinatorial logic can be optimized out in a way that reduces coverage, so it makes sense that the mechanism for reverting that would be fully combinatorial, too.

As expected, this plan worked well for making full VCD dumps. However, what I wasn't expecting is discovering that it is actually an approach that is faster in a wide range of circumstances. Consider that (with this changeset applied) saving a full VCD dump of a design built with `-O4` (which causes the value of every user-defined net to be recorded when it is computed) takes more than *twice the time* as it takes the same design built with `-O6` (which causes the intermediate results to be discarded after being used to advance the simulation and then computed anew once the VCD writer needs them). And this is a design that converges to fixed point in one delta cycle! For designs that converge in multiple delta cycles (e.g. non-flattened), evaluating all of this logic once after they converge multiplies the performance improvement.

Building the infrastructure that classifies and schedules netlists according to this model has resulted in another nice side effect. Contemporary HDL often comes in a very large number of interconnected modules. (Minerva has more than 40, and that's a fairly simple RISC-V CPU.) Consequently, a simulator that preserves the design hierarchy in its waveform dumps has to take into account that most nets in the design exist to preserve the correspondence between the (usually flattened) netlist and the hierarchical HDL source. (Out of 1816 user-defined nets in Minerva, 1285 are aliases.) CXXRTL had a way to represent aliases in debug information for a while, but the corresponding analysis was very conservative to make sure that e.g. the aliasee it picks will not be unexpectedly optimized out. Now that it has the ability to reconstruct every net that was optimized out, this is no longer an issue, which allows for precise alias detection, which in turn reduces the size of VCD files even as more traces are added.

What I didn't anticipate at all is that this all will be possible without increasing compilation time, and the reason for that is very silly. Being fed C++ code mechanically transformed from RTL netlists that relies on bignum arithmetics implemented with templates stacked dozens of levels deep, with so much redundancy that function merging is a hard requirement, and structured in a way that requires aggressive loop unrolling to *optimize for size*? Modern C++ compilers hardly find that a challenge, crunching through thousands of lines and far more template instantiations in just a few seconds while producing nice compact machine code. Then they spend about as long struggling with a futile attempt to optimize a function that's just 2000 coldest method calls in the entire unit, arranged in a straight line. I thought I'd have to rearrange half of the support template library to get a 2× speedup; nope, just had to place a single `__attribute__((optnone))`. Not that I complain.