### PR TITLE
verilog: strip leading and trailing spaces in macro args

### DIFF
--- a/frontends/verilog/preproc.cc
+++ b/frontends/verilog/preproc.cc
@@ -390,12 +390,16 @@ static void input_file(std::istream &f, std::string filename)
 // the argument list); false if we finished with ','.
 static bool read_argument(std::string &dest)
 {
+	skip_spaces();
 	std::vector<char> openers;
 	for (;;) {
 		std::string tok = next_token(true);
 		if (tok == ")") {
-			if (openers.empty())
+			if (openers.empty()) {
+				while (dest.size() && (dest.back() == ' ' || dest.back() == '\t'))
+					dest = dest.substr(0, dest.size() - 1);
 				return true;
+			}
 			if (openers.back() != '(')
 				log_error("Mismatched brackets in macro argument: %c and %c.\n",
 				          openers.back(), tok[0]);

--- a/tests/simple/macro_arg_surrounding_spaces.v
+++ b/tests/simple/macro_arg_surrounding_spaces.v
@@ -1,0 +1,20 @@
+module top(
+	IDENT_V_,
+	IDENT_W_,
+	IDENT_X_,
+	IDENT_Y_,
+	IDENT_Z_,
+	IDENT_A_,
+	IDENT_B_,
+	IDENT_C_
+);
+	`define MACRO(dummy, x) IDENT_``x``_
+	output wire IDENT_V_;
+	output wire `MACRO(_,W);
+	output wire `MACRO(_, X);
+	output wire `MACRO(_,Y );
+	output wire `MACRO(_, Z );
+	output wire `MACRO(_,	 A);
+	output wire `MACRO(_,B	 );
+	output wire `MACRO(_, C	);
+endmodule


### PR DESCRIPTION
Fixes a regression in #2550. Thanks @Xiretza for catching this!