### PR TITLE
Fix verific import of enum values with x and/or z

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -198,7 +198,7 @@ void VerificImporter::import_attributes(dict<RTLIL::IdString, RTLIL::Const> &att
 						p = nullptr;
 					else
 						for (auto q = p+2; *q != '\0'; q++)
-							if (*q != '0' && *q != '1') {
+							if (*q != '0' && *q != '1' && *q != 'x' && *q != 'z') {
 								p = nullptr;
 								break;
 							}


### PR DESCRIPTION
Test case:

```SystemVerilog
typedef enum logic {d0 = 1'b0, d1 = 1'b1, dx = 1'bx, dz = 1'bz} data_t;
typedef enum logic [3:0] {c0 = 4'b zzz1, c1 = 4'b zz1z, cx = 4'b z1zz, cz = 4'b 1zzz} ctrl_t;
module enum_xz(input logic clk, input ctrl_t ctrl, input data_t data, input data_t [0:3] cmp, output logic [1:0] out);
        always_comb begin
                casez (ctrl)
                        c0: out = {data === d0, data === cmp[0]};
                        c1: out = {data === d1, data === cmp[1]};
                        cx: out = {data === dx, data === cmp[2]};
                        cz: out = {data === dz, data === cmp[3]};
                        default: out = 2'b 00;
                endcase
        end
endmodule
```