### PR TITLE
gowin: Add support for MUX2_LUT5/6/7/8

### DIFF
--- a/kernel/ffmerge.cc
+++ b/kernel/ffmerge.cc
@@ -157,7 +157,7 @@ bool FfMergeHelper::find_output_ff(RTLIL::SigSpec sig, FfData &ff, pool<std::pai
 }
 
 bool FfMergeHelper::find_input_ff(RTLIL::SigSpec sig, FfData &ff, pool<std::pair<Cell *, int>> &bits) {
-	ff = FfData();
+	ff = FfData(module, initvals, NEW_ID);
 	sigmap->apply(sig);
 
 	bool found = false;

--- a/techlibs/gowin/Makefile.inc
+++ b/techlibs/gowin/Makefile.inc
@@ -10,6 +10,10 @@ $(eval $(call add_share_file,share/gowin,techlibs/gowin/brams_map.v))
 $(eval $(call add_share_file,share/gowin,techlibs/gowin/brams.txt))
 $(eval $(call add_share_file,share/gowin,techlibs/gowin/lutrams_map.v))
 $(eval $(call add_share_file,share/gowin,techlibs/gowin/lutrams.txt))
+$(eval $(call add_share_file,share/gowin,techlibs/gowin/mux2lut5_extract.v))
+$(eval $(call add_share_file,share/gowin,techlibs/gowin/mux2lut5_1_extract.v))
+$(eval $(call add_share_file,share/gowin,techlibs/gowin/mux2lut5_2_extract.v))
+$(eval $(call add_share_file,share/gowin,techlibs/gowin/mux2lut5_map.v))
 
 $(eval $(call add_share_file,share/gowin,techlibs/gowin/brams_init3.vh))
 

--- a/techlibs/gowin/mux2lut5_1_extract.v
+++ b/techlibs/gowin/mux2lut5_1_extract.v
@@ -1,0 +1,59 @@
+`default_nettype none
+
+// One of the mux inputs is constant 0 or 1
+// hw MUXes do not have their own inputs, you need a LUT. 
+// Making pass-through LUTs for VCC and GND is not very economical: 
+// it wastes resources on routing, so here such nets are identified 
+// and saved to be replaced by initialized LUTs in the future.
+// MUX2 with I0 == 0
+module MUX2_LUT5_ZERO_0(
+	input wire I1,
+	output wire O,
+	input wire S0);
+
+	MUX2_LUT5 mux(
+		.I0(1'b0),
+		.I1(I1),
+		.O(O),
+		.S0(S0));
+endmodule
+
+// MUX2 with I1 == 0
+module MUX2_LUT5_ZERO_1(
+	input wire I0,
+	output wire O,
+	input wire S0);
+
+	MUX2_LUT5 mux(
+		.I0(I0),
+		.I1(1'b0),
+		.O(O),
+		.S0(S0));
+endmodule
+
+// MUX2 with I0 == 1
+module MUX2_LUT5_ONE_0(
+	input wire I1,
+	output wire O,
+	input wire S0);
+
+	MUX2_LUT5 mux(
+		.I0(1'b1),
+		.I1(I1),
+		.O(O),
+		.S0(S0));
+endmodule
+
+// MUX2 with I1 == 1
+module MUX2_LUT5_ONE_1(
+	input wire I0,
+	output wire O,
+	input wire S0);
+
+	MUX2_LUT5 mux(
+		.I0(I0),
+		.I1(1'b1),
+		.O(O),
+		.S0(S0));
+endmodule
+

--- a/techlibs/gowin/mux2lut5_2_extract.v
+++ b/techlibs/gowin/mux2lut5_2_extract.v
@@ -1,0 +1,16 @@
+`default_nettype none
+// MUXes do not have separate inputs so you cannot wire from one LUT to two MUX inputs.
+// equal mux inputs
+module MUX2_LUT5_A_A(
+	output wire O,
+	input wire I,
+	input wire S0);
+
+	MUX2_LUT5 mux(
+		.I0(I),
+		.I1(I),
+		.O(O),
+		.S0(S0));
+endmodule
+
+

--- a/techlibs/gowin/mux2lut5_extract.v
+++ b/techlibs/gowin/mux2lut5_extract.v
@@ -1,0 +1,55 @@
+`default_nettype none
+// Both of the mux inputs is constant 0 or 1
+// hw MUXes do not have their own inputs, you need a LUT. 
+// Making pass-through LUTs for VCC and GND is not very economical: 
+// it wastes resources on routing, so here such nets are identified 
+// and saved to be replaced by initialized LUTs in the future.
+
+// I0 == I1 == 0
+module MUX2_LUT5_ZERO_ZERO(
+	output wire O,
+	input wire S0);
+
+	MUX2_LUT5 mux(
+		.I0(1'b0),
+		.I1(1'b0),
+		.O(O),
+		.S0(S0));
+endmodule
+
+// I0 == 0 I1 == 1
+module MUX2_LUT5_ZERO_ONE(
+	output wire O,
+	input wire S0);
+
+	MUX2_LUT5 mux(
+		.I0(1'b0),
+		.I1(1'b1),
+		.O(O),
+		.S0(S0));
+endmodule
+
+// I0 == 1 I1 == 0
+module MUX2_LUT5_ONE_ZERO(
+	output wire O,
+	input wire S0);
+
+	MUX2_LUT5 mux(
+		.I0(1'b1),
+		.I1(1'b0),
+		.O(O),
+		.S0(S0));
+endmodule
+
+// I0 == I1 == 1
+module MUX2_LUT5_ONE_ONE(
+	output wire O,
+	input wire S0);
+
+	MUX2_LUT5 mux(
+		.I0(1'b1),
+		.I1(1'b1),
+		.O(O),
+		.S0(S0));
+endmodule
+

--- a/techlibs/gowin/mux2lut5_map.v
+++ b/techlibs/gowin/mux2lut5_map.v
@@ -1,0 +1,121 @@
+// turn 0 and 1 into LUTs
+
+// Form the initialized LUTs and keep them.
+module MUX2_LUT5_ZERO_0(
+	input wire I1,
+	output wire O,
+	input wire S0);
+
+	wire luxout;
+
+	MUX2_LUT5 int_mux(
+		.I0(luxout),
+		.I1(I1),
+		.O(O),
+		.S0(S0));
+
+	(* keep *)
+	LUT4 #(.INIT(16'h0)) int_lut (
+		.F(luxout));
+endmodule
+
+module MUX2_LUT5_ZERO_1(
+	input wire I0,
+	output wire O,
+	input wire S0);
+
+	wire luxout;
+
+	MUX2_LUT5 int_mux(
+		.I0(I0),
+		.I1(luxout),
+		.O(O),
+		.S0(S0));
+
+	(* keep *)
+	LUT4 #(.INIT(16'h0)) int_lut (
+		.F(luxout));
+endmodule
+
+module MUX2_LUT5_ONE_0(
+	input wire I1,
+	output wire O,
+	input wire S0);
+
+	wire luxout;
+
+	MUX2_LUT5 int_mux(
+		.I0(luxout),
+		.I1(I1),
+		.O(O),
+		.S0(S0));
+
+	(* keep *)
+	LUT4 #(.INIT(16'hffff)) int_lut (
+		.F(luxout));
+endmodule
+
+module MUX2_LUT5_ONE_1(
+	input wire I0,
+	output wire O,
+	input wire S0);
+
+	wire luxout;
+
+	MUX2_LUT5 int_mux(
+		.I0(I0),
+		.I1(luxout),
+		.O(O),
+		.S0(S0));
+
+	(* keep *)
+	LUT4 #(.INIT(16'hffff)) int_lut (
+		.F(luxout));
+endmodule
+
+
+// When duplicating inputs we use only one LUT and 
+// use the fact that by default S0 == 1, so we free up the second input LUT.
+module MUX2_LUT5_ZERO_ZERO(
+	output wire O,
+	input wire S0);
+
+	wire luxout;
+
+	(* SINGLE_INPUT_MUX *)
+	MUX2_LUT5 int_mux(
+		.I1(luxout),
+		.O(O));
+
+	(* keep *)
+	LUT4 #(.INIT(16'h0)) int_lut (
+		.F(luxout));
+endmodule
+
+module MUX2_LUT5_ONE_ONE(
+	output wire O,
+	input wire S0);
+
+	wire luxout;
+
+	(* SINGLE_INPUT_MUX *)
+	MUX2_LUT5 int_mux(
+		.I1(luxout),
+		.O(O));
+
+	(* keep *)
+	LUT4 #(.INIT(16'hffff)) int_lut (
+		.F(luxout));
+endmodule
+
+module MUX2_LUT5_A_A(
+	input wire I,
+	output wire O);
+
+	wire luxout;
+
+	(* SINGLE_INPUT_MUX *)
+	MUX2_LUT5 int_mux(
+		.I1(I),
+		.O(O));
+endmodule


### PR DESCRIPTION
Hardware MUXes do not have separate inputs so LUTs are always used, with some slight optimization.