### PR TITLE
cxxrtl: completely rewrite netlist layout code

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -2807,10 +2807,10 @@ struct CxxrtlBackend : public Backend {
 		log("        no optimization.\n");
 		log("\n");
 		log("    -O1\n");
-		log("        localize internal wires if possible.\n");
+		log("        unbuffer internal wires if possible.\n");
 		log("\n");
 		log("    -O2\n");
-		log("        like -O1, and unbuffer internal wires if possible.\n");
+		log("        like -O1, and localize internal wires if possible.\n");
 		log("\n");
 		log("    -O3\n");
 		log("        like -O2, and inline internal wires if possible.\n");

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -93,6 +93,8 @@ extern Tcl_Obj *Tcl_NewIntObj(int intValue);
 extern Tcl_Obj *Tcl_NewListObj(int objc, Tcl_Obj *const objv[]);
 extern Tcl_Obj *Tcl_ObjSetVar2(Tcl_Interp *interp, Tcl_Obj *part1Ptr, Tcl_Obj *part2Ptr, Tcl_Obj *newValuePtr, int flags);
 #  endif
+#  undef CONST
+#  undef INLINE
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
See the commit messages for details. On Minerva SoC SRAM, this improves runtime by **20-25%** across the board, and compile time by **30-50%** only on clang (gcc is not affected). There are also other correctness and usability improvements; in particular the new netlist layout code is specifically written to take the greatest advantage of outlining.