### PR TITLE
Support for arrays with swapped ranges within structs

### DIFF
--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -203,7 +203,7 @@ namespace AST
 
 		// if this is a multirange memory then this vector contains offset and length of each dimension
 		std::vector<int> multirange_dimensions;
-		std::vector<bool> multirange_swapped; // true if range is swapped, not used for structs
+		std::vector<bool> multirange_swapped; // true if range is swapped
 
 		// this is set by simplify and used during RTLIL generation
 		AstNode *id2ast;

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -293,6 +293,8 @@ static void save_struct_range_swapped(AstNode *node, bool range_swapped)
 
 static int get_struct_array_width(AstNode *node)
 {
+	// This function is only useful for up to two array dimensions.
+	log_assert(node->multirange_dimensions.size() <= 2);
 	// the stride for the array, 1 if not an array
 	return (node->multirange_dimensions.size() != 2 ? 1 : node->multirange_dimensions[1]);
 
@@ -446,6 +448,8 @@ static AstNode *offset_indexed_range(int offset, int stride, AstNode *left_expr,
 
 static AstNode *make_struct_index_range(AstNode *node, AstNode *rnode, int stride, int offset, AstNode *member_node)
 {
+	// This function should be rewritten to support more than two array dimensions.
+	log_assert(member_node->multirange_dimensions.size() <= 2 && member_node->multirange_swapped.size() <= 2);
 	if (member_node->multirange_swapped[0]) {
 		// The struct item has swapped range; swap index into the struct accordingly.
 		int msb = member_node->multirange_dimensions[0] - 1;
@@ -470,6 +474,8 @@ static AstNode *make_struct_index_range(AstNode *node, AstNode *rnode, int strid
 
 static AstNode *slice_range(AstNode *rnode, AstNode *snode, AstNode *member_node)
 {
+	// This function should be rewritten to support more than two array dimensions.
+	log_assert(member_node->multirange_dimensions.size() <= 2 && member_node->multirange_swapped.size() <= 2);
 	if (member_node->multirange_swapped[1]) {
 		// The second dimension has swapped range; swap index into the struct accordingly.
 		int msb = member_node->multirange_dimensions[1] - 1;
@@ -503,6 +509,8 @@ AstNode *AST::make_struct_member_range(AstNode *node, AstNode *member_node)
 		// no range operations apply, return the whole width
 		return make_range(range_left, range_right);
 	}
+	// This function should be rewritten to support more than two array dimensions.
+	log_assert(member_node->multirange_dimensions.size() <= 2 && member_node->multirange_swapped.size() <= 2);
 	int stride = get_struct_array_width(member_node);
 	if (node->children.size() == 1 && node->children[0]->type == AST_RANGE) {
 		// bit or array indexing e.g. s.a[2] or s.a[1:0]

--- a/tests/svtypes/struct_array.sv
+++ b/tests/svtypes/struct_array.sv
@@ -1,7 +1,6 @@
 // test for array indexing in structures
 
 module top;
-
 	struct packed {
 		bit [5:0] [7:0] a;	// 6 element packed array of bytes
 		bit [15:0] b;		// filler for non-zero offset
@@ -39,4 +38,90 @@ module top;
 
 	always_comb assert(s2==80'hFC00_4200_0012_3400_FFFC);
 
+	// Same as s2, but with little endian addressing
+	struct packed {
+		bit [0:7] [7:0] a;	// 8 element packed array of bytes
+		bit [0:15] b;		// filler for non-zero offset
+	} s3;
+
+	initial begin
+		s3 = '0;
+
+		s3.a[5:6] = 16'h1234;
+		s3.a[2] = 8'h42;
+
+		s3.a[0] = '1;
+		s3.a[0][1:0] = '0;
+
+		s3.b = '1;
+		s3.b[14:15] = '0;
+	end
+
+	always_comb assert(s3==80'hFC00_4200_0012_3400_FFFC);
+
+	// Note that the tests below for unpacked arrays in structs rely on the
+	// fact that they are actually packed in Yosys.
+
+	// Same as s2, but using unpacked array syntax
+	struct packed {
+		bit [7:0] a [7:0];	// 8 element unpacked array of bytes
+		bit [15:0] b;		// filler for non-zero offset
+	} s4;
+
+	initial begin
+		s4 = '0;
+
+		s4.a[2:1] = 16'h1234;
+		s4.a[5] = 8'h42;
+
+		s4.a[7] = '1;
+		s4.a[7][1:0] = '0;
+
+		s4.b = '1;
+		s4.b[1:0] = '0;
+	end
+
+	always_comb assert(s4==80'hFC00_4200_0012_3400_FFFC);
+
+	// Same as s3, but using unpacked array syntax
+	struct packed {
+		bit [7:0] a [0:7];	// 8 element unpacked array of bytes
+		bit [0:15] b;		// filler for non-zero offset
+	} s5;
+
+	initial begin
+		s5 = '0;
+
+		s5.a[5:6] = 16'h1234;
+		s5.a[2] = 8'h42;
+
+		s5.a[0] = '1;
+		s5.a[0][1:0] = '0;
+
+		s5.b = '1;
+		s5.b[14:15] = '0;
+	end
+
+	always_comb assert(s5==80'hFC00_4200_0012_3400_FFFC);
+
+	// Same as s5, but using C-type unpacked array syntax
+	struct packed {
+		bit [7:0] a [8];	// 8 element unpacked array of bytes
+		bit [0:15] b;		// filler for non-zero offset
+	} s6;
+
+	initial begin
+		s6 = '0;
+
+		s6.a[5:6] = 16'h1234;
+		s6.a[2] = 8'h42;
+
+		s6.a[0] = '1;
+		s6.a[0][1:0] = '0;
+
+		s6.b = '1;
+		s6.b[14:15] = '0;
+	end
+
+	always_comb assert(s6==80'hFC00_4200_0012_3400_FFFC);
 endmodule

--- a/tests/svtypes/struct_array.sv
+++ b/tests/svtypes/struct_array.sv
@@ -1,6 +1,7 @@
 // test for array indexing in structures
 
 module top;
+
 	struct packed {
 		bit [5:0] [7:0] a;	// 6 element packed array of bytes
 		bit [15:0] b;		// filler for non-zero offset
@@ -80,6 +81,7 @@ module top;
 
 	always_comb assert(s3_b==80'hFC00_4200_0012_3400_FFFC);
 
+`ifndef VERIFIC
 	// Note that the tests below for unpacked arrays in structs rely on the
 	// fact that they are actually packed in Yosys.
 
@@ -166,4 +168,6 @@ module top;
 	end
 
 	always_comb assert(s6==80'hFC00_4200_0012_3400_FFFC);
+`endif
+
 endmodule

--- a/tests/svtypes/struct_array.sv
+++ b/tests/svtypes/struct_array.sv
@@ -59,6 +59,27 @@ module top;
 
 	always_comb assert(s3==80'hFC00_4200_0012_3400_FFFC);
 
+	// Same as s3, but with little endian bit addressing
+	struct packed {
+		bit [0:7] [0:7] a;	// 8 element packed array of bytes
+		bit [0:15] b;		// filler for non-zero offset
+	} s3_b;
+
+	initial begin
+		s3_b = '0;
+
+		s3_b.a[5:6] = 16'h1234;
+		s3_b.a[2] = 8'h42;
+
+		s3_b.a[0] = '1;
+		s3_b.a[0][6:7] = '0;
+
+		s3_b.b = '1;
+		s3_b.b[14:15] = '0;
+	end
+
+	always_comb assert(s3_b==80'hFC00_4200_0012_3400_FFFC);
+
 	// Note that the tests below for unpacked arrays in structs rely on the
 	// fact that they are actually packed in Yosys.
 
@@ -103,6 +124,27 @@ module top;
 	end
 
 	always_comb assert(s5==80'hFC00_4200_0012_3400_FFFC);
+
+	// Same as s5, but with little endian bit addressing
+	struct packed {
+		bit [0:7] a [0:7];	// 8 element unpacked array of bytes
+		bit [0:15] b;		// filler for non-zero offset
+	} s5_b;
+
+	initial begin
+		s5_b = '0;
+
+		s5_b.a[5:6] = 16'h1234;
+		s5_b.a[2] = 8'h42;
+
+		s5_b.a[0] = '1;
+		s5_b.a[0][6:7] = '0;
+
+		s5_b.b = '1;
+		s5_b.b[14:15] = '0;
+	end
+
+	always_comb assert(s5_b==80'hFC00_4200_0012_3400_FFFC);
 
 	// Same as s5, but using C-type unpacked array syntax
 	struct packed {


### PR DESCRIPTION
This also corrects the implementation of C type arrays within structs.

Fixes #3550