### PR TITLE
verific: Improve logic generated for SVA value change expressions

### DIFF
--- a/tests/sva/.gitignore
+++ b/tests/sva/.gitignore
@@ -3,5 +3,6 @@
 /*_pass
 /*_fail
 /*.ok
+/*.fst
 /vhdlpsl[0-9][0-9]
 /vhdlpsl[0-9][0-9].sby

--- a/tests/sva/Makefile
+++ b/tests/sva/Makefile
@@ -10,4 +10,5 @@ clean:
 	rm -rf $(addsuffix .ok,$(TESTS)) $(addsuffix .sby,$(TESTS)) $(TESTS)
 	rm -rf $(addsuffix _pass.sby,$(TESTS)) $(addsuffix _pass,$(TESTS))
 	rm -rf $(addsuffix _fail.sby,$(TESTS)) $(addsuffix _fail,$(TESTS))
+	rm -rf $(addsuffix .fst,$(TESTS))
 

--- a/tests/sva/runtest.sh
+++ b/tests/sva/runtest.sh
@@ -57,7 +57,9 @@ generate_sby() {
 	fi
 }
 
-if [ -f $prefix.sv ]; then
+if [ -f $prefix.ys ]; then
+	$PWD/../../yosys -q -e "Assert .* failed." -s $prefix.ys
+elif [ -f $prefix.sv ]; then
 	generate_sby pass > ${prefix}_pass.sby
 	generate_sby fail > ${prefix}_fail.sby
 	sby --yosys $PWD/../../yosys -f ${prefix}_pass.sby

--- a/tests/sva/sva_value_change_changed.sv
+++ b/tests/sva/sva_value_change_changed.sv
@@ -1,0 +1,17 @@
+module top (
+	input clk,
+	input a, b
+);
+	default clocking @(posedge clk); endclocking
+
+	assert property (
+		$changed(b)
+	);
+
+`ifndef FAIL
+	assume property (
+		b !== 'x ##1 $changed(b)
+	);
+`endif
+
+endmodule

--- a/tests/sva/sva_value_change_rose.sv
+++ b/tests/sva/sva_value_change_rose.sv
@@ -1,0 +1,20 @@
+module top (
+	input clk,
+	input a, b
+);
+	default clocking @(posedge clk); endclocking
+
+    wire a_copy;
+    assign a_copy = a;
+
+	assert property (
+		$rose(a) |-> b
+	);
+
+`ifndef FAIL
+	assume property (
+		$rose(a_copy) |-> b
+	);
+`endif
+
+endmodule

--- a/tests/sva/sva_value_change_sim.sv
+++ b/tests/sva/sva_value_change_sim.sv
@@ -1,0 +1,51 @@
+module top (
+	input clk
+);
+
+reg [7:0] counter = 0;
+
+reg a = 0;
+reg b = 1;
+reg c;
+
+wire a_fell; assign a_fell = $fell(a, @(posedge clk));
+wire a_rose; assign a_rose = $rose(a, @(posedge clk));
+wire a_stable; assign a_stable = $stable(a, @(posedge clk));
+
+wire b_fell; assign b_fell = $fell(b, @(posedge clk));
+wire b_rose; assign b_rose = $rose(b, @(posedge clk));
+wire b_stable; assign b_stable = $stable(b, @(posedge clk));
+
+wire c_fell; assign c_fell = $fell(c, @(posedge clk));
+wire c_rose; assign c_rose = $rose(c, @(posedge clk));
+wire c_stable; assign c_stable = $stable(c, @(posedge clk));
+
+always @(posedge clk) begin
+	counter <= counter + 1;
+
+	case (counter)
+		0: begin
+            assert property ( $fell(a) && !$rose(a) && !$stable(a));
+            assert property (!$fell(b) &&  $rose(b) && !$stable(b));
+            assert property (!$fell(c) && !$rose(c) &&  $stable(c));
+            a <= 1; b <= 1; c <= 1;
+        end
+		1: begin a <= 0; b <= 1; c <= 'x; end
+		2: begin
+            assert property ( $fell(a) && !$rose(a) && !$stable(a));
+            assert property (!$fell(b) && !$rose(b) &&  $stable(b));
+            assert property (!$fell(c) && !$rose(c) && !$stable(c));
+            a <= 0; b <= 0; c <= 0;
+        end
+		3: begin a <= 0; b <= 1; c <= 'x; end
+		4: begin
+            assert property (!$fell(a) && !$rose(a) &&  $stable(a));
+            assert property (!$fell(b) &&  $rose(b) && !$stable(b));
+            assert property (!$fell(c) && !$rose(c) && !$stable(c));
+            a <= 'x; b <= 'x; c <= 'x;
+        end
+		5: begin a <= 0; b <= 1; c <= 'x; counter <= 0; end
+	endcase;
+end
+
+endmodule

--- a/tests/sva/sva_value_change_sim.ys
+++ b/tests/sva/sva_value_change_sim.ys
@@ -1,0 +1,3 @@
+read -sv sva_value_change_sim.sv
+hierarchy -top top
+sim -clock clk -fst sva_value_change_sim.fst


### PR DESCRIPTION
The previously generated logic assumed an unconstrained past value in
the initial state and did not handle 'x values. While the current formal
verification flow uses 2-valued logic, SVA value change expressions
require a past value of 'x during the initial state to behave in the
expected way (i.e. to consider both an initial 0 and an initial 1 as
$changed and an initial 1 as $rose and an initial 0 as $fell).

This patch now generates logic that at the same time

*	a) provides the expected behavior in a 2-valued logic setting, not
	   depending on any dont-care optimizations, and

*	b) properly handles 'x values in yosys simulation