### PR TITLE
fix dumpAst() compilation warning

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -344,7 +344,7 @@ void AstNode::dumpAst(FILE *f, std::string indent) const
 	}
 	if (!multirange_swapped.empty()) {
 		fprintf(f, " multirange_swapped=[");
-		for (auto v : multirange_swapped)
+		for (bool v : multirange_swapped)
 			fprintf(f, " %d", v);
 		fprintf(f, " ]");
 	}


### PR DESCRIPTION
Without this change, Apple clang 13.0.0 produces the warning below.
```
frontends/ast/ast.cc:348:23: warning: format specifies type 'int' but the argument has type 'std::__bit_const_reference<std::vector<bool>>' [-Wformat]
                         fprintf(f, " %d", v);
                                      ~~   ^
```