### PR TITLE
Fix "make vgtest"

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -2674,6 +2674,7 @@ for_initialization:
 		AstNode *node = new AstNode(AST_ASSIGN_EQ, ident, $3);
 		ast_stack.back()->children.push_back(node);
 		SET_AST_NODE_LOC(node, @1, @3);
+		delete $1;
 	} |
 	non_io_wire_type range TOK_ID {
 		frontend_verilog_yyerror("For loop variable declaration is missing initialization!");

--- a/tests/simple/attrib01_module.v
+++ b/tests/simple/attrib01_module.v
@@ -1,4 +1,4 @@
-module bar(clk, rst, inp, out);
+module attrib01_bar(clk, rst, inp, out);
   input  wire clk;
   input  wire rst;
   input  wire inp;
@@ -10,12 +10,12 @@ module bar(clk, rst, inp, out);
 
 endmodule
 
-module foo(clk, rst, inp, out);
+module attrib01_foo(clk, rst, inp, out);
   input  wire clk;
   input  wire rst;
   input  wire inp;
   output wire out;
 
-  bar bar_instance (clk, rst, inp, out);
+  attrib01_bar bar_instance (clk, rst, inp, out);
 endmodule
 

--- a/tests/simple/attrib02_port_decl.v
+++ b/tests/simple/attrib02_port_decl.v
@@ -1,4 +1,4 @@
-module bar(clk, rst, inp, out);
+module attrib02_bar(clk, rst, inp, out);
   (* this_is_clock = 1 *)
   input  wire clk;
   (* this_is_reset = 1 *)
@@ -13,13 +13,13 @@ module bar(clk, rst, inp, out);
 
 endmodule
 
-module foo(clk, rst, inp, out);
+module attrib02_foo(clk, rst, inp, out);
   (* this_is_the_master_clock *)
   input  wire clk;
   input  wire rst;
   input  wire inp;
   output wire out;
 
-  bar bar_instance (clk, rst, inp, out);
+  attrib02_bar bar_instance (clk, rst, inp, out);
 endmodule
 

--- a/tests/simple/attrib03_parameter.v
+++ b/tests/simple/attrib03_parameter.v
@@ -1,4 +1,4 @@
-module bar(clk, rst, inp, out);
+module attrib03_bar(clk, rst, inp, out);
 
   (* bus_width *)
   parameter WIDTH = 2;
@@ -17,12 +17,12 @@ module bar(clk, rst, inp, out);
 
 endmodule
 
-module foo(clk, rst, inp, out);
+module attrib03_foo(clk, rst, inp, out);
   input  wire clk;
   input  wire rst;
   input  wire [7:0] inp;
   output wire [7:0] out;
 
-  bar # (.WIDTH(8)) bar_instance (clk, rst, inp, out);
+  attrib03_bar # (.WIDTH(8)) bar_instance (clk, rst, inp, out);
 endmodule
 

--- a/tests/simple/attrib04_net_var.v
+++ b/tests/simple/attrib04_net_var.v
@@ -1,4 +1,4 @@
-module bar(clk, rst, inp, out);
+module attrib04_bar(clk, rst, inp, out);
   input  wire clk;
   input  wire rst;
   input  wire inp;
@@ -21,12 +21,12 @@ module bar(clk, rst, inp, out);
 
 endmodule
 
-module foo(clk, rst, inp, out);
+module attrib04_foo(clk, rst, inp, out);
   input  wire clk;
   input  wire rst;
   input  wire inp;
   output wire out;
 
-  bar bar_instance (clk, rst, inp, out);
+  attrib04_bar bar_instance (clk, rst, inp, out);
 endmodule
 

--- a/tests/simple/attrib05_port_conn.v.DISABLED
+++ b/tests/simple/attrib05_port_conn.v.DISABLED
@@ -1,4 +1,4 @@
-module bar(clk, rst, inp, out);
+module attrib05_bar(clk, rst, inp, out);
   input  wire clk;
   input  wire rst;
   input  wire inp;
@@ -10,12 +10,12 @@ module bar(clk, rst, inp, out);
 
 endmodule
 
-module foo(clk, rst, inp, out);
+module attrib05_foo(clk, rst, inp, out);
   input  wire clk;
   input  wire rst;
   input  wire inp;
   output wire out;
 
-  bar bar_instance ( (* clock_connected *) clk, rst, (* this_is_the_input *) inp, out);
+  attrib05_bar bar_instance ( (* clock_connected *) clk, rst, (* this_is_the_input *) inp, out);
 endmodule
 

--- a/tests/simple/attrib06_operator_suffix.v
+++ b/tests/simple/attrib06_operator_suffix.v
@@ -1,4 +1,4 @@
-module bar(clk, rst, inp_a, inp_b, out);
+module attrib06_bar(clk, rst, inp_a, inp_b, out);
   input  wire clk;
   input  wire rst;
   input  wire [7:0] inp_a;
@@ -11,13 +11,13 @@ module bar(clk, rst, inp_a, inp_b, out);
 
 endmodule
 
-module foo(clk, rst, inp_a, inp_b, out);
+module attrib06_foo(clk, rst, inp_a, inp_b, out);
   input  wire clk;
   input  wire rst;
   input  wire [7:0] inp_a;
   input  wire [7:0] inp_b;
   output wire [7:0] out;
 
-  bar bar_instance (clk, rst, inp_a, inp_b, out);
+  attrib06_bar bar_instance (clk, rst, inp_a, inp_b, out);
 endmodule
 

--- a/tests/simple/attrib07_func_call.v.DISABLED
+++ b/tests/simple/attrib07_func_call.v.DISABLED
@@ -1,4 +1,4 @@
-function [7:0] do_add;
+function [7:0] attrib07_do_add;
   input [7:0] inp_a;
   input [7:0] inp_b;
 
@@ -6,7 +6,7 @@ function [7:0] do_add;
 
 endfunction
 
-module foo(clk, rst, inp_a, inp_b, out);
+module attri07_foo(clk, rst, inp_a, inp_b, out);
   input  wire clk;
   input  wire rst;
   input  wire [7:0] inp_a;
@@ -15,7 +15,7 @@ module foo(clk, rst, inp_a, inp_b, out);
 
   always @(posedge clk)
     if (rst) out <= 0;
-    else     out <= do_add (* combinational_adder *) (inp_a, inp_b);
+    else     out <= attrib07_do_add (* combinational_adder *) (inp_a, inp_b);
 
 endmodule
 

--- a/tests/simple/attrib08_mod_inst.v
+++ b/tests/simple/attrib08_mod_inst.v
@@ -1,4 +1,4 @@
-module bar(clk, rst, inp, out);
+module attrib08_bar(clk, rst, inp, out);
   input  wire clk;
   input  wire rst;
   input  wire inp;
@@ -10,13 +10,13 @@ module bar(clk, rst, inp, out);
 
 endmodule
 
-module foo(clk, rst, inp, out);
+module attrib08_foo(clk, rst, inp, out);
   input  wire clk;
   input  wire rst;
   input  wire inp;
   output wire out;
 
   (* my_module_instance = 99 *)
-  bar bar_instance (clk, rst, inp, out);
+  attrib08_bar bar_instance (clk, rst, inp, out);
 endmodule
 

--- a/tests/simple/attrib09_case.v
+++ b/tests/simple/attrib09_case.v
@@ -1,4 +1,4 @@
-module bar(clk, rst, inp, out);
+module attrib09_bar(clk, rst, inp, out);
   input  wire clk;
   input  wire rst;
   input  wire [1:0] inp;
@@ -15,12 +15,12 @@ module bar(clk, rst, inp, out);
 
 endmodule
 
-module foo(clk, rst, inp, out);
+module attrib09_foo(clk, rst, inp, out);
   input  wire clk;
   input  wire rst;
   input  wire [1:0] inp;
   output wire [1:0] out;
 
-  bar bar_instance (clk, rst, inp, out);
+  attrib09_bar bar_instance (clk, rst, inp, out);
 endmodule
 

--- a/tests/simple/case_expr_const.v
+++ b/tests/simple/case_expr_const.v
@@ -1,6 +1,6 @@
 // Note: case_expr_{,non_}const.v should be modified in tandem to ensure both
 // the constant and non-constant case evaluation logic is covered
-module top(
+module case_expr_const_top(
 	// expected to output all 1s
     output reg a, b, c, d, e, f, g, h
 );

--- a/tests/simple/case_expr_non_const.v
+++ b/tests/simple/case_expr_non_const.v
@@ -1,6 +1,6 @@
 // Note: case_expr_{,non_}const.v should be modified in tandem to ensure both
 // the constant and non-constant case evaluation logic is covered
-module top(
+module case_expr_non_const_top(
 	// expected to output all 1s
     output reg a, b, c, d, e, f, g, h
 );

--- a/tests/simple/case_large.v
+++ b/tests/simple/case_large.v
@@ -1,4 +1,4 @@
-module top (
+module case_lage_top (
     input wire [127:0] x,
     output reg [31:0] y
 );

--- a/tests/simple/const_branch_finish.v
+++ b/tests/simple/const_branch_finish.v
@@ -4,7 +4,7 @@
 		$finish; \
 	end
 
-module top;
+module case_branch_finish_top;
 	parameter WIDTH = 32;
 	integer j;
 	initial begin

--- a/tests/simple/const_fold_func.v
+++ b/tests/simple/const_fold_func.v
@@ -1,4 +1,4 @@
-module top(
+module const_fold_func_top(
 	input wire [3:0] inp,
 	output wire [3:0] out1, out2, out3, out4, out5,
 	output reg [3:0] out6

--- a/tests/simple/const_func_shadow.v
+++ b/tests/simple/const_func_shadow.v
@@ -1,4 +1,4 @@
-module top(w, x, y, z);
+module const_func_shadow_top(w, x, y, z);
 	function [11:0] func;
 		input reg [2:0] x;
 		input reg [2:0] y;

--- a/tests/simple/defvalue.sv
+++ b/tests/simple/defvalue.sv
@@ -1,4 +1,4 @@
-module top(input clock, input [3:0] delta, output [3:0] cnt1, cnt2);
+module defvalue_top(input clock, input [3:0] delta, output [3:0] cnt1, cnt2);
 	cnt #(1) foo (.clock, .cnt(cnt1), .delta);
 	cnt #(2) bar (.clock, .cnt(cnt2));
 endmodule

--- a/tests/simple/func_block.v
+++ b/tests/simple/func_block.v
@@ -1,6 +1,6 @@
 `default_nettype none
 
-module top(inp, out1, out2, out3);
+module func_block_top(inp, out1, out2, out3);
 	input wire [31:0] inp;
 
 	function automatic [31:0] func1;

--- a/tests/simple/func_recurse.v
+++ b/tests/simple/func_recurse.v
@@ -1,4 +1,4 @@
-module top(
+module func_recurse_top(
 	input wire [3:0] inp,
 	output wire [3:0] out1, out2
 );

--- a/tests/simple/func_width_scope.v
+++ b/tests/simple/func_width_scope.v
@@ -1,4 +1,4 @@
-module top(inp, out1, out2);
+module func_width_scope_top(inp, out1, out2);
 	input wire signed inp;
 
 	localparam WIDTH_A = 5;

--- a/tests/simple/genblk_collide.v
+++ b/tests/simple/genblk_collide.v
@@ -1,6 +1,6 @@
 `default_nettype none
 
-module top1;
+module genblock_collide_top1;
 	generate
 		if (1) begin : foo
 			if (1) begin : bar
@@ -12,7 +12,7 @@ module top1;
 	endgenerate
 endmodule
 
-module top2;
+module genblock_collide_top2;
 	genvar i;
 	generate
 		if (1) begin : foo

--- a/tests/simple/genblk_dive.v
+++ b/tests/simple/genblk_dive.v
@@ -1,5 +1,5 @@
 `default_nettype none
-module top(output wire x);
+module genblk_dive_top(output wire x);
 	generate
 		if (1) begin : Z
 			if (1) begin : A

--- a/tests/simple/genblk_order.v
+++ b/tests/simple/genblk_order.v
@@ -1,5 +1,5 @@
 `default_nettype none
-module top(
+module genblk_order_top(
 	output wire out1,
 	output wire out2
 );

--- a/tests/simple/genblk_port_shadow.v
+++ b/tests/simple/genblk_port_shadow.v
@@ -1,4 +1,4 @@
-module top(x);
+module genblock_port_shadow_top(x);
 	generate
 		if (1) begin : blk
 			wire x;

--- a/tests/simple/hierarchy.v
+++ b/tests/simple/hierarchy.v
@@ -1,6 +1,6 @@
 
 (* top *)
-module top(a, b, y1, y2, y3, y4);
+module hierarchy_top(a, b, y1, y2, y3, y4);
 input [3:0] a;
 input signed [3:0] b;
 output [7:0] y1, y2, y3, y4;

--- a/tests/simple/ifdef_1.v
+++ b/tests/simple/ifdef_1.v
@@ -1,4 +1,4 @@
-module top(o1, o2, o3, o4);
+module ifdef_1_top(o1, o2, o3, o4);
 
 `define FAIL input wire not_a_port;
 

--- a/tests/simple/ifdef_2.v
+++ b/tests/simple/ifdef_2.v
@@ -1,4 +1,4 @@
-module top(o1, o2, o3);
+module ifdef_2_top(o1, o2, o3);
 
 output wire o1;
 

--- a/tests/simple/local_loop_var.sv
+++ b/tests/simple/local_loop_var.sv
@@ -1,4 +1,4 @@
-module top(out);
+module local_loop_top(out);
 	output integer out;
 	initial begin
 		integer i;

--- a/tests/simple/loop_prefix_case.v
+++ b/tests/simple/loop_prefix_case.v
@@ -1,4 +1,4 @@
-module top(
+module loop_prefix_case_top(
 	input wire x,
 	output reg y
 );

--- a/tests/simple/loop_var_shadow.v
+++ b/tests/simple/loop_var_shadow.v
@@ -1,4 +1,4 @@
-module top(out);
+module loop_var_shadow_top(out);
 	genvar i;
 	generate
 		for (i = 0; i < 2; i = i + 1) begin : loop

--- a/tests/simple/macro_arg_spaces.sv
+++ b/tests/simple/macro_arg_spaces.sv
@@ -1,4 +1,4 @@
-module top(
+module macro_arg_spaces_top(
 	input wire [31:0] i,
 	output wire [31:0] x, y, z
 );

--- a/tests/simple/macro_arg_surrounding_spaces.v
+++ b/tests/simple/macro_arg_surrounding_spaces.v
@@ -1,4 +1,4 @@
-module top(
+module macr_arg_surrounding_spaces_top(
 	IDENT_V_,
 	IDENT_W_,
 	IDENT_X_,

--- a/tests/simple/matching_end_labels.sv
+++ b/tests/simple/matching_end_labels.sv
@@ -1,4 +1,4 @@
-module top(
+module matching_end_labels_top(
     output reg [7:0]
     out1, out2, out3, out4
 );

--- a/tests/simple/mem2reg_bounds_tern.v
+++ b/tests/simple/mem2reg_bounds_tern.v
@@ -1,4 +1,4 @@
-module top(
+module mem2reg_bounds_term_top(
     input clk,
     input wire [1:0] sel,
     input wire [7:0] base,

--- a/tests/simple/module_scope.v
+++ b/tests/simple/module_scope.v
@@ -1,29 +1,29 @@
 `default_nettype none
 
-module Example(o1, o2);
+module module_scope_Example(o1, o2);
    parameter [31:0] v1 = 10;
    parameter [31:0] v2 = 20;
    output [31:0] o1, o2;
-   assign Example.o1 = Example.v1;
-   assign Example.o2 = Example.v2;
+   assign module_scope_Example.o1 = module_scope_Example.v1;
+   assign module_scope_Example.o2 = module_scope_Example.v2;
 endmodule
 
-module ExampleLong(o1, o2);
+module module_scope_ExampleLong(o1, o2);
    parameter [31:0] ThisIsAnExtremelyLongParameterNameToTriggerTheSHA1Checksum1 = 10;
    parameter [31:0] ThisIsAnExtremelyLongParameterNameToTriggerTheSHA1Checksum2 = 20;
    output [31:0] o1, o2;
-   assign ExampleLong.o1 = ExampleLong.ThisIsAnExtremelyLongParameterNameToTriggerTheSHA1Checksum1;
-   assign ExampleLong.o2 = ExampleLong.ThisIsAnExtremelyLongParameterNameToTriggerTheSHA1Checksum2;
+   assign module_scope_ExampleLong.o1 = module_scope_ExampleLong.ThisIsAnExtremelyLongParameterNameToTriggerTheSHA1Checksum1;
+   assign module_scope_ExampleLong.o2 = module_scope_ExampleLong.ThisIsAnExtremelyLongParameterNameToTriggerTheSHA1Checksum2;
 endmodule
 
-module top(
+module module_scope_top(
    output [31:0] a1, a2, b1, b2, c1, c2,
    output [31:0] d1, d2, e1, e2, f1, f2
 );
-   Example a(a1, a2);
-   Example #(1) b(b1, b2);
-   Example #(1, 2) c(c1, c2);
-   ExampleLong d(d1, d2);
-   ExampleLong #(1) e(e1, e2);
-   ExampleLong #(1, 2) f(f1, f2);
+   module_scope_Example a(a1, a2);
+   module_scope_Example #(1) b(b1, b2);
+   module_scope_Example #(1, 2) c(c1, c2);
+   module_scope_ExampleLong d(d1, d2);
+   module_scope_ExampleLong #(1) e(e1, e2);
+   module_scope_ExampleLong #(1, 2) f(f1, f2);
 endmodule

--- a/tests/simple/module_scope_case.v
+++ b/tests/simple/module_scope_case.v
@@ -1,11 +1,11 @@
-module top(
+module module_scope_case_top(
 	input wire x,
 	output reg y
 );
 	always @* begin
-		case (top.x)
-			1: top.y = 0;
-			0: top.y = 1;
+		case (module_scope_case_top.x)
+			1: module_scope_case_top.y = 0;
+			0: module_scope_case_top.y = 1;
 		endcase
 	end
 endmodule

--- a/tests/simple/named_genblk.v
+++ b/tests/simple/named_genblk.v
@@ -1,5 +1,5 @@
 `default_nettype none
-module top;
+module named_genblk_top;
 	generate
 		if (1) begin
 			wire t;

--- a/tests/simple/nested_genblk_resolve.v
+++ b/tests/simple/nested_genblk_resolve.v
@@ -1,5 +1,5 @@
 `default_nettype none
-module top;
+module nested_genblk_resolve_top;
     generate
         if (1) begin
             wire x;

--- a/tests/simple/string_format.v
+++ b/tests/simple/string_format.v
@@ -1,4 +1,4 @@
-module top;
+module string_format_top;
 	parameter STR = "something interesting";
 	initial begin
 		$display("A: %s", STR);

--- a/tests/simple/unnamed_block_decl.sv
+++ b/tests/simple/unnamed_block_decl.sv
@@ -1,4 +1,4 @@
-module top(z);
+module unnamed_block_decl(z);
 	output integer z;
 	initial begin
 		integer x;

--- a/tests/simple/wandwor.v
+++ b/tests/simple/wandwor.v
@@ -5,9 +5,9 @@ module wandwor_test0 (A, B, C, D, X, Y, Z);
 	output Z;
 
 	assign X = A, X = B, Y = C, Y = D;
-	foo foo_0 (C, D, X);
-	foo foo_1 (A, B, Y);
-	foo foo_2 (X, Y, Z);
+	wandwor_foo foo_0 (C, D, X);
+	wandwor_foo foo_1 (A, B, Y);
+	wandwor_foo foo_2 (X, Y, Z);
 endmodule
 
 module wandwor_test1 (A, B, C, D, X, Y, Z);
@@ -16,7 +16,7 @@ module wandwor_test1 (A, B, C, D, X, Y, Z);
 	output wand [3:0] Y;
 	output Z;
 
-	bar bar_inst (
+	wandwor_bar bar_inst (
 		.I0({A, B}),
 		.I1({B, A}),
 		.O({X, Y})
@@ -27,10 +27,10 @@ module wandwor_test1 (A, B, C, D, X, Y, Z);
 	assign Z = ^{X,Y};
 endmodule
 
-module foo(input I0, I1, output O);
+module wandwor_foo(input I0, I1, output O);
 	assign O = I0 ^ I1;
 endmodule
 
-module bar(input [7:0] I0, I1, output [7:0] O);
+module wandwor_bar(input [7:0] I0, I1, output [7:0] O);
 	assign O = I0 + I1;
 endmodule


### PR DESCRIPTION
After fixing `make vgtest` we now get an actual (minor) memory leak reported:

```
==182230== 
==182230== HEAP SUMMARY:
==182230==     in use at exit: 768 bytes in 24 blocks
==182230==   total heap usage: 157,538,419 allocs, 157,538,395 frees, 14,311,762,581 bytes allocated
==182230== 
==182230== 224 bytes in 7 blocks are definitely lost in loss record 1 of 2
==182230==    at 0x4A39723: operator new(unsigned long) (vg_replace_malloc.c:417)
==182230==    by 0x766A4B: frontend_verilog_yylex(FRONTEND_VERILOG_YYSTYPE*, FRONTEND_VERILOG_YYLTYPE*) (verilog_lexer.l:428)
==182230==    by 0x74E944: frontend_verilog_yyparse() (verilog_parser.tab.cc:3388)
==182230==    by 0x76FC01: Yosys::VerilogFrontend::execute(std::istream*&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, Yosys::RTLIL::Design*) (verilog_frontend.cc:500)
==182230==    by 0x596223: Yosys::Frontend::execute(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, Yosys::RTLIL::Design*) (register.cc:466)
==182230==    by 0x596EB6: Yosys::Frontend::frontend_call(Yosys::RTLIL::Design*, std::istream*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >) (register.cc:617)
==182230==    by 0x596CC3: Yosys::Frontend::frontend_call(Yosys::RTLIL::Design*, std::istream*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (register.cc:595)
==182230==    by 0xA186F0: (anonymous namespace)::TechmapPass::execute(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, Yosys::RTLIL::Design*) (techmap.cc:1198)
==182230==    by 0x5954B6: Yosys::Pass::call(Yosys::RTLIL::Design*, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >) (register.cc:316)
==182230==    by 0x5950E9: Yosys::Pass::call(Yosys::RTLIL::Design*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (register.cc:293)
==182230==    by 0x595D89: Yosys::ScriptPass::run(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (register.cc:402)
==182230==    by 0xEEFCA8: (anonymous namespace)::SynthPass::script() (synth.cc:248)
==182230== 
==182230== 544 bytes in 17 blocks are definitely lost in loss record 2 of 2
==182230==    at 0x4A39723: operator new(unsigned long) (vg_replace_malloc.c:417)
==182230==    by 0x766A4B: frontend_verilog_yylex(FRONTEND_VERILOG_YYSTYPE*, FRONTEND_VERILOG_YYLTYPE*) (verilog_lexer.l:428)
==182230==    by 0x74E944: frontend_verilog_yyparse() (verilog_parser.tab.cc:3388)
==182230==    by 0x76FC01: Yosys::VerilogFrontend::execute(std::istream*&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, Yosys::RTLIL::Design*) (verilog_frontend.cc:500)
==182230==    by 0x596223: Yosys::Frontend::execute(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, Yosys::RTLIL::Design*) (register.cc:466)
==182230==    by 0x596EB6: Yosys::Frontend::frontend_call(Yosys::RTLIL::Design*, std::istream*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >) (register.cc:617)
==182230==    by 0x596CC3: Yosys::Frontend::frontend_call(Yosys::RTLIL::Design*, std::istream*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (register.cc:595)
==182230==    by 0x65B568: Yosys::run_frontend(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, Yosys::RTLIL::Design*) (yosys.cc:1074)
==182230==    by 0x585A57: main (driver.cc:523)
==182230== 
==182230== LEAK SUMMARY:
==182230==    definitely lost: 768 bytes in 24 blocks
==182230==    indirectly lost: 0 bytes in 0 blocks
==182230==      possibly lost: 0 bytes in 0 blocks
==182230==    still reachable: 0 bytes in 0 blocks
==182230==         suppressed: 0 bytes in 0 blocks
==182230== 
==182230== For lists of detected and suppressed errors, rerun with: -s
==182230== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```

cc @zachjs 