### PR TITLE
Fix the help message of synth_quicklogic command.

### DIFF
--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -225,8 +225,8 @@ struct SynthQuickLogicPass : public ScriptPass {
 		}
 
 		if (check_label("verilog")) {
-			if (!verilog_file.empty()) {
-				run("write_verilog -noattr -nohex " + verilog_file);
+			if (!verilog_file.empty() || help_mode) {
+				run(stringf("write_verilog -noattr -nohex %s", help_mode ? "<file-name>" : verilog_file.c_str()));
 			}
 		}
 	}


### PR DESCRIPTION
This PR helps add some missing fields in the reference manual.

Edit:
This PR helps fix the help message of `synth_quicklogic` command.

Before:

```
yosys> help synth_quicklogic
   synth_quicklogic [options]
This command runs synthesis for QuickLogic FPGAs
...
    verilog:

```

After:

```
yosys> help synth_quicklogic
   synth_quicklogic [options]
This command runs synthesis for QuickLogic FPGAs
...
    verilog:
        write_verilog -noattr -nohex <file-name>
```