### PR TITLE
ice40: Fix LUT input indices in opt_lut -dlogic (again).

### DIFF
--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -399,7 +399,7 @@ struct SynthIce40Pass : public ScriptPass
 			run("ice40_wrapcarry -unwrap");
 			run("techmap -map +/ice40/ff_map.v");
 			run("clean");
-			run("opt_lut -dlogic SB_CARRY:I0=2:I1=1:CI=0");
+			run("opt_lut -dlogic SB_CARRY:I0=1:I1=2:CI=3");
 		}
 
 		if (check_label("map_cells"))


### PR DESCRIPTION
Fixes #2061.