### PR TITLE
Add memory writes to processes.

### DIFF
--- a/backends/rtlil/rtlil_backend.cc
+++ b/backends/rtlil/rtlil_backend.cc
@@ -242,11 +242,28 @@ void RTLIL_BACKEND::dump_proc_sync(std::ostream &f, std::string indent, const RT
 	case RTLIL::STi: f << stringf("init\n"); break;
 	}
 
-	for (auto it = sy->actions.begin(); it != sy->actions.end(); ++it) {
+	for (auto &it: sy->actions) {
 		f << stringf("%s  update ", indent.c_str());
-		dump_sigspec(f, it->first);
+		dump_sigspec(f, it.first);
 		f << stringf(" ");
-		dump_sigspec(f, it->second);
+		dump_sigspec(f, it.second);
+		f << stringf("\n");
+	}
+
+	for (auto &it: sy->mem_write_actions) {
+		for (auto it2 = it.attributes.begin(); it2 != it.attributes.end(); ++it2) {
+			f << stringf("%s  attribute %s ", indent.c_str(), it2->first.c_str());
+			dump_const(f, it2->second);
+			f << stringf("\n");
+		}
+		f << stringf("%s  memwr %s ", indent.c_str(), it.memid.c_str());
+		dump_sigspec(f, it.address);
+		f << stringf(" ");
+		dump_sigspec(f, it.data);
+		f << stringf(" ");
+		dump_sigspec(f, it.enable);
+		f << stringf(" ");
+		dump_sigspec(f, it.priority_mask);
 		f << stringf("\n");
 	}
 }

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -54,6 +54,8 @@ namespace AST_INTERNAL {
 	AstNode *current_always, *current_top_block, *current_block, *current_block_child;
 	AstModule *current_module;
 	bool current_always_clocked;
+	dict<std::string, int> current_memwr_count;
+	dict<std::string, pool<int>> current_memwr_visible;
 }
 
 // convert node types to string

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -381,6 +381,8 @@ namespace AST_INTERNAL
 	extern AST::AstNode *current_always, *current_top_block, *current_block, *current_block_child;
 	extern AST::AstModule *current_module;
 	extern bool current_always_clocked;
+	extern dict<std::string, int> current_memwr_count;
+	extern dict<std::string, pool<int>> current_memwr_visible;
 	struct LookaheadRewriter;
 	struct ProcessGenerator;
 }

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1217,6 +1217,14 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 		}
 	}
 
+	dict<std::string, pool<int>> backup_memwr_visible;
+	dict<std::string, pool<int>> final_memwr_visible;
+
+	if (type == AST_CASE && stage == 2) {
+		backup_memwr_visible = current_memwr_visible;
+		final_memwr_visible = current_memwr_visible;
+	}
+
 	// simplify all children first
 	// (iterate by index as e.g. auto wires can add new children in the process)
 	for (size_t i = 0; i < children.size(); i++) {
@@ -1279,10 +1287,24 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 		}
 		flag_autowire = backup_flag_autowire;
 		unevaluated_tern_branch = backup_unevaluated_tern_branch;
