### PR TITLE
Makefile: use DESTDIR in yosys-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -749,9 +749,9 @@ LDLIBS_NOVERIFIC = $(LDLIBS)
 endif
 
 $(PROGRAM_PREFIX)yosys-config: misc/yosys-config.in
-	$(P) $(SED) -e 's#@CXXFLAGS@#$(subst -I. -I"$(YOSYS_SRC)",-I"$(DATDIR)/include",$(strip $(CXXFLAGS_NOVERIFIC)))#;' \
+	$(P) $(SED) -e 's#@CXXFLAGS@#$(subst -I. -I"$(YOSYS_SRC)",-I"$(DESTDIR)$(DATDIR)/include",$(strip $(CXXFLAGS_NOVERIFIC)))#;' \
 			-e 's#@CXX@#$(strip $(CXX))#;' -e 's#@LDFLAGS@#$(strip $(LDFLAGS) $(PLUGIN_LDFLAGS))#;' -e 's#@LDLIBS@#$(strip $(LDLIBS_NOVERIFIC))#;' \
-			-e 's#@BINDIR@#$(strip $(BINDIR))#;' -e 's#@DATDIR@#$(strip $(DATDIR))#;' < $< > $(PROGRAM_PREFIX)yosys-config
+			-e 's#@BINDIR@#$(strip $(DESTDIR)$(BINDIR))#;' -e 's#@DATDIR@#$(strip $(DESTDIR)$(DATDIR))#;' < $< > $(PROGRAM_PREFIX)yosys-config
 	$(Q) chmod +x $(PROGRAM_PREFIX)yosys-config
 
 abc/abc-$(ABCREV)$(EXE) abc/libabc-$(ABCREV).a:


### PR DESCRIPTION
Modifies the yosys-config rule, adding the $(DESTDIR) prefix to
references to $(DATDIR) and $(BINDIR). This ensures that the generated
yosys-config file refers to the same data and bin directories that the
install and uninstall rules refer to.

There seem to be other DESTDIR related problems in Makefile, but this
at least addresses some of them until a more comprehensive solution is
available.

Signed-off-by: Alan Green <avg@google.com>