### PR TITLE
sv: support declaration in generate for initialization

### DIFF
--- a/tests/verilog/genfor_decl_no_init.ys
+++ b/tests/verilog/genfor_decl_no_init.ys
@@ -1,0 +1,7 @@
+logger -expect error "Generate for loop variable declaration is missing initialization!" 1
+read_verilog -sv <<EOT
+module top;
+    for (genvar i; i < 10; i = i + 1)
+        wire x;
+endmodule
+EOT

--- a/tests/verilog/genfor_decl_no_sv.ys
+++ b/tests/verilog/genfor_decl_no_sv.ys
@@ -1,0 +1,7 @@
+logger -expect error "Generate for loop inline variable declaration is only supported in SystemVerilog mode!" 1
+read_verilog <<EOT
+module top;
+    for (genvar i = 1; i < 10; i = i + 1)
+        wire x;
+endmodule
+EOT

--- a/tests/verilog/genvar_loop_decl_1.sv
+++ b/tests/verilog/genvar_loop_decl_1.sv
@@ -1,0 +1,18 @@
+`default_nettype none
+
+module gate(a);
+	for (genvar i = 0; i < 2; i++)
+		wire [i:0] x = '1;
+
+	output wire [32:0] a;
+	assign a = {1'b0, genblk1[0].x, 1'b0, genblk1[1].x, 1'b0};
+endmodule
+
+module gold(a);
+	genvar i;
+	for (i = 0; i < 2; i++)
+		wire [i:0] x = '1;
+
+	output wire [32:0] a;
+	assign a = {1'b0, genblk1[0].x, 1'b0, genblk1[1].x, 1'b0};
+endmodule

--- a/tests/verilog/genvar_loop_decl_1.ys
+++ b/tests/verilog/genvar_loop_decl_1.ys
@@ -1,0 +1,14 @@
+read_verilog -sv genvar_loop_decl_1.sv
+
+select -assert-count 1 gate/genblk1[0].x
+select -assert-count 1 gate/genblk1[1].x
+select -assert-count 0 gate/genblk1[2].x
+
+select -assert-count 1 gold/genblk1[0].x
+select -assert-count 1 gold/genblk1[1].x
+select -assert-count 0 gold/genblk1[2].x
+
+proc
+equiv_make gold gate equiv
+equiv_simple
+equiv_status -assert

--- a/tests/verilog/genvar_loop_decl_2.sv
+++ b/tests/verilog/genvar_loop_decl_2.sv
@@ -1,0 +1,30 @@
+`default_nettype none
+
+module gate(out);
+    wire [3:0] x;
+    for (genvar x = 0; x < 2; x++) begin : blk
+        localparam w = x;
+        if (x == 0) begin : sub
+            wire [w:0] x;
+        end
+    end
+    assign x = 2;
+    assign blk[0].sub.x = '1;
+    output wire [9:0] out;
+    assign out = {1'bx, x, blk[0].sub.x};
+endmodule
+
+module gold(out);
+    wire [3:0] x;
+    genvar z;
+    for (z = 0; z < 2; z++) begin : blk
+        localparam w = z;
+        if (z == 0) begin : sub
+            wire [w:0] x;
+        end
+    end
+    assign x = 2;
+    assign blk[0].sub.x = '1;
+    output wire [9:0] out;
+    assign out = {1'bx, x, blk[0].sub.x};
+endmodule

--- a/tests/verilog/genvar_loop_decl_2.ys
+++ b/tests/verilog/genvar_loop_decl_2.ys
@@ -1,0 +1,5 @@
+read_verilog -sv genvar_loop_decl_2.sv
+proc
+equiv_make gold gate equiv
+equiv_simple
+equiv_status -assert

--- a/tests/verilog/genvar_loop_decl_3.sv
+++ b/tests/verilog/genvar_loop_decl_3.sv
@@ -1,0 +1,28 @@
+`default_nettype none
+
+module gate(x, y);
+    output reg [15:0] x, y;
+    if (1) begin : gen
+        integer x, y;
+        for (genvar x = 0; x < 2; x++)
+            if (x == 0)
+                initial gen.x = 10;
+        assign y = x + 1;
+    end
+    initial x = gen.x;
+    assign y = gen.y;
+endmodule
+
+module gold(x, y);
+    output reg [15:0] x, y;
+    if (1) begin : gen
+        integer x, y;
+        genvar z;
+        for (z = 0; z < 2; z++)
+            if (z == 0)
+                initial x = 10;
+        assign y = x + 1;
+    end
+    initial x = gen.x;
+    assign y = gen.y;
+endmodule

--- a/tests/verilog/genvar_loop_decl_3.ys
+++ b/tests/verilog/genvar_loop_decl_3.ys
@@ -1,0 +1,5 @@
+read_verilog -sv genvar_loop_decl_3.sv
+proc
+equiv_make gold gate equiv
+equiv_simple
+equiv_status -assert


### PR DESCRIPTION
This is accomplished by generating a unique name for the genvar, renaming references to the genvar only in the loop's initialization, guard, and incrementation, and finally adding a localparam inside the loop body with the original name so that the genvar can be shadowed as expected.