### PR TITLE
fmcombine: Add _gold/_gate suffix to memids

### DIFF
--- a/passes/sat/fmcombine.cc
+++ b/passes/sat/fmcombine.cc
@@ -64,6 +64,9 @@ struct FmcombineWorker
 		c->parameters = cell->parameters;
 		c->attributes = cell->attributes;
 
+		if (cell->is_mem_cell())
+			c->parameters[ID::MEMID] = cell->parameters[ID::MEMID].decode_string() + suffix;
+
 		for (auto &conn : cell->connections())
 			c->setPort(conn.first, import_sig(conn.second, suffix));
 


### PR DESCRIPTION
Without suffixes for memids fmcombine will always produce a collision when any mem cell is present. Adding suffixes fixes the assertion triggered in YosysHQ/mcy#32.

@mwkmwkmwk Should `Module::check()` check that the memid of a packed memory isn't used by any other mem cell? Or at least `get_all_memories`? Other passes that inline module contents like `flatten` and `techmap` already do such memid renaming and any pass like `write_smt2` that uses `get_all_memories` to handle both packed and unpacked memories in a uniform way will most likely run into issues with multiple packed memories sharing the same memid, so checking against this early sounds like a good idea to me.