### PR TITLE
Speed up the autoname pass by 3x. 

### DIFF
--- a/passes/cmds/autoname.cc
+++ b/passes/cmds/autoname.cc
@@ -36,14 +36,14 @@ int autoname_worker(Module *module, const dict<Wire*, int>& wire_score)
 					if (bit.wire != nullptr && bit.wire->name[0] != '$') {
 						if (suffix.empty())
 							suffix = stringf("_%s_%s", log_id(cell->type), log_id(conn.first));
-						IdString new_name(bit.wire->name.str() + suffix);
+						string new_name(bit.wire->name.str() + suffix);
 						int score = wire_score.at(bit.wire);
 						if (cell->output(conn.first)) score = 0;
 						score = 10000*score + new_name.size();
 						if (!proposed_cell_names.count(cell) || score < proposed_cell_names.at(cell).first) {
 							if (best_score < 0 || score < best_score)
 								best_score = score;
-							proposed_cell_names[cell] = make_pair(score, new_name);
+							proposed_cell_names[cell] = make_pair(score, IdString(new_name));
 						}
 					}
 			}
@@ -54,14 +54,14 @@ int autoname_worker(Module *module, const dict<Wire*, int>& wire_score)
 					if (bit.wire != nullptr && bit.wire->name[0] == '$' && !bit.wire->port_id) {
 						if (suffix.empty())
 							suffix = stringf("_%s", log_id(conn.first));
-						IdString new_name(cell->name.str() + suffix);
+						string new_name(cell->name.str() + suffix);
 						int score = wire_score.at(bit.wire);
 						if (cell->output(conn.first)) score = 0;
 						score = 10000*score + new_name.size();
 						if (!proposed_wire_names.count(bit.wire) || score < proposed_wire_names.at(bit.wire).first) {
 							if (best_score < 0 || score < best_score)
 								best_score = score;
-							proposed_wire_names[bit.wire] = make_pair(score, new_name);
+							proposed_wire_names[bit.wire] = make_pair(score, IdString(new_name));
 						}
 					}
 			}

--- a/passes/cmds/autoname.cc
+++ b/passes/cmds/autoname.cc
@@ -24,8 +24,8 @@ PRIVATE_NAMESPACE_BEGIN
 
 int autoname_worker(Module *module, const dict<Wire*, int>& wire_score)
 {
-	dict<Cell*, pair<int, IdString>> proposed_cell_names;
-	dict<Wire*, pair<int, IdString>> proposed_wire_names;
+	dict<Cell*, pair<int, string>> proposed_cell_names;
+	dict<Wire*, pair<int, string>> proposed_wire_names;
 	int best_score = -1;
 
 	for (auto cell : module->selected_cells()) {
@@ -34,8 +34,13 @@ int autoname_worker(Module *module, const dict<Wire*, int>& wire_score)
 				string suffix;
 				for (auto bit : conn.second)
 					if (bit.wire != nullptr && bit.wire->name[0] != '$') {
-						if (suffix.empty())
-							suffix = stringf("_%s_%s", log_id(cell->type), log_id(conn.first));
+						if (suffix.empty()) {
+							if (bit.wire->width > 1) {
+								suffix = stringf("%i_%s_%s", bit.offset, log_id(cell->type), log_id(conn.first));
+							} else {
+								suffix = stringf("_%s_%s", log_id(cell->type), log_id(conn.first));
+							}
+						}
 						string new_name(bit.wire->name.str() + suffix);
 						int score = wire_score.at(bit.wire);
 						if (cell->output(conn.first)) score = 0;
@@ -43,7 +48,7 @@ int autoname_worker(Module *module, const dict<Wire*, int>& wire_score)
 						if (!proposed_cell_names.count(cell) || score < proposed_cell_names.at(cell).first) {
 							if (best_score < 0 || score < best_score)
 								best_score = score;
-							proposed_cell_names[cell] = make_pair(score, IdString(new_name));
+							proposed_cell_names[cell] = make_pair(score, new_name);
 						}
 					}
 			}
@@ -52,8 +57,13 @@ int autoname_worker(Module *module, const dict<Wire*, int>& wire_score)
 				string suffix;
 				for (auto bit : conn.second)
 					if (bit.wire != nullptr && bit.wire->name[0] == '$' && !bit.wire->port_id) {
-						if (suffix.empty())
-							suffix = stringf("_%s", log_id(conn.first));
+						if (suffix.empty()) {
+							if (bit.wire->width > 1) {
+								suffix = stringf("%i_%s", bit.offset, log_id(conn.first));
+							} else {
+								suffix = stringf("_%s", log_id(conn.first));
+							}
+						}
 						string new_name(cell->name.str() + suffix);
 						int score = wire_score.at(bit.wire);
 						if (cell->output(conn.first)) score = 0;
@@ -61,7 +71,7 @@ int autoname_worker(Module *module, const dict<Wire*, int>& wire_score)
 						if (!proposed_wire_names.count(bit.wire) || score < proposed_wire_names.at(bit.wire).first) {
 							if (best_score < 0 || score < best_score)
 								best_score = score;
-							proposed_wire_names[bit.wire] = make_pair(score, IdString(new_name));
+							proposed_wire_names[bit.wire] = make_pair(score, new_name);
 						}
 					}
 			}
