### PR TITLE
Set init values for wrapped  async control signals

### DIFF
--- a/passes/sat/clk2fflogic.cc
+++ b/passes/sat/clk2fflogic.cc
@@ -44,6 +44,7 @@ struct Clk2fflogicPass : public Pass {
 	}
 	SigSpec wrap_async_control(Module *module, SigSpec sig, bool polarity, IdString past_sig_id) {
 		Wire *past_sig = module->addWire(past_sig_id, GetSize(sig));
+		past_sig->attributes[ID::init] = RTLIL::Const(polarity ? State::S0 : State::S1, GetSize(sig));
 		module->addFf(NEW_ID, sig, past_sig);
 		if (polarity)
 			sig = module->Or(NEW_ID, sig, past_sig);
@@ -56,6 +57,7 @@ struct Clk2fflogicPass : public Pass {
 	}
 	SigSpec wrap_async_control_gate(Module *module, SigSpec sig, bool polarity) {
 		Wire *past_sig = module->addWire(NEW_ID);
+		past_sig->attributes[ID::init] = RTLIL::Const(polarity ? State::S0 : State::S1, GetSize(sig));
 		module->addFfGate(NEW_ID, sig, past_sig);
 		if (polarity)
 			sig = module->OrGate(NEW_ID, sig, past_sig);


### PR DESCRIPTION
With current code next example fails since counter starts at wrong value.
Bug is noticed due to fact that all FFs are aldffs when imported trough Verific.

```
[options]
mode bmc
multiclock on
depth 2

[engines]
smtbmc boolector


[script]
read -formal aldff.v
prep -top aldff

[file aldff.v]
module aldff(
input clk
);
parameter WIDTH=10;

reg [3:0] f_count;

initial f_count = 1;
always @(posedge clk)
if (f_count == WIDTH-1)
	f_count <= 0;
else
	f_count <= f_count + 1'b1;

always @(*)
	assert(f_count < WIDTH);

endmodule
```