### PR TITLE
verilog: fix case expression sign and width handling

### DIFF
--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -291,7 +291,7 @@ namespace AST
 		// for expressions the resulting signal vector is returned
 		// all generated cell instances, etc. are written to the RTLIL::Module pointed to by AST_INTERNAL::current_module
 		RTLIL::SigSpec genRTLIL(int width_hint = -1, bool sign_hint = false);
-		RTLIL::SigSpec genWidthRTLIL(int width, const dict<RTLIL::SigBit, RTLIL::SigBit> *new_subst_ptr = NULL);
+		RTLIL::SigSpec genWidthRTLIL(int width, bool sgn, const dict<RTLIL::SigBit, RTLIL::SigBit> *new_subst_ptr = NULL);
 
 		// compare AST nodes
 		bool operator==(const AstNode &other) const;

--- a/tests/simple/case_expr_const.v
+++ b/tests/simple/case_expr_const.v
@@ -1,0 +1,49 @@
+// Note: case_expr_{,non_}const.v should be modified in tandem to ensure both
+// the constant and non-constant case evaluation logic is covered
+module top(
+	// expected to output all 1s
+    output reg a, b, c, d, e, f, g, h
+);
+    initial begin
+        case (2'b0)
+            1'b0:    a = 1;
+            default: a = 0;
+        endcase
+        case (2'sb11)
+            2'sb01:  b = 0;
+            1'sb1:   b = 1;
+        endcase
+        case (2'sb11)
+            1'sb0:   c = 0;
+            1'sb1:   c = 1;
+        endcase
+        case (2'sb11)
+            1'b0:    d = 0;
+            1'sb1:   d = 0;
+            default: d = 1;
+        endcase
+        case (2'b11)
+            1'sb0:   e = 0;
+            1'sb1:   e = 0;
+            default: e = 1;
+        endcase
+        case (1'sb1)
+            1'sb0:   f = 0;
+            2'sb11:  f = 1;
+            default: f = 0;
+        endcase
+        case (1'sb1)
+            1'sb0:   g = 0;
+            3'b0:    g = 0;
+            2'sb11:  g = 0;
+            default: g = 1;
+        endcase
+        case (1'sb1)
+            1'sb0:   h = 0;
+            1'b1:    h = 1;
+            3'b0:    h = 0;
+            2'sb11:  h = 0;
+            default: h = 0;
+        endcase
+    end
+endmodule

--- a/tests/simple/case_expr_non_const.v
+++ b/tests/simple/case_expr_non_const.v
@@ -1,0 +1,59 @@
+// Note: case_expr_{,non_}const.v should be modified in tandem to ensure both
+// the constant and non-constant case evaluation logic is covered
+module top(
+	// expected to output all 1s
+    output reg a, b, c, d, e, f, g, h
+);
+    reg x_1b0 = 1'b0;
+    reg x_1b1 = 1'b1;
+    reg signed x_1sb0 = 1'sb0;
+    reg signed x_1sb1 = 1'sb1;
+    reg [1:0] x_2b0 = 2'b0;
+    reg [1:0] x_2b11 = 2'b11;
+    reg signed [1:0] x_2sb01 = 2'sb01;
+    reg signed [1:0] x_2sb11 = 2'sb11;
+    reg [2:0] x_3b0 = 3'b0;
+
+    initial begin
+        case (x_2b0)
+            x_1b0:   a = 1;
+            default: a = 0;
+        endcase
+        case (x_2sb11)
+            x_2sb01: b = 0;
+            x_1sb1:  b = 1;
+        endcase
+        case (x_2sb11)
+            x_1sb0:  c = 0;
+            x_1sb1:  c = 1;
+        endcase
+        case (x_2sb11)
+            x_1b0:   d = 0;
+            x_1sb1:  d = 0;
+            default: d = 1;
+        endcase
+        case (x_2b11)
+            x_1sb0:  e = 0;
+            x_1sb1:  e = 0;
+            default: e = 1;
+        endcase
+        case (x_1sb1)
+            x_1sb0:  f = 0;
+            x_2sb11: f = 1;
+            default: f = 0;
+        endcase
+        case (x_1sb1)
+            x_1sb0:  g = 0;
+            x_3b0:   g = 0;
+            x_2sb11: g = 0;
+            default: g = 1;
+        endcase
+        case (x_1sb1)
+            x_1sb0:  h = 0;
+            x_1b1:   h = 1;
+            x_3b0:   h = 0;
+            x_2sb11: h = 0;
+            default: h = 0;
+        endcase
+    end
+endmodule


### PR DESCRIPTION
- The case expression and case item expressions are extended to the maximum width among them, and are only interpreted as signed if all of them are signed
- Add overall width and sign detection for AST_CASE
- Add sign argument to genWidthRTLIL helper
- Coverage for both const and non-const case statements

From Section 12.5 of IEEE 1800-2017:

> In a _case_expression_ comparison, the comparison only succeeds when each bit matches exactly with respect to the values `0`, `1`, `x`, and `z`. As a consequence, care is needed in specifying the expressions in the case statement. The bit length of all the expressions needs to be equal, so that exact bitwise matching can be performed. Therefore, the length of all the _case_item_expressions_, as well as the _case_expression_, shall be made equal to the length of the longest _case_expression_ and _case_item_expressions_. If any of these expressions is unsigned, then all of them shall be treated as unsigned. If all of these expressions are signed, then they shall be treated as signed.

Fixes #2528