### PR TITLE
Out of bounds checking for struct/union members

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -524,7 +524,13 @@ void AstNode::dumpVlog(FILE *f, std::string indent) const
 		break;
 
 	case AST_IDENTIFIER:
-		fprintf(f, "%s", id2vl(str).c_str());
+		{
+			AST::AstNode *member_node = AST::get_struct_member(this);
+			if (member_node)
+				fprintf(f, "%s[%d:%d]", id2vl(str).c_str(), member_node->range_left, member_node->range_right);
+			else
+				fprintf(f, "%s", id2vl(str).c_str());
+		}
 		for (auto child : children)
 			child->dumpVlog(f, "");
 		break;

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -380,6 +380,7 @@ namespace AST
 
 	// struct helper exposed from simplify for genrtlil
 	AstNode *make_struct_member_range(AstNode *node, AstNode *member_node);
+	AstNode *get_struct_member(const AstNode *node);
 
 	// generate standard $paramod... derived module name; parameters should be
 	// in the order they are declared in the instantiated module

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -1375,6 +1375,7 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 			RTLIL::SigChunk chunk;
 			bool is_interface = false;
 
+			AST::AstNode *member_node = NULL;
 			int add_undef_bits_msb = 0;
 			int add_undef_bits_lsb = 0;
 
@@ -1438,23 +1439,26 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 			chunk.width = wire->width;
 			chunk.offset = 0;
 
