### PR TITLE
rtlil: add const accessors for modules, wires, and cells

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -580,6 +580,11 @@ RTLIL::Module *RTLIL::Design::module(RTLIL::IdString name)
 	return modules_.count(name) ? modules_.at(name) : NULL;
 }
 
+const RTLIL::Module *RTLIL::Design::module(RTLIL::IdString name) const
+{
+	return modules_.count(name) ? modules_.at(name) : NULL;
+}
+
 RTLIL::Module *RTLIL::Design::top_module()
 {
 	RTLIL::Module *module = nullptr;

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1043,6 +1043,7 @@ struct RTLIL::Design
 
 	RTLIL::ObjRange<RTLIL::Module*> modules();
 	RTLIL::Module *module(RTLIL::IdString name);
+	const RTLIL::Module *module(RTLIL::IdString name) const;
 	RTLIL::Module *top_module();
 
 	bool has(RTLIL::IdString id) const {
@@ -1187,6 +1188,15 @@ public:
 		return it == wires_.end() ? nullptr : it->second;
 	}
 	RTLIL::Cell* cell(RTLIL::IdString id) {
+		auto it = cells_.find(id);
+		return it == cells_.end() ? nullptr : it->second;
+	}
+
+	const RTLIL::Wire* wire(RTLIL::IdString id) const{
+		auto it = wires_.find(id);
+		return it == wires_.end() ? nullptr : it->second;
+	}
+	const RTLIL::Cell* cell(RTLIL::IdString id) const {
 		auto it = cells_.find(id);
 		return it == cells_.end() ? nullptr : it->second;
 	}


### PR DESCRIPTION
This allows future changes to have const access to a `Design` and still meaningfully inspect portions of the hierarchy. I simply duplicated the non-const definitions of these three functions. Some prefer to define either the const or non-const accessor in terms of the other using `const_cast`. I have no preference either way.