### PR TITLE
Blackbox all whiteboxes after synthesis

### DIFF
--- a/techlibs/achronix/synth_achronix.cc
+++ b/techlibs/achronix/synth_achronix.cc
@@ -173,6 +173,7 @@ struct SynthAchronixPass : public ScriptPass {
         run("hierarchy -check");
         run("stat");
         run("check -noinit");
+        run("blackbox =A:whitebox");
       }
 
     if (check_label("vout"))

--- a/techlibs/anlogic/synth_anlogic.cc
+++ b/techlibs/anlogic/synth_anlogic.cc
@@ -211,6 +211,7 @@ struct SynthAnlogicPass : public ScriptPass
 			run("hierarchy -check");
 			run("stat");
 			run("check -noinit");
+			run("blackbox =A:whitebox");
 		}
 
 		if (check_label("edif"))

--- a/techlibs/coolrunner2/synth_coolrunner2.cc
+++ b/techlibs/coolrunner2/synth_coolrunner2.cc
@@ -192,6 +192,7 @@ struct SynthCoolrunner2Pass : public ScriptPass
 			run("hierarchy -check");
 			run("stat");
 			run("check -noinit");
+			run("blackbox =A:whitebox");
 		}
 
 		if (check_label("json"))

--- a/techlibs/easic/synth_easic.cc
+++ b/techlibs/easic/synth_easic.cc
@@ -175,6 +175,7 @@ struct SynthEasicPass : public ScriptPass
 			run("hierarchy -check");
 			run("stat");
 			run("check -noinit");
+			run("blackbox =A:whitebox");
 		}
 
 		if (check_label("vlog"))

--- a/techlibs/ecp5/synth_ecp5.cc
+++ b/techlibs/ecp5/synth_ecp5.cc
@@ -385,6 +385,7 @@ struct SynthEcp5Pass : public ScriptPass
 			run("hierarchy -check");
 			run("stat");
 			run("check -noinit");
+			run("blackbox =A:whitebox");
 		}
 
 		if (check_label("blif"))

--- a/techlibs/efinix/synth_efinix.cc
+++ b/techlibs/efinix/synth_efinix.cc
@@ -213,6 +213,7 @@ struct SynthEfinixPass : public ScriptPass
 			run("hierarchy -check");
 			run("stat");
 			run("check -noinit");
+			run("blackbox =A:whitebox");
 		}
 
 		if (check_label("edif"))

--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -289,6 +289,7 @@ struct SynthGowinPass : public ScriptPass
 			run("hierarchy -check");
 			run("stat");
 			run("check -noinit");
+			run("blackbox =A:whitebox");
 		}
 
 		if (check_label("vout"))

--- a/techlibs/greenpak4/synth_greenpak4.cc
+++ b/techlibs/greenpak4/synth_greenpak4.cc
@@ -196,6 +196,7 @@ struct SynthGreenPAK4Pass : public ScriptPass
 			run("hierarchy -check");
 			run("stat");
 			run("check -noinit");
+			run("blackbox =A:whitebox");
 		}
 
 		if (check_label("json"))

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -417,6 +417,7 @@ struct SynthIce40Pass : public ScriptPass
 			run("hierarchy -check");
 			run("stat");
 			run("check -noinit");
+			run("blackbox =A:whitebox");
 		}
 
 		if (check_label("blif"))

--- a/techlibs/intel/synth_intel.cc
+++ b/techlibs/intel/synth_intel.cc
@@ -233,6 +233,7 @@ struct SynthIntelPass : public ScriptPass {
 			run("hierarchy -check");
 			run("stat");
 			run("check -noinit");
+			run("blackbox =A:whitebox");
 		}
 
 		if (check_label("vqm")) {

--- a/techlibs/intel_alm/synth_intel_alm.cc
+++ b/techlibs/intel_alm/synth_intel_alm.cc
@@ -274,6 +274,7 @@ struct SynthIntelALMPass : public ScriptPass {
 			run("hierarchy -check");
 			run("stat");
 			run("check");
+			run("blackbox =A:whitebox");
 		}
 
 		if (check_label("quartus")) {

--- a/techlibs/machxo2/synth_machxo2.cc
+++ b/techlibs/machxo2/synth_machxo2.cc
@@ -212,6 +212,7 @@ struct SynthMachXO2Pass : public ScriptPass
 		{
 			run("hierarchy -check");
 			run("stat");
+			run("blackbox =A:whitebox");
 		}
 
 		if (check_label("blif"))

--- a/techlibs/nexus/synth_nexus.cc
+++ b/techlibs/nexus/synth_nexus.cc
@@ -406,6 +406,7 @@ struct SynthNexusPass : public ScriptPass
 			run("hierarchy -check");
 			run("stat");
 			run("check -noinit");
+			run("blackbox =A:whitebox");
 		}
 
 		if (check_label("json"))

--- a/techlibs/sf2/synth_sf2.cc
+++ b/techlibs/sf2/synth_sf2.cc
@@ -228,6 +228,7 @@ struct SynthSf2Pass : public ScriptPass
 			run("hierarchy -check");
 			run("stat");
 			run("check -noinit");
+			run("blackbox =A:whitebox");
 		}
 
 		if (check_label("edif"))

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -662,6 +662,7 @@ struct SynthXilinxPass : public ScriptPass
 			run("hierarchy -check");
 			run("stat -tech xilinx");
 			run("check -noinit");
+			run("blackbox =A:whitebox");
 		}
 
 		if (check_label("edif")) {

--- a/tests/arch/ecp5/mux.ys
+++ b/tests/arch/ecp5/mux.ys
@@ -15,9 +15,9 @@ proc
 equiv_opt -assert -map +/ecp5/cells_sim.v synth_ecp5 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux4 # Constrain all select calls below inside the top module
-select -assert-count 1 t:L6MUX21
-select -assert-count 4 t:LUT4
-select -assert-count 2 t:PFUMX
+select -assert-max 1 t:L6MUX21
+select -assert-max 4 t:LUT4
+select -assert-max 2 t:PFUMX
 
 select -assert-none t:LUT4 t:L6MUX21 t:PFUMX %% t:* %D
 
@@ -27,9 +27,9 @@ proc
 equiv_opt -assert -map +/ecp5/cells_sim.v synth_ecp5 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux8 # Constrain all select calls below inside the top module
-select -assert-count 1 t:L6MUX21
-select -assert-count 7 t:LUT4
-select -assert-count 2 t:PFUMX
+select -assert-max 1 t:L6MUX21
+select -assert-max 7 t:LUT4
+select -assert-max 2 t:PFUMX
 
 select -assert-none t:LUT4 t:L6MUX21 t:PFUMX %% t:* %D
 
@@ -39,8 +39,8 @@ proc
 equiv_opt -assert -map +/ecp5/cells_sim.v synth_ecp5 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux16 # Constrain all select calls below inside the top module
-select -assert-count 8 t:L6MUX21
-select -assert-count 26 t:LUT4
-select -assert-count 12 t:PFUMX
+select -assert-max 12 t:L6MUX21
+select -assert-max 34 t:LUT4
+select -assert-max 17 t:PFUMX
 
 select -assert-none t:LUT4 t:L6MUX21 t:PFUMX %% t:* %D


### PR DESCRIPTION
This prevents issues like processes in whiteboxes triggering an error in the JSON backend. Fixes #2667 

