### PR TITLE
autoname: simple perf optimizations

### DIFF
--- a/passes/cmds/autoname.cc
+++ b/passes/cmds/autoname.cc
@@ -22,25 +22,20 @@
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
-int autoname_worker(Module *module)
+int autoname_worker(Module *module, const dict<Wire*, int>& wire_score)
 {
 	dict<Cell*, pair<int, IdString>> proposed_cell_names;
 	dict<Wire*, pair<int, IdString>> proposed_wire_names;
-	dict<Wire*, int> wire_score;
 	int best_score = -1;
-
-	for (auto cell : module->selected_cells())
-	for (auto &conn : cell->connections())
-	for (auto bit : conn.second)
-		if (bit.wire != nullptr)
-			wire_score[bit.wire]++;
 
 	for (auto cell : module->selected_cells()) {
 		if (cell->name[0] == '$') {
 			for (auto &conn : cell->connections()) {
-				string suffix = stringf("_%s_%s", log_id(cell->type), log_id(conn.first));
+				string suffix;
 				for (auto bit : conn.second)
 					if (bit.wire != nullptr && bit.wire->name[0] != '$') {
+						if (suffix.empty())
+							suffix = stringf("_%s_%s", log_id(cell->type), log_id(conn.first));
 						IdString new_name(bit.wire->name.str() + suffix);
 						int score = wire_score.at(bit.wire);
 						if (cell->output(conn.first)) score = 0;
@@ -54,9 +49,11 @@ int autoname_worker(Module *module)
 			}
 		} else {
 			for (auto &conn : cell->connections()) {
-				string suffix = stringf("_%s", log_id(conn.first));
+				string suffix;
 				for (auto bit : conn.second)
 					if (bit.wire != nullptr && bit.wire->name[0] == '$' && !bit.wire->port_id) {
+						if (suffix.empty())
+							suffix = stringf("_%s", log_id(conn.first));
 						IdString new_name(cell->name.str() + suffix);
 						int score = wire_score.at(bit.wire);
 						if (cell->output(conn.first)) score = 0;
@@ -118,10 +115,17 @@ struct AutonamePass : public Pass {
 
 		for (auto module : design->selected_modules())
 		{
+			dict<Wire*, int> wire_score;
+			for (auto cell : module->selected_cells())
+			for (auto &conn : cell->connections())
+			for (auto bit : conn.second)
+				if (bit.wire != nullptr)
+					wire_score[bit.wire]++;
+
 			int count = 0, iter = 0;
 			while (1) {
 				iter++;
-				int n = autoname_worker(module);
+				int n = autoname_worker(module, wire_score);
 				if (!n) break;
 				count += n;
 			}


### PR DESCRIPTION
I'm not making any algorithmic changes, just trying to fix some low hanging fruit. I'm sure there is still a lot of room for improvement. On @anuejn's test case in #2816, these changes reduced the `autoname` runtime from ~85s to ~20s.