### PR TITLE
xilinx: Add FDDRCPE and FDDRRSE blackbox cells.

### DIFF
--- a/techlibs/xilinx/cells_xtra.py
+++ b/techlibs/xilinx/cells_xtra.py
@@ -188,6 +188,11 @@ CELLS = [
 
     # I/O logic.
     # Virtex 2, Spartan 3.
+    # Note: these two are not officially listed in the HDL library guide, but
+    # they are more fundamental than OFDDR* and are necessary to construct
+    # differential DDR outputs (OFDDR* can only do single-ended).
+    Cell('FDDRCPE', port_attrs={'C0': ['clkbuf_sink'], 'C1': ['clkbuf_sink']}),
+    Cell('FDDRRSE', port_attrs={'C0': ['clkbuf_sink'], 'C1': ['clkbuf_sink']}),
     Cell('IFDDRCPE', port_attrs={'C0': ['clkbuf_sink'], 'C1': ['clkbuf_sink'], 'D': ['iopad_external_pin']}),
     Cell('IFDDRRSE', port_attrs={'C0': ['clkbuf_sink'], 'C1': ['clkbuf_sink'], 'D': ['iopad_external_pin']}),
     Cell('OFDDRCPE', port_attrs={'C0': ['clkbuf_sink'], 'C1': ['clkbuf_sink'], 'Q': ['iopad_external_pin']}),

--- a/techlibs/xilinx/cells_xtra.v
+++ b/techlibs/xilinx/cells_xtra.v
@@ -5301,6 +5301,34 @@ module DSP48E2 (...);
     input RSTP;
 endmodule
 
+module FDDRCPE (...);
+    parameter INIT = 1'b0;
+    (* clkbuf_sink *)
+    input C0;
+    (* clkbuf_sink *)
+    input C1;
+    input CE;
+    input D0;
+    input D1;
+    input CLR;
+    input PRE;
+    output Q;
+endmodule
+
+module FDDRRSE (...);
+    parameter INIT = 1'b0;
+    output Q;
+    (* clkbuf_sink *)
+    input C0;
+    (* clkbuf_sink *)
+    input C1;
+    input CE;
+    input D0;
+    input D1;
+    input R;
+    input S;
+endmodule
+
 module IFDDRCPE (...);
     output Q0;
     output Q1;


### PR DESCRIPTION
These are necessary primitives for proper DDR support on Virtex 2 and
Spartan 3.