### PR TITLE
cxxrtl: treat wires with multiple defs as not inlinable

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -326,8 +326,14 @@ struct FlowGraph {
 		for (auto bit : sig.bits())
 			bit_has_state[bit] |= is_ff;
 		// Only comb defs of an entire wire in the right order can be inlined.
-		if (!is_ff && sig.is_wire())
-			wire_def_inlinable[sig.as_wire()] = inlinable;
+		if (!is_ff && sig.is_wire()) {
+			// Only a single def of a wire can be inlined. (Multiple defs of a wire are unsound, but we
+			// handle them anyway to avoid assertion failures later.)
+			if (!wire_def_inlinable.count(sig.as_wire()))
+				wire_def_inlinable[sig.as_wire()] = inlinable;
+			else
+				wire_def_inlinable[sig.as_wire()] = false;
+		}
 	}
 
 	void add_uses(Node *node, const RTLIL::SigSpec &sig)


### PR DESCRIPTION
Fixes #2883.