### PR TITLE
Adds is_wire to SigBit and SigChunk

### DIFF
--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -735,7 +735,7 @@ struct RTLIL::SigChunk
 
 	RTLIL::SigChunk extract(int offset, int length) const;
 	inline int size() const { return width; }
-	inline int is_wire() const { return wire != NULL; }
+	inline bool is_wire() const { return wire != NULL; }
 
 	bool operator <(const RTLIL::SigChunk &other) const;
 	bool operator ==(const RTLIL::SigChunk &other) const;
@@ -761,7 +761,7 @@ struct RTLIL::SigBit
 	SigBit(const RTLIL::SigBit &sigbit) = default;
 	RTLIL::SigBit &operator =(const RTLIL::SigBit &other) = default;
 
-	inline int is_wire() const { return wire != NULL; }
+	inline bool is_wire() const { return wire != NULL; }
 
 	bool operator <(const RTLIL::SigBit &other) const;
 	bool operator ==(const RTLIL::SigBit &other) const;

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -735,6 +735,7 @@ struct RTLIL::SigChunk
 
 	RTLIL::SigChunk extract(int offset, int length) const;
 	inline int size() const { return width; }
+	inline int is_wire() const { return wire != NULL; }
 
 	bool operator <(const RTLIL::SigChunk &other) const;
 	bool operator ==(const RTLIL::SigChunk &other) const;
@@ -759,6 +760,8 @@ struct RTLIL::SigBit
 	SigBit(const RTLIL::SigSpec &sig);
 	SigBit(const RTLIL::SigBit &sigbit) = default;
 	RTLIL::SigBit &operator =(const RTLIL::SigBit &other) = default;
+
+	inline int is_wire() const { return wire != NULL; }
 
 	bool operator <(const RTLIL::SigBit &other) const;
 	bool operator ==(const RTLIL::SigBit &other) const;


### PR DESCRIPTION
Useful for PYOSYS because Python can't easily check wire against NULL.