### PR TITLE
Fix hard-coded path to /bin/bash -> /usr/bin/env bash

### DIFF
--- a/misc/yosys-config.in
+++ b/misc/yosys-config.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 help() {
 	{


### PR DESCRIPTION
On Posix systems, the path /bin/bash is not guaranteed to exist and it is more portable to use /usr/bin/env instead.

Fixing this for yosys-config with is the most important for a functioning installation.
