### PR TITLE
cxxrtl: don't crash on empty designs

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -2763,7 +2763,7 @@ struct CxxrtlWorker {
 		// Recheck the design if it was modified.
 		if (did_anything)
 			check_design(design, has_top, has_sync_init, has_packed_mem);
-		log_assert(has_top && !has_sync_init && !has_packed_mem);
+		log_assert(!has_sync_init && !has_packed_mem);
 		log_pop();
 		if (did_anything)
 			log_spacer();


### PR DESCRIPTION
This crash (assertion failure) was unintentionally introduced in 65083e9520e3f39bef3e89a56ecc08f60c1286e6.