### PR TITLE
If direction NONE use that from first bit

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -1112,6 +1112,13 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::se
 
 		for (int i = portbus->LeftIndex();; i += portbus->IsUp() ? +1 : -1) {
 			if (portbus->ElementAtIndex(i) && portbus->ElementAtIndex(i)->GetNet()) {
+				if (portbus->GetDir() == DIR_NONE && !wire->port_input && !wire->port_output)  {
+					Port *p = portbus->ElementAtIndex(i);
+					if (p->GetDir() == DIR_INOUT || p->GetDir() == DIR_IN)
+						wire->port_input = true;
+					if (p->GetDir() == DIR_INOUT || p->GetDir() == DIR_OUT)
+						wire->port_output = true;
+				}
 				net = portbus->ElementAtIndex(i)->GetNet();
 				RTLIL::SigBit bit(wire, i - wire->start_offset);
 				if (net_map.count(net) == 0)


### PR DESCRIPTION
When interface is used there is a PortBus but direction for it is none. Patch set direction to one of first bit if defined.

[test_case.zip](https://github.com/YosysHQ/yosys/files/7675476/test_case.zip)
