### PR TITLE
Expand design from bottom up in hierarchy pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -807,6 +807,7 @@ test: $(TARGETS) $(EXTRA_TARGETS)
 	+cd tests/rpc && bash run-test.sh
 	+cd tests/memfile && bash run-test.sh
 	+cd tests/verilog && bash run-test.sh
+	+cd tests/bind && bash run-test.sh
 	@echo ""
 	@echo "  Passed \"make test\"."
 	@echo ""

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -348,7 +348,7 @@ namespace AST
 		RTLIL::IdString derive(RTLIL::Design *design, const dict<RTLIL::IdString, RTLIL::Const> &parameters, bool mayfail) override;
 		RTLIL::IdString derive(RTLIL::Design *design, const dict<RTLIL::IdString, RTLIL::Const> &parameters, const dict<RTLIL::IdString, RTLIL::Module*> &interfaces, const dict<RTLIL::IdString, RTLIL::IdString> &modports, bool mayfail) override;
 		std::string derive_common(RTLIL::Design *design, const dict<RTLIL::IdString, RTLIL::Const> &parameters, AstNode **new_ast_out, bool quiet = false);
-		void reprocess_module(RTLIL::Design *design, const dict<RTLIL::IdString, RTLIL::Module *> &local_interfaces) override;
+		void expand_interfaces(RTLIL::Design *design, const dict<RTLIL::IdString, RTLIL::Module *> &local_interfaces) override;
 		RTLIL::Module *clone() const override;
 		void loadconfig() const;
 	};
@@ -395,6 +395,18 @@ namespace AST_INTERNAL
 	extern dict<std::string, pool<int>> current_memwr_visible;
 	struct LookaheadRewriter;
 	struct ProcessGenerator;
+
+	// Create and add a new AstModule from new_ast, then use it to replace
+	// old_module in design, renaming old_module to move it out of the way.
+	// Return the new module.
+	//
+	// If original_ast is not null, it will be used as the AST node for the
+	// new module. Otherwise, new_ast will be used.
+	RTLIL::Module *
+	process_and_replace_module(RTLIL::Design *design,
+	                           RTLIL::Module *old_module,
+	                           AST::AstNode *new_ast,
+	                           AST::AstNode *original_ast = nullptr);
 }
 
 YOSYS_NAMESPACE_END

--- a/frontends/ast/ast_binding.cc
+++ b/frontends/ast/ast_binding.cc
@@ -46,4 +46,45 @@ AST::Binding::describe() const
 	return oss.str();
 }
 
+bool
+AST::Binding::bind_into(RTLIL::Design &design, RTLIL::Module &target) const
+{
+	if (target.get_bool_attribute(attr_name))
+		return false;
+
+	// Dynamically cast the target module to an AstModule. If we can't,
+	// we're trying to bind into a module that didn't come from parsing RTL
+	// code and there's not really much we can do!
+	AstModule *tgt_ast_mod = dynamic_cast<AstModule *>(&target);
+	if (!tgt_ast_mod) {
+		log_error("Cannot bind into module `%s' because it didn't originally come from RTL.\n",
+		          target.name.c_str());
+	}
+
+	tgt_ast_mod->loadconfig();
+
+	// Re-derive the module from its AstNode, after modifying the
+	// target's AST by inserting a copy of our own AST node to
+	// represent the thing being bound in.
+	AstNode *new_ast = tgt_ast_mod->ast->clone();
+	new_ast->children.push_back(ast_node->clone());
+
+	RTLIL::Module *new_module =
+		process_and_replace_module(&design, &target, new_ast);
+
+	// Set attr_name so that we don't try to bind into this module again.
+	new_module->set_bool_attribute(attr_name);
+
+	return true;
+}
+
+void
+AST::Binding::report_error(const std::string &msg) const
+{
+	log_file_error(ast_node->filename,
+	               ast_node->location.first_line,
+	               "%s\n",
+	               msg.c_str());
+}
+
 PRIVATE_NAMESPACE_END

--- a/frontends/ast/ast_binding.h
+++ b/frontends/ast/ast_binding.h
@@ -47,6 +47,11 @@ namespace AST
 
 		std::string describe() const override;
 
+		bool bind_into(RTLIL::Design &design,
+		               RTLIL::Module &target) const override;
+
+      [[noreturn]] void report_error(const std::string &msg) const override;
+
 	private:
 		// The syntax-level representation of the cell to be bound.
 		std::unique_ptr<AstNode> ast_node;

--- a/kernel/binding.cc
+++ b/kernel/binding.cc
@@ -24,6 +24,208 @@ YOSYS_NAMESPACE_BEGIN
 RTLIL::Binding::Binding(RTLIL::IdString target_type,
                         RTLIL::IdString target_name)
 	: target_type(target_type), target_name(target_name)
