### PR TITLE
abc9: holes module to instantiate cells with NEW_ID

### DIFF
--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -796,7 +796,7 @@ void prep_xaiger(RTLIL::Module *module, bool dff)
 		auto &holes_cell = r.first->second;
 		if (r.second) {
 			if (box_module->get_bool_attribute(ID::whitebox)) {
-				holes_cell = holes_module->addCell(cell->name, cell->type);
+				holes_cell = holes_module->addCell(NEW_ID, cell->type);
 
 				if (box_module->has_processes())
 					Pass::call_on_module(design, box_module, "proc");

--- a/tests/techmap/bug2759.ys
+++ b/tests/techmap/bug2759.ys
@@ -1,0 +1,14 @@
+read_verilog -specify <<EOT
+(* abc9_box, whitebox *)
+module box(input [1:0] i, output o);
+specify
+(i *> o) = 1;
+endspecify
+assign o = ^i;
+endmodule
+
+module top(input [1:0] i, output o);
+box i1(i, o);
+endmodule
+EOT
+abc9 -lut 4


### PR DESCRIPTION
Rather than using the identifier from the first matching cell in the user design.

Fixes #2759.