### PR TITLE
Add setundef -autoports

### DIFF
--- a/tests/various/setundef_autoports.ys
+++ b/tests/various/setundef_autoports.ys
@@ -1,0 +1,24 @@
+read_verilog -sv <<EOT
+module submod(input [3:0] foo, input bar);
+	always @* begin
+		assert (foo === 4'b0001);
+		assert (bar === 1'b0);
+	end
+endmodule
+module top;
+(* keep *) submod submod_i(.foo(1'b1));
+endmodule
+EOT
+
+prep -top top
+
+# Check that it fails before setundef
+design -save postprep
+flatten
+sat -falsify -prove-asserts
+
+# Check that it passes after setundef
+design -load postprep
+setundef -zero -autoports
+flatten
+sat -verify -prove-asserts


### PR DESCRIPTION
Some flows require all ports to be set to defined values, even those missing from instantiations. `setundef` on its own isn't enough to deal with this as the ports won't exist at all if not included in the instantiation, this adds a new mode to `setundef` to deal with this.