### PR TITLE
Fix double-free on unmatched logger error pattern

### DIFF
--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -345,15 +345,15 @@ static void logv_error_with_prefix(const char *prefix,
 
 	log_make_debug = bak_log_make_debug;
 
-	if (log_error_atexit)
-		log_error_atexit();
-
 	for (auto &item : log_expect_error)
 		if (YS_REGEX_NS::regex_search(log_last_error, item.second.pattern))
 			item.second.current_count++;
 
 	if (check_expected_logs)
 		log_check_expected();
+
+	if (log_error_atexit)
+		log_error_atexit();
 
 	YS_DEBUGTRAP_IF_DEBUGGING;
 


### PR DESCRIPTION
When an expected logger error pattern is unmatched, the logger raises another (hidden) error. Because of the previous ordering of actions, `logv_error_with_prefix()` would inadvertently invoke `yosys_atexit()` twice, causing a double-free.

This is related to, but should not necessarily close, #2606.