### PR TITLE
Updated the `plugin` command to better handle paths

### DIFF
--- a/passes/cmds/plugin.cc
+++ b/passes/cmds/plugin.cc
@@ -21,12 +21,12 @@
 
 #ifdef YOSYS_ENABLE_PLUGINS
 #  include <dlfcn.h>
+#  include <boost/filesystem.hpp>
+#  include <boost/algorithm/string/predicate.hpp>
 #endif
 
 #ifdef WITH_PYTHON
-#  include <boost/algorithm/string/predicate.hpp>
 #  include <Python.h>
-#  include <boost/filesystem.hpp>
 #endif
 
 YOSYS_NAMESPACE_BEGIN
@@ -41,19 +41,17 @@ std::map<std::string, std::string> loaded_plugin_aliases;
 void load_plugin(std::string filename, std::vector<std::string> aliases)
 {
 	std::string orig_filename = filename;
+	rewrite_filename(filename);
+	boost::filesystem::path full_path(filename);
 
-	if (filename.find('/') == std::string::npos)
-		filename = "./" + filename;
 
 	#ifdef WITH_PYTHON
-	if (!loaded_plugins.count(filename) && !loaded_python_plugins.count(filename)) {
+	if (!loaded_plugins.count(orig_filename) && !loaded_python_plugins.count(orig_filename)) {
 	#else
-	if (!loaded_plugins.count(filename)) {
+	if (!loaded_plugins.count(orig_filename)) {
 	#endif
 
 		#ifdef WITH_PYTHON
-
-		boost::filesystem::path full_path(filename);
 
 		if(strcmp(full_path.extension().c_str(), ".py") == 0)
 		{
@@ -75,10 +73,23 @@ void load_plugin(std::string filename, std::vector<std::string> aliases)
 		#endif
 
 		void *hdl = dlopen(filename.c_str(), RTLD_LAZY|RTLD_LOCAL);
-		if (hdl == NULL && orig_filename.find('/') == std::string::npos)
-			hdl = dlopen((proc_share_dirname() + "plugins/" + orig_filename + ".so").c_str(), RTLD_LAZY|RTLD_LOCAL);
+
+		// We were unable to open the file, try to do so from the plugin directory
+		if (hdl == NULL && filename.find('/') == std::string::npos) {
+			hdl = dlopen([filename]() {
+				std::string new_path = proc_share_dirname() + "plugins/" + filename;
+
+				// Check if we need to append .so
+				if (new_path.find(".so") == std::string::npos)
+					new_path.append(".so");
+
+				return new_path;
+			}().c_str(), RTLD_LAZY|RTLD_LOCAL);
+		}
+
 		if (hdl == NULL)
 			log_cmd_error("Can't load module `%s': %s\n", filename.c_str(), dlerror());
+
 		loaded_plugins[orig_filename] = hdl;
 		Pass::init_register();
 
@@ -182,4 +193,3 @@ struct PluginPass : public Pass {
 } PluginPass;
 
 YOSYS_NAMESPACE_END
-


### PR DESCRIPTION
This PR updates the `plugin -i` command to better deal with some edge cases and inconsistencies with how it behaved.

The first update is that it now ensures that the plugin does not end with `.so` before trying to append it. Previously when running `plugin -i nya.so` it would try to look for `nya.so.so` in the `YOSYS_SHARE/plugins` directory, that has been fixed.

The second update is that it now checks for the `.py` extension even without Python support being enabled, and produces an error message accordingly.

The final update is that the filename path is now also run through `rewrite_path`, as is done with a large portion of the other file inputs in Yosys.


This PR does not address #2545 nor #3151 yet, I wanted to get some basic restructuring done first to make implementation a little nicer.
