### PR TITLE
show -colorattr: extend colors to arrows when wires have attribute

### DIFF
--- a/passes/cmds/show.cc
+++ b/passes/cmds/show.cc
@@ -106,7 +106,7 @@ struct ShowWorker
 	{
 		std::string color = findColor(conn);
 		if (!color.empty()) return color;
-		return nextColor(conn.first, nextColor(conn.second, defaultColor));
+		return defaultColor;
 	}
 
 	std::string nextColor(const RTLIL::SigSpec &sig)
@@ -490,16 +490,14 @@ struct ShowWorker
 						conn.second, ct.cell_output(cell->type, conn.first));
 			}
 
-			std::string color = findColor(cell->name);
-			if (!color.empty()) color = ", " + color;
 #ifdef CLUSTER_CELLS_AND_PORTBOXES
 			if (!code.empty())
 				fprintf(f, "subgraph cluster_c%d {\nc%d [ shape=record, label=\"%s\"%s ];\n%s}\n",
 						id2num(cell->name), id2num(cell->name), label_string.c_str(), color.c_str(), code.c_str());
 			else
 #endif
-				fprintf(f, "c%d [ shape=record, label=\"%s\"%s ];\n%s",
-						id2num(cell->name), label_string.c_str(), color.c_str(), code.c_str());
+				fprintf(f, "c%d [ shape=record, label=\"%s\", %s ];\n%s",
+						id2num(cell->name), label_string.c_str(), findColor(cell->name).c_str(), code.c_str());
 		}
 
 		for (auto &it : module->processes)
@@ -569,9 +567,9 @@ struct ShowWorker
 				} else if (right_node[0] == 'x') {
 					net_conn_map[left_node].out.insert({right_node, GetSize(conn.first)});
 				} else {
-					net_conn_map[right_node].in.insert({stringf("x%d:e", single_idx_count), GetSize(conn.first)});
-					net_conn_map[left_node].out.insert({stringf("x%d:w", single_idx_count), GetSize(conn.first)});
-					fprintf(f, "x%d [shape=box, style=rounded, label=\"BUF\"];\n", single_idx_count++);
+					net_conn_map[right_node].in.insert({stringf("x%d", single_idx_count), GetSize(conn.first)});
+					net_conn_map[left_node].out.insert({stringf("x%d", single_idx_count), GetSize(conn.first)});
+					fprintf(f, "x%d [shape=box, style=rounded, label=\"BUF\", %s];\n", single_idx_count++, findColor(conn).c_str());
 				}
 			}
 		}

--- a/passes/cmds/show.cc
+++ b/passes/cmds/show.cc
@@ -84,7 +84,7 @@ struct ShowWorker
 	std::string nextColor()
 	{
 		if (currentColor == 0)
-			return "color=\"black\"";
+			return "color=\"black\", fontcolor=\"black\"";
 		return stringf("colorscheme=\"dark28\", color=\"%d\", fontcolor=\"%d\"", currentColor%8+1, currentColor%8+1);
 	}
 
@@ -97,18 +97,15 @@ struct ShowWorker
 
 	std::string nextColor(RTLIL::SigSpec sig, std::string defaultColor)
 	{
-		sig.sort_and_unify();
-		for (auto &c : sig.chunks()) {
-			if (c.wire != nullptr)
-				for (auto &s : color_selections)
-					if (s.second.selected_members.count(module->name) > 0 && s.second.selected_members.at(module->name).count(c.wire->name) > 0)
-						return stringf("color=\"%s\"", s.first.c_str());
-		}
+		std::string color = findColor(sig);
+		if (!color.empty()) return color;
 		return defaultColor;
 	}
 
 	std::string nextColor(const RTLIL::SigSig &conn, std::string defaultColor)
 	{
+		std::string color = findColor(conn);
+		if (!color.empty()) return color;
 		return nextColor(conn.first, nextColor(conn.second, defaultColor));
 	}
 
@@ -131,12 +128,28 @@ struct ShowWorker
 		return stringf("style=\"setlinewidth(3)\", label=\"<%d>\"", bits);
 	}
 