@@ -71,7 +81,7 @@ int autoname_worker(Module *module, const dict<Wire*, int>& wire_score)
 	for (auto &it : proposed_cell_names) {
 		if (best_score*2 < it.second.first)
 			continue;
-		IdString n = module->uniquify(it.second.second);
+		IdString n = module->uniquify(IdString(it.second.second));
 		log_debug("Rename cell %s in %s to %s.\n", log_id(it.first), log_id(module), log_id(n));
 		module->rename(it.first, n);
 	}
@@ -79,7 +89,7 @@ int autoname_worker(Module *module, const dict<Wire*, int>& wire_score)
 	for (auto &it : proposed_wire_names) {
 		if (best_score*2 < it.second.first)
 			continue;
-		IdString n = module->uniquify(it.second.second);
+		IdString n = module->uniquify(IdString(it.second.second));
 		log_debug("Rename wire %s in %s to %s.\n", log_id(it.first), log_id(module), log_id(n));
 		module->rename(it.first, n);
 	}

--- a/passes/cmds/autoname.cc
+++ b/passes/cmds/autoname.cc
@@ -34,13 +34,9 @@ int autoname_worker(Module *module, const dict<Wire*, int>& wire_score)
 				string suffix;
 				for (auto bit : conn.second)
 					if (bit.wire != nullptr && bit.wire->name[0] != '$') {
-						if (suffix.empty()) {
-							if (bit.wire->width > 1) {
-								suffix = stringf("%i_%s_%s", bit.offset, log_id(cell->type), log_id(conn.first));
-							} else {
-								suffix = stringf("_%s_%s", log_id(cell->type), log_id(conn.first));
-							}
-						}
+						if (suffix.empty())
+							suffix = stringf("_%s_%s", log_id(cell->type), log_id(conn.first));
+
 						string new_name(bit.wire->name.str() + suffix);
 						int score = wire_score.at(bit.wire);
 						if (cell->output(conn.first)) score = 0;
@@ -57,13 +53,9 @@ int autoname_worker(Module *module, const dict<Wire*, int>& wire_score)
 				string suffix;
 				for (auto bit : conn.second)
 					if (bit.wire != nullptr && bit.wire->name[0] == '$' && !bit.wire->port_id) {
-						if (suffix.empty()) {
-							if (bit.wire->width > 1) {
-								suffix = stringf("%i_%s", bit.offset, log_id(conn.first));
-							} else {
-								suffix = stringf("_%s", log_id(conn.first));
-							}
-						}
+						if (suffix.empty())
+							suffix = stringf("_%s", log_id(conn.first));
+
 						string new_name(cell->name.str() + suffix);
 						int score = wire_score.at(bit.wire);
 						if (cell->output(conn.first)) score = 0;

--- a/passes/cmds/autoname.cc
+++ b/passes/cmds/autoname.cc
@@ -36,7 +36,6 @@ int autoname_worker(Module *module, const dict<Wire*, int>& wire_score)
 					if (bit.wire != nullptr && bit.wire->name[0] != '$') {
 						if (suffix.empty())
 							suffix = stringf("_%s_%s", log_id(cell->type), log_id(conn.first));
-
 						string new_name(bit.wire->name.str() + suffix);
 						int score = wire_score.at(bit.wire);
 						if (cell->output(conn.first)) score = 0;
@@ -55,7 +54,6 @@ int autoname_worker(Module *module, const dict<Wire*, int>& wire_score)
 					if (bit.wire != nullptr && bit.wire->name[0] == '$' && !bit.wire->port_id) {
 						if (suffix.empty())
 							suffix = stringf("_%s", log_id(conn.first));
-
 						string new_name(cell->name.str() + suffix);
 						int score = wire_score.at(bit.wire);
 						if (cell->output(conn.first)) score = 0;


### PR DESCRIPTION
This is accomplished by only constucting IdString objects from plain strings that have a higher score.

Before:
![image](https://github.com/YosysHQ/yosys/assets/16907534/94e3e90a-1409-42f8-b69a-b32418bbd7f8)

After:
![image](https://github.com/YosysHQ/yosys/assets/16907534/ad3127c0-cf8a-4ae2-8843-2c7b546c6ac7)
