### PR TITLE
Add support for $aldff flip-flops to verific importer

### DIFF
--- a/frontends/verific/verific.h
+++ b/frontends/verific/verific.h
@@ -50,6 +50,7 @@ struct VerificClocking {
 	RTLIL::Cell *addDff(IdString name, SigSpec sig_d, SigSpec sig_q, Const init_value = Const());
 	RTLIL::Cell *addAdff(IdString name, RTLIL::SigSpec sig_arst, SigSpec sig_d, SigSpec sig_q, Const arst_value);
 	RTLIL::Cell *addDffsr(IdString name, RTLIL::SigSpec sig_set, RTLIL::SigSpec sig_clr, SigSpec sig_d, SigSpec sig_q);
+	RTLIL::Cell *addAldff(IdString name, RTLIL::SigSpec sig_aload, RTLIL::SigSpec sig_adata, SigSpec sig_d, SigSpec sig_q);
 
 	bool property_matches_sequence(const VerificClocking &seq) const {
 		if (clock_net != seq.clock_net)


### PR DESCRIPTION
Add support for `$aldff` flip-flops in verific importer. The new code will not be called unless the following change is applied to `verific.cc`:

```diff
- RuntimeFlags::SetVar("db_infer_set_reset_registers", 1);
+ RuntimeFlags::SetVar("db_infer_set_reset_registers", 0);
```