### PR TITLE
verilog: fix handling of nested ifdef directives

### DIFF
--- a/tests/simple/ifdef_1.v
+++ b/tests/simple/ifdef_1.v
@@ -1,0 +1,88 @@
+module top(o1, o2, o3, o4);
+
+`define FAIL input wire not_a_port;
+
+`ifdef COND_1
+	`FAIL
+`elsif COND_2
+	`FAIL
+`elsif COND_3
+	`FAIL
+`elsif COND_4
+	`FAIL
+`else
+
+	`define COND_4
+	output wire o4;
+
+	`ifdef COND_1
+		`FAIL
+	`elsif COND_2
+		`FAIL
+	`elsif COND_3
+		`FAIL
+	`elsif COND_4
+
+		`define COND_3
+		output wire o3;
+
+		`ifdef COND_1
+			`FAIL
+		`elsif COND_2
+			`FAIL
+		`elsif COND_3
+
+			`define COND_2
+			output wire o2;
+
+			`ifdef COND_1
+				`FAIL
+			`elsif COND_2
+
+				`define COND_1
+				output wire o1;
+
+				`ifdef COND_1
+
+					`ifdef COND_1
+					`elsif COND_2
+						`FAIL
+					`elsif COND_3
+						`FAIL
+					`elsif COND_4
+						`FAIL
+					`else
+						`FAIL
+					`endif
+
+				`elsif COND_2
+					`FAIL
+				`elsif COND_3
+					`FAIL
+				`elsif COND_4
+					`FAIL
+				`else
+					`FAIL
+				`endif
+
+			`elsif COND_3
+				`FAIL
+			`elsif COND_4
+				`FAIL
+			`else
+				`FAIL
+			`endif
+
+		`elsif COND_4
+			`FAIL
+		`else
+			`FAIL
+		`endif
+
+	`else
+		`FAIL
+	`endif
+
+`endif
+
+endmodule

--- a/tests/simple/ifdef_2.v
+++ b/tests/simple/ifdef_2.v
@@ -1,0 +1,21 @@
+module top(o1, o2, o3);
+
+output wire o1;
+
+`define COND_1
+`define COND_2
+`define COND_3
+
+`ifdef COND_1
+	output wire o2;
+`elsif COND_2
+	input wire dne1;
+`elsif COND_3
+	input wire dne2;
+`else
+	input wire dne3;
+`endif
+
+output wire o3;
+
+endmodule

--- a/tests/verilog/include_self.v
+++ b/tests/verilog/include_self.v
@@ -1,0 +1,30 @@
+`ifdef GUARD_5
+module top;
+	wire x;
+endmodule
+
+`elsif GUARD_4
+`define GUARD_5
+`include "include_self.v"
+
+`elsif GUARD_3
+`define GUARD_4
+`include "include_self.v"
+
+`elsif GUARD_2
+`define GUARD_3
+`include "include_self.v"
+
+`elsif GUARD_1
+`define GUARD_2
+`include "include_self.v"
+
+`elsif GUARD_0
+`define GUARD_1
+`include "include_self.v"
+
+`else
+`define GUARD_0
+`include "include_self.v"
+
+`endif

--- a/tests/verilog/include_self.ys
+++ b/tests/verilog/include_self.ys
@@ -1,0 +1,2 @@
+read_verilog include_self.v
+select -assert-count 1 top/x

--- a/tests/verilog/unmatched_else.ys
+++ b/tests/verilog/unmatched_else.ys
@@ -1,0 +1,6 @@
+logger -expect error "Found `else outside of macro conditional branch!" 1
+read_verilog <<EOT
+module top;
+`else
+endmodule
+EOT

--- a/tests/verilog/unmatched_elsif.ys
+++ b/tests/verilog/unmatched_elsif.ys
@@ -1,0 +1,6 @@
+logger -expect error "Found `elsif outside of macro conditional branch!" 1
+read_verilog <<EOT
+module top;
+`elsif
+endmodule
+EOT

--- a/tests/verilog/unmatched_endif.ys
+++ b/tests/verilog/unmatched_endif.ys
@@ -1,0 +1,6 @@
+logger -expect error "Found `endif outside of macro conditional branch!" 1
+read_verilog <<EOT
+module top;
+`endif
+endmodule
+EOT


### PR DESCRIPTION
- track depth so we know whether to consider higher-level elsifs
- error on unmatched endif/elsif/else

@rswarbrick 