+		if (stage == 2 && type == AST_CASE) {
+			for (auto &x : current_memwr_visible) {
+				for (int y : x.second)
+					final_memwr_visible[x.first].insert(y);
+			}
+			current_memwr_visible = backup_memwr_visible;
+		}
 	}
 	for (auto &attr : attributes) {
 		while (attr.second->simplify(true, false, false, stage, -1, false, true))
 			did_something = true;
+	}
+	if (type == AST_CASE && stage == 2) {
+		current_memwr_visible = final_memwr_visible;
+	}
+	if (type == AST_ALWAYS && stage == 2) {
+		current_memwr_visible.clear();
+		current_memwr_count.clear();
 	}
 
 	if (reset_width_after_children) {
@@ -2570,12 +2592,12 @@ skip_dynamic_range_lvalue_expansion:;
 			current_scope[wire_addr->str] = wire_addr;
 			while (wire_addr->simplify(true, false, false, 1, -1, false, false)) { }
 
-			AstNode *assign_addr = new AstNode(AST_ASSIGN_LE, new AstNode(AST_IDENTIFIER), mkconst_bits(x_bits_addr, false));
+			AstNode *assign_addr = new AstNode(AST_ASSIGN_EQ, new AstNode(AST_IDENTIFIER), mkconst_bits(x_bits_addr, false));
 			assign_addr->children[0]->str = id_addr;
 			assign_addr->children[0]->was_checked = true;
 			defNode->children.push_back(assign_addr);
 
-			assign_addr = new AstNode(AST_ASSIGN_LE, new AstNode(AST_IDENTIFIER), children[0]->children[0]->children[0]->clone());
+			assign_addr = new AstNode(AST_ASSIGN_EQ, new AstNode(AST_IDENTIFIER), children[0]->children[0]->children[0]->clone());
 			assign_addr->children[0]->str = id_addr;
 			assign_addr->children[0]->was_checked = true;
 			newNode->children.push_back(assign_addr);
@@ -2596,7 +2618,7 @@ skip_dynamic_range_lvalue_expansion:;
 			current_scope[wire_data->str] = wire_data;
 			while (wire_data->simplify(true, false, false, 1, -1, false, false)) { }
 
-			AstNode *assign_data = new AstNode(AST_ASSIGN_LE, new AstNode(AST_IDENTIFIER), mkconst_bits(x_bits_data, false));
+			AstNode *assign_data = new AstNode(AST_ASSIGN_EQ, new AstNode(AST_IDENTIFIER), mkconst_bits(x_bits_data, false));
 			assign_data->children[0]->str = id_data;
 			assign_data->children[0]->was_checked = true;
 			defNode->children.push_back(assign_data);
@@ -2616,7 +2638,7 @@ skip_dynamic_range_lvalue_expansion:;
 			current_scope[wire_en->str] = wire_en;
 			while (wire_en->simplify(true, false, false, 1, -1, false, false)) { }
 
-			AstNode *assign_en = new AstNode(AST_ASSIGN_LE, new AstNode(AST_IDENTIFIER), mkconst_int(0, false, mem_width));
+			AstNode *assign_en = new AstNode(AST_ASSIGN_EQ, new AstNode(AST_IDENTIFIER), mkconst_int(0, false, mem_width));
 			assign_en->children[0]->str = id_en;
 			assign_en->children[0]->was_checked = true;
 			defNode->children.push_back(assign_en);
@@ -2642,7 +2664,7 @@ skip_dynamic_range_lvalue_expansion:;
 
 				std::vector<RTLIL::State> padding_x(offset, RTLIL::State::Sx);
 
-				assign_data = new AstNode(AST_ASSIGN_LE, new AstNode(AST_IDENTIFIER),
+				assign_data = new AstNode(AST_ASSIGN_EQ, new AstNode(AST_IDENTIFIER),
 						new AstNode(AST_CONCAT, mkconst_bits(padding_x, false), children[1]->clone()));
 				assign_data->children[0]->str = id_data;
 				assign_data->children[0]->was_checked = true;
@@ -2650,7 +2672,7 @@ skip_dynamic_range_lvalue_expansion:;
 				if (current_always->type != AST_INITIAL) {
 					for (int i = 0; i < mem_width; i++)
 						set_bits_en[i] = offset <= i && i < offset+width ? RTLIL::State::S1 : RTLIL::State::S0;
-					assign_en = new AstNode(AST_ASSIGN_LE, new AstNode(AST_IDENTIFIER), mkconst_bits(set_bits_en, false));
+					assign_en = new AstNode(AST_ASSIGN_EQ, new AstNode(AST_IDENTIFIER), mkconst_bits(set_bits_en, false));
 					assign_en->children[0]->str = id_en;
 					assign_en->children[0]->was_checked = true;
 				}
@@ -2671,7 +2693,7 @@ skip_dynamic_range_lvalue_expansion:;
 					log_file_error(filename, location.first_line, "Unsupported expression on dynamic range select on signal `%s'!\n", str.c_str());
 				int width = abs(int(left_at_zero_ast->integer - right_at_zero_ast->integer)) + 1;
 
-				assign_data = new AstNode(AST_ASSIGN_LE, new AstNode(AST_IDENTIFIER),
+				assign_data = new AstNode(AST_ASSIGN_EQ, new AstNode(AST_IDENTIFIER),
 						new AstNode(AST_SHIFT_LEFT, children[1]->clone(), offset_ast->clone()));
 				assign_data->children[0]->str = id_data;
 				assign_data->children[0]->was_checked = true;
@@ -2679,7 +2701,7 @@ skip_dynamic_range_lvalue_expansion:;
 				if (current_always->type != AST_INITIAL) {
 					for (int i = 0; i < mem_width; i++)
 						set_bits_en[i] = i < width ? RTLIL::State::S1 : RTLIL::State::S0;
-					assign_en = new AstNode(AST_ASSIGN_LE, new AstNode(AST_IDENTIFIER),
+					assign_en = new AstNode(AST_ASSIGN_EQ, new AstNode(AST_IDENTIFIER),
 							new AstNode(AST_SHIFT_LEFT, mkconst_bits(set_bits_en, false), offset_ast->clone()));
 					assign_en->children[0]->str = id_en;
 					assign_en->children[0]->was_checked = true;
@@ -2693,13 +2715,13 @@ skip_dynamic_range_lvalue_expansion:;
 		else
 		{
 			if (!(children[0]->children.size() == 1 && children[1]->isConst())) {
-				assign_data = new AstNode(AST_ASSIGN_LE, new AstNode(AST_IDENTIFIER), children[1]->clone());
+				assign_data = new AstNode(AST_ASSIGN_EQ, new AstNode(AST_IDENTIFIER), children[1]->clone());
 				assign_data->children[0]->str = id_data;
 				assign_data->children[0]->was_checked = true;
 			}
 
 			if (current_always->type != AST_INITIAL) {
-				assign_en = new AstNode(AST_ASSIGN_LE, new AstNode(AST_IDENTIFIER), mkconst_bits(set_bits_en, false));
+				assign_en = new AstNode(AST_ASSIGN_EQ, new AstNode(AST_IDENTIFIER), mkconst_bits(set_bits_en, false));
 				assign_en->children[0]->str = id_en;
 				assign_en->children[0]->was_checked = true;
 			}
@@ -2712,7 +2734,21 @@ skip_dynamic_range_lvalue_expansion:;
 		AstNode *wrnode = new AstNode(current_always->type == AST_INITIAL ? AST_MEMINIT : AST_MEMWR, node_addr, node_data, node_en);
 		wrnode->str = children[0]->str;
 		wrnode->id2ast = children[0]->id2ast;
-		current_ast_mod->children.push_back(wrnode);
+		wrnode->location = location;
+		if (wrnode->type == AST_MEMWR) {
+			int portid = current_memwr_count[wrnode->str]++;
+			wrnode->children.push_back(mkconst_int(portid, false));
+			std::vector<RTLIL::State> priority_mask;
+			for (int i = 0; i < portid; i++) {
+				bool has_prio = current_memwr_visible[wrnode->str].count(i);
+				priority_mask.push_back(State(has_prio));
+			}
+			wrnode->children.push_back(mkconst_bits(priority_mask, false));
+			current_memwr_visible[wrnode->str].insert(portid);
+			current_always->children.push_back(wrnode);
+		} else {
+			current_ast_mod->children.push_back(wrnode);
+		}
 
 		if (newNode->children.empty()) {
 			delete newNode;

--- a/frontends/rtlil/rtlil_lexer.l
+++ b/frontends/rtlil/rtlil_lexer.l
@@ -79,6 +79,7 @@ USING_YOSYS_NAMESPACE
 "global"	{ return TOK_GLOBAL; }
 "init"		{ return TOK_INIT; }
 "update"	{ return TOK_UPDATE; }
+"memwr"		{ return TOK_MEMWR; }
 "process"	{ return TOK_PROCESS; }
 "end"		{ return TOK_END; }
 

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -4538,6 +4538,7 @@ RTLIL::SyncRule *RTLIL::SyncRule::clone() const
 	new_syncrule->type = type;
 	new_syncrule->signal = signal;
 	new_syncrule->actions = actions;
+	new_syncrule->mem_write_actions = mem_write_actions;
 	return new_syncrule;
 }
 

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -69,6 +69,7 @@ namespace RTLIL
 	struct SigSpec;
 	struct CaseRule;
 	struct SwitchRule;
+	struct MemWriteAction;
 	struct SyncRule;
 	struct Process;
 
@@ -1541,11 +1542,21 @@ struct RTLIL::SwitchRule : public RTLIL::AttrObject
 	RTLIL::SwitchRule *clone() const;
 };
 
+struct RTLIL::MemWriteAction : RTLIL::AttrObject
+{
+	RTLIL::IdString memid;
+	RTLIL::SigSpec address;
+	RTLIL::SigSpec data;
+	RTLIL::SigSpec enable;
+	RTLIL::Const priority_mask;
+};
+
 struct RTLIL::SyncRule
 {
 	RTLIL::SyncType type;
 	RTLIL::SigSpec signal;
 	std::vector<RTLIL::SigSig> actions;
+	std::vector<RTLIL::MemWriteAction> mem_write_actions;
 
 	template<typename T> void rewrite_sigspecs(T &functor);
 	template<typename T> void rewrite_sigspecs2(T &functor);
@@ -1693,6 +1704,11 @@ void RTLIL::SyncRule::rewrite_sigspecs(T &functor)
 		functor(it.first);
 		functor(it.second);
 	}
+	for (auto &it : mem_write_actions) {
+		functor(it.address);
+		functor(it.data);
+		functor(it.enable);
+	}
 }
 
 template<typename T>
@@ -1701,6 +1717,11 @@ void RTLIL::SyncRule::rewrite_sigspecs2(T &functor)
 	functor(signal);
 	for (auto &it : actions) {
 		functor(it.first, it.second);
+	}
+	for (auto &it : mem_write_actions) {
+		functor(it.address);
+		functor(it.data);
+		functor(it.enable);
 	}
 }
 

--- a/manual/CHAPTER_Overview.tex
+++ b/manual/CHAPTER_Overview.tex
@@ -350,8 +350,9 @@ to update {\tt \textbackslash{}q}.
 An RTLIL::Process is a container for zero or more RTLIL::SyncRule objects and
 exactly one RTLIL::CaseRule object, which is called the {\it root case}.
 
-An RTLIL::SyncRule object contains an (optional) synchronization condition (signal and edge-type) and zero or
-more assignments (RTLIL::SigSig). The {\tt always} synchronization condition is used to break combinatorial
+An RTLIL::SyncRule object contains an (optional) synchronization condition (signal and edge-type), zero or
+more assignments (RTLIL::SigSig), and zero or more memory writes (RTLIL::MemWriteAction).
+The {\tt always} synchronization condition is used to break combinatorial
 loops when a latch should be inferred instead.
 
 An RTLIL::CaseRule is a container for zero or more assignments (RTLIL::SigSig)

--- a/manual/CHAPTER_Verilog.tex
+++ b/manual/CHAPTER_Verilog.tex
@@ -503,6 +503,8 @@ signal to the temporary signal in its \lstinline[language=C++]{RTLIL::CaseRule}/
 \item Finally a \lstinline[language=C++]{RTLIL::SyncRule} is created for the \lstinline[language=C++]{RTLIL::Process} that
 assigns the temporary signals for the final values to the actual signals.
 %
+\item A process may also contain memory writes. A \lstinline[language=C++]{RTLIL::MemWriteAction} is created for each of them.
+%
 \item Calls to \lstinline[language=C++]{AST::AstNode::genRTLIL()} are generated for right hand sides as needed. When blocking
 assignments are used, \lstinline[language=C++]{AST::AstNode::genRTLIL()} is configured using global variables to use
 the temporary signals that hold the correct intermediate values whenever one of the previously assigned signals is used
@@ -820,6 +822,9 @@ the \C{RTLIL::SyncRule}s that describe the output registers.
 \item {\tt proc\_dff} \\
 This pass replaces the \C{RTLIL::SyncRule}s to d-type flip-flops (with
 asynchronous resets if necessary).
+%
+\item {\tt proc\_dff} \\
+This pass replaces the \C{RTLIL::MemWriteActions}s with {\tt \$memwr} cells.
 %
 \item {\tt proc\_clean} \\
 A final call to {\tt proc\_clean} removes the now empty \C{RTLIL::Process} objects.

--- a/passes/cmds/bugpoint.cc
+++ b/passes/cmds/bugpoint.cc
@@ -339,6 +339,23 @@ struct BugpointPass : public Pass {
 								return design_copy;
 							}
 						}
+						int i = 0;
+						for (auto it = sy->mem_write_actions.begin(); it != sy->mem_write_actions.end(); ++it, ++i)
+						{
+							if (index++ == seed)
+							{
+								log_header(design, "Trying to remove sync %s memwr %s %s %s %s in %s.%s.\n", log_signal(sy->signal), log_id(it->memid), log_signal(it->address), log_signal(it->data), log_signal(it->enable), log_id(mod), log_id(pr.first));
+								sy->mem_write_actions.erase(it);
+								// Remove the bit for removed action from other actions' priority masks.
+								for (auto it2 = sy->mem_write_actions.begin(); it2 != sy->mem_write_actions.end(); ++it2) {
+									auto &mask = it2->priority_mask;
+									if (GetSize(mask) > i) {
+										mask.bits.erase(mask.bits.begin() + i);
+									}
+								}
+								return design_copy;
+							}
+						}
 					}
 				}
 			}

