### PR TITLE
Fix crash in flowmap

### DIFF
--- a/passes/techmap/flowmap.cc
+++ b/passes/techmap/flowmap.cc
@@ -1406,7 +1406,8 @@ struct FlowmapWorker
 			RTLIL::SigSpec lut_a, lut_y = node;
 			for (auto input_node : input_nodes)
 				lut_a.append(input_node);
-			lut_a.append(RTLIL::Const(State::Sx, minlut - input_nodes.size()));
+			if ((int)input_nodes.size() < minlut)
+				lut_a.append(RTLIL::Const(State::Sx, minlut - input_nodes.size()));
 
 			RTLIL::Cell *lut = module->addLut(NEW_ID, lut_a, lut_y, lut_table);
 			mapped_nodes.insert(node);


### PR DESCRIPTION
In 2fcc1ee72e, the following is apparantly added in order to mark any number of undefined LUT inputs:

lut_a.append(RTLIL::Const(State::Sx, minlut - input_nodes.size()));

However this can only be done if the number of input nodes is less than minlut.

This fixes #3317