### PR TITLE
verilog: allow spaces in macro arguments

### DIFF
--- a/frontends/verilog/preproc.cc
+++ b/frontends/verilog/preproc.cc
@@ -392,7 +392,6 @@ static bool read_argument(std::string &dest)
 {
 	std::vector<char> openers;
 	for (;;) {
-		skip_spaces();
 		std::string tok = next_token(true);
 		if (tok == ")") {
 			if (openers.empty())

--- a/tests/simple/macro_arg_spaces.sv
+++ b/tests/simple/macro_arg_spaces.sv
@@ -1,0 +1,28 @@
+module top(
+	input wire [31:0] i,
+	output wire [31:0] x, y, z
+);
+
+`define BAR(a) a
+`define FOO(a = function automatic [31:0] f) a
+
+`BAR(function automatic [31:0] a);
+	input [31:0] i;
+	a = i * 2;
+endfunction
+
+`FOO();
+	input [31:0] i;
+	f = i * 3;
+endfunction
+
+`FOO(function automatic [31:0] b);
+	input [31:0] i;
+	b = i * 5;
+endfunction
+
+assign x = a(i);
+assign y = f(i);
+assign z = b(i);
+
+endmodule


### PR DESCRIPTION
@rswarbrick @clairexen 