### PR TITLE
kernel/mem: Add a coalesce_inits helper.

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -1835,6 +1835,8 @@ struct CxxrtlWorker {
 			f << ",\n";
 			inc_indent();
 				for (auto &init : mem->inits) {
+					if (init.removed)
+						continue;
 					dump_attrs(&init);
 					int words = GetSize(init.data) / mem->width;
 					f << indent << "memory<" << mem->width << ">::init<" << words << "> { "
@@ -2488,8 +2490,10 @@ struct CxxrtlWorker {
 
 			std::vector<Mem> &memories = mod_memories[module];
 			memories = Mem::get_all_memories(module);
-			for (auto &mem : memories)
+			for (auto &mem : memories) {
 				mem.narrow();
+				mem.coalesce_inits();
+			}
 
 			if (module->get_bool_attribute(ID(cxxrtl_blackbox))) {
 				for (auto port : module->ports) {

--- a/kernel/mem.h
+++ b/kernel/mem.h
@@ -97,6 +97,13 @@ struct Mem : RTLIL::AttrObject {
 	// Marks all inits as removed.
 	void clear_inits();
 
+	// Coalesces inits: whenever two inits have overlapping or touching
+	// address ranges, they are combined into one, with the higher-priority
+	// one's data overwriting the other.  Running this results in
+	// an inits list equivalent to the original, in which all entries
+	// cover disjoint (and non-touching) address ranges.
+	void coalesce_inits();
+
 	// Checks consistency of this memory and all its ports/inits, using
 	// log_assert.
 	void check();


### PR DESCRIPTION
While this helper is already useful to squash sequential initializations
into one in cxxrtl, its main purpose is to squash overlapping masked memory
initializations (when they land) and avoid having to deal with them in
cxxrtl runtime.