### PR TITLE
show: escape angle brackets

### DIFF
--- a/passes/cmds/show.cc
+++ b/passes/cmds/show.cc
@@ -208,7 +208,7 @@ struct ShowWorker
 				str += "&#9586;";
 				continue;
 			}
-			if (ch == '"')
+			if (ch == '"' || ch == '<' || ch == '>')
 				str += "\\";
 			str += ch;
 		}

--- a/passes/cmds/show.cc
+++ b/passes/cmds/show.cc
@@ -201,6 +201,12 @@ struct ShowWorker
 		if (id[0] == '\\')
 			id = id.substr(1);
 
+		// TODO: optionally include autoname + print correspondence in case of ambiguity
+		size_t max_label_len = abbreviateIds ? 256 : 16384;
+		if (id.size() > max_label_len) {
+			id = id.substr(0,max_label_len-3) + "...";
+		}
+
 		std::string str;
 		for (char ch : id) {
 			if (ch == '\\') {


### PR DESCRIPTION
This is mainly a problem for VHDL parameters assigned `(others=>0)`.

Reduced example to reproduce: `yosys -p show top.il`
```top.il
attribute \top 1
module \top
  wire width 9 input 0 \a
  wire width 9 input 1 \b
  wire width 18 output 2 \c
  cell \demo<=>cell \orig
    parameter \A_WIDTH 9
    parameter \B_WIDTH 9
    parameter \Y_WIDTH 18
    connect \A \a
    connect \B \b
    connect \Y \c
  end
end
```

Added a fix to truncate module names that are too long. (To 256 characters by default, get up to the max of 16k allowed by the dot format with `-long`.)