### PR TITLE
Add plugin.so.dSYM to .gitignore

### DIFF
--- a/tests/various/.gitignore
+++ b/tests/various/.gitignore
@@ -4,3 +4,4 @@
 /write_gzip.v.gz
 /run-test.mk
 /plugin.so
+/plugin.so.dSYM


### PR DESCRIPTION
This artifact is automatically generated by the builtin clang on macOS when -g is used.