--- a/passes/cmds/check.cc
+++ b/passes/cmds/check.cc
@@ -141,6 +141,14 @@ struct CheckPass : public Pass {
 						for (auto bit : sigmap(action.second))
 							if (bit.wire) used_wires.insert(bit);
 					}
+					for (auto memwr : sync->mem_write_actions) {
+						for (auto bit : sigmap(memwr.address))
+							if (bit.wire) used_wires.insert(bit);
+						for (auto bit : sigmap(memwr.data))
+							if (bit.wire) used_wires.insert(bit);
+						for (auto bit : sigmap(memwr.enable))
+							if (bit.wire) used_wires.insert(bit);
+					}
 				}
 			}
 

--- a/passes/cmds/show.cc
+++ b/passes/cmds/show.cc
@@ -339,6 +339,11 @@ struct ShowWorker
 	{
 		input_signals.insert(obj->signal);
 		collect_proc_signals(obj->actions, input_signals, output_signals);
+		for (auto it : obj->mem_write_actions) {
+			input_signals.insert(it.address);
+			input_signals.insert(it.data);
+			input_signals.insert(it.enable);
+		}
 	}
 
 	void collect_proc_signals(RTLIL::Process *obj, std::set<RTLIL::SigSpec> &input_signals, std::set<RTLIL::SigSpec> &output_signals)

