### PR TITLE
abc, abc9_exe: respect `-q` when built with linked ABC

### DIFF
--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1091,10 +1091,17 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 		buffer = stringf("\"%s\" -s -f %s/abc.script 2>&1", exe_file.c_str(), tempdir_name.c_str());
 		log("Running ABC command: %s\n", replace_tempdir(buffer, tempdir_name, show_tempdir).c_str());
 
-#ifndef YOSYS_LINK_ABC
 		abc_output_filter filt(tempdir_name, show_tempdir);
+#ifndef YOSYS_LINK_ABC
 		int ret = run_command(buffer, std::bind(&abc_output_filter::next_line, filt, std::placeholders::_1));
 #else
+		string temp_stdouterr_name = stringf("%s/stdouterr.txt", tempdir_name.c_str());
+		FILE *temp_stdouterr_w = fopen(temp_stdouterr_name.c_str(), "w");
+		if (temp_stdouterr_w == NULL)
+			log_error("ABC: cannot open a temporary file for output redirection");
+		FILE *old_stdout = stdout;
+		FILE *old_stderr = stderr;
+		stdout = stderr = temp_stdouterr_w;
 		// These needs to be mutable, supposedly due to getopt
 		char *abc_argv[5];
 		string tmp_script_name = stringf("%s/abc.script", tempdir_name.c_str());
@@ -1108,6 +1115,13 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 		free(abc_argv[1]);
 		free(abc_argv[2]);
 		free(abc_argv[3]);
+		stdout = old_stdout;
+		stderr = old_stderr;
+		fclose(temp_stdouterr_w);
+		std::ifstream temp_stdouterr_r(temp_stdouterr_name);
+		for (std::string line; std::getline(temp_stdouterr_r, line); )
+			filt.next_line(line + "\n");
+		temp_stdouterr_r.close();
 #endif
 		if (ret != 0)
 			log_error("ABC: execution of command \"%s\" failed: return code %d.\n", buffer.c_str(), ret);


### PR DESCRIPTION
This is mostly important for YoWASP builds, since those do not have a way to build with external ABC (I prototyped it but for some reason ABC always segfaults when built as an independent Wasm binary...)