### PR TITLE
Simulation improvements

### DIFF
--- a/kernel/fstdata.cc
+++ b/kernel/fstdata.cc
@@ -201,10 +201,11 @@ void FstData::reconstructAllAtTimes(std::vector<fstHandle> &signal, uint64_t sta
 	fstReaderSetUnlimitedTimeRange(ctx);
 	fstReaderSetFacProcessMaskAll(ctx);
 	fstReaderIterBlocks2(ctx, reconstruct_clb_attimes, reconstruct_clb_varlen_attimes, this, nullptr);
-	past_data = last_data;
-	callback(last_time);
-	if (last_time!=end_time)
-		callback(end_time);
+	if (last_time!=end_time) {
+		past_data = last_data;
+		callback(last_time);
+	}
+	callback(end_time);
 }
 
 std::string FstData::valueOf(fstHandle signal)

--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -809,13 +809,19 @@ struct SimInstance
 		for (auto cell : module->cells())
 		{
 			if (cell->type.in(ID($anyseq))) {
-				SigSpec sig_y= cell->getPort(ID::Y);
+				SigSpec sig_y = sigmap(cell->getPort(ID::Y));
 				if (sig_y.is_wire()) {
-					Wire *wire = sig_y.as_wire();
-					fstHandle id = shared->fst->getHandle(scope + "." + RTLIL::unescape_id(wire->name));
-					if (id==0)
-						log_error("Unable to find required '%s' signal in file\n",(scope + "." + RTLIL::unescape_id(wire->name)).c_str());
-					inputs[wire] = id;
+					bool found = false;
+					for(auto &item : fst_handles) {
+						if (item.second==0) continue; // Ignore signals not found
+						if (sig_y == sigmap(item.first)) {
+							inputs[sig_y.as_wire()] = item.second;
+							found = true;
+							break;
+						}
+					}
+					if (!found)
+						log_error("Unable to find required '%s' signal in file\n",(scope + "." + RTLIL::unescape_id(sig_y.as_wire()->name)).c_str());
 				}
 			}
 		}

--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -1805,8 +1805,9 @@ struct AIWWriter : public OutputWriter
 
 		std::map<int, Yosys::RTLIL::Const> current;
 		bool first = true;
-		for(auto& d : worker->output_data)
+		for (auto iter = worker->output_data.begin(); iter != std::prev(worker->output_data.end()); ++iter)
 		{
+			auto& d = *iter;
 			for (auto &data : d.second)
 			{
 				current[data.first] = data.second;

--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -1313,8 +1313,10 @@ struct SimWorker : SimShared
 	void run_cosim_btor2_witness(Module *topmod)
 	{
 		log_assert(top == nullptr);
-		if ((clock.size()+clockn.size())==0)
+		if (!multiclock && (clock.size()+clockn.size())==0)
 			log_error("Clock signal must be specified.\n");
+		if (multiclock && (clock.size()+clockn.size())>0)
+			log_error("For multiclock witness there should be no clock signal.\n");
 		std::ifstream f;
 		f.open(sim_filename.c_str());
 		if (f.fail() || GetSize(sim_filename) == 0)
@@ -1347,10 +1349,12 @@ struct SimWorker : SimShared
 					set_inports(clockn, State::S0);
 					update();
 					register_output_step(10*cycle+0);
-					set_inports(clock, State::S0);
-					set_inports(clockn, State::S1);
-					update();
-					register_output_step(10*cycle+5);
+					if (!multiclock) {
+						set_inports(clock, State::S0);
+						set_inports(clockn, State::S1);
+						update();
+						register_output_step(10*cycle+5);
+					}
 					cycle++;
 					prev_cycle = curr_cycle;
 				}

--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -1815,12 +1815,7 @@ struct AIWWriter : public OutputWriter
 				for (int i = 0;; i++)
 				{
 					if (aiw_latches.count(i)) {
-						SigBit bit = aiw_latches.at(i).first;
-						auto v = current[mapping[bit.wire]].bits.at(bit.offset);
-						if (v == State::S1)
-							aiwfile << (aiw_latches.at(i).second ? '0' : '1');
-						else
-							aiwfile << (aiw_latches.at(i).second ? '1' : '0');
+						aiwfile << '0';
 						continue;
 					}
 					aiwfile << '\n';


### PR DESCRIPTION
- handle multiclock for btor2 witness files
- properly set all signals coming from FST input in simulation model (this covers flip flops and $anyconst)
- handle $anyseq cells in simulation
- only if last sample of input FST file contains clock edge, ignore it, since solvers produce edge without updating rest of values
- fix aiger witness file to set latches to zero always independent if they are inverse latches