### PR TITLE
[ECP5] fix wrong link for syn_* attributes description

### DIFF
--- a/techlibs/ecp5/brams.txt
+++ b/techlibs/ecp5/brams.txt
@@ -38,7 +38,7 @@ bram $__ECP5_DP16KD
 endbram
 
 # The syn_* attributes are described in:
-# https://www.latticesemi.com/-/media/LatticeSemi/Documents/Tutorials/AK/LatticeDiamondTutorial311.ashx
+# https://www.latticesemi.com/view_document?document_id=51556
 attr_icase 1
 
 match $__ECP5_PDPW16KD

--- a/techlibs/ecp5/lutrams.txt
+++ b/techlibs/ecp5/lutrams.txt
@@ -12,7 +12,7 @@ bram $__TRELLIS_DPR16X4
 endbram
 
 # The syn_* attributes are described in:
-# https://www.latticesemi.com/-/media/LatticeSemi/Documents/Tutorials/AK/LatticeDiamondTutorial311.ashx
+# https://www.latticesemi.com/view_document?document_id=51556
 attr_icase 1
 
 match $__TRELLIS_DPR16X4


### PR DESCRIPTION
The current link points to a tutorial that does not (no longer?) describe these attributes. The new link points to "Lattice Synthesis Engine for Diamond User Guide". I hope this is the correct document, please check again before merging.

Thank you.