### PR TITLE
cellaigs: Drop initializer list in call to `IdString::in`

### DIFF
--- a/kernel/cellaigs.cc
+++ b/kernel/cellaigs.cc
@@ -385,17 +385,17 @@ Aig::Aig(Cell *cell)
 		goto optimize;
 	}
 
-	if (cell->type.in({ID($lt), ID($gt), ID($le), ID($ge)}))
+	if (cell->type.in(ID($lt), ID($gt), ID($le), ID($ge)))
 	{
 		int width = std::max(GetSize(cell->getPort(ID::A)),
 							 GetSize(cell->getPort(ID::B))) + 1;
 		vector<int> A = mk.inport_vec(ID::A, width);
 		vector<int> B = mk.inport_vec(ID::B, width);
 
-		if (cell->type.in({ID($gt), ID($ge)}))
+		if (cell->type.in(ID($gt), ID($ge)))
 			std::swap(A, B);
 
-		int carry = mk.bool_node(!cell->type.in({ID($le), ID($ge)}));
+		int carry = mk.bool_node(!cell->type.in(ID($le), ID($ge)));
 		for (auto &n : B)
 			n = mk.not_gate(n);
 		vector<int> Y = mk.adder(A, B, carry);


### PR DESCRIPTION
Remove superfluous curly braces in call to IdString::in to address a compilation error (reproduced below) under GCC 9 and earlier.

kernel/cellaigs.cc:395:18: error: call to member function 'in' is ambiguous if (cell->type.in({ID($gt), ID($ge)}))
~~~~~~~~~~~^~
./kernel/rtlil.h:383:8: note: candidate function
bool in(const std::string &rhs) const { return *this == rhs; } ^
./kernel/rtlil.h:384:8: note: candidate function
bool in(const pool &rhs) const { return rhs.co...
^

Should fix #3885.