### PR TITLE
gowin: Add support for MUX2_LUT5/6/7/8

### DIFF
--- a/techlibs/gowin/Makefile.inc
+++ b/techlibs/gowin/Makefile.inc
@@ -10,6 +10,10 @@ $(eval $(call add_share_file,share/gowin,techlibs/gowin/brams_map.v))
 $(eval $(call add_share_file,share/gowin,techlibs/gowin/brams.txt))
 $(eval $(call add_share_file,share/gowin,techlibs/gowin/lutrams_map.v))
 $(eval $(call add_share_file,share/gowin,techlibs/gowin/lutrams.txt))
+$(eval $(call add_share_file,share/gowin,techlibs/gowin/mux2lut5_extract.v))
+$(eval $(call add_share_file,share/gowin,techlibs/gowin/mux2lut5_1_extract.v))
+$(eval $(call add_share_file,share/gowin,techlibs/gowin/mux2lut5_2_extract.v))
+$(eval $(call add_share_file,share/gowin,techlibs/gowin/mux2lut5_map.v))
 
 $(eval $(call add_share_file,share/gowin,techlibs/gowin/brams_init3.vh))
 

--- a/techlibs/gowin/mux2lut5_1_extract.v
+++ b/techlibs/gowin/mux2lut5_1_extract.v
@@ -1,0 +1,59 @@
+`default_nettype none
+
+// One of the mux inputs is constant 0 or 1
+// hw MUXes do not have their own inputs, you need a LUT. 
+// Making pass-through LUTs for VCC and GND is not very economical: 
+// it wastes resources on routing, so here such nets are identified 
+// and saved to be replaced by initialized LUTs in the future.
+// MUX2 with I0 == 0
+module MUX2_LUT5_ZERO_0(
+	input wire I1,
+	output wire O,
+	input wire S0);
+
+	MUX2_LUT5 mux(
+		.I0(1'b0),
+		.I1(I1),
+		.O(O),
+		.S0(S0));
+endmodule
+
+// MUX2 with I1 == 0
+module MUX2_LUT5_ZERO_1(
+	input wire I0,
+	output wire O,
+	input wire S0);
+
+	MUX2_LUT5 mux(
+		.I0(I0),
+		.I1(1'b0),
+		.O(O),
+		.S0(S0));
+endmodule
+
+// MUX2 with I0 == 1
+module MUX2_LUT5_ONE_0(
+	input wire I1,
+	output wire O,
+	input wire S0);
+
+	MUX2_LUT5 mux(
+		.I0(1'b1),
+		.I1(I1),
+		.O(O),
+		.S0(S0));
+endmodule
+
+// MUX2 with I1 == 1
+module MUX2_LUT5_ONE_1(
+	input wire I0,
+	output wire O,
+	input wire S0);
+
+	MUX2_LUT5 mux(
+		.I0(I0),
+		.I1(1'b1),
+		.O(O),
+		.S0(S0));
+endmodule
+

--- a/techlibs/gowin/mux2lut5_2_extract.v
+++ b/techlibs/gowin/mux2lut5_2_extract.v
@@ -1,0 +1,16 @@
+`default_nettype none
+// MUXes do not have separate inputs so you cannot wire from one LUT to two MUX inputs.
+// equal mux inputs
+module MUX2_LUT5_A_A(
+	output wire O,
+	input wire I,
+	input wire S0);
+
+	MUX2_LUT5 mux(
+		.I0(I),
+		.I1(I),
+		.O(O),
+		.S0(S0));
+endmodule
+
+

