### PR TITLE
gatemate: cell library update

### DIFF
--- a/techlibs/gatemate/cells_bb.v
+++ b/techlibs/gatemate/cells_bb.v
@@ -123,6 +123,12 @@ module CC_CFG_CTRL(
 );
 endmodule
 
+(* blackbox *) (* keep *)
+module CC_USR_RSTN (
+	output USR_RSTN
+);
+endmodule
+
 (* blackbox *)
 module CC_FIFO_40K (
 	output A_ECC_1B_ERR,

--- a/techlibs/gatemate/cells_bb.v
+++ b/techlibs/gatemate/cells_bb.v
@@ -22,6 +22,9 @@ module CC_PLL #(
 	parameter REF_CLK = "", // e.g. "10.0"
 	parameter OUT_CLK = "", // e.g. "50.0"
 	parameter PERF_MD = "", // LOWPOWER, ECONOMY, SPEED
+	parameter LOCK_REQ = 1,
+	parameter CLK270_DOUB = 0,
+	parameter CLK180_DOUB = 0,
 	parameter LOW_JITTER = 1,
 	parameter CI_FILTER_CONST = 2,
 	parameter CP_FILTER_CONST = 4

--- a/techlibs/gatemate/cells_sim.v
+++ b/techlibs/gatemate/cells_sim.v
@@ -114,10 +114,10 @@ module CC_LVDS_IBUF #(
 	parameter [0:0] FF_IBF = 1'bx
 )(
 	(* iopad_external_pin *)
-	input  IP, IN,
+	input  I_P, I_N,
 	output Y
 );
-	assign Y = IP;
+	assign Y = I_P;
 
 endmodule
 
@@ -133,10 +133,10 @@ module CC_LVDS_OBUF #(
 )(
 	input  A,
 	(* iopad_external_pin *)
-	output OP, ON
+	output O_P, O_N
 );
-	assign OP = A;
-	assign ON = ~A;
+	assign O_P = A;
+	assign O_N = ~A;
 
 endmodule
 
@@ -152,10 +152,10 @@ module CC_LVDS_TOBUF #(
 )(
 	input  A, T,
 	(* iopad_external_pin *)
-	output OP, ON
+	output O_P, O_N
 );
-	assign OP = T ? 1'bz :  A;
-	assign ON = T ? 1'bz : ~A;
+	assign O_P = T ? 1'bz :  A;
+	assign O_N = T ? 1'bz : ~A;
 
 endmodule
 
@@ -174,12 +174,12 @@ module CC_LVDS_IOBUF #(
 )(
 	input  A, T,
 	(* iopad_external_pin *)
-	inout  IOP, ION,
+	inout  IO_P, IO_N,
 	output Y
 );
-	assign IOP = T ? 1'bz :  A;
-	assign ION = T ? 1'bz : ~A;
-	assign Y = IOP;
+	assign IO_P = T ? 1'bz :  A;
+	assign IO_N = T ? 1'bz : ~A;
+	assign Y = IO_P;
 
 endmodule
 


### PR DESCRIPTION
With these commits, some minor adjustments are made to the cells:

- 81b18307073f57bf3c049fa3259fbd705422911f fixes incompatibilities with reserved VHDL keywords (`IN`and `ON`) in LVDS buffers/ports
- 59c543bf584401be095ff0508054a4106acd3d48 adds parameters for the clock doubling feature and lock behavior of `CC_PLL` as described in [UG1001](https://www.colognechip.com/docs/ug1001-gatemate1-primitives-library-latest.pdf) from page 107
- 2432c01044fd19ed2aea059c741473755c97bc5a introduces the `CC_USR_RSTN` primitive as described in [UG1001](https://www.colognechip.com/docs/ug1001-gatemate1-primitives-library-latest.pdf) from page 105