### PR TITLE
json: Add support for memories.

### DIFF
--- a/frontends/json/jsonparse.cc
+++ b/frontends/json/jsonparse.cc
@@ -539,6 +539,52 @@ void json_import(Design *design, string &modname, JsonNode *node)
 				json_parse_attr_param(cell->parameters, cell_node->data_dict.at("parameters"));
 		}
 	}
+
+	if (node->data_dict.count("memories"))
+	{
+		JsonNode *memories_node = node->data_dict.at("memories");
+
+		if (memories_node->type != 'D')
+			log_error("JSON memories node is not a dictionary.\n");
+
+		for (auto &memory_node_it : memories_node->data_dict)
+		{
+			IdString memory_name = RTLIL::escape_id(memory_node_it.first.c_str());
+			JsonNode *memory_node = memory_node_it.second;
+
+			RTLIL::Memory *mem = new RTLIL::Memory;
+			mem->name = memory_name;
+
+			if (memory_node->type != 'D')
+				log_error("JSON memory node '%s' is not a dictionary.\n", log_id(memory_name));
+
+			if (memory_node->data_dict.count("width") == 0)
+				log_error("JSON memory node '%s' has no width attribute.\n", log_id(memory_name));
+			JsonNode *width_node = memory_node->data_dict.at("width");
+			if (width_node->type != 'N')
+				log_error("JSON memory node '%s' has a non-number width.\n", log_id(memory_name));
+			mem->width = width_node->data_number;
+
+			if (memory_node->data_dict.count("size") == 0)
+				log_error("JSON memory node '%s' has no size attribute.\n", log_id(memory_name));
+			JsonNode *size_node = memory_node->data_dict.at("size");
+			if (size_node->type != 'N')
+				log_error("JSON memory node '%s' has a non-number size.\n", log_id(memory_name));
+			mem->size = size_node->data_number;
+
+			mem->start_offset = 0;
+			if (memory_node->data_dict.count("start_offset") != 0) {
+				JsonNode *val = memory_node->data_dict.at("start_offset");
+				if (val->type == 'N')
+					mem->start_offset = val->data_number;
+			}
+
+			if (memory_node->data_dict.count("attributes"))
+				json_parse_attr_param(mem->attributes, memory_node->data_dict.at("attributes"));
+
+			module->memories[mem->name] = mem;
+		}
+	}
 }
 
 struct JsonFrontend : public Frontend {


### PR DESCRIPTION
Previously, memories were silently discarded by the JSON backend, making
round-tripping modules with them crash.

Since there are already some users using JSON to implement custom
external passes that use memories (and infer width/size from memory
ports), let's fix this by just making JSON backend and frontend support
memories as first-class objects.

Processes are still not supported, and will now cause a hard error.

Fixes #1908.