### PR TITLE
smt2, btor: Use memory_map -rom-only to make ROMs usable for k-induction

### DIFF
--- a/backends/btor/btor.cc
+++ b/backends/btor/btor.cc
@@ -1402,6 +1402,7 @@ struct BtorBackend : public Backend {
 		log_header(design, "Executing BTOR backend.\n");
 
 		log_push();
+		Pass::call(design, "memory_map -rom-only");
 		Pass::call(design, "bmuxmap");
 		Pass::call(design, "demuxmap");
 		log_pop();

--- a/backends/smt2/smt2.cc
+++ b/backends/smt2/smt2.cc
@@ -1609,6 +1609,7 @@ struct Smt2Backend : public Backend {
 		log_header(design, "Executing SMT2 backend.\n");
 
 		log_push();
+		Pass::call(design, "memory_map -rom-only");
 		Pass::call(design, "bmuxmap");
 		Pass::call(design, "demuxmap");
 		log_pop();


### PR DESCRIPTION
This avoids provability regressions now that we infer more ROMs.

This fixes #3378