### PR TITLE
WIP: Proc dff complex aldff

### DIFF
--- a/passes/opt/opt_dff.cc
+++ b/passes/opt/opt_dff.cc
@@ -571,11 +571,23 @@ struct OptDffWorker
 				}
 			}
 
-			if (ff.has_aload && !ff.has_clk && ff.sig_ad == ff.sig_q) {
-				log("Handling AD = Q on %s (%s) from module %s (removing async load path).\n",
-						log_id(cell), log_id(cell->type), log_id(module));
-				ff.has_aload = false;
-				changed = true;
+			if (ff.has_aload && ff.sig_ad == ff.sig_q) {
+				if (ff.has_clk) {
+					log_assert(!ff.has_ce);
+					log("Handling AD = Q on %s (%s) from module %s (turning async load feedback into CE).\n",
+							log_id(cell), log_id(cell->type), log_id(module));
+					ff.sig_ce = ff.sig_aload;
+					ff.pol_ce = !ff.pol_aload;
+					ff.has_ce = true;
+					ff.has_aload = false;
+					ff.has_ce = true;
+					changed = true;
+				} else {
+					log("Handling AD = Q on %s (%s) from module %s (removing async load path).\n",
+							log_id(cell), log_id(cell->type), log_id(module));
+					ff.has_aload = false;
+					changed = true;
+				}
 			}
 
 			// The cell has been simplified as much as possible already.  Now try to spice it up with enables / sync resets.


### PR DESCRIPTION
This is a WIP/quick-test that makes proc_dff use $aldff instead of $dffsr for complex async FFs, making it more similar to the verific
frontend.

The new gen_aldff_complex is a straight-forward adaption of gen_dffsr_complex, and arguably implementing the logic using $aldff is simpler than using $dffsr.

This enables it unconditionally and leaves gen_dffsr_complex as dead code. Most likely should be an option.

It also breaks a few tests, and I have not looked into whether that are actual bugs or just violates assumptions made by tests.

Also contains a simple optimization that can turn $aldff with Q->AD feedback into $dffce, making the output of the testcase in #3442 match the verific frontend. There are more optimizations that could be done on $aldff cells, applicable to both frontends, but implementing those would be a lot more involved.

I do not plan to continue on this for now, just leaving it here in case this comes up again.