### PR TITLE
Fix parameters using struct as a wiretype

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1613,6 +1613,7 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 			if (template_node->type == AST_STRUCT || template_node->type == AST_UNION) {
 				// replace with wire representing the packed structure
 				newNode = make_packed_struct(template_node, str);
+				newNode->attributes[ID::wiretype] = mkconst_str(resolved_type_node->str);
 				// add original input/output attribute to resolved wire
 				newNode->is_input = this->is_input;
 				newNode->is_output = this->is_output;
@@ -1677,6 +1678,7 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 			if (template_node->type == AST_STRUCT || template_node->type == AST_UNION) {
 				// replace with wire representing the packed structure
 				newNode = make_packed_struct(template_node, str);
+				newNode->attributes[ID::wiretype] = mkconst_str(resolved_type_node->str);
 				newNode->type = type;
 				current_scope[str] = this;
 				// copy param value, it needs to be 1st value

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1661,18 +1661,32 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 		if (is_custom_type) {
 			log_assert(children.size() == 2);
 			log_assert(children[1]->type == AST_WIRETYPE);
-			if (!current_scope.count(children[1]->str))
-				log_file_error(filename, location.first_line, "Unknown identifier `%s' used as type name\n", children[1]->str.c_str());
-			AstNode *resolved_type_node = current_scope.at(children[1]->str);
+			auto type_name = children[1]->str;
+			if (!current_scope.count(type_name)) {
+				log_file_error(filename, location.first_line, "Unknown identifier `%s' used as type name\n", type_name.c_str());
+			}
+			AstNode *resolved_type_node = current_scope.at(type_name);
 			if (resolved_type_node->type != AST_TYPEDEF)
-				log_file_error(filename, location.first_line, "`%s' does not name a type\n", children[1]->str.c_str());
+				log_file_error(filename, location.first_line, "`%s' does not name a type\n", type_name.c_str());
 			log_assert(resolved_type_node->children.size() == 1);
 			AstNode *template_node = resolved_type_node->children[0];
-			delete children[1];
-			children.pop_back();
 
 			// Ensure typedef itself is fully simplified
-			while(template_node->simplify(const_fold, at_zero, in_lvalue, stage, width_hint, sign_hint, in_param)) {};
+			while (template_node->simplify(const_fold, at_zero, in_lvalue, stage, width_hint, sign_hint, in_param)) {};
+
+			if (template_node->type == AST_STRUCT || template_node->type == AST_UNION) {
+				// replace with wire representing the packed structure
+				newNode = make_packed_struct(template_node, str);
+				newNode->type = type;
+				current_scope[str] = this;
+				// copy param value, it needs to be 1st value
+				delete children[1];
+				children.pop_back();
+				newNode->children.insert(newNode->children.begin(), children[0]->clone());
+				goto apply_newNode;
+			}
+			delete children[1];
+			children.pop_back();
 
 			if (template_node->type == AST_MEMORY)
 				log_file_error(filename, location.first_line, "unpacked array type `%s' cannot be used for a parameter\n", children[1]->str.c_str());

--- a/tests/various/param_struct.ys
+++ b/tests/various/param_struct.ys
@@ -1,23 +1,49 @@
-read_verilog -sv -dump_ast1 -dump_ast2 << EOF
+read_verilog -sv << EOF
 package p;
 typedef struct packed {
   logic a;
   logic b;
 } struct_t;
 
+typedef struct packed {
+  struct_t g;
+  logic [2:0] h;
+} nested_struct_t;
+
+typedef union packed {
+  logic [4:0] x;
+} nested_union_t;
+
 parameter struct_t c = {1'b1, 1'b0};
+parameter nested_struct_t x = {{1'b1, 1'b0}, 1'b1, 1'b1, 1'b1};
 endpackage
 
 module dut ();
 parameter p::struct_t d = p::c;
+parameter p::nested_struct_t i = p::x;
 
-logic e = d.a;
-logic f = d.b;
+parameter p::nested_union_t u = {5'b11001};
+
+localparam e = d.a;
+localparam f = d.b;
+
+localparam j = i.g.a;
+localparam k = i.g.b;
+localparam l = i.h;
+localparam m = i.g;
+
+localparam o = u.x;
 
 always_comb begin
   assert(d == 2'b10);
   assert(e == 1'b1);
   assert(f == 1'b0);
+  assert(j == 1'b1);
+  assert(k == 1'b0);
+  assert(l == 3'b111);
+// TODO: support access to whole sub-structs and unions
+//  assert(m == 2'b10);
+  assert(u == 5'b11001);
 end
 endmodule
 EOF

--- a/tests/various/param_struct.ys
+++ b/tests/various/param_struct.ys
@@ -1,0 +1,25 @@
+read_verilog -sv -dump_ast1 -dump_ast2 << EOF
+package p;
+typedef struct packed {
+  logic a;
+  logic b;
+} struct_t;
+
+parameter struct_t c = {1'b1, 1'b0};
+endpackage
+
+module dut ();
+parameter p::struct_t d = p::c;
+
+logic e = d.a;
+logic f = d.b;
+
+always_comb begin
+  assert(d == 2'b10);
+  assert(e == 1'b1);
+  assert(f == 1'b0);
+end
+endmodule
+EOF
+hierarchy; proc; opt
+sat -verify -seq 1 -tempinduct -prove-asserts -show-all


### PR DESCRIPTION
This PR fixes the case when parameter is used with a wiretype of a struct.

Currently, all of the wiretype children are copied to the parameter children (this includes e.g. ``AST_STRUCT_ITEM``). This makes ``param_has_no_default`` (https://github.com/YosysHQ/yosys/blob/master/frontends/ast/ast.cc#L981) check fail as it assumes that simplified parameter can only have at most 2 children.

``AST_STRUCT_ITEM`` is unused as children to AST_PARAMETER, so I changed it to only copy AST_RANGE from wiretype node.
