### PR TITLE
Remove noalu from synth_gowin json output as Apicula now supports it

### DIFF
--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -126,7 +126,6 @@ struct SynthGowinPass : public ScriptPass
 				json_file = args[++argidx];
 				nobram = true;
 				nolutram = true;
-				noalu = true;
 				continue;
 			}
 			if (args[argidx] == "-run" && argidx+1 < args.size()) {


### PR DESCRIPTION
As of [0.0.1a12](https://github.com/YosysHQ/apicula/releases/tag/0.0.1a12) Apicula supports ALU, so this no longer needs to be disabled in the nextpnr flow.