### PR TITLE
Fix emcc warnings for WebAssembly build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,14 +248,15 @@ CXX = emcc
 LD = emcc
 CXXFLAGS := -std=c++11 $(filter-out -fPIC -ggdb,$(CXXFLAGS))
 ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H -DABC_MEMALIGN=8"
-EMCCFLAGS := -Os -Wno-warn-absolute-paths
-EMCCFLAGS += --memory-init-file 0 --embed-file share -s NO_EXIT_RUNTIME=1
-EMCCFLAGS += -s EXPORTED_FUNCTIONS="['_main','_run','_prompt','_errmsg','_memset']"
-EMCCFLAGS += -s TOTAL_MEMORY=134217728
-EMCCFLAGS += -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]'
+EMCC_CXXFLAGS := -Os -Wno-warn-absolute-paths
+EMCC_LDFLAGS := --memory-init-file 0 --embed-file share
+EMCC_LDFLAGS := -s NO_EXIT_RUNTIME=1
+EMCC_LDFLAGS += -s EXPORTED_FUNCTIONS="['_main','_run','_prompt','_errmsg','_memset']"
+EMCC_LDFLAGS += -s TOTAL_MEMORY=134217728
+EMCC_LDFLAGS += -s EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]'
 # https://github.com/kripken/emscripten/blob/master/src/settings.js
-CXXFLAGS += $(EMCCFLAGS)
-LDFLAGS += $(EMCCFLAGS)
+CXXFLAGS += $(EMCC_CXXFLAGS)
+LDFLAGS += $(EMCC_LDFLAGS)
 LDLIBS =
 EXE = .js
 
@@ -273,7 +274,7 @@ viz.js:
 	wget -O viz.js.part https://github.com/mdaines/viz.js/releases/download/0.0.3/viz.js
 	mv viz.js.part viz.js
 
-yosysjs-$(YOSYS_VER).zip: yosys.js yosys.wasm viz.js misc/yosysjs/*
+yosysjs-$(YOSYS_VER).zip: yosys.js viz.js misc/yosysjs/*
 	rm -rf yosysjs-$(YOSYS_VER) yosysjs-$(YOSYS_VER).zip
 	mkdir -p yosysjs-$(YOSYS_VER)
 	cp viz.js misc/yosysjs/* yosys.js yosys.wasm yosysjs-$(YOSYS_VER)/


### PR DESCRIPTION
The WebAssembly build (`make config-emcc`) generates tons of unnecessary warnings. This PR fixes these warnings by splitting the compiler and linker arguments in the Makefile.

Warnings that are resolved:
```
emcc: warning: linker flag ignored during compilation: '--memory-init-file' [-Wunused-command-line-argument]
emcc: warning: linker flag ignored during compilation: '--embed-file' [-Wunused-command-line-argument]
emcc: warning: linker setting ignored during compilation: 'NO_EXIT_RUNTIME' [-Wunused-command-line-argument]
emcc: warning: linker setting ignored during compilation: 'EXPORTED_FUNCTIONS' [-Wunused-command-line-argument]
emcc: warning: linker setting ignored during compilation: 'TOTAL_MEMORY' [-Wunused-command-line-argument]
emcc: warning: linker setting ignored during compilation: 'EXTRA_EXPORTED_RUNTIME_METHODS' [-Wunused-command-
line-argument]

emcc: warning: EXTRA_EXPORTED_RUNTIME_METHODS is deprecated, please use EXPORTED_RUNTIME_METHODS instead [-Wdeprecated]
```

The change on line 276 removes `yosys.wasm`, because this is not a valid target in the Makefile. It will still be included in the zip because of the `cp` command on line 279.