### PR TITLE
abc9: uniquify blackboxes like whiteboxes

### DIFF
--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -180,6 +180,9 @@ void prep_hier(RTLIL::Design *design, bool dff_mode)
 			if (cell->parameters.empty()) {
 				derived_type = cell->type;
 				derived_module = inst_module;
+
+				if (derived_module->get_blackbox_attribute(true /* ignore_wb */))
+					continue;
 			}
 			else {
 				// Check potential for any one of those three
@@ -189,8 +192,6 @@ void prep_hier(RTLIL::Design *design, bool dff_mode)
 				derived_type = inst_module->derive(design, cell->parameters);
 				derived_module = design->module(derived_type);
 			}
-			if (derived_module->get_blackbox_attribute(true /* ignore_wb */))
-				continue;
 
 			if (derived_module->get_bool_attribute(ID::abc9_flop)) {
 				if (!dff_mode)

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -780,14 +780,12 @@ void prep_xaiger(RTLIL::Module *module, bool dff)
 		if (!box_module->get_bool_attribute(ID::abc9_box))
 			continue;
 		if (!cell->parameters.empty())
-			// At this stage of the ABC9 flow, all modules must be nonparametric, because ABC itself requires concrete netlists, and the presence of
-			// parameters implies a non-concrete netlist. This error needs some explaining, because there are (at least) two ways to get this:
-			// 1) You have an (* abc9_box *) parametric whitebox but due to a bug somewhere this hasn't been monomorphised into a concrete blackbox.
-			//    This is a bug, and a bug report would be welcomed.
-			// 2) You have an (* abc9_box *) parametric blackbox (e.g. to store associated cell data) but want to provide timing data for ABC9.
-			//    This is not supported due to the presence of parameters. If you want to store associated cell data for a box, one approach could be
-			//    to techmap the parameters to constant module inputs, and then after ABC9 use _TECHMAP_CONSTVAL_XX_ to retrieve the values again.
-			log_error("Black box '%s' is marked (* abc9_box *) and has parameters, which is forbidden in prep_xaiger\n", log_id(cell_name));
+		{
+		    // At this stage of the ABC9 flow, all modules must be nonparametric, because ABC itself requires concrete netlists, and the presence of
+		    // parameters implies a non-concrete netlist. This means an (* abc9_box *) parametric module but due to a bug somewhere this hasn't been
+		    // uniquified into a concrete parameter-free module. This is a bug, and a bug report would be welcomed.
+		    log_error("Not expecting parameters on module '%s'  marked (* abc9_box *)\n", log_id(cell_name));
+		}
 		log_assert(box_module->get_blackbox_attribute());
 
 		cell->attributes[ID::abc9_box_seq] = box_count++;

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -180,9 +180,6 @@ void prep_hier(RTLIL::Design *design, bool dff_mode)
 			if (cell->parameters.empty()) {
 				derived_type = cell->type;
 				derived_module = inst_module;
-
-				if (derived_module->get_blackbox_attribute(true /* ignore_wb */))
-					continue;
 			}
 			else {
 				// Check potential for any one of those three

--- a/tests/various/abc9.ys
+++ b/tests/various/abc9.ys
@@ -90,7 +90,7 @@ $_DFF_N_ ff4(.C(clk), .D(1'b1), .Q(z));
 endmodule
 EOT
 simplemap
-equiv_opt abc9 -lut 4 -dff
+equiv_opt -assert abc9 -lut 4 -dff
 design -load postopt
 cd abc9_test038
 select -assert-count 3 t:$_DFF_N_
@@ -99,3 +99,58 @@ clean
 select -assert-count 2 a:init
 select -assert-count 1 w:w a:init %i
 select -assert-count 1 c:ff4 %co c:ff4 %d %a a:init %i
+
+
+# Check that non-dangling ABC9 black-boxes are preserved
+design -reset
+read_verilog -specify <<EOT
+(* abc9_box, blackbox *)
+module mux_with_param(input I0, I1, S, output O);
+parameter P = 0;
+specify
+    (I0 => O) = P;
+    (I1 => O) = P;
+    (S => O) = P;
+endspecify
+endmodule
+
+module abc9_test039(output O);
+  mux_with_param #(.P(1)) m (
+    .I0(1'b1),
+    .I1(1'b1),
+    .O(O),
+    .S(1'b0)
+  );
+endmodule
+EOT
+abc9 -lut 4
+cd abc9_test039
+select -assert-count 1 t:mux_with_param
+
+
+# Check that dangling ABC9 black-boxes are swept away
+design -reset
+read_verilog -specify <<EOT
+(* abc9_box, blackbox *)
+module mux_with_param(input I0, I1, S, output O);
+parameter P = 0;
+specify
+    (I0 => O) = P;
+    (I1 => O) = P;
+    (S => O) = P;
+endspecify
+endmodule
+
+module abc9_test040(output O);
+  wire w;
+  mux_with_param #(.P(1)) m (
+    .I0(1'b1),
+    .I1(1'b1),
+    .O(w),
+    .S(1'b0)
+  );
+endmodule
+EOT
+abc9 -lut 4
+cd abc9_test040
+select -assert-count 0 t:mux_with_param


### PR DESCRIPTION
`abc9` will uniquify parameterised whiteboxes (i.e. create a unique module with parameter values constant-propagated) but not blackboxes. This is an oversight resolved here.

Whiteboxes would be typically preferred so that `abc9` can optimise the box away or short it if necessary. It won't do that for a blackbox, however, it will still sweep that box away if it has a dangling/redundant output (making this not a completely bulletproof equivalent to `(* keep *)` which hides it from `abc9` entirely -- but also means it will not be considered for timing-aware mapping).

CC: @Ravenslofty