### PR TITLE
opt_share: Fix input confusion with ANDNOT, ORNOT gates

### DIFF
--- a/passes/opt/opt_share.cc
+++ b/passes/opt/opt_share.cc
@@ -131,6 +131,9 @@ RTLIL::IdString decode_port_semantics(RTLIL::Cell *cell, RTLIL::IdString port_na
 	if (cell->type.in(ID($lt), ID($le), ID($ge), ID($gt), ID($div), ID($mod), ID($divfloor), ID($modfloor), ID($concat), SHIFT_OPS) && port_name == ID::B)
 		return port_name;
 
+	if (cell->type.in(ID($_ANDNOT_), ID($_ORNOT_)))
+		return port_name;
+
 	return "";
 }
 

--- a/tests/opt/bug3848.ys
+++ b/tests/opt/bug3848.ys
@@ -1,0 +1,28 @@
+read_verilog -icells <<EOF
+module test(a, b, s, y);
+  input a, b, s;
+  output y;
+  wire f, g;
+
+  $_ANDNOT_ g1(.A(a), .B(b), .Y(f));
+  $_ANDNOT_ g2(.A(b), .B(a), .Y(g));
+  $_MUX_ m(.A(f), .B(g), .S(s), .Y(y));
+endmodule
+EOF
+
+equiv_opt -assert opt_share
+
+design -reset
+read_verilog -icells <<EOF
+module test(a, b, s, y);
+  input a, b, s;
+  output y;
+  wire f, g;
+
+  $_ORNOT_ g1(.A(a), .B(b), .Y(f));
+  $_ORNOT_ g2(.A(b), .B(a), .Y(g));
+  $_MUX_ m(.A(f), .B(g), .S(s), .Y(y));
+endmodule
+EOF
+
+equiv_opt -assert opt_share


### PR DESCRIPTION
Distinguish between the A, B input ports of `$_ANDNOT_`, `$_ORNOT_` gates when considering those for sharing. Unlike the input ports of the other supported single-bit gates, those are not interchangeable.

Fixes #3848.