### PR TITLE
Makefile cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -492,10 +492,8 @@ CXXFLAGS += -DYOSYS_LINK_ABC
 ifeq ($(DISABLE_ABC_THREADS),0)
 LDLIBS += -lpthread
 endif
-else
-ifeq ($(ABCEXTERNAL),)
+else ifeq ($(ABCEXTERNAL),)
 TARGETS += $(PROGRAM_PREFIX)yosys-abc$(EXE)
-endif
 endif
 endif
 
@@ -529,11 +527,9 @@ endif
 ifeq ($(ENABLE_CCACHE),1)
 CC := ccache $(CC)
 CXX := ccache $(CXX)
-else
-ifeq ($(ENABLE_SCCACHE),1)
+else ifeq ($(ENABLE_SCCACHE),1)
 CC := sccache $(CC)
 CXX := sccache $(CXX)
-endif
 endif
 
 define add_share_file

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ endif
 ifeq ($(CONFIG),clang)
 CC = clang
 CXX = clang++
-LD = clang++
+LD = clang
 CXXFLAGS += -std=c++11 -Os
 ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H"
 
@@ -215,7 +215,7 @@ CXXFLAGS += -std=c++11 -Os
 ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H"
 
 else ifeq ($(CONFIG),gcc-static)
-LD = $(CXX)
+LD = $(CC)
 LDFLAGS := $(filter-out -rdynamic,$(LDFLAGS)) -static
 LDLIBS := $(filter-out -lrt,$(LDLIBS))
 CXXFLAGS := $(filter-out -fPIC,$(CXXFLAGS))
@@ -291,14 +291,14 @@ else ifeq ($(CONFIG),wasi)
 ifeq ($(WASI_SDK),)
 CC = clang
 CXX = clang++
-LD = clang++
+LD = clang
 AR = llvm-ar
 RANLIB = llvm-ranlib
 WASIFLAGS := -target wasm32-wasi --sysroot $(WASI_SYSROOT) $(WASIFLAGS)
 else
 CC = $(WASI_SDK)/bin/clang
 CXX = $(WASI_SDK)/bin/clang++
-LD = $(WASI_SDK)/bin/clang++
+LD = $(WASI_SDK)/bin/clang
 AR = $(WASI_SDK)/bin/ar
 RANLIB = $(WASI_SDK)/bin/ranlib
 WASIFLAGS := --sysroot $(WASI_SDK)/share/wasi-sysroot $(WASIFLAGS)
@@ -322,7 +322,7 @@ else ifeq ($(CONFIG),mxe)
 PKG_CONFIG = /usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-pkg-config
 CC = /usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-gcc
 CXX = /usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-g++
-LD = /usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-g++
+LD = /usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-gcc
 CXXFLAGS += -std=c++11 -Os -D_POSIX_SOURCE -DYOSYS_MXE_HACKS -Wno-attributes
 CXXFLAGS := $(filter-out -fPIC,$(CXXFLAGS))
 LDFLAGS := $(filter-out -rdynamic,$(LDFLAGS)) -s
@@ -335,7 +335,7 @@ EXE = .exe
 else ifeq ($(CONFIG),msys2-32)
 CC = i686-w64-mingw32-gcc
 CXX = i686-w64-mingw32-g++
-LD = i686-w64-mingw32-g++
+LD = i686-w64-mingw32-gcc
 CXXFLAGS += -std=c++11 -Os -D_POSIX_SOURCE -DYOSYS_WIN32_UNIX_DIR
 CXXFLAGS := $(filter-out -fPIC,$(CXXFLAGS))
 LDFLAGS := $(filter-out -rdynamic,$(LDFLAGS)) -s
@@ -347,7 +347,7 @@ EXE = .exe
 else ifeq ($(CONFIG),msys2-64)
 CC = x86_64-w64-mingw32-gcc
 CXX = x86_64-w64-mingw32-g++
-LD = x86_64-w64-mingw32-g++
+LD = x86_64-w64-mingw32-gcc
 CXXFLAGS += -std=c++11 -Os -D_POSIX_SOURCE -DYOSYS_WIN32_UNIX_DIR
 CXXFLAGS := $(filter-out -fPIC,$(CXXFLAGS))
 LDFLAGS := $(filter-out -rdynamic,$(LDFLAGS)) -s

--- a/Makefile
+++ b/Makefile
@@ -194,14 +194,14 @@ ifneq ($(SANITIZER),)
 $(info [Clang Sanitizer] $(SANITIZER))
 CXXFLAGS += -g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=$(SANITIZER)
 LDFLAGS += -g -fsanitize=$(SANITIZER)
-ifeq ($(SANITIZER),address)
+ifneq ($(findstring address,$(SANITIZER)),)
 ENABLE_COVER := 0
 endif
-ifeq ($(SANITIZER),memory)
+ifneq ($(findstring memory,$(SANITIZER)),)
 CXXFLAGS += -fPIE -fsanitize-memory-track-origins
 LDFLAGS += -fPIE -fsanitize-memory-track-origins
 endif
-ifeq ($(SANITIZER),cfi)
+ifneq ($(findstring cfi,$(SANITIZER)),)
 CXXFLAGS += -flto
 LDFLAGS += -flto
 endif

