### PR TITLE
abc9_ops -prep_hier to unmap entire module

### DIFF
--- a/tests/arch/xilinx/dsp_abc9.ys
+++ b/tests/arch/xilinx/dsp_abc9.ys
@@ -1,3 +1,5 @@
+logger -nowarn "Yosys has only limited support for tri-state logic at the moment\. .*"
+
 read_verilog <<EOT
 module top(input [24:0] A, input [17:0] B, output [47:0] P);
 DSP48E1 #(.PREG(0)) dsp(.A(A), .B(B), .P(P));
@@ -35,3 +37,18 @@ techmap -autoproc -wb -map +/xilinx/cells_sim.v
 opt -full -fine
 select -assert-count 0 t:* t:$assert %d
 sat -verify -prove-asserts
+
+
+design -reset
+read_verilog <<EOT
+module top(input signed [29:0] A, input signed [17:0] B, output signed [47:0] P);
+wire [47:0] casc;
+DSP48E1 #(.AREG(1)) u1(.A(A), .B(B), .PCOUT(casc));
+DSP48E1 #(.AREG(1)) u2(.A(A), .B(B), .PCIN(casc), .P(P));
+endmodule
+EOT
+synth_xilinx -run :prepare
+abc9
+clean
+check
+logger -expect-no-warnings


### PR DESCRIPTION
As demonstrated in the included test:
```
module top(input signed [29:0] A, input signed [17:0] B, output signed [47:0] P);
wire [47:0] casc;
DSP48E1 #(.AREG(1)) u1(.A(A), .B(B), .PCOUT(casc));
DSP48E1 #(.AREG(1)) u2(.A(A), .B(B), .PCIN(casc), .P(P));
endmodule
```

`abc9_ops -prep_hier` would encounter `u2` first and create an "unmap" module that is used later to transform `u2` (and `u1`) from its derived (mapped) cell back into the parameterised cell. The problem is that the unmap module is not general: since `u2` does not have a `PCOUT` port, the unmap will not have one either. As a result, `u1` gets its `PCOUT` connection dropped.

Fix that here.