### PR TITLE
abc9: make re-entrant

### DIFF
--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -450,6 +450,9 @@ struct Abc9Pass : public ScriptPass
 			run("design -delete $abc9_unmap");
 			if (saved_designs.count("$abc9_holes") || help_mode)
 				run("design -delete $abc9_holes");
+                        run("delete =*_$abc9_byp");
+                        run("setattr -mod -unset abc9_box_id");
+
 		}
 	}
 } Abc9Pass;

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -289,8 +289,10 @@ struct Abc9Pass : public ScriptPass
 			run("scc -specify -set_attr abc9_scc_id {}");
 			if (help_mode)
 				run("abc9_ops -prep_bypass [-prep_dff]", "(option if -dff)");
-			else
+			else {
+				active_design->scratchpad_unset("abc9_ops.prep_bypass.did_something");
 				run(stringf("abc9_ops -prep_bypass %s", dff_mode ? "-prep_dff" : ""));
+			}
 			if (dff_mode) {
 				run("design -copy-to $abc9_map @$abc9_flops", "(only if -dff)");
 				run("select -unset $abc9_flops", "             (only if -dff)");
@@ -450,9 +452,9 @@ struct Abc9Pass : public ScriptPass
 			run("design -delete $abc9_unmap");
 			if (saved_designs.count("$abc9_holes") || help_mode)
 				run("design -delete $abc9_holes");
-                        run("delete =*_$abc9_byp");
-                        run("setattr -mod -unset abc9_box_id");
-
+			if (help_mode || active_design->scratchpad_get_bool("abc9_ops.prep_bypass.did_something"))
+				run("delete =*_$abc9_byp");
+			run("setattr -mod -unset abc9_box_id");
 		}
 	}
 } Abc9Pass;

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -926,15 +926,8 @@ void prep_box(RTLIL::Design *design)
 {
 	TimingInfo timing;
 
-	std::stringstream ss;
 	int abc9_box_id = 1;
-	for (auto module : design->modules()) {
-		auto it = module->attributes.find(ID::abc9_box_id);
-		if (it == module->attributes.end())
-			continue;
-		abc9_box_id = std::max(abc9_box_id, it->second.as_int());
-	}
-
+	std::stringstream ss;
 	dict<IdString,std::vector<IdString>> box_ports;
 	for (auto module : design->modules()) {
 		auto it = module->attributes.find(ID::abc9_box);

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -424,6 +424,8 @@ void prep_bypass(RTLIL::Design *design)
 				}
 			}
 			unmap_module->fixup_ports();
+
+			design->scratchpad_set_bool("abc9_ops.prep_bypass.did_something", true);
 		}
 }
 

--- a/tests/techmap/bug2972.ys
+++ b/tests/techmap/bug2972.ys
@@ -1,0 +1,20 @@
+read_verilog -specify <<EOT
+(* abc9_box, blackbox*)
+module box(input clk, d, output reg q, output do);
+parameter P = 0;
+always @(posedge clk)
+    q <= d;
+assign do = d;
+specify
+    (posedge clk => (q : d)) = 1;
+    (d => do) = 1;
+endspecify
+endmodule
+
+module top(input clk, d, output q);
+box i1(clk, d, q);
+endmodule
+EOT
+hierarchy
+abc9 -lut 4
+abc9 -lut 4


### PR DESCRIPTION
Clean up some state at the end of `abc9` so that it can be re-entrant.

Fixes #2972.