### PR TITLE
Replace assert in addModule with more useful error message

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -613,7 +613,8 @@ void RTLIL::Design::add(RTLIL::Module *module)
 
 RTLIL::Module *RTLIL::Design::addModule(RTLIL::IdString name)
 {
-	log_assert(modules_.count(name) == 0);
+	if (modules_.count(name) != 0)
+		log_error("Attempted to add new module named '%s', but a module by that name already exists\n", name.c_str());
 	log_assert(refcount_modules_ == 0);
 
 	RTLIL::Module *module = new RTLIL::Module;


### PR DESCRIPTION
I'm increasingly finding `log_assert` to be unhelpful, especially when users are presented with them due to bugs. I just hit this one and thought it would be significantly more helpful to describe the error condition without having to spend time looking at the surrounding context to work out the problem.