### PR TITLE
Fixed missing goto statement in passes/techmap/abc.cc

### DIFF
--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1794,6 +1794,7 @@ struct AbcPass : public Pass {
 					gate_list.push_back("OAI4");
 					gate_list.push_back("MUX");
 					gate_list.push_back("NMUX");
+					goto ok_alias;
 				}
 				if (g_arg_from_cmd)
 					cmd_error(args, g_argidx, stringf("Unsupported gate type: %s", g.c_str()));


### PR DESCRIPTION
The goto statement seems to be missing.
Specifying "-g all" for abc produces an error: `ERROR: Command syntax error: Unsupported gate type: all`

**If this is not a bug then just close this PR**.