### PR TITLE
intel_alm: re-enable 8x40-bit M10K support

### DIFF
--- a/techlibs/intel_alm/common/bram_m10k.txt
+++ b/techlibs/intel_alm/common/bram_m10k.txt
@@ -10,6 +10,8 @@ bram $__MISTRAL_M10K
     dbits 10   @D1024x10
     abits  9   @D512x20
     dbits 20   @D512x20
+    abits  8   @D256x40
+    dbits 40   @D256x40
     groups 2
     ports  1 1
     wrmode 1 0

--- a/techlibs/intel_alm/common/bram_m10k_map.v
+++ b/techlibs/intel_alm/common/bram_m10k_map.v
@@ -13,6 +13,14 @@ input [CFG_DBITS-1:0] A1DATA;
 input A1EN, B1EN;
 output reg [CFG_DBITS-1:0] B1DATA;
 
-MISTRAL_M10K #(.INIT(INIT), .CFG_ABITS(CFG_ABITS), .CFG_DBITS(CFG_DBITS)) _TECHMAP_REPLACE_ (.CLK1(CLK1), .A1ADDR(A1ADDR), .A1DATA(A1DATA), .A1EN(!A1EN), .B1ADDR(B1ADDR), .B1DATA(B1DATA), .B1EN(B1EN));
+// Normal M10K configs use WREN[1], which is negative-true.
+// However, 8x40-bit mode uses WREN[0], which is positive-true.
+wire a1en;
+if (CFG_DBITS == 40)
+    assign a1en = A1EN;
+else
+    assign a1en = !A1EN;
+
+MISTRAL_M10K #(.INIT(INIT), .CFG_ABITS(CFG_ABITS), .CFG_DBITS(CFG_DBITS)) _TECHMAP_REPLACE_ (.CLK1(CLK1), .A1ADDR(A1ADDR), .A1DATA(A1DATA), .A1EN(a1en), .B1ADDR(B1ADDR), .B1DATA(B1DATA), .B1EN(B1EN));
 
 endmodule


### PR DESCRIPTION
This is effectively a revert of #3124, which was a misunderstanding of how the M10K works - I had assumed that one port is a 20-bit write and one port is a 20-bit read, but in fact both ports have a 20-bit data input and a 20-bit data output, so this can function as a 8x40-bit SDP.

I've plumbed support into nextpnr as YosysHQ/nextpnr#1169, so let's enable it in Yosys as well.

