### PR TITLE
sv: auto add nosync to certain always_comb local vars

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,9 @@ Yosys 0.11 .. Yosys 0.12
       operations
     - Fixed static size casts ignoring expression signedness
     - Fixed static size casts not extending unbased unsized literals
+    - Added automatic `nosync` inference for local variables in `always_comb`
+      procedures which are always assigned before they are used to avoid errant
+      latch inference
 
  * New commands and options
     - Added "-genlib" option to "abc" pass

--- a/tests/verilog/always_comb_latch_1.ys
+++ b/tests/verilog/always_comb_latch_1.ys
@@ -1,0 +1,13 @@
+read_verilog -sv <<EOF
+module top;
+logic x;
+always_comb begin
+    logic y;
+    if (x)
+        y = 1;
+    x = y;
+end
+endmodule
+EOF
+logger -expect error "^Latch inferred for signal `\\top\.\$unnamed_block\$1\.y' from always_comb process" 1
+proc

--- a/tests/verilog/always_comb_latch_2.ys
+++ b/tests/verilog/always_comb_latch_2.ys
@@ -1,0 +1,15 @@
+read_verilog -sv <<EOF
+module top;
+logic x;
+always_comb begin
+    logic y;
+    if (x)
+        x = 1;
+    else
+        y = 1;
+    x = y;
+end
+endmodule
+EOF
+logger -expect error "^Latch inferred for signal `\\top\.\$unnamed_block\$1\.y' from always_comb process" 1
+proc

--- a/tests/verilog/always_comb_latch_3.ys
+++ b/tests/verilog/always_comb_latch_3.ys
@@ -1,0 +1,20 @@
+read_verilog -sv <<EOF
+module top;
+logic x;
+logic z;
+assign z = 1'b1;
+always_comb begin
+    logic y;
+    case (x)
+    1'b0:
+        y = 1;
+    endcase
+    if (z)
+        x = y;
+    else
+        x = 1'b0;
+end
+endmodule
+EOF
+logger -expect error "^Latch inferred for signal `\\top\.\$unnamed_block\$1\.y' from always_comb process" 1
+proc

--- a/tests/verilog/always_comb_latch_4.ys
+++ b/tests/verilog/always_comb_latch_4.ys
@@ -1,0 +1,17 @@
+read_verilog -sv <<EOF
+module top;
+parameter AVOID_LATCH = 0;
+logic x, z;
+assign z = 1'b1;
+always_comb begin
+    logic y;
+    if (z)
+        y = 0;
+    for (int i = 1; i == AVOID_LATCH; i++)
+        y = 1;
+    x = z ? y : 1'b0;
+end
+endmodule
+EOF
+logger -expect error "^Latch inferred for signal `\\top\.\$unnamed_block\$3\.y' from always_comb process" 1
+proc

--- a/tests/verilog/always_comb_nolatch_1.ys
+++ b/tests/verilog/always_comb_nolatch_1.ys
@@ -1,0 +1,16 @@
+read_verilog -sv <<EOF
+module top;
+logic [4:0] x;
+logic z;
+assign z = 1'b1;
+always_comb begin
+    x = '0;
+    if (z) begin
+        for (int i = 0; i < 5; i++) begin
+            x[i] = 1'b1;
+        end
+    end
+end
+endmodule
+EOF
+proc

--- a/tests/verilog/always_comb_nolatch_2.ys
+++ b/tests/verilog/always_comb_nolatch_2.ys
@@ -1,0 +1,17 @@
+read_verilog -sv <<EOF
+module top;
+logic [4:0] x;
+logic z;
+assign z = 1'b1;
+always_comb begin
+    x = '0;
+    if (z) begin
+        int i;
+        for (i = 0; i < 5; i++) begin
+            x[i] = 1'b1;
+        end
+    end
+end
+endmodule
+EOF
+proc

--- a/tests/verilog/always_comb_nolatch_3.ys
+++ b/tests/verilog/always_comb_nolatch_3.ys
@@ -1,0 +1,21 @@
+read_verilog -sv <<EOF
+module top;
+logic x;
+logic z;
+assign z = 1'b1;
+always_comb begin
+    logic y;
+    case (x)
+    1'b0:
+        y = 1;
+    default:
+        y = 0;
+    endcase
+    if (z)
+        x = y;
+    else
+        x = 1'b0;
+end
+endmodule
+EOF
+proc

--- a/tests/verilog/always_comb_nolatch_4.ys
+++ b/tests/verilog/always_comb_nolatch_4.ys
@@ -1,0 +1,16 @@
+read_verilog -sv <<EOF
+module top;
+parameter AVOID_LATCH = 1;
+logic x, z;
+assign z = 1'b1;
+always_comb begin
+    logic y;
+    if (z)
+        y = 0;
+    for (int i = 1; i == AVOID_LATCH; i++)
+        y = 1;
+    x = z ? y : 1'b0;
+end
+endmodule
+EOF
+proc


### PR DESCRIPTION
If a local variable is always assigned before it is used, then adding nosync prevents latches from being needlessly generated.

This supplants #3059.

@tgorochowik @kamilrakoczy