### PR TITLE
smtbmc: fix bmc with no assertions

### DIFF
--- a/backends/smt2/smtbmc.py
+++ b/backends/smt2/smtbmc.py
@@ -1589,6 +1589,8 @@ else:  # not tempind, covermode
                             active_assert_expr = "(and %s)" % " ".join(active_assert_exprs)
 
                         smt_assert("(not %s)" % active_assert_expr)
+                    else:
+                        smt_assert("false")
 
 
                     if smt_check_sat() == "sat":


### PR DESCRIPTION
this was broken by the `--keep-going` changes