### PR TITLE
dfflegalize: remove redundant check for initialized dlatch

### DIFF
--- a/passes/techmap/dfflegalize.cc
+++ b/passes/techmap/dfflegalize.cc
@@ -718,10 +718,6 @@ flip_dqisr:;
 					goto error;
 				}
 
-				if (!(supported_dlatch & ~INIT_X)) {
-					reason = "initialized dlatch are not supported";
-					goto error;
-				}
 				// If we got here, initialized dlatch is supported, but not this
 				// particular reset+init combination (nor its negation).
 				// The only hope left is breaking down to adff + dff + dlatch + mux.


### PR DESCRIPTION
This `if (!(supported_dlatch & ~INIT_X))` condition is repeated verbatim on lines 716 and 721, and I can't imagine a legitimate way the inputs could change in between. I imagine it's a copy/paste mistake.

It's not doing any harm, but it's presence is a bit confusing (I was encountering this error and trying to understand why).

Just to make sure I wasn't missing some subtle difference between the two, I asked `diff`, but it exits 0 with no diff:

```sh
diff -u \
    <(sed -n '716,+3p' passes/techmap/dfflegalize.cc) \
    <(sed -n '721,+3p' passes/techmap/dfflegalize.cc)
```