### PR TITLE
pyosys: Clear SIGINT handler after Python loads

### DIFF
--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -71,6 +71,7 @@
 
 #include <limits.h>
 #include <errno.h>
+#include <signal.h>
 
 YOSYS_NAMESPACE_BEGIN
 
@@ -540,6 +541,7 @@ void yosys_setup()
 		PyImport_AppendInittab((char*)"libyosys", INIT_MODULE);
 		Py_Initialize();
 		PyRun_SimpleString("import sys");
+		signal(SIGINT, SIG_DFL);
 	#endif
 
 	Pass::init_register();


### PR DESCRIPTION
This is equivalent to https://github.com/YosysHQ/nextpnr/commit/b1cbae1293fecf3ba14a7ce073d26dcfb07177f0 from way-back-when.

Python sets up its own SIGINT handler which stops Ctrl+C from working in pyosys builds, this clears that after Python has been initialised. 