### PR TITLE
test/arch/{ecp5,ice40}/memories.ys: Use read_verilog -defer.

### DIFF
--- a/tests/arch/ecp5/memories.ys
+++ b/tests/arch/ecp5/memories.ys
@@ -1,197 +1,228 @@
 # ================================ RAM ================================
 # RAM bits <= 18K; Data width <= 36; Address width <= 9: -> PDPW16KD
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 9 -set DATA_WIDTH 36 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:PDPW16KD
 
 ## With parameters
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 36 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 0 t:PDPW16KD # too inefficient
 select -assert-count 9 t:TRELLIS_DPR16X4
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 36 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set syn_ramstyle "block_ram" m:memory
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:PDPW16KD
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 36 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set syn_ramstyle "Block_RAM" m:memory
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:PDPW16KD # any case works
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 36 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set ram_block 1 m:memory
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:PDPW16KD
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 36 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set syn_ramstyle "registers" m:memory
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 0 t:PDPW16KD # requested FFRAM explicitly
 select -assert-count 180 t:TRELLIS_FF
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 36 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set logic_block 1 m:memory
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 0 t:PDPW16KD # requested FFRAM explicitly
 select -assert-count 180 t:TRELLIS_FF
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 36 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set syn_romstyle "ebr" m:memory
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:$mem_v2 # requested BROM but this is a RAM
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 36 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set rom_block 1 m:memory
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:$mem_v2 # requested BROM but this is a RAM
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 36 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set syn_ramstyle "block_ram" m:memory
 synth_ecp5 -top sync_ram_sdp -nobram; cd sync_ram_sdp
 select -assert-count 1 t:$mem_v2 # requested BRAM but BRAM is disabled
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 36 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set ram_block 1 m:memory
 synth_ecp5 -top sync_ram_sdp -nobram; cd sync_ram_sdp
 select -assert-count 1 t:$mem_v2 # requested BRAM but BRAM is disabled
 
 # RAM bits <= 18K; Data width <= 18; Address width <= 10: -> DP16KD
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 10 -set DATA_WIDTH 18 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:DP16KD
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 11 -set DATA_WIDTH 9 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:DP16KD
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 12 -set DATA_WIDTH 4 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:DP16KD
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 13 -set DATA_WIDTH 2 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:DP16KD
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 14 -set DATA_WIDTH 1 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:DP16KD
 
 ## With parameters
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 18 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 0 t:DP16KD # too inefficient
 select -assert-count 5 t:TRELLIS_DPR16X4
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 18 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set syn_ramstyle "block_ram" m:memory
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:DP16KD
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 18 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set syn_ramstyle "Block_RAM" m:memory
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:DP16KD # any case works
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 18 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set ram_block 1 m:memory
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:DP16KD
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 18 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set syn_ramstyle "registers" m:memory
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 0 t:DP16KD # requested FFRAM explicitly
 select -assert-count 90 t:TRELLIS_FF
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 18 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set logic_block 1 m:memory
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 0 t:DP16KD # requested FFRAM explicitly
 select -assert-count 90 t:TRELLIS_FF
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 18 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set syn_romstyle "ebr" m:memory
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:$mem_v2 # requested BROM but this is a RAM
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 18 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set rom_block 1 m:memory
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:$mem_v2 # requested BROM but this is a RAM
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 18 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set syn_ramstyle "block_ram" m:memory
 synth_ecp5 -top sync_ram_sdp -nobram; cd sync_ram_sdp
 select -assert-count 1 t:$mem_v2 # requested BRAM but BRAM is disabled
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 18 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set ram_block 1 m:memory
 synth_ecp5 -top sync_ram_sdp -nobram; cd sync_ram_sdp
 select -assert-count 1 t:$mem_v2 # requested BRAM but BRAM is disabled
 
 # RAM bits <= 64; Data width <= 4; Address width <= 4: -> DPR16X4
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 4 -set DATA_WIDTH 4 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:TRELLIS_DPR16X4
 
 ## With parameters
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 4 -set DATA_WIDTH 4 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set syn_ramstyle "distributed" m:memory
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:TRELLIS_DPR16X4
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 4 -set DATA_WIDTH 4 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set syn_ramstyle "registers" m:memory
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 0 t:TRELLIS_DPR16X4 # requested FFRAM explicitly
 select -assert-count 68 t:TRELLIS_FF
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 4 -set DATA_WIDTH 4 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set logic_block 1 m:memory
 synth_ecp5 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 0 t:TRELLIS_DPR16X4 # requested FFRAM explicitly
 select -assert-count 68 t:TRELLIS_FF
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 4 -set DATA_WIDTH 4 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set syn_ramstyle "distributed" m:memory
 synth_ecp5 -top sync_ram_sdp -nolutram; cd sync_ram_sdp
 select -assert-count 1 t:$mem_v2 # requested LUTRAM but LUTRAM is disabled