--- a/passes/memory/memory.cc
+++ b/passes/memory/memory.cc
@@ -36,7 +36,7 @@ struct MemoryPass : public Pass {
 		log("This pass calls all the other memory_* passes in a useful order:\n");
 		log("\n");
 		log("    opt_mem\n");
-		log("    memory_dff [-nordff]                (-memx implies -nordff)\n");
+		log("    memory_dff                          (skipped if called with -nordff or -memx)\n");
 		log("    opt_clean\n");
 		log("    memory_share\n");
 		log("    opt_clean\n");
@@ -83,7 +83,8 @@ struct MemoryPass : public Pass {
 		extra_args(args, argidx, design);
 
 		Pass::call(design, "opt_mem");
-		Pass::call(design, flag_nordff ? "memory_dff -nordff" : "memory_dff");
+		if (!flag_nordff)
+			Pass::call(design, "memory_dff");
 		Pass::call(design, "opt_clean");
 		Pass::call(design, "memory_share");
 		if (flag_memx)

--- a/passes/memory/memory_nordff.cc
+++ b/passes/memory/memory_nordff.cc
@@ -33,7 +33,7 @@ struct MemoryNordffPass : public Pass {
 		log("    memory_nordff [options] [selection]\n");
 		log("\n");
 		log("This pass extracts FFs from memory read ports. This results in a netlist\n");
-		log("similar to what one would get from calling memory_dff with -nordff.\n");
+		log("similar to what one would get from not calling memory_dff.\n");
 		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override

--- a/passes/proc/Makefile.inc
+++ b/passes/proc/Makefile.inc
@@ -8,3 +8,4 @@ OBJS += passes/proc/proc_arst.o
 OBJS += passes/proc/proc_mux.o
 OBJS += passes/proc/proc_dlatch.o
 OBJS += passes/proc/proc_dff.o
+OBJS += passes/proc/proc_memwr.o

--- a/passes/proc/proc.cc
+++ b/passes/proc/proc.cc
@@ -43,6 +43,7 @@ struct ProcPass : public Pass {
 		log("    proc_mux\n");
 		log("    proc_dlatch\n");
 		log("    proc_dff\n");
+		log("    proc_memwr\n");
 		log("    proc_clean\n");
 		log("\n");
 		log("This replaces the processes in the design with multiplexers,\n");
@@ -102,6 +103,7 @@ struct ProcPass : public Pass {
 			Pass::call(design, ifxmode ? "proc_mux -ifx" : "proc_mux");
 		Pass::call(design, "proc_dlatch");
 		Pass::call(design, "proc_dff");
+		Pass::call(design, "proc_memwr");
 		Pass::call(design, "proc_clean");
 
 		log_pop();

--- a/passes/proc/proc_arst.cc
+++ b/passes/proc/proc_arst.cc
@@ -153,6 +153,30 @@ void eliminate_const(RTLIL::Module *mod, RTLIL::CaseRule *cs, RTLIL::SigSpec con
 	}
 }
 
+RTLIL::SigSpec apply_reset(RTLIL::Module *mod, RTLIL::Process *proc, RTLIL::SyncRule *sync, SigMap &assign_map, RTLIL::SigSpec root_sig, bool polarity, RTLIL::SigSpec sig, RTLIL::SigSpec log_sig) {
+	RTLIL::SigSpec rspec = assign_map(sig);
+	RTLIL::SigSpec rval = RTLIL::SigSpec(RTLIL::State::Sm, rspec.size());
+	for (int i = 0; i < GetSize(rspec); i++)
+		if (rspec[i].wire == NULL)
+			rval[i] = rspec[i];
+	RTLIL::SigSpec last_rval;
+	for (int count = 0; rval != last_rval; count++) {
+		last_rval = rval;
+		apply_const(mod, rspec, rval, &proc->root_case, root_sig, polarity, false);
+		assign_map.apply(rval);
+		if (rval.is_fully_const())
+			break;
+		if (count > 100)
+			log_error("Async reset %s yields endless loop at value %s for signal %s.\n",
+					log_signal(sync->signal), log_signal(rval), log_signal(log_sig));
+		rspec = rval;
+	}
+	if (rval.has_marked_bits())
+		log_error("Async reset %s yields non-constant value %s for signal %s.\n",
+				log_signal(sync->signal), log_signal(rval), log_signal(log_sig));
+	return rval;
+}
+
 void proc_arst(RTLIL::Module *mod, RTLIL::Process *proc, SigMap &assign_map)
 {
 restart_proc_arst:
@@ -172,28 +196,18 @@ restart_proc_arst:
 					sync->type = sync->type == RTLIL::SyncType::STp ? RTLIL::SyncType::ST1 : RTLIL::SyncType::ST0;
 				}
 				for (auto &action : sync->actions) {
-					RTLIL::SigSpec rspec = assign_map(action.second);
-					RTLIL::SigSpec rval = RTLIL::SigSpec(RTLIL::State::Sm, rspec.size());
-					for (int i = 0; i < GetSize(rspec); i++)
-						if (rspec[i].wire == NULL)
-							rval[i] = rspec[i];
-					RTLIL::SigSpec last_rval;
-					for (int count = 0; rval != last_rval; count++) {
-						last_rval = rval;
-						apply_const(mod, rspec, rval, &proc->root_case, root_sig, polarity, false);
-						assign_map.apply(rval);
-						if (rval.is_fully_const())
-							break;
-						if (count > 100)
-							log_error("Async reset %s yields endless loop at value %s for signal %s.\n",
-									log_signal(sync->signal), log_signal(rval), log_signal(action.first));
-						rspec = rval;
-					}
-					if (rval.has_marked_bits())
-						log_error("Async reset %s yields non-constant value %s for signal %s.\n",
-								log_signal(sync->signal), log_signal(rval), log_signal(action.first));
-					action.second = rval;
+					action.second = apply_reset(mod, proc, sync, assign_map, root_sig, polarity, action.second, action.first);
 				}
+				for (auto &memwr : sync->mem_write_actions) {
+					RTLIL::SigSpec en = apply_reset(mod, proc, sync, assign_map, root_sig, polarity, memwr.enable, memwr.enable);
+					if (!en.is_fully_zero()) {
+						log_error("Async reset %s causes memory write to %s.\n",
+								log_signal(sync->signal), log_id(memwr.memid));
+					}
+					apply_reset(mod, proc, sync, assign_map, root_sig, polarity, memwr.address, memwr.address);
+					apply_reset(mod, proc, sync, assign_map, root_sig, polarity, memwr.data, memwr.data);
+				}
+				sync->mem_write_actions.clear();
 				eliminate_const(mod, &proc->root_case, root_sig, polarity);
 				goto restart_proc_arst;
 			}

--- a/passes/proc/proc_clean.cc
+++ b/passes/proc/proc_clean.cc
@@ -161,7 +161,7 @@ void proc_clean(RTLIL::Module *mod, RTLIL::Process *proc, int &total_count, bool
 		for (size_t j = 0; j < proc->syncs[i]->actions.size(); j++)
 			if (proc->syncs[i]->actions[j].first.size() == 0)
 				proc->syncs[i]->actions.erase(proc->syncs[i]->actions.begin() + (j--));
-		if (proc->syncs[i]->actions.size() == 0) {
+		if (proc->syncs[i]->actions.size() == 0 && proc->syncs[i]->mem_write_actions.size() == 0) {
 			delete proc->syncs[i];
 			proc->syncs.erase(proc->syncs.begin() + (i--));
 		}

--- a/passes/proc/proc_dlatch.cc
+++ b/passes/proc/proc_dlatch.cc
@@ -342,7 +342,6 @@ struct proc_dlatch_db_t
 
 void proc_dlatch(proc_dlatch_db_t &db, RTLIL::Process *proc)
 {
-	std::vector<RTLIL::SyncRule*> new_syncs;
 	RTLIL::SigSig latches_bits, nolatches_bits;
 	dict<SigBit, SigBit> latches_out_in;
 	dict<SigBit, int> latches_hold;
@@ -351,7 +350,6 @@ void proc_dlatch(proc_dlatch_db_t &db, RTLIL::Process *proc)
 	for (auto sr : proc->syncs)
 	{
 		if (sr->type != RTLIL::SyncType::STa) {
-			new_syncs.push_back(sr);
 			continue;
 		}
 
@@ -373,8 +371,7 @@ void proc_dlatch(proc_dlatch_db_t &db, RTLIL::Process *proc)
 			for (int i = 0; i < GetSize(ss.first); i++)
 				latches_out_in[ss.first[i]] = ss.second[i];
 		}
-
-		delete sr;
+		sr->actions.clear();
 	}
 
 	latches_out_in.sort();
@@ -441,8 +438,6 @@ void proc_dlatch(proc_dlatch_db_t &db, RTLIL::Process *proc)
 
 		offset += width;
 	}
-
-	new_syncs.swap(proc->syncs);
 }
 
 struct ProcDlatchPass : public Pass {

--- a/passes/proc/proc_init.cc
+++ b/passes/proc/proc_init.cc
@@ -71,17 +71,8 @@ void proc_init(RTLIL::Module *mod, SigMap &sigmap, RTLIL::Process *proc)
 					offset += lhs_c.width;
 				}
 			}
+			sync->actions.clear();
 		}
-
-	if (found_init) {
-		std::vector<RTLIL::SyncRule*> new_syncs;
-		for (auto &sync : proc->syncs)
-			if (sync->type == RTLIL::SyncType::STi)
-				delete sync;
-			else
-				new_syncs.push_back(sync);
-		proc->syncs.swap(new_syncs);
-	}
 }
 
 struct ProcInitPass : public Pass {

--- a/passes/proc/proc_memwr.cc
+++ b/passes/proc/proc_memwr.cc
@@ -1,0 +1,111 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2021  Marcelina Kościelnicka <mwk@0x04.net>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/register.h"
+#include "kernel/sigtools.h"
+#include "kernel/ffinit.h"
+#include "kernel/consteval.h"
+#include "kernel/log.h"
+#include <sstream>
+#include <stdlib.h>
+#include <stdio.h>
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+void proc_memwr(RTLIL::Module *mod, RTLIL::Process *proc, dict<IdString, int> &next_priority)
+{
+	for (auto sr : proc->syncs)
+	{
+		for (auto memwr : sr->mem_write_actions) {
+			RTLIL::Cell *cell = mod->addCell(NEW_ID, ID($memwr));
+			cell->attributes = memwr.attributes;
+			cell->setParam(ID::MEMID, Const(memwr.memid.str()));
+			cell->setParam(ID::ABITS, GetSize(memwr.address));
+			cell->setParam(ID::WIDTH, GetSize(memwr.data));
+			cell->setParam(ID::PRIORITY, next_priority[memwr.memid]++);
+			cell->setPort(ID::ADDR, memwr.address);
+			cell->setPort(ID::DATA, memwr.data);
+			SigSpec enable = memwr.enable;
+			for (auto sr2 : proc->syncs) {
+				if (sr2->type == RTLIL::SyncType::ST0) {
+					log_assert(sr2->mem_write_actions.empty());
+					enable = mod->Mux(NEW_ID, Const(State::S0, GetSize(enable)), enable, sr2->signal);
+				} else if (sr2->type == RTLIL::SyncType::ST1) {
+					log_assert(sr2->mem_write_actions.empty());
+					enable = mod->Mux(NEW_ID, enable, Const(State::S0, GetSize(enable)), sr2->signal);
+				}
+			}
+			cell->setPort(ID::EN, enable);
+			if (sr->type == RTLIL::SyncType::STa) {
+				cell->setPort(ID::CLK, State::Sx);
+				cell->setParam(ID::CLK_ENABLE, State::S0);
+				cell->setParam(ID::CLK_POLARITY, State::Sx);
+			} else if (sr->type == RTLIL::SyncType::STp) {
+				cell->setPort(ID::CLK, sr->signal);
+				cell->setParam(ID::CLK_ENABLE, State::S1);
+				cell->setParam(ID::CLK_POLARITY, State::S1);
+			} else if (sr->type == RTLIL::SyncType::STn) {
+				cell->setPort(ID::CLK, sr->signal);
+				cell->setParam(ID::CLK_ENABLE, State::S1);
+				cell->setParam(ID::CLK_POLARITY, State::S0);
+			} else {
+				log_error("process memory write with unsupported sync type in %s.%s", log_id(mod), log_id(proc));
+			}
+		}
+		sr->mem_write_actions.clear();
+	}
+}
+
+struct ProcMemWrPass : public Pass {
+	ProcMemWrPass() : Pass("proc_memwr", "extract memory writes from processes") { }
+	void help() override
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    proc_memwr [selection]\n");
+		log("\n");
+		log("This pass converts memory writes in processes into $memwr cells.\n");
+		log("\n");
+	}
+	void execute(std::vector<std::string> args, RTLIL::Design *design) override
+	{
+		log_header(design, "Executing PROC_MEMWR pass (convert process memory writes to cells).\n");
+
+		extra_args(args, 1, design);
+
+		for (auto module : design->selected_modules()) {
+			dict<IdString, int> next_priority;
+			for (auto cell : module->cells()) {
+				if (cell->type == ID($memwr)) {
+					IdString memid = cell->parameters.at(ID::MEMID).decode_string();
+					int priority = cell->parameters.at(ID::PRIORITY).as_int();
+					if (priority >= next_priority[memid])
+						next_priority[memid] = priority + 1;
+				}
+			}
+			for (auto &proc_it : module->processes)
+				if (design->selected(module, proc_it.second))
+					proc_memwr(module, proc_it.second, next_priority);
+		}
+	}
+} ProcMemWrPass;
+
+PRIVATE_NAMESPACE_END
+

