### PR TITLE
cxxrtl: don't mark buffered internal wires as UNUSED for debug

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -2795,7 +2795,7 @@ struct CxxrtlWorker {
 					const auto &wire_type = wire_types[wire];
 					auto &debug_wire_type = debug_wire_types[wire];
 					if (wire_type.type == WireType::UNUSED) continue;
-					if (!wire->name.isPublic()) continue;
+					if (!wire->name.isPublic() && !wire_type.is_buffered()) continue;
 
 					if (!debug_info) continue;
 					if (wire->port_input || wire_type.is_buffered())


### PR DESCRIPTION
Public wires may alias buffered internal wires, so keep `BUFFERED` wires in debug information even if they are private. Debug items are only created for public wires, so this does not otherwise affect how debug information is emitted.

Fixes #2540.
Fixes #2841.
Supersedes #2541.