@@ -199,130 +230,150 @@ select -assert-count 1 t:$mem_v2 # requested LUTRAM but LUTRAM is disabled
 # ================================ ROM ================================
 # ROM bits <= 18K; Data width <= 36; Address width <= 9: -> PDPW16KD
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 9 -set DATA_WIDTH 36 sync_rom
+hierarchy -top sync_rom
 synth_ecp5 -top sync_rom; cd sync_rom
 select -assert-count 1 t:PDPW16KD
 
 ## With parameters
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 3 -set DATA_WIDTH 36 sync_rom
+hierarchy -top sync_rom
 synth_ecp5 -top sync_rom; cd sync_rom
 select -assert-count 0 t:PDPW16KD # too inefficient
 select -assert-min 18 t:LUT4
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 36 sync_rom
+hierarchy -top sync_rom
 setattr -set syn_romstyle "ebr" m:memory
 synth_ecp5 -top sync_rom; cd sync_rom
 select -assert-count 1 t:PDPW16KD
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 36 sync_rom
+hierarchy -top sync_rom
 setattr -set rom_block 1 m:memory
 synth_ecp5 -top sync_rom; cd sync_rom
 select -assert-count 1 t:PDPW16KD
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 3 -set DATA_WIDTH 36 sync_rom
+hierarchy -top sync_rom
 setattr -set syn_romstyle "logic" m:memory
 synth_ecp5 -top sync_rom; cd sync_rom
 select -assert-count 0 t:PDPW16KD # requested LUTROM explicitly
 select -assert-min 18 t:LUT4
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 3 -set DATA_WIDTH 36 sync_rom
+hierarchy -top sync_rom
 setattr -set logic_block 1 m:memory
 synth_ecp5 -top sync_rom; cd sync_rom
 select -assert-count 0 t:PDPW16KD # requested LUTROM explicitly
 select -assert-min 18 t:LUT4
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 36 sync_rom
+hierarchy -top sync_rom
 setattr -set syn_ramstyle "block_ram" m:memory
 synth_ecp5 -top sync_rom; cd sync_rom
 select -assert-count 1 t:$mem_v2 # requested BRAM but this is a ROM
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 36 sync_rom
+hierarchy -top sync_rom
 setattr -set ram_block 1 m:memory
 synth_ecp5 -top sync_rom; cd sync_rom
 select -assert-count 1 t:$mem_v2 # requested BRAM but this is a ROM
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 36 sync_rom
+hierarchy -top sync_rom
 setattr -set syn_ramstyle "block_rom" m:memory
 synth_ecp5 -top sync_rom -nobram; cd sync_rom
 select -assert-count 1 t:$mem_v2 # requested BROM but BRAM is disabled
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 36 sync_rom
+hierarchy -top sync_rom
 setattr -set rom_block 1 m:memory
 synth_ecp5 -top sync_rom -nobram; cd sync_rom
 select -assert-count 1 t:$mem_v2 # requested BROM but BRAM is disabled
 
 # ROM bits <= 18K; Data width <= 18; Address width <= 10: -> DP16KD
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 10 -set DATA_WIDTH 18 sync_rom
+hierarchy -top sync_rom
 synth_ecp5 -top sync_rom; cd sync_rom
 select -assert-count 1 t:DP16KD
 
 ## With parameters
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 3 -set DATA_WIDTH 18 sync_rom
+hierarchy -top sync_rom
 synth_ecp5 -top sync_rom; cd sync_rom
 select -assert-count 0 t:DP16KD # too inefficient
 select -assert-min 9 t:LUT4
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 18 sync_rom
+hierarchy -top sync_rom
 setattr -set syn_romstyle "ebr" m:memory
 synth_ecp5 -top sync_rom; cd sync_rom
 select -assert-count 1 t:DP16KD
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 18 sync_rom
+hierarchy -top sync_rom
 setattr -set rom_block 1 m:memory
 synth_ecp5 -top sync_rom; cd sync_rom
 select -assert-count 1 t:DP16KD
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 3 -set DATA_WIDTH 18 sync_rom
+hierarchy -top sync_rom
 setattr -set syn_romstyle "logic" m:memory
 synth_ecp5 -top sync_rom; cd sync_rom
 select -assert-count 0 t:DP16KD # requested LUTROM explicitly
 select -assert-min 9 t:LUT4
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 3 -set DATA_WIDTH 18 sync_rom
+hierarchy -top sync_rom
 setattr -set logic_block 1 m:memory
 synth_ecp5 -top sync_rom; cd sync_rom
 select -assert-count 0 t:DP16KD # requested LUTROM explicitly
 select -assert-min 9 t:LUT4
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 18 sync_rom
+hierarchy -top sync_rom
 setattr -set syn_ramstyle "block_ram" m:memory
 synth_ecp5 -top sync_rom; cd sync_rom
 select -assert-count 1 t:$mem_v2 # requested BRAM but this is a ROM
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 18 sync_rom
+hierarchy -top sync_rom
 setattr -set ram_block 1 m:memory
 synth_ecp5 -top sync_rom; cd sync_rom
 select -assert-count 1 t:$mem_v2 # requested BRAM but this is a ROM
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 18 sync_rom
+hierarchy -top sync_rom
 setattr -set syn_ramstyle "block_rom" m:memory
 synth_ecp5 -top sync_rom -nobram; cd sync_rom
 select -assert-count 1 t:$mem_v2 # requested BROM but BRAM is disabled
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 18 sync_rom
+hierarchy -top sync_rom
 setattr -set rom_block 1 m:memory
 synth_ecp5 -top sync_rom -nobram; cd sync_rom
 select -assert-count 1 t:$mem_v2 # requested BROM but BRAM is disabled

