### PR TITLE
smt2: Make write port array stores conditional on nonzero write mask

### DIFF
--- a/backends/smt2/smt2.cc
+++ b/backends/smt2/smt2.cc
@@ -1185,10 +1185,12 @@ struct Smt2Worker
 						data = stringf("(bvor (bvand %s %s) (bvand (select (|%s#%d#%d| state) %s) (bvnot %s)))",
 								data.c_str(), mask.c_str(), get_id(module), arrayid, i, addr.c_str(), mask.c_str());
 
+						string empty_mask(mem->width, '0');
+
 						decls.push_back(stringf("(define-fun |%s#%d#%d| ((state |%s_s|)) (Array (_ BitVec %d) (_ BitVec %d)) "
-								"(store (|%s#%d#%d| state) %s %s)) ; %s\n",
+								"(ite (= %s #b%s) (|%s#%d#%d| state) (store (|%s#%d#%d| state) %s %s))) ; %s\n",
 								get_id(module), arrayid, i+1, get_id(module), abits, mem->width,
-								get_id(module), arrayid, i, addr.c_str(), data.c_str(), get_id(mem->memid)));
+								mask.c_str(), empty_mask.c_str(), get_id(module), arrayid, i, get_id(module), arrayid, i, addr.c_str(), data.c_str(), get_id(mem->memid)));
 					}
 				}
 


### PR DESCRIPTION
Currently, for smt2, write ports are encoded by unconditionally applying the `store` operation to the array containing the previous state's memory content. When the write mask is all zeros, this results in a store operation that leaves the array unchanged, but solvers might take a long time to discover this useful fact. This PR changes the encoding to explicitly select the previous state's array as new memory content when the write mask is all zero (matching the encoding used for btor output). This encoding change results in much faster solving times for the benchmarks I tested it on. For example when using riscv-formal's reg_check for the picorv32 core I get the following results:

* `smtbmc boolector` (before): 18:04.20 total
* `smtbmc boolector` (this PR): 2:49.22 total

This closes most of the performance gap between smtbmc and btormc:

* `btor btormc`: 2:24.16 total

It also doesn't seem to hurt for other solvers, although on this particular benchmark they're slow enough that I did not test them all:

* `smtbmc z3` (before): I interrupted it after over 1h
* `smtbmc z3` (this PR): 40:02.95 total