-{}
+{
+	// A counter of the number of bindings that have been created so far.
+	static int binding_counter;
+	attr_name = stringf("\\bound%d", binding_counter++);
+}
+
+// Return true if mod is either called name or is derived from an abstract
+// module that was called name.
+static bool
+module_original_type_matches(const RTLIL::Module &mod, RTLIL::IdString name)
+{
+	if (mod.name == name) return true;
+
+	// A module derived from 'foo' will have a name starting with $paramod
+	// and an 'hdlname' attribute equal to '\foo'.
+	if (!mod.name.begins_with("$paramod"))
+		return false;
+
+	RTLIL::IdString hdlname = mod.get_string_attribute(ID::hdlname);
+	log_assert(!hdlname.empty());
+	return (hdlname == name);
+}
+
+// Search through the design for modules called name, or that are derived from
+// one called name. If is_root, only match the top of the instantiation
+// hierarchy.
+static std::vector<RTLIL::Module *>
+find_concrete_modules(RTLIL::Design &design, RTLIL::IdString name, bool is_root)
+{
+	std::vector<RTLIL::Module *> mods;
+
+	for (const auto &pr : design.modules_) {
+		// The top of the instantiation tree has the "initial_top",
+		// rather than "top", attribute (because we're running in the
+		// hierarchy pass before we've finished expanding everything)
+		if (is_root && !pr.second->get_bool_attribute(ID::initial_top))
+			continue;
+
+		if (module_original_type_matches(*pr.second, name))
+			mods.push_back(pr.second);
+	}
+
+	return mods;
+}
+
+// Try to find a cell below mod whose (dot-separated) name is given by path.
+// Modify so_far in place and return true on success.
+static bool
+find_cell_in(RTLIL::Binding::Path *so_far,
+             RTLIL::Design &design, RTLIL::Module &mod, const char *path)
+{
+	// There's a little bit of cleverness needed here to deal with named
+	// generate blocks. Their names get incorporated into hierarchical
+	// paths but the blocks don't appear as modules in the hierarchy. For
+	// example, "a.b" might mean that we have an instance called "a" which,
+	// in turn, contains an instance called "b". Or it could mean that we
+	// have a generate block called "a" with an instance called "b". This
+	// second case is represented in Yosys by a cell called "\a.b".
+	//
+	// Search path in "ever-deepening generate blocks". So when expanding
+	// "a.b.c.d", we look for a cell called "a" first and one called
+	// "a.b.c.d" last. If we have a hit for a prefix ("a.b", say), we
+	// assume that there isn't any hits for longer names, because that
+	// would imply a generate block with the same name ("b") as an
+	// instance, which isn't allowed.
+	const char *dot = strchr(path, '.');
+	RTLIL::Cell *cell = nullptr;
+	for (;;) {
+		// If non-null, dot points at some '.' in path. On this
+		// iteration of the loop, we treat everything before dot as the
+		// cell name and everything after it as a hierarchical path to
+		// search that cell for. If dot is null, the entirety of path
+		// is treated as a cell name.
+		std::string cell_name =
+			dot ? std::string(path, dot - path) : std::string(path);
+		cell = mod.cell('\\' + cell_name);
+
+		if (cell) {
+			break;
+		}
+
+		if (!dot)
+			return false;
+
+		dot = strchr(dot + 1, '.');
+	}
+
+	// At this point, we've got a local match. dot is as in the for loop
+	// above, either pointing at a '.' (in which case we need to recurse)
+	// or null (in which case we've got a complete match).
+	so_far->push_back(RTLIL::Binding::Item(&mod, cell));
+	if (!dot)
+		return true;
+
+	// We found a child cell, but there's more searching to do. Recurse to
+	// search the cell's module.
+	return find_cell_in(so_far, design, *cell->module, dot + 1);
+}
+
+RTLIL::Binding::Path
+RTLIL::Binding::find_rel_cell(RTLIL::Design &design, RTLIL::Module &start) const
+{
+	Path ret;
+	bool found = find_cell_in(&ret, design, start, target_name.c_str() + 1);
+	if (!found)
+		return Path();
+
+	log_assert(ret.size());
+	check_cell_type(design, *ret.back().second);
+	return ret;
+}
+
+std::vector<RTLIL::Binding::Path>
+RTLIL::Binding::find_tl_cells(RTLIL::Design &design) const
+{
+	std::vector<Path> paths;
+
+	std::string tgt_name = target_name.str();
+	size_t tgt_off = 0;
+	bool is_root = false;
+
+	// The target name should always start with a backslash
+	log_assert(tgt_name[0] == '\\');
+
+	// Is the name absolute (starts with $root)? If so, skip past that, but
+	// set a flag so that we'll only match the root of the instantiation
+	// tree.
+	if (tgt_name.compare(0, 7, "\\$root.") == 0) {
+		tgt_off = 7;
+		is_root = true;
+	} else {
+		tgt_off = 1;
+	}
+
+	// This function can only find cells (as opposed to modules at the top
+	// level). If there's no '.' after tgt_off, give up.
+	size_t dot_off = tgt_name.find('.', tgt_off);
+	if (dot_off == std::string::npos)
+		return paths;
+
+	// Otherwise, characters with indices {tgt_off .. dot_off - 1} should
+	// name a module and then {dot_off + 1 .. } should name the cell
+	// relative to the module.
+	//
+	// Note that we need to prefix the module name with a backslash (which
+	// is separated from the actual module name if the name started with
+	// $root) before interning the string.
+	std::string mod_name = '\\' + tgt_name.substr(tgt_off, dot_off - tgt_off);
+	const char *cell_path = tgt_name.c_str() + dot_off + 1;
+
+	std::vector<RTLIL::Module *> mods =
+		find_concrete_modules(design, mod_name, is_root);
+	for (RTLIL::Module *mod : mods) {
+		Path path;
+		bool found = find_cell_in(&path, design, *mod, cell_path);
+		if (found) {
+			log_assert(path.size());
+			check_cell_type(design, *path.back().second);
+			paths.push_back(path);
+		}
+	}
+
+	// If no concrete modules for mod_name have a cell at cell_path, then
+	// paths will be an empty vector. If *some* have the cell (possible with
+	// a generate if/else or similar), we should probably complain.
+	if (paths.size() > 0 && paths.size() != mods.size()) {
+		log_error("Some, but not all, specialized modules "
+		          "with original name %s have a cell at path %s.",
+		          mod_name.c_str(), cell_path);
+	}
+
+	return paths;
+}
+
+std::vector<RTLIL::Module *>
+RTLIL::Binding::find_concrete_module_targets(RTLIL::Design &design) const
+{
+	// If target_type is nonempty, the bind statement had an instantiation
+	// list. In which case, we definitely don't want to interpret this as a
+	// module name.
+	if(!target_type.empty())
+		return std::vector<RTLIL::Module *>();
+
+	return find_concrete_modules(design, target_name, false);
+}
+
+void
+RTLIL::Binding::check_cell_type(RTLIL::Design &design,
+                                const RTLIL::Cell &cell) const
+{
+	// If the user specified the module type, check it matches
+	if (!target_type.empty()) {
+		const RTLIL::Module *cell_mod = design.module(cell.type);
+		log_assert(cell_mod);
+		if (!module_original_type_matches(*cell_mod, target_type)) {
+			std::ostringstream oss;
+			oss << "The " << describe()
+			    << " matches a cell, but that cell has the wrong type ("
+			    << cell_mod->name.c_str() << ").";
+			report_error(oss.str());
+		}
+	}
+}
 
 YOSYS_NAMESPACE_END

