### PR TITLE
fabulous: Add CLK to BRAM interface primitives

### DIFF
--- a/techlibs/fabulous/prims.v
+++ b/techlibs/fabulous/prims.v
@@ -93,13 +93,13 @@ module Global_Clock (output CLK);
 endmodule
 
 (* blackbox, keep *)
-module InPass4_frame_config (output O0, O1, O2, O3);
+module InPass4_frame_config (input CLK, output O0, O1, O2, O3);
 
 endmodule
 
 
 (* blackbox, keep *)
-module OutPass4_frame_config (input I0, I1, I2, I3);
+module OutPass4_frame_config (input CLK, I0, I1, I2, I3);
 
 endmodule
 


### PR DESCRIPTION
This lets us do timing analysis on these in nextpnr (which always requires a clock port for clocked timing relationships).