### PR TITLE
yosys-witness: Don't treat aiw x-bits as don't change

### DIFF
--- a/backends/smt2/witness.py
+++ b/backends/smt2/witness.py
@@ -194,7 +194,7 @@ def aiw2yw(input, mapfile, output):
 
         values = WitnessValues()
         for i, v in enumerate(inline):
-            if v == "x" or outyw.t > 0 and i in aiger_map.init_inputs:
+            if outyw.t > 0 and i in aiger_map.init_inputs:
                 continue
 
             try:


### PR DESCRIPTION
While treating initialization only bits as don't change during later cycles is correct, actual x-bits should be kept as x-bits.