### PR TITLE
Support ids as consts

### DIFF
--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -395,6 +395,14 @@ void dump_attributes(std::ostream &f, std::string indent, dict<RTLIL::IdString, 
 	}
 }
 
+void dump_parameter(std::ostream &f, std::string indent, RTLIL::IdString id_string, RTLIL::Const parameter)
+{
+	f << stringf("%sparameter %s", indent.c_str(), id(id_string).c_str());
+	f << stringf(" = ");
+	dump_const(f, parameter);
+	f << stringf(";\n");
+}
+
 void dump_wire(std::ostream &f, std::string indent, RTLIL::Wire *wire)
 {
 	dump_attributes(f, indent, wire->attributes, '\n', /*modattr=*/false, /*regattr=*/reg_wires.count(wire->name));
@@ -2083,6 +2091,9 @@ void dump_module(std::ostream &f, std::string indent, RTLIL::Module *module)
 		initial_id = NEW_ID;
 		f << indent + "  " << "reg " << id(initial_id) << " = 0;\n";
 	}
+
+	for (auto p : module->parameter_default_values)
+		dump_parameter(f, indent + "  ", p.first, p.second);
 
 	for (auto w : module->wires())
 		dump_wire(f, indent + "  ", w);

--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -188,6 +188,11 @@ bool is_reg_wire(RTLIL::SigSpec sig, std::string &reg_name)
 
 void dump_const(std::ostream &f, const RTLIL::Const &data, int width = -1, int offset = 0, bool no_decimal = false, bool escape_comment = false)
 {
+	if (data.flags & RTLIL::CONST_FLAG_ID) {
+		f << stringf("%s", data.decode_string().c_str());
+		return;
+	}
+
 	bool set_signed = (data.flags & RTLIL::CONST_FLAG_SIGNED) != 0;
 	if (width < 0)
 		width = data.bits.size() - offset;

--- a/frontends/json/jsonparse.cc
+++ b/frontends/json/jsonparse.cc
@@ -302,6 +302,9 @@ void json_import(Design *design, string &modname, JsonNode *node)
 	if (node->data_dict.count("attributes"))
 		json_parse_attr_param(module->attributes, node->data_dict.at("attributes"));
 
+	if (node->data_dict.count("parameter_default_values"))
+		json_parse_attr_param(module->parameter_default_values, node->data_dict.at("parameter_default_values"));
+
 	dict<int, SigBit> signal_bits;
 
 	if (node->data_dict.count("ports"))

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -50,7 +50,8 @@ namespace RTLIL
 		CONST_FLAG_NONE   = 0,
 		CONST_FLAG_STRING = 1,
 		CONST_FLAG_SIGNED = 2,  // only used for parameters
-		CONST_FLAG_REAL   = 4   // only used for parameters
+		CONST_FLAG_REAL   = 4,  // only used for parameters
+		CONST_FLAG_ID     = 5
 	};
 
 	struct Const;


### PR DESCRIPTION
Please deal with #3389 first; leaving this as a draft until that PR is dealt with.

This enables using identifiers as constant values. Specifically, this is useful for when we want to use a module parameter to initialize a cell's parameter, e.g.:

```
module test(...);
  parameter p = ...;
  ...
  MyCell #(.my_cell_param(p) mycell0 (...);
endmodule
```

This is a bit of a hack; please advise on how to do this in a more Yosys-friendly way!