### PR TITLE
Make docs reproducibility more robust

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.v linguist-language=Verilog
 /.gitcommit export-subst
+/.gitepoch export-subst

--- a/.gitepoch
+++ b/.gitepoch
@@ -1,0 +1,1 @@
+$Format:%ct$

--- a/Makefile
+++ b/Makefile
@@ -143,16 +143,7 @@ endif
 
 YOSYS_VER := 0.33+0
 
-# Note: We arrange for .gitcommit to contain the (short) commit hash in
-# tarballs generated with git-archive(1) using .gitattributes. The git repo
-# will have this file in its unexpanded form tough, in which case we fall
-# back to calling git directly.
-TARBALL_GIT_REV := $(shell cat $(YOSYS_SRC)/.gitcommit)
-ifeq ($(TARBALL_GIT_REV),$$Format:%h$$)
-GIT_REV := $(shell GIT_DIR=$(YOSYS_SRC)/.git git rev-parse --short=9 HEAD || echo UNKNOWN)
-else
-GIT_REV := $(TARBALL_GIT_REV)
-endif
+include git.mk #< sets $(GIT_REV)
 
 OBJS = kernel/version_$(GIT_REV).o
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,6 +14,11 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) sou
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
+# Reproducibility
+include ../git.mk #< sets $(GIT_EPOCH)
+export FORCE_SOURCE_DATE ?= 1
+export SOURCE_DATE_EPOCH ?= $(GIT_EPOCH)
+
 .PHONY: help
 help:
 	@echo "Please use \`make <target>' where <target> is one of"

--- a/docs/images/Makefile
+++ b/docs/images/Makefile
@@ -21,9 +21,9 @@ dots: $(DOT_PDF)
 tex: $(TEX_PDF)
 svg: $(SVG_OUTPUT)
 
+include ../../git.mk #< sets $(GIT_EPOCH)
 export FORCE_SOURCE_DATE ?= 1
-export SOURCE_DATE_EPOCH ?= 1640991600
-#^ 2022-01-01 00:00:00
+export SOURCE_DATE_EPOCH ?= $(GIT_EPOCH)
 
 011/%.pdf: $(DOT_LOC)/%.dot
 	dot -Tpdf -o $@ $<

--- a/docs/images/Makefile
+++ b/docs/images/Makefile
@@ -21,11 +21,15 @@ dots: $(DOT_PDF)
 tex: $(TEX_PDF)
 svg: $(SVG_OUTPUT)
 
+export FORCE_SOURCE_DATE ?= 1
+export SOURCE_DATE_EPOCH ?= 1640991600
+#^ 2022-01-01 00:00:00
+
 011/%.pdf: $(DOT_LOC)/%.dot
-	faketime -f '2022-01-01 00:00:00 x0,001' dot -Tpdf -o $@ $<
+	dot -Tpdf -o $@ $<
 
 011/%.pdf: 011/%.tex
-	cd 011 && faketime -f '2022-01-01 00:00:00 x0,001' pdflatex $(<F) --interaction=nonstopmode
+	cd 011 && pdflatex $(<F) --interaction=nonstopmode
 
 %.pdf: %.tex
 	pdflatex $< --interaction=nonstopmode

--- a/git.mk
+++ b/git.mk
@@ -1,0 +1,16 @@
+GIT_METADATA_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+
+# Note: We arrange for .gitcommit to contain the (short) commit hash in
+# tarballs generated with git-archive(1) using .gitattributes. The git repo
+# will have this file in its unexpanded form tough, in which case we fall
+# back to calling git directly.
+
+TARBALL_GIT_REV := $(shell cat $(GIT_METADATA_DIR)/.gitcommit)
+ifeq ($(TARBALL_GIT_REV),$$Format:%h$$)
+GIT_REV := $(shell GIT_DIR=$(GIT_METADATA_DIR)/.git git rev-parse --short=9 HEAD || echo UNKNOWN)
+GIT_EPOCH = $(shell GIT_DIR=$(GIT_METADATA_DIR)/.git git show --format=%ct -q || echo 1640991600)
+#^ 1640991600 == 2022-01-01 00:00:00
+else
+GIT_REV := $(TARBALL_GIT_REV)
+GIT_EPOCH = $(shell cat $(GIT_METADATA_DIR)/.gitepoch)
+endif


### PR DESCRIPTION
Commits:

- Replace faketime with SOURCE_DATE_EPOCH for docs

On Debian some architectures don't support using the faketime wrapper and
it will simply bail out. Turns out pdflatex now natively supports
SOURCE_DATE_EPOCH though as long as you also set FORCE_SOURCE_DATE,
otherwise it won't take effect. Graphviz (dot) also supports the former.

- Introduce GIT_EPOCH for getting SOURCE_DATE_EPOCH date in tarball