+			if ((member_node = get_struct_member(this))) {
+				// Clamp wire chunk to range of member within struct/union.
+				chunk.width = member_node->range_left - member_node->range_right + 1;
+				chunk.offset = member_node->range_right;
+			}
+
 		use_const_chunk:
 			if (children.size() != 0) {
 				if (children[0]->type != AST_RANGE)
 					log_file_error(filename, location.first_line, "Single range expected.\n");
 				int source_width = id2ast->range_left - id2ast->range_right + 1;
 				int source_offset = id2ast->range_right;
-				int item_left = source_width - 1;
-				int item_right = 0;
+				int chunk_left = source_width - 1;
+				int chunk_right = 0;
 
-				// Check for item in struct/union.
-				AST::AstNode *item_node;
-				if (attributes.count(ID::wiretype) && (item_node = attributes[ID::wiretype]) &&
-				    (item_node->type == AST_STRUCT_ITEM || item_node->type == AST_STRUCT || item_node->type == AST_UNION))
-				{
-					// Clamp chunk to range of item within struct/union.
-					item_left = item_node->range_left;
-					item_right = item_node->range_right;
+				if (member_node) {
+					// Clamp wire chunk to range of member within struct/union.
+					log_assert(!source_offset && !id2ast->range_swapped);
+					chunk_left = chunk.offset + chunk.width - 1;
+					chunk_right = chunk.offset;
 				}
 
 				if (!children[0]->range_valid) {
@@ -1468,14 +1472,16 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 					AstNode *fake_ast = new AstNode(AST_NONE, clone(), children[0]->children.size() >= 2 ?
 							children[0]->children[1]->clone() : children[0]->children[0]->clone());
 					fake_ast->children[0]->delete_children();
+					if (member_node)
+						fake_ast->children[0]->attributes[ID::wiretype] = member_node->clone();
 
 					int fake_ast_width = 0;
 					bool fake_ast_sign = true;
 					fake_ast->children[1]->detectSignWidth(fake_ast_width, fake_ast_sign);
 					RTLIL::SigSpec shift_val = fake_ast->children[1]->genRTLIL(fake_ast_width, fake_ast_sign);
 
-					if (id2ast->range_right != 0) {
-						shift_val = current_module->Sub(NEW_ID, shift_val, id2ast->range_right, fake_ast_sign);
+					if (source_offset != 0) {
+						shift_val = current_module->Sub(NEW_ID, shift_val, source_offset, fake_ast_sign);
 						fake_ast->children[1]->is_signed = true;
 					}
 					if (id2ast->range_swapped) {
@@ -1491,10 +1497,10 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 					return sig;
 				} else {
 					chunk.width = children[0]->range_left - children[0]->range_right + 1;
-					chunk.offset = children[0]->range_right - source_offset;
+					chunk.offset += children[0]->range_right - source_offset;
 					if (id2ast->range_swapped)
-						chunk.offset = (id2ast->range_left - id2ast->range_right + 1) - (chunk.offset + chunk.width);
-					if (chunk.offset > item_left || chunk.offset + chunk.width < item_right) {
+						chunk.offset = source_width - (chunk.offset + chunk.width);
+					if (chunk.offset > chunk_left || chunk.offset + chunk.width < chunk_right) {
 						if (chunk.width == 1)
 							log_file_warning(filename, location.first_line, "Range select out of bounds on signal `%s': Setting result bit to undef.\n",
 									str.c_str());
@@ -1503,12 +1509,12 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 									children[0]->range_left, children[0]->range_right, str.c_str(), chunk.width);
 						chunk = RTLIL::SigChunk(RTLIL::State::Sx, chunk.width);
 					} else {
-						if (chunk.offset + chunk.width - 1 > item_left) {
-							add_undef_bits_msb = (chunk.offset + chunk.width - 1) - item_left;
+						if (chunk.offset + chunk.width - 1 > chunk_left) {
+							add_undef_bits_msb = (chunk.offset + chunk.width - 1) - chunk_left;
 							chunk.width -= add_undef_bits_msb;
 						}
-						if (chunk.offset < item_right) {
-							add_undef_bits_lsb = item_right - chunk.offset;
+						if (chunk.offset < chunk_right) {
+							add_undef_bits_lsb = chunk_right - chunk.offset;
 							chunk.width -= add_undef_bits_lsb;
 							chunk.offset += add_undef_bits_lsb;
 						}

--- a/tests/gen-tests-makefile.sh
+++ b/tests/gen-tests-makefile.sh
@@ -75,7 +75,7 @@ generate_tests() {
 	if [[ $do_sv = true ]]; then
 		for x in *.sv; do
 			if [ ! -f "${x%.sv}.ys"  ]; then
-				generate_ys_test "$x" "-p \"prep -top top; sat -verify -prove-asserts\" $yosys_args"
+				generate_ys_test "$x" "-p \"prep -top top; sat -enable_undef -verify -prove-asserts\" $yosys_args"
 			fi;
 		done
 	fi;

--- a/tests/svtypes/struct_array.sv
+++ b/tests/svtypes/struct_array.sv
@@ -18,6 +18,9 @@ module top;
 	end
 
 	always_comb assert(s==64'h4200_0012_3400_FFFC);
+	always_comb assert(s.b[23:16]===8'hxx);
+	always_comb assert(s.b[19:12]===8'hxf);
+	always_comb assert(s.a[0][3:-4]===8'h0x);
 
 	struct packed {
 		bit [7:0] [7:0] a;	// 8 element packed array of bytes

--- a/tests/svtypes/struct_array.sv
+++ b/tests/svtypes/struct_array.sv
@@ -12,15 +12,16 @@ module top;
 
 		s.a[2:1] = 16'h1234;
 		s.a[5] = 8'h42;
+		s.a[-1] = '0;
 
 		s.b = '1;
 		s.b[1:0] = '0;
 	end
 
 	always_comb assert(s==64'h4200_0012_3400_FFFC);
+	always_comb assert(s.a[0][3:-4]===8'h0x);
 	always_comb assert(s.b[23:16]===8'hxx);
 	always_comb assert(s.b[19:12]===8'hxf);
-	always_comb assert(s.a[0][3:-4]===8'h0x);
 
 	struct packed {
 		bit [7:0] [7:0] a;	// 8 element packed array of bytes

--- a/tests/svtypes/struct_dynamic_range.sv
+++ b/tests/svtypes/struct_dynamic_range.sv
@@ -1,0 +1,67 @@
+module range_shift_mask(
+    input logic [2:0] addr_i,
+    input logic [7:0] data_i,
+    input logic [2:0] addr_o,
+    output logic [7:0] data_o
+);
+    // (* nowrshmsk = 0 *)
+    struct packed {
+        logic [7:0] msb;
+        logic [0:3][7:0] data;
+        logic [7:0] lsb;
+    } s;
+
+    always_comb begin
+        s = '1;
+        s.data[addr_i] = data_i;
+        data_o = s.data[addr_o];
+    end
+endmodule
+
+module range_case(
+    input logic [2:0] addr_i,
+    input logic [7:0] data_i,
+    input logic [2:0] addr_o,
+    output logic [7:0] data_o
+);
+    // (* nowrshmsk = 1 *)
+    struct packed {
+        logic [7:0] msb;
+        logic [0:3][7:0] data;
+        logic [7:0] lsb;
+    } s;
+
+    always_comb begin
+        s = '1;
+        s.data[addr_i] = data_i;
+        data_o = s.data[addr_o];
+    end
+endmodule
+
+module top;
+    logic [7:0] data_shift_mask1;
+    range_shift_mask range_shift_mask1(3'd1, 8'h7e, 3'd1, data_shift_mask1);
+    logic [7:0] data_shift_mask2;
+    range_shift_mask range_shift_mask2(3'd1, 8'h7e, 3'd2, data_shift_mask2);
+    logic [7:0] data_shift_mask3;
+    range_shift_mask range_shift_mask3(3'd1, 8'h7e, 3'd4, data_shift_mask3);
+
+    always_comb begin
+        assert(data_shift_mask1 === 8'h7e);
+        assert(data_shift_mask2 === 8'hff);
+        assert(data_shift_mask3 === 8'hxx);
+    end
+
+    logic [7:0] data_case1;
+    range_case range_case1(3'd1, 8'h7e, 3'd1, data_case1);
+    logic [7:0] data_case2;
+    range_case range_case2(3'd1, 8'h7e, 3'd2, data_case2);
+    logic [7:0] data_case3;
+    range_case range_case3(3'd1, 8'h7e, 3'd4, data_case3);
+
+    always_comb begin
+        assert(data_case1 === 8'h7e);
+        assert(data_case2 === 8'hff);
+        assert(data_case3 === 8'hxx);
+    end
+endmodule

--- a/tests/svtypes/struct_dynamic_range.ys
+++ b/tests/svtypes/struct_dynamic_range.ys
@@ -1,0 +1,4 @@
+read_verilog -sv struct_dynamic_range.sv
+prep -top top
+flatten
+sat -enable_undef -verify -prove-asserts


### PR DESCRIPTION
Currently, only constant indices are checked.