### PR TITLE
verilog: impose limit on maximum expression width

### DIFF
--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -1000,6 +1000,12 @@ void AstNode::detectSignWidth(int &width_hint, bool &sign_hint, bool *found_real
 	if (found_real)
 		*found_real = false;
 	detectSignWidthWorker(width_hint, sign_hint, found_real);
+
+	constexpr int kWidthLimit = 1 << 24;
+	if (width_hint >= kWidthLimit)
+		log_file_error(filename, location.first_line,
+			"Expression width %d exceeds implementation limit of %d!\n",
+			width_hint, kWidthLimit);
 }
 
 static void check_unique_id(RTLIL::Module *module, RTLIL::IdString id,

--- a/tests/verilog/absurd_width.ys
+++ b/tests/verilog/absurd_width.ys
@@ -1,0 +1,17 @@
+logger -expect error "Expression width 1073741824 exceeds implementation limit of 16777216!" 1
+read_verilog <<EOF
+module top(
+    input inp,
+    output out
+);
+    assign out =
+        {1024 {
+        {1024 {
+        {1024 {
+        inp
+        }}
+        }}
+        }}
+        ;
+endmodule
+EOF

--- a/tests/verilog/absurd_width_const.ys
+++ b/tests/verilog/absurd_width_const.ys
@@ -1,0 +1,16 @@
+logger -expect error "Expression width 1073741824 exceeds implementation limit of 16777216!" 1
+read_verilog <<EOF
+module top(
+    output out
+);
+    assign out =
+        {1024 {
+        {1024 {
+        {1024 {
+        1'b1
+        }}
+        }}
+        }}
+        ;
+endmodule
+EOF


### PR DESCRIPTION
Designs with unreasonably wide expressions would previously get stuck allocating memory forever.

Fixes #2290 