### PR TITLE
Fix build on FreeBSD, which has no alloca.h

### DIFF
--- a/libs/fst/config.h
+++ b/libs/fst/config.h
@@ -21,6 +21,9 @@
 #undef HAVE_LIBPTHREAD
 #undef HAVE_FSEEKO
 #endif
+#ifdef __FreeBSD__
+#undef HAVE_ALLOCA_H
+#endif
 
 # ifndef __STDC_FORMAT_MACROS
 #  define __STDC_FORMAT_MACROS 1


### PR DESCRIPTION
After this fix, `abc` compilation failed, which was fixed upstream in https://github.com/berkeley-abc/abc/pull/147. I have applied that change locally and used `ABCREV=default` to buid). Do you prefer to merge upstream changes into https://github.com/YosysHQ/abc, or should I make a PR with that change for your fork?