### PR TITLE
gowin: Fix X output of $alu techmap

### DIFF
--- a/techlibs/gowin/arith_map.v
+++ b/techlibs/gowin/arith_map.v
@@ -62,6 +62,6 @@ module _80_gw1n_alu(A, B, CI, BI, X, Y, CO);
 	  .SUM(Y[i])
 	  );
    end endgenerate
-   assign X = AA ^ BB;
+   assign X = AA ^ BB ^ {Y_WIDTH{BI}};
 endmodule
 

--- a/tests/arch/gowin/compare.v
+++ b/tests/arch/gowin/compare.v
@@ -1,0 +1,20 @@
+module top
+(
+    input [4:0] x,
+    input [4:0] y,
+
+    output lt,
+    output le,
+    output gt,
+    output ge,
+    output eq,
+    output ne
+);
+
+    assign lt = x < y;
+    assign le = x <= y;
+    assign gt = x > y;
+    assign ge = x >= y;
+    assign eq = x == y;
+    assign ne = x != y;
+endmodule

--- a/tests/arch/gowin/compare.ys
+++ b/tests/arch/gowin/compare.ys
@@ -1,0 +1,9 @@
+read_verilog compare.v
+hierarchy -top top
+proc
+equiv_opt -assert -map +/gowin/cells_sim.v synth_gowin # equivalency check
+design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
+cd top # Constrain all select calls below inside the top module
+select -assert-count 5 t:ALU
+
+


### PR DESCRIPTION
The `X` output in the gowin `$alu` mapping didn't take the `BI` input into account, which caused `$eq`, `$ne`, `$le` and `$ge` comparisons to be broken: https://github.com/YosysHQ/apicula/issues/140.