### PR TITLE
write_smt2: Check for constant bool after fully resolving signal

### DIFF
--- a/backends/smt2/smt2.cc
+++ b/backends/smt2/smt2.cc
@@ -329,12 +329,13 @@ struct Smt2Worker
 	{
 		sigmap.apply(bit);
 
+		if (bit_driver.count(bit)) {
+			export_cell(bit_driver.at(bit));
+			sigmap.apply(bit);
+		}
+
 		if (bit.wire == nullptr)
 			return bit == RTLIL::State::S1 ? "true" : "false";
-
-		if (bit_driver.count(bit))
-			export_cell(bit_driver.at(bit));
-		sigmap.apply(bit);
 
 		if (fcache.count(bit) == 0) {
 			if (verbose) log("%*s-> external bool: %s\n", 2+2*GetSize(recursive_cells), "",


### PR DESCRIPTION
Fixes #3769.

The issue occured when exporting a bit that is driven through some connections by the output of a cell, but is known to be a constant. This happens with e.g. the following
```verilog
module top(input wire a, output wire b);
wire [1:0] inner = |a;
assign b = inner[1];
endmodule
```
where `b` is always `0`, but is driven by the `$reduce_or` cell.

The previous code would export the `$reduce_or` just for `inner[0]`. When exporting `b`, the `sigmap` would be unable to map `b` through to the constant value driving it, so would create a fresh `declare-fun` for it.

With this change, when exporting `b` we first ensure that if there is a cell driving `b` it has been mapped and apply the `sigmap`. This allows the subsequent code to see that `b` is constant, and thus emit `true`/`false` directly, instead of doing `declare-fun`.