### PR TITLE
Speed up RTLIL::Const::decode_string by 1.7x.

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -321,7 +321,7 @@ std::string RTLIL::Const::decode_string() const
 	if (i < n) {
 		char ch = 0;
 		for (int j = 0; j < (n - i); j++) {
-			if (bits[j + i] == RTLIL::State::S1) {
+			if (bits[i + j] == RTLIL::State::S1) {
 				ch |= 1 << j;
 			}
 		}
@@ -332,7 +332,7 @@ std::string RTLIL::Const::decode_string() const
 	for (; i >= 0; i -= 8) {
 		char ch = 0;
 		for (int j = 0; j < 8; j++) {
-			if (bits[j + i] == RTLIL::State::S1) {
+			if (bits[i + j] == RTLIL::State::S1) {
 				ch |= 1 << j;
 			}
 		}

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -313,18 +313,33 @@ RTLIL::Const RTLIL::Const::from_string(const std::string &str)
 
 std::string RTLIL::Const::decode_string() const
 {
-	std::string string;
-	string.reserve(GetSize(bits)/8);
-	for (int i = 0; i < GetSize(bits); i += 8) {
+	const int n = GetSize(bits);
+	const int n_over_8 = n / 8;
+	std::string s;
+	s.reserve(n_over_8);
+	int i = n_over_8 * 8;
+	if (i < n) {
 		char ch = 0;
-		for (int j = 0; j < 8 && i + j < int (bits.size()); j++)
-			if (bits[i + j] == RTLIL::State::S1)
+		for (int j = 0; j < (n - i); j++) {
+			if (bits[j + i] == RTLIL::State::S1) {
 				ch |= 1 << j;
+			}
+		}
 		if (ch != 0)
-			string.append({ch});
+			s.append({ch});
 	}
-	std::reverse(string.begin(), string.end());
-	return string;
+	i -= 8;
+	for (; i >= 0; i -= 8) {
+		char ch = 0;
+		for (int j = 0; j < 8; j++) {
+			if (bits[j + i] == RTLIL::State::S1) {
+				ch |= 1 << j;
+			}
+		}
+		if (ch != 0)
+			s.append({ch});
+	}
+	return s;
 }
 
 bool RTLIL::Const::is_fully_zero() const
@@ -4044,7 +4059,7 @@ void RTLIL::SigSpec::replace(const RTLIL::SigSpec &pattern, const RTLIL::SigSpec
 			other->bits_[j] = with.bits_[it->second];
 		}
 	}
-	
+
 	other->check();
 }
 


### PR DESCRIPTION
This replaces part of https://github.com/YosysHQ/yosys/pull/3940. The main source of the speedup is from implementing the extraction of the data from all but the last n % 8 bits as a fixed trip-count loop, which the compiler can unroll. 

Benchmark measurements for a synthesis run of a representative circuit:

Before:
![image](https://github.com/YosysHQ/yosys/assets/16907534/17c45227-8ab4-404a-8310-d1f3696e63b8)

After:
![image](https://github.com/YosysHQ/yosys/assets/16907534/5c3581d2-bd4e-44c1-9c69-e6059f1c2584)
