### PR TITLE
verilog: fix sizing of ports with int types in module headers

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -546,8 +546,9 @@ module_arg:
 		node->str = *$4;
 		SET_AST_NODE_LOC(node, @4, @4);
 		node->port_id = ++port_counter;
-		if ($3 != NULL)
-			node->children.push_back($3);
+		AstNode *range = checkRange(node, $3);
+		if (range != NULL)
+			node->children.push_back(range);
 		if (!node->is_input && !node->is_output)
 			frontend_verilog_yyerror("Module port `%s' is neither input nor output.", $4->c_str());
 		if (node->is_reg && node->is_input && !node->is_output && !sv_mode)

--- a/tests/verilog/port_int_types.sv
+++ b/tests/verilog/port_int_types.sv
@@ -1,0 +1,50 @@
+`define INITS \
+    assign a = -1; \
+    assign b = -2; \
+    assign c = -3; \
+    assign d = -4; \
+    assign a_ext = a; \
+    assign b_ext = b; \
+    assign c_ext = c; \
+    assign d_ext = d;
+
+module gate_a(
+    output byte a,
+    output byte unsigned b,
+    output shortint c,
+    output shortint unsigned d,
+    output [31:0] a_ext,
+    output [31:0] b_ext,
+    output [31:0] c_ext,
+    output [31:0] d_ext
+);
+    `INITS
+endmodule
+
+module gate_b(
+    a, b, c, d,
+    a_ext, b_ext, c_ext, d_ext
+);
+    output byte a;
+    output byte unsigned b;
+    output shortint c;
+    output shortint unsigned d;
+    output [31:0] a_ext;
+    output [31:0] b_ext;
+    output [31:0] c_ext;
+    output [31:0] d_ext;
+    `INITS
+endmodule
+
+module gold(
+    output signed [7:0] a,
+    output unsigned [7:0] b,
+    output signed [15:0] c,
+    output unsigned [15:0] d,
+    output [31:0] a_ext,
+    output [31:0] b_ext,
+    output [31:0] c_ext,
+    output [31:0] d_ext
+);
+    `INITS
+endmodule

--- a/tests/verilog/port_int_types.ys
+++ b/tests/verilog/port_int_types.ys
@@ -1,0 +1,11 @@
+read_verilog -sv port_int_types.sv
+equiv_make gold gate_a equiv
+equiv_simple
+equiv_status -assert
+
+design -reset
+
+read_verilog -sv port_int_types.sv
+equiv_make gold gate_b equiv
+equiv_simple
+equiv_status -assert


### PR DESCRIPTION
Declaring the ports as standard module items already worked as expected. This adds a missing usage of `checkRange()` so that headers such as `module m(output integer x);` now work correctly.