### PR TITLE
sta: warn on unrecognised cells only once

### DIFF
--- a/passes/cmds/sta.cc
+++ b/passes/cmds/sta.cc
@@ -58,11 +58,14 @@ struct StaWorker
 	{
 		TimingInfo timing;
 
+		pool<IdString> unrecognised_cells;
+
 		for (auto cell : module->cells())
 		{
 			Module *inst_module = design->module(cell->type);
 			if (!inst_module) {
-				log_warning("Cell type '%s' not recognised! Ignoring.\n", log_id(cell->type));
+				if (unrecognised_cells.insert(cell->type).second)
+					log_warning("Cell type '%s' not recognised! Ignoring.\n", log_id(cell->type));
 				continue;
 			}
 


### PR DESCRIPTION
I got a bit tired of being spammed with warnings in complex designs.