### PR TITLE
preprocessor: do not destroy double slash escaped identifiers

### DIFF
--- a/frontends/verilog/preproc.cc
+++ b/frontends/verilog/preproc.cc
@@ -142,6 +142,16 @@ static std::string next_token(bool pass_newline = false)
 				return_char(ch);
 		}
 	}
+	else if (ch == '\\')
+	{
+		while ((ch = next_char()) != 0) {
+			if (ch < 33 || ch > 126) {
+				return_char(ch);
+				break;
+			}
+			token += ch;
+		}
+	}
 	else if (ch == '/')
 	{
 		if ((ch = next_char()) != 0) {

--- a/tests/verilog/doubleslash.ys
+++ b/tests/verilog/doubleslash.ys
@@ -1,0 +1,19 @@
+read_verilog -sv <<EOT
+module doubleslash
+  (input  logic   a,
+   input  logic   b,
+   output logic   z);
+
+  logic \a//b ;
+
+  assign \a//b = a & b;
+  assign z = ~\a//b ;
+
+endmodule : doubleslash
+EOT
+
+hierarchy
+proc
+opt -full
+
+write_verilog doubleslash.v


### PR DESCRIPTION
The preprocessor currently destroys double slash containing escaped
identifiers (for example \a//b ). This is due to next_token trying to
convert single line comments (//) into /* */ comments. This then leads
to an unintuitive error message like this:
ERROR: syntax error, unexpected '*'

This patch fixes the error by recognizing escaped identifiers and
returning them as single token. It also adds a testcase.