### PR TITLE
fixes issue where unextend incorrectly erases 0-bit of signed signal

### DIFF
--- a/passes/pmgen/ice40_dsp.pmg
+++ b/passes/pmgen/ice40_dsp.pmg
@@ -23,7 +23,7 @@ match mul
 endmatch
 
 code sigA sigB sigH
-	auto unextend = [](const SigSpec &sig) {
+	auto unextend = [](const SigSpec &sig,bool is_signed) {
 		int i;
 		for (i = GetSize(sig)-1; i > 0; i--)
 			if (sig[i] != sig[i-1])
@@ -31,10 +31,13 @@ code sigA sigB sigH
 		// Do not remove non-const sign bit
 		if (sig[i].wire)
 			++i;
+    // Do not remove const sign bit if signed
+    else if (is_signed)
+      ++i;
 		return sig.extract(0, i);
 	};
-	sigA = unextend(port(mul, \A));
-	sigB = unextend(port(mul, \B));
+	sigA = unextend(port(mul, \A), param(mul, \A_SIGNED).as_bool());
+	sigB = unextend(port(mul, \B), param(mul, \B_SIGNED).as_bool());
 
 	SigSpec O;
 	if (mul->type == $mul)


### PR DESCRIPTION
This PR addresses an issue for ice40_dsp where `unextend` incorrectly erases the 0-sign bit of a const signed signal. This only addresses the ice40 case but the issue may be affecting `xiling_dsp*` which feature a similar `unextend` lambda.
