### PR TITLE
blif: Use library cells' start_offset and upto for wideports.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -804,6 +804,7 @@ test: $(TARGETS) $(EXTRA_TARGETS)
 	+cd tests/svinterfaces && bash run-test.sh $(SEEDOPT)
 	+cd tests/svtypes && bash run-test.sh $(SEEDOPT)
 	+cd tests/proc && bash run-test.sh
+	+cd tests/blif && bash run-test.sh
 	+cd tests/opt && bash run-test.sh
 	+cd tests/aiger && bash run-test.sh $(ABCOPT)
 	+cd tests/arch && bash run-test.sh

--- a/frontends/blif/blifparse.cc
+++ b/frontends/blif/blifparse.cc
@@ -65,17 +65,21 @@ static std::pair<RTLIL::IdString, int> wideports_split(std::string name)
 	for (int i = 0; i+1 < GetSize(name); i++) {
 		if (name[i] == '[')
 			pos = i;
-		else if (name[i] < '0' || name[i] > '9')
+		else if (name[i] != '-' && (name[i] < '0' || name[i] > '9'))
+			pos = -1;
+		else if (name[i] == '-' && ((i != pos+1) || name[i+1] == ']'))
+			pos = -1;
+		else if (i == pos+2 && name[i] == '0' && name[i-1] == '-')
 			pos = -1;
 		else if (i == pos+1 && name[i] == '0' && name[i+1] != ']')
 			pos = -1;
 	}
 
 	if (pos >= 0)
-		return std::pair<RTLIL::IdString, int>("\\" + name.substr(0, pos), atoi(name.c_str() + pos+1)+1);
+		return std::pair<RTLIL::IdString, int>("\\" + name.substr(0, pos), atoi(name.c_str() + pos+1));
 
 failed:
-	return std::pair<RTLIL::IdString, int>("\\" + name, 0);
+	return std::pair<RTLIL::IdString, int>(RTLIL::IdString(), 0);
 }
 
 void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool run_clean, bool sop_mode, bool wideports)
