### PR TITLE
Update tcl doc, yosys does not return data to tcl

### DIFF
--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -774,6 +774,12 @@ struct TclPass : public Pass {
 		log("If any arguments are specified, these arguments are provided to the script via\n");
 		log("the standard $argc and $argv variables.\n");
 		log("\n");
+		log("Note, tcl will not recieve the output of any yosys command. If the output\n");
+		log("of the tcl commands are needed, use the yosys command 'tee' to redirect yosys's\n");
+		log("output to a temporary file.\n");
+
+
+		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *) override {
 		if (args.size() < 2)

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -777,8 +777,6 @@ struct TclPass : public Pass {
 		log("Note, tcl will not recieve the output of any yosys command. If the output\n");
 		log("of the tcl commands are needed, use the yosys command 'tee' to redirect yosys's\n");
 		log("output to a temporary file.\n");
-
-
 		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *) override {


### PR DESCRIPTION
This pull request is to address YosysHQ/yosys#2980.

The documentation, as originally written, does not make it clear that yosys commands, when used within a tcl script, do not return any value to the tcl script.

This pull request notes this and offers a workaround via tee as noted in the issue.