### PR TITLE
Delete unused found_init variable

### DIFF
--- a/passes/proc/proc_init.cc
+++ b/passes/proc/proc_init.cc
@@ -28,12 +28,9 @@ PRIVATE_NAMESPACE_BEGIN
 
 void proc_init(RTLIL::Module *mod, SigMap &sigmap, RTLIL::Process *proc)
 {
-	bool found_init = false;
-
 	for (auto &sync : proc->syncs)
 		if (sync->type == RTLIL::SyncType::STi)
 		{
-			found_init = true;
 			log("Found init rule in `%s.%s'.\n", mod->name.c_str(), proc->name.c_str());
 
 			for (auto &action : sync->actions)


### PR DESCRIPTION
Spotted during compilation:

    passes/proc/proc_init.cc: In function ‘void {anonymous}::proc_init(Yosys::RTLIL::Module*, Yosys::SigMap&, Yosys::RTLIL::Process*)’:
    passes/proc/proc_init.cc:31:7: warning: variable ‘found_init’ set but not used [-Wunused-but-set-variable]