### PR TITLE
gatemate: Enable register initialization

### DIFF
--- a/techlibs/gatemate/cells_sim.v
+++ b/techlibs/gatemate/cells_sim.v
@@ -242,7 +242,8 @@ module CC_DFF #(
 	parameter [0:0] CLK_INV = 1'b0,
 	parameter [0:0] EN_INV  = 1'b0,
 	parameter [0:0] SR_INV  = 1'b0,
-	parameter [0:0] SR_VAL  = 1'b0
+	parameter [0:0] SR_VAL  = 1'b0,
+	parameter [0:0] INIT    = 1'bx
 )(
 	input D,
 	(* clkbuf_sink *)
@@ -256,7 +257,7 @@ module CC_DFF #(
 	assign en  = (EN_INV)  ?  ~EN :  EN;
 	assign sr  = (SR_INV)  ?  ~SR :  SR;
 
-	initial Q = 1'bX;
+	initial Q = INIT;
 
 	always @(posedge clk or posedge sr)
 	begin
@@ -272,9 +273,10 @@ endmodule
 
 
 module CC_DLT #(
-	parameter [0:0] G_INV = 1'b0,
+	parameter [0:0] G_INV  = 1'b0,
 	parameter [0:0] SR_INV = 1'b0,
-	parameter [0:0] SR_VAL = 1'b0
+	parameter [0:0] SR_VAL = 1'b0,
+	parameter [0:0] INIT   = 1'bx
 )(
 	input D,
 	input G,
@@ -285,7 +287,7 @@ module CC_DLT #(
 	assign en  = (G_INV) ? ~G : G;
 	assign sr  = (SR_INV) ? ~SR : SR;
 
-	initial Q = 1'bX;
+	initial Q = INIT;
 
 	always @(*)
 	begin

--- a/techlibs/gatemate/reg_map.v
+++ b/techlibs/gatemate/reg_map.v
@@ -21,25 +21,31 @@
 module \$_DFFE_xxxx_ (input D, C, R, E, output Q);
 
 	parameter _TECHMAP_CELLTYPE_ = "";
+	parameter _TECHMAP_WIREINIT_Q_ = 1'bx;
 
 	CC_DFF #(
 		.CLK_INV(_TECHMAP_CELLTYPE_[39:32] == "N"),
 		.EN_INV(_TECHMAP_CELLTYPE_[15:8] == "N"),
 		.SR_INV(_TECHMAP_CELLTYPE_[31:24] == "N"),
-		.SR_VAL(_TECHMAP_CELLTYPE_[23:16] == "1")
+		.SR_VAL(_TECHMAP_CELLTYPE_[23:16] == "1"),
+		.INIT(_TECHMAP_WIREINIT_Q_)
 	) _TECHMAP_REPLACE_ (.D(D), .EN(E), .CLK(C), .SR(R), .Q(Q));
 
+	wire _TECHMAP_REMOVEINIT_Q_ = 1;
 endmodule
 
 (* techmap_celltype = "$_DLATCH_[NP][NP][01]_" *)
 module \$_DLATCH_xxx_ (input E, R, D, output Q);
 
 	parameter _TECHMAP_CELLTYPE_ = "";
+	parameter _TECHMAP_WIREINIT_Q_ = 1'bx;
 
 	CC_DLT #(
 		.G_INV(_TECHMAP_CELLTYPE_[31:24] == "N"),
 		.SR_INV(_TECHMAP_CELLTYPE_[23:16] == "N"),
-		.SR_VAL(_TECHMAP_CELLTYPE_[15:8] == "1")
+		.SR_VAL(_TECHMAP_CELLTYPE_[15:8] == "1"),
+		.INIT(_TECHMAP_WIREINIT_Q_)
 	) _TECHMAP_REPLACE_ (.D(D), .G(E), .SR(R), .Q(Q));
 
+	wire _TECHMAP_REMOVEINIT_Q_ = 1;
 endmodule

--- a/techlibs/gatemate/synth_gatemate.cc
+++ b/techlibs/gatemate/synth_gatemate.cc
@@ -283,7 +283,7 @@ struct SynthGateMatePass : public ScriptPass
 		if (check_label("map_regs"))
 		{
 			run("opt_clean");
-			run("dfflegalize -cell $_DFFE_????_ x -cell $_DLATCH_???_ x");
+			run("dfflegalize -cell $_DFFE_????_ 01 -cell $_DLATCH_???_ 01");
 			run("techmap -map +/gatemate/reg_map.v");
 			run("opt_expr -mux_undef");
 			run("simplemap");


### PR DESCRIPTION
We managed to implement register initialization through specific configuration of CPEs in the P&R bitstream. This commit enables both 0 and 1 initialization with `dfflegalize`.