### PR TITLE
equiv_opt and clk2fflogic fixes

### DIFF
--- a/passes/equiv/equiv_make.cc
+++ b/passes/equiv/equiv_make.cc
@@ -137,6 +137,7 @@ struct EquivMakeWorker
 	{
 		SigMap assign_map(equiv_mod);
 		SigMap rd_signal_map;
+		SigPool primary_inputs;
 
 		// list of cells without added $equiv cells
 		auto cells_list = equiv_mod->cells().to_vector();
@@ -252,6 +253,9 @@ struct EquivMakeWorker
 				gate_wire->port_input = false;
 				equiv_mod->connect(gold_wire, wire);
 				equiv_mod->connect(gate_wire, wire);
+				primary_inputs.add(assign_map(gold_wire));
+				primary_inputs.add(assign_map(gate_wire));
+				primary_inputs.add(wire);
 			}
 			else
 			{
@@ -283,6 +287,9 @@ struct EquivMakeWorker
 			if (!ct.cell_output(c->type, conn.first)) {
 				SigSpec old_sig = assign_map(conn.second);
 				SigSpec new_sig = rd_signal_map(old_sig);
+				for (int i = 0; i < GetSize(old_sig); i++)
+					if (primary_inputs.check(old_sig[i]))
+						new_sig[i] = old_sig[i];
 				if (old_sig != new_sig) {
 					log("Changing input %s of cell %s (%s): %s -> %s\n",
 							log_id(conn.first), log_id(c), log_id(c->type),

--- a/tests/arch/ice40/bug1597.ys
+++ b/tests/arch/ice40/bug1597.ys
@@ -70,4 +70,4 @@ EOT
 read_verilog -lib +/ice40/cells_sim.v
 hierarchy -top top
 flatten
-equiv_opt -multiclock -map +/ice40/cells_sim.v synth_ice40
+equiv_opt -assert -multiclock -map +/ice40/cells_sim.v synth_ice40

--- a/tests/arch/ice40/bug1597.ys
+++ b/tests/arch/ice40/bug1597.ys
@@ -3,7 +3,7 @@ module top (
     input CLK, PIN_1, PIN_2, PIN_3, PIN_4, PIN_5,
         PIN_6, PIN_7, PIN_8, PIN_9, PIN_10, PIN_11, PIN_12, PIN_13, PIN_25,
     output USBPU, PIN_14, PIN_15, PIN_16, PIN_17, PIN_18,
-        PIN_19, PIN_20, PIN_21, PIN_22, PIN_23, PIN_24,
+        PIN_19,
 );
     assign USBPU = 0;
 
@@ -67,6 +67,7 @@ module SSCounter6o (input wire rst, clk, adv, jmp, input wire [5:0] in, output w
     SB_LUT4 #(.LUT_INIT(16'h8BB8)) l5 (lo[5], in[5], jmp, out[5], co[4]);
 endmodule
 EOT
+read_verilog -lib +/ice40/cells_sim.v
 hierarchy -top top
 flatten
 equiv_opt -multiclock -map +/ice40/cells_sim.v synth_ice40

--- a/tests/arch/ice40/ice40_opt.ys
+++ b/tests/arch/ice40/ice40_opt.ys
@@ -21,6 +21,7 @@ module top(input CI, I0, output [1:0] CO, output O);
 endmodule
 EOT
 
+read_verilog -icells -lib +/ice40/abc9_model.v +/ice40/cells_sim.v
 equiv_opt -assert -map +/ice40/abc9_model.v -map +/ice40/cells_sim.v ice40_opt
 design -load postopt
 select -assert-count 1 t:*

--- a/tests/arch/intel_alm/counter.ys
+++ b/tests/arch/intel_alm/counter.ys
@@ -2,7 +2,7 @@ read_verilog ../common/counter.v
 hierarchy -top top
 proc
 flatten
-equiv_opt -async2sync -map +/intel_alm/common/alm_sim.v -map +/intel_alm/common/dff_sim.v synth_intel_alm -family cyclonev -noiopad -noclkbuf # equivalency check
+equiv_opt -assert -async2sync -map +/intel_alm/common/alm_sim.v -map +/intel_alm/common/dff_sim.v synth_intel_alm -family cyclonev -noiopad -noclkbuf # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
 
@@ -17,7 +17,7 @@ read_verilog ../common/counter.v
 hierarchy -top top
 proc
 flatten
-equiv_opt -async2sync -map +/intel_alm/common/alm_sim.v -map +/intel_alm/common/dff_sim.v synth_intel_alm -family cyclone10gx -noiopad -noclkbuf # equivalency check
+equiv_opt -assert -async2sync -map +/intel_alm/common/alm_sim.v -map +/intel_alm/common/dff_sim.v synth_intel_alm -family cyclone10gx -noiopad -noclkbuf # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
 

--- a/tests/arch/xilinx/abc9_dff.ys
+++ b/tests/arch/xilinx/abc9_dff.ys
@@ -12,6 +12,7 @@ FDCE_1 #(.INIT(0)) fd7(.C(C), .CE(1'b1), .D(D), .CLR(1'b1), .Q(Q[6]));
 FDPE_1 #(.INIT(0)) fd8(.C(C), .CE(1'b1), .D(D), .PRE(1'b1), .Q(Q[7]));
 endmodule
 EOT
+read_verilog -lib +/xilinx/cells_sim.v
 equiv_opt -assert -multiclock -map +/xilinx/cells_sim.v synth_xilinx -abc9 -dff -noiopad -noclkbuf
 design -load postopt
 select -assert-count 6 t:FD*
@@ -31,6 +32,7 @@ FDCE_1 #(.INIT(0)) fd7(.C(C), .CE(1'b0), .D(D), .CLR(1'b0), .Q(Q[6]));
 FDPE_1 #(.INIT(0)) fd8(.C(C), .CE(1'b0), .D(D), .PRE(1'b0), .Q(Q[7]));
 endmodule
 EOT
+read_verilog -lib +/xilinx/cells_sim.v
 equiv_opt -assert -multiclock -map +/xilinx/cells_sim.v synth_xilinx -abc9 -dff -noiopad -noclkbuf
 design -load postopt
 select -assert-count 4 t:FD*
@@ -54,6 +56,7 @@ logger -expect warning "Whitebox '\$paramod\\FDRE\\INIT=.*1' with \(\* abc9_flop
 logger -expect warning "Whitebox '\$paramod\\FDRE_1\\INIT=.*1' with \(\* abc9_flop \*\) contains a \$dff cell with non-zero initial state -- this is not supported for ABC9 sequential synthesis. Treating as a blackbox\." 1
 logger -expect warning "Whitebox 'FDSE' with \(\* abc9_flop \*\) contains a \$dff cell with non-zero initial state -- this is not supported for ABC9 sequential synthesis. Treating as a blackbox\." 1
 logger -expect warning "Whitebox '\$paramod\\FDSE_1\\INIT=.*1' with \(\* abc9_flop \*\) contains a \$dff cell with non-zero initial state -- this is not supported for ABC9 sequential synthesis. Treating as a blackbox\." 1
+read_verilog -lib +/xilinx/cells_sim.v
 equiv_opt -assert -multiclock -map +/xilinx/cells_sim.v synth_xilinx -abc9 -dff -noiopad -noclkbuf
 design -load postopt
 select -assert-count 8 t:FD*
@@ -75,6 +78,7 @@ always @(posedge clk or posedge pre)
 endmodule
 EOT
 proc
+read_verilog -lib +/xilinx/cells_sim.v
 equiv_opt -assert -multiclock -map +/xilinx/cells_sim.v synth_xilinx -abc9 -dff -noiopad -noclkbuf
 design -load postopt
 select -assert-count 1 t:FDCE
@@ -94,6 +98,7 @@ assign q = ~r;
 endmodule
 EOT
 proc
+read_verilog -lib +/xilinx/cells_sim.v
 equiv_opt -assert -multiclock -map +/xilinx/cells_sim.v synth_xilinx -abc9 -dff -noiopad -noclkbuf
 design -load postopt
 select -assert-count 1 t:FDRE %co w:r %i
@@ -111,6 +116,7 @@ assign q2 = r;
 endmodule
 EOT
 proc
+read_verilog -lib +/xilinx/cells_sim.v
 equiv_opt -assert -multiclock -map +/xilinx/cells_sim.v synth_xilinx -abc9 -dff -noiopad -noclkbuf
 design -load postopt
 select -assert-count 1 t:FDRE %co %a w:r %i
@@ -128,6 +134,7 @@ assign o = r1 | r2;
 endmodule
 EOT
 proc
+read_verilog -lib +/xilinx/cells_sim.v
 equiv_opt -assert -multiclock -map +/xilinx/cells_sim.v synth_xilinx -abc9 -dff -noiopad -noclkbuf
 
 

--- a/tests/arch/xilinx/opt_lut_ins.ys
+++ b/tests/arch/xilinx/opt_lut_ins.ys
@@ -18,6 +18,7 @@ end
 
 EOF
 
+read_verilog -lib +/xilinx/cells_sim.v
 equiv_opt -assert -map +/xilinx/cells_sim.v opt_lut_ins -tech xilinx
 
 design -load postopt

--- a/tests/arch/xilinx/xilinx_dffopt.ys
+++ b/tests/arch/xilinx/xilinx_dffopt.ys
@@ -5,7 +5,7 @@ read_verilog << EOT
 module t0 (...);
 input wire clk;
 input wire [7:0] i;
-output wire [7:0] o;
+output wire [0:0] o;
 
 wire [7:0] tmp ;
 
@@ -52,7 +52,7 @@ read_verilog << EOT
 module t0 (...);
 input wire clk;
 input wire [7:0] i;
-output wire [7:0] o;
+output wire [0:0] o;
 
 wire [7:0] tmp ;
 
@@ -100,7 +100,7 @@ read_verilog << EOT
 module t0 (...);
 input wire clk;
 input wire [7:0] i;
-output wire [7:0] o;
+output wire [0:0] o;
 
 wire [7:0] tmp ;
 
@@ -137,7 +137,7 @@ read_verilog << EOT
 module t0 (...);
 input wire clk;
 input wire [7:0] i;
-output wire [7:0] o;
+output wire [0:0] o;
 
 wire [7:0] tmp ;
 
@@ -183,7 +183,7 @@ read_verilog << EOT
 module t0 (...);
 input wire clk;
 input wire [7:0] i;
-output wire [7:0] o;
+output wire [0:0] o;
 
 wire [7:0] tmp ;
 
@@ -232,7 +232,7 @@ read_verilog << EOT
 module t0 (...);
 input wire clk;
 input wire [7:0] i;
-output wire [7:0] o;
+output wire [0:0] o;
 
 wire [7:0] tmp ;
 

--- a/tests/opt/opt_dff_en.ys
+++ b/tests/opt/opt_dff_en.ys
@@ -6,7 +6,7 @@ module top(...);
 
 input CLK;
 input [1:0] D;
-output [15:0] Q;
+output [11:0] Q;
 input SRST;
 input ARST;
 input [1:0] CLR;

--- a/tests/opt/opt_dff_mux.ys
+++ b/tests/opt/opt_dff_mux.ys
@@ -7,7 +7,7 @@ module top(...);
 input CLK;
 input NE, NS;
 input EN;
-output [23:0] Q;
+output [17:0] Q;
 input [23:0] D;
 input SRST;
 input ARST;

--- a/tests/opt/opt_dff_qd.ys
+++ b/tests/opt/opt_dff_qd.ys
@@ -7,7 +7,7 @@ module top(...);
 input CLK;
 input EN;
 (* init = 24'h555555 *)
-output [23:0] Q;
+output [19:0] Q;
 input SRST;
 input ARST;
 input [1:0] CLR;

--- a/tests/opt/opt_dff_sr.ys
+++ b/tests/opt/opt_dff_sr.ys
@@ -22,10 +22,9 @@ EOT
 
 design -save orig
 
-# Equivalence check will fail for unmapped adlatch and dlatchsr due to negative hold hack.
-#equiv_opt -undef -assert -multiclock opt_dff
-#design -load postopt
-opt_dff
+equiv_opt -undef -assert -multiclock opt_dff
+design -load postopt
+
 select -assert-count 1 t:$dffsr
 select -assert-count 1 t:$dffsr r:WIDTH=2 %i
 select -assert-count 1 t:$dffsre
@@ -36,9 +35,9 @@ select -assert-none t:$sr
 
 design -load orig
 
-#equiv_opt -undef -assert -multiclock opt_dff -keepdc
-#design -load postopt
-opt_dff -keepdc
+equiv_opt -undef -assert -multiclock opt_dff -keepdc
+design -load postopt
+
 select -assert-count 1 t:$dffsr
 select -assert-count 1 t:$dffsr r:WIDTH=4 %i
 select -assert-count 1 t:$dffsre
@@ -51,9 +50,9 @@ select -assert-count 1 t:$sr r:WIDTH=4 %i
 design -load orig
 simplemap
 
-#equiv_opt -undef -assert -multiclock opt_dff
-#design -load postopt
-opt_dff
+equiv_opt -undef -assert -multiclock opt_dff
+design -load postopt
+
 select -assert-count 1 t:$_DFF_PP0_
 select -assert-count 1 t:$_DFF_PP1_
 select -assert-count 1 t:$_DFFE_PN0P_
@@ -65,9 +64,9 @@ select -assert-none t:$_DFF_PP0_ t:$_DFF_PP1_ t:$_DFFE_PN0P_ t:$_DFFE_PN1P_ t:$_
 design -load orig
 simplemap
 
-#equiv_opt -undef -assert -multiclock opt_dff -keepdc
-#design -load postopt
-opt_dff -keepdc
+equiv_opt -undef -assert -multiclock opt_dff -keepdc
+design -load postopt
+
 select -assert-count 1 t:$_DFF_PP0_
 select -assert-count 1 t:$_DFF_PP1_
 select -assert-count 2 t:$_DFFSR_PPP_

--- a/tests/opt/opt_expr_xor.ys
+++ b/tests/opt/opt_expr_xor.ys
@@ -10,7 +10,7 @@ design -save read
 select -assert-count 2 t:$xor
 select -assert-count 2 t:$xnor
 
-equiv_opt opt_expr
+equiv_opt -assert opt_expr
 design -load postopt
 select -assert-none t:$xor
 select -assert-none t:$xnor
@@ -19,7 +19,7 @@ select -assert-count 2 t:$not
 
 design -load read
 simplemap
-equiv_opt opt_expr
+equiv_opt -assert opt_expr
 design -load postopt
 select -assert-none t:$_XOR_
 select -assert-none t:$_XNOR_ # NB: simplemap does $xnor -> $_XOR_+$_NOT_
@@ -34,7 +34,7 @@ $_XNOR_ u1(.A(1'b1), .B(a), .Y(y[1]));
 endmodule
 EOT
 select -assert-count 2 t:$_XNOR_
-equiv_opt opt_expr
+equiv_opt -assert opt_expr
 design -load postopt
 select -assert-none t:$_XNOR_ # NB: simplemap does $xnor -> $_XOR_+$_NOT_
 select -assert-count 1 t:$_NOT_
@@ -49,7 +49,7 @@ assign y = a~^1'b0;
 assign z = a~^1'b1;
 endmodule
 EOT
-equiv_opt opt_expr
+equiv_opt -assert opt_expr
 
 
 # Single-bit $xor

--- a/tests/techmap/adff2dff.ys
+++ b/tests/techmap/adff2dff.ys
@@ -16,4 +16,4 @@ EOT
 
 proc
 
-equiv_opt -async2sync techmap -map +/adff2dff.v
+#equiv_opt -assert -async2sync techmap -map +/adff2dff.v

--- a/tests/techmap/dff2ff.ys
+++ b/tests/techmap/dff2ff.ys
@@ -13,4 +13,4 @@ EOT
 
 proc
 
-equiv_opt techmap -map +/dff2ff.v
+equiv_opt -assert techmap -map +/dff2ff.v

--- a/tests/techmap/dfflegalize_adlatch.ys
+++ b/tests/techmap/dfflegalize_adlatch.ys
@@ -12,7 +12,7 @@ $_DLATCH_PN1_ ff1 (.E(E), .R(R), .D(D), .Q(Q[1]));
 $_DLATCH_NP1_ ff2 (.E(E), .R(R), .D(D), .Q(Q[2]));
 endmodule
 
-module top(input C, E, R, D, output [13:0] Q);
+module top(input C, E, R, D, output [5:0] Q);
 adlatch0 adlatch0_(.E(E), .R(R), .D(D), .Q(Q[2:0]));
 adlatch1 adlatch1_(.E(E), .R(R), .D(D), .Q(Q[5:3]));
 endmodule

--- a/tests/techmap/dfflegalize_adlatch_init.ys
+++ b/tests/techmap/dfflegalize_adlatch_init.ys
@@ -12,7 +12,7 @@ $_DLATCH_PN1_ ff1 (.E(E), .R(R), .D(D), .Q(Q[1]));
 $_DLATCH_NP1_ ff2 (.E(E), .R(R), .D(D), .Q(Q[2]));
 endmodule
 
-module top(input C, E, R, D, output [13:0] Q);
+module top(input C, E, R, D, output [5:0] Q);
 adlatch0 adlatch0_(.E(E), .R(R), .D(D), .Q(Q[2:0]));
 adlatch1 adlatch1_(.E(E), .R(R), .D(D), .Q(Q[5:3]));
 endmodule

--- a/tests/techmap/dfflegalize_aldff.ys
+++ b/tests/techmap/dfflegalize_aldff.ys
@@ -24,8 +24,8 @@ design -save orig
 flatten
 equiv_opt -assert -multiclock dfflegalize -cell $_ALDFF_PP_ x
 equiv_opt -assert -multiclock dfflegalize -cell $_ALDFFE_PPP_ x
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFFSR_PPP_ x
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFFSRE_PPPP_ x
+equiv_opt -assert -multiclock dfflegalize -cell $_DFFSR_PPP_ x
+equiv_opt -assert -multiclock dfflegalize -cell $_DFFSRE_PPPP_ x
 
 
 # Convert everything to ALDFFs.

--- a/tests/techmap/dfflegalize_aldff_init.ys
+++ b/tests/techmap/dfflegalize_aldff_init.ys
@@ -26,10 +26,10 @@ equiv_opt -assert -multiclock dfflegalize -cell $_ALDFF_PP_ 0
 equiv_opt -assert -multiclock dfflegalize -cell $_ALDFF_PP_ 1
 equiv_opt -assert -multiclock dfflegalize -cell $_ALDFFE_PPP_ 0
 equiv_opt -assert -multiclock dfflegalize -cell $_ALDFFE_PPP_ 1
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFFSR_PPP_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFFSR_PPP_ 1
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFFSRE_PPPP_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFFSRE_PPPP_ 1
+equiv_opt -assert -multiclock dfflegalize -cell $_DFFSR_PPP_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DFFSR_PPP_ 1
+equiv_opt -assert -multiclock dfflegalize -cell $_DFFSRE_PPPP_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DFFSRE_PPPP_ 1
 
 
 # Convert everything to ALDFFs.

--- a/tests/techmap/dfflegalize_dffsr_init.ys
+++ b/tests/techmap/dfflegalize_dffsr_init.ys
@@ -41,18 +41,18 @@ EOT
 
 design -save orig
 flatten
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFF_PP0_ 0 -cell $_SR_PP_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFF_PP0_ 1 -cell $_SR_PP_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFF_PP1_ 0 -cell $_SR_PP_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFF_PP1_ 1 -cell $_SR_PP_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFFE_PP0P_ 0 -cell $_SR_PP_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFFE_PP0P_ 1 -cell $_SR_PP_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFFE_PP1P_ 0 -cell $_SR_PP_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFFE_PP1P_ 1 -cell $_SR_PP_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFFSR_PPP_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFFSR_PPP_ 1
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFFSRE_PPPP_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFFSRE_PPPP_ 1
+equiv_opt -assert -multiclock dfflegalize -cell $_DFF_PP0_ 0 -cell $_SR_PP_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DFF_PP0_ 1 -cell $_SR_PP_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DFF_PP1_ 0 -cell $_SR_PP_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DFF_PP1_ 1 -cell $_SR_PP_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DFFE_PP0P_ 0 -cell $_SR_PP_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DFFE_PP0P_ 1 -cell $_SR_PP_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DFFE_PP1P_ 0 -cell $_SR_PP_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DFFE_PP1P_ 1 -cell $_SR_PP_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DFFSR_PPP_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DFFSR_PPP_ 1
+equiv_opt -assert -multiclock dfflegalize -cell $_DFFSRE_PPPP_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DFFSRE_PPPP_ 1
 
 
 # Convert everything to ADFFs.

--- a/tests/techmap/dfflegalize_dlatchsr_init.ys
+++ b/tests/techmap/dfflegalize_dlatchsr_init.ys
@@ -14,7 +14,7 @@ $_DLATCHSR_PNP_ ff2 (.E(E), .R(R), .S(S), .D(D), .Q(Q[2]));
 $_DLATCHSR_NPP_ ff3 (.E(E), .R(R), .S(S), .D(D), .Q(Q[3]));
 endmodule
 
-module top(input C, E, R, S, D, output [17:0] Q);
+module top(input C, E, R, S, D, output [7:0] Q);
 dlatchsr0 dlatchsr0_(.E(E), .R(R), .S(S), .D(D), .Q(Q[3:0]));
 dlatchsr1 dlatchsr1_(.E(E), .R(R), .S(S), .D(D), .Q(Q[7:4]));
 endmodule
@@ -23,12 +23,12 @@ EOT
 
 design -save orig
 flatten
-#equiv_opt -assert -multiclock dfflegalize -cell $_DLATCH_PP0_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DLATCH_PP0_ 1
-#equiv_opt -assert -multiclock dfflegalize -cell $_DLATCH_PP1_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DLATCH_PP1_ 1
-#equiv_opt -assert -multiclock dfflegalize -cell $_DLATCHSR_PPP_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DLATCHSR_PPP_ 1
+equiv_opt -assert -multiclock dfflegalize -cell $_DLATCH_PP0_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DLATCH_PP0_ 1
+equiv_opt -assert -multiclock dfflegalize -cell $_DLATCH_PP1_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DLATCH_PP1_ 1
+equiv_opt -assert -multiclock dfflegalize -cell $_DLATCHSR_PPP_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DLATCHSR_PPP_ 1
 
 
 # Convert everything to ADLATCHs.

--- a/tests/techmap/dfflegalize_sr_init.ys
+++ b/tests/techmap/dfflegalize_sr_init.ys
@@ -21,18 +21,18 @@ EOT
 
 design -save orig
 flatten
-#equiv_opt -assert -multiclock dfflegalize -cell $_SR_PP_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_SR_PP_ 1
-#equiv_opt -assert -multiclock dfflegalize -cell $_DLATCH_PP0_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DLATCH_PP0_ 1
-#equiv_opt -assert -multiclock dfflegalize -cell $_DLATCH_PP1_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DLATCH_PP1_ 1
-#equiv_opt -assert -multiclock dfflegalize -cell $_DLATCHSR_PPP_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DLATCHSR_PPP_ 1
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFFSR_PPP_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFFSR_PPP_ 1
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFFSRE_PPPP_ 0
-#equiv_opt -assert -multiclock dfflegalize -cell $_DFFSRE_PPPP_ 1
+equiv_opt -assert -multiclock dfflegalize -cell $_SR_PP_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_SR_PP_ 1
+equiv_opt -assert -multiclock dfflegalize -cell $_DLATCH_PP0_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DLATCH_PP0_ 1
+equiv_opt -assert -multiclock dfflegalize -cell $_DLATCH_PP1_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DLATCH_PP1_ 1
+equiv_opt -assert -multiclock dfflegalize -cell $_DLATCHSR_PPP_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DLATCHSR_PPP_ 1
+equiv_opt -assert -multiclock dfflegalize -cell $_DFFSR_PPP_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DFFSR_PPP_ 1
+equiv_opt -assert -multiclock dfflegalize -cell $_DFFSRE_PPPP_ 0
+equiv_opt -assert -multiclock dfflegalize -cell $_DFFSRE_PPPP_ 1
 
 
 # Convert everything to SRs.

--- a/tests/techmap/dfflibmap.ys
+++ b/tests/techmap/dfflibmap.ys
@@ -17,9 +17,11 @@ EOT
 simplemap
 
 design -save orig
+read_liberty -lib dfflibmap.lib
 
-#equiv_opt -map dfflibmap-sim.v -assert -multiclock dfflibmap -liberty dfflibmap.lib
-#equiv_opt -map dfflibmap-sim.v -assert -multiclock dfflibmap -prepare -liberty dfflibmap.lib
+equiv_opt -map dfflibmap-sim.v -assert -multiclock dfflibmap -liberty dfflibmap.lib
+equiv_opt -map dfflibmap-sim.v -assert -multiclock dfflibmap -prepare -liberty dfflibmap.lib
+
 dfflibmap -prepare -liberty dfflibmap.lib
 equiv_opt -map dfflibmap-sim.v -assert -multiclock dfflibmap -map-only -liberty dfflibmap.lib
 

--- a/tests/techmap/dffunmap.ys
+++ b/tests/techmap/dffunmap.ys
@@ -4,7 +4,7 @@ module top(...);
 
 input C, R, E, S;
 input [1:0] D;
-output [20:0] Q;
+output [17:0] Q;
 
 $dff #(.CLK_POLARITY(1'b0), .WIDTH(2)) ff0 (.CLK(C), .D(D), .Q(Q[1:0]));
 $dffe #(.CLK_POLARITY(1'b0), .EN_POLARITY(1'b0), .WIDTH(2)) ff1 (.CLK(C), .EN(E), .D(D), .Q(Q[3:2]));

--- a/tests/techmap/pmux2mux.ys
+++ b/tests/techmap/pmux2mux.ys
@@ -12,4 +12,4 @@ output [3:0] O;
 endmodule
 EOT
 
-equiv_opt techmap -map +/pmux2mux.v
+equiv_opt -assert techmap -map +/pmux2mux.v

--- a/tests/techmap/shiftx2mux.ys
+++ b/tests/techmap/shiftx2mux.ys
@@ -106,4 +106,4 @@ endmodule
 EOT
 opt
 wreduce
-equiv_opt techmap
+equiv_opt -assert techmap

--- a/tests/techmap/zinit.ys
+++ b/tests/techmap/zinit.ys
@@ -13,6 +13,8 @@ $_DFF_PN1_ dff5 (.C(C), .D(D[0]), .R(R), .Q(Q[5]));
 $_DFF_PP0_ dff6 (.C(C), .D(D[0]), .R(R), .Q(Q[6]));
 $_DFF_PP1_ dff7 (.C(C), .D(D[0]), .R(R), .Q(Q[7]));
 
+assign Q[8] = 0;
+
 $adff #(.WIDTH(2), .CLK_POLARITY(1), .ARST_POLARITY(1'b0), .ARST_VALUE(2'b10)) dff8 (.CLK(C), .ARST(R), .D(D), .Q(Q[10:9]));
 $adff #(.WIDTH(2), .CLK_POLARITY(0), .ARST_POLARITY(1'b1), .ARST_VALUE(2'b01)) dff9 (.CLK(C), .ARST(R), .D(D), .Q(Q[12:11]));
 endmodule
@@ -43,6 +45,8 @@ $_DFF_PN0_ dff4 (.C(C), .D(D[0]), .R(R), .Q(Q[4]));
 $_DFF_PN1_ dff5 (.C(C), .D(D[0]), .R(R), .Q(Q[5]));
 $_DFF_PP0_ dff6 (.C(C), .D(D[0]), .R(R), .Q(Q[6]));
 $_DFF_PP1_ dff7 (.C(C), .D(D[0]), .R(R), .Q(Q[7]));
+
+assign Q[8] = 0;
 
 $adff #(.WIDTH(2), .CLK_POLARITY(1), .ARST_POLARITY(1'b0), .ARST_VALUE(2'b10)) dff8 (.CLK(C), .ARST(R), .D(D), .Q(Q[10:9]));
 $adff #(.WIDTH(2), .CLK_POLARITY(0), .ARST_POLARITY(1'b1), .ARST_VALUE(2'b01)) dff9 (.CLK(C), .ARST(R), .D(D), .Q(Q[12:11]));

--- a/tests/techmap/zinit.ys
+++ b/tests/techmap/zinit.ys
@@ -95,9 +95,8 @@ $_SDFFE_PP1P_ dff23(.C(C), .D(D[0]),.E(E),  .R(R), .Q(Q[23]));
 
 endmodule
 EOT
-#equiv_opt -assert -multiclock zinit
-#design -load postopt
-zinit
+equiv_opt -assert -multiclock zinit
+design -load postopt
 
 select -assert-count 48 t:$_NOT_
 select -assert-count 0 w:Q a:init %i
@@ -142,9 +141,8 @@ $_SDFFE_PP1P_ dff23(.C(C), .D(D[0]),.E(E),  .R(R), .Q(Q[23]));
 
 endmodule
 EOT
-#equiv_opt -assert -multiclock zinit
-#design -load postopt
-zinit
+equiv_opt -assert -multiclock zinit
+design -load postopt
 
 select -assert-count 0 t:$_NOT_
 select -assert-count 1 w:Q a:init=24'b0 %i


### PR DESCRIPTION
Fix and re-enable essentially all equiv_opt based tests. This is based on #2740 but instead of changing the negative hold time behavior of clk2fflogic it fixes the underlying issue in the logic used to emulate negative hold time using $ff cells.

Apart from fixing the previously disabled tests in the test suite, this also fixes the following issues:

* #639 remains fixed, even after now having reverted the incorrect previous fix for this
* fixes #2728
* fixes #3169 
* fixes #3428