### PR TITLE
verilog: Support tri/triand/trior wire types.

### DIFF
--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -277,8 +277,11 @@ static bool isUserType(std::string &s)
 "output"  { return TOK_OUTPUT; }
 "inout"   { return TOK_INOUT; }
 "wire"    { return TOK_WIRE; }
+"tri"     { return TOK_WIRE; }
 "wor"     { return TOK_WOR; }
+"trior"   { return TOK_WOR; }
 "wand"    { return TOK_WAND; }
+"triand"  { return TOK_WAND; }
 "reg"     { return TOK_REG; }
 "integer" { return TOK_INTEGER; }
 "signed"  { return TOK_SIGNED; }


### PR DESCRIPTION
These are, by the standard, just aliases for wire/wand/wor.

Fixes #2918.