### PR TITLE
modtools: fix use-after-free of cell pointers in ModWalker

### DIFF
--- a/kernel/modtools.h
+++ b/kernel/modtools.h
@@ -395,6 +395,8 @@ struct ModWalker
 		signal_consumers.clear();
 		signal_inputs.clear();
 		signal_outputs.clear();
+		cell_inputs.clear();
+		cell_outputs.clear();
 
 		for (auto &it : module->wires_)
 			add_wire(it.second);


### PR DESCRIPTION
`cell_inputs` and `cell_outputs` retain cell pointers as their keys across invocations of `setup()`, which may however be invalidated in the meantime (as happens in e.g. [`passes/opt/share.cc:1432`](https://github.com/YosysHQ/yosys/blob/e178d0367a315213560514f827072595adfd4b4a/passes/opt/share.cc#L1432)). A later rehash of the dicts (caused e.g. by inserting in `ModWalker::add_wire()`) will cause them to be dereferenced.

I have to admit I don't fully understand the internals of the share pass, is it supposed to share across modules? The test suite didn't complain locally, so if this fix actually breaks it, it should probably be tested for explicitly.

Note: I found this issue by running the test suite under ASan, is it worth adding that as a CI pass?