### PR TITLE
Add support for the Bitwuzla solver and the timeout option

### DIFF
--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -203,14 +203,14 @@ class SmtIo:
                 print('timeout option is not supported for mathsat.')
                 sys.exit(1)
 
-        if self.solver == "boolector":
+        if self.solver in ["boolector", "bitwuzla"]:
             if self.noincr:
-                self.popen_vargs = ['boolector', '--smt2'] + self.solver_opts
+                self.popen_vargs = [self.solver, '--smt2'] + self.solver_opts
             else:
-                self.popen_vargs = ['boolector', '--smt2', '-i'] + self.solver_opts
+                self.popen_vargs = [self.solver, '--smt2', '-i'] + self.solver_opts
             self.unroll = True
             if self.timeout != 0:
-                print('timeout option is not supported for boolector.')
+                print('timeout option is not supported for %s.' % self.solver)
                 sys.exit(1)
 
         if self.solver == "abc":
@@ -1010,7 +1010,7 @@ class SmtOpts:
     def helpmsg(self):
         return """
     -s <solver>
-        set SMT solver: z3, yices, boolector, cvc4, mathsat, dummy
+        set SMT solver: z3, yices, boolector, bitwuzla, cvc4, mathsat, dummy
         default: yices
 
     -S <opt>


### PR DESCRIPTION
The boolector team appears to be developing a new solver, [bitwuzla](https://bitwuzla.github.io/). I have a case where it is 3X faster than boolector, though another where it's 2X slower, so it is perhaps not always quicker. It seems to be where most of their development effort is going and was the tool they entered in the 2021 SMT competition, so I would expect it might continue to improve.

The interface unsurprisingly seems very similar to boolector, so I've added it to the same code path.

Both solvers support a timeout with the ``--time`` or ``-t`` options, so I've added support for that as well.