### PR TITLE
smt2: Fix operation width computation for boolean producing cells

### DIFF
--- a/backends/smt2/smt2.cc
+++ b/backends/smt2/smt2.cc
@@ -462,7 +462,10 @@ struct Smt2Worker
 		int width = GetSize(sig_y);
 
 		if (type == 's' || type == 'S' || type == 'd' || type == 'b') {
-			width = max(width, GetSize(cell->getPort(ID::A)));
+			if (type == 'b')
+				width = GetSize(cell->getPort(ID::A));
+			else
+				width = max(width, GetSize(cell->getPort(ID::A)));
 			if (cell->hasPort(ID::B))
 				width = max(width, GetSize(cell->getPort(ID::B)));
 		}


### PR DESCRIPTION
The output width for the boolean value should not influence the operation width. The previous incorrect width extension would still produce correct results, but could produce invalid smt2 output for reduction operators when the output width was larger than the width of the vector to which the reduction was applied.

This fixes #3654