--- a/kernel/binding.h
+++ b/kernel/binding.h
@@ -36,8 +36,54 @@ struct RTLIL::Binding
 
 	virtual ~Binding() {}
 
+	// A "path" for a bind that matches an instance. When we search for an
+	// instance that needs changing, we return the path to it (which allows
+	// the hierarchy code to insert bindings into target modules one at a
+	// time).
+	//
+	// Each item is of the form (m, c) where c is a cell of the module m. A
+	// path of [(m0, c0), (m1, c1)] means that the instance in question is
+	// c1 in the module m1, where the relevant instance of m1 appears as
+	// cell c0 in the module m0.
+	typedef std::pair<RTLIL::Module *, RTLIL::Cell *> Item;
+	typedef std::vector<Item> Path;
+
+	// Search in the module given by the start argument for a cell with the
+	// right name for target_name. Returns an empty path on no match.
+	Path find_rel_cell(RTLIL::Design &design, RTLIL::Module &start) const;
+
+	// Search from top-level for a cell with the right name for target_name.
+	// This handles references like A.B.C, which can confusingly mean
+	// "search for B.C inside a top-level module called A". There might be
+	// multiple results because of parameter specialisation.
+	//
+	// If the target name contains no "." symbols, this won't return any
+	// results (but find_concrete_module_targets might).
+	std::vector<Path> find_tl_cells(RTLIL::Design &design) const;
+
+	// Return a (possibly empty) list of non-abstract modules that should be
+	// considered targets of this bind directive.
+	std::vector<RTLIL::Module *>
+	find_concrete_module_targets(RTLIL::Design &design) const;
+
 	// Return a string describing the binding
 	virtual std::string describe() const = 0;
+
+	RTLIL::IdString get_attr_name() const { return attr_name; }
+
+	// Apply this binding to the target module and return true. If the
+	// binding has already been applied, return false. Implemented by
+	// AST::Binding (which holds a syntax-level represention of what is to
+	// be bound)
+	virtual bool bind_into(RTLIL::Design &design,
+	                       RTLIL::Module &target) const = 0;
+
+	// Report an error caused by this binding to stderr and exit.
+	//
+	// This is pure virtual because AST::Binding knows the source
+	// location for the binding syntax, which means it can report
+	// things more clearly.
+	[[noreturn]] virtual void report_error(const std::string &msg) const = 0;
 
 protected:
 	// May be empty. If not, it's the name of the module or interface to
@@ -53,6 +99,9 @@ protected:
 	// An attribute name which contains an ID that's unique across binding
 	// instances (used to ensure we don't apply a binding twice to a module)
 	RTLIL::IdString attr_name;
+
+	// Check that a cell we've found matches any type we're expecting.
+	void check_cell_type(RTLIL::Design &design, const RTLIL::Cell &cell) const;
 };
 
 YOSYS_NAMESPACE_END

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -922,9 +922,9 @@ void RTLIL::Module::makeblackbox()
 	set_bool_attribute(ID::blackbox);
 }
 
-void RTLIL::Module::reprocess_module(RTLIL::Design *, const dict<RTLIL::IdString, RTLIL::Module *> &)
+void RTLIL::Module::expand_interfaces(RTLIL::Design *, const dict<RTLIL::IdString, RTLIL::Module *> &)
 {
-	log_error("Cannot reprocess_module module `%s' !\n", id2cstr(name));
+	log_error("Class doesn't support expand_interfaces (module: `%s')!\n", id2cstr(name));
 }
 
 RTLIL::IdString RTLIL::Module::derive(RTLIL::Design*, const dict<RTLIL::IdString, RTLIL::Const> &, bool mayfail)

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1160,7 +1160,7 @@ public:
 	virtual RTLIL::IdString derive(RTLIL::Design *design, const dict<RTLIL::IdString, RTLIL::Const> &parameters, bool mayfail = false);
 	virtual RTLIL::IdString derive(RTLIL::Design *design, const dict<RTLIL::IdString, RTLIL::Const> &parameters, const dict<RTLIL::IdString, RTLIL::Module*> &interfaces, const dict<RTLIL::IdString, RTLIL::IdString> &modports, bool mayfail = false);
 	virtual size_t count_id(RTLIL::IdString id);
-	virtual void reprocess_module(RTLIL::Design *design, const dict<RTLIL::IdString, RTLIL::Module *> &local_interfaces);
+	virtual void expand_interfaces(RTLIL::Design *design, const dict<RTLIL::IdString, RTLIL::Module *> &local_interfaces);
 
 	virtual void sort();
 	virtual void check();

--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -19,6 +19,7 @@
  */
 
 #include "kernel/yosys.h"
