### PR TITLE
xilinx_dffopt: Don't crash on missing IS_*_INVERTED.

### DIFF
--- a/techlibs/xilinx/cells_sim.v
+++ b/techlibs/xilinx/cells_sim.v
@@ -633,6 +633,41 @@ module FDRSE (
       Q <= d;
 endmodule
 
+module FDRSE_1 (
+  output reg Q,
+  (* clkbuf_sink *)
+  (* invertible_pin = "IS_C_INVERTED" *)
+  input C,
+  (* invertible_pin = "IS_CE_INVERTED" *)
+  input CE,
+  (* invertible_pin = "IS_D_INVERTED" *)
+  input D,
+  (* invertible_pin = "IS_R_INVERTED" *)
+  input R,
+  (* invertible_pin = "IS_S_INVERTED" *)
+  input S
+);
+  parameter [0:0] INIT = 1'b0;
+  parameter [0:0] IS_C_INVERTED = 1'b0;
+  parameter [0:0] IS_CE_INVERTED = 1'b0;
+  parameter [0:0] IS_D_INVERTED = 1'b0;
+  parameter [0:0] IS_R_INVERTED = 1'b0;
+  parameter [0:0] IS_S_INVERTED = 1'b0;
+  initial Q <= INIT;
+  wire c = C ^ IS_C_INVERTED;
+  wire ce = CE ^ IS_CE_INVERTED;
+  wire d = D ^ IS_D_INVERTED;
+  wire r = R ^ IS_R_INVERTED;
+  wire s = S ^ IS_S_INVERTED;
+  always @(negedge c)
+    if (r)
+      Q <= 0;
+    else if (s)
+      Q <= 1;
+    else if (ce)
+      Q <= d;
+endmodule
+
 (* abc9_box, lib_whitebox *)
 module FDCE (
   output reg Q,
@@ -823,6 +858,51 @@ module FDCPE (
       qc <= D;
   end
   always @(posedge c, posedge pre) begin
+    if (pre)
+      qp <= 1;
+    else if (CE)
+      qp <= D;
+  end
+  always @* begin
+    if (clr)
+      qs <= 0;
+    else if (pre)
+      qs <= 1;
+  end
+  assign Q = qs ? qp : qc;
+endmodule
+
+module FDCPE_1 (
+  output wire Q,
+  (* clkbuf_sink *)
+  (* invertible_pin = "IS_C_INVERTED" *)
+  input C,
+  input CE,
+  (* invertible_pin = "IS_CLR_INVERTED" *)
+  input CLR,
+  input D,
+  (* invertible_pin = "IS_PRE_INVERTED" *)
+  input PRE
+);
+  parameter [0:0] INIT = 1'b0;
+  parameter [0:0] IS_C_INVERTED = 1'b0;
+  parameter [0:0] IS_CLR_INVERTED = 1'b0;
+  parameter [0:0] IS_PRE_INVERTED = 1'b0;
+  wire c = C ^ IS_C_INVERTED;
+  wire clr = CLR ^ IS_CLR_INVERTED;
+  wire pre = PRE ^ IS_PRE_INVERTED;
+  // Hacky model to avoid simulation-synthesis mismatches.
+  reg qc, qp, qs;
+  initial qc = INIT;
+  initial qp = INIT;
+  initial qs = 0;
+  always @(negedge c, posedge clr) begin
+    if (clr)
+      qc <= 0;
+    else if (CE)
+      qc <= D;
+  end
+  always @(negedge c, posedge pre) begin
     if (pre)
       qp <= 1;
     else if (CE)

--- a/techlibs/xilinx/xilinx_dffopt.cc
+++ b/techlibs/xilinx/xilinx_dffopt.cc
@@ -209,7 +209,7 @@ lut_sigin_done:
 					continue;
 				LutData lut_d = it_D->second.first;
 				Cell *cell_d = it_D->second.second;
-				if (cell->getParam(ID(IS_D_INVERTED)).as_bool()) {
+				if (cell->hasParam(ID(IS_D_INVERTED)) && cell->getParam(ID(IS_D_INVERTED)).as_bool()) {
 					// Flip all bits in the LUT.
 					for (int i = 0; i < GetSize(lut_d.first); i++)
 						lut_d.first.bits[i] = (lut_d.first.bits[i] == State::S1) ? State::S0 : State::S1;
@@ -249,7 +249,7 @@ lut_sigin_done:
 				if (has_s) {
 					SigBit sig_S = sigmap(cell->getPort(ID::S));
 					LutData lut_s = LutData(Const(2, 2), {sig_S});
-					bool inv_s = cell->getParam(ID(IS_S_INVERTED)).as_bool();
+					bool inv_s = cell->hasParam(ID(IS_S_INVERTED)) && cell->getParam(ID(IS_S_INVERTED)).as_bool();
 					auto it_S = bit_to_lut.find(sig_S);
 					if (it_S != bit_to_lut.end())
 						lut_s = it_S->second.first;
@@ -271,7 +271,7 @@ lut_sigin_done:
 				if (has_r) {
 					SigBit sig_R = sigmap(cell->getPort(ID::R));
 					LutData lut_r = LutData(Const(2, 2), {sig_R});
-					bool inv_r = cell->getParam(ID(IS_R_INVERTED)).as_bool();
+					bool inv_r = cell->hasParam(ID(IS_R_INVERTED)) && cell->getParam(ID(IS_R_INVERTED)).as_bool();
 					auto it_R = bit_to_lut.find(sig_R);
 					if (it_R != bit_to_lut.end())
 						lut_r = it_R->second.first;

--- a/tests/arch/xilinx/mux.ys
+++ b/tests/arch/xilinx/mux.ys
@@ -40,10 +40,11 @@ proc
 equiv_opt -assert -map +/xilinx/cells_sim.v synth_xilinx -noiopad # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux16 # Constrain all select calls below inside the top module
+select -assert-max 2 t:LUT3
 select -assert-max 2 t:LUT4
 select -assert-min 4 t:LUT6
 select -assert-max 7 t:LUT6
 select -assert-max 2 t:MUXF7
 dump
 
-select -assert-none t:LUT6 t:LUT4 t:MUXF7 %% t:* %D
+select -assert-none t:LUT6 t:LUT4 t:LUT3 t:MUXF7 %% t:* %D

--- a/tests/arch/xilinx/xilinx_dffopt.ys
+++ b/tests/arch/xilinx/xilinx_dffopt.ys
@@ -223,3 +223,49 @@ select -assert-count 1 t:LUT2
 select -assert-none t:FDRSE t:LUT4 t:LUT2 %% t:* %D
 
 design -reset
+
+
+read_verilog << EOT
+
+// FDSE_1, mergeable CE and S, but CE only not worth it.
+
+module t0 (...);
+input wire clk;
+input wire [7:0] i;
+output wire [7:0] o;
+
+wire [7:0] tmp ;
+
+LUT2 #(.INIT(4'h6)) lut0 (.I0(i[0]), .I1(i[1]), .O(tmp[0]));
+LUT2 #(.INIT(4'h6)) lut1 (.I0(i[1]), .I1(i[2]), .O(tmp[1]));
+
+FDSE_1 ff (.D(tmp[0]), .CE(i[7]), .S(tmp[1]), .Q(o[0]));
+
+endmodule
+
+EOT
+
+read_verilog -lib +/xilinx/cells_sim.v
+design -save t0
+
+equiv_opt -blacklist xilinx_dffopt_blacklist.txt -assert -map +/xilinx/cells_sim.v xilinx_dffopt
+design -load postopt
+clean
+
+cd t0
+select -assert-count 1 t:FDSE_1
+select -assert-count 1 t:LUT5
+select -assert-none t:FDSE_1 t:LUT5 %% t:* %D
+
+design -load t0
+
+equiv_opt -blacklist xilinx_dffopt_blacklist.txt -assert -map +/xilinx/cells_sim.v xilinx_dffopt -lut4
+design -load postopt
+clean
+
+cd t0
+select -assert-count 1 t:FDSE_1
+select -assert-count 2 t:LUT2
+select -assert-none t:FDSE_1 t:LUT2 %% t:* %D
+
+design -reset


### PR DESCRIPTION
The presence of `IS_*_INVERTED` on `FD*` cells follows Vivado, which apparently has been decided by a dice roll.  Just assume false if the
parameter doesn't exist.

Fixes #2559.