### PR TITLE
Add check for BLIF with no model name

### DIFF
--- a/frontends/blif/blifparse.cc
+++ b/frontends/blif/blifparse.cc
@@ -166,7 +166,10 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 					goto error;
 				module = new RTLIL::Module;
 				lastcell = nullptr;
-				module->name = RTLIL::escape_id(strtok(NULL, " \t\r\n"));
+				char *name = strtok(NULL, " \t\r\n");
+				if (name == nullptr)
+					goto error;
+				module->name = RTLIL::escape_id(name);
 				obj_attributes = &module->attributes;
 				obj_parameters = nullptr;
 				if (design->module(module->name))

--- a/tests/blif/bug3374.ys
+++ b/tests/blif/bug3374.ys
@@ -1,0 +1,3 @@
+read_blif <<EOF
+.model
+EOF

--- a/tests/blif/bug3374.ys
+++ b/tests/blif/bug3374.ys
@@ -1,3 +1,4 @@
+logger -expect error "Syntax error in line 1!" 1
 read_blif <<EOF
 .model
 EOF


### PR DESCRIPTION
Add a check when parsing BLIF that model name is not nullptr.
Fixes #3374 