### PR TITLE
Fixes #3515

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__
 /.cproject
 /.project
 /.settings
+/.vscode
 /qtcreator.files
 /qtcreator.includes
 /qtcreator.config

--- a/libs/subcircuit/subcircuit.cc
+++ b/libs/subcircuit/subcircuit.cc
@@ -911,6 +911,10 @@ class SubCircuit::SolverWorker
 	bool pruneEnumerationMatrix(std::vector<std::set<int>> &enumerationMatrix, const GraphData &needle, const GraphData &haystack, int &nextRow, bool allowOverlap)
 	{
 		bool didSomething = true;
+
+		// Map of j:[i where j is used]
+		std::map<int, std::set<int>> usedNodes;
+
 		while (didSomething)
 		{
 			nextRow = -1;
@@ -922,13 +926,23 @@ class SubCircuit::SolverWorker
 						didSomething = true;
 					else if (!allowOverlap && haystack.usedNodes[j])
 						didSomething = true;
-					else
+					else {
 						newRow.insert(j);
+						usedNodes[j].insert(i); // Store the needle index by haystack node index
+					}
 				}
+
+				// This indicates there are no available haystack nodes to assign to the needle
 				if (newRow.size() == 0)
 					return false;
+
+				// If there are multiple needles assigned to the haystack node, the solution is invalid
+				if (newRow.size() == 1 && usedNodes[*newRow.begin()].size() > 1)
+					return false;
+
 				if (newRow.size() >= 2 && (nextRow < 0 || needle.adjMatrix.at(nextRow).size() < needle.adjMatrix.at(i).size()))
 					nextRow = i;
+
 				enumerationMatrix[i].swap(newRow);
 			}
 		}


### PR DESCRIPTION
The `pruneEnumerationMatrix` function basically removes haystack nodes from the `enumerationMatrix`, that are either invalid or in use. This is done on a row by row (needle by needle) basis.  The function is gnostic of used haystack nodes that have been properly processed as part of a valid solution. However, it is agnosic of the usage of nodes within the rows of the matrix within the function itself.

This PR proposes to keep track of which nodes have already been assigned to needles during the function's execution.

After processing each node for each row, the row as a whole is evaluated. A check has been added to compares the number of rows that is assocated with a node. If the count > 1, the node is used in more than one needle, and since further recursion is not possible, the solution is invalid.