### PR TITLE
tests: in xprop tests, use MAKE variable if set

### DIFF
--- a/tests/xprop/run-test.sh
+++ b/tests/xprop/run-test.sh
@@ -2,4 +2,4 @@
 set -e
 
 python3 generate.py $@
-make -f run-test.mk
+${MAKE:-make} -f run-test.mk


### PR DESCRIPTION
Needed in case make isn't compatible with GNU make.