### PR TITLE
cxxrtl: Fix liveness checking for debug wires

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -2647,7 +2647,10 @@ struct CxxrtlWorker {
 					auto &debug_wire_type = debug_wire_types[wire];
 					if (wire->name.isPublic()) continue;
 
-					if (live_wires[wire].empty() && debug_live_wires[wire].empty()) {
+					// In constructing liveness for debug nodes, we skip member nodes updated during regular eval()
+					// this prevents debug_eval() from messing with eval()'s state, that process skips tagging members
+					// as live. By considering member wires live, debug wires that alias members work properly
+					if (debug_live_wires[wire].empty() && !wire_type.is_member()) {
 						continue; // wire never used
 					} else if (flow.is_inlinable(wire, debug_live_wires[wire])) {
 						log_assert(flow.wire_comb_defs[wire].size() == 1);

--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -2647,7 +2647,7 @@ struct CxxrtlWorker {
 					auto &debug_wire_type = debug_wire_types[wire];
 					if (wire->name.isPublic()) continue;
 
-					if (live_wires[wire].empty() || debug_live_wires[wire].empty()) {
+					if (live_wires[wire].empty() && debug_live_wires[wire].empty()) {
 						continue; // wire never used
 					} else if (flow.is_inlinable(wire, debug_live_wires[wire])) {
 						log_assert(flow.wire_comb_defs[wire].size() == 1);


### PR DESCRIPTION
The current liveness checking for cxxrtl breaks in certain esoteric cases. Notably when signals that were completely optimized out get reintroduced into the design (so called "outline wires") those wires are wholly calculated inside the debug pass, this is because we want to keep the optimized code for the main eval pass and only do the full computation if the debug state is requested explicitly.

Due to some annoyances of yosys itself, it's actually somewhat difficult to have public wires in a design that are unused, as at some point earlier (likely the flatten pass?) yosys has essentially renamed the public signal into a internal unnamed signal, since cxxrtl only generates this additional debug information for used public signals (i.e. ones that are optimized out but not completely unused), this feature currently mostly goes to waste.

Issue #2540 managed to find a test case that actually triggered the generation of these "compute on demand" outline wires, revealing that it wasn't tagging all the proper wires as "live" and used during debug that it should have, causing asserts to fail while generating the debug pass. The details of the problem and proposed fix are explained further in a comment below. 