### PR TITLE
assertpmux: Fix crash on unused $pmux output.

### DIFF
--- a/passes/sat/assertpmux.cc
+++ b/passes/sat/assertpmux.cc
@@ -88,7 +88,7 @@ struct AssertpmuxWorker
 		{
 			SigSpec output;
 
-			for (auto muxuser : sigbit_muxusers.at(bit))
+			for (auto muxuser : sigbit_muxusers[bit])
 			{
 				Cell *cell = std::get<0>(muxuser);
 				int portidx = std::get<1>(muxuser);

--- a/tests/sat/bug2595.ys
+++ b/tests/sat/bug2595.ys
@@ -1,0 +1,18 @@
+read_ilang <<EOT
+module \top
+  wire input 3 \A
+  wire width 2 input 2 \B
+  wire width 2 input 1 \S
+  wire \Y
+  cell $pmux \my_pmux
+    parameter signed \S_WIDTH 2
+    parameter signed \WIDTH 1
+    connect \A \A
+    connect \B \B
+    connect \S \S
+    connect \Y \Y
+  end
+end
+EOT
+
+assertpmux


### PR DESCRIPTION
Fixes #2595.