### PR TITLE
sv: allow globals in one file to depend on globals in another

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -1288,7 +1288,6 @@ void AST::process(RTLIL::Design *design, AstNode *ast, bool dump_ast1, bool dump
 			// must be global definition
 			if ((*it)->type == AST_PARAMETER)
 				(*it)->type = AST_LOCALPARAM; // cannot be overridden
-			(*it)->simplify(false, false, false, 1, -1, false, false); //process enum/other declarations
 			design->verilog_globals.push_back((*it)->clone());
 			current_scope.clear();
 		}

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -192,6 +192,7 @@ void AstNode::annotateTypedEnums(AstNode *template_node)
 		log_assert(current_scope.count(enum_type) == 1);
 		AstNode *enum_node = current_scope.at(enum_type);
 		log_assert(enum_node->type == AST_ENUM);
+		while (enum_node->simplify(true, false, false, 1, -1, false, true)) { }
 		//get width from 1st enum item:
 		log_assert(enum_node->children.size() >= 1);
 		AstNode *enum_item0 = enum_node->children[0];

--- a/tests/verilog/parameters_across_files.ys
+++ b/tests/verilog/parameters_across_files.ys
@@ -1,0 +1,20 @@
+read_verilog -sv <<EOF
+parameter Q = 1;
+EOF
+read_verilog -sv <<EOF
+parameter P = Q;
+module top(
+    output integer out
+);
+    assign out = P;
+    always @*
+        assert (out == 1);
+endmodule
+EOF
+
+hierarchy
+proc
+flatten
+opt -full
+select -module top
+sat -verify -seq 1 -tempinduct -prove-asserts -show-all


### PR DESCRIPTION
This defers the simplification of globals so that globals in one file may depend on globals in other files. Adds a simplify() call downstream because globals are appended at the end.

Fixes #2571