### PR TITLE
verilog: Support module-scoped task/function calls

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,9 @@ Yosys 0.22 .. Yosys 0.22-dev
       Setting it to 1 causes abort() to be called when Yosys terminates with an
       error message.
 
+ * Verilog
+    - Support for module-scoped identifiers referring to tasks and functions.
+
 Yosys 0.21 .. Yosys 0.22
 --------------------------
  * Verific support

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -3656,6 +3656,8 @@ skip_dynamic_range_lvalue_expansion:;
 				goto apply_newNode;
 			}
 
+			if (current_scope.count(str) == 0)
+				str = try_pop_module_prefix();
 			if (current_scope.count(str) == 0 || current_scope[str]->type != AST_FUNCTION)
 				log_file_error(filename, location.first_line, "Can't resolve function name `%s'.\n", str.c_str());
 		}
@@ -3727,6 +3729,8 @@ skip_dynamic_range_lvalue_expansion:;
 				goto apply_newNode;
 			}
 
+			if (current_scope.count(str) == 0)
+				str = try_pop_module_prefix();
 			if (current_scope.count(str) == 0 || current_scope[str]->type != AST_TASK)
 				log_file_error(filename, location.first_line, "Can't resolve task name `%s'.\n", str.c_str());
 		}

--- a/tests/simple/module_scope_func.v
+++ b/tests/simple/module_scope_func.v
@@ -1,0 +1,45 @@
+// Some strict implementatins either forbid hierarchical identifiers within
+// constant expressions, or forbid declaring functions in generate blocks, or
+// both. Yosys and Iverilog are not strict in either of these ways.
+module module_scope_func_top(
+    input wire inp,
+    output wire [31:0] out1, out2, out4, out5, out7, out8,
+    output reg [31:0] out3, out6, out9
+);
+    function automatic integer incr;
+        input integer value;
+        incr = value + 1;
+    endfunction
+    task send;
+        output integer out;
+        out = 55;
+    endtask
+
+    assign out1 = module_scope_func_top.incr(inp);
+    localparam C = module_scope_func_top.incr(10);
+    assign out2 = C;
+    initial module_scope_func_top.send(out3);
+
+    if (1) begin : blk
+        // shadows module_scope_func_top.incr
+        function automatic integer incr;
+            input integer value;
+            incr = value * 2;
+        endfunction
+        // shadows module_scope_func_top.send
+        task send;
+            output integer out;
+            out = 66;
+        endtask
+
+        assign out4 = module_scope_func_top.incr(inp);
+        localparam D = module_scope_func_top.incr(20);
+        assign out5 = D;
+        initial module_scope_func_top.send(out6);
+
+        assign out7 = incr(inp);
+        localparam E = incr(30);
+        assign out8 = E;
+        initial send(out9);
+    end
+endmodule


### PR DESCRIPTION
I noticed this issue while investigating https://github.com/zachjs/sv2v/issues/223 / https://github.com/YosysHQ/yosys/issues/3520. This change is primarily intended to enable the standard-permitted use of module-scoped identifiers to refer to tasks and non-constant functions. As a side-effect, this also adds support for the non-standard use of module-scoped identifiers referring to constant functions, a feature that is supported in some other tools, including Iverilog.