### PR TITLE
async2sync: turn FFs with const clks into gclk FFs with feedback

### DIFF
--- a/passes/sat/async2sync.cc
+++ b/passes/sat/async2sync.cc
@@ -75,6 +75,9 @@ struct Async2syncPass : public Pass {
 				if (ff.has_gclk)
 					continue;
 
+				if (ff.has_clk && ff.sig_clk.is_fully_const())
+					ff.has_ce = ff.has_clk = ff.has_srst = false;
+
 				if (ff.has_clk)
 				{
 					if (ff.has_sr) {


### PR DESCRIPTION
The formal backends do not support multiple clocks. This includes
constant clocks. Constant clocks do appear in what isn't a proper
multiclock design, for example when mapping not fully initialized ROMs.
As converting FFs with constant clocks to FFs using the global is doable
even in a single clock flow, make async2sync do this.