### PR TITLE
Fix the python generator for a bunch of const cases 

### DIFF
--- a/misc/py_wrap_generator.py
+++ b/misc/py_wrap_generator.py
@@ -1367,10 +1367,17 @@ class WFunction:
 			func.args.append(parsed)
 		return func
 
+	@property
+	def mangled_name(self):
+		mangled_typename = lambda code: code.replace("::", "_").replace("<","_").replace(">","_") \
+										   .replace(" ","").replace("*","").replace(",","")
+
+		return self.name + "".join(
+			f"__{mangled_typename(arg.wtype.gen_text_cpp())}" for arg in self.args
+		)
+
 	def gen_alias(self):
-		self.alias = self.name
-		for arg in self.args:
-			self.alias += "__" + arg.wtype.gen_text_cpp().replace("::", "_").replace("<","_").replace(">","_").replace(" ","").replace("*","").replace(",","")
+		self.alias = self.mangled_name
 
 	def gen_decl(self):
 		if self.duplicate:
@@ -2196,12 +2203,15 @@ def clean_duplicates():
 			for fun in class_.found_funs:
 				if fun.gen_decl_hash_py() in known_decls:
 					debug("Multiple declarations of " + fun.gen_decl_hash_py(),3)
+
 					other = known_decls[fun.gen_decl_hash_py()]
-					other.gen_alias()
-					fun.gen_alias()
-					if fun.gen_decl_hash_py() == other.gen_decl_hash_py():
+					if fun.mangled_name == other.mangled_name:
 						fun.duplicate = True
 						debug("Disabled \"" + fun.gen_decl_hash_py() + "\"", 3)
+						continue
+
+					other.gen_alias()
+					fun.gen_alias()
 				else:
 					known_decls[fun.gen_decl_hash_py()] = fun
 			known_decls = []

--- a/misc/py_wrap_generator.py
+++ b/misc/py_wrap_generator.py
@@ -178,6 +178,8 @@ class WType:
 		t.cont = None
 		t.attr_type = attr_types.default
 		if str_def.find("<") != -1:# and str_def.find("<") < str_def.find(" "):
+			str_def = str_def.replace("const ", "")
+
 			candidate = WContainer.from_string(str_def, containing_file, line_number)
 			if candidate == None:
 				return None
@@ -203,8 +205,12 @@ class WType:
 
 		prefix = ""
 
+		if str.startswith(str_def, "const "):
+			if "char_p" in str_def:
+				prefix = "const "
+			str_def = str_def[6:]
 		if str.startswith(str_def, "unsigned "):
-			prefix = "unsigned "
+			prefix = "unsigned " + prefix
 			str_def = str_def[9:]
 		while str.startswith(str_def, "long "):
 			prefix= "long " + prefix
@@ -1285,7 +1291,7 @@ class WFunction:
 		prefix = ""
 		i = 0
 		for part in parts:
-			if part in ["unsigned", "long", "short"]:
+			if part in ["unsigned", "long", "short", "const"]:
 				prefix += part + " "
 				i += 1
 			else:


### PR DESCRIPTION
Makes the below show up in the binding.

    .def<const char * (IdString::*)(void)>("c_str", &IdString::c_str)

    .def<boost::python::list (SigSpec::*)(void)>("chunks", &SigSpec::chunks)
    .def<boost::python::list (SigSpec::*)(void)>("bits", &SigSpec::bits)
    .def<SigBit (SigSpec::*)(int, const SigBit* )>("at", &SigSpec::at)

    .def<SigSpec (Cell::*)(const IdString* )>("getPort", &Cell::getPort)
    .def<boost::python::dict (Cell::*)(void)>("connections", &Cell::connections)
    .def<Const (Cell::*)(const IdString* )>("getParam", &Cell::getParam)

    .def<boost::python::list (Module::*)(void)>("connections", &Module::connections)

    def<const char * (*)(const SigSpec* )>("log_signal", YOSYS_PYTHON::log_signal);
    def<const char * (*)(const SigSpec* , bool)>("log_signal", YOSYS_PYTHON::log_signal);
    def<const char * (*)(const Const* )>("log_const", YOSYS_PYTHON::log_const);
    def<const char * (*)(const Const* , bool)>("log_const", YOSYS_PYTHON::log_const);
    def<const char * (*)(const IdString* )>("log_id", YOSYS_PYTHON::log_id);