### PR TITLE
opt_share: Fix X and CO signal width for shifted $alu in opt_share.

### DIFF
--- a/passes/opt/opt_share.cc
+++ b/passes/opt/opt_share.cc
@@ -244,8 +244,8 @@ void merge_operators(RTLIL::Module *module, RTLIL::Cell *mux, const std::vector<
 	}
 
 	if (shared_op->type.in(ID($alu))) {
-		shared_op->setPort(ID::X, module->addWire(NEW_ID, GetSize(new_sig_out)));
-		shared_op->setPort(ID::CO, module->addWire(NEW_ID, GetSize(new_sig_out)));
+		shared_op->setPort(ID::X, module->addWire(NEW_ID, GetSize(new_out)));
+		shared_op->setPort(ID::CO, module->addWire(NEW_ID, GetSize(new_out)));
 	}
 
 	bool is_fine = shared_op->type.in(FINE_BITWISE_OPS);

--- a/tests/opt/opt_share_bug2538.ys
+++ b/tests/opt/opt_share_bug2538.ys
@@ -1,0 +1,20 @@
+read_verilog <<EOT
+
+module top(...);
+
+input [3:0] A;
+input S;
+output [1:0] Y;
+
+wire [3:0] A1 = A + 1;
+wire [3:0] A2 = A + 2;
+assign Y = S ? A1[3:2] : A2[3:2];
+
+endmodule
+
+EOT
+
+proc
+alumacc
+equiv_opt -assert opt_share
+


### PR DESCRIPTION
These need to be the same length as actual Y, not visible part of Y.

Fixes #2538.