### PR TITLE
Add support for GHDL modfloor operator to cxxrtl backend

### DIFF
--- a/backends/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/cxxrtl.h
@@ -1575,6 +1575,27 @@ value<BitsY> mod_ss(const value<BitsA> &a, const value<BitsB> &b) {
 	return divmod_ss<BitsY>(a, b).second;
 }
 
+template<size_t BitsY, size_t BitsA, size_t BitsB>
+CXXRTL_ALWAYS_INLINE
+value<BitsY> modfloor_uu(const value<BitsA> &a, const value<BitsB> &b) {
+	return divmod_uu<BitsY>(a, b).second;
+}
+
+// GHDL Modfloor operator. Returns r=a mod b, such that r has the same sign as b and
+// a=b*N+r where N is some integer
+// In practical terms, when a and b have different signs and the remainder returned by divmod_ss is not 0
+// then return the remainder + b
+template<size_t BitsY, size_t BitsA, size_t BitsB>
+CXXRTL_ALWAYS_INLINE
+value<BitsY> modfloor_ss(const value<BitsA> &a, const value<BitsB> &b) {
+	value<BitsY> r;
+	r = divmod_ss<BitsY>(a, b).second;
+	if((b.is_neg() != a.is_neg()) && !r.is_zero())
+		return add_ss<BitsY>(b, r);
+	return r;
+}
+
+
 // Memory helper
 struct memory_index {
 	bool valid;

--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -185,7 +185,7 @@ bool is_binary_cell(RTLIL::IdString type)
 		ID($and), ID($or), ID($xor), ID($xnor), ID($logic_and), ID($logic_or),
 		ID($shl), ID($sshl), ID($shr), ID($sshr), ID($shift), ID($shiftx),
 		ID($eq), ID($ne), ID($eqx), ID($nex), ID($gt), ID($ge), ID($lt), ID($le),
-		ID($add), ID($sub), ID($mul), ID($div), ID($mod));
+		ID($add), ID($sub), ID($mul), ID($div), ID($mod), ID($modfloor));
 }
 
 bool is_extending_cell(RTLIL::IdString type)


### PR DESCRIPTION
ghdl-yosys-plugin generates $modfloor cells when it encounters a statement like so:
`r <= a mod b;`. 
This PR adds support for such statements to the cxxrtl backend. The behavior of the unsigned and signed implementations has been verified against GHDL's behavior in simulation. 