### PR TITLE
Gowin: deal with active-low tristate

### DIFF
--- a/techlibs/gowin/cells_map.v
+++ b/techlibs/gowin/cells_map.v
@@ -127,7 +127,7 @@ module \$__GW_IOBUF (input I, OE, output O, inout IO);
 endmodule
 
 module \$__GW_TBUF (input I, OE, output O);
-	TBUF _TECHMAP_REPLACE_ (.I(I), .O(), .OEN(~OE), .O(O));
+	TBUF _TECHMAP_REPLACE_ (.I(I), .OEN(~OE), .O(O));
 endmodule
 
 module \$lut (A, Y);

--- a/techlibs/gowin/cells_map.v
+++ b/techlibs/gowin/cells_map.v
@@ -122,6 +122,13 @@ module	\$_DFFE_NP0P_ (input D, C, R, E, output Q);
 	wire _TECHMAP_REMOVEINIT_Q_ = 1;
 endmodule
 
+module \$__GW_IOBUF (input I, OE, output O, inout IO);
+	IOBUF _TECHMAP_REPLACE_ (.I(I), .O(O), .OEN(~OE), .IO(IO));
+endmodule
+
+module \$__GW_TBUF (input I, OE, output O);
+	TBUF _TECHMAP_REPLACE_ (.I(I), .O(), .OEN(~OE), .O(O));
+endmodule
 
 module \$lut (A, Y);
 	parameter WIDTH = 0;

--- a/techlibs/gowin/cells_sim.v
+++ b/techlibs/gowin/cells_sim.v
@@ -573,14 +573,14 @@ endmodule
 module TBUF (O, I, OEN);
   input I, OEN;
   output O;
-  assign O = OEN ? I : 1'bz;
+  assign O = OEN ? 1'bz : I;
 endmodule
 
 module IOBUF (O, IO, I, OEN);
   input I,OEN;
   output O;
   inout IO;
-  assign IO = OEN ? I : 1'bz;
+  assign IO = OEN ? 1'bz : I;
   assign I = IO;
 endmodule
 

--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -241,6 +241,9 @@ struct SynthGowinPass : public ScriptPass
 			if (retime || help_mode)
 				run("abc -dff -D 1", "(only if -retime)");
 			run("splitnets");
+			if (!noiopads || help_mode)
+				run("iopadmap -bits -inpad IBUF O:I -outpad OBUF I:O "
+					"-toutpad $__GW_TBUF OE:I:O -tinoutpad $__GW_IOBUF OE:O:I:IO", "(unless -noiopads)");
 		}
 
 		if (check_label("map_ffs"))
@@ -277,9 +280,6 @@ struct SynthGowinPass : public ScriptPass
 			run("opt_lut_ins -tech gowin");
 			run("setundef -undriven -params -zero");
 			run("hilomap -singleton -hicell VCC V -locell GND G");
-			if (!noiopads || help_mode)
-				run("iopadmap -bits -inpad IBUF O:I -outpad OBUF I:O "
-					"-toutpad TBUF OEN:I:O -tinoutpad IOBUF OEN:O:I:IO", "(unless -noiopads)");
 			run("clean");
 			run("autoname");
 		}

--- a/techlibs/nexus/cells_map.v
+++ b/techlibs/nexus/cells_map.v
@@ -58,7 +58,7 @@ module \$__NX_TINOUTPAD (input I, OE, output O, inout B);
 endmodule
 
 module \$__NX_TOUTPAD (input I, OE, output O);
-	OBZ _TECHMAP_REPLACE_ (.I(I), .O(), .T(~OE), .O(O));
+	OBZ _TECHMAP_REPLACE_ (.I(I), .T(~OE), .O(O));
 endmodule
 
 `ifndef NO_LUT

--- a/tests/arch/gowin/tribuf.ys
+++ b/tests/arch/gowin/tribuf.ys
@@ -9,5 +9,6 @@ design -load postopt # load the post-opt design (otherwise equiv_opt loads the p
 cd tristate # Constrain all select calls below inside the top module
 #Internal cell type used. Need support it.
 select -assert-count 1 t:TBUF
+select -assert-count 1 t:LUT1
 select -assert-count 2 t:IBUF
-select -assert-none t:TBUF t:IBUF %% t:* %D
+select -assert-none t:TBUF t:IBUF t:LUT1 %% t:* %D


### PR DESCRIPTION
Now that we're adding support in Apicula for inout and tristate buffers we're finding that they are actually active-low, causing inverted behavior.

This PR matches the behavior of Nexus explained in #2916 by using an intermediate cell.
It also moves the iopadmap earlier into the process, so that there is more room to optimize away the inverter.