### PR TITLE
kernel/mem: Add priority_mask to model.

### DIFF
--- a/kernel/mem.h
+++ b/kernel/mem.h
@@ -40,6 +40,7 @@ struct MemWr {
 	dict<IdString, Const> attributes;
 	Cell *cell;
 	bool clk_enable, clk_polarity;
+	std::vector<bool> priority_mask;
 	SigSpec clk, en, addr, data;
 	MemWr() : removed(false), cell(nullptr) {}
 };


### PR DESCRIPTION
This is going to be used to store arbitrary priority masks in the
future.  Right now, it is not supported by our cell library, so the
priority_mask is computed from port order on helper construction,
and discarded when emitted.  However, this allows us to already convert
helper-using passes to the new model.