### PR TITLE
Accept disable case for SVA liveness properties.

### DIFF
--- a/frontends/verific/verificsva.cc
+++ b/frontends/verific/verificsva.cc
@@ -1759,6 +1759,11 @@ struct VerificSvaImporter
 						clocking.addDff(NEW_ID, sig_en, sig_en_q, State::S0);
 					}
 
+					// accept in disable case
+
+					if (clocking.disable_sig != State::S0)
+						sig_a_q = module->Or(NEW_ID, sig_a_q, clocking.disable_sig);
+
 					// generate fair/live cell
 
 					RTLIL::Cell *c = nullptr;


### PR DESCRIPTION
This PR handles default disable clauses for live/fair properties that caused those properties to fail.

Consider this example of a storage device that becomes `1'b1` forever, fulfilling the property semantics:
``` systemverilog
        var logic tmp;
        always_ff @(posedge clk) begin
                if (!rstn) tmp <= 1'b0;
                else       tmp <= 1'b1;
        end
        assign a = tmp;
        ap0: assert property (@(posedge clk) disable iff (!rstn)
                              s_eventually nexttime a);
```

Without this PR, `SBY` in `live` mode fails to prove the property. By looking into the model, the RTL semantics are wrong due missing `clocking.disable_sig`.

```
SBY 16:36:56 [liveness_test] engine_0: Status returned by engine: FAIL
```

Since proving liveness in Yosys, without aiger or super prove is not possible, I am not adding any kind of test to this PR but will add it to SymbiYosys repo.