### PR TITLE
Fix handling of verific -L options, add implicit "-L work"

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -2791,6 +2791,20 @@ struct VerificPass : public Pass {
 		}
 
 		veri_file::RemoveAllLOptions();
+		veri_file::AddLOption("work");
+		for (int i = argidx; i < GetSize(args); i++)
+		{
+			if (args[i] == "-work" && i+1 < GetSize(args)) {
+				++i;
+				continue;
+			}
+			if (args[i] == "-L" && i+1 < GetSize(args)) {
+				if (args[++i] == "work")
+					veri_file::RemoveAllLOptions();
+				continue;
+			}
+			break;
+		}
 		for (; argidx < GetSize(args); argidx++)
 		{
 			if (args[argidx] == "-work" && argidx+1 < GetSize(args)) {


### PR DESCRIPTION
As discussed on Friday: Add an implicit `-L work` at the beginning of the Verific -L option list, unless `-L work` is already present at any (other) position in the list. (That exception enables the user to specify a library with module implementations that should replace the implementations that come with the design, by specifying that library first, followed by `-L work`.)