### PR TITLE
verilog_parser: fix missing is_signed attribute in type_atom

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -1491,10 +1491,10 @@ enum_base_type: type_atom type_signing
 	| %empty			{ astbuf1->is_reg = true; addRange(astbuf1); }
 	;
 
-type_atom: TOK_INTEGER		{ astbuf1->is_reg = true; addRange(astbuf1); }		// 4-state signed
-	|  TOK_INT		{ astbuf1->is_reg = true; addRange(astbuf1); }		// 2-state signed
-	|  TOK_SHORTINT		{ astbuf1->is_reg = true; addRange(astbuf1, 15, 0); }	// 2-state signed
-	|  TOK_BYTE		{ astbuf1->is_reg = true; addRange(astbuf1,  7, 0); }	// 2-state signed
+type_atom: TOK_INTEGER		{ astbuf1->is_reg = true; astbuf1->is_signed = true; addRange(astbuf1); }		// 4-state signed
+	|  TOK_INT		{ astbuf1->is_reg = true; astbuf1->is_signed = true; addRange(astbuf1); }		// 2-state signed
+	|  TOK_SHORTINT		{ astbuf1->is_reg = true; astbuf1->is_signed = true; addRange(astbuf1, 15, 0); }	// 2-state signed
+	|  TOK_BYTE		{ astbuf1->is_reg = true; astbuf1->is_signed = true; addRange(astbuf1,  7, 0); }	// 2-state signed
 	;
 
 type_vec: TOK_REG		{ astbuf1->is_reg   = true; }		// unsigned

--- a/tests/verilog/atom_type_signedness.ys
+++ b/tests/verilog/atom_type_signedness.ys
@@ -1,0 +1,19 @@
+read_verilog -dump_ast1 -dump_ast2 -sv <<EOT
+module dut();
+
+enum integer  { uInteger  = -10 } a;
+enum int      { uInt      = -11 } b;
+enum shortint { uShortInt = -12 } c;
+enum byte     { uByte     = -13 } d;
+
+always_comb begin
+  assert(-10 == uInteger);
+  assert(-11 == uInt);
+  assert(-12 == uShortInt);
+  assert(-13 == uByte);
+end
+endmodule
+EOT
+hierarchy; proc; opt
+select -module dut
+sat -verify -seq 1 -tempinduct -prove-asserts -show-all


### PR DESCRIPTION
This PR adds missing ``is_signed`` attribute in ``type_atom``.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>