### PR TITLE
Prune Linux CI builds

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -11,9 +11,7 @@ jobs:
           - { id: ubuntu-20.04, name: focal }
         compiler:
           - 'clang-12'
-          - 'clang-11'
           - 'gcc-11'
-          - 'gcc-10'
         cpp_std:
           - 'c++11'
           - 'c++14'
@@ -21,6 +19,12 @@ jobs:
           - 'c++20'
         include:
           # Limit the older compilers to C++11 mode
+          - os: { id: ubuntu-20.04, name: focal }
+            compiler: 'clang-11'
+            cpp_std: 'c++11'
+          - os: { id: ubuntu-20.04, name: focal }
+            compiler: 'gcc-10'
+            cpp_std: 'c++11'
           - os: { id: ubuntu-18.04, name: bionic }
             compiler: 'clang-3.9'
             cpp_std: 'c++11'


### PR DESCRIPTION
This PR aims to remove excess build variants from the CI. Please feel free to share any comments or concerns!

**Update:** see https://github.com/YosysHQ/yosys/pull/3222#issuecomment-1065015254

Below are the 18 current Linux matrix runs, with the 10 runs this PR removes struck.

* ubuntu-20.04, focal, clang-12, c++11
* ~~ubuntu-20.04, focal, clang-12, c++14~~
* ~~ubuntu-20.04, focal, clang-12, c++17~~
* ubuntu-20.04, focal, clang-12, c++20
* ubuntu-20.04, focal, clang-11, c++11
* ~~ubuntu-20.04, focal, clang-11, c++14~~
* ~~ubuntu-20.04, focal, clang-11, c++17~~
* ~~ubuntu-20.04, focal, clang-11, c++20~~
* ubuntu-20.04, focal, gcc-11, c++11
* ~~ubuntu-20.04, focal, gcc-11, c++14~~
* ~~ubuntu-20.04, focal, gcc-11, c++17~~
* ubuntu-20.04, focal, gcc-11, c++20
* ubuntu-20.04, focal, gcc-10, c++11
* ~~ubuntu-20.04, focal, gcc-10, c++14~~
* ~~ubuntu-20.04, focal, gcc-10, c++17~~
* ~~ubuntu-20.04, focal, gcc-10, c++20~~
* ubuntu-18.04, bionic, clang-3.9, c++11
* ubuntu-18.04, bionic, gcc-4.8, c++11

C++11 is the default standard for Yosys. To my understanding, we build using the newer standards primarily to ensure forward-compatibility.

Although there are likely exceptions, I would expect that for a particular environment, coverage for C++11 and C++20 should obviate the need to test with C++14 and C++17, especially given we are not currently planning to specifically target those standards by default.

I also dropped C++20 for the older compilers given that they likely don't provide significant additional value over the matching C++11 build combined with the newer C++20 build.
