### PR TITLE
Update WaveDrom script URLs in YosysJS demo

### DIFF
--- a/misc/yosysjs/demo03.html
+++ b/misc/yosysjs/demo03.html
@@ -1,8 +1,8 @@
 <html><head>
 <title>YosysJS Example Application #02</title>
 <script type="text/javascript" src="yosysjs.js"></script>
-<script src="http://wavedrom.com/skins/default.js" type="text/javascript"></script>
-<script src="http://wavedrom.com/WaveDrom.js" type="text/javascript"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/wavedrom/2.8.1/skins/default.min.js" ></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/wavedrom/2.8.1/wavedrom.min.js"></script>
 <style type="text/css">
 .noedit { color: #666; }
 </style>


### PR DESCRIPTION
The WaveDrom script URLs no longer exist, so use the latest version from a CDN instead (Cloudflare is recommended in WaveDrom's README).