### PR TITLE
Observe $TMPDIR variable when creating tmp files

### DIFF
--- a/kernel/fstdata.cc
+++ b/kernel/fstdata.cc
@@ -33,7 +33,7 @@ FstData::FstData(std::string filename) : ctx(nullptr)
 	std::string filename_trim = file_base_name(filename);
 	if (filename_trim.size() > 4 && filename_trim.compare(filename_trim.size()-4, std::string::npos, ".vcd") == 0) {
 		filename_trim.erase(filename_trim.size()-4);
-		tmp_file = stringf("/tmp/converted_%s.fst", filename_trim.c_str());
+		tmp_file = stringf("%s/converted_%s.fst", get_base_tmpdir().c_str(), filename_trim.c_str());
 		std::string cmd = stringf("vcd2fst %s %s", filename.c_str(), tmp_file.c_str());
 		log("Exec: %s\n", cmd.c_str());
 		if (run_command(cmd) != 0)

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -278,8 +278,9 @@ bool patmatch(const char *pattern, const char *string);
 #if !defined(YOSYS_DISABLE_SPAWN)
 int run_command(const std::string &command, std::function<void(const std::string&)> process_line = std::function<void(const std::string&)>());
 #endif
-std::string make_temp_file(std::string template_str = "/tmp/yosys_XXXXXX");
-std::string make_temp_dir(std::string template_str = "/tmp/yosys_XXXXXX");
+std::string get_base_tmpdir();
+std::string make_temp_file(std::string template_str = get_base_tmpdir() + "/yosys_XXXXXX");
+std::string make_temp_dir(std::string template_str = get_base_tmpdir() + "/yosys_XXXXXX");
 bool check_file_exists(std::string filename, bool is_exec = false);
 bool is_absolute_path(std::string filename);
 void remove_directory(std::string dirname);

--- a/passes/sat/qbfsat.cc
+++ b/passes/sat/qbfsat.cc
@@ -251,7 +251,7 @@ QbfSolutionType call_qbf_solver(RTLIL::Module *mod, const QbfSolveOptions &opt, 
 
 QbfSolutionType qbf_solve(RTLIL::Module *mod, const QbfSolveOptions &opt) {
 	QbfSolutionType ret, best_soln;
-	const std::string tempdir_name = make_temp_dir("/tmp/yosys-qbfsat-XXXXXX");
+	const std::string tempdir_name = make_temp_dir(get_base_tmpdir() + "/yosys-qbfsat-XXXXXX");
 	RTLIL::Module *module = mod;
 	RTLIL::Design *design = module->design;
 	std::string module_name = module->name.str();

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -780,7 +780,7 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 	if (dff_mode && clk_sig.empty())
 		log_cmd_error("Clock domain %s not found.\n", clk_str.c_str());
 
-	std::string tempdir_name = "/tmp/" + proc_program_prefix()+ "yosys-abc-XXXXXX";
+	std::string tempdir_name = get_base_tmpdir() + "/" + proc_program_prefix()+ "yosys-abc-XXXXXX";
 	if (!cleanup)
 		tempdir_name[0] = tempdir_name[4] = '_';
 	tempdir_name = make_temp_dir(tempdir_name);

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -404,7 +404,7 @@ struct Abc9Pass : public ScriptPass
 					if (!active_design->selected_whole_module(mod))
 						log_error("Can't handle partially selected module %s!\n", log_id(mod));
 
-					std::string tempdir_name = "/tmp/" + proc_program_prefix() + "yosys-abc-XXXXXX";
+					std::string tempdir_name = get_base_tmpdir() + "/" + proc_program_prefix() + "yosys-abc-XXXXXX";
 					if (!cleanup)
 						tempdir_name[0] = tempdir_name[4] = '_';
 					tempdir_name = make_temp_dir(tempdir_name);


### PR DESCRIPTION
POSIX defines $TMPDIR as containing the pathname of the directory where
programs can create temporary files. On most systems, this variable points to
"/tmp". However, on some systems it can point to a different location.
Without respecting this variable, yosys fails to run on such systems.

Signed-off-by: Mohamed A. Bamakhrama <mohamed@alumni.tum.de>