### PR TITLE
MachXO2 unification of TRELLIS primitives with ECP5

### DIFF
--- a/techlibs/machxo2/Makefile.inc
+++ b/techlibs/machxo2/Makefile.inc
@@ -1,6 +1,7 @@
 
 OBJS += techlibs/machxo2/synth_machxo2.o
 
+$(eval $(call add_share_file,share/machxo2,techlibs/ecp5/cells_io.vh))
 $(eval $(call add_share_file,share/machxo2,techlibs/machxo2/cells_map.v))
 $(eval $(call add_share_file,share/machxo2,techlibs/machxo2/cells_sim.v))
 

--- a/techlibs/machxo2/cells_map.v
+++ b/techlibs/machxo2/cells_map.v
@@ -25,10 +25,6 @@ module \$lut (A, Y);
 endmodule
 
 // DFFs
-module  \$_DFF_P_ (input D, C, output Q); FACADE_FF #(.CEMUX("1"), .CLKMUX("CLK"), .LSRMUX("LSR"), .REGSET("RESET")) _TECHMAP_REPLACE_ (.CLK(C), .LSR(1'b0), .DI(D), .Q(Q)); endmodule
+module  \$_DFF_P_ (input D, C, output Q); TRELLIS_FF #(.CEMUX("1"), .CLKMUX("CLK"), .LSRMUX("LSR"), .REGSET("RESET")) _TECHMAP_REPLACE_ (.CLK(C), .LSR(1'b0), .DI(D), .Q(Q)); endmodule
 
