### PR TITLE
mem/extract_rdff: Fix "no FF made" edge case.

### DIFF
--- a/kernel/mem.cc
+++ b/kernel/mem.cc
@@ -579,7 +579,8 @@ Cell *Mem::extract_rdff(int idx, FfInitVals *initvals) {
 			if (port.addr[i].wire)
 				width++;
 
-		if (width) {
+		if (width)
+		{
 			SigSpec sig_q = module->addWire(stringf("$%s$rdreg[%d]$q", memid.c_str(), idx), width);
 			SigSpec sig_d;
 
@@ -591,6 +592,8 @@ Cell *Mem::extract_rdff(int idx, FfInitVals *initvals) {
 				}
 
 			c = module->addDff(stringf("$%s$rdreg[%d]", memid.c_str(), idx), port.clk, sig_d, sig_q, port.clk_polarity);
+		} else {
+			c = nullptr;
 		}
 	}
 	else

--- a/passes/memory/memory_nordff.cc
+++ b/passes/memory/memory_nordff.cc
@@ -57,9 +57,12 @@ struct MemoryNordffPass : public Pass {
 			for (auto &mem : Mem::get_selected_memories(module))
 			{
 				bool changed = false;
-				for (int i = 0; i < GetSize(mem.rd_ports); i++)
-					if (mem.extract_rdff(i, &initvals))
+				for (int i = 0; i < GetSize(mem.rd_ports); i++) {
+					if (mem.rd_ports[i].clk_enable) {
+						mem.extract_rdff(i, &initvals);
 						changed = true;
+					}
+				}
 
 				if (changed)
 					mem.emit();


### PR DESCRIPTION
When converting a sync transparent read port with const address to async
read port, nothing at all needs to be done other than clk_enable change,
and thus we have no FF cell to return.  Handle this case correctly in
the helper and in its users.