### PR TITLE
Make 'stat' and 'select -count' save counts to scratchpad

### DIFF
--- a/passes/cmds/select.cc
+++ b/passes/cmds/select.cc
@@ -1456,7 +1456,10 @@ struct SelectPass : public Pass {
 				}
 			}
 			if (count_mode)
+			{
+				design->scratchpad_set_int("select.count", total_count);
 				log("%d objects.\n", total_count);
+			}
 			if (f != nullptr)
 				fclose(f);
 		#undef LOG_OBJECT

--- a/passes/cmds/stat.cc
+++ b/passes/cmds/stat.cc
@@ -381,6 +381,15 @@ struct StatPass : public Pass {
 
 			log("\n");
 			data.log_data(top_mod->name, true);
+			design->scratchpad_set_int("stat.num_wires", data.num_wires);
+			design->scratchpad_set_int("stat.num_wire_bits", data.num_wire_bits);
+			design->scratchpad_set_int("stat.num_pub_wires", data.num_pub_wires);
+			design->scratchpad_set_int("stat.num_pub_wire_bits", data.num_pub_wire_bits);
+			design->scratchpad_set_int("stat.num_memories", data.num_memories);
+			design->scratchpad_set_int("stat.num_memory_bits", data.num_memory_bits);
+			design->scratchpad_set_int("stat.num_processes", data.num_processes);
+			design->scratchpad_set_int("stat.num_cells", data.num_cells);
+			design->scratchpad_set_int("stat.area", data.area);
 		}
 
 		log("\n");


### PR DESCRIPTION
E.g. so the value can be accessed for decision making in script passes.