### PR TITLE
Add $countbits, $countones, $isunknown, $onehot and $onehot0 functions

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -3148,6 +3148,34 @@ skip_dynamic_range_lvalue_expansion:;
 				goto apply_newNode;
 			}
 
+			if (str == "\\$countones" || str == "\\$isunknown" || str == "\\$onehot" || str == "\\$onehot0") {
+				if (children.size() != 1)
+					log_file_error(filename, location.first_line, "System function %s got %d arguments, expected 1.\n",
+							RTLIL::unescape_id(str).c_str(), int(children.size()));
+
+				AstNode *countbits = clone();
+				countbits->str = "\\$countbits";
+
+				if (str == "\\$countones") {
+					countbits->children.push_back(mkconst_bits({RTLIL::State::S1}, false));
+					newNode = countbits;
+				} else if (str == "\\$isunknown") {
+					countbits->children.push_back(mkconst_bits({RTLIL::Sx}, false));
+					countbits->children.push_back(mkconst_bits({RTLIL::Sz}, false));
+					newNode = new AstNode(AST_GT, countbits, mkconst_int(0, false));
+				} else if (str == "\\$onehot") {
+					countbits->children.push_back(mkconst_bits({RTLIL::State::S1}, false));
+					newNode = new AstNode(AST_EQ, countbits, mkconst_int(1, false));
+				} else if (str == "\\$onehot0") {
+					countbits->children.push_back(mkconst_bits({RTLIL::State::S1}, false));
+					newNode = new AstNode(AST_LE, countbits, mkconst_int(1, false));
+				} else {
+					log_abort();
+				}
+
+				goto apply_newNode;
+			}
+
 			if (current_scope.count(str) != 0 && current_scope[str]->type == AST_DPI_FUNCTION)
 			{
 				AstNode *dpi_decl = current_scope[str];

--- a/tests/various/countbits.sv
+++ b/tests/various/countbits.sv
@@ -1,0 +1,69 @@
+module top;
+
+	assert property ($countbits(15'b011xxxxzzzzzzzz, '0            ) ==  1);
+	assert property ($countbits(15'b011xxxxzzzzzzzz, '1            ) ==  2);
+	assert property ($countbits(15'b011xxxxzzzzzzzz, 'x            ) ==  4);
+	assert property ($countbits(15'b011xxxxzzzzzzzz, 'z            ) ==  8);
+	assert property ($countbits(15'b011xxxxzzzzzzzz, '0, '1        ) ==  3);
+	assert property ($countbits(15'b011xxxxzzzzzzzz, '1, '1, '0    ) ==  3);
+	assert property ($countbits(15'b011xxxxzzzzzzzz, '0, 'x        ) ==  5);
+	assert property ($countbits(15'b011xxxxzzzzzzzz, '0, 'z        ) ==  9);
+	assert property ($countbits(15'bz1x10xzxzzxzzzz, '0, 'z        ) ==  9);
+	assert property ($countbits(15'b011xxxxzzzzzzzz, 'x, 'z        ) == 12);
+	assert property ($countbits(15'b011xxxxzzzzzzzz, '1, 'z        ) == 10);
+	assert property ($countbits(15'b011xxxxzzzzzzzz, '1, 'x, 'z    ) == 14);
+	assert property ($countbits(15'b011xxxxzzzzzzzz, '1, 'x, 'z, '0) == 15);
+
+	assert property ($countbits(0,      '0) == 32); // test integers
+	assert property ($countbits(0,      '1) ==  0);
+	assert property ($countbits(80'b0,  '0) == 80); // test something bigger than integer
+	assert property ($countbits(80'bx0, 'x) == 79);
+
+	always_comb begin
+		logic       one;
+		logic [1:0] two;
+		logic [3:0] four;
+
+		// Make sure that the width of the whole expression doesn't affect the width of the shift
+		// operations inside the function.
+		one  = $countbits(3'b100, '1) & 1'b1;
+		two  = $countbits(3'b111, '1) & 2'b11;
+		four = $countbits(3'b111, '1) & 4'b1111;
+
+		assert (one  == 1);
+		assert (two  == 3);
+		assert (four == 3);
+	end
+
+	assert property ($countones(8'h00) == 0);
+	assert property ($countones(8'hff) == 8);
+	assert property ($countones(8'ha5) == 4);
+	assert property ($countones(8'h13) == 3);
+
+	logic       test1 = 1'b1;
+	logic [4:0] test5 = 5'b10101;
+
+	assert property ($countones(test1) == 1);
+	assert property ($countones(test5) == 3);
+
+	assert property ($isunknown(8'h00) == 0);
+	assert property ($isunknown(8'hff) == 0);
+	assert property ($isunknown(8'hx0) == 1);
+	assert property ($isunknown(8'h1z) == 1);
+	assert property ($isunknown(8'hxz) == 1);
+
+	assert property ($onehot(8'h00) == 0);
+	assert property ($onehot(8'hff) == 0);
+	assert property ($onehot(8'h01) == 1);
+	assert property ($onehot(8'h80) == 1);
+	assert property ($onehot(8'h81) == 0);
+	assert property ($onehot(8'h20) == 1);
+
+	assert property ($onehot0(8'h00) == 1);
+	assert property ($onehot0(8'hff) == 0);
+	assert property ($onehot0(8'h01) == 1);
+	assert property ($onehot0(8'h80) == 1);
+	assert property ($onehot0(8'h81) == 0);
+	assert property ($onehot0(8'h20) == 1);
+
+endmodule

--- a/tests/various/countbits.ys
+++ b/tests/various/countbits.ys
@@ -1,0 +1,7 @@
+read_verilog -sv countbits.sv
+hierarchy
+proc
+flatten
+opt -full
+select -module top
+sat -verify -seq 1 -tempinduct -prove-asserts -show-all


### PR DESCRIPTION
I have implemented those functions so I can write
`assert ($onehot0(foo[2:0]));`
instead of
`assert (foo[0] + foo[1] + foo[2] <= 1);`

`$countbits(foo, 'z)` doesn't really work and `$countbits(foo, 'x)` counts both `'x` and `'z`. I guess this is because `'1&'z` results in `'x` and not `'z`. I hope this is okay.

I think that some test cases would be good, but before I take a look at that, I wanted to check if you are interested to merge this and if my code is acceptable or if I messed something up. I'm not sure about `children.size()`. It was written as `GetSize(children)` at other places I think. Is there a preference?