@@ -263,8 +267,8 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 
 					if (wideports) {
 						std::pair<RTLIL::IdString, int> wp = wideports_split(p);
-						if (wp.second > 0) {
-							wideports_cache[wp.first].first = std::max(wideports_cache[wp.first].first, wp.second);
+						if (!wp.first.empty() && wp.second >= 0) {
+							wideports_cache[wp.first].first = std::max(wideports_cache[wp.first].first, wp.second + 1);
 							wideports_cache[wp.first].second = !strcmp(cmd, ".inputs");
 						}
 					}
@@ -375,6 +379,7 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 
 				IdString celltype = RTLIL::escape_id(p);
 				RTLIL::Cell *cell = module->addCell(NEW_ID, celltype);
+				RTLIL::Module *cell_mod = design->module(celltype);
 
 				dict<RTLIL::IdString, dict<int, SigBit>> cell_wideports_cache;
 
@@ -387,10 +392,10 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 
 					if (wideports) {
 						std::pair<RTLIL::IdString, int> wp = wideports_split(p);
-						if (wp.second > 0)
-							cell_wideports_cache[wp.first][wp.second-1] = blif_wire(q);
-						else
+						if (wp.first.empty())
 							cell->setPort(RTLIL::escape_id(p), *q ? blif_wire(q) : SigSpec());
+						else
+							cell_wideports_cache[wp.first][wp.second] = blif_wire(q);
 					} else {
 						cell->setPort(RTLIL::escape_id(p), *q ? blif_wire(q) : SigSpec());
 					}
@@ -399,14 +404,26 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 				for (auto &it : cell_wideports_cache)
 				{
 					int width = 0;
+					int offset = 0;
+					bool upto = false;
 					for (auto &b : it.second)
 						width = std::max(width, b.first + 1);
+
+					if (cell_mod) {
+						Wire *cell_port = cell_mod->wire(it.first);
+						if (cell_port && (cell_port->port_input || cell_port->port_output)) {
+							offset = cell_port->start_offset;
+							upto = cell_port->upto;
+							width = cell_port->width;
+						}
+					}
 
 					SigSpec sig;
 
 					for (int i = 0; i < width; i++) {
-						if (it.second.count(i))
-							sig.append(it.second.at(i));
+						int idx = offset + (upto ? width - 1 - i: i);
+						if (it.second.count(idx))
+							sig.append(it.second.at(idx));
 						else
 							sig.append(module->addWire(NEW_ID));
 					}

--- a/passes/cmds/connect.cc
+++ b/passes/cmds/connect.cc
@@ -60,7 +60,7 @@ struct ConnectPass : public Pass {
 		log("Unconnect all existing drivers for the specified expression.\n");
 		log("\n");
 		log("\n");
-		log("    connect [-nomap] -port <cell> <port> <expr>\n");
+		log("    connect [-nomap] [-assert] -port <cell> <port> <expr>\n");
 		log("\n");
 		log("Connect the specified cell port to the specified cell port.\n");
 		log("\n");
@@ -71,6 +71,9 @@ struct ConnectPass : public Pass {
 		log("\n");
 		log("The connect command operates in one module only. Either only one module must\n");
 		log("be selected or an active module must be set using the 'cd' command.\n");
+		log("\n");
+		log("The -assert option verifies that the connection already exists, instead of\n");
+		log("making it.\n");
 		log("\n");
 		log("This command does not operate on module with processes.\n");
 		log("\n");
@@ -88,7 +91,7 @@ struct ConnectPass : public Pass {
 		if (!module->processes.empty())
 			log_cmd_error("Found processes in selected module.\n");
 
-		bool flag_nounset = false, flag_nomap = false;
+		bool flag_nounset = false, flag_nomap = false, flag_assert = false;
 		std::string set_lhs, set_rhs, unset_expr;
 		std::string port_cell, port_port, port_expr;
 
@@ -102,6 +105,10 @@ struct ConnectPass : public Pass {
 			}
 			if (arg == "-nomap") {
 				flag_nomap = true;
+				continue;
+			}
+			if (arg == "-assert") {
+				flag_assert = true;
 				continue;
 			}
 			if (arg == "-set" && argidx+2 < args.size()) {
@@ -126,7 +133,7 @@ struct ConnectPass : public Pass {
 		if (!flag_nomap)
 			for (auto &it : module->connections()) {
 				std::vector<RTLIL::SigBit> lhs = it.first.to_sigbit_vector();
-				std::vector<RTLIL::SigBit> rhs = it.first.to_sigbit_vector();
+				std::vector<RTLIL::SigBit> rhs = it.second.to_sigbit_vector();
 				for (size_t i = 0; i < lhs.size(); i++)
 					if (rhs[i].wire != nullptr)
 						sigmap.add(lhs[i], rhs[i]);
@@ -136,6 +143,9 @@ struct ConnectPass : public Pass {
 		{
 			if (!unset_expr.empty() || !port_cell.empty())
 				log_cmd_error("Can't use -set together with -unset and/or -port.\n");
+
+			if (flag_assert)
+				log_cmd_error("The -assert option is only supported with -port.\n");
 
 			RTLIL::SigSpec sig_lhs, sig_rhs;
 			if (!RTLIL::SigSpec::parse_sel(sig_lhs, design, module, set_lhs))
@@ -157,6 +167,9 @@ struct ConnectPass : public Pass {
 			if (!port_cell.empty() || flag_nounset)
 				log_cmd_error("Can't use -unset together with -port and/or -nounset.\n");
 
+			if (flag_assert)
+				log_cmd_error("The -assert option is only supported with -port.\n");
+
 			RTLIL::SigSpec sig;
 			if (!RTLIL::SigSpec::parse_sel(sig, design, module, unset_expr))
 				log_cmd_error("Failed to parse unset expression `%s'.\n", unset_expr.c_str());
@@ -177,7 +190,14 @@ struct ConnectPass : public Pass {
 			if (!RTLIL::SigSpec::parse_sel(sig, design, module, port_expr))
 				log_cmd_error("Failed to parse port expression `%s'.\n", port_expr.c_str());
 
-			module->cell(RTLIL::escape_id(port_cell))->setPort(RTLIL::escape_id(port_port), sigmap(sig));
+			if (!flag_assert) {
+				module->cell(RTLIL::escape_id(port_cell))->setPort(RTLIL::escape_id(port_port), sigmap(sig));
+			} else {
+				SigSpec cur = module->cell(RTLIL::escape_id(port_cell))->getPort(RTLIL::escape_id(port_port));
+				if (sigmap(sig) != sigmap(cur)) {
+					log_cmd_error("Expected connection not present: expected %s, found %s.\n", log_signal(sig), log_signal(cur));
+				}
+			}
 		}
 		else
 			log_cmd_error("Expected -set, -unset, or -port.\n");

--- a/tests/blif/bug2729.ys
+++ b/tests/blif/bug2729.ys
@@ -1,0 +1,20 @@
+read_verilog <<EOF
+
+module cell (input [2:12] I, output [5:-5] O);
+endmodule
+
+module top(input [10:0] A, output [10:0] B);
+cell my_cell(.I(A), .O(B));
+endmodule
+
+EOF
+
+write_blif tmp-bug2729.blif
+delete top
+read_blif -wideports tmp-bug2729.blif
+!rm tmp-bug2729.blif
+rename -enumerate t:cell
+dump
+cd top
+connect -assert -port _0_ I A
+connect -assert -port _0_ O B

--- a/tests/blif/run-test.sh
+++ b/tests/blif/run-test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+for x in *.ys; do
+  echo "Running $x.."
+  ../../yosys -ql ${x%.ys}.log $x
+done


### PR DESCRIPTION
Fixes #2729.