### PR TITLE
Do not enable features that require the support of compression compiled in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -594,11 +594,15 @@ $(eval $(call add_include_file,kernel/satgen.h))
 $(eval $(call add_include_file,kernel/qcsat.h))
 $(eval $(call add_include_file,kernel/ff.h))
 $(eval $(call add_include_file,kernel/ffinit.h))
+ifeq ($(ENABLE_ZLIB),1)
 $(eval $(call add_include_file,kernel/fstdata.h))
+endif
 $(eval $(call add_include_file,kernel/mem.h))
 $(eval $(call add_include_file,libs/ezsat/ezsat.h))
 $(eval $(call add_include_file,libs/ezsat/ezminisat.h))
+ifeq ($(ENABLE_ZLIB),1)
 $(eval $(call add_include_file,libs/fst/fstapi.h))
+endif
 $(eval $(call add_include_file,libs/sha1/sha1.h))
 $(eval $(call add_include_file,libs/json11/json11.hpp))
 $(eval $(call add_include_file,passes/fsm/fsmdata.h))
@@ -620,7 +624,10 @@ ifneq ($(ABCEXTERNAL),)
 kernel/yosys.o: CXXFLAGS += -DABCEXTERNAL='"$(ABCEXTERNAL)"'
 endif
 endif
-OBJS += kernel/cellaigs.o kernel/celledges.o kernel/satgen.o kernel/qcsat.o kernel/mem.o kernel/ffmerge.o kernel/ff.o kernel/fstdata.o
+OBJS += kernel/cellaigs.o kernel/celledges.o kernel/satgen.o kernel/qcsat.o kernel/mem.o kernel/ffmerge.o kernel/ff.o
+ifeq ($(ENABLE_ZLIB),1)
+OBJS += kernel/fstdata.o
+endif
 
 kernel/log.o: CXXFLAGS += -DYOSYS_SRC='"$(YOSYS_SRC)"'
 kernel/yosys.o: CXXFLAGS += -DYOSYS_DATDIR='"$(DATDIR)"' -DYOSYS_PROGRAM_PREFIX='"$(PROGRAM_PREFIX)"'
@@ -644,9 +651,11 @@ OBJS += libs/minisat/SimpSolver.o
 OBJS += libs/minisat/Solver.o
 OBJS += libs/minisat/System.o
 
+ifeq ($(ENABLE_ZLIB),1)
 OBJS += libs/fst/fstapi.o
 OBJS += libs/fst/fastlz.o
 OBJS += libs/fst/lz4.o
+endif
 
 include $(YOSYS_SRC)/frontends/*/Makefile.inc
 include $(YOSYS_SRC)/passes/*/Makefile.inc

--- a/passes/sat/Makefile.inc
+++ b/passes/sat/Makefile.inc
@@ -2,7 +2,9 @@
 OBJS += passes/sat/sat.o
 OBJS += passes/sat/freduce.o
 OBJS += passes/sat/eval.o
+ifeq ($(ENABLE_ZLIB),1)
 OBJS += passes/sat/sim.o
+endif
 OBJS += passes/sat/miter.o
 OBJS += passes/sat/expose.o
 OBJS += passes/sat/assertpmux.o


### PR DESCRIPTION
Currently several files are compiled always despite a dependency on inclusion of libraries that are conditionally compiled in. This fixes the issue by expressing the dependency in the build system properly.