### PR TITLE
Fix digit-formatting calculation for small numbers.

### DIFF
--- a/frontends/aiger/aigerparse.cc
+++ b/frontends/aiger/aigerparse.cc
@@ -55,6 +55,10 @@ inline int32_t from_big_endian(int32_t i32) {
 #define log_debug2(...) ;
 //#define log_debug2(...) log_debug(__VA_ARGS__)
 
+static int decimal_digits(unsigned n) {
+	return n > 1 ? ceil(log10(n)) : 1;
+}
+
 struct ConstEvalAig
 {
 	RTLIL::Module *module;
@@ -515,7 +519,7 @@ void AigerReader::parse_aiger_ascii()
 	unsigned l1, l2, l3;
 
 	// Parse inputs
-	int digits = ceil(log10(I));
+	int digits = decimal_digits(I);
 	for (unsigned i = 1; i <= I; ++i, ++line_count) {
 		if (!(f >> l1))
 			log_error("Line %u cannot be interpreted as an input!\n", line_count);
@@ -537,7 +541,7 @@ void AigerReader::parse_aiger_ascii()
 		clk_wire->port_input = true;
 		clk_wire->port_output = false;
 	}
-	digits = ceil(log10(L));
+	digits = decimal_digits(L);
 	for (unsigned i = 0; i < L; ++i, ++line_count) {
 		if (!(f >> l1 >> l2))
 			log_error("Line %u cannot be interpreted as a latch!\n", line_count);
@@ -575,7 +579,7 @@ void AigerReader::parse_aiger_ascii()
 	}
 
 	// Parse outputs
-	digits = ceil(log10(O));
+	digits = decimal_digits(O);
 	for (unsigned i = 0; i < O; ++i, ++line_count) {
 		if (!(f >> l1))
 			log_error("Line %u cannot be interpreted as an output!\n", line_count);
@@ -643,7 +647,7 @@ void AigerReader::parse_aiger_binary()
 	std::string line;
 
 	// Parse inputs
-	int digits = ceil(log10(I));
+	int digits = decimal_digits(I);
 	for (unsigned i = 1; i <= I; ++i) {
 		log_debug2("%d is an input\n", i);
 		RTLIL::Wire *wire = module->addWire(stringf("$i%0*d", digits, i));
@@ -662,7 +666,7 @@ void AigerReader::parse_aiger_binary()
 		clk_wire->port_input = true;
 		clk_wire->port_output = false;
 	}
-	digits = ceil(log10(L));
+	digits = decimal_digits(L);
 	l1 = (I+1) * 2;
 	for (unsigned i = 0; i < L; ++i, ++line_count, l1 += 2) {
 		if (!(f >> l2))
@@ -700,7 +704,7 @@ void AigerReader::parse_aiger_binary()
 	}
 
 	// Parse outputs
-	digits = ceil(log10(O));
+	digits = decimal_digits(O);
 	for (unsigned i = 0; i < O; ++i, ++line_count) {
 		if (!(f >> l1))
 			log_error("Line %u cannot be interpreted as an output!\n", line_count);

--- a/frontends/aiger/aigerparse.cc
+++ b/frontends/aiger/aigerparse.cc
@@ -55,8 +55,15 @@ inline int32_t from_big_endian(int32_t i32) {
 #define log_debug2(...) ;
 //#define log_debug2(...) log_debug(__VA_ARGS__)
 
-static int decimal_digits(unsigned n) {
-	return n > 1 ? ceil(log10(n)) : 1;
+static int decimal_digits(uint32_t n) {
+	static uint32_t digit_cutoff[9] = {
+		10, 100, 1000, 10000, 100000,
+		1000000, 10000000, 100000000, 1000000000
+	};
+	for (int i = 0; i < 9; ++i) {
+		if (n < digit_cutoff[i]) return i + 1;
+	}
+	return 10;
 }
 
 struct ConstEvalAig


### PR DESCRIPTION
Calling log10() on zero causes a non-sensical value to be calculated. On some
compile options, I've observed yosys crashing with an illegal
instruction (SIGILL).

To make it safe, fix the calculation to do a range check; wrap it a
decimal_digits() function, and use it where the previous ceil(log10(n)) call
was used. As a side, it also improves readability.

Signed-off-by: Henner Zeller <h.zeller@acm.org>