### PR TITLE
proc_clean doesn't handle State::Sa, will remove switches that use them

### DIFF
--- a/passes/proc/proc_clean.cc
+++ b/passes/proc/proc_clean.cc
@@ -41,7 +41,7 @@ void proc_clean_switch(RTLIL::SwitchRule *sw, RTLIL::CaseRule *parent, bool &did
 				break;
 			for (int j = 0; j < int(cs->compare.size()); j++) {
 				RTLIL::SigSpec &val = cs->compare[j];
-				if (!val.is_fully_const())
+				if (!val.is_fully_def())
 					continue;
 				if (val == sw->signal) {
 					cs->compare.clear();

--- a/passes/proc/proc_clean.cc
+++ b/passes/proc/proc_clean.cc
@@ -31,7 +31,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 void proc_clean_switch(RTLIL::SwitchRule *sw, RTLIL::CaseRule *parent, bool &did_something, int &count, int max_depth)
 {
-	if (sw->signal.size() > 0 && sw->signal.is_fully_const())
+	if (sw->signal.size() > 0 && sw->signal.is_fully_def())
 	{
 		int found_matching_case_idx = -1;
 		for (int i = 0; i < int(sw->cases.size()) && found_matching_case_idx < 0; i++)

--- a/tests/proc/clean_undef_case.ys
+++ b/tests/proc/clean_undef_case.ys
@@ -1,6 +1,6 @@
 read_rtlil <<EOT
 
-module \m
+module \a
   wire width 1 \w
   process $p
     switch 3'001
@@ -14,9 +14,24 @@ module \m
   end
 end
 
+module \b
+  wire width 1 \w
+  process $p
+    switch 3'--1
+      case 3'001
+        assign \w 3'001
+      case 3'010
+        assign \w 3'010
+      case 3'100
+        assign \w 3'100
+    end
+  end
+end
+
 EOT
 
 proc_clean  # Bug: removes the cases.
 proc_clean  # Removes the now-empty switch and its containing process.
 
-select -assert-count 1 */p:*
+select -assert-count 1 a/p:*
+select -assert-count 1 b/p:*

--- a/tests/proc/clean_undef_case.ys
+++ b/tests/proc/clean_undef_case.ys
@@ -1,0 +1,22 @@
+read_rtlil <<EOT
+
+module \m
+  wire width 1 \w
+  process $p
+    switch 3'001
+      case 3'--1
+        assign \w 3'001
+      case 3'-1-
+        assign \w 3'010
+      case 3'1--
+        assign \w 3'100
+    end
+  end
+end
+
+EOT
+
+proc_clean  # Bug: removes the cases.
+proc_clean  # Removes the now-empty switch and its containing process.
+
+select -assert-count 1 */p:*


### PR DESCRIPTION
This is a bug report with a suggested fix.

Consider the following RTLIL:

```rtlil
module \m
  wire width 1 \w
  process $p
    switch 2'10
      case 2'-1
        assign \w 1'0
      case 2'1-
        assign \w 1'1
    end
  end
end
```

Invoking `proc` on this will first run `proc_clean`. `proc_clean` does not know how to handle `Sa`, and for fully-const switch operands (`2'10` here) that don't `==` fully-const case operands (`2'-1` and `2'1-` here), the case operand will be removed:

https://github.com/YosysHQ/yosys/blob/2829cd9caa5729b3b7e2393d3428e265cd038ea6/passes/proc/proc_clean.cc#L44-L51

`SigSpec::operator ==` doesn't do "don't care" matching, so none are considered equal. Accordingly, post-`proc_clean` we get:

```rtlil
autoidx 1
module \m
  wire \w
  process $p
    switch 2'10
    end
  end
end
```

The only passes invoked by `proc` that handle `Sa` are `proc_mux` and `proc_rmdead`, and indeed, if we run `proc_mux` first, the cases are pulled out into individual muxes which implement the desired behavior.

`proc_rmdead` does manage to erase all but the first case that matches (if any) -- this is because it uses `BitPatternPool`, which understands `Sa`. (We are guaranteed to use `BitPatternPool` because `can_use_fully_defined_pool` L36-L38 returns false if any part of the signal operand is const.)

Other passes invoked by `proc` that haven't been mentioned yet don't mess with the cases afaict.

I see four options going forward:

1. `proc_clean` avoids doing strict equality checking on operands that are not **fully-defined**, rather than fully-const. This is this PR.
   1. There's an additional weirdness here: we can `switch 2'-1`, too, and it will likewise degenerate and not match `case 2'01` (but will match `case 2'-1`). Perhaps we should not be permitting inclusion of `Sa` in a switch operand at all (? unclear to me), but as long as it is permitted, I am supposing we should not be eliminating it like this. This PR therefore adjusts the condition on the switch operand in addition to the case operands.
2. `proc_clean` learns to match considering `Sa` (on both sides).
3. `proc` invokes `proc_mux` before `proc_clean`. (Perhaps in addition to where it's currently situated?) This feels liable to mess with workflows.
4. We decide this input isn't okay.

This came from Amaranth, where a `If(0) ... Elif(1) ...` control structure assigning synchronously to a register is turned into the above process.

/cc @mcclure who hit this!