### PR TITLE
memory_map: -keepdc option for formal

### DIFF
--- a/backends/btor/btor.cc
+++ b/backends/btor/btor.cc
@@ -1405,7 +1405,7 @@ struct BtorBackend : public Backend {
 		log_header(design, "Executing BTOR backend.\n");
 
 		log_push();
-		Pass::call(design, "memory_map -rom-only");
+		Pass::call(design, "memory_map -rom-only -keepdc");
 		Pass::call(design, "bmuxmap");
 		Pass::call(design, "demuxmap");
 		log_pop();

--- a/backends/smt2/smt2.cc
+++ b/backends/smt2/smt2.cc
@@ -1609,7 +1609,7 @@ struct Smt2Backend : public Backend {
 		log_header(design, "Executing SMT2 backend.\n");
 
 		log_push();
-		Pass::call(design, "memory_map -rom-only");
+		Pass::call(design, "memory_map -rom-only -keepdc");
 		Pass::call(design, "bmuxmap");
 		Pass::call(design, "demuxmap");
 		log_pop();


### PR DESCRIPTION
Use it when invoking memory_map -rom-only from write_{smt2,btor}.