### PR TITLE
sv: support wand and wor of data types

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -56,7 +56,7 @@ Yosys 0.9 .. Yosys 0.9-dev
     - Added "portlist" command
     - Added "check -mapped"
     - Added "check -allow-tbuf"
-    - Added "autoname" pass 
+    - Added "autoname" pass
     - Added "write_verilog -extmem"
     - Added "opt_mem" pass
     - Added "scratchpad" pass
@@ -94,6 +94,7 @@ Yosys 0.9 .. Yosys 0.9-dev
     - Added support for parsing the 'bind' construct
     - support declaration in procedural for initialization
     - support declaration in generate for initialization
+    - Support wand and wor of data types
 
  * Verific support
     - Added "verific -L"

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -832,16 +832,10 @@ opt_wire_type_token:
 	wire_type_token | %empty;
 
 wire_type_token:
-	TOK_WOR {
-		astbuf3->is_wor = true;
+	// nets
+	net_type {
 	} |
-	TOK_WAND {
-		astbuf3->is_wand = true;
-	} |
-	// wires
-	TOK_WIRE {
-	} |
-	TOK_WIRE logic_type {
+	net_type logic_type {
 	} |
 	// regs
 	TOK_REG {
@@ -867,6 +861,15 @@ wire_type_token:
 		astbuf3->range_left = 31;
 		astbuf3->range_right = 0;
 	};
+
+net_type:
+	TOK_WOR {
+		astbuf3->is_wor = true;
+	} |
+	TOK_WAND {
+		astbuf3->is_wand = true;
+	} |
+	TOK_WIRE;
 
 logic_type:
 	TOK_LOGIC {

--- a/tests/verilog/net_types.sv
+++ b/tests/verilog/net_types.sv
@@ -1,0 +1,34 @@
+module top;
+    wire logic wire_logic_0; assign wire_logic_0 = 0;
+    wire logic wire_logic_1; assign wire_logic_1 = 1;
+    wand logic wand_logic_0; assign wand_logic_0 = 0; assign wand_logic_0 = 1;
+    wand logic wand_logic_1; assign wand_logic_1 = 1; assign wand_logic_1 = 1;
+    wor logic wor_logic_0; assign wor_logic_0 = 0; assign wor_logic_0 = 0;
+    wor logic wor_logic_1; assign wor_logic_1 = 1; assign wor_logic_1 = 0;
+
+    wire integer wire_integer; assign wire_integer = 4'b1001;
+    wand integer wand_integer; assign wand_integer = 4'b1001; assign wand_integer = 4'b1010;
+    wor integer wor_integer; assign wor_integer = 4'b1001; assign wor_integer = 4'b1010;
+
+    typedef logic [3:0] typename;
+    wire typename wire_typename; assign wire_typename = 4'b1001;
+    wand typename wand_typename; assign wand_typename = 4'b1001; assign wand_typename = 4'b1010;
+    wor typename wor_typename; assign wor_typename = 4'b1001; assign wor_typename = 4'b1010;
+
+    always @* begin
+        assert (wire_logic_0 == 0);
+        assert (wire_logic_1 == 1);
+        assert (wand_logic_0 == 0);
+        assert (wand_logic_1 == 1);
+        assert (wor_logic_0 == 0);
+        assert (wor_logic_1 == 1);
+
+        assert (wire_integer == 4'b1001);
+        assert (wand_integer == 4'b1000);
+        assert (wor_integer == 4'b1011);
+
+        assert (wire_typename == 4'b1001);
+        assert (wand_typename == 4'b1000);
+        assert (wor_typename == 4'b1011);
+    end
+endmodule

--- a/tests/verilog/net_types.ys
+++ b/tests/verilog/net_types.ys
@@ -1,0 +1,5 @@
+read_verilog -sv net_types.sv
+hierarchy
+proc
+opt -full
+sat -verify -prove-asserts -show-all


### PR DESCRIPTION
This enables the usage of declarations of wand or wor with a base type of logic, integer, or a typename. Note that declarations of nets with 2-state base types is still permitted, in violation of the spec.