### PR TITLE
smtbmc: Fix witness handling for k-induction failures

### DIFF
--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -701,7 +701,7 @@ class SmtIo:
                 if witness["type"] == "mem":
                     if allregs and not witness["rom"]:
                         width, size = witness["width"], witness["size"]
-                        witness = {**witness, "uninitialized": {"width": width * size, "offset": 0}}
+                        witness = {**witness, "uninitialized": [{"width": width * size, "offset": 0}]}
                     if not witness["uninitialized"]:
                         continue
 


### PR DESCRIPTION
The "uninitialized" value is a _list_ of chunks that are part of the initial state for the witness trace.