### PR TITLE
Better compatibility for OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -450,9 +450,12 @@ endif
 ifeq ($(ENABLE_TCL),1)
 TCL_VERSION ?= tcl$(shell bash -c "tclsh <(echo 'puts [info tclversion]')")
 ifeq ($(OS), $(filter $(OS),FreeBSD OpenBSD NetBSD))
+# BSDs usually use tcl8.6, but the lib is named "libtcl86"
 TCL_INCLUDE ?= /usr/local/include/$(TCL_VERSION)
+TCL_LIBS ?= -l$(subst .,,$(TCL_VERSION))
 else
 TCL_INCLUDE ?= /usr/include/$(TCL_VERSION)
+TCL_LIBS ?= -l$(TCL_VERSION)
 endif
 
 ifeq ($(CONFIG),mxe)
@@ -460,12 +463,7 @@ CXXFLAGS += -DYOSYS_ENABLE_TCL
 LDLIBS += -ltcl86 -lwsock32 -lws2_32 -lnetapi32 -lz -luserenv
 else
 CXXFLAGS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --cflags tcl || echo -I$(TCL_INCLUDE)) -DYOSYS_ENABLE_TCL
-ifeq ($(OS), $(filter $(OS),FreeBSD OpenBSD NetBSD))
-# BSDs usually use tcl8.6, but the lib is named "libtcl86"
-LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --libs tcl || echo -l$(TCL_VERSION) | tr -d '.')
-else
-LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --libs tcl || echo -l$(TCL_VERSION))
-endif
+LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --libs tcl || echo $(TCL_LIBS))
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,9 @@ endif
 
 else
 LDFLAGS += -rdynamic
+ifneq ($(OS), OpenBSD)
 LDLIBS += -lrt
+endif
 endif
 
 YOSYS_VER := 0.19+18
@@ -395,7 +397,7 @@ endif # ENABLE_PYOSYS
 
 ifeq ($(ENABLE_READLINE),1)
 CXXFLAGS += -DYOSYS_ENABLE_READLINE
-ifeq ($(OS), FreeBSD)
+ifeq ($(OS), $(filter $(OS),FreeBSD OpenBSD NetBSD))
 CXXFLAGS += -I/usr/local/include
 endif
 LDLIBS += -lreadline
@@ -430,7 +432,7 @@ endif
 ifeq ($(ENABLE_PLUGINS),1)
 CXXFLAGS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --cflags libffi) -DYOSYS_ENABLE_PLUGINS
 LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --libs libffi || echo -lffi)
-ifneq ($(OS), FreeBSD)
+ifneq ($(OS), $(filter $(OS),FreeBSD OpenBSD NetBSD))
 LDLIBS += -ldl
 endif
 endif
@@ -447,7 +449,7 @@ endif
 
 ifeq ($(ENABLE_TCL),1)
 TCL_VERSION ?= tcl$(shell bash -c "tclsh <(echo 'puts [info tclversion]')")
-ifeq ($(OS), FreeBSD)
+ifeq ($(OS), $(filter $(OS),FreeBSD OpenBSD NetBSD))
 TCL_INCLUDE ?= /usr/local/include/$(TCL_VERSION)
 else
 TCL_INCLUDE ?= /usr/include/$(TCL_VERSION)
@@ -458,8 +460,8 @@ CXXFLAGS += -DYOSYS_ENABLE_TCL
 LDLIBS += -ltcl86 -lwsock32 -lws2_32 -lnetapi32 -lz -luserenv
 else
 CXXFLAGS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --cflags tcl || echo -I$(TCL_INCLUDE)) -DYOSYS_ENABLE_TCL
-ifeq ($(OS), FreeBSD)
-# FreeBSD uses tcl8.6, but lib is named "libtcl86"
+ifeq ($(OS), $(filter $(OS),FreeBSD OpenBSD NetBSD))
+# BSDs usually use tcl8.6, but the lib is named "libtcl86"
 LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --libs tcl || echo -l$(TCL_VERSION) | tr -d '.')
 else
 LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --libs tcl || echo -l$(TCL_VERSION))

--- a/libs/fst/config.h
+++ b/libs/fst/config.h
@@ -21,7 +21,7 @@
 #undef HAVE_LIBPTHREAD
 #undef HAVE_FSEEKO
 #endif
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 #undef HAVE_ALLOCA_H
 #endif
 


### PR DESCRIPTION
These three commits are all it takes to compile the yosys part!

```
$ gmake ENABLE_TCL=0 ENABLE_READLINE=0
[Makefile.conf] CONFIG := clang
[  0%] Building kernel/version_52c275a8c.cc
[  0%] Building kernel/version_52c275a8c.o
[100%] Building yosys
/usr/local/bin/ld: libs/fst/fstapi.o: in function `fstWriterEmitHdrBytes(fstWriterContext*)':
/home/josuah/Code/yosys/libs/fst/fstapi.cc:893: warning: strcpy() is almost always misused, please use strlcpy()
/usr/local/bin/ld: libs/fst/fstapi.o: in function `fstWriterClose':
/home/josuah/Code/yosys/libs/fst/fstapi.cc:1994: warning: sprintf() is often misused, please use snprintf()
[100%] Building yosys-config
[100%] Building abc/abc-5f40c47
Pulling ABC from https://github.com/YosysHQ/abc:
+ test -d abc
+ git clone https://github.com/YosysHQ/abc abc
Cloning into 'abc'...
[...]
[100%] Building share/xilinx/mux_map.v
[100%] Building share/xilinx/xc3s_mult_map.v
[100%] Building share/xilinx/xc3sda_dsp_map.v
[100%] Building share/xilinx/xc6s_dsp_map.v
[100%] Building share/xilinx/xc4v_dsp_map.v
[100%] Building share/xilinx/xc5v_dsp_map.v
[100%] Building share/xilinx/xc7_dsp_map.v
[100%] Building share/xilinx/xcu_dsp_map.v
[100%] Building share/xilinx/abc9_model.v

  Build successful.

```

And then the compilation of https://github.com/YosysHQ/abc pursue, another topic.

I am not sure how many yosys OpenBSD users there are, but yosys is on [OpenBSD ports tree with a few patches](https://github.com/openbsd/ports/tree/master/cad/yosys/patches).

[EDIT: completed the log to show the end of the build happening on my setup]