### PR TITLE
write_aiger: Fix non-$_FF_ FFs

### DIFF
--- a/backends/aiger/aiger.cc
+++ b/backends/aiger/aiger.cc
@@ -202,7 +202,7 @@ struct AigerWriter
 				ff_map[Q] = D;
 
 				if (cell->type != ID($_FF_)) {
-					auto sig_clk = sigmap(cell->getPort(ID::CLK).as_bit());
+					auto sig_clk = sigmap(cell->getPort(ID::C).as_bit());
 					ywmap_clocks[sig_clk] |= cell->type == ID($_DFF_N_) ? 2 : 1;
 				}
 				continue;

--- a/tests/various/aiger_dff.ys
+++ b/tests/various/aiger_dff.ys
@@ -1,0 +1,7 @@
+read_verilog -icells <<EOT
+module top(input clk, d, output q);
+\$_DFF_N_ dffn(.C(clk), .D(d), .Q(q));
+endmodule
+EOT
+write_aiger -zinit -ywmap aiger_dff.out /dev/null
+!grep -qF negedge aiger_dff.out


### PR DESCRIPTION
This broke while switching sby's formal flows to always use $_FF_'s.