### PR TITLE
manual: Fix cell-stmt order

### DIFF
--- a/manual/CHAPTER_TextRtlil.tex
+++ b/manual/CHAPTER_TextRtlil.tex
@@ -217,7 +217,7 @@ Cells perform functions on input signals. See Chap.~\ref{chapter:celllib} for a 
 \begin{indentgrammar}{<cell-body-stmt>}
 <cell> ::= <attr-stmt>$*$ <cell-stmt> <cell-body-stmt>$*$ <cell-end-stmt>
 
-<cell-stmt> ::= "cell" <cell-id> <cell-type> <eol>
+<cell-stmt> ::= "cell" <cell-type> <cell-id> <eol>
 
 <cell-id> ::= <id>
 


### PR DESCRIPTION
In RTLIL cell statements; the type becomes before the name.

e.g. `cell $sub $5`