### PR TITLE
opt_expr: Propagate constants to port connections.

### DIFF
--- a/tests/opt/opt_expr_constconn.v
+++ b/tests/opt/opt_expr_constconn.v
@@ -1,0 +1,8 @@
+module top(...);
+
+input [7:0] A;
+output [7:0] B;
+wire [7:0] C = 3;
+assign B = A + C;
+
+endmodule

--- a/tests/opt/opt_expr_constconn.ys
+++ b/tests/opt/opt_expr_constconn.ys
@@ -1,0 +1,7 @@
+read_verilog opt_expr_constconn.v
+select -assert-count 1 t:$add
+select -assert-count 1 t:$add %ci w:C %i
+equiv_opt -assert opt_expr
+design -load postopt
+select -assert-count 1 t:$add
+select -assert-count 0 t:$add %ci w:C %i


### PR DESCRIPTION
This adds one simple piece of functionality to opt_expr: when a cell
port is connected to a fully-constant signal (as determined by sigmap),
the port is reconnected directly to the constant value.  This is just
enough optimization to fix the "non-constant $meminit input" problem
without requiring a full opt_clean or a separate pass.