--- a/techlibs/gowin/mux2lut5_extract.v
+++ b/techlibs/gowin/mux2lut5_extract.v
@@ -1,0 +1,55 @@
+`default_nettype none
+// Both of the mux inputs is constant 0 or 1
+// hw MUXes do not have their own inputs, you need a LUT. 
+// Making pass-through LUTs for VCC and GND is not very economical: 
+// it wastes resources on routing, so here such nets are identified 
+// and saved to be replaced by initialized LUTs in the future.
+
+// I0 == I1 == 0
+module MUX2_LUT5_ZERO_ZERO(
+	output wire O,
+	input wire S0);
+
+	MUX2_LUT5 mux(
+		.I0(1'b0),
+		.I1(1'b0),
+		.O(O),
+		.S0(S0));
+endmodule
+
+// I0 == 0 I1 == 1
+module MUX2_LUT5_ZERO_ONE(
+	output wire O,
+	input wire S0);
+
+	MUX2_LUT5 mux(
+		.I0(1'b0),
+		.I1(1'b1),
+		.O(O),
+		.S0(S0));
+endmodule
+
+// I0 == 1 I1 == 0
+module MUX2_LUT5_ONE_ZERO(
+	output wire O,
+	input wire S0);
+
+	MUX2_LUT5 mux(
+		.I0(1'b1),
+		.I1(1'b0),
+		.O(O),
+		.S0(S0));
+endmodule
+
+// I0 == I1 == 1
+module MUX2_LUT5_ONE_ONE(
+	output wire O,
+	input wire S0);
+
+	MUX2_LUT5 mux(
+		.I0(1'b1),
+		.I1(1'b1),
+		.O(O),
+		.S0(S0));
+endmodule
+

--- a/techlibs/gowin/mux2lut5_map.v
+++ b/techlibs/gowin/mux2lut5_map.v
@@ -1,0 +1,121 @@
+// turn 0 and 1 into LUTs
+
+// Form the initialized LUTs and keep them.
+module MUX2_LUT5_ZERO_0(
+	input wire I1,
+	output wire O,
+	input wire S0);
+
+	wire luxout;
+
+	MUX2_LUT5 int_mux(
+		.I0(luxout),
+		.I1(I1),
+		.O(O),
+		.S0(S0));
+
+	(* keep *)
+	LUT4 #(.INIT(16'h0)) int_lut (
+		.F(luxout));
+endmodule
+
+module MUX2_LUT5_ZERO_1(
+	input wire I0,
+	output wire O,
+	input wire S0);
+
+	wire luxout;
+
+	MUX2_LUT5 int_mux(
+		.I0(I0),
+		.I1(luxout),
+		.O(O),
+		.S0(S0));
+
+	(* keep *)
+	LUT4 #(.INIT(16'h0)) int_lut (
+		.F(luxout));
+endmodule
+
+module MUX2_LUT5_ONE_0(
+	input wire I1,
+	output wire O,
+	input wire S0);
+
+	wire luxout;
+
+	MUX2_LUT5 int_mux(
+		.I0(luxout),
+		.I1(I1),
+		.O(O),
+		.S0(S0));
+
+	(* keep *)
+	LUT4 #(.INIT(16'hffff)) int_lut (
+		.F(luxout));
+endmodule
+
+module MUX2_LUT5_ONE_1(
+	input wire I0,
+	output wire O,
+	input wire S0);
+
+	wire luxout;
+
+	MUX2_LUT5 int_mux(
+		.I0(I0),
+		.I1(luxout),
+		.O(O),
+		.S0(S0));
+
+	(* keep *)
+	LUT4 #(.INIT(16'hffff)) int_lut (
+		.F(luxout));
+endmodule
+
+
+// When duplicating inputs we use only one LUT and 
+// use the fact that by default S0 == 1, so we free up the second input LUT.
+module MUX2_LUT5_ZERO_ZERO(
+	output wire O,
+	input wire S0);
+
+	wire luxout;
+
+	(* SINGLE_INPUT_MUX *)
+	MUX2_LUT5 int_mux(
+		.I1(luxout),
+		.O(O));
+
+	(* keep *)
+	LUT4 #(.INIT(16'h0)) int_lut (
+		.F(luxout));
+endmodule
+
+module MUX2_LUT5_ONE_ONE(
+	output wire O,
+	input wire S0);
+
+	wire luxout;
+
+	(* SINGLE_INPUT_MUX *)
+	MUX2_LUT5 int_mux(
+		.I1(luxout),
+		.O(O));
+
+	(* keep *)
+	LUT4 #(.INIT(16'hffff)) int_lut (
+		.F(luxout));
+endmodule
+
+module MUX2_LUT5_A_A(
+	input wire I,
+	output wire O);
+
+	wire luxout;
+
+	(* SINGLE_INPUT_MUX *)
+	MUX2_LUT5 int_mux(
+		.I1(I),
+		.O(O));
+endmodule

--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -17,16 +17,17 @@
  *
  */
 
-#include "kernel/celltypes.h"
-#include "kernel/log.h"
 #include "kernel/register.h"
+#include "kernel/celltypes.h"
 #include "kernel/rtlil.h"
+#include "kernel/log.h"
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
-struct SynthGowinPass : public ScriptPass {
-	SynthGowinPass() : ScriptPass("synth_gowin", "synthesis for Gowin FPGAs") {}
+struct SynthGowinPass : public ScriptPass
+{
+	SynthGowinPass() : ScriptPass("synth_gowin", "synthesis for Gowin FPGAs") { }
 
 	void help() override
 	{
@@ -111,28 +112,29 @@ struct SynthGowinPass : public ScriptPass {
 		clear_flags();
 
 		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++) {
-			if (args[argidx] == "-top" && argidx + 1 < args.size()) {
+		for (argidx = 1; argidx < args.size(); argidx++)
+		{
+			if (args[argidx] == "-top" && argidx+1 < args.size()) {
 				top_opt = "-top " + args[++argidx];
 				continue;
 			}
-			if (args[argidx] == "-vout" && argidx + 1 < args.size()) {
+			if (args[argidx] == "-vout" && argidx+1 < args.size()) {
 				vout_file = args[++argidx];
 				continue;
 			}
-			if (args[argidx] == "-json" && argidx + 1 < args.size()) {
+			if (args[argidx] == "-json" && argidx+1 < args.size()) {
 				json_file = args[++argidx];
 				nobram = true;
 				nolutram = true;
 				noalu = true;
 				continue;
 			}
-			if (args[argidx] == "-run" && argidx + 1 < args.size()) {
-				size_t pos = args[argidx + 1].find(':');
+			if (args[argidx] == "-run" && argidx+1 < args.size()) {
+				size_t pos = args[argidx+1].find(':');
 				if (pos == std::string::npos)
 					break;
 				run_from = args[++argidx].substr(0, pos);
-				run_to = args[argidx].substr(pos + 1);
+				run_to = args[argidx].substr(pos+1);
 				continue;
 			}
 			if (args[argidx] == "-retime") {
@@ -143,7 +145,7 @@ struct SynthGowinPass : public ScriptPass {
 				nobram = true;
 				continue;
 			}
-			if (args[argidx] == "-nolutram" || /*deprecated*/ args[argidx] == "-nodram") {
+			if (args[argidx] == "-nolutram" || /*deprecated*/args[argidx] == "-nodram") {
 				nolutram = true;
 				continue;
 			}
@@ -188,40 +190,47 @@ struct SynthGowinPass : public ScriptPass {
 
 	void script() override
 	{
-		if (check_label("begin")) {
+		if (check_label("begin"))
+		{
 			run("read_verilog -specify -lib +/gowin/cells_sim.v");
 			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
 		}
 
-		if (flatten && check_label("flatten", "(unless -noflatten)")) {
+		if (flatten && check_label("flatten", "(unless -noflatten)"))
+		{
 			run("proc");
 			run("flatten");
 			run("tribuf -logic");
 			run("deminout");
 		}
 
-		if (check_label("coarse")) {
+		if (check_label("coarse"))
+		{
 			run("synth -run coarse");
 		}
 
-		if (!nobram && check_label("map_bram", "(skip if -nobram)")) {
+		if (!nobram && check_label("map_bram", "(skip if -nobram)"))
+		{
 			run("memory_bram -rules +/gowin/brams.txt");
 			run("techmap -map +/gowin/brams_map.v");
 		}
 
-		if (!nolutram && check_label("map_lutram", "(skip if -nolutram)")) {
+		if (!nolutram && check_label("map_lutram", "(skip if -nolutram)"))
+		{
 			run("memory_bram -rules +/gowin/lutrams.txt");
 			run("techmap -map +/gowin/lutrams_map.v");
 			run("setundef -params -zero t:RAM16S4");
 		}
 
-		if (check_label("map_ffram")) {
+		if (check_label("map_ffram"))
+		{
 			run("opt -fast -mux_undef -undriven -fine");
 			run("memory_map");
 			run("opt -undriven -fine");
 		}
 
-		if (check_label("map_gates")) {
+		if (check_label("map_gates"))
+		{
 			if (noalu) {
 				run("techmap -map +/techmap.v");
 			} else {
@@ -233,23 +242,23 @@ struct SynthGowinPass : public ScriptPass {
 			run("splitnets");
 			if (!noiopads || help_mode)
 				run("iopadmap -bits -inpad IBUF O:I -outpad OBUF I:O "
-				    "-toutpad $__GW_TBUF OE:I:O -tinoutpad $__GW_IOBUF OE:O:I:IO",
-				    "(unless -noiopads)");
+					"-toutpad $__GW_TBUF OE:I:O -tinoutpad $__GW_IOBUF OE:O:I:IO", "(unless -noiopads)");
 		}
 
-		if (check_label("map_ffs")) {
+		if (check_label("map_ffs"))
+		{
 			run("opt_clean");
 			if (nodffe)
 				run("dfflegalize -cell $_DFF_?_ 0 -cell $_SDFF_?P?_ r -cell $_DFF_?P?_ r");
 			else
-				run("dfflegalize -cell $_DFF_?_ 0 -cell $_DFFE_?P_ 0 -cell $_SDFF_?P?_ r -cell $_SDFFE_?P?P_ r -cell $_DFF_?P?_ r "
-				    "-cell $_DFFE_?P?P_ r");
+				run("dfflegalize -cell $_DFF_?_ 0 -cell $_DFFE_?P_ 0 -cell $_SDFF_?P?_ r -cell $_SDFFE_?P?P_ r -cell $_DFF_?P?_ r -cell $_DFFE_?P?P_ r");
 			run("techmap -map +/gowin/cells_map.v");
 			run("opt_expr -mux_undef");
 			run("simplemap");
 		}
 
-		if (check_label("map_luts")) {
+		if (check_label("map_luts"))
+		{
 			if (nowidelut && abc9) {
 				run("read_verilog -icells -lib -specify +/abc9_model.v");
 				run("abc9 -maxlut 4 -W 500");
@@ -264,7 +273,8 @@ struct SynthGowinPass : public ScriptPass {
 			run("clean");
 		}
 
-		if (check_label("map_cells")) {
+		if (check_label("map_cells"))
+		{
 			run("techmap -map +/gowin/cells_map.v");
 			run("opt_lut_ins -tech gowin");
 			run("setundef -undriven -params -zero");
@@ -277,21 +287,25 @@ struct SynthGowinPass : public ScriptPass {
 			run("autoname");
 		}
 
-		if (check_label("check")) {
+		if (check_label("check"))
+		{
 			run("hierarchy -check");
 			run("stat");
 			run("check -noinit");
 			run("blackbox =A:whitebox");
 		}
 
-		if (check_label("vout")) {
+		if (check_label("vout"))
+		{
 			if (!vout_file.empty() || help_mode)
-				run(stringf("write_verilog -decimal -attr2comment -defparam -renameprefix gen %s",
-					    help_mode ? "<file-name>" : vout_file.c_str()));
+				 run(stringf("write_verilog -decimal -attr2comment -defparam -renameprefix gen %s",
+						help_mode ? "<file-name>" : vout_file.c_str()));
 			if (!json_file.empty() || help_mode)
-				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file.c_str()));
+				 run(stringf("write_json %s",
+						help_mode ? "<file-name>" : json_file.c_str()));
 		}
 	}
 } SynthGowinPass;
 
 PRIVATE_NAMESPACE_END
+


### PR DESCRIPTION
Hardware MUXes do not have separate inputs so LUTs are always used, with some slight optimization.