--- a/tests/arch/ice40/memories.ys
+++ b/tests/arch/ice40/memories.ys
@@ -1,86 +1,100 @@
 # ================================ RAM ================================
 # RAM bits <= 4K; Data width <= 16; Address width <= 11: -> SB_RAM40_4K
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 11 -set DATA_WIDTH 2 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 synth_ice40 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:SB_RAM40_4K
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 10 -set DATA_WIDTH 4 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 synth_ice40 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:SB_RAM40_4K
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 9 -set DATA_WIDTH 8 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 synth_ice40 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:SB_RAM40_4K
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 8 -set DATA_WIDTH 16 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 synth_ice40 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:SB_RAM40_4K
 
 ## With parameters
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 synth_ice40 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 0 t:SB_RAM40_4K # too inefficient
 select -assert-min 1 t:SB_DFFE
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set syn_ramstyle "block_ram" m:memory
 synth_ice40 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:SB_RAM40_4K
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set syn_ramstyle "Block_RAM" m:memory
 synth_ice40 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:SB_RAM40_4K # any case works
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set ram_block 1 m:memory
 synth_ice40 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:SB_RAM40_4K
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set syn_ramstyle "registers" m:memory
 synth_ice40 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 0 t:SB_RAM40_4K # requested FFRAM explicitly
 select -assert-min 1 t:SB_DFFE
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set logic_block 1 m:memory
 synth_ice40 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 0 t:SB_RAM40_4K # requested FFRAM explicitly
 select -assert-min 1 t:SB_DFFE
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set syn_romstyle "ebr" m:memory
 synth_ice40 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:$mem_v2 # requested BROM but this is a RAM
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set rom_block 1 m:memory
 synth_ice40 -top sync_ram_sdp; cd sync_ram_sdp
 select -assert-count 1 t:$mem_v2 # requested BROM but this is a RAM
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set syn_ramstyle "block_ram" m:memory
 synth_ice40 -top sync_ram_sdp -nobram; cd sync_ram_sdp
 select -assert-count 1 t:$mem_v2 # requested BRAM but BRAM is disabled
 
