### PR TITLE
Add support for parsing the SystemVerilog 'bind' construct

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -177,6 +177,7 @@ std::string AST::type2str(AstNodeType type)
 	X(AST_STRUCT)
 	X(AST_UNION)
 	X(AST_STRUCT_ITEM)
+	X(AST_BIND)
 #undef X
 	default:
 		log_abort();

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -160,7 +160,8 @@ namespace AST
 		AST_TYPEDEF,
 		AST_STRUCT,
 		AST_UNION,
-		AST_STRUCT_ITEM
+		AST_STRUCT_ITEM,
+		AST_BIND
 	};
 
 	struct AstSrcLocType {

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -1959,6 +1959,11 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 			}
 		} break;
 
+	case AST_BIND: {
+		// The bind construct. Currently unimplemented: just ignore it.
+		break;
+	}
+
 	case AST_FCALL: {
 			if (str == "\\$anyconst" || str == "\\$anyseq" || str == "\\$allconst" || str == "\\$allseq")
 			{

--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -260,6 +260,7 @@ static bool isUserType(std::string &s)
 "const"      { if (formal_mode) return TOK_CONST; SV_KEYWORD(TOK_CONST); }
 "checker"    { if (formal_mode) return TOK_CHECKER; SV_KEYWORD(TOK_CHECKER); }
 "endchecker" { if (formal_mode) return TOK_ENDCHECKER; SV_KEYWORD(TOK_ENDCHECKER); }
+"bind"       { if (formal_mode) return TOK_BIND; SV_KEYWORD(TOK_BIND); }
 "final"      { SV_KEYWORD(TOK_FINAL); }
 "logic"      { SV_KEYWORD(TOK_LOGIC); }
 "var"        { SV_KEYWORD(TOK_VAR); }

--- a/tests/bind/.gitignore
+++ b/tests/bind/.gitignore
@@ -1,0 +1,2 @@
+*.log
+run-test.mk

--- a/tests/bind/basic.sv
+++ b/tests/bind/basic.sv
@@ -1,0 +1,20 @@
+// A basic example of the bind construct
+
+module foo (input logic a, input logic b, output logic c);
+  // Magic happens here...
+endmodule
+
+module bar (input a, input b, output c);
+  assign c = a ^ b;
+endmodule
+
+module top ();
+  logic u, v, w;
+  foo foo_i (.a (u), .b (v), .c (w));
+
+  bind foo bar bound_i (.*);
+
+  always_comb begin
+    assert(w == u ^ v);
+  end
+endmodule

--- a/tests/bind/basic.ys
+++ b/tests/bind/basic.ys
@@ -1,0 +1,1 @@
+read_verilog -sv basic.sv

--- a/tests/bind/cell_list.sv
+++ b/tests/bind/cell_list.sv
@@ -1,0 +1,26 @@
+// An example of specifying multiple bind instances in a single directive. This
+// also uses explicit bound names.
+
+module foo (input logic a0, input logic b0, output logic c0,
+            input logic a1, input logic b1, output logic c1);
+  // Magic happens here...
+endmodule
+
+module bar (input a, input b, output c);
+  assign c = a ^ b;
+endmodule
+
+module top ();
+  logic u0, v0, w0;
+  logic u1, v1, w1;
+
+  foo foo0 (.a0 (u0), .b0 (v0), .c0 (w0),
+            .a1 (u1), .b1 (v1), .c1 (w1));
+
+  bind foo bar bar0 (.a(a0), .b(b0), .c(c0)), bar1 (.a(a1), .b(b1), .c(c1));
+
+  always_comb begin
+    assert(w0 == u0 ^ v0);
+    assert(w1 == u1 ^ v1);
+  end
+endmodule

--- a/tests/bind/cell_list.ys
+++ b/tests/bind/cell_list.ys
@@ -1,0 +1,1 @@
+read_verilog -sv cell_list.sv

--- a/tests/bind/hier.sv
+++ b/tests/bind/hier.sv
@@ -1,0 +1,20 @@
+// An example of the bind construct using a hierarchical reference starting with $root
+
+module foo (input logic a, input logic b, output logic c);
+  // Magic happens here...
+endmodule
+
+module bar (input a, input b, output c);
+  assign c = a ^ b;
+endmodule
+
+module top ();
+  logic u, v, w;
+  foo foo_i (.a (u), .b (v), .c (w));
+
+  always_comb begin
+    assert(w == u ^ v);
+  end
+endmodule
+
+bind $root.top.foo_i bar bound_i (.*);

--- a/tests/bind/hier.ys
+++ b/tests/bind/hier.ys
@@ -1,0 +1,1 @@
+read_verilog -sv hier.sv

--- a/tests/bind/inst_list.sv
+++ b/tests/bind/inst_list.sv
@@ -1,0 +1,24 @@
+// An example of specifying multiple bind targets with an instance list
+
+module foo (input logic a, input logic b, output logic c);
+  // Magic happens here...
+endmodule
+
+module bar (input a, input b, output c);
+  assign c = a ^ b;
+endmodule
+
+module top ();
+  logic u0, v0, w0;
+  logic u1, v1, w1;
+
+  foo foo0 (.a (u0), .b (v0), .c (w0));
+  foo foo1 (.a (u1), .b (v1), .c (w1));
+
+  bind foo : foo0, foo1 bar bound_i (.*);
+
+  always_comb begin
+    assert(w0 == u0 ^ v0);
+    assert(w1 == u1 ^ v1);
+  end
+endmodule

--- a/tests/bind/inst_list.ys
+++ b/tests/bind/inst_list.ys
@@ -1,0 +1,1 @@
+read_verilog -sv inst_list.sv

--- a/tests/bind/param.sv
+++ b/tests/bind/param.sv
@@ -1,0 +1,26 @@
+// An example showing how parameters get inferred when binding
+
+module foo (input logic a, input logic b, output logic c);
+  parameter doit = 1;
+
+  // Magic happens here...
+endmodule
+
+module bar (input a, input b, output c);
+  parameter doit = 1;
+
+  assign c = doit ? a ^ b : 0;
+endmodule
+
+module top (input u0, input v0, output w0,
+            input u1, input v1, output w1);
+  foo #(.doit (0)) foo0 (.a (u0), .b (v0), .c (w0));
+  foo #(.doit (1)) foo1 (.a (u1), .b (v1), .c (w1));
+
+  bind foo bar #(.doit (doit)) bound_i (.*);
+
+  always_comb begin
+    assert (w0 == '0);
+    assert (w1 == u1 ^ v1);
+  end
+endmodule

--- a/tests/bind/param.ys
+++ b/tests/bind/param.ys
@@ -1,0 +1,1 @@
+read_verilog -sv param.sv

--- a/tests/bind/run-test.sh
+++ b/tests/bind/run-test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+{
+echo "all::"
+for x in *.ys; do
+	echo "all:: run-$x"
+	echo "run-$x:"
+	echo "	@echo 'Running $x..'"
+	echo "	@../../yosys -ql ${x%.ys}.log $x"
+done
+for s in *.sh; do
+	if [ "$s" != "run-test.sh" ]; then
+		echo "all:: run-$s"
+		echo "run-$s:"
+		echo "	@echo 'Running $s..'"
+		echo "	@bash $s"
+	fi
+done
+} > run-test.mk
+exec ${MAKE:-make} -f run-test.mk

--- a/tests/bind/toplevel.sv
+++ b/tests/bind/toplevel.sv
@@ -1,0 +1,20 @@
+// The bind construct occurring at top-level in the script
+
+module foo (input logic a, input logic b, output logic c);
+  // Magic happens here...
+endmodule
+
+module bar (input a, input b, output c);
+  assign c = a ^ b;
+endmodule
+
+module top ();
+  logic u, v, w;
+  foo foo_i (.a (u), .b (v), .c (w));
+
+  always_comb begin
+    assert(w == u ^ v);
+  end
+endmodule
+
+bind top.foo_i bar bound_i (.*);

--- a/tests/bind/toplevel.ys
+++ b/tests/bind/toplevel.ys
@@ -1,0 +1,1 @@
+read_verilog -sv toplevel.sv


### PR DESCRIPTION
This doesn't do anything useful yet: the patch just adds support for
the syntax to the lexer and parser and adds some tests to check the
syntax parses properly. This generates AST nodes, but doesn't yet
generate RTLIL.

Since our existing `hierarchical_identifier` parser doesn't allow bit
selects (so you can't do something like `foo[1].bar[2].baz`), I've also
not added support for a trailing bit select (the `constant_bit_select`
non-terminal in `bind_target_instance` in the spec). If we turn out to
need this in future, we'll want to augment `hierarchical_identifier` and
its other users too.

Note that you can't easily use the BNF from the spec:

    bind_directive ::=
        "bind" bind_target_scope [ : bind_target_instance_list]
               bind_instantiation ;
      | "bind" bind_target_instance bind_instantiation ;

even if you fix the lookahead problem, because code like this matches
both branches in the BNF:

    bind a b b_i (.*);

The problem is that 'a' could either be a module name or a degenerate
hierarchical reference. This seems to be a genuine syntactic
ambiguity, which the spec resolves (p739) by saying that we have to
wait until resolution time (the hierarchy pass) and take whatever is
defined, treating 'a' as an instance name if it names both an instance
and a module.

To keep the parser simple, it currently accepts this invalid syntax:

    bind a.b : c d e (.*);

This is invalid because we're in the first branch of the BNF above, so
the `a.b` term should match bind_target_scope: a module or interface
identifier, not an arbitrary hierarchical identifier.

This will fail in the hierarchy pass (when it's implemented in a
future patch).

This is part of the commit queue in #2752, but has been split out to make reviewing easier.