### PR TITLE
read_liberty: respect `dont_use` attribute of cells in `.lib` file

### DIFF
--- a/manual/command-reference-manual.tex
+++ b/manual/command-reference-manual.tex
@@ -4034,6 +4034,9 @@ Read cells from liberty file as modules into current design.
 
     -setattr <attribute_name>
         set the specified attribute (to the value 1) on all loaded modules
+
+    -ignore_dont_use
+        ignore dont_use attribute in cell description of lib file
 \end{lstlisting}
 
 \section{read\_rtlil -- read modules from RTLIL file}


### PR DESCRIPTION
First of all really cool project 💯 

I am currently working on a project where I use `yosys` extensively. I really like the tool :-). I noticed that when I use `read_liberty` it just imports all the cells whether or not they do have the `dont_use` flag. 

I saw that this filtering is implemented for `dfflibmap`. https://github.com/YosysHQ/yosys/blob/55e8f5061af57bf25bd9e30528de8196c6eabe9e/passes/techmap/dfflibmap.cc#L134-L136

This PR adds this filtering to `read_liberty`. It also adds the option to deactivate the filtering to go back to the previous behaviour using the `-ignore_dont_use` flag.

I do believe that filtering the `dont_use` should be the default behaviour but we can also change it to non-default.
