### PR TITLE
Failure to read FST files on *BSD systems

### DIFF
--- a/libs/fst/fstapi.cc
+++ b/libs/fst/fstapi.cc
@@ -4272,6 +4272,7 @@ int fstReaderInit(struct fstReaderContext *xc)
 #endif
 
         zfd = dup(fileno(xc->f));
+	lseek(zfd, ftell(xc->f), SEEK_SET);
         zhandle = gzdopen(zfd, "rb");
         if (zhandle) {
             for (offpnt = 0; offpnt < uclen; offpnt += FST_GZIO_LEN) {

--- a/libs/fst/fstapi.cc
+++ b/libs/fst/fstapi.cc
@@ -3607,6 +3607,7 @@ static int fstReaderRecreateHierFile(struct fstReaderContext *xc)
             fflush(xc->f);
 #endif
             zfd = dup(fileno(xc->f));
+	    lseek(zfd, ftell(xc->f), SEEK_SET);
             zhandle = gzdopen(zfd, "rb");
             if (!zhandle) {
                 close(zfd);


### PR DESCRIPTION
The *BSD stdio library seems to buffer data from the FST file leading to the seek position of the underlying file description being ahead of the stdio maintained seek position (that's what buffering is for after all). 

fstapi.cc uses gzdopen(dup(fileno())) to open and so zlib is given the underlying seek position instead of the seek position that the stdio using application is expecting with the result that gzread() starts reading from EOF instead of byte 17.

This PR moves the underlying seek position so that gzread() will read from the location that the application expects. This doesn't appear to affect stdio (which is still sharing that underlying seek position) because in one of the cases, the original FILE is promptly closed and in the other case the FST library seeks the original file anyway. 

The grom.ys unittest now succeeds on NetBSD when it didn't before.
