### PR TITLE
Specify minimum bison version 3.0+

### DIFF
--- a/frontends/rtlil/rtlil_parser.y
+++ b/frontends/rtlil/rtlil_parser.y
@@ -22,6 +22,8 @@
  *
  */
 
+%require "3.0"
+
 %{
 #include <list>
 #include "frontends/rtlil/rtlil_frontend.h"

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -33,6 +33,8 @@
  *
  */
 
+%require "3.0"
+
 %{
 #include <list>
 #include <stack>


### PR DESCRIPTION
Yosys works with bison 3.0 (or newer), but not bison 2.7 (the previous release). Ideally, we would require "3" rather than "3.0" to give a better error message, but bison 2.3, which still ships with macOS, does not support major-only version requirements. With this change, building with an outdated bison yields: `frontends/rtlil/rtlil_parser.y:25.10-14: require bison 3.0, but have 2.3`.