### PR TITLE
Use clk2fflogic attr on cells to track original FF names in witnesses and fix a sim initialization bug.

### DIFF
--- a/backends/aiger/aiger.cc
+++ b/backends/aiger/aiger.cc
@@ -733,6 +733,9 @@ struct AigerWriter
 				auto sig_qy = cell->getPort(cell->type.in(ID($anyconst), ID($anyseq)) ? ID::Y : ID::Q);
 				SigSpec sig = sigmap(sig_qy);
 
+				if (cell->get_bool_attribute(ID(clk2fflogic)))
+					sig_qy = cell->getPort(ID::D); // For a clk2fflogic $_FF_ the named signal is the D input not the Q output
+
 				for (int i = 0; i < GetSize(sig_qy); i++) {
 					if (sig_qy[i].wire == nullptr || sig[i].wire == nullptr)
 						continue;

--- a/backends/btor/btor.cc
+++ b/backends/btor/btor.cc
@@ -728,7 +728,10 @@ struct BtorWorker
 			else
 				btorf("%d state %d %s\n", nid, sid, log_id(symbol));
 
-			ywmap_state(sig_q);
+			if (cell->get_bool_attribute(ID(clk2fflogic)))
+				ywmap_state(cell->getPort(ID::D)); // For a clk2fflogic FF the named signal is the D input not the Q output
+			else
+				ywmap_state(sig_q);
 
 			if (nid_init_val >= 0) {
 				int nid_init = next_nid++;

--- a/backends/smt2/smt2.cc
+++ b/backends/smt2/smt2.cc
@@ -626,8 +626,9 @@ struct Smt2Worker
 				}
 
 				bool init_only = cell->type.in(ID($anyconst), ID($anyinit), ID($allconst));
+				bool clk2fflogic = cell->type == ID($anyinit) && cell->get_bool_attribute(ID(clk2fflogic));
 				int smtoffset = 0;
-				for (auto chunk : cell->getPort(QY).chunks()) {
+				for (auto chunk : cell->getPort(clk2fflogic ? ID::D : QY).chunks()) {
 					if (chunk.is_wire())
 						decls.push_back(witness_signal(init_only ? "init" : "seq", chunk.width, chunk.offset, "", idcounter, chunk.wire, smtoffset));
 					smtoffset += chunk.width;

--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -292,10 +292,12 @@ bool rmunused_module_signals(RTLIL::Module *module, bool purge_mode, bool verbos
 	if (!purge_mode)
 		for (auto &it : module->cells_) {
 			RTLIL::Cell *cell = it.second;
-			if (ct_reg.cell_known(cell->type))
+			if (ct_reg.cell_known(cell->type)) {
+				bool clk2fflogic = cell->get_bool_attribute(ID(clk2fflogic));
 				for (auto &it2 : cell->connections())
-					if (ct_reg.cell_output(cell->type, it2.first))
+					if (clk2fflogic ? it2.first == ID::D : ct_reg.cell_output(cell->type, it2.first))
 						register_signals.add(it2.second);
+			}
 			for (auto &it2 : cell->connections())
 				connected_signals.add(it2.second);
 		}


### PR DESCRIPTION
See e36c71b5b743e578f3a965cda9926a426cd5c295 for a detailed description.