### PR TITLE
extract_fa: Fix handling inversion of an FA xor output

### DIFF
--- a/passes/techmap/extract_fa.cc
+++ b/passes/techmap/extract_fa.cc
@@ -413,13 +413,13 @@ struct ExtractFaWorker
 				}
 
 				if (func3.at(key).count(xor3_func)) {
-					SigBit YY = invert_xy ? module->NotGate(NEW_ID, Y) : Y;
+					SigBit YY = invert_xy != f3i.inv_y ? module->NotGate(NEW_ID, Y) : Y;
 					for (auto bit : func3.at(key).at(xor3_func))
 						assign_new_driver(bit, YY);
 				}
 
 				if (func3.at(key).count(xnor3_func)) {
-					SigBit YY = invert_xy ? Y : module->NotGate(NEW_ID, Y);
+					SigBit YY = invert_xy != f3i.inv_y ? Y : module->NotGate(NEW_ID, Y);
 					for (auto bit : func3.at(key).at(xnor3_func))
 						assign_new_driver(bit, YY);
 				}

--- a/tests/various/bug3879.ys
+++ b/tests/various/bug3879.ys
@@ -1,0 +1,29 @@
+read_verilog <<EOF
+module gcd(I, D);
+
+  output [2:0] I;
+  input [3:0] D;
+
+  assign I = D[0]+D[1]+D[2]+D[3];
+endmodule
+EOF
+design -save input
+
+prep
+
+design -stash gold
+
+design -load input
+
+synth  -top gcd -flatten
+
+extract_fa -v
+
+design -stash gate
+
+design -copy-from gold -as gold gcd
+design -copy-from gate -as gate gcd
+
+miter -equiv -make_assert -flatten gold gate miter
+
+sat -verify -prove-asserts -show-all miter


### PR DESCRIPTION
Fixes what seems to be a missing inversion of the xor output when the heueristic decides to use an inverted FA.

