### PR TITLE
sv: fix some edge cases for unbased unsized literals

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -317,6 +317,8 @@ void AstNode::dumpAst(FILE *f, std::string indent) const
 		fprintf(f, " reg");
 	if (is_signed)
 		fprintf(f, " signed");
+	if (is_unsized)
+		fprintf(f, " unsized");
 	if (basic_prep)
 		fprintf(f, " basic_prep");
 	if (lookahead)

--- a/tests/verilog/unbased_unsized.sv
+++ b/tests/verilog/unbased_unsized.sv
@@ -1,0 +1,40 @@
+module pass_through(
+    input [63:0] inp,
+    output [63:0] out
+);
+    assign out = inp;
+endmodule
+
+module top;
+    logic [63:0]
+        o01, o02, o03, o04,
+        o05, o06, o07, o08,
+        o09, o10, o11, o12,
+        o13, o14, o15, o16;
+    assign o01 = '0;
+    assign o02 = '1;
+    assign o03 = 'x;
+    assign o04 = 'z;
+    assign o05 = 3'('0);
+    assign o06 = 3'('1);
+    assign o07 = 3'('x);
+    assign o08 = 3'('z);
+    pass_through pt09('0, o09);
+    pass_through pt10('1, o10);
+    pass_through pt11('x, o11);
+    pass_through pt12('z, o12);
+    always @* begin
+        assert (o01 === {64 {1'b0}});
+        assert (o02 === {64 {1'b1}});
+        assert (o03 === {64 {1'bx}});
+        assert (o04 === {64 {1'bz}});
+        assert (o05 === {61'b0, 3'b000});
+        assert (o06 === {61'b0, 3'b111});
+        assert (o07 === {61'b0, 3'bxxx});
+        assert (o08 === {61'b0, 3'bzzz});
+        assert (o09 === {64 {1'b0}});
+        assert (o10 === {64 {1'b1}});
+        assert (o11 === {64 {1'bx}});
+        assert (o12 === {64 {1'bz}});
+    end
+endmodule

--- a/tests/verilog/unbased_unsized.ys
+++ b/tests/verilog/unbased_unsized.ys
@@ -1,0 +1,7 @@
+read_verilog -sv unbased_unsized.sv
+hierarchy
+proc
+flatten
+opt -full
+select -module top
+sat -verify -seq 1 -tempinduct -prove-asserts -show-all


### PR DESCRIPTION
- Fix explicit size cast of unbased unsized literals
- Fix unbased unsized literal bound directly to port
- Output `is_unsized` flag in `dumpAst`

Related to #2622 