### PR TITLE
verilog: support recursive functions using ternary expressions

### DIFF
--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -270,6 +270,9 @@ namespace AST
 		bool is_simple_const_expr();
 		std::string process_format_str(const std::string &sformat, int next_arg, int stage, int width_hint, bool sign_hint);
 
+		bool is_recursive_function() const;
+		std::pair<AstNode*, AstNode*> get_tern_choice();
+
 		// create a human-readable text representation of the AST (for debugging)
 		void dumpAst(FILE *f, std::string indent) const;
 		void dumpVlog(FILE *f, std::string indent) const;

--- a/tests/various/fib_tern.v
+++ b/tests/various/fib_tern.v
@@ -1,0 +1,70 @@
+module gate(
+    off, fib0, fib1, fib2, fib3, fib4, fib5, fib6, fib7, fib8, fib9
+);
+    input wire signed [31:0] off;
+
+    function automatic blah(
+        input x
+    );
+        blah = x;
+    endfunction
+
+    function automatic integer fib(
+        input integer k
+    );
+        fib = k == 0
+                ? 0
+                : k == 1
+                    ? 1
+                    : fib(k - 1) + fib(k - 2);
+    endfunction
+
+    function automatic integer fib_wrap(
+        input integer k,
+        output integer o
+    );
+        o = off + fib(k);
+    endfunction
+
+    output integer fib0;
+    output integer fib1;
+    output integer fib2;
+    output integer fib3;
+    output integer fib4;
+    output integer fib5;
+    output integer fib6;
+    output integer fib7;
+    output integer fib8;
+    output integer fib9;
+
+    initial begin : blk
+        integer unused;
+        unused = fib_wrap(0, fib0);
+        unused = fib_wrap(1, fib1);
+        unused = fib_wrap(2, fib2);
+        unused = fib_wrap(3, fib3);
+        unused = fib_wrap(4, fib4);
+        unused = fib_wrap(5, fib5);
+        unused = fib_wrap(6, fib6);
+        unused = fib_wrap(7, fib7);
+        unused = fib_wrap(8, fib8);
+        unused = fib_wrap(9, fib9);
+    end
+endmodule
+
+module gold(
+    off, fib0, fib1, fib2, fib3, fib4, fib5, fib6, fib7, fib8, fib9
+);
+    input wire signed [31:0] off;
+
+    output integer fib0 = off + 0;
+    output integer fib1 = off + 1;
+    output integer fib2 = off + 1;
+    output integer fib3 = off + 2;
+    output integer fib4 = off + 3;
+    output integer fib5 = off + 5;
+    output integer fib6 = off + 8;
+    output integer fib7 = off + 13;
+    output integer fib8 = off + 21;
+    output integer fib9 = off + 34;
+endmodule

--- a/tests/various/fib_tern.ys
+++ b/tests/various/fib_tern.ys
@@ -1,0 +1,6 @@
+read_verilog fib_tern.v
+hierarchy
+proc
+equiv_make gold gate equiv
+equiv_simple
+equiv_status -assert


### PR DESCRIPTION
This adds a mechanism for marking certain portions of elaboration as occurring within unevaluated ternary branches. To enable elaboration of the overall ternary, this also adds width detection for these unelaborated function calls.

While this implementation is meant to be low-impact for prior inputs, I do think the introduction of `unevaluated_tern_branch` is not necessarily ideal. I'm eager for any feedback or alternative suggestions.

This fixes #247 (the original example uses a ternary in this way).