### PR TITLE
bugpoint: add runner option

### DIFF
--- a/manual/command-reference-manual.tex
+++ b/manual/command-reference-manual.tex
@@ -656,6 +656,9 @@ are specified, all parts of design will be removed.
 
     -updates
         try to remove process updates from syncs.
+
+    -runner "<prefix>"
+        child process wrapping command, e.g., "timeout 30", or valgrind.
 \end{lstlisting}
 
 \section{cd -- a shortcut for 'select -module <name>'}


### PR DESCRIPTION
This has been updated to the more general `-runner` option proposed below. *nix systems appear to have the `timeout` command available in general. I confirmed that with the recent zero-width chunk fix reverted, the following script
```
read_rtlil <<EOF
module \top
  wire output 1 \a
  wire width 0 $dummy
  cell \abc \abc
    connect \a \a
    connect \b $dummy
  end
  wire width 1 \foo
  wire width 2 \bar
end
EOF

bugpoint -yosys "./yosys" -command opt_clean -runner "timeout 5"
```
correctly runs and produces
```
autoidx 5
module \top
  wire width 0 $delete_wire$2
  wire $delete_wire$4
  cell \abc \abc
    connect \a $delete_wire$4
    connect \b $delete_wire$2
  end
end
```

Fixes #2629 