### PR TITLE
verilog: disallow overriding global parameters

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -1286,6 +1286,8 @@ void AST::process(RTLIL::Design *design, AstNode *ast, bool dump_ast1, bool dump
 		}
 		else {
 			// must be global definition
+			if ((*it)->type == AST_PARAMETER)
+				(*it)->type = AST_LOCALPARAM; // cannot be overridden
 			(*it)->simplify(false, false, false, 1, -1, false, false); //process enum/other declarations
 			design->verilog_globals.push_back((*it)->clone());
 			current_scope.clear();

--- a/tests/verilog/global_parameter.ys
+++ b/tests/verilog/global_parameter.ys
@@ -1,0 +1,16 @@
+read_verilog -sv <<EOF
+parameter P = 1;
+module example(
+    output integer out
+);
+    assign out = P;
+endmodule
+module top(
+    output integer out
+);
+    example #(2) e1(out);
+endmodule
+EOF
+
+logger -expect error "Can't find object for defparam" 1
+hierarchy


### PR DESCRIPTION
It was previously possible to override global parameters on a per-instance basis. This could be dangerous when using positional parameter bindings, hiding oversupplied parameters.

I'm not certain that this is forbidden by the LRM. Some tools allow it, others don't. I believe the current behavior is accidental. Let's use this PR to discuss which behavior we prefer.