### PR TITLE
Support parameter default values in JSON frontend and Verilog backend

### DIFF
--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -395,6 +395,14 @@ void dump_attributes(std::ostream &f, std::string indent, dict<RTLIL::IdString, 
 	}
 }
 
+void dump_parameter(std::ostream &f, std::string indent, RTLIL::IdString id_string, RTLIL::Const parameter)
+{
+	f << stringf("%sparameter %s", indent.c_str(), id(id_string).c_str());
+	f << stringf(" = ");
+	dump_const(f, parameter);
+	f << stringf(";\n");
+}
+
 void dump_wire(std::ostream &f, std::string indent, RTLIL::Wire *wire)
 {
 	dump_attributes(f, indent, wire->attributes, '\n', /*modattr=*/false, /*regattr=*/reg_wires.count(wire->name));
@@ -2083,6 +2091,9 @@ void dump_module(std::ostream &f, std::string indent, RTLIL::Module *module)
 		initial_id = NEW_ID;
 		f << indent + "  " << "reg " << id(initial_id) << " = 0;\n";
 	}
+
+	for (auto p : module->parameter_default_values)
+		dump_parameter(f, indent + "  ", p.first, p.second);
 
 	for (auto w : module->wires())
 		dump_wire(f, indent + "  ", w);

--- a/frontends/json/jsonparse.cc
+++ b/frontends/json/jsonparse.cc
@@ -302,6 +302,9 @@ void json_import(Design *design, string &modname, JsonNode *node)
 	if (node->data_dict.count("attributes"))
 		json_parse_attr_param(module->attributes, node->data_dict.at("attributes"));
 
+	if (node->data_dict.count("parameter_default_values"))
+		json_parse_attr_param(module->parameter_default_values, node->data_dict.at("parameter_default_values"));
+
 	dict<int, SigBit> signal_bits;
 
 	if (node->data_dict.count("ports"))


### PR DESCRIPTION
This enables the reading in of the `parameter_default_values` value in JSON, and the writing out of the value in Verilog.