### PR TITLE
Replace assert in get_reference with more useful error message

### DIFF
--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -166,7 +166,8 @@ namespace RTLIL
 			log_assert(p[0] == '$' || p[0] == '\\');
 			log_assert(p[1] != 0);
 			for (const char *c = p; *c; c++)
-				log_assert((unsigned)*c > (unsigned)' ');
+				if ((unsigned)*c <= (unsigned)' ')
+					log_error("Found control character or space (0x%02hhx) in string '%s' which is not allowed in RTLIL identifiers\n", *c, p);
 
 		#ifndef YOSYS_NO_IDS_REFCNT
 			if (global_free_idx_list_.empty()) {


### PR DESCRIPTION
This assert caught the regression caused by #2646, so it deserves a promotion into a human-readable error.