### PR TITLE
simlib: Simplify recently changed $mux model

### DIFF
--- a/techlibs/common/simlib.v
+++ b/techlibs/common/simlib.v
@@ -1279,11 +1279,9 @@ parameter WIDTH = 0;
 
 input [WIDTH-1:0] A, B;
 input S;
-output reg [WIDTH-1:0] Y;
+output [WIDTH-1:0] Y;
 
-always @* begin
-	assign Y = S ? B : A;
-end
+assign Y = S ? B : A;
 
 endmodule
 


### PR DESCRIPTION
The use of a procedural continuous assignment introduced in #3526 was unintended and is completely unnecessary for the actual change of that PR.