### PR TITLE
tests: Fix path of yosys invocation in xprop tests

### DIFF
--- a/tests/xprop/test.py
+++ b/tests/xprop/test.py
@@ -47,7 +47,7 @@ if "clean" in steps:
 
 
 def yosys(command):
-    subprocess.check_call(["yosys", "-Qp", command])
+    subprocess.check_call(["../../../yosys", "-Qp", command])
 
 def remove(file):
     try:


### PR DESCRIPTION
For now xprop test failures are still expected and ignored, but without this change, they did not even run unless the yosys build was in path.