### PR TITLE
Add support for the SystemVerilog bind keyword

### DIFF
--- a/frontends/ast/ast_binding.h
+++ b/frontends/ast/ast_binding.h
@@ -47,6 +47,9 @@ namespace AST
 
 		std::string describe() const override;
 
+		bool bind_into(RTLIL::Design &design,
+		               RTLIL::Module &target) const override;
+
 	private:
 		// The syntax-level representation of the cell to be bound.
 		std::unique_ptr<AstNode> ast_node;

--- a/kernel/binding.cc
+++ b/kernel/binding.cc
@@ -24,6 +24,163 @@ YOSYS_NAMESPACE_BEGIN
 RTLIL::Binding::Binding(RTLIL::IdString target_type,
                         RTLIL::IdString target_name)
 	: target_type(target_type), target_name(target_name)
-{}
+{
+	// A counter of the number of bindings that have been created so far.
+	static int binding_counter;
+	attr_name = stringf("\\bound%d", binding_counter++);
+}
+
+// Return true if mod is either called name or is derived from an abstract
+// module that was called name.
+static bool
+module_original_type_matches(const RTLIL::Module &mod, RTLIL::IdString name)
+{
+	if (mod.name == name) return true;
+
+	// A module derived from 'foo' will have a name starting with $paramod
+	// and an 'hdlname' attribute equal to '\foo'.
+	if (!mod.name.begins_with("$paramod"))
+		return false;
+
+	RTLIL::IdString hdlname = mod.get_string_attribute(ID::hdlname);
+	log_assert(!hdlname.empty());
+	return (hdlname == name);
+}
+
+// Search through the design for modules called name, or that are derived from
+// one called name.
+static std::vector<RTLIL::Module *>
+find_concrete_modules(RTLIL::Design &design, RTLIL::IdString name)
+{
+	std::vector<RTLIL::Module *> mods;
+
+	for (const auto &pr : design.modules_) {
+		if (module_original_type_matches(*pr.second, name))
+			mods.push_back(pr.second);
+	}
+
+	return mods;
+}
+
+// Try to find a cell below mod whose (dot-separated) name is given by path.
+// Modify so_far in place and return true on success.
+static bool
+find_cell_in(RTLIL::Binding::Path *so_far,
+             RTLIL::Design &design, RTLIL::Module &mod, const char *path)
+{
+	const char *dot = strchr(path, '.');
+	std::string cell_name =
+		dot ? std::string(path, dot - path) : std::string(path);
+
+	RTLIL::Cell *cell = mod.cell('\\' + cell_name);
+	if (!cell)
+		return false;
+
+	so_far->push_back(RTLIL::Binding::Item(&mod, cell));
+	if (!dot)
+		return true;
+
+	// We found a child cell, but there's more searching to do. Recurse to
+	// search the cell's module.
+	return find_cell_in(so_far, design, *cell->module, dot + 1);
+}
+
+RTLIL::Binding::Path
+RTLIL::Binding::find_rel_cell(RTLIL::Design &design, RTLIL::Module &start) const
+{
+	Path ret;
+	bool found = find_cell_in(&ret, design, start, target_name.c_str() + 1);
+	if (!found)
+		return Path();
+
+	log_assert(ret.size());
+	check_cell_type(design, *ret.back().second);
+	return ret;
+}
+
+std::vector<RTLIL::Binding::Path>
+RTLIL::Binding::find_tl_cells(RTLIL::Design &design) const
+{
+	std::vector<Path> paths;
+
+	std::string tgt_name = target_name.str();
+	size_t tgt_off = 0;
+
+	// The target name should always start with a backslash
+	log_assert(tgt_name[0] == '\\');
+
+	// Is the name absolute (starts with $root)? If so, just skip past that:
+	// we're at the top already.
+	if (tgt_name.compare(0, 7, "\\$root.") == 0)
+		tgt_off = 7;
+	else
+		tgt_off = 1;
+
+	// This function can only find cells (as opposed to modules at the top
+	// level). If there's no '.' after tgt_off, give up.
+	size_t dot_off = tgt_name.find('.', tgt_off);
+	if (dot_off == std::string::npos)
+		return paths;
+
+	// Otherwise, characters with indices {tgt_off .. dot_off - 1} should
+	// name a module and then {dot_off + 1 .. } should name the cell
+	// relative to the module.
+	//
+	// Note that we need to prefix the module name with a backslash (which
+	// is separated from the actual module name if the name started with
+	// $root) before interning the string.
+	std::string mod_name = '\\' + tgt_name.substr(tgt_off, dot_off - tgt_off);
+	const char *cell_path = tgt_name.c_str() + dot_off + 1;
+
+	std::vector<RTLIL::Module *> mods = find_concrete_modules(design, mod_name);
+	for (RTLIL::Module *mod : mods) {
+		Path path;
+		bool found = find_cell_in(&path, design, *mod, cell_path);
+		if (found) {
+			log_assert(path.size());
+			check_cell_type(design, *path.back().second);
+			paths.push_back(path);
+		}
+	}
+
+	// If no concrete modules for mod_name have a cell at cell_path, then
+	// paths will be an empty vector. If *some* have the cell (possible with
+	// a generate if/else or similar), we should probably complain.
+	if (paths.size() > 0 && paths.size() != mods.size()) {
+		log_error("Some, but not all, specialized modules "
+		          "with original name %s have a cell at path %s.",
+		          mod_name.c_str(), cell_path);
+	}
+
+	return paths;
+}
+
+std::vector<RTLIL::Module *>
+RTLIL::Binding::find_concrete_module_targets(RTLIL::Design &design) const
+{
+	// If target_type is nonempty, the bind statement had an instantiation
+	// list. In which case, we definitely don't want to interpret this as a
+	// module name.
+	if(!target_type.empty())
+		return std::vector<RTLIL::Module *>();
+
+	return find_concrete_modules(design, target_name);
+}
+
+void
+RTLIL::Binding::check_cell_type(RTLIL::Design &design,
+                                const RTLIL::Cell &cell) const
+{
+	// If the user specified the module type, check it matches
+	if (!target_type.empty()) {
+		const RTLIL::Module *cell_mod = design.module(cell.type);
+		log_assert(cell_mod);
+		if (!module_original_type_matches(*cell_mod, target_type)) {
+			log_error("The %s matches a cell, "
+				  "but that cell has the wrong type (%s).",
+				  describe().c_str(), cell_mod->name.c_str());
+		}
+	}
+}
 
 YOSYS_NAMESPACE_END

