### PR TITLE
kernel: When a wire is removed, change its 0-length SigChunks to const.

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1826,8 +1826,13 @@ void RTLIL::Module::remove(const pool<RTLIL::Wire*> &wires)
 			sig.pack();
 			for (auto &c : sig.chunks_)
 				if (c.wire != NULL && wires_p->count(c.wire)) {
-					c.wire = module->addWire(stringf("$delete_wire$%d", autoidx++), c.width);
-					c.offset = 0;
+					if (c.width) {
+						c.wire = module->addWire(stringf("$delete_wire$%d", autoidx++), c.width);
+						c.offset = 0;
+					} else {
+						c.wire = nullptr;
+						c.offset = 0;
+					}
 				}
 		}
 

--- a/tests/opt/bug2623.ys
+++ b/tests/opt/bug2623.ys
@@ -1,0 +1,14 @@
+read_rtlil << EOT
+
+module \top
+  wire output 1 \a
+  wire width 0 $dummy
+  cell \abc \abc
+    connect \a \a
+    connect \b $dummy
+  end
+end
+
+EOT
+
+opt_clean


### PR DESCRIPTION
This prevents re-creating 0-length wires in a loop.

Fixes #2623.