### PR TITLE
opt_clean: Make the init attribute follow the FF's Q.

### DIFF
--- a/tests/techmap/iopadmap.ys
+++ b/tests/techmap/iopadmap.ys
@@ -169,7 +169,7 @@ sub s2(.i(i[1]), .o(w[1]));
 assign o = oe ? w : 2'bz;
 endmodule
 
-module c(input i, oe, (* init=2'b00 *) inout io, output o1, o2);
+module c(input i, oe, (* init=1'b0 *) inout io, output o1, o2);
 assign io = oe ? i : 1'bz;
 assign {o1,o2} = {io,io};
 endmodule
@@ -182,5 +182,5 @@ select -assert-count 1 a/c:s %co a/a:init=1'b1 %i
 select -assert-count 1 a/a:init
 select -assert-count 1 b/c:s* %co %a b/a:init=2'b1x %i
 select -assert-count 1 b/a:init
-select -assert-count 1 c/t:iobuf %co c/a:init=2'b00 %i
+select -assert-count 1 c/t:iobuf %co c/a:init=1'b0 %i
 select -assert-count 1 c/a:init


### PR DESCRIPTION
Previously, opt_clean would reconnect all ports (including FF Q ports)
to a "canonical" SigBit chosen by complex rules, but would leave the
init attribute on the old wire.  This change applies the same
canonicalization rules to the init attributes, ensuring that init moves
to wherever the Q port moved.

Part of another jab at #2920.