--- a/tests/bind/basic.sv
+++ b/tests/bind/basic.sv
@@ -1,4 +1,12 @@
 // A basic example of the bind construct
+//
+// act contains an instance of foo. foo is empty, but we bind in an instance of
+// bar to do the XOR. ref is the "reference implementation" that contains a bar
+// with no binding required.
+//
+// The code to drive this is in basic.ys, which runs the hierarchy pass (to
+// insert the bound module), flattens the design and then runs an equivalence
+// check between act and ref.
 
 module foo (input logic a, input logic b, output logic c);
   // Magic happens here...
@@ -8,13 +16,11 @@ module bar (input a, input b, output c);
   assign c = a ^ b;
 endmodule
 
-module top ();
-  logic u, v, w;
+module act (input u, input v, output w);
   foo foo_i (.a (u), .b (v), .c (w));
-
   bind foo bar bound_i (.*);
+endmodule
 
-  always_comb begin
-    assert(w == u ^ v);
-  end
+module ref (input u, input v, output w);
+  assign w = u ^ v;
 endmodule

--- a/tests/bind/basic.ys
+++ b/tests/bind/basic.ys
@@ -1,1 +1,6 @@
 read_verilog -sv basic.sv
+hierarchy
+flatten
+equiv_make ref act equiv
+equiv_simple
+equiv_status -assert

--- a/tests/bind/cell_list.sv
+++ b/tests/bind/cell_list.sv
@@ -10,17 +10,16 @@ module bar (input a, input b, output c);
   assign c = a ^ b;
 endmodule
 
-module top ();
-  logic u0, v0, w0;
-  logic u1, v1, w1;
-
+module act (input u0, input v0, output w0,
+            input u1, input v1, output w1);
   foo foo0 (.a0 (u0), .b0 (v0), .c0 (w0),
             .a1 (u1), .b1 (v1), .c1 (w1));
 
   bind foo bar bar0 (.a(a0), .b(b0), .c(c0)), bar1 (.a(a1), .b(b1), .c(c1));
+endmodule
 
-  always_comb begin
-    assert(w0 == u0 ^ v0);
-    assert(w1 == u1 ^ v1);
-  end
+module ref (input u0, input v0, output w0,
+            input u1, input v1, output w1);
+  assign w0 = u0 ^ v0;
+  assign w1 = u1 ^ v1;
 endmodule

--- a/tests/bind/cell_list.ys
+++ b/tests/bind/cell_list.ys
@@ -1,1 +1,6 @@
 read_verilog -sv cell_list.sv
+hierarchy
+flatten
+equiv_make ref act equiv
+equiv_simple
+equiv_status -assert

--- a/tests/bind/hier.sv
+++ b/tests/bind/hier.sv
@@ -1,4 +1,6 @@
-// An example of the bind construct using a hierarchical reference starting with $root
+// An example of a bind construct at top-level using a hierarchical reference
+// starting with $root
+//
 
 module foo (input logic a, input logic b, output logic c);
   // Magic happens here...
@@ -8,13 +10,12 @@ module bar (input a, input b, output c);
   assign c = a ^ b;
 endmodule
 
-module top ();
-  logic u, v, w;
+module act (input u, input v, output w);
   foo foo_i (.a (u), .b (v), .c (w));
-
-  always_comb begin
-    assert(w == u ^ v);
-  end
 endmodule
 
-bind $root.top.foo_i bar bound_i (.*);
+bind $root.act.foo_i bar bound_i (.*);
+
+module ref (input u, input v, output w);
+  assign w = u ^ v;
+endmodule

