### PR TITLE
No need to allocate more memory than used

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -1143,7 +1143,6 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::se
 			module->memories[memory->name] = memory;
 
 			int number_of_bits = net->Size();
-			number_of_bits = 1 << ceil_log2(number_of_bits);
 			int bits_in_word = number_of_bits;
 			FOREACH_PORTREF_OF_NET(net, si, pr) {
 				if (pr->GetInst()->Type() == OPER_READ_PORT) {


### PR DESCRIPTION
This was introduced time ago in https://github.com/YosysHQ/yosys/commit/71072d1945b76107a4adc84f6666d100beca6ced#diff-a7714cc0445546659a3412ba5023bc0031110ccda62581ef0622319dfa51d42f where there was actually failure. Meanwhile Verific changed, and widths are properly calculated in all cases, but due to this line we have allocated more memory then needed by design in usual cases.
This also fixes  https://github.com/YosysHQ/yosys/issues/3054 