### PR TITLE
kernel/mem: Add model support for read port init value and resets.

### DIFF
--- a/kernel/mem.h
+++ b/kernel/mem.h
@@ -30,9 +30,10 @@ struct MemRd {
 	dict<IdString, Const> attributes;
 	Cell *cell;
 	int wide_log2;
-	bool clk_enable, clk_polarity;
+	bool clk_enable, clk_polarity, ce_over_srst;
+	Const arst_value, srst_value, init_value;
 	bool transparent;
-	SigSpec clk, en, addr, data;
+	SigSpec clk, en, arst, srst, addr, data;
 	MemRd() : removed(false), cell(nullptr) {}
 };
 


### PR DESCRIPTION
Like wide port support, this is still completely unusable, and support
in various passes will be gradually added later.  It also has no support
at all in the cell library, so attempting to create a read port with
a reset or initial value will cause an assert failure for now.
