### PR TITLE
ast: Substitute rvalues when parsing out print arguments

### DIFF
--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -759,7 +759,7 @@ struct AST_INTERNAL::ProcessGenerator
 						arg.realtime = true;
 					} else {
 						arg.type = VerilogFmtArg::INTEGER;
-						arg.sig = node->genRTLIL();
+						arg.sig = node->genWidthRTLIL(-1, false, &subst_rvalue_map.stdmap());
 						arg.signed_ = is_signed;
 					}
 					args.push_back(arg);


### PR DESCRIPTION
Apply the local substitutions stemming from process context when parsing out format arguments to `$display` or other statements.

This is to fix #3917.