### PR TITLE
WIP: machxo2: Make sure tristates are mapped to active-low enable before

### DIFF
--- a/techlibs/machxo2/cells_map.v
+++ b/techlibs/machxo2/cells_map.v
@@ -30,5 +30,13 @@ module  \$_DFF_P_ (input D, C, output Q); FACADE_FF #(.CEMUX("1"), .CLKMUX("CLK"
 // IO- "$__" cells for the iopadmap pass.
 module  \$__FACADE_OUTPAD (input I, output O); FACADE_IO #(.DIR("OUTPUT")) _TECHMAP_REPLACE_ (.PAD(O), .I(I), .T(1'b0)); endmodule
 module  \$__FACADE_INPAD (input I, output O); FACADE_IO #(.DIR("INPUT")) _TECHMAP_REPLACE_ (.PAD(I), .O(O)); endmodule
-module  \$__FACADE_TOUTPAD (input I, OE, output O); FACADE_IO #(.DIR("OUTPUT")) _TECHMAP_REPLACE_ (.PAD(O), .I(I), .T(~OE)); endmodule
-module  \$__FACADE_TINOUTPAD (input I, OE, output O, inout B); FACADE_IO #(.DIR("BIDIR")) _TECHMAP_REPLACE_ (.PAD(B), .I(I), .O(O), .T(~OE)); endmodule
+// iopadmap doesn't have active-low tristate enables, so we techmap to
+// active-low enable early- before converting all logic to LUTs with ABC.
+// If we wait until after ABC is run, we'll end up with $not cells which
+// don't map to anything on device.
+// TODO: Perhaps converting $nots to LUT4s which only use one input might also
+// be acceptable?
+module  \$__FACADE_TOUTPAD_HI (input I, OE, output O); \$__FACADE_TOUTPAD _TECHMAP_REPLACE_ (.I(I), .OE(~OE), .O(O)); endmodule
+module  \$__FACADE_TINOUTPAD_HI (input I, OE, output O, inout B); \$__FACADE_TINOUTPAD _TECHMAP_REPLACE_ (.I(I), .OE(~OE), .O(O), .B(B)); endmodule
+module  \$__FACADE_TOUTPAD (input I, OE, output O); FACADE_IO #(.DIR("OUTPUT")) _TECHMAP_REPLACE_ (.PAD(O), .I(I), .T(OE)); endmodule
+module  \$__FACADE_TINOUTPAD (input I, OE, output O, inout B); FACADE_IO #(.DIR("BIDIR")) _TECHMAP_REPLACE_ (.PAD(B), .I(I), .O(O), .T(OE)); endmodule

--- a/techlibs/machxo2/synth_machxo2.cc
+++ b/techlibs/machxo2/synth_machxo2.cc
@@ -185,7 +185,8 @@ struct SynthMachXO2Pass : public ScriptPass
 		{
 			if (!noiopad || help_mode)
 			{
-				run("iopadmap -bits -outpad $__FACADE_OUTPAD I:O -inpad $__FACADE_INPAD O:I -toutpad $__FACADE_TOUTPAD OE:I:O -tinoutpad $__FACADE_TINOUTPAD OE:O:I:B A:top");
+				run("iopadmap -bits -outpad $__FACADE_OUTPAD I:O -inpad $__FACADE_INPAD O:I -toutpad $__FACADE_TOUTPAD_HI OE:I:O -tinoutpad $__FACADE_TINOUTPAD_HI OE:O:I:B A:top");
+				run("techmap -max_iter 1 -map +/machxo2/cells_map.v t:$__FACADE_T*OUTPAD_HI");
 				run("attrmvcp -attr src -attr LOC t:$__FACADE_OUTPAD %x:+[O] t:$__FACADE_TOUTPAD %x:+[O] t:$__FACADE_TINOUTPAD %x:+[B]");
 				run("attrmvcp -attr src -attr LOC -driven t:$__FACADE_INPAD %x:+[I]");
 			}


### PR DESCRIPTION
techmapping to machxo2 cells.

It appears I missed the cutoff for `0.11` :D! Oh well...

MachXO2 tristates are active low, which `iopadmap` does not support directly. My techmap to create active-low tristates runs after ABC has created `$luts`. The end result is that designs using tristates would have a `$not` cell that wasn't properly mapped to a `LUT4`. Since `nextpnr` can't map `$not` cells on `machxo2`, this ends up being a problem creating bitstreams with tristates. These changes fix this problem so that bitstreams with tristates can be generated.

This is a WIP because the `arch/machxo2/tribuf.ys` test passes without any changes, and still produces a `$not` gate as output. I wouldn't expect this, but according to [tribuf.log](https://github.com/YosysHQ/yosys/files/7487985/tribuf.log):

```
5.2.17.1. Extracting gate netlist of module `\tristate' to `<abc-temp-dir>/input.blif'..
Extracted 0 gates and 0 wires to a netlist network with 0 inputs and 0 outputs.
Don't call ABC as there is nothing to map.
Removing temp directory.
Removed 0 unused cells and 4 unused wires.
```

`yosys` decides not to call ABC at all, and I don't understand why `yosys` thinks there is nothing to map. This is what the circuit looks like _just_ before the `map_luts` label of the `synth_machxo2` pass:

![show](https://user-images.githubusercontent.com/6418027/140556329-4beebe7d-5d2a-446e-b0bf-c89f4ca7cab1.png)

And this is what it looks like after ABC has run `map_luts:map_cells`:
![show](https://user-images.githubusercontent.com/6418027/140556452-165e4675-b6a6-42f5-a139-4d0a6c807e5c.png)

Should `yosys` be adding a LUT here, or did I do something specifically wrong with mapping to active-low tristates using an intermediate `techmap`?
