### PR TITLE
frontend: json: parse negative values

### DIFF
--- a/frontends/json/jsonparse.cc
+++ b/frontends/json/jsonparse.cc
@@ -72,10 +72,17 @@ struct JsonNode
 				break;
 			}
 
-			if ('0' <= ch && ch <= '9')
+			if (('0' <= ch && ch <= '9') || ch == '-')
 			{
+				bool negative = false;
 				type = 'N';
-				data_number = ch - '0';
+				if (ch == '-') {
+					data_number = 0;
+				       	negative = true;
+				} else {
+					data_number = ch - '0';
+				}
+
 				data_string += ch;
 
 				while (1)
@@ -97,6 +104,7 @@ struct JsonNode
 					data_string += ch;
 				}
 
+				data_number = negative ? -data_number : data_number;
 				data_string = "";
 				break;
 


### PR DESCRIPTION
When scc breaks logic loops with `$__ABC9_SCC_BREAKER` module it adds the following entry to resulting json:

```"$__ABC9_SCC_BREAKER": {
  "attributes": {
    "blackbox": "00000000000000000000000000000001",
    "cells_not_processed": "00000000000000000000000000000001",
    "dynports": "00000000000000000000000000000001",
    "src": "/(...)/share/yosys/abc9_model.v:9.1-11.10"
  },  
  "cells": {}, 
  "netnames": {
    "I": {
      "attributes": {
        "src": "/(...)/share/yosys/abc9_model.v:9.47-9.48"
      },  
      "bits": [
        2,  
        3   
      ],  
      "hide_name": 0,
      "offset": -1, 
      "upto": 1
    }, 
```
reading the json back to yosys results in:
```
ERROR: Unexpected character in JSON file: '-'
```
in the `"offset": -1,` line

This PR fixes that