### PR TITLE
Fix always_comb latch when for is inside function

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -2341,15 +2341,12 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 	{
 		expand_genblock(str + ".");
 
-		// if this is an autonamed block is in an always_comb
-		if (current_always && current_always->attributes.count(ID::always_comb)
-				&& str.at(0) == '$')
-			// track local variables in this block so we can consider adding
-			// nosync once the block has been fully elaborated
-			for (AstNode *child : children)
-				if (child->type == AST_WIRE &&
-						!child->attributes.count(ID::nosync))
-					mark_auto_nosync(this, child);
+		// track local variables in this block so we can consider adding
+		// nosync once the block has been fully elaborated
+		for (AstNode *child : children)
+			if (child->type == AST_WIRE &&
+					!child->attributes.count(ID::nosync))
+				mark_auto_nosync(this, child);
 
 		std::vector<AstNode*> new_children;
 		for (size_t i = 0; i < children.size(); i++)

--- a/tests/verilog/always_comb_nolatch_5.ys
+++ b/tests/verilog/always_comb_nolatch_5.ys
@@ -1,0 +1,22 @@
+read_verilog -sv <<EOF
+module top();
+logic z;
+logic [3:0] a;
+logic [3:0] b;
+function automatic logic [3:0] transpose(logic [3:0] in);
+  logic [3:0] transpose;
+  transpose = '0;
+  for (int j=0; j<4; j++) begin
+    transpose[j] = in[3 - j];
+  end 
+endfunction 
+always_comb begin
+  unique case (z)
+    1'b0: a = '0;
+    1'b1: a = transpose(b);
+    default: a = '0;
+  endcase
+end
+endmodule
+EOF
+proc


### PR DESCRIPTION
This PR fixes latch in ``always_comb`` block when ``for`` is inside function (and this function is used inside ``always_comb`` block.

I'm not sure if this is the correct way to fix this issue, but none of already existing tests are failing with this change.

Related to: https://github.com/YosysHQ/yosys/pull/3150