### PR TITLE
fix iverilog compatibility for new case expr tests

### DIFF
--- a/tests/simple/case_expr_extend.sv
+++ b/tests/simple/case_expr_extend.sv
@@ -1,7 +1,7 @@
 module top(
     output logic [5:0] out
 );
-always_comb begin
+initial begin
     out = '0;
     case (1'b1 << 1)
         2'b10: out = '1;

--- a/tests/simple/case_expr_query.sv
+++ b/tests/simple/case_expr_query.sv
@@ -1,7 +1,7 @@
 module top(
     output logic [5:0] out
 );
-always_comb begin
+initial begin
     out = '0;
     case ($bits (out)) 6:
     case ($size (out)) 6:


### PR DESCRIPTION
The Docker image uses an older version of iverilog (10.2). I confirmed the build works with these changes, and that the tests are still providing the intended coverage. @Trolldemorted, can you double check that this fixes your build? 

Fixes #3132.

