### PR TITLE
sv: fix size cast clipping expression width

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,8 @@ Yosys 0.11 .. Yosys 0.12
     - Support parameters using struct as a wiretype
     - Fixed regression preventing the use array querying functions in case
       expressions and case item expressions
+    - Fixed static size casts inadvertently limiting the result width of binary
+      operations
 
  * New commands and options
     - Added "-genlib" option to "abc" pass

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -932,7 +932,8 @@ void AstNode::detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *foun
 		if (children.at(0)->type != AST_CONSTANT)
 			log_file_error(filename, location.first_line, "Static cast with non constant expression!\n");
 		children.at(1)->detectSignWidthWorker(width_hint, sign_hint);
-		width_hint = children.at(0)->bitsAsConst().as_int();
+		this_width = children.at(0)->bitsAsConst().as_int();
+		width_hint = max(width_hint, this_width);
 		if (width_hint <= 0)
 			log_file_error(filename, location.first_line, "Static cast with zero or negative size!\n");
 		break;

--- a/tests/simple/lesser_size_cast.sv
+++ b/tests/simple/lesser_size_cast.sv
@@ -1,0 +1,7 @@
+module top (
+    input signed [1:0] a,
+    input signed [2:0] b,
+    output signed [4:0] c
+);
+    assign c = 2'(a) * b;
+endmodule


### PR DESCRIPTION
This fixes the `c2` case in #3090. Fixes for `c3` will come separately after further investigation.