### PR TITLE
Remove a statement without effect.

### DIFF
--- a/kernel/yw.cc
+++ b/kernel/yw.cc
@@ -190,8 +190,6 @@ RTLIL::Const ReadWitness::get_bits(int t, int bits_offset, int width) const
 	int read_begin = GetSize(bits) - 1 - bits_offset;
 	int read_end = max(-1, read_begin - width);
 
-	min(width, GetSize(bits) - bits_offset);
-
 	for (int i = read_begin, j = 0; i > read_end; i--, j++) {
 		RTLIL::State bit = State::Sa;
 		switch (bits[i]) {


### PR DESCRIPTION
The return value of the min(...) call is never used. Looks like some leftover from some previous implementation.