### PR TITLE
Fix use of blif name in synth_xilinx command

### DIFF
--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -672,7 +672,7 @@ struct SynthXilinxPass : public ScriptPass
 
 		if (check_label("blif")) {
 			if (!blif_file.empty() || help_mode)
-				run(stringf("write_blif %s", edif_file.c_str()));
+				run(stringf("write_blif %s", blif_file.c_str()));
 		}
 	}
 } SynthXilinxPass;


### PR DESCRIPTION
## Problem
Yosys ignores the name of the BLIF file passed in with the `synth_xilinx` command.

## Before
For example, 

```bash
yosys -p "synth_xilinx -top toplevel -blif counter.blif" counter.v
```

Yosys ignores the given BLIF name (`counter.blif`), and instead prints the BLIF output to the command line.

<img width="731" alt="Screen Shot 2021-04-27 at 2 36 52 AM" src="https://user-images.githubusercontent.com/2482771/116220338-6ec2d400-a701-11eb-8653-41324c7615ad.png">

## After
This fix now causes `counter.blif` to be written to.

<img width="731" alt="Screen Shot 2021-04-27 at 2 36 10 AM" src="https://user-images.githubusercontent.com/2482771/116220250-5783e680-a701-11eb-8123-23b541bd1bc0.png">