### PR TITLE
extract_rdff: Add initvals parameter.

### DIFF
--- a/kernel/mem.cc
+++ b/kernel/mem.cc
@@ -445,7 +445,7 @@ std::vector<Mem> Mem::get_selected_memories(Module *module) {
 	return res;
 }
 
-Cell *Mem::extract_rdff(int idx) {
+Cell *Mem::extract_rdff(int idx, FfInitVals *initvals) {
 	MemRd &port = rd_ports[idx];
 
 	if (!port.clk_enable)

--- a/kernel/mem.h
+++ b/kernel/mem.h
@@ -21,6 +21,7 @@
 #define MEM_H
 
 #include "kernel/yosys.h"
+#include "kernel/ffinit.h"
 
 YOSYS_NAMESPACE_BEGIN
 
@@ -70,7 +71,7 @@ struct Mem {
 	Const get_init_data() const;
 	static std::vector<Mem> get_all_memories(Module *module);
 	static std::vector<Mem> get_selected_memories(Module *module);
-	Cell *extract_rdff(int idx);
+	Cell *extract_rdff(int idx, FfInitVals *initvals);
 	Mem(Module *module, IdString memid, int width, int start_offset, int size) : module(module), memid(memid), packed(false), mem(nullptr), cell(nullptr), width(width), start_offset(start_offset), size(size) {}
 };
 

--- a/passes/memory/memory_map.cc
+++ b/passes/memory/memory_map.cc
@@ -34,10 +34,12 @@ struct MemoryMapWorker
 
 	RTLIL::Design *design;
 	RTLIL::Module *module;
+	SigMap sigmap;
+	FfInitVals initvals;
 
 	std::map<std::pair<RTLIL::SigSpec, RTLIL::SigSpec>, RTLIL::SigBit> decoder_cache;
 
-	MemoryMapWorker(RTLIL::Design *design, RTLIL::Module *module) : design(design), module(module) {}
+	MemoryMapWorker(RTLIL::Design *design, RTLIL::Module *module) : design(design), module(module), sigmap(module), initvals(&sigmap, module) {}
 
 	std::string map_case(std::string value) const
 	{
@@ -228,7 +230,7 @@ struct MemoryMapWorker
 		for (int i = 0; i < GetSize(mem.rd_ports); i++)
 		{
 			auto &port = mem.rd_ports[i];
-			if (mem.extract_rdff(i))
+			if (mem.extract_rdff(i, &initvals))
 				count_dff++;
 			RTLIL::SigSpec rd_addr = port.addr;
 			rd_addr.extend_u0(abits, false);

--- a/passes/memory/memory_nordff.cc
+++ b/passes/memory/memory_nordff.cc
@@ -51,15 +51,19 @@ struct MemoryNordffPass : public Pass {
 		extra_args(args, argidx, design);
 
 		for (auto module : design->selected_modules())
-		for (auto &mem : Mem::get_selected_memories(module))
 		{
-			bool changed = false;
-			for (int i = 0; i < GetSize(mem.rd_ports); i++)
-				if (mem.extract_rdff(i))
-					changed = true;
+			SigMap sigmap(module);
+			FfInitVals initvals(&sigmap, module);
+			for (auto &mem : Mem::get_selected_memories(module))
+			{
+				bool changed = false;
+				for (int i = 0; i < GetSize(mem.rd_ports); i++)
+					if (mem.extract_rdff(i, &initvals))
+						changed = true;
 
-			if (changed)
-				mem.emit();
+				if (changed)
+					mem.emit();
+			}
 		}
 	}
 } MemoryNordffPass;


### PR DESCRIPTION
This is not used yet, but will be needed when read port reset/initial
value support lands.