### PR TITLE
Fix i386 FP excess-precision issue in fstapi (Fixes: #3898)

### DIFF
--- a/libs/fst/fstapi.cc
+++ b/libs/fst/fstapi.cc
@@ -4334,7 +4334,7 @@ int fstReaderInit(struct fstReaderContext *xc)
                     hdr_incomplete = (xc->start_time == 0) && (xc->end_time == 0);
 
                     fstFread(&dcheck, 8, 1, xc->f);
-                    xc->double_endian_match = (dcheck == FST_DOUBLE_ENDTEST);
+                    xc->double_endian_match = (dcheck == (double)FST_DOUBLE_ENDTEST);
                     if (!xc->double_endian_match) {
                         union
                         {


### PR DESCRIPTION
Likely related to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323#c225

Thanks to @jix for digging this up