-// IO- "$__" cells for the iopadmap pass.
-module  \$__FACADE_OUTPAD (input I, output O); FACADE_IO #(.DIR("OUTPUT")) _TECHMAP_REPLACE_ (.PAD(O), .I(I), .T(1'b0)); endmodule
-module  \$__FACADE_INPAD (input I, output O); FACADE_IO #(.DIR("INPUT")) _TECHMAP_REPLACE_ (.PAD(I), .O(O)); endmodule
-module  \$__FACADE_TOUTPAD (input I, T, output O); FACADE_IO #(.DIR("OUTPUT")) _TECHMAP_REPLACE_ (.PAD(O), .I(I), .T(T)); endmodule
-module  \$__FACADE_TINOUTPAD (input I, T, output O, inout B); FACADE_IO #(.DIR("BIDIR")) _TECHMAP_REPLACE_ (.PAD(B), .I(I), .O(O), .T(T)); endmodule
+`include "cells_io.vh"

--- a/techlibs/machxo2/synth_machxo2.cc
+++ b/techlibs/machxo2/synth_machxo2.cc
@@ -214,9 +214,9 @@ struct SynthMachXO2Pass : public ScriptPass
 		{
 			if (!noiopad || help_mode)
 			{
-				run("iopadmap -bits -outpad $__FACADE_OUTPAD I:O -inpad $__FACADE_INPAD O:I -toutpad $__FACADE_TOUTPAD ~T:I:O -tinoutpad $__FACADE_TINOUTPAD ~T:O:I:B A:top");
-				run("attrmvcp -attr src -attr LOC t:$__FACADE_OUTPAD %x:+[O] t:$__FACADE_TOUTPAD %x:+[O] t:$__FACADE_TINOUTPAD %x:+[B]");
-				run("attrmvcp -attr src -attr LOC -driven t:$__FACADE_INPAD %x:+[I]");
+				run("iopadmap -bits -outpad OB I:O -inpad IB O:I -toutpad OBZ ~T:I:O -tinoutpad BB ~T:O:I:B A:top", "(only if '-iopad')");
+				run("attrmvcp -attr src -attr LOC t:OB %x:+[O] t:OBZ %x:+[O] t:BB %x:+[B]");
+				run("attrmvcp -attr src -attr LOC -driven t:IB %x:+[I]");
 			}
 		}
 

--- a/tests/arch/machxo2/add_sub.ys
+++ b/tests/arch/machxo2/add_sub.ys
@@ -5,4 +5,4 @@ equiv_opt -assert -map +/machxo2/cells_sim.v synth_machxo2 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
 select -assert-count 10 t:LUT4
-select -assert-none t:LUT4 t:FACADE_IO %% t:* %D
+select -assert-none t:LUT4 t:TRELLIS_IO %% t:* %D

--- a/tests/arch/machxo2/dffs.ys
+++ b/tests/arch/machxo2/dffs.ys
@@ -6,8 +6,8 @@ proc
 equiv_opt -assert -map +/machxo2/cells_sim.v synth_machxo2 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd dff # Constrain all select calls below inside the top module
-select -assert-count 1 t:FACADE_FF
-select -assert-none t:FACADE_FF t:FACADE_IO %% t:* %D
+select -assert-count 1 t:TRELLIS_FF
+select -assert-none t:TRELLIS_FF t:TRELLIS_IO %% t:* %D
 
 design -load read
 hierarchy -top dffe
@@ -15,5 +15,5 @@ proc
 equiv_opt -assert -map +/machxo2/cells_sim.v synth_machxo2 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd dffe # Constrain all select calls below inside the top module
-select -assert-count 2 t:FACADE_FF t:LUT4
-select -assert-none t:FACADE_FF t:LUT4 t:FACADE_IO %% t:* %D
+select -assert-count 2 t:TRELLIS_FF t:LUT4
+select -assert-none t:TRELLIS_FF t:LUT4 t:TRELLIS_IO %% t:* %D

--- a/tests/arch/machxo2/fsm.ys
+++ b/tests/arch/machxo2/fsm.ys
@@ -11,5 +11,5 @@ design -load postopt # load the post-opt design (otherwise equiv_opt loads the p
 cd fsm # Constrain all select calls below inside the top module
 
 select -assert-max 16 t:LUT4
-select -assert-count 6 t:FACADE_FF
-select -assert-none t:FACADE_FF t:LUT4 t:FACADE_IO %% t:* %D
+select -assert-count 6 t:TRELLIS_FF
+select -assert-none t:TRELLIS_FF t:LUT4 t:TRELLIS_IO %% t:* %D

--- a/tests/arch/machxo2/logic.ys
+++ b/tests/arch/machxo2/logic.ys
@@ -5,4 +5,4 @@ equiv_opt -assert -map +/machxo2/cells_sim.v synth_machxo2 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
 select -assert-count 9 t:LUT4
-select -assert-none t:LUT4 t:FACADE_IO %% t:* %D
+select -assert-none t:LUT4 t:TRELLIS_IO %% t:* %D

--- a/tests/arch/machxo2/mux.ys
+++ b/tests/arch/machxo2/mux.ys
@@ -7,7 +7,7 @@ equiv_opt -assert -map +/machxo2/cells_sim.v synth_machxo2 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux2 # Constrain all select calls below inside the top module
 select -assert-count 1 t:LUT4
-select -assert-none t:LUT4 t:FACADE_IO %% t:* %D
+select -assert-none t:LUT4 t:TRELLIS_IO %% t:* %D
 
 design -load read
 hierarchy -top mux4
@@ -17,7 +17,7 @@ design -load postopt # load the post-opt design (otherwise equiv_opt loads the p
 cd mux4 # Constrain all select calls below inside the top module
 select -assert-count 2 t:LUT4
 
-select -assert-none t:LUT4 t:FACADE_IO %% t:* %D
+select -assert-none t:LUT4 t:TRELLIS_IO %% t:* %D
 
 design -load read
 hierarchy -top mux8
@@ -27,7 +27,7 @@ design -load postopt # load the post-opt design (otherwise equiv_opt loads the p
 cd mux8 # Constrain all select calls below inside the top module
 select -assert-count 5 t:LUT4
 
-select -assert-none t:LUT4 t:FACADE_IO %% t:* %D
+select -assert-none t:LUT4 t:TRELLIS_IO %% t:* %D
 
 design -load read
 hierarchy -top mux16
@@ -37,4 +37,4 @@ design -load postopt # load the post-opt design (otherwise equiv_opt loads the p
 cd mux16 # Constrain all select calls below inside the top module
 select -assert-max 12 t:LUT4
 
-select -assert-none t:LUT4 t:FACADE_IO %% t:* %D
+select -assert-none t:LUT4 t:TRELLIS_IO %% t:* %D

--- a/tests/arch/machxo2/shifter.ys
+++ b/tests/arch/machxo2/shifter.ys
@@ -6,5 +6,5 @@ equiv_opt -assert -map +/machxo2/cells_sim.v synth_machxo2 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
 
-select -assert-count 8 t:FACADE_FF
-select -assert-none t:FACADE_FF t:FACADE_IO %% t:* %D
+select -assert-count 8 t:TRELLIS_FF
+select -assert-none t:TRELLIS_FF t:TRELLIS_IO %% t:* %D

--- a/tests/arch/machxo2/tribuf.ys
+++ b/tests/arch/machxo2/tribuf.ys
@@ -5,6 +5,6 @@ flatten
 equiv_opt -assert -map +/machxo2/cells_sim.v synth_machxo2 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd tristate # Constrain all select calls below inside the top module
-select -assert-count 3 t:FACADE_IO
+select -assert-count 3 t:TRELLIS_IO
 select -assert-count 1 t:LUT4
-select -assert-none t:FACADE_IO t:LUT4 %% t:* %D
+select -assert-none t:TRELLIS_IO t:LUT4 %% t:* %D


### PR DESCRIPTION
Note this is minimal effort unification, enough to provide proper handling and simulation of these primitives, in future, they can fully share simulation models for these.

https://github.com/YosysHQ/yosys/pull/3705 is needed since cells_io.vh from ECP5 is being used.