### PR TITLE
verlog: allow shadowing module ports within generate blocks

### DIFF
--- a/tests/simple/genblk_port_shadow.v
+++ b/tests/simple/genblk_port_shadow.v
@@ -1,0 +1,10 @@
+module top(x);
+	generate
+		if (1) begin : blk
+			wire x;
+			assign x = 0;
+		end
+	endgenerate
+	output wire x;
+	assign x = blk.x;
+endmodule

--- a/tests/verilog/genblk_port_decl.ys
+++ b/tests/verilog/genblk_port_decl.ys
@@ -1,0 +1,12 @@
+logger -expect error "Cannot declare module port `\\x' within a generate block\." 1
+read_verilog <<EOT
+module top(x);
+    generate
+        if (1) begin : blk
+            output wire x;
+            assign x = 1;
+        end
+    endgenerate
+    output wire x;
+endmodule
+EOT


### PR DESCRIPTION
This is a somewhat obscure edge case I encountered while working on test cases for earlier changes. Declarations in generate blocks should not be checked against the list of ports. This change also adds a check forbidding declarations within generate blocks being tagged as inputs or outputs.