### PR TITLE
Fallback for finding the executable directory

### DIFF
--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -498,6 +498,12 @@ int main(int argc, char **argv)
 	if (print_stats)
 		log_hasher = new SHA1;
 
+#if defined(__OpenBSD__)
+	// save the executable origin for proc_self_dirname()
+	yosys_argv0 = argv[0];
+	realpath(yosys_argv0, yosys_path);
+#endif
+
 #if defined(__linux__)
 	// set stack size to >= 128 MB
 	{

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -871,6 +871,35 @@ std::string proc_self_dirname()
 {
 	return "/";
 }
+#elif defined(__OpenBSD__)
+char Yosys::yosys_path[PATH_MAX];
+char *Yosys::yosys_argv0;
+
+std::string proc_self_dirname(void)
+{
+	char buf[PATH_MAX + 1] = "", *path, *p;
+	// if case argv[0] contains a valid path, return it
+	if (strlen(yosys_path) > 0) {
+		p = strrchr(yosys_path, '/');
+		snprintf(buf, sizeof buf, "%*s/", (int)(yosys_path - p), yosys_path);
+		return buf;
+	}
+	// if argv[0] does not, reconstruct the path out of $PATH
+	path = strdup(getenv("PATH"));
+	if (!path)
+		log_error("getenv(\"PATH\") failed: %s\n",  strerror(errno));
+	for (p = strtok(path, ":"); p; p = strtok(NULL, ":")) {
+		snprintf(buf, sizeof buf, "%s/%s", p, yosys_argv0);
+		if (access(buf, X_OK) == 0) {
+			*(strrchr(buf, '/') + 1) = '\0';
+			free(path);
+			return buf;
+		}
+	}
+	free(path);
+	log_error("Can't determine yosys executable path\n.");
+	return NULL;
+}
 #else
 	#error "Don't know how to determine process executable base path!"
 #endif

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -361,6 +361,10 @@ extern std::set<std::string> yosys_input_files, yosys_output_files;
 // from kernel/version_*.o (cc source generated from Makefile)
 extern const char *yosys_version_str;
 
+// from kernel/driver.cc
+extern char *yosys_argv0;
+extern char yosys_path[PATH_MAX];
+
 // from passes/cmds/design.cc
 extern std::map<std::string, RTLIL::Design*> saved_designs;
 extern std::vector<RTLIL::Design*> pushed_designs;


### PR DESCRIPTION
In reference to #3406, this change is independent and touches different files.

The path is reconstructed out of argv[0], directly or from $PATH
depending on how the binary was called.

For instance, multiple operating systems do not support "/proc/self/exe":
https://marc.info/?l=openbsd-misc&m=144987773230417&w=2

But most will support access(2) and realpath(3) as used in this
approach.