### PR TITLE
memory_share: fix wrong argidx in extra_args

### DIFF
--- a/passes/memory/memory_share.cc
+++ b/passes/memory/memory_share.cc
@@ -555,7 +555,7 @@ struct MemorySharePass : public Pass {
 			}
 			break;
 		}
-		extra_args(args, 1, design);
+		extra_args(args, argidx, design);
 		MemoryShareWorker msw(design, flag_widen, flag_sat);
 
 		for (auto module : design->selected_modules())


### PR DESCRIPTION
In memory_share pass, the call to `extra_args` specifies `1` as `argidx` which makes memory_share fail when any of the options is specified:

```
yosys> memory_share -nowiden

2. Executing MEMORY_SHARE pass (consolidating $memrd/$memwr cells).

Syntax error in command `memory_share -nowiden':

    memory_share [-nosat] [-nowiden] [selection]

This pass merges share-able memory ports into single memory ports.

The following methods are used to consolidate the number of memory ports:

  - When multiple write ports access the same address then this is converted
    to a single write port with a more complex data and/or enable logic path.

  - When multiple read or write ports access adjacent aligned addresses, they are
    merged to a single wide read or write port.  This transformation can be
    disabled with the "-nowiden" option.

  - When multiple write ports are never accessed at the same time (a SAT
    solver is used to determine this), then the ports are merged into a single
    write port.  This transformation can be disabled with the "-nosat" option.

Note that in addition to the algorithms implemented in this pass, the $memrd
and $memwr cells are also subject to generic resource sharing passes (and other
optimizations) such as "share" and "opt_merge".

ERROR: Command syntax error: Unknown option or option in arguments.
> memory_share -nowiden
> 
```

This pull request fixes the `extra_args` call with a correct `argidx` value.