### PR TITLE
Import Verific netlist in consistent order

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -2233,10 +2233,10 @@ void verific_import(Design *design, const std::map<std::string,std::string> &par
 		Netlist *nl = it->second;
 		if (nl_done.count(it->first) == 0) {
 			VerificImporter importer(false, false, false, false, false, false, false);
+			nl_done[it->first] = it->second;
 			importer.import_netlist(design, nl, nl_todo, nl->Owner()->Name() == top);
 		}
 		nl_todo.erase(it);
-		nl_done[it->first] = it->second;
 	}
 
 	veri_file::Reset();
@@ -3242,10 +3242,10 @@ struct VerificPass : public Pass {
 				if (nl_done.count(it->first) == 0) {
 					VerificImporter importer(mode_gates, mode_keep, mode_nosva,
 							mode_names, mode_verific, mode_autocover, mode_fullinit);
+					nl_done[it->first] = it->second;
 					importer.import_netlist(design, nl, nl_todo, top_mod_names.count(nl->Owner()->Name()));
 				}
 				nl_todo.erase(it);
-				nl_done[it->first] = it->second;
 			}
 
 			veri_file::Reset();

--- a/frontends/verific/verific.h
+++ b/frontends/verific/verific.h
@@ -94,7 +94,7 @@ struct VerificImporter
 	void merge_past_ffs_clock(pool<RTLIL::Cell*> &candidates, SigBit clock, bool clock_pol);
 	void merge_past_ffs(pool<RTLIL::Cell*> &candidates);
 
-	void import_netlist(RTLIL::Design *design, Verific::Netlist *nl, std::set<Verific::Netlist*> &nl_todo, bool norename = false);
+	void import_netlist(RTLIL::Design *design, Verific::Netlist *nl, std::map<std::string,Verific::Netlist*> &nl_todo, bool norename = false);
 };
 
 void verific_import_sva_assert(VerificImporter *importer, Verific::Instance *inst);


### PR DESCRIPTION
In current implementation std::set is used and that one is ordered, but it is ordered per pointer which is not consistent. 
Changed data structure to use std::map which will be ordered by imported module name.

Also found error that check in line 2213 did not have any sense, and verific -import was not properly assigning top attribute, due to missing check (added in line 3209)