### PR TITLE
kernel/mem: Introduce transparency masks.

### DIFF
--- a/passes/memory/memory_dff.cc
+++ b/passes/memory/memory_dff.cc
@@ -143,7 +143,8 @@ struct MemoryDffWorker
 		port.addr = ff.sig_d;
 		port.clk_enable = true;
 		port.clk_polarity = ff.pol_clk;
-		port.transparent = true;
+		for (int i = 0; i < GetSize(mem.wr_ports); i++)
+			port.transparency_mask[i] = true;
 		mem.emit();
 		log("merged address FF to cell.\n");
 	}

--- a/passes/memory/memory_share.cc
+++ b/passes/memory/memory_share.cc
@@ -22,6 +22,7 @@
 #include "kernel/sigtools.h"
 #include "kernel/modtools.h"
 #include "kernel/mem.h"
+#include "kernel/ffinit.h"
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
@@ -32,6 +33,7 @@ struct MemoryShareWorker
 	RTLIL::Module *module;
 	SigMap sigmap, sigmap_xmux;
 	ModWalker modwalker;
+	FfInitVals initvals;
 	bool flag_widen;
 
 
@@ -106,8 +108,6 @@ struct MemoryShareWorker
 					continue;
 				if (port1.ce_over_srst != port2.ce_over_srst)
 					continue;
-				if (port1.transparent != port2.transparent)
-					continue;
 				// If the width of the ports doesn't match, they can still be
 				// merged by widening the narrow one.  Check if the conditions
 				// hold for that.
@@ -147,8 +147,10 @@ struct MemoryShareWorker
 					continue;
 				if (!merge_rst_value(mem, srst_value, wide_log2, port1.srst_value, sub1, port2.srst_value, sub2))
 					continue;
+				// At this point we are committed to the merge.
 				{
 					log("  Merging ports %d, %d (address %s).\n", i, j, log_signal(port1.addr));
+					mem.prepare_rd_merge(i, j, &initvals);
 					mem.widen_prep(wide_log2);
 					SigSpec new_data = module->addWire(NEW_ID, mem.width << wide_log2);
 					module->connect(port1.data, new_data.extract(sub1 * mem.width, mem.width << port1.wide_log2));
@@ -231,7 +233,7 @@ struct MemoryShareWorker
 						continue;
 				}
 				log("  Merging ports %d, %d (address %s).\n", i, j, log_signal(port1.addr));
-				mem.prepare_wr_merge(i, j);
+				mem.prepare_wr_merge(i, j, &initvals);
 				port1.addr = sigmap_xmux(port1.addr);
 				port2.addr = sigmap_xmux(port2.addr);
 				mem.widen_wr_port(i, wide_log2);
@@ -391,7 +393,7 @@ struct MemoryShareWorker
 					}
 
 					log("  Merging port %d into port %d.\n", idx2, idx1);
-					mem.prepare_wr_merge(idx1, idx2);
+					mem.prepare_wr_merge(idx1, idx2, &initvals);
 					port_to_sat_variable.at(idx1) = qcsat.ez->OR(port_to_sat_variable.at(idx1), port_to_sat_variable.at(idx2));
 
 					RTLIL::SigSpec last_addr = port1.addr;
@@ -453,6 +455,7 @@ struct MemoryShareWorker
 
 		this->module = module;
 		sigmap.set(module);
+		initvals.set(&sigmap, module);
 
 		sigmap_xmux = sigmap;
 		for (auto cell : module->cells())

--- a/passes/opt/opt_mem_feedback.cc
+++ b/passes/opt/opt_mem_feedback.cc
@@ -43,6 +43,7 @@ struct OptMemFeedbackWorker
 	RTLIL::Design *design;
 	RTLIL::Module *module;
 	SigMap sigmap, sigmap_xmux;
+	FfInitVals initvals;
 
 	dict<RTLIL::SigBit, std::pair<RTLIL::Cell*, int>> sig_to_mux;
 	dict<RTLIL::SigBit, int> sig_users_count;
@@ -245,7 +246,7 @@ struct OptMemFeedbackWorker
 
 			for (int i = 0; i < wrport_idx; i++)
 				if (port.priority_mask[i])
-					mem.emulate_priority(i, wrport_idx);
+					mem.emulate_priority(i, wrport_idx, &initvals);
 		}
 
 		for (auto &it : portbit_conds)
@@ -278,6 +279,7 @@ struct OptMemFeedbackWorker
 
 		this->module = module;
 		sigmap.set(module);
+		initvals.set(&sigmap, module);
 		sig_to_mux.clear();
 		conditions_logic_cache.clear();
 


### PR DESCRIPTION
This should be in mergeable state, but I'd like to delay the merge until it has been properly validated by the following follow-up PRs:

- #2807, rebased on top of this and with transparency mask support in new cells
- future PR that will add transparency logic recognition to `memory_dff`