### PR TITLE
fix width detection of array querying function in case and case item expressions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,8 @@ Yosys 0.11 .. Yosys 0.12
 
  * SystemVerilog
     - Support parameters using struct as a wiretype
+    - Fixed regression preventing the use array querying functions in case
+      expressions and case item expressions
 
  * New commands and options
     - Added "-genlib" option to "abc" pass

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -1087,6 +1087,11 @@ void AstNode::detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *foun
 			}
 			break;
 		}
+		if (str == "\\$size" || str == "\\$bits" || str == "\\$high" || str == "\\$low" || str == "\\$left" || str == "\\$right") {
+			width_hint = 32;
+			sign_hint = true;
+			break;
+		}
 		if (current_scope.count(str))
 		{
 			// This width detection is needed for function calls which are

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1389,8 +1389,6 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 
 	if (const_fold && type == AST_CASE)
 	{
-		int width_hint;
-		bool sign_hint;
 		detectSignWidth(width_hint, sign_hint);
 		while (children[0]->simplify(const_fold, at_zero, in_lvalue, stage, width_hint, sign_hint, in_param)) { }
 		if (children[0]->type == AST_CONSTANT && children[0]->bits_only_01()) {

--- a/tests/simple/case_expr_extend.sv
+++ b/tests/simple/case_expr_extend.sv
@@ -1,0 +1,11 @@
+module top(
+    output logic [5:0] out
+);
+always_comb begin
+    out = '0;
+    case (1'b1 << 1)
+        2'b10: out = '1;
+        default: out = '0;
+    endcase
+end
+endmodule

--- a/tests/simple/case_expr_query.sv
+++ b/tests/simple/case_expr_query.sv
@@ -1,0 +1,32 @@
+module top(
+    output logic [5:0] out
+);
+always_comb begin
+    out = '0;
+    case ($bits (out)) 6:
+    case ($size (out)) 6:
+    case ($high (out)) 5:
+    case ($low  (out)) 0:
+    case ($left (out)) 5:
+    case ($right(out)) 0:
+    case (6) $bits (out):
+    case (6) $size (out):
+    case (5) $high (out):
+    case (0) $low  (out):
+    case (5) $left (out):
+    case (0) $right(out):
+        out = '1;
+    endcase
+    endcase
+    endcase
+    endcase
+    endcase
+    endcase
+    endcase
+    endcase
+    endcase
+    endcase
+    endcase
+    endcase
+end
+endmodule


### PR DESCRIPTION
I also removed the unnecessary shadowing of `width_hint` and `sign_hint` in the corresponding case in `simplify()`.

This fixes the issue raised in #3082, while also handling the (now covered) edge case that requires the existing ordering of `detectSignWidth` and `simplify`.