### PR TITLE
sf2: fix name of AND modules

### DIFF
--- a/techlibs/sf2/cells_sim.v
+++ b/techlibs/sf2/cells_sim.v
@@ -1,20 +1,20 @@
 // https://coredocs.s3.amazonaws.com/Libero/12_0_0/Tool/sf2_mlg.pdf
 
-module ADD2 (
+module AND2 (
 	input A, B,
 	output Y
 );
 	assign Y = A & B;
 endmodule
 
-module ADD3 (
+module AND3 (
 	input A, B, C,
 	output Y
 );
 	assign Y = A & B & C;
 endmodule
 
-module ADD4 (
+module AND4 (
 	input A, B, C, D,
 	output Y
 );


### PR DESCRIPTION
When searching through the techlibs to reuse implementations I stumbled upon this file and got a bit confused by modules called `ADD` when they are in fact AND gates. Looking at the referenced pdf confirms that the modules should be called AND2, etc.

I grep'ed through the repo and luckily nothing else is referencing or using the wrong names, so the PR should be pretty much safe. (famous last words)

Kind regards,
Riesi