### PR TITLE
verilog: save and restore overwritten macro arguments

### DIFF
--- a/frontends/verilog/preproc.h
+++ b/frontends/verilog/preproc.h
@@ -42,6 +42,7 @@ struct define_map_t
 
 	// Add a definition, overwriting any existing definition for name.
 	void add(const std::string &name, const std::string &txt, const arg_map_t *args = nullptr);
+	void add(const std::string &name, const define_body_t &body);
 
 	// Merge in another map of definitions (which take precedence
 	// over anything currently defined).

--- a/tests/verilog/macro_arg_tromp.sv
+++ b/tests/verilog/macro_arg_tromp.sv
@@ -1,0 +1,21 @@
+// Taken from: https://github.com/YosysHQ/yosys/issues/2867
+
+`define MIN(x, y) ((x) < (y) ? (x) : (y))
+`define CEIL_DIV(x, y) (((x) / (y)) + `MIN((x) % (y), 1))
+
+module pad_msg1 (input logic [`MIN(512*`CEIL_DIV(64, 512), 64)-1:0] x,
+                output logic [`MIN(512*`CEIL_DIV(64, 512), 64)-1:0] y);
+   assign y[63:0] = x;
+endmodule
+
+module pad_msg2 (input logic [((512*`CEIL_DIV(64, 512)) < (64) ? (512*`CEIL_DIV(64,512)) : (64))-1:0] x,
+                output logic [((512*`CEIL_DIV(64, 512)) < (64) ? (512*`CEIL_DIV(64,512)) : (64))-1:0] y);
+   assign y[63:0] = x;
+endmodule
+
+module top(...);
+`define add(x) x +
+input [3:0] A;
+output [3:0] B;
+assign B = `add(`add(3)A)A;
+endmodule

--- a/tests/verilog/macro_arg_tromp.ys
+++ b/tests/verilog/macro_arg_tromp.ys
@@ -1,0 +1,2 @@
+logger -expect-no-warnings
+read_verilog -sv macro_arg_tromp.sv


### PR DESCRIPTION
Fixes #2867