### PR TITLE
flatten: clarify confusing error message

### DIFF
--- a/passes/techmap/flatten.cc
+++ b/passes/techmap/flatten.cc
@@ -211,7 +211,7 @@ struct FlattenWorker
 			log_assert(new_conn.first.size() == new_conn.second.size());
 
 			if (sigmap(new_conn.first).has_const())
-				log_error("Mismatch in directionality for cell port %s.%s.%s: %s <= %s\n",
+				log_error("Cell port %s.%s.%s is driving constant bits: %s <= %s\n",
 					log_id(module), log_id(cell), log_id(port_it.first), log_signal(new_conn.first), log_signal(new_conn.second));
 
 			module->connect(new_conn);


### PR DESCRIPTION
This error does not always indicate any mismatch in directionality or any problem with the cell at all. For example, in this case, which was extracted from a large codebase where a developer had mistakenly left the second `assign` after some modifications:
```verilog
module m1(...);
	output wire x;
	assign x = 1'b0;
endmodule

module m2(...);
	wire y;
	assign y = 1'b0; // this was left here by mistake
	m1 c(y);
endmodule
```

The new message is still not a perfect solution (which would be to detect multiple drivers properly, something I wanted to see in Yosys for years now) but it is at least not flat out wrong.