### PR TITLE
ignore # comment lines

### DIFF
--- a/backends/smt2/smtbmc.py
+++ b/backends/smt2/smtbmc.py
@@ -492,7 +492,7 @@ if aimfile is not None:
             got_state = True
 
         for entry in f.read().splitlines():
-            if len(entry) == 0 or entry[0] in "bcjfu.":
+            if len(entry) == 0 or entry[0] in "bcjfu.#":
                 continue
 
             if not got_state:


### PR DESCRIPTION
abc adds [comment lines](https://github.com/berkeley-abc/abc/blob/ee228339e5e14b7a3651454814e91b80c3cb4b1e/src/base/io/io.c#L2694) starting with `#` to the witness. Ignore these when parsing `.aiw` files.