### PR TITLE
wreduce: Group reconnections

### DIFF
--- a/passes/opt/wreduce.cc
+++ b/passes/opt/wreduce.cc
@@ -364,10 +364,16 @@ struct WreduceWorker
 			if (cell->type == ID($mul))
 				max_y_size = a_size + b_size;
 
-			while (GetSize(sig) > 1 && GetSize(sig) > max_y_size) {
-				module->connect(sig[GetSize(sig)-1], is_signed ? sig[GetSize(sig)-2] : State::S0);
-				sig.remove(GetSize(sig)-1);
-				bits_removed++;
+			max_y_size = std::max(max_y_size, 1);
+
+			if (GetSize(sig) > max_y_size) {
+				SigSpec extra_bits = sig.extract(max_y_size, GetSize(sig) - max_y_size);
+
+				bits_removed += GetSize(extra_bits);
+				sig.remove(max_y_size, GetSize(extra_bits));
+
+				SigBit padbit = is_signed ? sig[GetSize(sig)-1] : State::S0;
+				module->connect(extra_bits, SigSpec(padbit, GetSize(extra_bits)));
 			}
 		}
 


### PR DESCRIPTION
Group the reconnections, so that instead of producing

    connect $auto$wreduce.cc:455:run$24 [0] 1'0
    connect $auto$wreduce.cc:455:run$23 [31] 1'0
    connect $auto$wreduce.cc:455:run$23 [30] 1'0
    ... (40 more lines)

we produce

    connect $auto$wreduce.cc:461:run$23 [31:11] 21'000000000000000000000
    connect $auto$wreduce.cc:461:run$24 [31:10] 22'0000000000000000000000

.