### PR TITLE
yosys: passes: cmds: show: added filename re-writing to `show -lib`

### DIFF
--- a/passes/cmds/show.cc
+++ b/passes/cmds/show.cc
@@ -825,6 +825,7 @@ struct ShowPass : public Pass {
 
 		for (auto filename : libfiles) {
 			std::ifstream f;
+			rewrite_filename(filename);
 			f.open(filename.c_str());
 			yosys_input_files.insert(filename);
 			if (f.fail())


### PR DESCRIPTION
This PR adds file re-writing to the `show -lib` command to allow for `+/` paths. This closes #409