### PR TITLE
Make user data types default to variables

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -702,6 +702,7 @@ opt_wire_type_token:
 
 wire_type_token:
 	hierarchical_type_id {
+		astbuf3->is_logic = true;
 		astbuf3->is_custom_type = true;
 		astbuf3->children.push_back(new AstNode(AST_WIRETYPE));
 		astbuf3->children.back()->str = *$1;

--- a/tests/svtypes/typedef_initial_and_assign.sv
+++ b/tests/svtypes/typedef_initial_and_assign.sv
@@ -1,0 +1,29 @@
+package pkg;
+	typedef logic pkg_user_t;
+endpackage
+
+module top;
+	typedef logic user_t;
+
+	// Continuous assignment to a variable is legal
+	user_t var_1;
+	assign var_1 = 0;
+
+	pkg::pkg_user_t var_2;
+	assign var_2 = 0;
+
+	// Mixing continuous and procedural assignments is illegal
+	user_t var_3 = 0;
+	assign var_3 = 1; // warning: reg assigned in a continuous assignment
+
+	user_t var_4;
+	initial var_4 = 0;
+	assign var_4 = 1; // warning: reg assigned in a continuous assignment
+
+	pkg::pkg_user_t var_5 = 0;
+	assign var_5 = 1; // warning: reg assigned in a continuous assignment
+
+	pkg::pkg_user_t var_6;
+	initial var_6 = 0;
+	assign var_6 = 1; // warning: reg assigned in a continuous assignment
+endmodule

--- a/tests/svtypes/typedef_initial_and_assign.ys
+++ b/tests/svtypes/typedef_initial_and_assign.ys
@@ -1,0 +1,7 @@
+logger -expect-no-warnings
+logger -expect warning "reg '\\var_3' is assigned in a continuous assignment" 1
+logger -expect warning "reg '\\var_4' is assigned in a continuous assignment" 1
+logger -expect warning "reg '\\var_5' is assigned in a continuous assignment" 1
+logger -expect warning "reg '\\var_6' is assigned in a continuous assignment" 1
+
+read_verilog -sv typedef_initial_and_assign.sv


### PR DESCRIPTION
Fixes #2846

A declaration beginning with a data type and without a net type (e.g.
wire) is a variable. This was handled correctly for built-in data types,
but not user-defined types.

Declaring a net with a net type keyword or a variable with the var keyword
preceding a user-defined type is not currently supported like it is with
built-in types. Adding support for this resulted in non-trivial parsing
conflicts. This handles typical usage though.