### PR TITLE
Add outputs before inputs to the sigmap in the AIGER backend.

### DIFF
--- a/backends/aiger/aiger.cc
+++ b/backends/aiger/aiger.cc
@@ -119,14 +119,14 @@ struct AigerWriter
 			if (wire->name.isPublic())
 				sigmap.add(wire);
 
-		// promote input wires
-		for (auto wire : module->wires())
-			if (wire->port_input)
-				sigmap.add(wire);
-
 		// promote output wires
 		for (auto wire : module->wires())
 			if (wire->port_output)
+				sigmap.add(wire);
+
+		// promote input wires
+		for (auto wire : module->wires())
+			if (wire->port_input)
 				sigmap.add(wire);
 
 		for (auto wire : module->wires())


### PR DESCRIPTION
## Summary
This change fixes an issue where the input port ordering isn't maintained when writing an AIGER file if an output is directly connected to an input.

For example, if the inputs are `[a, b, c]` and `b` is connected to an output, then `b` gets moved to the end, and the inputs in the AIG are incorrectly ordered `[a, c, b]`.

## Reproducible example
Verilog file `/tmp/circuit.v`:
```verilog
module circuit(a, b, c, out);
  input a;
  input b;
  input c;
  wire a;
  wire b;
  wire c;
  output [2:0] out;
  wire [2:0] out;
  assign out[0] = b;
  assign out[1] = a & c;
endmodule
```
Command: `yosys -p "read_verilog -sv /tmp/circuit.v; aigmap; write_aiger -ascii -symbols /tmp/circuit.aig"`

### Output

The AIGER file shows the following snippet in the symbol table, showing that the inputs are being ordered `[a, c, b]`:
```
i0 a
i1 c
i2 b
```

### Expected output

The AIGER file shows the following snippet in the symbol table, showing that the inputs are being ordered `[a, b, c]`:
```
i0 a
i1 b
i2 c
```

## Debugging
The root cause seems to be that the [disjoint set data structure (called sigmap)](https://github.com/YosysHQ/yosys/blob/7efc50367ed8f582001a5a293a9cd51f788f6a13/backends/aiger/aiger.cc#L45) is being used to identify when some bits are the same. In this case, input `b` and output `out[0]` are identified to be the same. Each collection of bits has a canonical representative, which is the most recent bit that was added to the sigmap. Because the output bits are [being added to the sigmap](https://github.com/YosysHQ/yosys/blob/7efc50367ed8f582001a5a293a9cd51f788f6a13/backends/aiger/aiger.cc#L127-L130) after [the input bits are](https://github.com/YosysHQ/yosys/blob/7efc50367ed8f582001a5a293a9cd51f788f6a13/backends/aiger/aiger.cc#L122-L125), the canonical representative of an input/output bit pair that are identified to be the same is always the output bit. In this case, the canonical representative of `{b, out[0]}` is `out[0]`.

In the AIGER backend, the [input bits are being sorted](https://github.com/YosysHQ/yosys/blob/7efc50367ed8f582001a5a293a9cd51f788f6a13/backends/aiger/aiger.cc#L318). Sorting is defined on bits by sorting first on the associated wire, then by position. Because the canonical representative of `b` is `out[0]`, `b` is sorted after the other inputs as its wire attribute is taken to be the output wire.