### PR TITLE
backends/firrtl: Ensure `modInstance` is valid

### DIFF
--- a/backends/firrtl/firrtl.cc
+++ b/backends/firrtl/firrtl.cc
@@ -346,6 +346,12 @@ void emit_elaborated_extmodules(RTLIL::Design *design, std::ostream &f)
 			{
 				// Find the module corresponding to this instance.
 				auto modInstance = design->module(cell->type);
+				// Ensure that we actually have a module instance
+				if (modInstance == nullptr) {
+					log_error("Unknown cell type %s\n", cell->type.c_str());
+					return;
+				}
+
 				bool modIsBlackbox = modInstance->get_blackbox_attribute();
 
 				if (modIsBlackbox)


### PR DESCRIPTION
This should fix #3648 where when calling `emit_elaborated_extmodules` it checks to see if a module is a black-box, however there was no validation that the cell type was actually known, and it just always assumed that we would get a valid instance, causing a segfault.