### PR TITLE
Add test for typenames using constants shadowed later on

### DIFF
--- a/tests/verilog/typedef_const_shadow.sv
+++ b/tests/verilog/typedef_const_shadow.sv
@@ -1,0 +1,12 @@
+module top;
+    localparam W = 5;
+    typedef logic [W-1:0] T;
+    T x; // width 5
+    if (1) begin : blk
+        localparam W = 10;
+        typedef T U;
+        typedef logic [W-1:0] V;
+        U y; // width 5
+        V z; // width 10
+    end
+endmodule

--- a/tests/verilog/typedef_const_shadow.ys
+++ b/tests/verilog/typedef_const_shadow.ys
@@ -1,0 +1,4 @@
+read_verilog -sv typedef_const_shadow.sv
+select -assert-count 1 w:x s:5 %i
+select -assert-count 1 w:blk.y s:5 %i
+select -assert-count 1 w:blk.z s:10 %i


### PR DESCRIPTION
This possible edge case came up while reviewing #3555. It is currently handled correctly, but there is no clear test coverage.

@daglem, FYI.