### PR TITLE
Fix typo in emcc flags (typo introduced by #3053)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ CXXFLAGS := -std=$(CXXSTD) $(filter-out -fPIC -ggdb,$(CXXFLAGS))
 ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H -DABC_MEMALIGN=8"
 EMCC_CXXFLAGS := -Os -Wno-warn-absolute-paths
 EMCC_LDFLAGS := --memory-init-file 0 --embed-file share
-EMCC_LDFLAGS := -s NO_EXIT_RUNTIME=1
+EMCC_LDFLAGS += -s NO_EXIT_RUNTIME=1
 EMCC_LDFLAGS += -s EXPORTED_FUNCTIONS="['_main','_run','_prompt','_errmsg','_memset']"
 EMCC_LDFLAGS += -s TOTAL_MEMORY=134217728
 EMCC_LDFLAGS += -s EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]'


### PR DESCRIPTION
The `EMCC_LDFLAGS` in the `Makefile` are overwritten in the second line due to a typo. This typo breaks the emcc build during WebAssembly runtime, because the `share` folder is not embedded.