+#include "kernel/binding.h"
 #include "frontends/verific/verific.h"
 #include <stdlib.h>
 #include <stdio.h>
@@ -439,7 +440,7 @@ void check_cell_connections(const RTLIL::Module &module, RTLIL::Cell &cell, RTLI
 	}
 }
 
-bool expand_module(RTLIL::Design *design, RTLIL::Module *module, bool flag_check, bool flag_simcheck, std::vector<std::string> &libdirs)
+bool expand_module(RTLIL::Design *design, RTLIL::Module *module, bool flag_check, bool flag_simcheck, const std::vector<std::string> &libdirs)
 {
 	bool did_something = false;
 	std::map<RTLIL::Cell*, std::pair<int, int>> array_cells;
@@ -554,7 +555,7 @@ bool expand_module(RTLIL::Design *design, RTLIL::Module *module, bool flag_check
 
 	// If any interface instances or interface ports were found in the module, we need to rederive it completely:
 	if ((if_expander.interfaces_in_module.size() > 0 || has_interface_ports) && !module->get_bool_attribute(ID::interfaces_replaced_in_module)) {
-		module->reprocess_module(design, if_expander.interfaces_in_module);
+		module->expand_interfaces(design, if_expander.interfaces_in_module);
 		return did_something;
 	}
 
@@ -708,6 +709,422 @@ RTLIL::Wire *find_implicit_port_wire(Module *module, Cell *cell, const std::stri
 			return found;
 	}
 	return module->wire(port);
+}
+
+// Expand any parameterised modules used in the design and fold away any
+// interfaces.
+//
+// This may change the current top module.
+void
+expand_design(RTLIL::Design &design,
+              RTLIL::Module **top_mod,
+              bool flag_check,
+              bool flag_simcheck,
+              const std::vector<std::string> &libdirs)
+{
+	int iters;
+	for (iters = 0; ; ++iters) {
+		bool did_something = false;
+
+		std::set<RTLIL::Module*, IdString::compare_ptr_by_name<Module>> used_modules;
+		if (*top_mod) {
+			log_header(&design, "Analyzing design hierarchy..\n");
+			hierarchy_worker(&design, used_modules, *top_mod, 0);
+		} else {
+			for (auto mod : design.modules())
+				used_modules.insert(mod);
+		}
+
+		for (auto module : used_modules) {
+			if (expand_module(&design, module, flag_check, flag_simcheck, libdirs))
+				did_something = true;
+		}
+
+		// The top module might have changed if interface instances have
+		// been detected in it:
+		RTLIL::Module *tmp_top_mod = check_if_top_has_changed(&design, *top_mod);
+		if (tmp_top_mod && (tmp_top_mod != *top_mod)) {
+			*top_mod = tmp_top_mod;
+			did_something = true;
+		}
+
+		// Delete modules marked as 'to_delete':
+		std::vector<RTLIL::Module *> modules_to_delete;
+		for(auto mod : design.modules()) {
+			if (mod->get_bool_attribute(ID::to_delete)) {
+				modules_to_delete.push_back(mod);
+			}
+		}
+		for (auto mod : modules_to_delete) {
+			design.remove(mod);
+		}
+
+		if (! did_something)
+			break;
+	}
+}
+
+// Generate a fresh name for a module by inserting a counter
+static RTLIL::IdString
+fresh_mod_name(const RTLIL::Design &design, const std::string &pfx, const std::string &suf)
+{
+	static int bind_counter;
+
+	for (;;) {
+		std::ostringstream oss;
+		oss << pfx << bind_counter << suf;
+		++bind_counter;
+
+		RTLIL::IdString name (oss.str());
+		if (!design.has(name))
+			return name;
+	}
+}
+
+// Generate a fresh name for a module by suffixing "\bound<i>" for some i.
+static RTLIL::IdString
+fresh_binding_mod_name(const RTLIL::Design &design, const RTLIL::Module &module)
+{
+	// Search for the last \bound<i> occurrence in the name
+	std::string old_name = module.name.str();
+	size_t idx = old_name.rfind("\\bound");
+
+	// If there is none, append one.
+	if (idx == std::string::npos)
+		return fresh_mod_name(design, old_name + "\\bound", "");
+
+	// The old name had something like "\bound123" in it. Walk to the next
+	// backslash or the end of string.
+	size_t end = old_name.find('\\', idx + 6);
+
+	// If there is no next backslash then we were at the the end of the
+	// string already.
+	if (end == std::string::npos)
+		return fresh_mod_name(design, old_name.substr(0, idx + 6), "");
+
+	// Otherwise, we need to pass everything from that backslash onwards as
+	// a suffix to use in the new name.
+	return fresh_mod_name(design,
+			      old_name.substr(0, idx + 6),
+			      old_name.substr(end));
+}
+
+// Clone a module with a fresh name and no blackbox flag and insert it
+// into the design.
+//
+// Also update counts, subtracting one from the count for the old module and
+// adding one to the count for the new one.
+static RTLIL::Module *
+fresh_binding_module(RTLIL::Design &design,
+                     dict<RTLIL::IdString, int> &counts,
+                     const RTLIL::Module &module)
+{
+	RTLIL::Module *new_mod = module.clone();
+	new_mod->name = fresh_binding_mod_name(design, module);
+	new_mod->set_bool_attribute(ID::blackbox, false);
+	design.add(new_mod);
+
+	// Look up the old module in counts (it will definitely have been found
+	// by get_cell_type_counts because it's a module in the design).
+	auto old_count_it = counts.find(module.name);
+	log_assert(old_count_it != counts.end());
+
+	// Subtract one from the count and add it to the new module. The count
+	// is at least 1 (because we found the module as the type of a cell at
+	// some path in the design).
+	log_assert(old_count_it->second >= 1);
+	old_count_it->second -= 1;
+
+	// Add one to the count for the new module. Since it's a fresh name, we
+	// can just insert a count of 1.
+	auto pr = counts.insert(std::make_pair(new_mod->name, 1));
+	log_assert(pr.second);
+
+	return new_mod;
+}
+
+// Apply a binding (if needed) all the way down a path. Return true if this did
+// anything. Update top_mod if necessary.
+//
+// See the comment above insert_binding for the exact rename vs. in-place
+// modification semantics and how we use the counts argument.
+static bool
+bind_path(RTLIL::Design               &design,
+          dict<RTLIL::IdString, int>  &counts,
+          const RTLIL::Binding::Path  &path,
+          const RTLIL::Binding        &binding,
+          RTLIL::Module              **top_mod)
+{
+	log_assert(path.size());
+
+	design.check();
+
+	// The first job is to grab the leaf cell and check whether we've
+	// already applied the binding. If so, stop.
+	const RTLIL::Binding::Item &last_item = path.back();
+	RTLIL::IdString orig_type = last_item.second->type;
+	RTLIL::Module *orig_module = design.module(orig_type);
+	log_assert(orig_module);
+	if (orig_module->get_bool_attribute(binding.get_attr_name()))
+		return false;
+
+	// Otherwise, we need to decide whether we can operate in place.
+	// Conceptually, we clone, rename and modify modules from the bottom of
+	// the path up. However, if a module and all modules above it in the
+	// path only appear once in the design then we can just edit it in
+	// place, avoiding spurious clones (and avoiding renaming the top-level
+	// module, which would be very confusing).
+	//
+	// Here, split_point is the index in the path for the first pair (m, c)
+	// where the module for c appears multiple times in the design. It is
+	// -1 if all modules appear just once.
+	int split_point = -1;
+	for (int i = 0; i < GetSize(path); ++i) {
+		const RTLIL::Binding::Item &item = path[i];
+		// Since item appears in a path, we can be certain that it was
+		// found by get_cell_type_counts and appears in counts with a
+		// count of at least 1.
+		auto count_it = counts.find(item.second->type);
+		log_assert(count_it != counts.end());
+		int count = count_it->second;
+		log_assert(count >= 1);
+
+		if (count > 1) {
+			split_point = i;
+			break;
+		}
+	}
+
+	// If split_point == -1, the target module and all its parents appear
+	// just once, so we can operate in place.
+	return binding.bind_into(design, *orig_module);
+
+	// Otherwise, use create_binding_module on the cell's module to make a
+	// version with the binding applied.
+	RTLIL::Module *last_mod =
+		fresh_binding_module(design, counts, *orig_module);
+
+	bool newly_bound = binding.bind_into(design, *last_mod);
+	// We checked at the start that the binding was needed.
+	log_assert(newly_bound);
+
+	// Update top_mod if necessary (this would be quite odd, because it
+	// would mean that the top module is a child of last_item.first)
+	if (orig_module == *top_mod) *top_mod = last_mod;
+
+	// Walk the path (from bottom to top). For each (mod, cell) pair, work
+	// as above: if we are at or below the split point, create a new
+	// version of mod where cell now points at lastmod and update lastmod
+	// to point at that module. If we're above the split point, operate in
+	// place to replace the old cell with the new one (in last_mod).
+	for (int i = GetSize(path) - 1; i >= 0; --i) {
+		const RTLIL::Binding::Item &item = path[i];
+
+		log_assert(i >= split_point - 1);
+		bool needs_rename = (i >= split_point);
+
+		RTLIL::Module *next_mod =
+			needs_rename ?
+			fresh_binding_module(design, counts, *item.first) :
+			item.first;
+
+		// Update top_mod if necessary (this can probably only happen
+		// when i == 0 and will only have any effect if needs_rename,
+		// but there's no need to check)
+		if (item.first == *top_mod) *top_mod = next_mod;
+
+		// Find the cell in next_mod with the right name and modify it
+		// to be an instance of last_mod.
+		RTLIL::Cell *new_cell = next_mod->cell(item.second->name);
+		log_assert(new_cell);
+		new_cell->type = last_mod->name;
+
+		last_mod = next_mod;
+		if (!needs_rename)
+			break;
+	}
+
+	return true;
+}
+
+// Apply a binding and return true if this had any effect.
+//
+// If mod is not null, it is the current module. Otherwise, this binding was at
+// top-level in the design. counts is a dictionary mapping cell types to the
+// number of places that a cell is instantiated in other modules.
+//
+// If this binding applies to a module (rather than a specific cell
+// instantiating that module), we can modify the module, operating in place. If
+// the binding applies to just one instance, we might have to make a copy
+// (because a version of the module without something bound in might be
+// instantiated somewhere else). We can tell whether that's needed by looking
+// at the counts dictionary. If the count is at most 1, we can still operate in
+// place: the module either only appears at top-level or only appears as the
+// instance into which we're binding. If the count is 2 or greater, we need to
+// take a copy. In this case, we take the copy and modify it. We then decrement
+// the count for the original and give the new copy a count of 1.
+//
+// Finally, this function updates top_mod if *top_mod is non-null and **top_mod
+// is a module that was updated.
+static bool
+insert_binding(RTLIL::Design               &design,
+               dict<RTLIL::IdString, int>  &counts,
+               RTLIL::Module               *mod,
+               const RTLIL::Binding        &binding,
+               RTLIL::Module              **top_mod)
+{
+	std::string desc = binding.describe();
+
+	// If we're not at top-level, look for a cell in mod with the right
+	// (hierarchical) name. This is what section 23.3.1 of IEEE 1800 refers
+	// to as "the local A.B.C".
+	if (mod) {
+		RTLIL::Binding::Path path = binding.find_rel_cell(design, *mod);
+		if (path.size()) {
+			log("Applying %s at a local path.\n", desc.c_str());
+			return bind_path(design, counts, path, binding, top_mod);
+		}
+	}
+
+	// If no luck, try to interpret the name as a hierarchical reference
+	// starting at the top level.
+	std::vector<RTLIL::Binding::Path> paths = binding.find_tl_cells(design);
+	if (!paths.empty()) {
+		bool did_something = false;
+		log("Applying %s at %d top-level path%s.\n",
+		    desc.c_str(), GetSize(paths), paths.size() > 1 ? "s" : "");
+		for (const auto &path : paths)
+			did_something |=
+				bind_path(design, counts, path, binding, top_mod);
+		return did_something;
+	}
+
+	// If neither of these worked, search for a module by name. Note that
+	// this takes no account of design hierarchy.
+	std::vector<RTLIL::Module *> mods = binding.find_concrete_module_targets(design);
+	if (!mods.empty()) {
+		// We can add the binding directly to the module, operating in place.
+		bool did_something = false;
+		log("Applying %s to %d module%s.\n",
+		    desc.c_str(), GetSize(mods), mods.size() > 1 ? "s" : "");
+		for (auto mod : mods)
+			did_something |= binding.bind_into(design, *mod);
+		return did_something;
+	}
+
+	std::ostringstream err_msg;
+	err_msg << "Couldn't find a target for " << desc << ".";
+	binding.report_error(err_msg.str());
+
+	// This is unreachable because binding.report_error() is noreturn.
+	// Unfortunately, the [[noreturn]] attribute cannot be relied on for
+	// virtual functions, so we have to return something here.
+	log_assert(0);
+	return false;
+}
+
+// Worker function for get_cell_type_counts. To avoid double counting, we
+// assume that any module that has already been processed has an entry in
+// counts. Top-level modules get a count of zero added just before calling this
+// function on them.
+static void
+get_cell_type_counts_worker(RTLIL::Design &design,
+                            dict<RTLIL::IdString, int> &counts,
+                            RTLIL::Module &mod)
+{
+	for (auto cell : mod.cells()) {
+		// Set counts[cell->type] to 1 if it isn't defined
+		// yet, or increment if it is.
+		counts[cell->type]++;
+
+		// If the count is greater than 1, we have visited
+		// this cell type before, so we don't need to recurse.
+		if (counts[cell->type] > 1)
+			continue;
+
+		RTLIL::Module *child_mod = design.module(cell->type);
+		if (child_mod)
+			get_cell_type_counts_worker(design,
+						    counts, *child_mod);
+	}
+}
+
+// Count the number of times cell type in the design appears as a cell in
+// another module. Cell types for modules that only appear at top-level have a
+// count of zero.
+//
+// Returns a dictionary keyed by module name. Every module will appear in the
+// dictionary, plus any other cell that's used.
+static dict<RTLIL::IdString, int>
+get_cell_type_counts(RTLIL::Design &design)
+{
+	dict<RTLIL::IdString, int> counts;
+	for (auto mod : design.modules()) {
+		counts.insert(std::make_pair(mod->name, 0));
+		get_cell_type_counts_worker(design, counts, *mod);
+	}
+
+	return counts;
+}
+
+// Try to insert cells as instructed by bind directives
+//
+// Returns true if any were inserted. Update *top_mod if necessary.
+static bool insert_bindings(RTLIL::Design &design, RTLIL::Module **top_mod)
+{
+	dict<RTLIL::IdString, int> counts = get_cell_type_counts(design);
+
+	bool bound_something = false;
+
+	// First job: look at any top-level cells that we might need to insert.
+	// These are stored on the Design object itself.
+	for (RTLIL::Binding *binding : design.bindings_)
+		bound_something |=
+			insert_binding(design, counts, nullptr, *binding, top_mod);
+
+	// Now walk the design's modules, looking for binding statements.
+	// We walk all the modules in the design, regardless of whether we
+	// have a top module.
+	//
+	// Inserting a binding might add a module to the design, which
+	// itself has a binding to add. To handle this properly, we take a
+	// copy of design.modules() (to avoid iterating over a changing
+	// container) and then iterate until done.
+	for (;;) {
+		bool bound_module = false;
+		std::vector<RTLIL::Module *> mods = design.modules();
+		for (RTLIL::Module *mod : mods) {
+			for (RTLIL::Binding *binding : mod->bindings_)
+				bound_something |=
+					insert_binding(design, counts,
+					               mod, *binding, top_mod);
+		}
+		bound_something |= bound_module;
+		if (!bound_module)
+			break;
+	}
+
+	return bound_something;
+}
+
+// Completely expand the design, specialising parameterised modules, folding
+// away interfaces and inserting any bound cells. The top module might change.
+void
+expand_all(RTLIL::Module **top_mod,
+           RTLIL::Design &design,
+           bool flag_check,
+           bool flag_simcheck,
+           const std::vector<std::string> &libdirs)
+{
+	// Expand the design as necessary before trying to insert any bound cells.
+	expand_design(design, top_mod, flag_check, flag_simcheck, libdirs);
+
+	// At this point, we can assume that the design is fully elaborated and
+	// specialised. The only thing that might be missing is some bound
+	// cells. If insert_bindings returns true, it inserted some cells and we
+	// should run expand_design again on the result.
+	if (insert_bindings(design, top_mod))
+		expand_design(design, top_mod, flag_check, flag_simcheck, libdirs);
 }
 
 struct HierarchyPass : public Pass {
@@ -1020,47 +1437,7 @@ struct HierarchyPass : public Pass {
 					mod->attributes.erase(ID::initial_top);
 		}
 
-		bool did_something = true;
-		while (did_something)
-		{
-			did_something = false;
-
-			std::set<RTLIL::Module*, IdString::compare_ptr_by_name<Module>> used_modules;
-			if (top_mod != NULL) {
-				log_header(design, "Analyzing design hierarchy..\n");
-				hierarchy_worker(design, used_modules, top_mod, 0);
-			} else {
-				for (auto mod : design->modules())
-					used_modules.insert(mod);
-			}
-
-			for (auto module : used_modules) {
-				if (expand_module(design, module, flag_check, flag_simcheck, libdirs))
-					did_something = true;
-			}
-
-
-			// The top module might have changed if interface instances have been detected in it:
-			RTLIL::Module *tmp_top_mod = check_if_top_has_changed(design, top_mod);
-			if (tmp_top_mod != NULL) {
-				if (tmp_top_mod != top_mod){
-					top_mod = tmp_top_mod;
-					did_something = true;
-				}
-			}
-
-			// Delete modules marked as 'to_delete':
-			std::vector<RTLIL::Module *> modules_to_delete;
-			for(auto mod : design->modules()) {
-				if (mod->get_bool_attribute(ID::to_delete)) {
-					modules_to_delete.push_back(mod);
-				}
-			}
-			for(size_t i=0; i<modules_to_delete.size(); i++) {
-				design->remove(modules_to_delete[i]);
-			}
-		}
-
+		expand_all(&top_mod, *design, flag_check, flag_simcheck, libdirs);
 
 		if (top_mod != NULL) {
 			log_header(design, "Analyzing design hierarchy..\n");

--- a/tests/bind/bad_target.sv
+++ b/tests/bind/bad_target.sv
@@ -1,0 +1,7 @@
+// An example of a bind construct that points at a non-existent target
+
+module bar (input a, input b, output c);
+  assign c = a ^ b;
+endmodule
+
+bind cabbage bar bound_i (.*);

--- a/tests/bind/bad_target.ys
+++ b/tests/bind/bad_target.ys
@@ -1,0 +1,3 @@
+read_verilog -sv bad_target.sv
+logger -expect error "Couldn't find a target for directive to bind \\bound_i to \\cabbage" 1
+hierarchy

--- a/tests/bind/bad_type.sv
+++ b/tests/bind/bad_type.sv
@@ -1,0 +1,17 @@
+// An example of a bind construct using bind_target_instance_list which points at the wrong sort of
+// cell.
+
+module foo0 (input logic a, input logic b, output logic c);
+endmodule
+
+module foo1 (input logic a, input logic b, output logic c);
+endmodule
+
+module bar (input a, input b, output c);
+  assign c = a ^ b;
+endmodule
+
+module act (input u, input v, output w);
+  foo0 foo_i (.a (u), .b (v), .c (w));
+  bind foo1 : foo_i bar bound_i (.*);
+endmodule

--- a/tests/bind/bad_type.ys
+++ b/tests/bind/bad_type.ys
@@ -1,0 +1,3 @@
+read_verilog -sv bad_type.sv
+logger -expect error "cell has the wrong type" 1
+hierarchy

--- a/tests/bind/basic.sv
+++ b/tests/bind/basic.sv
@@ -1,4 +1,10 @@
 // A basic example of the bind construct
+//
+// act contains an instance of foo. foo is empty, but we bind in an instance of bar to do the XOR.
+// gold is the "reference implementation" that contains a bar with no binding required.
+//
+// The code to drive this is in basic.ys, which runs the hierarchy pass (to insert the bound
+// module), flattens the design and then runs an equivalence check between act and gold.
 
 module foo (input logic a, input logic b, output logic c);
   // Magic happens here...
@@ -8,13 +14,11 @@ module bar (input a, input b, output c);
   assign c = a ^ b;
 endmodule
 
-module top ();
-  logic u, v, w;
+module act (input u, input v, output w);
   foo foo_i (.a (u), .b (v), .c (w));
-
   bind foo bar bound_i (.*);
+endmodule
 
-  always_comb begin
-    assert(w == u ^ v);
-  end
+module gold (input u, input v, output w);
+  assign w = u ^ v;
 endmodule

--- a/tests/bind/basic.ys
+++ b/tests/bind/basic.ys
@@ -1,1 +1,6 @@
 read_verilog -sv basic.sv
+hierarchy
+flatten
+equiv_make gold act equiv
+equiv_simple
+equiv_status -assert

--- a/tests/bind/cell_list.sv
+++ b/tests/bind/cell_list.sv
@@ -10,17 +10,16 @@ module bar (input a, input b, output c);
   assign c = a ^ b;
 endmodule
 
-module top ();
-  logic u0, v0, w0;
-  logic u1, v1, w1;
-
+module act (input u0, input v0, output w0,
+            input u1, input v1, output w1);
   foo foo0 (.a0 (u0), .b0 (v0), .c0 (w0),
             .a1 (u1), .b1 (v1), .c1 (w1));
 
   bind foo bar bar0 (.a(a0), .b(b0), .c(c0)), bar1 (.a(a1), .b(b1), .c(c1));
+endmodule
 
-  always_comb begin
-    assert(w0 == u0 ^ v0);
-    assert(w1 == u1 ^ v1);
-  end
+module gold (input u0, input v0, output w0,
+             input u1, input v1, output w1);
+  assign w0 = u0 ^ v0;
+  assign w1 = u1 ^ v1;
 endmodule

--- a/tests/bind/cell_list.ys
+++ b/tests/bind/cell_list.ys
@@ -1,1 +1,6 @@
 read_verilog -sv cell_list.sv
+hierarchy
+flatten
+equiv_make gold act equiv
+equiv_simple
+equiv_status -assert

--- a/tests/bind/gen_block.sv
+++ b/tests/bind/gen_block.sv
@@ -1,7 +1,13 @@
-// The bind construct occurring at top-level in the script
+// An example of hierarchical bind names that include a named generate block
+//
+module foo1 (input logic a, input logic b, output logic c);
+  // Magic happens here...
+endmodule
 
 module foo (input logic a, input logic b, output logic c);
-  // Magic happens here...
+  if (1'b1) begin : g_myblock
+    foo1 f1 (.*);
+  end
 endmodule
 
 module bar (input a, input b, output c);
@@ -10,9 +16,8 @@ endmodule
 
 module act (input u, input v, output w);
   foo foo_i (.a (u), .b (v), .c (w));
+  bind foo.g_myblock.f1 bar bound_i (.*);
 endmodule
-
-bind act.foo_i bar bound_i (.*);
 
 module gold (input u, input v, output w);
   assign w = u ^ v;

--- a/tests/bind/gen_block.ys
+++ b/tests/bind/gen_block.ys
@@ -1,4 +1,4 @@
-read_verilog -sv param.sv
+read_verilog -sv gen_block.sv
 hierarchy
 flatten
 equiv_make gold act equiv

--- a/tests/bind/hier.sv
+++ b/tests/bind/hier.sv
@@ -1,4 +1,6 @@
-// An example of the bind construct using a hierarchical reference starting with $root
+// An example of a bind construct at top-level using a hierarchical reference
+// starting with $root
+//
 
 module foo (input logic a, input logic b, output logic c);
   // Magic happens here...
@@ -8,13 +10,12 @@ module bar (input a, input b, output c);
   assign c = a ^ b;
 endmodule
 
-module top ();
-  logic u, v, w;
+module act (input u, input v, output w);
   foo foo_i (.a (u), .b (v), .c (w));
-
-  always_comb begin
-    assert(w == u ^ v);
-  end
 endmodule
 
-bind $root.top.foo_i bar bound_i (.*);
+bind $root.act.foo_i bar bound_i (.*);
+
+module gold (input u, input v, output w);
+  assign w = u ^ v;
+endmodule

--- a/tests/bind/hier.ys
+++ b/tests/bind/hier.ys
@@ -1,1 +1,14 @@
 read_verilog -sv hier.sv
+
+# Make sure that the hierarchy pass doesn't throw away the gold module
+# (which we're using as a reference in the mitre circuit below)
+setattr -mod -set whitebox 1 gold
+
+# Run the hierarchy pass, which inserts bindings. Explicitly set the
+# top of the instantiation tree to be the act module.
+hierarchy -top act
+
+flatten
+equiv_make gold act equiv
+equiv_simple
+equiv_status -assert

--- a/tests/bind/inst_list.sv
+++ b/tests/bind/inst_list.sv
@@ -8,17 +8,16 @@ module bar (input a, input b, output c);
   assign c = a ^ b;
 endmodule
 
-module top ();
-  logic u0, v0, w0;
-  logic u1, v1, w1;
-
+module act (input u0, input v0, output w0,
+            input u1, input v1, output w1);
   foo foo0 (.a (u0), .b (v0), .c (w0));
   foo foo1 (.a (u1), .b (v1), .c (w1));
 
   bind foo : foo0, foo1 bar bound_i (.*);
+endmodule
 
-  always_comb begin
-    assert(w0 == u0 ^ v0);
-    assert(w1 == u1 ^ v1);
-  end
+module gold (input u0, input v0, output w0,
+             input u1, input v1, output w1);
+  assign w0 = u0 ^ v0;
+  assign w1 = u1 ^ v1;
 endmodule

--- a/tests/bind/inst_list.ys
+++ b/tests/bind/inst_list.ys
@@ -1,1 +1,6 @@
-read_verilog -sv inst_list.sv
+read_verilog -sv cell_list.sv
+hierarchy
+flatten
+equiv_make gold act equiv
+equiv_simple
+equiv_status -assert

--- a/tests/bind/param.sv
+++ b/tests/bind/param.sv
@@ -12,15 +12,16 @@ module bar (input a, input b, output c);
   assign c = doit ? a ^ b : 0;
 endmodule
 
-module top (input u0, input v0, output w0,
+module act (input u0, input v0, output w0,
             input u1, input v1, output w1);
   foo #(.doit (0)) foo0 (.a (u0), .b (v0), .c (w0));
   foo #(.doit (1)) foo1 (.a (u1), .b (v1), .c (w1));
 
   bind foo bar #(.doit (doit)) bound_i (.*);
+endmodule
 
-  always_comb begin
-    assert (w0 == '0);
-    assert (w1 == u1 ^ v1);
-  end
+module gold (input u0, input v0, output w0,
+             input u1, input v1, output w1);
+  assign w0 = 0;
+  assign w1 = u1 ^ v1;
 endmodule

--- a/tests/bind/toplevel.ys
+++ b/tests/bind/toplevel.ys
@@ -1,1 +1,6 @@
 read_verilog -sv toplevel.sv
+hierarchy
+flatten
+equiv_make gold act equiv
+equiv_simple
+equiv_status -assert


### PR DESCRIPTION
*This is in draft because it depends on #2752 (I'm being optimistic and assuming that won't change too much, so this should minimise the work for rebasing). The commit that's unique to this PR is the second one (+76 -28), with the following commit message:*

This is a prerequisite for supporting hierarchical references (because
you need the things you instantiate to have been sorted out before you
if you want to probe into their internals).
