### PR TITLE
opt_expr: Fix 'signed X>=0' replacement for wide output ports

### DIFF
--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -2165,7 +2165,7 @@ skip_alu_split:
 					{
 						condition   = "signed X>=0";
 						replacement = stringf("X[%d]", var_width - 1);
-						module->addNot(NEW_ID, var_sig[var_width - 1], cell->getPort(ID::Y));
+						module->addLogicNot(NEW_ID, var_sig[var_width - 1], cell->getPort(ID::Y));
 						remove = true;
 					}
 				}

--- a/tests/opt/bug3867.ys
+++ b/tests/opt/bug3867.ys
@@ -1,0 +1,7 @@
+read_verilog <<EOF
+module test (input signed [4:0] i, output [5:0] o);
+assign o = (i >= 0);
+endmodule
+EOF
+
+equiv_opt -assert opt_expr -fine


### PR DESCRIPTION
If the `$ge` cell we are replacing has wide output port, the upper bits on the port should be driven to zero. That's not what a `$not` cell with a single-bit input does. Instead opt for a `$logic_not` cell, which does zero-pad its output.

Fixes #3867.