### PR TITLE
smt2: py3.12+: avoid SyntaxWarning.

### DIFF
--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -768,7 +768,7 @@ class SmtIo:
 
             if self.timeinfo:
                 i = 0
-                s = "/-\|"
+                s = r"/-\|"
 
                 count = 0
                 num_bs = 0
@@ -1171,7 +1171,7 @@ class MkVcd:
 
     def escape_name(self, name):
         name = re.sub(r"\[([0-9a-zA-Z_]*[a-zA-Z_][0-9a-zA-Z_]*)\]", r"<\1>", name)
-        if re.match("[\[\]]", name) and name[0] != "\\":
+        if re.match(r"[\[\]]", name) and name[0] != "\\":
             name = "\\" + name
         return name
 


### PR DESCRIPTION
Python 3.12 emits a SyntaxWarning when encountering invalid escape sequences.  They still parse as expected.  Marking these raw produces the same result without the warnings.