-	const char *findColor(std::string member_name)
+	std::string findColor(RTLIL::SigSpec sig)
+	{
+		sig.sort_and_unify();
+		for (auto &c : sig.chunks()) {
+			if (c.wire != nullptr)
+				return findColor(c.wire->name);
+		}
+		return "";
+	}
+
+	std::string findColor(const RTLIL::SigSig &conn)
+	{
+		std::string firstColor = findColor(conn.first);
+		if (findColor(conn.second) == firstColor) return firstColor;
+		return "";
+	}
+
+	std::string findColor(IdString member_name)
 	{
 		for (auto &s : color_selections)
 			if (s.second.selected_member(module->name, member_name)) {
-				dot_escape_store.push_back(stringf(", color=\"%s\"", s.first.c_str()));
-				return dot_escape_store.back().c_str();
+				return stringf("color=\"%s\", fontcolor=\"%s\"", s.first.c_str(), s.first.c_str());
 			}
 
 		RTLIL::Const colorattr_value;
@@ -155,8 +168,7 @@ struct ShowWorker
 			colorattr_cache[colorattr_value] = (next_id % 8) + 1;
 		}
 
-		dot_escape_store.push_back(stringf(", colorscheme=\"dark28\", color=\"%d\", fontcolor=\"%d\"", colorattr_cache.at(colorattr_value), colorattr_cache.at(colorattr_value)));
-		return dot_escape_store.back().c_str();
+		return stringf("colorscheme=\"dark28\", color=\"%d\", fontcolor=\"%d\"", colorattr_cache.at(colorattr_value), colorattr_cache.at(colorattr_value));
 	}
 
 	const char *findLabel(std::string member_name)
@@ -414,9 +426,9 @@ struct ShowWorker
 			if (wire->port_input || wire->port_output)
 				shape = "octagon";
 			if (wire->name.isPublic()) {
-				fprintf(f, "n%d [ shape=%s, label=\"%s\", %s, fontcolor=\"black\" ];\n",
+				fprintf(f, "n%d [ shape=%s, label=\"%s\", %s ];\n",
 						id2num(wire->name), shape, findLabel(wire->name.str()),
-						nextColor(RTLIL::SigSpec(wire), "color=\"black\"").c_str());
+						nextColor(RTLIL::SigSpec(wire), "color=\"black\", fontcolor=\"black\"").c_str());
 				if (wire->port_input)
 					all_sources.insert(stringf("n%d", id2num(wire->name)));
 				else if (wire->port_output)
@@ -478,14 +490,16 @@ struct ShowWorker
 						conn.second, ct.cell_output(cell->type, conn.first));
 			}
 
+			std::string color = findColor(cell->name);
+			if (!color.empty()) color = ", " + color;
 #ifdef CLUSTER_CELLS_AND_PORTBOXES
 			if (!code.empty())
 				fprintf(f, "subgraph cluster_c%d {\nc%d [ shape=record, label=\"%s\"%s ];\n%s}\n",
-						id2num(cell->name), id2num(cell->name), label_string.c_str(), findColor(cell->name), code.c_str());
+						id2num(cell->name), id2num(cell->name), label_string.c_str(), color.c_str(), code.c_str());
 			else
 #endif
 				fprintf(f, "c%d [ shape=record, label=\"%s\"%s ];\n%s",
-						id2num(cell->name), label_string.c_str(), findColor(cell->name.str()), code.c_str());
+						id2num(cell->name), label_string.c_str(), color.c_str(), code.c_str());
 		}
 
 		for (auto &it : module->processes)


### PR DESCRIPTION
This updates the show command to use similar logic for the `-color <color> <selection>` and `-colorattr <attr>` options. Both will now color the cells, wires, and connection arrows for the designated elements.

Also adds a `-viewer none` option to disable opening the viewer (this is already possible indirectly because specifying `-format <foo>` disables the viewer).

Also fixes a bug where the `:e` and `:w` compass port options would be added twice on some nodes (graphviz doesn't mind the redundancy so this didn't change anything functionally).