### PR TITLE
kernel/mem: Assert ABITS is not below wide_log2

### DIFF
--- a/kernel/mem.cc
+++ b/kernel/mem.cc
@@ -451,6 +451,7 @@ void Mem::check() {
 		log_assert(GetSize(port.en) == 1);
 		log_assert(GetSize(port.arst) == 1);
 		log_assert(GetSize(port.srst) == 1);
+		log_assert(GetSize(port.addr) >= port.wide_log2);
 		log_assert(GetSize(port.data) == (width << port.wide_log2));
 		log_assert(GetSize(port.init_value) == (width << port.wide_log2));
 		log_assert(GetSize(port.arst_value) == (width << port.wide_log2));
@@ -484,6 +485,7 @@ void Mem::check() {
 		log_assert(GetSize(port.clk) == 1);
 		log_assert(GetSize(port.en) == (width << port.wide_log2));
 		log_assert(GetSize(port.data) == (width << port.wide_log2));
+		log_assert(GetSize(port.addr) >= port.wide_log2);
 		for (int j = 0; j < port.wide_log2; j++) {
 			log_assert(port.addr[j] == State::S0);
 		}


### PR DESCRIPTION
Later in the check() code we check the bottom wide_log2 bits on the address port are zeroed out. If the address port is too narrow, we crash due to out of bounds access. Explicitly assert the address port is wide enough, so we don't crash on input such as

    read_rtlil <<EOF
    module \top
      wire input 1 \clk

      memory width 8 size 2 \mem

      cell $memwr $auto$:1:$8
        parameter \PRIORITY 1'0
        parameter \CLK_POLARITY 1'1
        parameter \CLK_ENABLE 1'1
        parameter \MEMID "\\mem"
        parameter \ABITS 1'0
        parameter \WIDTH 6'010000
        connect \DATA 16'0000000000000000
        connect \ADDR { }
        connect \EN 16'0000000000000000
        connect \CLK \clk
      end
    end
    EOF
    memory