### PR TITLE
sv: extended support for integer types

### DIFF
--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -267,6 +267,7 @@ static bool isUserType(std::string &s)
 "int"        { SV_KEYWORD(TOK_INT); }
 "byte"       { SV_KEYWORD(TOK_BYTE); }
 "shortint"   { SV_KEYWORD(TOK_SHORTINT); }
+"longint"    { SV_KEYWORD(TOK_LONGINT); }
 
 "eventually"   { if (formal_mode) return TOK_EVENTUALLY; SV_KEYWORD(TOK_EVENTUALLY); }
 "s_eventually" { if (formal_mode) return TOK_EVENTUALLY; SV_KEYWORD(TOK_EVENTUALLY); }

--- a/tests/verilog/int_types.sv
+++ b/tests/verilog/int_types.sv
@@ -1,0 +1,47 @@
+`define TEST(typ, width, is_signed) \
+    if (1) begin \
+        typ x = -1; \
+        localparam typ y = -1; \
+        logic [127:0] a = x; \
+        logic [127:0] b = y; \
+        if ($bits(x) != width) \
+            $error(`"typ doesn't have expected size width`"); \
+        if ($bits(x) != $bits(y)) \
+            $error(`"localparam typ doesn't match size of typ`"); \
+        function automatic typ f; \
+            input integer x; \
+            f = x; \
+        endfunction \
+        logic [127:0] c = f(-1); \
+        always @* begin \
+            assert (x == y); \
+            assert (a == b); \
+            assert (a == c); \
+            assert ((a == -1) == is_signed); \
+        end \
+    end
+
+`define TEST_INTEGER_ATOM(typ, width) \
+    `TEST(typ, width, 1) \
+    `TEST(typ signed, width, 1) \
+    `TEST(typ unsigned, width, 0)
+
+`define TEST_INTEGER_VECTOR(typ) \
+    `TEST(typ, 1, 0) \
+    `TEST(typ signed, 1, 1) \
+    `TEST(typ unsigned, 1, 0) \
+    `TEST(typ [1:0], 2, 0) \
+    `TEST(typ signed [1:0], 2, 1) \
+    `TEST(typ unsigned [1:0], 2, 0)
+
+module top;
+    `TEST_INTEGER_ATOM(integer, 32)
+    `TEST_INTEGER_ATOM(int, 32)
+    `TEST_INTEGER_ATOM(shortint, 16)
+    `TEST_INTEGER_ATOM(longint, 64)
+    `TEST_INTEGER_ATOM(byte, 8)
+
+    `TEST_INTEGER_VECTOR(reg)
+    `TEST_INTEGER_VECTOR(logic)
+    `TEST_INTEGER_VECTOR(bit)
+endmodule

--- a/tests/verilog/int_types.ys
+++ b/tests/verilog/int_types.ys
@@ -1,0 +1,7 @@
+read_verilog -sv int_types.sv
+hierarchy
+proc
+flatten
+opt -full
+select -module top
+sat -verify -seq 1 -tempinduct -prove-asserts -show-all

--- a/tests/verilog/param_int_types.sv
+++ b/tests/verilog/param_int_types.sv
@@ -1,0 +1,19 @@
+module gate(out);
+    parameter integer a = -1;
+    parameter int b = -2;
+    parameter shortint c = -3;
+    parameter longint d = -4;
+    parameter byte e = -5;
+    output wire [1023:0] out;
+    assign out = {a, b, c, d, e};
+endmodule
+
+module gold(out);
+    integer a = -1;
+    int b = -2;
+    shortint c = -3;
+    longint d = -4;
+    byte e = -5;
+    output wire [1023:0] out;
+    assign out = {a, b, c, d, e};
+endmodule

--- a/tests/verilog/param_int_types.ys
+++ b/tests/verilog/param_int_types.ys
@@ -1,0 +1,5 @@
+read_verilog -sv param_int_types.sv
+proc
+equiv_make gold gate equiv
+equiv_simple
+equiv_status -assert


### PR DESCRIPTION
- Standard data declarations can now use any integer type
- Parameters and localparams can now use any integer type
- Function returns types can now use any integer type
- Fix `parameter logic`, `localparam reg`, etc. to be 1 bit (previously 32 bits)
- Added longint type (64 bits)
- Unified parser source for integer type widths