### PR TITLE
Add extra time at the end of a sat VCD trace

### DIFF
--- a/passes/sat/sat.cc
+++ b/passes/sat/sat.cc
@@ -758,6 +758,7 @@ struct SatHelper
 		if (last_timestep == -2)
 			log("  no model variables selected for display.\n");
 
+		fprintf(f, "#%d\n", last_timestep+1);
 		fclose(f);
 	}
 


### PR DESCRIPTION
Otherwise the final values will not show up in gtkwave waveforms when looking at the generated traces.

Signed-off-by: Claire Xenia Wolf <claire@clairexen.net>