### PR TITLE
gha: trim macOS dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,7 @@ jobs:
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
       run: |
-        brew update
-        brew tap Homebrew/bundle
-        brew bundle
+        brew install bison gawk libffi pkg-config bash
 
     - name: Setup environment (Linux)
       if: runner.os == 'Linux'


### PR DESCRIPTION
- Only install needed dependencies rather than using Brewfile
- Remove brew update (recent enough formulae already baked in)
- Saves ~16 minutes in macOS CI