### PR TITLE
stat: fix and improve JSON report

### DIFF
--- a/passes/cmds/stat.cc
+++ b/passes/cmds/stat.cc
@@ -289,14 +289,14 @@ struct statdata_t
 		if (tech == "xilinx")
 		{
 			log(",\n");
-			log("         \"estimated_num_lc\": %10u", estimate_xilinx_lc());
+			log("         \"estimated_num_lc\": %u", estimate_xilinx_lc());
 		}
 		if (tech == "cmos")
 		{
 			bool tran_cnt_exact = true;
 			unsigned int tran_cnt = cmos_transistor_count(&tran_cnt_exact);
 			log(",\n");
-			log("         \"estimated_num_transistors\": \"%10u%s\"", tran_cnt, tran_cnt_exact ? "" : "+");
+			log("         \"estimated_num_transistors\": \"%u%s\"", tran_cnt, tran_cnt_exact ? "" : "+");
 		}
 		log("\n");
 		log("      }");


### PR DESCRIPTION
Currently, the JSON report does not include any of the technology-specific numbers.
 - refactor resource utilization estimation/calculations for Xilinx and CMOS
 - add tech tech-specific utilizations to json

The generated output (used for example with "tee" to redirect to a file), is not a valid JSON, as it includes a log header text ("x. Printing statistics.")/
 - don't print log_header if the "-json" flag is provided.