### PR TITLE
cxxrtl: follow aliases to outlines when emitting $memrd.ADDR

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -1231,7 +1231,9 @@ struct CxxrtlWorker {
 			RTLIL::Memory *memory = cell->module->memories[cell->getParam(ID::MEMID).decode_string()];
 			std::string valid_index_temp = fresh_temporary();
 			f << indent << "auto " << valid_index_temp << " = memory_index(";
-			dump_sigspec_rhs(cell->getPort(ID::ADDR));
+			// Almost all non-elidable cells cannot appear in debug_eval(), but $memrd is an exception; asynchronous
+			// memory read ports can.
+			dump_sigspec_rhs(cell->getPort(ID::ADDR), for_debug);
 			f << ", " << memory->start_offset << ", " << memory->size << ");\n";
 			if (cell->type == ID($memrd)) {
 				bool has_enable = cell->getParam(ID::CLK_ENABLE).as_bool() && !cell->getPort(ID::EN).is_fully_ones();


### PR DESCRIPTION
Otherwise, this combination (with #2634)
```
Debug wire types:
  \terminal.cpu.i_tv80_core.RegAddrA: OUTLINE
  \terminal.cpu.i_tv80_core.i_reg.AddrA: ALIAS = \terminal.cpu.i_tv80_core.RegAddrA
```
resulted in `\terminal.cpu.i_tv80_core.i_reg.AddrA` being referenced but not defined.