### PR TITLE
manual: fix pdflatex inputenc undefined char error

### DIFF
--- a/manual/command-reference-manual.tex
+++ b/manual/command-reference-manual.tex
@@ -3156,7 +3156,7 @@ for removal of the read port.
     opt_mem_priority [selection]
 
 This pass detects cases where one memory write port has priority over another
-even though they can never collide with each other — ie. there can never be
+even though they can never collide with each other -- ie. there can never be
 a situation where a given memory bit is written by both ports at the same
 time, for example because of always-different addresses, or mutually exclusive
 enable signals. In such cases, the priority relation is removed.


### PR DESCRIPTION
Building `yosys` as a package for Fedora, I get the following `pdflatex` / `inputenc` error while building the manual:

```
! Package inputenc Error: Keyboard character used is undefined
(inputenc)                in inputencoding `latin1'.

See the inputenc package documentation for explanation.
Type  H <return>  for immediate help.
 ...                                              
                                                  
l.3159 ...y can never collide with each other — 
                                                  ie. there can never be
!  ==> Fatal error occurred, no output PDF file produced!
Transcript written on manual.log.
make: *** [Makefile:897: manual] Error 1
```

With this PR applied, the manual PDF once again builds correctly.