### PR TITLE
verilog: check for module scope identifiers during width detection

### DIFF
--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -326,6 +326,9 @@ namespace AST
 
 		// helpers for locations
 		std::string loc_string() const;
+
+		// Helper for looking up identifiers which are prefixed with the current module name
+		std::string try_pop_module_prefix() const;
 	};
 
 	// process an AST tree (ast must point to an AST_DESIGN node) and generate RTLIL code

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -767,8 +767,15 @@ void AstNode::detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *foun
 
 	case AST_IDENTIFIER:
 		id_ast = id2ast;
-		if (id_ast == NULL && current_scope.count(str))
-			id_ast = current_scope.at(str);
+		if (!id_ast) {
+			if (current_scope.count(str))
+				id_ast = current_scope[str];
+			else {
+				std::string alt = try_pop_module_prefix();
+				if (current_scope.count(alt))
+					id_ast = current_scope[alt];
+			}
+		}
 		if (!id_ast)
 			log_file_error(filename, location.first_line, "Failed to resolve identifier %s for width detection!\n", str.c_str());
 		if (id_ast->type == AST_PARAMETER || id_ast->type == AST_LOCALPARAM || id_ast->type == AST_ENUM_ITEM) {

--- a/tests/simple/module_scope_case.v
+++ b/tests/simple/module_scope_case.v
@@ -1,0 +1,11 @@
+module top(
+	input wire x,
+	output reg y
+);
+	always @* begin
+		case (top.x)
+			1: top.y = 0;
+			0: top.y = 1;
+		endcase
+	end
+endmodule


### PR DESCRIPTION
The recent fix for case expression width detection causes the width of
the expressions to be queried before they are simplified. Because the
logic supporting module scope identifiers only existed in simplify,
looking them up would fail during width detection. This moves the logic
to a common helper used in both simplify() and detectSignWidthWorker().