### PR TITLE
resetall does not affect text defines, but undefineall does

### DIFF
--- a/frontends/verilog/preproc.cc
+++ b/frontends/verilog/preproc.cc
@@ -961,6 +961,10 @@ frontend_verilog_preproc(std::istream                 &f,
 		}
 
 		if (tok == "`resetall") {
+			continue;
+		}
+
+		if (tok == "`undefineall" && sv_mode) {
 			defines.clear();
 			global_defines_cache.clear();
 			continue;

--- a/frontends/verilog/preproc.cc
+++ b/frontends/verilog/preproc.cc
@@ -961,6 +961,7 @@ frontend_verilog_preproc(std::istream                 &f,
 		}
 
 		if (tok == "`resetall") {
+			default_nettype_wire = true;
 			continue;
 		}
 


### PR DESCRIPTION
According to specs text macros are not affected by `resetall but they are with `undefineall (which is SystemVerilog only)

This fixes https://github.com/YosysHQ/yosys/issues/3410 