--- a/Makefile
+++ b/Makefile
@@ -700,7 +700,7 @@ endif
 
 %.pyh: %.h
 	$(Q) mkdir -p $(dir $@)
-	$(P) cat $< | grep -E -v "#[ ]*(include|error)" | $(LD) $(CXXFLAGS) -x c++ -o $@ -E -P -
+	$(P) cat $< | grep -E -v "#[ ]*(include|error)" | $(CXX) $(CXXFLAGS) -x c++ -o $@ -E -P -
 
 ifeq ($(ENABLE_PYOSYS),1)
 $(PY_WRAPPER_FILE).cc: misc/$(PY_GEN_SCRIPT).py $(PY_WRAP_INCLUDES)

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ LDLIBS += -lrt
 endif
 
 YOSYS_VER := 0.9+4081
-GIT_REV := $(shell cd $(YOSYS_SRC) && git rev-parse --short HEAD 2> /dev/null || echo UNKNOWN)
+GIT_REV := $(shell git -C $(YOSYS_SRC) rev-parse --short HEAD 2> /dev/null || echo UNKNOWN)
 OBJS = kernel/version_$(GIT_REV).o
 
 bumpversion:
@@ -739,7 +739,7 @@ ifneq ($(ABCREV),default)
 	$(Q) if test -d abc/.hg; then \
 		echo 'REEBE: NOP qverpgbel vf n ut jbexvat pbcl! Erzbir nop/ naq er-eha "znxr".' | tr 'A-Za-z' 'N-ZA-Mn-za-m'; false; \
 	fi
-	$(Q) if ( cd abc 2> /dev/null && ! git diff-index --quiet HEAD; ); then \
+	$(Q) if test -d abc && ! git -C abc diff-index --quiet HEAD; then \
 		echo 'REEBE: NOP pbagnvaf ybpny zbqvsvpngvbaf! Frg NOPERI=qrsnhyg va Lbflf Znxrsvyr!' | tr 'A-Za-z' 'N-ZA-Mn-za-m'; false; \
 	fi
 # set a variable so the test fails if git fails to run - when comparing outputs directly, empty string would match empty string
@@ -751,7 +751,7 @@ ifneq ($(ABCREV),default)
 	fi
 endif
 	$(Q) rm -f abc/abc-[0-9a-f]*
-	$(Q) cd abc && $(MAKE) $(S) $(ABCMKARGS) $(if $(filter %.a,$@),PROG="abc-$(ABCREV)",PROG="abc-$(ABCREV)$(EXE)") MSG_PREFIX="$(eval P_OFFSET = 5)$(call P_SHOW)$(eval P_OFFSET = 10) ABC: " $(if $(filter %.a,$@),libabc-$(ABCREV).a)
+	$(Q) $(MAKE) -C abc $(S) $(ABCMKARGS) $(if $(filter %.a,$@),PROG="abc-$(ABCREV)",PROG="abc-$(ABCREV)$(EXE)") MSG_PREFIX="$(eval P_OFFSET = 5)$(call P_SHOW)$(eval P_OFFSET = 10) ABC: " $(if $(filter %.a,$@),libabc-$(ABCREV).a)
 
 ifeq ($(ABCREV),default)
 .PHONY: abc/abc-$(ABCREV)$(EXE)

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ bumpversion:
 ABCREV = 4f5f73d
 ABCPULL = 1
 ABCURL ?= https://github.com/YosysHQ/abc
-ABCMKARGS = CC="$(CC)" CXX="$(CXX)" LD="$(LD)" ABC_USE_LIBSTDCXX=1
+ABCMKARGS = CC="$(CC)" CXX="$(CXX)" LD="$(LD)" ABC_USE_LIBSTDCXX=1 VERBOSE=$(Q)
 
 # set ABCEXTERNAL = <abc-command> to use an external ABC instance
 # Note: The in-tree ABC (yosys-abc) will not be installed when ABCEXTERNAL is set.

--- a/Makefile
+++ b/Makefile
@@ -676,9 +676,9 @@ $(PROGRAM_PREFIX)yosys$(EXE): $(OBJS)
 
 libyosys.so: $(filter-out kernel/driver.o,$(OBJS))
 ifeq ($(OS), Darwin)
-	$(P) $(LD) -o libyosys.so -shared -Wl,-install_name,$(DESTDIR)$(LIBDIR)/libyosys.so $(LDFLAGS) $^ $(LDLIBS)
+	$(P) $(LD) -o libyosys.so -shared -Wl,-install_name,$(LIBDIR)/libyosys.so $(LDFLAGS) $^ $(LDLIBS)
 else
-	$(P) $(LD) -o libyosys.so -shared -Wl,-soname,$(DESTDIR)$(LIBDIR)/libyosys.so $(LDFLAGS) $^ $(LDLIBS)
+	$(P) $(LD) -o libyosys.so -shared -Wl,-soname,$(LIBDIR)/libyosys.so $(LDFLAGS) $^ $(LDLIBS)
 endif
 
 %.o: %.cc


### PR DESCRIPTION
Another round of fiddling with the Makefile and trying to improve whatever I come across. This is inspired by #2011 and fixes some of the issues listed there, however `$(LD)` still points to the main compiler frontend and `$(LDFLAGS)` contains escaped flags because that seems to be The Done Thing.