### PR TITLE
ECP5 techlibs changes to support bitfile simulation

### DIFF
--- a/techlibs/ecp5/cells_sim.v
+++ b/techlibs/ecp5/cells_sim.v
@@ -240,7 +240,7 @@ module DPR16X4C (
 		input [3:0] WAD,
 		output [3:0] DO
 );
-	// For legacy Lattice compatibility, INITIVAL is a hex
+	// For legacy Lattice compatibility, INITVAL is a hex
 	// string rather than a numeric parameter
 	parameter INITVAL = "0x0000000000000000";
 
@@ -530,6 +530,9 @@ module TRELLIS_SLICE(
 				.S0(F0), .S1(F1),
 				.COUT(FCO)
 			);
+			// TODO: confirm these connections
+			assign OFX0 = F0;
+			assign OFX1 = F1;
 		end else if (MODE == "RAMW") begin
 			assign WDO0 = C1m;
 			assign WDO1 = A1m;


### PR DESCRIPTION
For a Pwn2Win 2021 CTF challenge, we developed some code which converts ECP5 bitfiles into Verilog. Most of that will be submitted to https://github.com/YosysHQ/prjtrellis; this PR is for the techlib bits which that code depends on for simulation.

This PR adds an apparently missing pair of connections in the CCU2 slice mode, which were necessary to get the simulated design to behave correctly.