### PR TITLE
Add YOSYS_ABORT_ON_LOG_ERROR environment variable for debugging.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,10 @@ List of major changes and improvements between releases
 
 Yosys 0.22 .. Yosys 0.22-dev
 --------------------------
+ * Various
+    - Added YOSYS_ABORT_ON_LOG_ERROR environment variable for debugging.
+      Setting it to 1 causes abort() to be called when Yosys terminates with an
+      error message.
 
 Yosys 0.21 .. Yosys 0.22
 --------------------------

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -352,6 +352,9 @@ static void logv_error_with_prefix(const char *prefix,
 		log_error_atexit();
 
 	YS_DEBUGTRAP_IF_DEBUGGING;
+	const char *e = getenv("YOSYS_ABORT_ON_LOG_ERROR");
+	if (e && atoi(e))
+		abort();
 
 #ifdef EMSCRIPTEN
 	log_files = backup_log_files;


### PR DESCRIPTION
A debug feature to always get core-dumps on yosys errors without having to re-run yosys under a debugger.