### PR TITLE
memory_share: Add -nosat and -nowiden options.

### DIFF
--- a/passes/memory/memory.cc
+++ b/passes/memory/memory.cc
@@ -31,7 +31,7 @@ struct MemoryPass : public Pass {
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
-		log("    memory [-nomap] [-nordff] [-memx] [-bram <bram_rules>] [selection]\n");
+		log("    memory [-nomap] [-nordff] [-nowiden] [-nosat] [-memx] [-bram <bram_rules>] [selection]\n");
 		log("\n");
 		log("This pass calls all the other memory_* passes in a useful order:\n");
 		log("\n");
@@ -40,7 +40,7 @@ struct MemoryPass : public Pass {
 		log("    opt_mem_feedback\n");
 		log("    memory_dff                          (skipped if called with -nordff or -memx)\n");
 		log("    opt_clean\n");
-		log("    memory_share\n");
+		log("    memory_share [-nowiden] [-nosat]\n");
 		log("    memory_memx                         (when called with -memx)\n");
 		log("    opt_clean\n");
 		log("    memory_collect\n");
@@ -57,6 +57,7 @@ struct MemoryPass : public Pass {
 		bool flag_nordff = false;
 		bool flag_memx = false;
 		string memory_bram_opts;
+		string memory_share_opts;
 
 		log_header(design, "Executing MEMORY pass.\n");
 		log_push();
@@ -76,6 +77,14 @@ struct MemoryPass : public Pass {
 				flag_memx = true;
 				continue;
 			}
+			if (args[argidx] == "-nowiden") {
+				memory_share_opts += " -nowiden";
+				continue;
+			}
+			if (args[argidx] == "-nosat") {
+				memory_share_opts += " -nosat";
+				continue;
+			}
 			if (argidx+1 < args.size() && args[argidx] == "-bram") {
 				memory_bram_opts += " -rules " + args[++argidx];
 				continue;
@@ -90,7 +99,7 @@ struct MemoryPass : public Pass {
 		if (!flag_nordff)
 			Pass::call(design, "memory_dff");
 		Pass::call(design, "opt_clean");
-		Pass::call(design, "memory_share");
+		Pass::call(design, "memory_share" + memory_share_opts);
 		if (flag_memx)
 			Pass::call(design, "memory_memx");
 		Pass::call(design, "opt_clean");

--- a/tests/memories/run-test.sh
+++ b/tests/memories/run-test.sh
@@ -23,6 +23,10 @@ for f in `egrep -l 'expect-(wr-ports|rd-ports|rd-clk)' *.v`; do
 		grep -q "parameter \\\\WR_PORTS $(gawk '/expect-wr-ports/ { print $3; }' $f)\$" ${f%.v}.dmp ||
 				{ echo " ERROR: Unexpected number of write ports."; false; }
 	fi
+	if grep -q expect-wr-wide-continuation $f; then
+		grep -q "parameter \\\\WR_WIDE_CONTINUATION $(gawk '/expect-wr-wide-continuation/ { print $3; }' $f)\$" ${f%.v}.dmp ||
+				{ echo " ERROR: Unexpected write wide continuation."; false; }
+	fi
 	if grep -q expect-rd-ports $f; then
 		grep -q "parameter \\\\RD_PORTS $(gawk '/expect-rd-ports/ { print $3; }' $f)\$" ${f%.v}.dmp ||
 				{ echo " ERROR: Unexpected number of read ports."; false; }
@@ -54,6 +58,10 @@ for f in `egrep -l 'expect-(wr-ports|rd-ports|rd-clk)' *.v`; do
 	if grep -q expect-rd-init-val $f; then
 		grep -q "parameter \\\\RD_INIT_VALUE $(gawk '/expect-rd-init-val/ { print $3; }' $f)\$" ${f%.v}.dmp ||
 				{ echo " ERROR: Unexpected read init value."; false; }
+	fi
+	if grep -q expect-rd-wide-continuation $f; then
+		grep -q "parameter \\\\RD_WIDE_CONTINUATION $(gawk '/expect-rd-wide-continuation/ { print $3; }' $f)\$" ${f%.v}.dmp ||
+				{ echo " ERROR: Unexpected read wide continuation."; false; }
 	fi
 	if grep -q expect-no-rd-clk $f; then
 		grep -q "connect \\\\RD_CLK 1'x\$" ${f%.v}.dmp ||

--- a/tests/memories/wide_read_async.v
+++ b/tests/memories/wide_read_async.v
@@ -1,0 +1,27 @@
+// expect-wr-ports 1
+// expect-rd-ports 4
+// expect-rd-wide-continuation 4'1110
+
+module test(
+	input clk,
+	input we,
+	input [5:0] ra,
+	input [7:0] wa,
+	input [7:0] wd,
+	output [31:0] rd
+);
+
+reg [7:0] mem[0:255];
+
+assign rd[7:0] = mem[{ra, 2'b00}];
+assign rd[15:8] = mem[{ra, 2'b01}];
+assign rd[23:16] = mem[{ra, 2'b10}];
+assign rd[31:24] = mem[{ra, 2'b11}];
+
+always @(posedge clk) begin
+	if (we)
+		mem[wa] <= wd;
+end
+
+endmodule
+

--- a/tests/memories/wide_read_mixed.v
+++ b/tests/memories/wide_read_mixed.v
@@ -1,0 +1,46 @@
+// expect-wr-ports 1
+// expect-rd-ports 4
+// expect-rd-wide-continuation 4'1110
+// expect-rd-srst-val 32'10000111011001010100001100100001
+// expect-rd-init-val 32'10101011110011011110111110101011
+
+// In this testcase, the byte-wide read ports are merged into a single
+// word-wide port despite mismatched transparency, with soft transparency
+// logic inserted on half the port to preserve the semantics.
+
+module test(
+	input clk,
+	input re, rr,
+	input we,
+	input [5:0] ra,
+	input [7:0] wa,
+	input [7:0] wd,
+	output reg [31:0] rd
+);
+
+reg [7:0] mem[0:255];
+
+initial rd = 32'habcdefab;
+
+always @(posedge clk) begin
+	if (rr) begin
+		rd <= 32'h87654321;
+	end else if (re) begin
+		rd[7:0] <= mem[{ra, 2'b00}];
+		rd[15:8] <= mem[{ra, 2'b01}];
+		rd[23:16] <= mem[{ra, 2'b10}];
+		rd[31:24] <= mem[{ra, 2'b11}];
+		if (we && wa == {ra, 2'b00})
+			rd [7:0] <= wd;
+		if (we && wa == {ra, 2'b01})
+			rd [15:8] <= wd;
+	end
+end
+
+always @(posedge clk) begin
+	if (we)
+		mem[wa] <= wd;
+end
+
+endmodule
+

--- a/tests/memories/wide_read_sync.v
+++ b/tests/memories/wide_read_sync.v
@@ -1,0 +1,32 @@
+// expect-wr-ports 1
+// expect-rd-ports 4
+// expect-rd-wide-continuation 4'1110
+
+module test(
+	input clk,
+	input re,
+	input we,
+	input [5:0] ra,
+	input [7:0] wa,
+	input [7:0] wd,
+	output reg [31:0] rd
+);
+
+reg [7:0] mem[0:255];
+
+always @(posedge clk) begin
+	if (re) begin
+		rd[7:0] <= mem[{ra, 2'b00}];
+		rd[15:8] <= mem[{ra, 2'b01}];
+		rd[23:16] <= mem[{ra, 2'b10}];
+		rd[31:24] <= mem[{ra, 2'b11}];
+	end
+end
+
+always @(posedge clk) begin
+	if (we)
+		mem[wa] <= wd;
+end
+
+endmodule
+

--- a/tests/memories/wide_read_trans.v
+++ b/tests/memories/wide_read_trans.v
@@ -1,0 +1,40 @@
+// expect-wr-ports 1
+// expect-rd-ports 4
+// expect-rd-wide-continuation 4'1110
+
+module test(
+	input clk,
+	input re,
+	input we,
+	input [5:0] ra,
+	input [7:0] wa,
+	input [7:0] wd,
+	output reg [31:0] rd
+);
+
+reg [7:0] mem[0:255];
+
+always @(posedge clk) begin
+	if (re) begin
+		rd[7:0] <= mem[{ra, 2'b00}];
+		rd[15:8] <= mem[{ra, 2'b01}];
+		rd[23:16] <= mem[{ra, 2'b10}];
+		rd[31:24] <= mem[{ra, 2'b11}];
+		if (we && wa == {ra, 2'b00})
+			rd [7:0] <= wd;
+		if (we && wa == {ra, 2'b01})
+			rd [15:8] <= wd;
+		if (we && wa == {ra, 2'b10})
+			rd [23:16] <= wd;
+		if (we && wa == {ra, 2'b11})
+			rd [31:24] <= wd;
+	end
+end
+
+always @(posedge clk) begin
+	if (we)
+		mem[wa] <= wd;
+end
+
+endmodule
+

--- a/tests/memories/wide_thru_priority.v
+++ b/tests/memories/wide_thru_priority.v
@@ -1,0 +1,29 @@
+// expect-wr-ports 3
+// expect-rd-ports 1
+// expect-wr-wide-continuation 3'010
+
+module test(
+	input clk,
+	input we1, we2,
+	input [5:0] ra,
+	input [4:0] wa1,
+	input [5:0] wa2,
+	input [15:0] wd1,
+	input [7:0] wd2,
+	output [7:0] rd
+);
+
+reg [7:0] mem[0:63];
+
+assign rd = mem[ra];
+
+always @(posedge clk) begin
+	if (we1)
+		mem[{wa1, 1'b0}] <= wd1[7:0];
+	if (we2)
+		mem[wa2] <= wd2;
+	if (we1)
+		mem[{wa1, 1'b1}] <= wd1[15:8];
+end
+
+endmodule

--- a/tests/memories/wide_write.v
+++ b/tests/memories/wide_write.v
@@ -1,0 +1,29 @@
+// expect-wr-ports 4
+// expect-rd-ports 1
+// expect-wr-wide-continuation 4'1110
+
+module test(
+	input clk,
+	input [3:0] we,
+	input [7:0] ra,
+	input [5:0] wa,
+	input [31:0] wd,
+	output [7:0] rd
+);
+
+reg [7:0] mem[0:255];
+
+assign rd = mem[ra];
+
+always @(posedge clk) begin
+	if (we[0])
+		mem[{wa, 2'b00}] <= wd[7:0];
+	if (we[1])
+		mem[{wa, 2'b01}] <= wd[15:8];
+	if (we[2])
+		mem[{wa, 2'b10}] <= wd[23:16];
+	if (we[3])
+		mem[{wa, 2'b11}] <= wd[31:24];
+end
+
+endmodule

--- a/tests/opt/memory_dff_trans.ys
+++ b/tests/opt/memory_dff_trans.ys
@@ -759,6 +759,10 @@ memory_dff
 memory_collect
 select -assert-count 1 t:$mem_v2
 select -assert-count 1 t:$mem_v2 r:RD_TRANSPARENCY_MASK=4'b1111 r:RD_COLLISION_X_MASK=4'b0000 %i %i
+memory_share
+select -assert-count 1 t:$mem_v2
+select -assert-count 1 t:$mem_v2 r:RD_TRANSPARENCY_MASK=4'b1111 r:RD_COLLISION_X_MASK=4'b0000 %i %i
+select -assert-count 1 t:$mem_v2 r:RD_WIDE_CONTINUATION=4'b1110 %i
 
 design -reset
 
@@ -808,6 +812,10 @@ memory_dff
 memory_collect
 select -assert-count 1 t:$mem_v2
 select -assert-count 1 t:$mem_v2 r:RD_TRANSPARENCY_MASK=4'b1111 r:RD_COLLISION_X_MASK=4'b0000 %i %i
+memory_share
+select -assert-count 1 t:$mem_v2
+select -assert-count 1 t:$mem_v2 r:RD_TRANSPARENCY_MASK=4'b1111 r:RD_COLLISION_X_MASK=4'b0000 %i %i
+select -assert-count 1 t:$mem_v2 r:WR_WIDE_CONTINUATION=4'b1110 %i
 
 design -reset
 
@@ -858,5 +866,9 @@ select -assert-count 1 t:$memrd_v2 r:TRANSPARENCY_MASK=4'b0001 r:COLLISION_X_MAS
 select -assert-count 1 t:$memrd_v2 r:TRANSPARENCY_MASK=4'b0010 r:COLLISION_X_MASK=4'b1101 %i %i
 select -assert-count 1 t:$memrd_v2 r:TRANSPARENCY_MASK=4'b0100 r:COLLISION_X_MASK=4'b1011 %i %i
 select -assert-count 1 t:$memrd_v2 r:TRANSPARENCY_MASK=4'b1000 r:COLLISION_X_MASK=4'b0111 %i %i
+memory_share
+select -assert-count 1 t:$memrd_v2
+select -assert-count 1 t:$memwr_v2
+select -assert-count 1 t:$memrd_v2 r:TRANSPARENCY_MASK=1'b1 r:COLLISION_X_MASK=1'b0 %i %i
 
 design -reset

--- a/tests/opt/opt_mem_priority.ys
+++ b/tests/opt/opt_mem_priority.ys
@@ -200,6 +200,10 @@ EOT
 hierarchy -auto-top
 proc
 opt
-memory -nomap
+opt_mem_priority
+memory_collect
 select -assert-count 1 t:$mem_v2
 select -assert-count 1 t:$mem_v2 r:WR_PRIORITY_MASK=64'h0804020100000000 %i
+memory_share
+select -assert-count 1 t:$mem_v2 r:WR_PRIORITY_MASK=64'h0f0f0f0f00000000 %i
+select -assert-count 1 t:$mem_v2 r:WR_WIDE_CONTINUATION=8'hee %i


### PR DESCRIPTION
This unlocks wide port recognition by default.

Submitting as draft, as it's still missing tests.