### PR TITLE
chformal: Add -coverenable option

### DIFF
--- a/passes/cmds/chformal.cc
+++ b/passes/cmds/chformal.cc
@@ -273,8 +273,8 @@ struct ChformalPass : public Pass {
 			if (mode =='p')
 			{
 				for (auto cell : constr_cells)
-					module->addCover(NEW_ID, cell->getPort(ID::EN), State::S1,
-						"$auto$coverprecond$" + cell->get_src_attribute());
+					module->addCover(NEW_ID_SUFFIX("coverprecond"),
+						cell->getPort(ID::EN), State::S1, cell->get_src_attribute());
 			}
 			else
 			if (mode == 'c')

--- a/passes/cmds/chformal.cc
+++ b/passes/cmds/chformal.cc
@@ -55,6 +55,9 @@ struct ChformalPass : public Pass {
 		log("    -skip <N>\n");
 		log("        ignore activation of the constraint in the first <N> clock cycles\n");
 		log("\n");
+		log("    -coverprecond\n");
+		log("        add a cover statement for the precondition (enable signal) of the cells\n");
+		log("\n");
 		log("    -assert2assume\n");
 		log("    -assume2assert\n");
 		log("    -live2fair\n");
@@ -112,6 +115,10 @@ struct ChformalPass : public Pass {
 			if (mode == 0 && args[argidx] == "-skip" && argidx+1 < args.size()) {
 				mode = 's';
 				mode_arg = atoi(args[++argidx].c_str());
+				continue;
+			}
+			if (mode == 0 && args[argidx] == "-coverprecond") {
+				mode = 'p';
 				continue;
 			}
 			if ((mode == 0 || mode == 'c') && args[argidx] == "-assert2assume") {
@@ -261,6 +268,13 @@ struct ChformalPass : public Pass {
 
 				for (auto cell : constr_cells)
 					cell->setPort(ID::EN, module->LogicAnd(NEW_ID, en, cell->getPort(ID::EN)));
+			}
+			else
+			if (mode =='p')
+			{
+				for (auto cell : constr_cells)
+					module->addCover(NEW_ID, cell->getPort(ID::EN), State::S1,
+						"$auto$coverprecond$" + cell->get_src_attribute());
 			}
 			else
 			if (mode == 'c')

--- a/passes/cmds/chformal.cc
+++ b/passes/cmds/chformal.cc
@@ -55,8 +55,8 @@ struct ChformalPass : public Pass {
 		log("    -skip <N>\n");
 		log("        ignore activation of the constraint in the first <N> clock cycles\n");
 		log("\n");
-		log("    -coverprecond\n");
-		log("        add a cover statement for the precondition (enable signal) of the cells\n");
+		log("    -coverenable\n");
+		log("        add cover statements for the enable signals of the constraints\n");
 		log("\n");
 		log("    -assert2assume\n");
 		log("    -assume2assert\n");
@@ -117,7 +117,7 @@ struct ChformalPass : public Pass {
 				mode_arg = atoi(args[++argidx].c_str());
 				continue;
 			}
-			if (mode == 0 && args[argidx] == "-coverprecond") {
+			if (mode == 0 && args[argidx] == "-coverenable") {
 				mode = 'p';
 				continue;
 			}
@@ -273,7 +273,7 @@ struct ChformalPass : public Pass {
 			if (mode =='p')
 			{
 				for (auto cell : constr_cells)
-					module->addCover(NEW_ID_SUFFIX("coverprecond"),
+					module->addCover(NEW_ID_SUFFIX("coverenable"),
 						cell->getPort(ID::EN), State::S1, cell->get_src_attribute());
 			}
 			else

--- a/passes/cmds/chformal.cc
+++ b/passes/cmds/chformal.cc
@@ -58,6 +58,11 @@ struct ChformalPass : public Pass {
 		log("    -coverenable\n");
 		log("        add cover statements for the enable signals of the constraints\n");
 		log("\n");
+#ifdef YOSYS_ENABLE_VERIFIC
+		log("        Note: For the Verific frontend it is currently not guaranteed that a\n");
+		log("        reachable SVA statement corresponds to an active enable signal.\n");
+		log("\n");
+#endif
 		log("    -assert2assume\n");
 		log("    -assume2assert\n");
 		log("    -live2fair\n");

--- a/tests/various/chformal_coverenable.ys
+++ b/tests/various/chformal_coverenable.ys
@@ -15,11 +15,11 @@ prep -top top
 
 select -assert-count 1 t:$cover
 
-chformal -cover -coverprecond
+chformal -cover -coverenable
 select -assert-count 2 t:$cover
 
-chformal -assert -coverprecond
+chformal -assert -coverenable
 select -assert-count 4 t:$cover
 
-chformal -assume -coverprecond
+chformal -assume -coverenable
 select -assert-count 5 t:$cover

--- a/tests/various/chformal_coverprecond.ys
+++ b/tests/various/chformal_coverprecond.ys
@@ -1,0 +1,25 @@
+read_verilog -formal <<EOT
+module top(input a, b, c, d);
+
+    always @* begin
+        if (a) assert (b == c);
+        if (!a) assert (b != c);
+        if (b) assume (c);
+        if (c) cover (d);
+    end
+
+endmodule
+EOT
+
+prep -top top
+
+select -assert-count 1 t:$cover
+
+chformal -cover -coverprecond
+select -assert-count 2 t:$cover
+
+chformal -assert -coverprecond
+select -assert-count 4 t:$cover
+
+chformal -assume -coverprecond
+select -assert-count 5 t:$cover


### PR DESCRIPTION
This inserts $cover cells to cover the enable signal (precondition/antecedent) for the selected formal cells. This allows you to check that your properties are not vacuous.

This will not cover preconditions that you write as part of the statement (e.g. this will cover `a` for `if (a) assert(b)`, but not for `assert(!a || b)`). ~~This should also work with preconditions arising from SVA in the verific front end (if the preconditions are converted to the enable signal as I believe they are?) but I do not have a copy to check~~ (it does not as sequential properties are more complex).