--- a/techlibs/common/prep.cc
+++ b/techlibs/common/prep.cc
@@ -61,7 +61,7 @@ struct PrepPass : public ScriptPass
 		log("        do not run any of the memory_* passes\n");
 		log("\n");
 		log("    -rdff\n");
-		log("        do not pass -nordff to 'memory_dff'. This enables merging of FFs into\n");
+		log("        call 'memory_dff'. This enables merging of FFs into\n");
 		log("        memory read ports.\n");
 		log("\n");
 		log("    -nokeepdc\n");
@@ -79,7 +79,7 @@ struct PrepPass : public ScriptPass
 	}
 
 	string top_module, fsm_opts;
-	bool autotop, flatten, ifxmode, memxmode, nomemmode, nokeepdc, nordff;
+	bool autotop, flatten, ifxmode, memxmode, nomemmode, nokeepdc, rdff;
 
 	void clear_flags() override
 	{
@@ -91,7 +91,7 @@ struct PrepPass : public ScriptPass
 		memxmode = false;
 		nomemmode = false;
 		nokeepdc = false;
-		nordff = true;
+		rdff = false;
 	}
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
@@ -137,11 +137,11 @@ struct PrepPass : public ScriptPass
 				continue;
 			}
 			if (args[argidx] == "-nordff") {
-				nordff = true;
+				rdff = false;
 				continue;
 			}
 			if (args[argidx] == "-rdff") {
-				nordff = false;
+				rdff = true;
 				continue;
 			}
 			if (args[argidx] == "-nokeepdc") {
@@ -202,7 +202,8 @@ struct PrepPass : public ScriptPass
 					run(memxmode ? "wreduce -keepdc -memx" : "wreduce -keepdc");
 			}
 			if (!nomemmode) {
-				run(string("memory_dff") + (help_mode ? " [-nordff]" : nordff ? " -nordff" : ""));
+				if (help_mode || rdff)
+					run("memory_dff", "(if -rdff)");
 				if (help_mode || memxmode)
 					run("memory_memx", "(if -memx)");
 				run("opt_clean");

--- a/tests/opt/opt_clean_mem.ys
+++ b/tests/opt/opt_clean_mem.ys
@@ -22,7 +22,6 @@ endmodule
 EOT
 
 proc
-memory_dff
 
 select -assert-count 2 t:$memrd
 select -assert-count 1 t:$memwr

--- a/tests/tools/autotest.sh
+++ b/tests/tools/autotest.sh
@@ -197,7 +197,7 @@ do
 			test_passes -f "$frontend $include_opts" -p "hierarchy; synth -run coarse; techmap; opt; abc -dff" ${bn}_ref.${refext}
 			if [ -n "$firrtl2verilog" ]; then
 			    if test -z "$xfirrtl" || ! grep "$fn" "$xfirrtl" ; then
-				"$toolsdir"/../../yosys -b "firrtl" -o ${bn}_ref.fir -f "$frontend $include_opts" -p "prep -nordff; proc; opt -nodffe -nosdff; fsm; opt; memory; opt -full -fine; pmuxtree" ${bn}_ref.${refext}
+				"$toolsdir"/../../yosys -b "firrtl" -o ${bn}_ref.fir -f "$frontend $include_opts" -p "prep; proc; opt -nodffe -nosdff; fsm; opt; memory; opt -full -fine; pmuxtree" ${bn}_ref.${refext}
 				$firrtl2verilog -i ${bn}_ref.fir -o ${bn}_ref.fir.v
 				test_passes -f "$frontend $include_opts" -p "hierarchy; proc; opt -nodffe -nosdff; fsm; opt; memory; opt -full -fine" ${bn}_ref.fir.v
 			    fi


### PR DESCRIPTION
As discussed on the 2021-02-15 meeting, this is the proper fix for #2473 and related issues — no more `memory_dff` converting async ports to sync ports, instead the memory writes are first emitted by the frontend as part of processes, and then converted to `$memwr` cells by `proc_memwr`, which has enough information to know the proper clock (or lack thereof).

This patch also adds more granular priority tracking in the frontend — the priority masks store information on which write ports need to have priority over which other ones, and which ones are unordered.  Currently this information is lost in `proc_memwr` (and converted to an arbitrary total order), but it will be properly hooked up and used in the upcoming memory inference changes.

TODO:

- the `tests/bram` test is now *broken* — it relies on memory write ports always having priority according to their source location, which is no longer true (writes from distinct processes can be executed in any order).
- `proc_arst` handling may not be the best (the enable signal should be ANDed with `!rst`, basically)