### PR TITLE
Produce `$bmux` cells in shiftmul transformation

### DIFF
--- a/passes/pmgen/Makefile.inc
+++ b/passes/pmgen/Makefile.inc
@@ -42,7 +42,8 @@ GENFILES += passes/pmgen/peepopt_pm.h
 passes/pmgen/peepopt.o: passes/pmgen/peepopt_pm.h
 $(eval $(call add_extra_objs,passes/pmgen/peepopt_pm.h))
 
-PEEPOPT_PATTERN  = passes/pmgen/peepopt_shiftmul.pmg
+PEEPOPT_PATTERN  = passes/pmgen/peepopt_shiftmul_right.pmg
+PEEPOPT_PATTERN += passes/pmgen/peepopt_shiftmul_left.pmg
 PEEPOPT_PATTERN += passes/pmgen/peepopt_muldiv.pmg
 
 passes/pmgen/peepopt_pm.h: passes/pmgen/pmgen.py $(PEEPOPT_PATTERN)

--- a/passes/pmgen/peepopt.cc
+++ b/passes/pmgen/peepopt.cc
@@ -59,7 +59,7 @@ struct PeepoptPass : public Pass {
 		if (!genmode.empty())
 		{
 			if (genmode == "shiftmul")
-				GENERATE_PATTERN(peepopt_pm, shiftmul);
+				GENERATE_PATTERN(peepopt_pm, shiftmul_right);
 			else if (genmode == "muldiv")
 				GENERATE_PATTERN(peepopt_pm, muldiv);
 			else
@@ -79,7 +79,8 @@ struct PeepoptPass : public Pass {
 
 				pm.setup(module->selected_cells());
 
-				pm.run_shiftmul();
+				pm.run_shiftmul_right();
+				pm.run_shiftmul_left();
 				pm.run_muldiv();
 			}
 		}

--- a/passes/pmgen/peepopt.cc
+++ b/passes/pmgen/peepopt.cc
@@ -45,11 +45,20 @@ struct PeepoptPass : public Pass {
 
 		log_header(design, "Executing PEEPOPT pass (run peephole optimizers).\n");
 
+		bool bmux_mode = false, wshift_mode = false;
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
 		{
 			if (args[argidx] == "-generate" && argidx+1 < args.size()) {
 				genmode = args[++argidx];
+				continue;
+			}
+			if (args[argidx] == "-bmux") {
+				bmux_mode = true;
+				continue;
+			}
+			if (args[argidx] == "-wshift") {
+				wshift_mode = true;
 				continue;
 			}
 			break;
@@ -78,6 +87,9 @@ struct PeepoptPass : public Pass {
 				peepopt_pm pm(module);
 
 				pm.setup(module->selected_cells());
+
+				pm.ud_shiftmul_right.bmux_mode = bmux_mode;
+				pm.ud_shiftmul_right.wshift_mode = wshift_mode;
 
 				pm.run_shiftmul_right();
 				pm.run_shiftmul_left();

--- a/passes/pmgen/peepopt_shiftmul.pmg
+++ b/passes/pmgen/peepopt_shiftmul.pmg
@@ -42,7 +42,11 @@ match mul
 
 	define <IdString> varport (constport == \A ? \B : \A)
 	set mul_const port(mul, constport).as_const()
-	set mul_din port(mul, varport)
+	// get mul_din unmapped (so no `port()` shorthand)
+	// because we will be using it to set the \A port
+	// on the shift cell, and we want to stay close
+	// to the original design
+	set mul_din mul->getPort(varport)
 endmatch
 
 code

--- a/passes/pmgen/peepopt_shiftmul.pmg
+++ b/passes/pmgen/peepopt_shiftmul.pmg
@@ -8,9 +8,13 @@ match shift
 	filter !port(shift, \B).empty()
 endmatch
 
+// the right shift amount
 state <SigSpec> shift_amount
+// log2 scale factor in interpreting of shift_amount
+// due to zero padding on the shift cell's B port
+state <int> log2scale
 
-code shift_amount
+code shift_amount log2scale
 	shift_amount = port(shift, \B);
 	if (shift->type.in($shr) || !param(shift, \B_SIGNED).as_bool())
 		shift_amount.append(State::S0);
@@ -23,6 +27,13 @@ code shift_amount
 	while (shift_amount.bits().back() == State::S0) {
 		shift_amount.remove(GetSize(shift_amount) - 1);
 		if (shift_amount.empty()) reject;
+	}
+
+	log2scale = 0;
+	while (shift_amount[0] == State::S0) {
+		shift_amount.remove(0);
+		if (shift_amount.empty()) reject;
+		log2scale++;
 	}
 
 	if (GetSize(shift_amount) > 20)
@@ -41,7 +52,7 @@ match mul
 	filter port(mul, constport).is_fully_const()
 
 	define <IdString> varport (constport == \A ? \B : \A)
-	set mul_const port(mul, constport).as_const()
+	set mul_const SigSpec({port(mul, constport), SigSpec(State::S0, log2scale)}).as_const()
 	// get mul_din unmapped (so no `port()` shorthand)
 	// because we will be using it to set the \A port
 	// on the shift cell, and we want to stay close
@@ -61,7 +72,7 @@ code
 
 	int factor_bits = ceil_log2(mul_const.as_int());
 	// make sure the multiplication never wraps around
-	if (GetSize(shift_amount) < factor_bits + GetSize(mul_din))
+	if (GetSize(shift_amount) + log2scale < factor_bits + GetSize(mul_din))
 		reject;
 
 	did_something = true;

--- a/passes/pmgen/peepopt_shiftmul.pmg
+++ b/passes/pmgen/peepopt_shiftmul.pmg
@@ -3,61 +3,67 @@ pattern shiftmul
 // Optimize mul+shift pairs that result from expressions such as foo[s*W+:W]
 //
 
-state <SigSpec> shamt
-
 match shift
 	select shift->type.in($shift, $shiftx, $shr)
+	filter !port(shift, \B).empty()
 endmatch
 
-code shamt
-	shamt = port(shift, \B);
-	if (shamt.empty())
+state <SigSpec> shift_amount
+
+code shift_amount
+	shift_amount = port(shift, \B);
+	if (shift->type.in($shr) || !param(shift, \B_SIGNED).as_bool())
+		shift_amount.append(State::S0);
+
+	// at this point shift_amount is signed, make
+	// sure we can never go negative
+	if (shift_amount.bits().back() != State::S0)
 		reject;
-	if (shamt[GetSize(shamt)-1] == State::S0) {
-		do {
-			shamt.remove(GetSize(shamt)-1);
-			if (shamt.empty())
-				reject;
-		} while (shamt[GetSize(shamt)-1] == State::S0);
-	} else
-	if (shift->type.in($shift, $shiftx) && param(shift, \B_SIGNED).as_bool()) {
-		reject;
+
+	while (shift_amount.bits().back() == State::S0) {
+		shift_amount.remove(GetSize(shift_amount) - 1);
+		if (shift_amount.empty()) reject;
 	}
-	if (GetSize(shamt) > 20)
+
+	if (GetSize(shift_amount) > 20)
 		reject;
 endcode
 
+state <SigSpec> mul_din
+state <Const> mul_const
+
 match mul
 	select mul->type.in($mul)
-	select port(mul, \A).is_fully_const() || port(mul, \B).is_fully_const()
-	index <SigSpec> port(mul, \Y) === shamt
+	index <SigSpec> port(mul, \Y) === shift_amount
 	filter !param(mul, \A_SIGNED).as_bool()
+
+	choice <IdString> constport {\A, \B}
+	filter port(mul, constport).is_fully_const()
+
+	define <IdString> varport (constport == \A ? \B : \A)
+	set mul_const port(mul, constport).as_const()
+	set mul_din port(mul, varport)
 endmatch
 
 code
 {
-	IdString const_factor_port = port(mul, \A).is_fully_const() ? \A : \B;
-	Const const_factor_cnst = port(mul, const_factor_port).as_const();
-	int const_factor = const_factor_cnst.as_int();
-
-	if (GetSize(const_factor_cnst) == 0)
+	if (mul_const.empty() || GetSize(mul_const) > 20)
 		reject;
 
-	if (GetSize(const_factor_cnst) > 20)
+	// make sure there's no overlap in the signal
+	// selections by the shiftmul pattern
+	if (GetSize(port(shift, \Y)) > mul_const.as_int())
 		reject;
 
-	if (GetSize(port(shift, \Y)) > const_factor)
-		reject;
-
-	int factor_bits = ceil_log2(const_factor);
-	SigSpec mul_din = port(mul, const_factor_port == \A ? \B : \A);
-
-	if (GetSize(shamt) < factor_bits+GetSize(mul_din))
+	int factor_bits = ceil_log2(mul_const.as_int());
+	// make sure the multiplication never wraps around
+	if (GetSize(shift_amount) < factor_bits + GetSize(mul_din))
 		reject;
 
 	did_something = true;
 	log("shiftmul pattern in %s: shift=%s, mul=%s\n", log_id(module), log_id(shift), log_id(mul));
 
+	int const_factor = mul_const.as_int();
 	int new_const_factor = 1 << factor_bits;
 	SigSpec padding(State::Sx, new_const_factor-const_factor);
 	SigSpec old_a = port(shift, \A), new_a;

--- a/passes/pmgen/peepopt_shiftmul_left.pmg
+++ b/passes/pmgen/peepopt_shiftmul_left.pmg
@@ -1,0 +1,159 @@
+pattern shiftmul_left
+//
+// Optimize mul+shift pairs that result from expressions such as foo[s*W+:W]
+//
+
+match shift
+	select shift->type.in($shift, $shiftx, $shl)
+	select shift->type.in($shl) || param(shift, \B_SIGNED).as_bool()
+	filter !port(shift, \B).empty()
+endmatch
+
+match neg
+	if shift->type.in($shift, $shiftx)
+	index <SigSpec> port(neg, \Y) === port(shift, \B)
+	filter !port(shift, \A).empty()
+endmatch
+
+// the left shift amount
+state <SigSpec> shift_amount
+// log2 scale factor in interpreting of shift_amount
+// due to zero padding on the shift cell's B port
+state <int> log2scale
+
+code shift_amount log2scale
+	if (neg) {
+		// case of `$shift`, `$shiftx`
+		shift_amount = port(neg, \A);
+		if (!param(neg, \A_SIGNED).as_bool())
+			shift_amount.append(State::S0);
+	} else {
+		// case of `$shl`
+		shift_amount = port(shift, \B);
+		if (!param(neg, \B_SIGNED).as_bool())
+			shift_amount.append(State::S0);
+	}
+
+	// at this point shift_amount is signed, make
+	// sure we can never go negative
+	if (shift_amount.bits().back() != State::S0)
+		reject;
+
+	while (shift_amount.bits().back() == State::S0) {
+		shift_amount.remove(GetSize(shift_amount) - 1);
+		if (shift_amount.empty()) reject;
+	}
+
+	log2scale = 0;
+	while (shift_amount[0] == State::S0) {
+		shift_amount.remove(0);
+		if (shift_amount.empty()) reject;
+		log2scale++;
+	}
+
+	if (GetSize(shift_amount) > 20)
+		reject;
+endcode
+
+state <SigSpec> mul_din
+state <Const> mul_const
+
+match mul
+	select mul->type.in($mul)
+	index <SigSpec> port(mul, \Y) === shift_amount
+	filter !param(mul, \A_SIGNED).as_bool()
+
+	choice <IdString> constport {\A, \B}
+	filter port(mul, constport).is_fully_const()
+
+	define <IdString> varport (constport == \A ? \B : \A)
+	set mul_const SigSpec({port(mul, constport), SigSpec(State::S0, log2scale)}).as_const()
+	// get mul_din unmapped (so no `port()` shorthand)
+	// because we will be using it to set the \A port
+	// on the shift cell, and we want to stay close
+	// to the original design
+	set mul_din mul->getPort(varport)
+endmatch
+
+code
+{
+	if (mul_const.empty() || GetSize(mul_const) > 20)
+		reject;
+
+	// make sure there's no overlap in the signal
+	// selections by the shiftmul pattern
+	if (GetSize(port(shift, \A)) > mul_const.as_int())
+		reject;
+
+	int factor_bits = ceil_log2(mul_const.as_int());
+	// make sure the multiplication never wraps around
+	if (GetSize(shift_amount) < factor_bits + GetSize(mul_din))
+		reject;
+
+	if (neg) {
+		// make sure the negation never wraps around
+		if (GetSize(port(shift, \B)) < factor_bits + GetSize(mul_din)
+										+ log2scale + 1)
+			reject;
+	}
+
+	did_something = true;
+	log("left shiftmul pattern in %s: shift=%s, mul=%s\n", log_id(module), log_id(shift), log_id(mul));
+
+	int const_factor = mul_const.as_int();
+	int new_const_factor = 1 << factor_bits;
+	SigSpec padding(State::Sm, new_const_factor-const_factor);
+	SigSpec old_y = port(shift, \Y), new_y;
+	int trunc = 0;
+
+	if (GetSize(old_y) % const_factor != 0) {
+		trunc = const_factor - GetSize(old_y) % const_factor;
+		old_y.append(SigSpec(State::Sm, trunc));
+	}
+
+	for (int i = 0; i*const_factor < GetSize(old_y); i++) {
+		SigSpec slice = old_y.extract(i*const_factor, const_factor);
+		new_y.append(slice);
+		new_y.append(padding);
+	}
+
+	if (trunc > 0)
+		new_y.remove(GetSize(new_y)-trunc, trunc);
+
+	{
+		// Now replace occurences of Sm in new_y with bits
+		// of a dummy wire
+		int padbits = 0;
+		for (auto bit : new_y)
+		if (bit == SigBit(State::Sm))
+			padbits++;
+
+		SigSpec padwire = module->addWire(NEW_ID, padbits);
+
+		for (int i = new_y.size() - 1; i >= 0; i--)
+		if (new_y[i] == SigBit(State::Sm)) {
+			new_y[i] = padwire.bits().back();
+			padwire.remove(padwire.size() - 1);
+		}
+	}
+
+	SigSpec new_b = {mul_din, SigSpec(State::S0, factor_bits)};
+
+	shift->setPort(\Y, new_y);
+	shift->setParam(\Y_WIDTH, GetSize(new_y));
+	if (shift->type == $shl) {
+		if (param(shift, \B_SIGNED).as_bool())
+			new_b.append(State::S0);
+		shift->setPort(\B, new_b);
+		shift->setParam(\B_WIDTH, GetSize(new_b));
+	} else {
+		SigSpec b_neg = module->addWire(NEW_ID, GetSize(new_b) + 1);
+		module->addNeg(NEW_ID, new_b, b_neg);
+		shift->setPort(\B, b_neg);
+		shift->setParam(\B_WIDTH, GetSize(b_neg));
+	}
+
+	blacklist(shift);
+	accept;
+}
+endcode

--- a/passes/pmgen/peepopt_shiftmul_right.pmg
+++ b/passes/pmgen/peepopt_shiftmul_right.pmg
@@ -1,4 +1,4 @@
-pattern shiftmul
+pattern shiftmul_right
 //
 // Optimize mul+shift pairs that result from expressions such as foo[s*W+:W]
 //
@@ -76,7 +76,7 @@ code
 		reject;
 
 	did_something = true;
-	log("shiftmul pattern in %s: shift=%s, mul=%s\n", log_id(module), log_id(shift), log_id(mul));
+	log("right shiftmul pattern in %s: shift=%s, mul=%s\n", log_id(module), log_id(shift), log_id(mul));
 
 	int const_factor = mul_const.as_int();
 	int new_const_factor = 1 << factor_bits;

--- a/passes/pmgen/peepopt_shiftmul_right.pmg
+++ b/passes/pmgen/peepopt_shiftmul_right.pmg
@@ -3,6 +3,8 @@ pattern shiftmul_right
 // Optimize mul+shift pairs that result from expressions such as foo[s*W+:W]
 //
 
+udata <bool> bmux_mode wshift_mode
+
 match shift
 	select shift->type.in($shift, $shiftx, $shr)
 	filter !port(shift, \B).empty()
@@ -68,6 +70,7 @@ code
 	// make sure there's no overlap in the signal
 	// selections by the shiftmul pattern
 	if (GetSize(port(shift, \Y)) > mul_const.as_int())
+	if (!bmux_mode && !wshift_mode)
 		reject;
 
 	int factor_bits = ceil_log2(mul_const.as_int());
@@ -77,6 +80,72 @@ code
 
 	did_something = true;
 	log("right shiftmul pattern in %s: shift=%s, mul=%s\n", log_id(module), log_id(shift), log_id(mul));
+
+	if (bmux_mode) {
+		SigSpec out = port(shift, \Y);
+		int shift_stride = mul_const.as_int();
+		SigSpec shift_vector = port(shift, \A);
+		SigBit padbit = (shift->type != $shiftx) ? (param(shift, \A_SIGNED)).as_bool() ?
+						port(shift, \A).bits().back() : State::S0 : State::Sx;
+
+		// Construct the input vector for the new bmux cell
+		SigSpec bmux_vector;
+		for (int i = 0; i * shift_stride < GetSize(shift_vector); i++) {
+			int validbits = std::min(GetSize(out),
+									 GetSize(shift_vector) - i * shift_stride);
+			bmux_vector.append(shift_vector.extract(i * shift_stride, validbits));
+		}
+
+		// Prep the select signal
+		SigSpec bmux_sel = mul_din;
+		bmux_sel.extend_u0(ceil_log2(GetSize(bmux_vector)));
+
+		// Pad the vector
+		int vector_targetlen = GetSize(out) << GetSize(bmux_sel);
+		if (vector_targetlen > GetSize(bmux_vector))
+			bmux_vector.append(SigSpec(padbit, vector_targetlen - GetSize(bmux_vector)));
+		else
+			bmux_vector.remove(vector_targetlen, GetSize(bmux_vector) - vector_targetlen);
+
+		// Build the bmux, add an extra mux to handle top bits on the old select signal
+		SigSpec bmux_out, out_of_range;
+		std::string src = shift->get_src_attribute();
+		bmux_out = module->Bmux(NEW_ID, bmux_vector, bmux_sel, src);
+		if (GetSize(mul_din) > GetSize(bmux_sel)) {
+			out_of_range = module->ReduceBool(NEW_ID, mul_din.extract_end(GetSize(bmux_sel)), false, src);
+			module->addMux(NEW_ID, bmux_out, SigSpec(padbit, GetSize(out)), out_of_range, out, src);
+		} else {
+			module->connect(out, bmux_out);
+		}
+		autoremove(shift);
+		accept;
+	} else if (wshift_mode) {
+		SigSpec out = port(shift, \Y);
+		SigSpec shift_vector = port(shift, \A);
+		int shift_stride = mul_const.as_int();
+		for (int j = 0; j < shift_stride; j++) {
+			SigSpec slice_vector;
+			SigSpec slice_out;
+			for (int off = j; off < GetSize(shift_vector); off += shift_stride)
+				slice_vector.append(shift_vector.extract(off, 1));
+			if (param(shift, \A_SIGNED).as_bool())
+				slice_vector.append(shift_vector.bits().back());
+			for (int off = j; off < GetSize(out); off += shift_stride)
+				slice_out.append(out.extract(off, 1));
+
+			if (slice_out.empty()) continue;
+			Cell *slice = module->addCell(NEW_ID, shift);
+			slice->setParam(\A_WIDTH, GetSize(slice_vector));
+			slice->setPort(\A, slice_vector);
+			slice->setParam(\B_WIDTH, GetSize(mul_din));
+			slice->setParam(\B_SIGNED, Const(1, 0));
+			slice->setPort(\B, mul_din);
+			slice->setParam(\Y_WIDTH, GetSize(slice_out));
+			slice->setPort(\Y, slice_out);
+		}
+		autoremove(shift);
+		accept;
+	}
 
 	int const_factor = mul_const.as_int();
 	int new_const_factor = 1 << factor_bits;


### PR DESCRIPTION
Prompted by the discussion in #3873 I played around with changing the right shiftmul transformation to either (1) produce `$bmux` cells; (2) produce a number of independent shift cells. For now these are special modes conditioned on a `-bmux` or `-wshift` option, and in contrast to the original shiftmul transformation in those modes we allow for what we call the `W2>W` case over at #3873.

The code here is on top of the other PR, but the last commit is where the focus is.

Cc: @phsauter