### PR TITLE
intel_alm: re-enable carry chains for ABC9

### DIFF
--- a/techlibs/intel_alm/common/alm_sim.v
+++ b/techlibs/intel_alm/common/alm_sim.v
@@ -1,5 +1,5 @@
 // The core logic primitive of the Cyclone V/10GX is the Adaptive Logic Module
-// (ALM). Each ALM is made up of an 8-input, 2-output look-up table, covered 
+// (ALM). Each ALM is made up of an 8-input, 2-output look-up table, covered
 // in this file, connected to combinational outputs, a carry chain, and four
 // D flip-flops (which are covered as MISTRAL_FF in dff_sim.v).
 //
@@ -283,10 +283,8 @@ assign Q = ~A;
 
 endmodule
 
-// Despite the abc9_carry attributes, this doesn't seem to stop ABC9 adding illegal fanout to the carry chain that nextpnr cannot handle.
-// So we treat it as a total blackbox from ABC9's perspective for now.
-// (* abc9_box, lib_whitebox *)
-module MISTRAL_ALUT_ARITH(input A, B, C, D0, D1, /* (* abc9_carry *) */ input CI, output SO, /* (* abc9_carry *) */ output CO);
+(* abc9_box, lib_whitebox *)
+module MISTRAL_ALUT_ARITH(input A, B, C, D0, D1, (* abc9_carry *) input CI, output SO, (* abc9_carry *) output CO);
 
 parameter LUT0 = 16'h0000;
 parameter LUT1 = 16'h0000;

--- a/tests/arch/intel_alm/counter.ys
+++ b/tests/arch/intel_alm/counter.ys
@@ -6,7 +6,7 @@ equiv_opt -assert -async2sync -map +/intel_alm/common/alm_sim.v -map +/intel_alm
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
 
-select -assert-count 1 t:MISTRAL_NOT
+select -assert-count 2 t:MISTRAL_NOT
 select -assert-count 8 t:MISTRAL_ALUT_ARITH
 select -assert-count 8 t:MISTRAL_FF
 select -assert-none t:MISTRAL_NOT t:MISTRAL_ALUT_ARITH t:MISTRAL_FF %% t:* %D
@@ -21,7 +21,7 @@ equiv_opt -assert -async2sync -map +/intel_alm/common/alm_sim.v -map +/intel_alm
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
 
-select -assert-count 1 t:MISTRAL_NOT
+select -assert-count 2 t:MISTRAL_NOT
 select -assert-count 8 t:MISTRAL_ALUT_ARITH
 select -assert-count 8 t:MISTRAL_FF
 select -assert-none t:MISTRAL_NOT t:MISTRAL_ALUT_ARITH t:MISTRAL_FF %% t:* %D


### PR DESCRIPTION
The issue of whitebox carry chains having multiple fanout seems to have been fixed by berkeley-abc/abc#139, so we can safely revert 34a08750fa1a490be09411b07f64f4236eff234e to re-enable whitebox optimisation of carry chains.