### PR TITLE
Add OS selector for Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,6 +25,19 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: os
+    attributes:
+      label: On which OS did this happen?
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - BSD
+      multiple: true
+    validations:
+      required: true
+
   - type: markdown
     attributes:
       value: >
@@ -60,4 +73,3 @@ body:
       description: "Please describe how the behavior you see differs from the expected behavior."
     validations:
       required: true
-


### PR DESCRIPTION
This PR adds an OS selection drop down for our issue templates to better help identify on which OS or which set of OS families the issues occur on.