### PR TITLE
Extract missing module support in hierarchy.cc to a helper function

### DIFF
--- a/tests/svinterfaces/load_and_derive.sv
+++ b/tests/svinterfaces/load_and_derive.sv
@@ -1,0 +1,20 @@
+// This test checks that we correctly elaborate interfaces in modules, even if they are loaded on
+// demand. The "ondemand" module is defined in ondemand.sv in this directory and will be read as
+// part of the hierarchy pass.
+
+interface iface;
+  logic [7:0] x;
+  logic [7:0] y;
+endinterface
+
+module dut (input logic [7:0] x, output logic [7:0] y);
+  iface intf();
+  assign intf.x = x;
+  assign y = intf.y;
+
+  ondemand u(.intf);
+endmodule
+
+module ref (input logic [7:0] x, output logic [7:0] y);
+  assign y = ~x;
+endmodule

--- a/tests/svinterfaces/load_and_derive.ys
+++ b/tests/svinterfaces/load_and_derive.ys
@@ -1,0 +1,6 @@
+read_verilog -sv load_and_derive.sv
+hierarchy -libdir . -check
+flatten
+equiv_make ref dut equiv
+equiv_simple
+equiv_status -assert

--- a/tests/svinterfaces/ondemand.sv
+++ b/tests/svinterfaces/ondemand.sv
@@ -1,0 +1,5 @@
+// This is used by the load_and_derive test.
+
+module ondemand (iface intf);
+  assign intf.y = ~intf.x;
+endmodule

--- a/tests/svinterfaces/run-test.sh
+++ b/tests/svinterfaces/run-test.sh
@@ -1,6 +1,6 @@
 #/bin/bash -e
 
-
-
 ./runone.sh  svinterface1
 ./runone.sh  svinterface_at_top
+
+./run_simple.sh load_and_derive

--- a/tests/svinterfaces/run_simple.sh
+++ b/tests/svinterfaces/run_simple.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Run a simple test with a .ys file
+
+if [ $# != 1 ]; then
+    echo >&2 "Expected 1 argument"
+    exit 1
+fi
+
+echo -n "Test: $1 ->"
+../../yosys $1.ys >$1.log_stdout 2>$1.log_stderr || {
+    echo "ERROR!"
+    exit 1
+}
+echo "ok"


### PR DESCRIPTION
*(Text edited after a force-push)*

This PR has two commits. The first is a small clean-up in `hierarchy.cc`. The second adds a test to check that this functionality interacts properly with interface expansion. The message for the first commit is:

> I think the code is now a bit easier to follow (and has lost some
> levels of indentation!).
> 
> The only non-trivial change is that I removed the check for
> `cell->type[0] != '$'` when deciding whether to complain if we couldn't
> find a module. This will always be true because of the early exit
> earlier in the function.

This is part of the commit queue in #2752, but has been split out to make reviewing easier.