### PR TITLE
fixup verilog doubleslash test

### DIFF
--- a/tests/verilog/.gitignore
+++ b/tests/verilog/.gitignore
@@ -3,3 +3,4 @@
 /run-test.mk
 /const_arst.v
 /const_sr.v
+/doubleslash.v

--- a/tests/verilog/doubleslash.ys
+++ b/tests/verilog/doubleslash.ys
@@ -17,3 +17,5 @@ proc
 opt -full
 
 write_verilog doubleslash.v
+design -reset
+read_verilog doubleslash.v


### PR DESCRIPTION
This test was recently introduced in #2982. My original motivation was to prevent running the `verilog` suite from making the working directory dirty. Rather than avoid creating the file, I decided to extend the test to make use of it.

- add generated doubleslash.v to .gitignore
- ensure backend verilog can be read again