### PR TITLE
opt_dff: fix sequence point copy paste bug

### DIFF
--- a/passes/opt/opt_dff.cc
+++ b/passes/opt/opt_dff.cc
@@ -557,7 +557,7 @@ struct OptDffWorker
 					// The D input path is effectively useless, so remove it (this will be a const-input D latch, SR latch, or a const driver).
 					log("Handling D = Q on %s (%s) from module %s (removing D path).\n",
 							log_id(cell), log_id(cell->type), log_id(module));
-					ff.has_clk = ff.has_ce = ff.has_clk = false;
+					ff.has_clk = ff.has_ce = false;
 					changed = true;
 				}
 			}


### PR DESCRIPTION
Newer GCCs emit the following warning for opt_dff:

    passes/opt/opt_dff.cc:560:17: warning: operation on ‘ff.Yosys::FfData::has_clk’ may be undefined [-Wsequence-point]
      560 |      ff.has_clk = ff.has_ce = ff.has_clk = false;
          |      ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Which is correct: the order of whether the read or write of has_clk occurs first is undefined since there is no sequence point between them.

This is almost certainly just a typo/copy paste error and objectively wrong, so just fix it.