### PR TITLE
verilog: error on macro invocations with missing argument lists

### DIFF
--- a/frontends/verilog/preproc.cc
+++ b/frontends/verilog/preproc.cc
@@ -477,7 +477,16 @@ static bool try_expand_macro(define_map_t &defines, std::string &tok)
 	std::string name = tok.substr(1);
 	std::string skipped_spaces = skip_spaces();
 	tok = next_token(false);
-	if (tok == "(" && body->has_args) {
+	if (body->has_args) {
+		if (tok != "(") {
+			if (tok.size() == 1 && iscntrl(tok[0])) {
+				char buf[5];
+				snprintf(buf, sizeof(buf), "\\x%02x", tok[0]);
+				tok = buf;
+			}
+			log_error("Expected to find '(' to begin macro arguments for '%s', but instead found '%s'\n",
+				name.c_str(), tok.c_str());
+		}
 		std::vector<std::string> args;
 		bool done = false;
 		while (!done) {

--- a/tests/verilog/macro_unapplied.ys
+++ b/tests/verilog/macro_unapplied.ys
@@ -1,0 +1,17 @@
+logger -expect-no-warnings
+read_verilog -sv <<EOT
+`define MACRO(a = 1, b = 2) initial $display("MACRO(a = %d, b = %d)", a, b)
+module top;
+    `MACRO();
+endmodule
+EOT
+
+design -reset
+
+logger -expect error "Expected to find '\(' to begin macro arguments for 'MACRO', but instead found ';'" 1
+read_verilog -sv <<EOT
+`define MACRO(a = 1, b = 2) initial $display("MACRO(a = %d, b = %d)", a, b)
+module top;
+    `MACRO;
+endmodule
+EOT

--- a/tests/verilog/macro_unapplied_newline.ys
+++ b/tests/verilog/macro_unapplied_newline.ys
@@ -1,0 +1,5 @@
+logger -expect error "Expected to find '\(' to begin macro arguments for 'foo', but instead found '\\x0a'" 1
+read_verilog -sv <<EOT
+`define foo(a=1) (a)
+`foo
+EOT


### PR DESCRIPTION
This would previously complain about an undefined internal macro if the unapplied macro had not already been used. If it had, it would incorrectly use the arguments from the previous invocation.

@rswarbrick 