### PR TITLE
Add GCC 9 to CI builds

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -25,6 +25,9 @@ jobs:
           - os: { id: ubuntu-20.04, name: focal }
             compiler: 'gcc-10'
             cpp_std: 'c++11'
+          - os: { id: ubuntu-20.04, name: focal }
+            compiler: 'gcc-9'
+            cpp_std: 'c++11'
       fail-fast: false
     steps:
       - name: Install Dependencies


### PR DESCRIPTION
Bug #3889 was a case of build failure under GCC 9 which wasn't replicated by any of the other compilers. Add GCC 9 to the test build matrix.

Test run here: https://github.com/povik/yosys/actions/runs/5857751293/job/15880288410