### PR TITLE
Set BISON when building with brew on mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,8 @@ LDFLAGS += -L$(BREW_PREFIX)/readline/lib
 PKG_CONFIG_PATH := $(BREW_PREFIX)/libffi/lib/pkgconfig:$(PKG_CONFIG_PATH)
 PKG_CONFIG_PATH := $(BREW_PREFIX)/tcl-tk/lib/pkgconfig:$(PKG_CONFIG_PATH)
 export PATH := $(BREW_PREFIX)/bison/bin:$(BREW_PREFIX)/gettext/bin:$(BREW_PREFIX)/flex/bin:$(PATH)
+BISON := $(BREW_PREFIX)/bison/bin/bison
+LDFLAGS += "-L{BREW_PRFIX}/bison/lib"
 
 # macports search paths
 else ifneq ($(shell :; command -v port),)


### PR DESCRIPTION
When building on Mac M2 with brew, I hit an issue with build picking up the wrong bison. This fixes that issue.