### PR TITLE
fix handling of escaped chars in json backend and frontend (mostly)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -915,7 +915,7 @@ clean:
 	rm -rf tests/simple/*.out tests/simple/*.log
 	rm -rf tests/memories/*.out tests/memories/*.log tests/memories/*.dmp
 	rm -rf tests/sat/*.log tests/techmap/*.log tests/various/*.log
-	rm -rf tests/bram/temp tests/fsm/temp tests/realmath/temp tests/share/temp tests/smv/temp
+	rm -rf tests/bram/temp tests/fsm/temp tests/realmath/temp tests/share/temp tests/smv/temp tests/various/temp
 	rm -rf vloghtb/Makefile vloghtb/refdat vloghtb/rtl vloghtb/scripts vloghtb/spec vloghtb/check_yosys vloghtb/vloghammer_tb.tar.bz2 vloghtb/temp vloghtb/log_test_*
 	rm -f tests/svinterfaces/*.log_stdout tests/svinterfaces/*.log_stderr tests/svinterfaces/dut_result.txt tests/svinterfaces/reference_result.txt tests/svinterfaces/a.out tests/svinterfaces/*_syn.v tests/svinterfaces/*.diff
 	rm -f  tests/tools/cmp_tbdata

--- a/backends/json/json.cc
+++ b/backends/json/json.cc
@@ -52,8 +52,23 @@ struct JsonWriter
 		string newstr = "\"";
 		for (char c : str) {
 			if (c == '\\')
+				newstr += "\\\\";
+			else if (c == '"')
+				newstr += "\\\"";
+			else if (c == '\b')
+				newstr += "\\b";
+			else if (c == '\f')
+				newstr += "\\f";
+			else if (c == '\n')
+				newstr += "\\n";
+			else if (c == '\r')
+				newstr += "\\r";
+			else if (c == '\t')
+				newstr += "\\t";
+			else if (c < 0x20)
+				newstr += stringf("\\u%04X", c);
+			else
 				newstr += c;
-			newstr += c;
 		}
 		return newstr + "\"";
 	}

--- a/tests/various/.gitignore
+++ b/tests/various/.gitignore
@@ -5,3 +5,4 @@
 /run-test.mk
 /plugin.so
 /plugin.so.dSYM
+/temp

--- a/tests/various/json_escape_chars.ys
+++ b/tests/various/json_escape_chars.ys
@@ -1,0 +1,14 @@
+! mkdir -p temp
+read_verilog <<EOT
+(* src = "\042 \057 \134 \010 \014 \012 \015 \011 \025 \033" *)
+module foo;
+endmodule
+EOT
+write_json temp/test_escapes.json
+design -reset
+read_json temp/test_escapes.json
+write_json temp/test_escapes.json
+design -reset
+read_json temp/test_escapes.json
+write_rtlil temp/test_escapes.json.il
+! grep -F 'attribute \src "\" / \\ \010 \014 \n \015 \t \025 \033"' temp/test_escapes.json.il


### PR DESCRIPTION
https://www.json.org/json-en.html

It is mandatory to escape the characters `\`, `"`, and any control character (<0x20) in JSON. This uses the two-character escapes `\\ \" \r \t \n \f \b` preferentially, and `\uXXXX` escapes for others in `write_json`.

It's optionally allowed to escape any character. This accepts any of the above in `read_json`, but *does not* implement parsing of code points >0x7F (despite this being mandatory according to the standard).