### PR TITLE
muxcover: do not add decode muxes with x inputs

### DIFF
--- a/passes/techmap/muxcover.cc
+++ b/passes/techmap/muxcover.cc
@@ -179,7 +179,7 @@ struct MuxcoverWorker
 
 	int prepare_decode_mux(SigBit &A, SigBit B, SigBit sel, SigBit bit)
 	{
-		if (A == B || sel == State::Sx)
+		if (A == B || A == State::Sx || B == State::Sx || sel == State::Sx)
 			return 0;
 
 		tuple<SigBit, SigBit, SigBit> key(A, B, sel);
@@ -195,9 +195,6 @@ struct MuxcoverWorker
 		std::get<1>(entry).insert(bit);
 
 		if (std::get<2>(entry))
-			return 0;
-
-		if (A == State::Sx || B == State::Sx)
 			return 0;
 
 		return cost_dmux / GetSize(std::get<1>(entry));

--- a/tests/various/muxcover.ys
+++ b/tests/various/muxcover.ys
@@ -508,3 +508,43 @@ design -import gate -as gate
 
 miter -equiv -flatten -make_assert -make_outputs -ignore_gold_x gold gate miter
 sat -verify -prove-asserts -show-ports miter
+
+## implement a mux6 as a mux8 :: https://github.com/YosysHQ/yosys/issues/3591
+
+design -reset
+read_verilog << EOF
+module test (A, S, Y);
+        parameter INPUTS = 6;
+
+        input [INPUTS-1:0] A;
+        input [$clog2(INPUTS)-1:0] S;
+
+        wire [15:0] AA = {{(16-INPUTS){1'b0}}, A};
+        wire [3:0] SS = {{(4-$clog2(INPUTS)){1'b0}}, S};
+
+        output Y = SS[3] ? (SS[2] ? SS[1] ? (SS[0] ? AA[15] : AA[14])
+                                          : (SS[0] ? AA[13] : AA[12])
+                                  : SS[1] ? (SS[0] ? AA[11] : AA[10])
+                                          : (SS[0] ? AA[9] : AA[8]))
+                         : (SS[2] ? SS[1] ? (SS[0] ? AA[7] : AA[6])
+                                          : (SS[0] ? AA[5] : AA[4])
+                                  : SS[1] ? (SS[0] ? AA[3] : AA[2])
+                                          : (SS[0] ? AA[1] : AA[0]));
+endmodule
+EOF
+
+prep
+design -save gold
+simplemap t:\$mux
+muxcover
+opt_clean -purge
+select -assert-count 1 t:$_MUX8_
+select -assert-none t:$_MUX8_ %% t:* %D
+techmap -map +/simcells.v t:$_MUX8_
+design -stash gate
+
+design -import gold -as gold
+design -import gate -as gate
+
+miter -equiv -flatten -make_assert -make_outputs -ignore_gold_x gold gate miter
+sat -verify -prove-asserts -show-ports miter


### PR DESCRIPTION
This turned out to be a surprisingly simple fix: if a decode mux would map to a buffer, don't set it up as a mux.

I'm expecting some tests will need to be modified as this changes how mux trees get mapped in designs, but hopefully nothing too severe.

Fixes #3591.