### PR TITLE
rtlil: Disallow 0-width chunks in SigSpec.

### DIFF
--- a/tests/opt/bug2623.ys
+++ b/tests/opt/bug2623.ys
@@ -1,0 +1,14 @@
+read_rtlil << EOT
+
+module \top
+  wire output 1 \a
+  wire width 0 $dummy
+  cell \abc \abc
+    connect \a \a
+    connect \b $dummy
+  end
+end
+
+EOT
+
+opt_clean


### PR DESCRIPTION
Among other problems, this also fixes equality comparisons between
SigSpec by enforcing a canonical form.

Also fix another minor issue with possible non-canonical SigSpec.

Fixes #2623.