### PR TITLE
verilog_parser: add label check to gen_block

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -2794,6 +2794,8 @@ gen_block:
 		ast_stack.push_back(node);
 	} module_gen_body TOK_END opt_label {
 		exitTypeScope();
+		if ($3 != NULL && $7 != NULL && *$3 != *$7)
+			frontend_verilog_yyerror("Begin label (%s) and end label (%s) don't match.", $3->c_str()+1, $7->c_str()+1);
 		delete $3;
 		delete $7;
 		SET_AST_NODE_LOC(ast_stack.back(), @1, @7);

--- a/tests/verilog/block_labels.ys
+++ b/tests/verilog/block_labels.ys
@@ -1,0 +1,26 @@
+read_verilog <<EOT
+module foo;
+
+	genvar a = 0;
+	for (a = 0; a < 10; a++) begin : a
+	end : a
+endmodule
+EOT
+read_verilog <<EOT
+module foo2;
+
+	genvar a = 0;
+	for (a = 0; a < 10; a++) begin : a
+	end
+endmodule
+EOT
+
+logger -expect error "Begin label \(a\) and end label \(b\) don't match\." 1
+read_verilog <<EOT
+module foo3;
+
+	genvar a = 0;
+	for (a = 0; a < 10; a++) begin : a
+	end : b
+endmodule
+EOT


### PR DESCRIPTION
This PR adds a check for begin/end labels mismatches in genblocks - this is similar to what is currently done for behavrioral_stmt blocks