### PR TITLE
Use compiler-generated default  copy constructor for RTLIL::Const::Const

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -204,7 +204,7 @@ RTLIL::Const::Const()
 	flags = RTLIL::CONST_FLAG_NONE;
 }
 
-RTLIL::Const::Const(std::string str)
+RTLIL::Const::Const(const std::string &str)
 {
 	flags = RTLIL::CONST_FLAG_STRING;
 	bits.reserve(str.size() * 8);
@@ -241,14 +241,6 @@ RTLIL::Const::Const(const std::vector<bool> &bits)
 	this->bits.reserve(bits.size());
 	for (const auto &b : bits)
 		this->bits.emplace_back(b ? State::S1 : State::S0);
-}
-
-RTLIL::Const::Const(const RTLIL::Const &c)
-{
-	flags = c.flags;
-	this->bits.reserve(c.size());
-	for (const auto &b : c.bits)
-		this->bits.push_back(b);
 }
 
 bool RTLIL::Const::operator <(const RTLIL::Const &other) const

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -636,12 +636,12 @@ struct RTLIL::Const
 	std::vector<RTLIL::State> bits;
 
 	Const();
-	Const(std::string str);
+	Const(const std::string &str);
 	Const(int val, int width = 32);
 	Const(RTLIL::State bit, int width = 1);
 	Const(const std::vector<RTLIL::State> &bits) : bits(bits) { flags = CONST_FLAG_NONE; }
 	Const(const std::vector<bool> &bits);
-	Const(const RTLIL::Const &c);
+	Const(const RTLIL::Const &c) = default;
 	RTLIL::Const &operator =(const RTLIL::Const &other) = default;
 
 	bool operator <(const RTLIL::Const &other) const;


### PR DESCRIPTION
No need for a manual implementation.
While at it: have the constructor that takes a string take a
const string reference instead to avoid a copy.