### PR TITLE
Standard compliance for tests/verilog/block_labels.ys

### DIFF
--- a/tests/verilog/block_labels.ys
+++ b/tests/verilog/block_labels.ys
@@ -1,7 +1,7 @@
 read_verilog <<EOT
 module foo;
 
-	genvar a = 0;
+	genvar a;
 	for (a = 0; a < 10; a++) begin : a
 	end : a
 endmodule
@@ -9,7 +9,7 @@ EOT
 read_verilog <<EOT
 module foo2;
 
-	genvar a = 0;
+	genvar a;
 	for (a = 0; a < 10; a++) begin : a
 	end
 endmodule
@@ -19,7 +19,7 @@ logger -expect error "Begin label \(a\) and end label \(b\) don't match\." 1
 read_verilog <<EOT
 module foo3;
 
-	genvar a = 0;
+	genvar a;
 	for (a = 0; a < 10; a++) begin : a
 	end : b
 endmodule


### PR DESCRIPTION
genvar declaration cannot take an initial value when declared as a module_or_generate_item_declaration. Correct this test so that it doesn't fail unexpectedly if Yosys aligns with the standard.