### PR TITLE
proc_dff: Fix emitted FF when a register is not assigned in async reset branch

### DIFF
--- a/passes/proc/proc_dff.cc
+++ b/passes/proc/proc_dff.cc
@@ -328,6 +328,10 @@ void proc_dff(RTLIL::Module *mod, RTLIL::Process *proc, ConstEval &ce)
 		ce.assign_map.apply(sig);
 
 		if (rstval == sig) {
+			if (sync_level->type == RTLIL::SyncType::ST1)
+				insig = mod->Mux(NEW_ID, insig, sig, sync_level->signal);
+			else
+				insig = mod->Mux(NEW_ID, sig, insig, sync_level->signal);
 			rstval = RTLIL::SigSpec(RTLIL::State::Sz, sig.size());
 			sync_level = NULL;
 		}

--- a/tests/proc/bug2619.ys
+++ b/tests/proc/bug2619.ys
@@ -1,0 +1,23 @@
+read_verilog << EOT
+
+module top(...);
+
+input D1, D2, R, CLK;
+output reg Q1, Q2;
+
+always @(posedge CLK, posedge R) begin
+	Q1 <= 0;
+	if (!R) begin
+		Q1 <= D1;
+		Q2 <= D2;
+	end
+end
+
+endmodule
+
+EOT
+
+proc
+opt
+select -assert-count 1 t:$adff
+select -assert-count 1 t:$dffe


### PR DESCRIPTION
Fixes #2619.