### PR TITLE
smtbmc: Force nonincremental mode when yices is used with forall

### DIFF
--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -176,7 +176,10 @@ class SmtIo:
             self.unroll = False
 
         if self.solver == "yices":
-            if self.noincr or self.forall:
+            if self.forall:
+                self.noincr = True
+
+            if self.noincr:
                 self.popen_vargs = ['yices-smt2'] + self.solver_opts
             else:
                 self.popen_vargs = ['yices-smt2', '--incremental'] + self.solver_opts


### PR DESCRIPTION
Previously Yices was already started in nonincremental mode (Yices does not support mixing quantifiers and incremental solving) but smtbmc itself did not switch into nonincremental mode, so solving always failed.