### PR TITLE
Now calls Tcl_Init after creating the interp, fixes clock format.

### DIFF
--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -734,7 +734,7 @@ extern Tcl_Interp *yosys_get_tcl_interp()
 	if (yosys_tcl_interp == NULL) {
 		yosys_tcl_interp = Tcl_CreateInterp();
 		if (Tcl_Init(yosys_tcl_interp)!=TCL_OK)
-			log("Tcl_Init() call failed\n");
+			log_warning("Tcl_Init() call failed - %s\n",Tcl_ErrnoMsg(Tcl_GetErrno()));
 		Tcl_CreateCommand(yosys_tcl_interp, "yosys", tcl_yosys_cmd, NULL, NULL);
 	}
 	return yosys_tcl_interp;

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -733,6 +733,8 @@ extern Tcl_Interp *yosys_get_tcl_interp()
 {
 	if (yosys_tcl_interp == NULL) {
 		yosys_tcl_interp = Tcl_CreateInterp();
+		if (Tcl_Init(yosys_tcl_interp)!=TCL_OK)
+			log("Tcl_Init() call failed\n");
 		Tcl_CreateCommand(yosys_tcl_interp, "yosys", tcl_yosys_cmd, NULL, NULL);
 	}
 	return yosys_tcl_interp;


### PR DESCRIPTION
Without this patch, Yosys doesn't call Tcl_Init(), which means that a handful of Tcl commands don't work - for example, attempting to use "clock format" results in the following error:
ERROR: TCL interpreter returned an error: invalid command name "::tcl::clock::format"
Tcl_Init() calls the init.tcl script, part of the Tcl standard library code, which fills in some implemented-in-tcl commands in the ::tcl::clock namespace, namely clock format, clock add and clock scan.

Adding this call fixes the problem.
