### PR TITLE
Split module ports, 20 per line

### DIFF
--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -2062,6 +2062,7 @@ void dump_module(std::ostream &f, std::string indent, RTLIL::Module *module)
 	dump_attributes(f, indent, module->attributes, '\n', /*modattr=*/true);
 	f << stringf("%s" "module %s(", indent.c_str(), id(module->name, false).c_str());
 	bool keep_running = true;
+	int cnt = 0;
 	for (int port_id = 1; keep_running; port_id++) {
 		keep_running = false;
 		for (auto wire : module->wires()) {
@@ -2070,6 +2071,7 @@ void dump_module(std::ostream &f, std::string indent, RTLIL::Module *module)
 					f << stringf(", ");
 				f << stringf("%s", id(wire->name).c_str());
 				keep_running = true;
+				if (cnt==20) { f << stringf("\n"); cnt = 0; } else cnt++;
 				continue;
 			}
 		}


### PR DESCRIPTION
Verilator can not handle verilog input where modules do have large number of ports defined.
Splitting it multiple lines for easier parsing. Should help other software consuming verilog as well.