-design -reset; read_verilog ../common/blockram.v
+design -reset; read_verilog -defer ../common/blockram.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_ram_sdp
+hierarchy -top sync_ram_sdp
 setattr -set ram_block 1 m:memory
 synth_ice40 -top sync_ram_sdp -nobram; cd sync_ram_sdp
 select -assert-count 1 t:$mem_v2 # requested BRAM but BRAM is disabled
@@ -88,80 +102,93 @@ select -assert-count 1 t:$mem_v2 # requested BRAM but BRAM is disabled
 # ================================ ROM ================================
 # ROM bits <= 4K; Data width <= 16; Address width <= 11: -> SB_RAM40_4K
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 11 -set DATA_WIDTH 2 sync_rom
+hierarchy -top sync_rom
 synth_ice40 -top sync_rom; cd sync_rom
 select -assert-count 1 t:SB_RAM40_4K
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 10 -set DATA_WIDTH 4 sync_rom
+hierarchy -top sync_rom
 synth_ice40 -top sync_rom; cd sync_rom
 select -assert-count 1 t:SB_RAM40_4K
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 9 -set DATA_WIDTH 8 sync_rom
+hierarchy -top sync_rom
 synth_ice40 -top sync_rom; cd sync_rom
 select -assert-count 1 t:SB_RAM40_4K
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 8 -set DATA_WIDTH 16 sync_rom
+hierarchy -top sync_rom
 synth_ice40 -top sync_rom; cd sync_rom
 select -assert-count 1 t:SB_RAM40_4K
 
 ## With parameters
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_rom
+hierarchy -top sync_rom
 synth_ice40 -top sync_rom; cd sync_rom
 select -assert-count 0 t:SB_RAM40_4K # too inefficient
 select -assert-min 1 t:SB_LUT4
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_rom
+hierarchy -top sync_rom
 setattr -set syn_romstyle "ebr" m:memory
 synth_ice40 -top sync_rom; cd sync_rom
 select -assert-count 1 t:SB_RAM40_4K
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_rom
+hierarchy -top sync_rom
 setattr -set rom_block 1 m:memory
 synth_ice40 -top sync_rom; cd sync_rom
 select -assert-count 1 t:SB_RAM40_4K
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_rom
+hierarchy -top sync_rom
 setattr -set syn_romstyle "logic" m:memory
 synth_ice40 -top sync_rom; cd sync_rom
 select -assert-count 0 t:SB_RAM40_4K # requested LUTROM explicitly
 select -assert-min 1 t:SB_LUT4
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_rom
+hierarchy -top sync_rom
 setattr -set logic_block 1 m:memory
 synth_ice40 -top sync_rom; cd sync_rom
 select -assert-count 0 t:SB_RAM40_4K # requested LUTROM explicitly
 select -assert-min 1 t:SB_LUT4
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_rom
+hierarchy -top sync_rom
 setattr -set syn_ramstyle "block_ram" m:memory
 synth_ice40 -top sync_rom; cd sync_rom
 select -assert-count 1 t:$mem_v2 # requested BRAM but this is a ROM
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_rom
+hierarchy -top sync_rom
 setattr -set ram_block 1 m:memory
 synth_ice40 -top sync_rom; cd sync_rom
 select -assert-count 1 t:$mem_v2 # requested BRAM but this is a ROM
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_rom
+hierarchy -top sync_rom
 setattr -set syn_romstyle "ebr" m:memory
 synth_ice40 -top sync_rom -nobram; cd sync_rom
 select -assert-count 1 t:$mem_v2 # requested BROM but BRAM is disabled
 
-design -reset; read_verilog ../common/blockrom.v
+design -reset; read_verilog -defer ../common/blockrom.v
 chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 8 sync_rom
+hierarchy -top sync_rom
 setattr -set rom_block 1 m:memory
 synth_ice40 -top sync_rom -nobram; cd sync_rom
 select -assert-count 1 t:$mem_v2 # requested BROM but BRAM is disabled


### PR DESCRIPTION
These parts keep rereading a Verilog module, then using chparam
to test it with various parameter combinations.  Since the default
parameters are on the large side, this spends a lot of time
needlessly elaborating the default parametrization that will then
be discarded.  Fix it with -deref and manual hierarchy call.

Shaves 30s off the test time on my machine.