### PR TITLE
Change the type of current_module to Module

### DIFF
--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -379,7 +379,7 @@ namespace AST_INTERNAL
 	extern const dict<RTLIL::SigBit, RTLIL::SigBit> *genRTLIL_subst_ptr;
 	extern RTLIL::SigSpec ignoreThisSignalsInInitial;
 	extern AST::AstNode *current_always, *current_top_block, *current_block, *current_block_child;
-	extern AST::AstModule *current_module;
+	extern RTLIL::Module *current_module;
 	extern bool current_always_clocked;
 	extern dict<std::string, int> current_memwr_count;
 	extern dict<std::string, pool<int>> current_memwr_visible;


### PR DESCRIPTION
The current_module global is needed so that genRTLIL has somewhere to
put cells and wires that it generates as it makes sense of expressions
that it sees. However, that doesn't actually need to be an AstModule:
the Module base class is enough.

This patch should cause no functional change, but the point is that
it's now possible to call genRTLIL with a module that isn't an
AstModule as "current_module". This will be needed for 'bind' support.

(Note: This patch is part of the larger queue at #2752. The idea is to split things out to avoid having a giant PR to review all at once)