### PR TITLE
simplify: Do not recursively simplify AST_CELL within AST_CELLARRAY

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1627,6 +1627,8 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 			break;
 		if (type == AST_GENBLOCK)
 			break;
+		if (type == AST_CELLARRAY && children[i]->type == AST_CELL)
+			continue;
 		if (type == AST_BLOCK && !str.empty())
 			break;
 		if (type == AST_PREFIX && i >= 1)

--- a/tests/various/cellarray_array_connections.ys
+++ b/tests/various/cellarray_array_connections.ys
@@ -1,0 +1,45 @@
+# Regression test for #3467
+read_verilog <<EOT
+
+module bit_buf (
+    input wire bit_in,
+    output wire bit_out
+);
+    assign bit_out = bit_in;
+endmodule
+
+module top (
+	input wire [3:0] data_in,
+	output wire [3:0] data_out
+);
+
+    wire [3:0] data [0:4];
+
+    assign data[0] = data_in;
+    assign data_out = data[4];
+
+	genvar i;
+	generate
+		for (i=0; i<=3; i=i+1) begin
+			bit_buf bit_buf_instance[3:0] (
+				.bit_in(data[i]),
+				.bit_out(data[i + 1])
+			);
+		end
+	endgenerate
+endmodule
+
+module top2 (
+	input wire [3:0] data_in,
+	output wire [3:0] data_out
+);
+    assign data_out = data_in;
+endmodule
+
+EOT
+
+hierarchy
+proc
+
+miter -equiv -make_assert -flatten top top2 miter
+sat -prove-asserts -verify miter


### PR DESCRIPTION
Otherwise the AST_CELL simplification uses the wrong celltype before the AST_CELLARRAY simplification has a chance to unroll it and change it to the $array... celltype.

- [x] Add regression tests to this PR.