--- a/tests/bind/hier.ys
+++ b/tests/bind/hier.ys
@@ -1,1 +1,6 @@
 read_verilog -sv hier.sv
+hierarchy
+flatten
+equiv_make ref act equiv
+equiv_simple
+equiv_status -assert

--- a/tests/bind/inst_list.sv
+++ b/tests/bind/inst_list.sv
@@ -8,17 +8,16 @@ module bar (input a, input b, output c);
   assign c = a ^ b;
 endmodule
 
-module top ();
-  logic u0, v0, w0;
-  logic u1, v1, w1;
-
+module act (input u0, input v0, output w0,
+            input u1, input v1, output w1);
   foo foo0 (.a (u0), .b (v0), .c (w0));
   foo foo1 (.a (u1), .b (v1), .c (w1));
 
   bind foo : foo0, foo1 bar bound_i (.*);
+endmodule
 
-  always_comb begin
-    assert(w0 == u0 ^ v0);
-    assert(w1 == u1 ^ v1);
-  end
+module ref (input u0, input v0, output w0,
+            input u1, input v1, output w1);
+  assign w0 = u0 ^ v0;
+  assign w1 = u1 ^ v1;
 endmodule

--- a/tests/bind/inst_list.ys
+++ b/tests/bind/inst_list.ys
@@ -1,1 +1,6 @@
-read_verilog -sv inst_list.sv
+read_verilog -sv cell_list.sv
+hierarchy
+flatten
+equiv_make ref act equiv
+equiv_simple
+equiv_status -assert

--- a/tests/bind/param.sv
+++ b/tests/bind/param.sv
@@ -12,15 +12,16 @@ module bar (input a, input b, output c);
   assign c = doit ? a ^ b : 0;
 endmodule
 
-module top (input u0, input v0, output w0,
+module act (input u0, input v0, output w0,
             input u1, input v1, output w1);
   foo #(.doit (0)) foo0 (.a (u0), .b (v0), .c (w0));
   foo #(.doit (1)) foo1 (.a (u1), .b (v1), .c (w1));
 
   bind foo bar #(.doit (doit)) bound_i (.*);
+endmodule
 
-  always_comb begin
-    assert (w0 == '0);
-    assert (w1 == u1 ^ v1);
-  end
+module ref (input u0, input v0, output w0,
+            input u1, input v1, output w1);
+  assign w0 = 0;
+  assign w1 = u1 ^ v1;
 endmodule

--- a/tests/bind/param.ys
+++ b/tests/bind/param.ys
@@ -1,1 +1,6 @@
 read_verilog -sv param.sv
+hierarchy
+flatten
+equiv_make ref act equiv
+equiv_simple
+equiv_status -assert

--- a/tests/bind/toplevel.sv
+++ b/tests/bind/toplevel.sv
@@ -8,13 +8,12 @@ module bar (input a, input b, output c);
   assign c = a ^ b;
 endmodule
 
-module top ();
-  logic u, v, w;
+module act (input u, input v, output w);
   foo foo_i (.a (u), .b (v), .c (w));
-
-  always_comb begin
-    assert(w == u ^ v);
-  end
 endmodule
 
-bind top.foo_i bar bound_i (.*);
+bind act.foo_i bar bound_i (.*);
+
+module ref (input u, input v, output w);
+  assign w = u ^ v;
+endmodule

--- a/tests/bind/toplevel.ys
+++ b/tests/bind/toplevel.ys
@@ -1,1 +1,6 @@
 read_verilog -sv toplevel.sv
+hierarchy
+flatten
+equiv_make ref act equiv
+equiv_simple
+equiv_status -assert


### PR DESCRIPTION
EDIT: This used to be a large patch set, but it's now mostly merged. The remaining commit has the following commit message:

**Implement bind elaboration in the hierarchy pass**

This is surprisingly finicky, because of the difference between `bind`
directives that target modules and those that target specific
instances of those modules (i.e. specific cells).

In the first case, we can just operate on the module in place. In the
second, we have to make fresh copies of the target module and the
"path of cells" from the bind directive down to it. For instance, in
something like this:

    bind $root.foo.bar_i.baz_i qux bound_i (.*);

(where `bar_i` and `baz_i` are instances of modules called `bar` and `baz`,
respectively), we need to make a fresh clone of `baz` (let's call it
`baz1`) into which we insert an instance of `qux`. But we can't just
modify bar to re-type its `baz_i` cell from `baz` to `baz1`: what if there
are other instances of `bar` in the design? So we then need to make a
fresh clone of `bar` (let's call it `bar1`). Since `foo` here refers to the
module, rather than a particular instance, we *can* now modify `foo` to
re-type it's `bar_i` cell from `bar` to `bar1` (phew!).

To avoid some extra un-needed renames, we actually count the number of
times each cell type appears in the design (see `get_cell_type_counts`).
If the design in the example above didn't actually use `bar` except as
`bar_i` in module `foo`, we actually operate in place rather than
renaming.
