### PR TITLE
kernel/rtlil: Extract some helpers for checking memory cell types.

### DIFF
--- a/backends/btor/btor.cc
+++ b/backends/btor/btor.cc
@@ -708,7 +708,7 @@ struct BtorWorker
 			goto okay;
 		}
 
-		if (cell->type.in(ID($mem), ID($memrd), ID($memwr), ID($meminit)))
+		if (cell->is_mem_cell())
 		{
 			Mem *mem = mem_cells[cell];
 

--- a/backends/smt2/smt2.cc
+++ b/backends/smt2/smt2.cc
@@ -182,7 +182,7 @@ struct Smt2Worker
 				continue;
 
 			// Handled above.
-			if (cell->type.in(ID($mem), ID($memrd), ID($memwr), ID($meminit))) {
+			if (cell->is_mem_cell()) {
 				mem_cells[cell] = mem_dict[cell->parameters.at(ID::MEMID).decode_string()];
 				continue;
 			}
@@ -694,7 +694,7 @@ struct Smt2Worker
 			// FIXME: $slice $concat
 		}
 
-		if (memmode && cell->type.in(ID($mem), ID($memrd), ID($memwr), ID($meminit)))
+		if (memmode && cell->is_mem_cell())
 		{
 			Mem *mem = mem_cells[cell];
 

--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -1464,7 +1464,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 void dump_cell(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 {
 	// Handled by dump_memory
-	if (cell->type.in(ID($mem), ID($memwr), ID($memrd), ID($meminit)))
+	if (cell->is_mem_cell())
 		return;
 
 	if (cell->type[0] == '$' && !noexpr) {

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -3125,6 +3125,16 @@ void RTLIL::Cell::fixup_parameters(bool set_a_signed, bool set_b_signed)
 	check();
 }
 
+bool RTLIL::Cell::has_memid() const
+{
+	return type.in(ID($memwr), ID($memrd), ID($meminit));
+}
+
+bool RTLIL::Cell::is_mem_cell() const
+{
+	return type == ID($mem) || has_memid();
+}
+
 RTLIL::SigChunk::SigChunk()
 {
 	wire = NULL;

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1522,6 +1522,9 @@ public:
 #ifdef WITH_PYTHON
 	static std::map<unsigned int, RTLIL::Cell*> *get_all_cells(void);
 #endif
+
+	bool has_memid() const;
+	bool is_mem_cell() const;
 };
 
 struct RTLIL::CaseRule : public RTLIL::AttrObject

--- a/passes/cmds/delete.cc
+++ b/passes/cmds/delete.cc
@@ -103,7 +103,7 @@ struct DeletePass : public Pass {
 			for (auto cell : module->cells()) {
 				if (design->selected(module, cell))
 					delete_cells.insert(cell);
-				if (cell->type.in(ID($memrd), ID($memwr)) &&
+				if (cell->has_memid() &&
 						delete_mems.count(cell->parameters.at(ID::MEMID).decode_string()) != 0)
 					delete_cells.insert(cell);
 			}

--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -164,7 +164,7 @@ struct SimInstance
 				ff_database[cell] = ff;
 			}
 
-			if (cell->type.in(ID($mem), ID($meminit), ID($memwr), ID($memrd)))
+			if (cell->is_mem_cell())
 			{
 				mem_cells[cell] = cell->parameters.at(ID::MEMID).decode_string();
 			}

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -155,21 +155,6 @@ void prep_hier(RTLIL::Design *design, bool dff_mode)
 		r.first->second = new Design;
 	Design *unmap_design = r.first->second;
 
-	static const pool<IdString> seq_types{
-		ID($dff), ID($dffsr), ID($adff),
-		ID($dlatch), ID($dlatchsr), ID($sr),
-		ID($mem),
-		ID($_DFF_N_), ID($_DFF_P_),
-		ID($_DFFSR_NNN_), ID($_DFFSR_NNP_), ID($_DFFSR_NPN_), ID($_DFFSR_NPP_),
-		ID($_DFFSR_PNN_), ID($_DFFSR_PNP_), ID($_DFFSR_PPN_), ID($_DFFSR_PPP_),
-		ID($_DFF_N_), ID($_DFF_NN0_), ID($_DFF_NN1_), ID($_DFF_NP0_), ID($_DFF_NP1_),
-		ID($_DFF_P_), ID($_DFF_PN0_), ID($_DFF_PN1_), ID($_DFF_PP0_), ID($_DFF_PP1_),
-		ID($_DLATCH_N_), ID($_DLATCH_P_),
-		ID($_DLATCHSR_NNN_), ID($_DLATCHSR_NNP_), ID($_DLATCHSR_NPN_), ID($_DLATCHSR_NPP_),
-		ID($_DLATCHSR_PNN_), ID($_DLATCHSR_PNP_), ID($_DLATCHSR_PPN_), ID($_DLATCHSR_PPP_),
-		ID($_SR_NN_), ID($_SR_NP_), ID($_SR_PN_), ID($_SR_PP_)
-	};
-
 	for (auto module : design->selected_modules())
 		for (auto cell : module->cells()) {
 			auto inst_module = design->module(cell->type);
@@ -221,7 +206,7 @@ void prep_hier(RTLIL::Design *design, bool dff_mode)
 				}
 				else if (derived_module->get_bool_attribute(ID::abc9_box)) {
 					for (auto derived_cell : derived_module->cells())
-						if (seq_types.count(derived_cell->type)) {
+						if (derived_cell->is_mem_cell() || RTLIL::builtin_ff_cell_types().count(derived_cell->type)) {
 							derived_module->set_bool_attribute(ID::abc9_box, false);
 							derived_module->set_bool_attribute(ID::abc9_bypass);
 							break;

--- a/passes/techmap/flatten.cc
+++ b/passes/techmap/flatten.cc
@@ -133,10 +133,10 @@ struct FlattenWorker
 		for (auto tpl_cell : tpl->cells()) {
 			RTLIL::Cell *new_cell = module->addCell(map_name(cell, tpl_cell), tpl_cell);
 			map_attributes(cell, new_cell, tpl_cell->name);
-			if (new_cell->type.in(ID($memrd), ID($memwr), ID($meminit))) {
+			if (new_cell->has_memid()) {
 				IdString memid = new_cell->getParam(ID::MEMID).decode_string();
 				new_cell->setParam(ID::MEMID, Const(memory_map.at(memid).str()));
-			} else if (new_cell->type == ID($mem)) {
+			} else if (new_cell->is_mem_cell()) {
 				IdString memid = new_cell->getParam(ID::MEMID).decode_string();
 				new_cell->setParam(ID::MEMID, Const(concat_name(cell, memid).str()));
 			}

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -364,13 +364,11 @@ struct TechmapWorker
 			for (auto &it2 : autopurge_ports)
 				c->unsetPort(it2);
 
-			if (c->type.in(ID($memrd), ID($memwr), ID($meminit))) {
+			if (c->has_memid()) {
 				IdString memid = c->getParam(ID::MEMID).decode_string();
 				log_assert(memory_renames.count(memid) != 0);
 				c->setParam(ID::MEMID, Const(memory_renames[memid].str()));
-			}
-
-			if (c->type == ID($mem)) {
+			} else if (c->is_mem_cell()) {
 				IdString memid = c->getParam(ID::MEMID).decode_string();
 				apply_prefix(cell->name, memid);
 				c->setParam(ID::MEMID, Const(memid.c_str()));


### PR DESCRIPTION
There will soon be more (versioned) memory cells, so handle passes that
only care if a cell is memory-related by a simple helper call instead of
a hardcoded list.