### PR TITLE
Fix protobuf backend build dependencies - intermittent build issue due to missing rule

### DIFF
--- a/backends/protobuf/Makefile.inc
+++ b/backends/protobuf/Makefile.inc
@@ -3,6 +3,8 @@ ifeq ($(ENABLE_PROTOBUF),1)
 backends/protobuf/yosys.pb.cc backends/protobuf/yosys.pb.h: misc/yosys.proto
 	$(Q) cd misc && protoc --cpp_out "../backends/protobuf" yosys.proto
 
+backends/protobuf/protobuf.cc: backends/protobuf/yosys.pb.h
+
 OBJS += backends/protobuf/protobuf.o backends/protobuf/yosys.pb.o
 
 endif


### PR DESCRIPTION
`backends/protobuf/protobuf.cc` depends on the source and header files generated by `protoc`, but this dependency wasn't explicitly declared. This PR adds a rule to the Makefile to fix intermittent build failures when the protobuf header/source file isn't (due to sheer luck) built before `protobuf.cc`.