### PR TITLE
Optimization of nowrshmsk

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -850,6 +850,25 @@ AstNode *AstNode::mkconst_str(const std::string &str)
 	return node;
 }
 
+// create a temporary register
+AstNode *AstNode::mktemp_logic(const std::string &name, AstNode *mod, bool nosync, int range_left, int range_right, bool is_signed)
+{
+	AstNode *wire = new AstNode(AST_WIRE, new AstNode(AST_RANGE, mkconst_int(range_left, true), mkconst_int(range_right, true)));
+	wire->str = stringf("%s%s:%d$%d", name.c_str(), RTLIL::encode_filename(filename).c_str(), location.first_line, autoidx++);
+	if (nosync)
+		wire->set_attribute(ID::nosync, AstNode::mkconst_int(1, false));
+	wire->is_signed = is_signed;
+	wire->is_logic = true;
+	mod->children.push_back(wire);
+	while (wire->simplify(true, 1, -1, false)) { }
+
+	AstNode *ident = new AstNode(AST_IDENTIFIER);
+	ident->str = wire->str;
+	ident->id2ast = wire;
+
+	return ident;
+}
+
 bool AstNode::bits_only_01() const
 {
 	for (auto bit : bits)

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -321,6 +321,9 @@ namespace AST
 		static AstNode *mkconst_str(const std::vector<RTLIL::State> &v);
 		static AstNode *mkconst_str(const std::string &str);
 
+		// helper function to create an AST node for a temporary register
+		AstNode *mktemp_logic(const std::string &name, AstNode *mod, bool nosync, int range_left, int range_right, bool is_signed);
+
 		// helper function for creating sign-extended const objects
 		RTLIL::Const bitsAsConst(int width, bool is_signed);
 		RTLIL::Const bitsAsConst(int width = -1);

--- a/tests/various/dynamic_part_select.ys
+++ b/tests/various/dynamic_part_select.ys
@@ -69,6 +69,24 @@ design -copy-from gate -as gate gate
 miter -equiv -make_assert -make_outcmp -flatten gold gate equiv
 sat -prove-asserts -seq 10 -show-public -verify -set-init-zero equiv
 
+### For-loop select, one dynamic input, (* nowrshmsk *)
+design -reset
+read_verilog ./dynamic_part_select/forloop_select_nowrshmsk.v
+proc
+rename -top gold
+design -stash gold
+
+read_verilog ./dynamic_part_select/forloop_select_gate.v
+proc
+rename -top gate
+design -stash gate
+
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+
+miter -equiv -make_assert -make_outcmp -flatten gold gate equiv
+sat -prove-asserts -seq 10 -show-public -verify -set-init-zero equiv
+
 #### Double loop (part-select, reset) ### 
 design -reset
 read_verilog ./dynamic_part_select/reset_test.v

--- a/tests/various/dynamic_part_select/forloop_select_nowrshmsk.v
+++ b/tests/various/dynamic_part_select/forloop_select_nowrshmsk.v
@@ -1,0 +1,20 @@
+`default_nettype none
+module forloop_select #(parameter WIDTH=16, SELW=4, CTRLW=$clog2(WIDTH), DINW=2**SELW)
+   (input wire             clk,
+    input wire [CTRLW-1:0] ctrl,
+    input wire [DINW-1:0]  din,
+    input wire             en,
+    (* nowrshmsk *)
+    output reg [WIDTH-1:0] dout);
+
+   reg [SELW:0]            sel;
+   localparam SLICE = WIDTH/(SELW**2);
+
+   always @(posedge clk)
+     begin
+        if (en) begin
+           for (sel = 0; sel <= 4'hf; sel=sel+1'b1)
+             dout[(ctrl*sel)+:SLICE] <= din;
+        end
+     end
+endmodule

--- a/tests/verilog/dynamic_range_lhs.sh
+++ b/tests/verilog/dynamic_range_lhs.sh
@@ -15,7 +15,7 @@ run() {
         -p "read_verilog dynamic_range_lhs.v" \
         -p "proc" \
         -p "equiv_make gold gate equiv" \
-        -p "equiv_simple" \
+        -p "equiv_simple -undef" \
         -p "equiv_status -assert"
 }
 

--- a/tests/verilog/dynamic_range_lhs.v
+++ b/tests/verilog/dynamic_range_lhs.v
@@ -1,6 +1,6 @@
 module gate(
-    output reg [`LEFT:`RIGHT] out_u, out_s,
     (* nowrshmsk = `ALT *)
+    output reg [`LEFT:`RIGHT] out_u, out_s,
     input wire data,
     input wire [1:0] sel1, sel2
 );

--- a/tests/verilog/dynamic_range_lhs.v
+++ b/tests/verilog/dynamic_range_lhs.v
@@ -5,8 +5,8 @@ module gate(
     input wire [1:0] sel1, sel2
 );
 always @* begin
-    out_u = 0;
-    out_s = 0;
+    out_u = 'x;
+    out_s = 'x;
     case (`SPAN)
     1: begin
         out_u[sel1*sel2] = data;
@@ -43,8 +43,8 @@ task set;
         out_s[b] = data;
 endtask
 always @* begin
-    out_u = 0;
-    out_s = 0;
+    out_u = 'x;
+    out_s = 'x;
     case (sel1*sel2)
         2'b00: set(0, 0);
         2'b01: set(1, 1);


### PR DESCRIPTION
Generation of minimal AST_CASE for variable slices on the form dst[i*stride +: width] = src.

Corrections of corner cases, now correctly tested by tests/verilog/dynamic_range_lhs.v