### PR TITLE
Fix tmpdir naming when passing -nocleanup option to abc(9) on mac

### DIFF
--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -782,9 +782,12 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 	if (dff_mode && clk_sig.empty())
 		log_cmd_error("Clock domain %s not found.\n", clk_str.c_str());
 
-	std::string tempdir_name = get_base_tmpdir() + "/" + proc_program_prefix()+ "yosys-abc-XXXXXX";
-	if (!cleanup)
-		tempdir_name[0] = tempdir_name[4] = '_';
+	std::string tempdir_name;
+	if (cleanup) 
+		tempdir_name = get_base_tmpdir() + "/";
+	else
+		tempdir_name = "_tmp_";
+	tempdir_name += proc_program_prefix() + "yosys-abc-XXXXXX";
 	tempdir_name = make_temp_dir(tempdir_name);
 	log_header(design, "Extracting gate netlist of module `%s' to `%s/input.blif'..\n",
 			module->name.c_str(), replace_tempdir(tempdir_name, tempdir_name, show_tempdir).c_str());

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -404,9 +404,12 @@ struct Abc9Pass : public ScriptPass
 					if (!active_design->selected_whole_module(mod))
 						log_error("Can't handle partially selected module %s!\n", log_id(mod));
 
-					std::string tempdir_name = get_base_tmpdir() + "/" + proc_program_prefix() + "yosys-abc-XXXXXX";
-					if (!cleanup)
-						tempdir_name[0] = tempdir_name[4] = '_';
+					std::string tempdir_name;
+					if (cleanup) 
+						tempdir_name = get_base_tmpdir() + "/";
+					else
+						tempdir_name = "_tmp_";
+					tempdir_name += proc_program_prefix() + "yosys-abc-XXXXXX";
 					tempdir_name = make_temp_dir(tempdir_name);
 
 					if (!lut_mode)


### PR DESCRIPTION
#3333 changed the base directory for the abc tmpdir to use `$TMPDIR`, but didn't change the path rewriting logic for the `-nocleanup` option which assumed that the base directory is `/tmp/`.

This fixes that logic so that the `-nocleanup` option works even on systems (like macOS) where `$TMPDIR` is not `/tmp/`.