### PR TITLE
Handling of attributes for struct / union variables

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -1809,7 +1809,12 @@ enum_decl: enum_type enum_var_list ';'		{ delete $1; }
 // struct or union
 //////////////////
 
-struct_decl: struct_type struct_var_list ';' 	{ delete astbuf2; }
+struct_decl:
+	attr struct_type {
+		append_attr($2, $1);
+	} struct_var_list ';' {
+		delete astbuf2;
+	}
 	;
 
 struct_type: struct_union { astbuf2 = $1; } struct_body { $$ = astbuf2; }

--- a/tests/svtypes/.gitignore
+++ b/tests/svtypes/.gitignore
@@ -1,4 +1,3 @@
 /*.log
 /*.out
 /run-test.mk
-/temp

--- a/tests/svtypes/.gitignore
+++ b/tests/svtypes/.gitignore
@@ -1,3 +1,4 @@
 /*.log
 /*.out
 /run-test.mk
+/temp

--- a/tests/svtypes/struct_dynamic_range.sv
+++ b/tests/svtypes/struct_dynamic_range.sv
@@ -4,7 +4,7 @@ module range_shift_mask(
     input logic [2:0] addr_o,
     output logic [7:0] data_o
 );
-    // (* nowrshmsk = 0 *)
+    (* nowrshmsk = 0 *)
     struct packed {
         logic [7:0] msb;
         logic [0:3][7:0] data;
@@ -24,7 +24,7 @@ module range_case(
     input logic [2:0] addr_o,
     output logic [7:0] data_o
 );
-    // (* nowrshmsk = 1 *)
+    (* nowrshmsk = 1 *)
     struct packed {
         logic [7:0] msb;
         logic [0:3][7:0] data;

--- a/tests/svtypes/struct_dynamic_range.ys
+++ b/tests/svtypes/struct_dynamic_range.ys
@@ -1,4 +1,8 @@
+! mkdir -p temp
 read_verilog -sv struct_dynamic_range.sv
+write_rtlil temp/struct_dynamic_range.il
+! grep -F -q ' cell $shift ' temp/struct_dynamic_range.il
+! grep -F -q ' switch $mul' temp/struct_dynamic_range.il
 prep -top top
 flatten
 sat -enable_undef -verify -prove-asserts

--- a/tests/svtypes/struct_dynamic_range.ys
+++ b/tests/svtypes/struct_dynamic_range.ys
@@ -1,8 +1,7 @@
-! mkdir -p temp
 read_verilog -sv struct_dynamic_range.sv
-write_rtlil temp/struct_dynamic_range.il
-! grep -F -q ' cell $shift ' temp/struct_dynamic_range.il
-! grep -F -q ' switch $mul' temp/struct_dynamic_range.il
+select -assert-count 4 t:$mul
+select -assert-count 2 t:$shift
+select -assert-count 2 t:$shiftx
 prep -top top
 flatten
 sat -enable_undef -verify -prove-asserts


### PR DESCRIPTION
(* nowrshmsk *) on a struct / union variable now affects bit slice assignments to members of the struct / union.