### PR TITLE
Speed up simplemap_mux by 9.6x.

### DIFF
--- a/passes/techmap/simplemap.cc
+++ b/passes/techmap/simplemap.cc
@@ -18,10 +18,10 @@
  */
 
 #include "simplemap.h"
-#include "kernel/ff.h"
 #include "kernel/sigtools.h"
-#include <stdio.h>
+#include "kernel/ff.h"
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 
 USING_YOSYS_NAMESPACE
@@ -64,16 +64,11 @@ void simplemap_bitop(RTLIL::Module *module, RTLIL::Cell *cell)
 	}
 
 	IdString gate_type;
-	if (cell->type == ID($and))
-		gate_type = ID($_AND_);
-	if (cell->type == ID($or))
-		gate_type = ID($_OR_);
-	if (cell->type == ID($xor))
-		gate_type = ID($_XOR_);
-	if (cell->type == ID($xnor))
-		gate_type = ID($_XNOR_);
-	if (cell->type == ID($bweqx))
-		gate_type = ID($_XNOR_);
+	if (cell->type == ID($and))   gate_type = ID($_AND_);
+	if (cell->type == ID($or))    gate_type = ID($_OR_);
+	if (cell->type == ID($xor))   gate_type = ID($_XOR_);
+	if (cell->type == ID($xnor))  gate_type = ID($_XNOR_);
+	if (cell->type == ID($bweqx)) gate_type = ID($_XNOR_);
 	log_assert(!gate_type.empty());
 
 	for (int i = 0; i < GetSize(sig_y); i++) {
@@ -94,44 +89,36 @@ void simplemap_reduce(RTLIL::Module *module, RTLIL::Cell *cell)
 		return;
 
 	if (sig_a.size() == 0) {
-		if (cell->type == ID($reduce_and))
-			module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(1, sig_y.size())));
-		if (cell->type == ID($reduce_or))
-			module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(0, sig_y.size())));
-		if (cell->type == ID($reduce_xor))
-			module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(0, sig_y.size())));
-		if (cell->type == ID($reduce_xnor))
-			module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(1, sig_y.size())));
-		if (cell->type == ID($reduce_bool))
-			module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(0, sig_y.size())));
+		if (cell->type == ID($reduce_and))  module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(1, sig_y.size())));
+		if (cell->type == ID($reduce_or))   module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(0, sig_y.size())));
+		if (cell->type == ID($reduce_xor))  module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(0, sig_y.size())));
+		if (cell->type == ID($reduce_xnor)) module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(1, sig_y.size())));
+		if (cell->type == ID($reduce_bool)) module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(0, sig_y.size())));
 		return;
 	}
 
 	if (sig_y.size() > 1) {
-		module->connect(RTLIL::SigSig(sig_y.extract(1, sig_y.size() - 1), RTLIL::SigSpec(0, sig_y.size() - 1)));
+		module->connect(RTLIL::SigSig(sig_y.extract(1, sig_y.size()-1), RTLIL::SigSpec(0, sig_y.size()-1)));
 		sig_y = sig_y.extract(0, 1);
 	}
 
 	IdString gate_type;
-	if (cell->type == ID($reduce_and))
-		gate_type = ID($_AND_);
-	if (cell->type == ID($reduce_or))
-		gate_type = ID($_OR_);
-	if (cell->type == ID($reduce_xor))
-		gate_type = ID($_XOR_);
-	if (cell->type == ID($reduce_xnor))
-		gate_type = ID($_XOR_);
-	if (cell->type == ID($reduce_bool))
-		gate_type = ID($_OR_);
+	if (cell->type == ID($reduce_and))  gate_type = ID($_AND_);
+	if (cell->type == ID($reduce_or))   gate_type = ID($_OR_);
+	if (cell->type == ID($reduce_xor))  gate_type = ID($_XOR_);
+	if (cell->type == ID($reduce_xnor)) gate_type = ID($_XOR_);
+	if (cell->type == ID($reduce_bool)) gate_type = ID($_OR_);
 	log_assert(!gate_type.empty());
 
 	RTLIL::Cell *last_output_cell = NULL;
 
-	while (sig_a.size() > 1) {
+	while (sig_a.size() > 1)
+	{
 		RTLIL::SigSpec sig_t = module->addWire(NEW_ID, sig_a.size() / 2);
 
-		for (int i = 0; i < sig_a.size(); i += 2) {
-			if (i + 1 == sig_a.size()) {
+		for (int i = 0; i < sig_a.size(); i += 2)
+		{
+			if (i+1 == sig_a.size()) {
 				sig_t.append(sig_a[i]);
 				continue;
 			}
@@ -139,8 +126,8 @@ void simplemap_reduce(RTLIL::Module *module, RTLIL::Cell *cell)
 			RTLIL::Cell *gate = module->addCell(NEW_ID, gate_type);
 			gate->attributes[ID::src] = cell->attributes[ID::src];
 			gate->setPort(ID::A, sig_a[i]);
-			gate->setPort(ID::B, sig_a[i + 1]);
-			gate->setPort(ID::Y, sig_t[i / 2]);
+			gate->setPort(ID::B, sig_a[i+1]);
+			gate->setPort(ID::Y, sig_t[i/2]);
 			last_output_cell = gate;
 		}
 
@@ -166,11 +153,13 @@ void simplemap_reduce(RTLIL::Module *module, RTLIL::Cell *cell)
 
 static void logic_reduce(RTLIL::Module *module, RTLIL::SigSpec &sig, RTLIL::Cell *cell)
 {
-	while (sig.size() > 1) {
+	while (sig.size() > 1)
+	{
 		RTLIL::SigSpec sig_t = module->addWire(NEW_ID, sig.size() / 2);
 
-		for (int i = 0; i < sig.size(); i += 2) {
-			if (i + 1 == sig.size()) {
+		for (int i = 0; i < sig.size(); i += 2)
+		{
+			if (i+1 == sig.size()) {
 				sig_t.append(sig[i]);
 				continue;
 			}
@@ -178,8 +167,8 @@ static void logic_reduce(RTLIL::Module *module, RTLIL::SigSpec &sig, RTLIL::Cell
 			RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_OR_));
 			gate->attributes[ID::src] = cell->attributes[ID::src];
 			gate->setPort(ID::A, sig[i]);
-			gate->setPort(ID::B, sig[i + 1]);
-			gate->setPort(ID::Y, sig_t[i / 2]);
+			gate->setPort(ID::B, sig[i+1]);
+			gate->setPort(ID::Y, sig_t[i/2]);
 		}
 
 		sig = sig_t;
@@ -200,7 +189,7 @@ void simplemap_lognot(RTLIL::Module *module, RTLIL::Cell *cell)
 		return;
 
 	if (sig_y.size() > 1) {
-		module->connect(RTLIL::SigSig(sig_y.extract(1, sig_y.size() - 1), RTLIL::SigSpec(0, sig_y.size() - 1)));
+		module->connect(RTLIL::SigSig(sig_y.extract(1, sig_y.size()-1), RTLIL::SigSpec(0, sig_y.size()-1)));
 		sig_y = sig_y.extract(0, 1);
 	}
 
@@ -224,15 +213,13 @@ void simplemap_logbin(RTLIL::Module *module, RTLIL::Cell *cell)
 		return;
 
 	if (sig_y.size() > 1) {
-		module->connect(RTLIL::SigSig(sig_y.extract(1, sig_y.size() - 1), RTLIL::SigSpec(0, sig_y.size() - 1)));
+		module->connect(RTLIL::SigSig(sig_y.extract(1, sig_y.size()-1), RTLIL::SigSpec(0, sig_y.size()-1)));
 		sig_y = sig_y.extract(0, 1);
 	}
 
 	IdString gate_type;
-	if (cell->type == ID($logic_and))
-		gate_type = ID($_AND_);
-	if (cell->type == ID($logic_or))
-		gate_type = ID($_OR_);
+	if (cell->type == ID($logic_and)) gate_type = ID($_AND_);
+	if (cell->type == ID($logic_or))  gate_type = ID($_OR_);
 	log_assert(!gate_type.empty());
 
 	RTLIL::Cell *gate = module->addCell(NEW_ID, gate_type);
@@ -253,22 +240,19 @@ void simplemap_eqne(RTLIL::Module *module, RTLIL::Cell *cell)
 	RTLIL::SigSpec xor_out = module->addWire(NEW_ID, max(GetSize(sig_a), GetSize(sig_b)));
 	RTLIL::Cell *xor_cell = module->addXor(NEW_ID, sig_a, sig_b, xor_out, is_signed);
 	xor_cell->attributes[ID::src] = cell->attributes[ID::src];
-	// xor_cell->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
 	simplemap_bitop(module, xor_cell);
 	module->remove(xor_cell);
 
 	RTLIL::SigSpec reduce_out = is_ne ? sig_y : module->addWire(NEW_ID);
 	RTLIL::Cell *reduce_cell = module->addReduceOr(NEW_ID, xor_out, reduce_out);
 	reduce_cell->attributes[ID::src] = cell->attributes[ID::src];
-	//	reduce_cell->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
 	simplemap_reduce(module, reduce_cell);
 	module->remove(reduce_cell);
 
 	if (!is_ne) {
 		RTLIL::Cell *not_cell = module->addLogicNot(NEW_ID, reduce_out, sig_y);
 		not_cell->attributes[ID::src] = cell->attributes[ID::src];
-		//		not_cell->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
-		simplemap_lognot(module, not_cell);
+                simplemap_lognot(module, not_cell);
 		module->remove(not_cell);
 	}
 }
@@ -328,15 +312,15 @@ void simplemap_bmux(RTLIL::Module *module, RTLIL::Cell *cell)
 	int width = GetSize(cell->getPort(ID::Y));
 
 	for (int idx = 0; idx < GetSize(sel); idx++) {
-		SigSpec new_data = module->addWire(NEW_ID, GetSize(data) / 2);
+		SigSpec new_data = module->addWire(NEW_ID, GetSize(data)/2);
 		for (int i = 0; i < GetSize(new_data); i += width) {
 			for (int k = 0; k < width; k++) {
 				RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_MUX_));
 				gate->attributes[ID::src] = cell->attributes[ID::src];
-				gate->setPort(ID::A, data[i * 2 + k]);
-				gate->setPort(ID::B, data[i * 2 + width + k]);
+				gate->setPort(ID::A, data[i*2+k]);
+				gate->setPort(ID::B, data[i*2+width+k]);
 				gate->setPort(ID::S, sel[idx]);
-				gate->setPort(ID::Y, new_data[i + k]);
+				gate->setPort(ID::Y, new_data[i+k]);
 			}
 		}
 		data = new_data;
@@ -352,14 +336,14 @@ void simplemap_lut(RTLIL::Module *module, RTLIL::Cell *cell)
 	lut_data.extend_u0(1 << cell->getParam(ID::WIDTH).as_int());
 
 	for (int idx = 0; GetSize(lut_data) > 1; idx++) {
-		SigSpec new_lut_data = module->addWire(NEW_ID, GetSize(lut_data) / 2);
+		SigSpec new_lut_data = module->addWire(NEW_ID, GetSize(lut_data)/2);
 		for (int i = 0; i < GetSize(lut_data); i += 2) {
 			RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_MUX_));
 			gate->attributes[ID::src] = cell->attributes[ID::src];
 			gate->setPort(ID::A, lut_data[i]);
-			gate->setPort(ID::B, lut_data[i + 1]);
+			gate->setPort(ID::B, lut_data[i+1]);
 			gate->setPort(ID::S, lut_ctrl[idx]);
-			gate->setPort(ID::Y, new_lut_data[i / 2]);
+			gate->setPort(ID::Y, new_lut_data[i/2]);
 		}
 		lut_data = new_lut_data;
 	}
@@ -381,11 +365,11 @@ void simplemap_sop(RTLIL::Module *module, RTLIL::Cell *cell)
 	for (int i = 0; i < depth; i++) {
 		SigSpec in, pat;
 		for (int j = 0; j < width; j++) {
-			if (table[2 * i * width + 2 * j + 0] == State::S1) {
+			if (table[2*i*width + 2*j + 0] == State::S1) {
 				in.append(ctrl[j]);
 				pat.append(State::S0);
 			}
-			if (table[2 * i * width + 2 * j + 1] == State::S1) {
+			if (table[2*i*width + 2*j + 1] == State::S1) {
 				in.append(ctrl[j]);
 				pat.append(State::S1);
 			}
@@ -423,56 +407,56 @@ void simplemap_ff(RTLIL::Module *, RTLIL::Cell *cell)
 	}
 }
 
-void simplemap_get_mappers(dict<IdString, void (*)(RTLIL::Module *, RTLIL::Cell *)> &mappers)
+void simplemap_get_mappers(dict<IdString, void(*)(RTLIL::Module*, RTLIL::Cell*)> &mappers)
 {
-	mappers[ID($not)] = simplemap_not;
-	mappers[ID($pos)] = simplemap_pos;
-	mappers[ID($and)] = simplemap_bitop;
-	mappers[ID($or)] = simplemap_bitop;
-	mappers[ID($xor)] = simplemap_bitop;
-	mappers[ID($xnor)] = simplemap_bitop;
-	mappers[ID($bweqx)] = simplemap_bitop;
-	mappers[ID($reduce_and)] = simplemap_reduce;
-	mappers[ID($reduce_or)] = simplemap_reduce;
-	mappers[ID($reduce_xor)] = simplemap_reduce;
+	mappers[ID($not)]         = simplemap_not;
+	mappers[ID($pos)]         = simplemap_pos;
+	mappers[ID($and)]         = simplemap_bitop;
+	mappers[ID($or)]          = simplemap_bitop;
+	mappers[ID($xor)]         = simplemap_bitop;
+	mappers[ID($xnor)]        = simplemap_bitop;
+	mappers[ID($bweqx)]       = simplemap_bitop;
+	mappers[ID($reduce_and)]  = simplemap_reduce;
+	mappers[ID($reduce_or)]   = simplemap_reduce;
+	mappers[ID($reduce_xor)]  = simplemap_reduce;
 	mappers[ID($reduce_xnor)] = simplemap_reduce;
 	mappers[ID($reduce_bool)] = simplemap_reduce;
-	mappers[ID($logic_not)] = simplemap_lognot;
-	mappers[ID($logic_and)] = simplemap_logbin;
-	mappers[ID($logic_or)] = simplemap_logbin;
-	mappers[ID($eq)] = simplemap_eqne;
-	mappers[ID($eqx)] = simplemap_eqne;
-	mappers[ID($ne)] = simplemap_eqne;
-	mappers[ID($nex)] = simplemap_eqne;
-	mappers[ID($mux)] = simplemap_mux;
-	mappers[ID($bwmux)] = simplemap_bwmux;
-	mappers[ID($tribuf)] = simplemap_tribuf;
-	mappers[ID($bmux)] = simplemap_bmux;
-	mappers[ID($lut)] = simplemap_lut;
-	mappers[ID($sop)] = simplemap_sop;
-	mappers[ID($slice)] = simplemap_slice;
-	mappers[ID($concat)] = simplemap_concat;
-	mappers[ID($sr)] = simplemap_ff;
-	mappers[ID($ff)] = simplemap_ff;
-	mappers[ID($dff)] = simplemap_ff;
-	mappers[ID($dffe)] = simplemap_ff;
-	mappers[ID($dffsr)] = simplemap_ff;
-	mappers[ID($dffsre)] = simplemap_ff;
-	mappers[ID($adff)] = simplemap_ff;
-	mappers[ID($sdff)] = simplemap_ff;
-	mappers[ID($adffe)] = simplemap_ff;
-	mappers[ID($sdffe)] = simplemap_ff;
-	mappers[ID($sdffce)] = simplemap_ff;
-	mappers[ID($aldff)] = simplemap_ff;
-	mappers[ID($aldffe)] = simplemap_ff;
-	mappers[ID($dlatch)] = simplemap_ff;
-	mappers[ID($adlatch)] = simplemap_ff;
-	mappers[ID($dlatchsr)] = simplemap_ff;
+	mappers[ID($logic_not)]   = simplemap_lognot;
+	mappers[ID($logic_and)]   = simplemap_logbin;
+	mappers[ID($logic_or)]    = simplemap_logbin;
+	mappers[ID($eq)]          = simplemap_eqne;
+	mappers[ID($eqx)]         = simplemap_eqne;
+	mappers[ID($ne)]          = simplemap_eqne;
+	mappers[ID($nex)]         = simplemap_eqne;
+	mappers[ID($mux)]         = simplemap_mux;
+	mappers[ID($bwmux)]       = simplemap_bwmux;
+	mappers[ID($tribuf)]      = simplemap_tribuf;
+	mappers[ID($bmux)]        = simplemap_bmux;
+	mappers[ID($lut)]         = simplemap_lut;
+	mappers[ID($sop)]         = simplemap_sop;
+	mappers[ID($slice)]       = simplemap_slice;
+	mappers[ID($concat)]      = simplemap_concat;
+	mappers[ID($sr)]          = simplemap_ff;
+	mappers[ID($ff)]          = simplemap_ff;
+	mappers[ID($dff)]         = simplemap_ff;
+	mappers[ID($dffe)]        = simplemap_ff;
+	mappers[ID($dffsr)]       = simplemap_ff;
+	mappers[ID($dffsre)]      = simplemap_ff;
+	mappers[ID($adff)]        = simplemap_ff;
+	mappers[ID($sdff)]        = simplemap_ff;
+	mappers[ID($adffe)]       = simplemap_ff;
+	mappers[ID($sdffe)]       = simplemap_ff;
+	mappers[ID($sdffce)]      = simplemap_ff;
+	mappers[ID($aldff)]       = simplemap_ff;
+	mappers[ID($aldffe)]      = simplemap_ff;
+	mappers[ID($dlatch)]      = simplemap_ff;
+	mappers[ID($adlatch)]     = simplemap_ff;
+	mappers[ID($dlatchsr)]    = simplemap_ff;
 }
 
 void simplemap(RTLIL::Module *module, RTLIL::Cell *cell)
 {
-	static dict<IdString, void (*)(RTLIL::Module *, RTLIL::Cell *)> mappers;
+	static dict<IdString, void(*)(RTLIL::Module*, RTLIL::Cell*)> mappers;
 	static bool initialized_mappers = false;
 
 	if (!initialized_mappers) {
@@ -487,7 +471,7 @@ YOSYS_NAMESPACE_END
 PRIVATE_NAMESPACE_BEGIN
 
 struct SimplemapPass : public Pass {
-	SimplemapPass() : Pass("simplemap", "mapping simple coarse-grain cells") {}
+	SimplemapPass() : Pass("simplemap", "mapping simple coarse-grain cells") { }
 	void help() override
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
@@ -509,13 +493,13 @@ struct SimplemapPass : public Pass {
 		log_header(design, "Executing SIMPLEMAP pass (map simple cells to gate primitives).\n");
 		extra_args(args, 1, design);
 
-		dict<IdString, void (*)(RTLIL::Module *, RTLIL::Cell *)> mappers;
+		dict<IdString, void(*)(RTLIL::Module*, RTLIL::Cell*)> mappers;
 		simplemap_get_mappers(mappers);
 
 		for (auto mod : design->modules()) {
 			if (!design->selected(mod) || mod->get_blackbox_attribute())
 				continue;
-			std::vector<RTLIL::Cell *> cells = mod->cells();
+			std::vector<RTLIL::Cell*> cells = mod->cells();
 			for (auto cell : cells) {
 				if (mappers.count(cell->type) == 0)
 					continue;

--- a/passes/techmap/simplemap.cc
+++ b/passes/techmap/simplemap.cc
@@ -18,10 +18,10 @@
  */
 
 #include "simplemap.h"
-#include "kernel/sigtools.h"
 #include "kernel/ff.h"
-#include <stdlib.h>
+#include "kernel/sigtools.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 USING_YOSYS_NAMESPACE
@@ -36,7 +36,7 @@ void simplemap_not(RTLIL::Module *module, RTLIL::Cell *cell)
 
 	for (int i = 0; i < GetSize(sig_y); i++) {
 		RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_NOT_));
-		gate->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
+		gate->attributes[ID::src] = cell->attributes[ID::src];
 		gate->setPort(ID::A, sig_a[i]);
 		gate->setPort(ID::Y, sig_y[i]);
 	}
@@ -64,16 +64,21 @@ void simplemap_bitop(RTLIL::Module *module, RTLIL::Cell *cell)
 	}
 
 	IdString gate_type;
-	if (cell->type == ID($and))   gate_type = ID($_AND_);
-	if (cell->type == ID($or))    gate_type = ID($_OR_);
-	if (cell->type == ID($xor))   gate_type = ID($_XOR_);
-	if (cell->type == ID($xnor))  gate_type = ID($_XNOR_);
-	if (cell->type == ID($bweqx)) gate_type = ID($_XNOR_);
+	if (cell->type == ID($and))
+		gate_type = ID($_AND_);
+	if (cell->type == ID($or))
+		gate_type = ID($_OR_);
+	if (cell->type == ID($xor))
+		gate_type = ID($_XOR_);
+	if (cell->type == ID($xnor))
+		gate_type = ID($_XNOR_);
+	if (cell->type == ID($bweqx))
+		gate_type = ID($_XNOR_);
 	log_assert(!gate_type.empty());
 
 	for (int i = 0; i < GetSize(sig_y); i++) {
 		RTLIL::Cell *gate = module->addCell(NEW_ID, gate_type);
-		gate->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
+		gate->attributes[ID::src] = cell->attributes[ID::src];
 		gate->setPort(ID::A, sig_a[i]);
 		gate->setPort(ID::B, sig_b[i]);
 		gate->setPort(ID::Y, sig_y[i]);
@@ -89,45 +94,53 @@ void simplemap_reduce(RTLIL::Module *module, RTLIL::Cell *cell)
 		return;
 
 	if (sig_a.size() == 0) {
-		if (cell->type == ID($reduce_and))  module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(1, sig_y.size())));
-		if (cell->type == ID($reduce_or))   module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(0, sig_y.size())));
-		if (cell->type == ID($reduce_xor))  module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(0, sig_y.size())));
-		if (cell->type == ID($reduce_xnor)) module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(1, sig_y.size())));
-		if (cell->type == ID($reduce_bool)) module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(0, sig_y.size())));
+		if (cell->type == ID($reduce_and))
+			module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(1, sig_y.size())));
+		if (cell->type == ID($reduce_or))
+			module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(0, sig_y.size())));
+		if (cell->type == ID($reduce_xor))
+			module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(0, sig_y.size())));
+		if (cell->type == ID($reduce_xnor))
+			module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(1, sig_y.size())));
+		if (cell->type == ID($reduce_bool))
+			module->connect(RTLIL::SigSig(sig_y, RTLIL::SigSpec(0, sig_y.size())));
 		return;
 	}
 
 	if (sig_y.size() > 1) {
-		module->connect(RTLIL::SigSig(sig_y.extract(1, sig_y.size()-1), RTLIL::SigSpec(0, sig_y.size()-1)));
+		module->connect(RTLIL::SigSig(sig_y.extract(1, sig_y.size() - 1), RTLIL::SigSpec(0, sig_y.size() - 1)));
 		sig_y = sig_y.extract(0, 1);
 	}
 
 	IdString gate_type;
-	if (cell->type == ID($reduce_and))  gate_type = ID($_AND_);
-	if (cell->type == ID($reduce_or))   gate_type = ID($_OR_);
-	if (cell->type == ID($reduce_xor))  gate_type = ID($_XOR_);
-	if (cell->type == ID($reduce_xnor)) gate_type = ID($_XOR_);
-	if (cell->type == ID($reduce_bool)) gate_type = ID($_OR_);
+	if (cell->type == ID($reduce_and))
+		gate_type = ID($_AND_);
+	if (cell->type == ID($reduce_or))
+		gate_type = ID($_OR_);
+	if (cell->type == ID($reduce_xor))
+		gate_type = ID($_XOR_);
+	if (cell->type == ID($reduce_xnor))
+		gate_type = ID($_XOR_);
+	if (cell->type == ID($reduce_bool))
+		gate_type = ID($_OR_);
 	log_assert(!gate_type.empty());
 
 	RTLIL::Cell *last_output_cell = NULL;
 
-	while (sig_a.size() > 1)
-	{
+	while (sig_a.size() > 1) {
 		RTLIL::SigSpec sig_t = module->addWire(NEW_ID, sig_a.size() / 2);
 
-		for (int i = 0; i < sig_a.size(); i += 2)
-		{
-			if (i+1 == sig_a.size()) {
+		for (int i = 0; i < sig_a.size(); i += 2) {
+			if (i + 1 == sig_a.size()) {
 				sig_t.append(sig_a[i]);
 				continue;
 			}
 
 			RTLIL::Cell *gate = module->addCell(NEW_ID, gate_type);
-			gate->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
+			gate->attributes[ID::src] = cell->attributes[ID::src];
 			gate->setPort(ID::A, sig_a[i]);
-			gate->setPort(ID::B, sig_a[i+1]);
-			gate->setPort(ID::Y, sig_t[i/2]);
+			gate->setPort(ID::B, sig_a[i + 1]);
+			gate->setPort(ID::Y, sig_t[i / 2]);
 			last_output_cell = gate;
 		}
 
@@ -137,7 +150,7 @@ void simplemap_reduce(RTLIL::Module *module, RTLIL::Cell *cell)
 	if (cell->type == ID($reduce_xnor)) {
 		RTLIL::SigSpec sig_t = module->addWire(NEW_ID);
 		RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_NOT_));
-		gate->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
+		gate->attributes[ID::src] = cell->attributes[ID::src];
 		gate->setPort(ID::A, sig_a);
 		gate->setPort(ID::Y, sig_t);
 		last_output_cell = gate;
@@ -153,22 +166,20 @@ void simplemap_reduce(RTLIL::Module *module, RTLIL::Cell *cell)
 
 static void logic_reduce(RTLIL::Module *module, RTLIL::SigSpec &sig, RTLIL::Cell *cell)
 {
-	while (sig.size() > 1)
-	{
+	while (sig.size() > 1) {
 		RTLIL::SigSpec sig_t = module->addWire(NEW_ID, sig.size() / 2);
 
-		for (int i = 0; i < sig.size(); i += 2)
-		{
-			if (i+1 == sig.size()) {
+		for (int i = 0; i < sig.size(); i += 2) {
+			if (i + 1 == sig.size()) {
 				sig_t.append(sig[i]);
 				continue;
 			}
 
 			RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_OR_));
-			gate->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
+			gate->attributes[ID::src] = cell->attributes[ID::src];
 			gate->setPort(ID::A, sig[i]);
-			gate->setPort(ID::B, sig[i+1]);
-			gate->setPort(ID::Y, sig_t[i/2]);
+			gate->setPort(ID::B, sig[i + 1]);
+			gate->setPort(ID::Y, sig_t[i / 2]);
 		}
 
 		sig = sig_t;
@@ -189,12 +200,12 @@ void simplemap_lognot(RTLIL::Module *module, RTLIL::Cell *cell)
 		return;
 
 	if (sig_y.size() > 1) {
-		module->connect(RTLIL::SigSig(sig_y.extract(1, sig_y.size()-1), RTLIL::SigSpec(0, sig_y.size()-1)));
+		module->connect(RTLIL::SigSig(sig_y.extract(1, sig_y.size() - 1), RTLIL::SigSpec(0, sig_y.size() - 1)));
 		sig_y = sig_y.extract(0, 1);
 	}
 
 	RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_NOT_));
-	gate->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
+	gate->attributes[ID::src] = cell->attributes[ID::src];
 	gate->setPort(ID::A, sig_a);
 	gate->setPort(ID::Y, sig_y);
 }
@@ -213,17 +224,19 @@ void simplemap_logbin(RTLIL::Module *module, RTLIL::Cell *cell)
 		return;
 
 	if (sig_y.size() > 1) {
-		module->connect(RTLIL::SigSig(sig_y.extract(1, sig_y.size()-1), RTLIL::SigSpec(0, sig_y.size()-1)));
+		module->connect(RTLIL::SigSig(sig_y.extract(1, sig_y.size() - 1), RTLIL::SigSpec(0, sig_y.size() - 1)));
 		sig_y = sig_y.extract(0, 1);
 	}
 
 	IdString gate_type;
-	if (cell->type == ID($logic_and)) gate_type = ID($_AND_);
-	if (cell->type == ID($logic_or))  gate_type = ID($_OR_);
+	if (cell->type == ID($logic_and))
+		gate_type = ID($_AND_);
+	if (cell->type == ID($logic_or))
+		gate_type = ID($_OR_);
 	log_assert(!gate_type.empty());
 
 	RTLIL::Cell *gate = module->addCell(NEW_ID, gate_type);
-	gate->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
+	gate->attributes[ID::src] = cell->attributes[ID::src];
 	gate->setPort(ID::A, sig_a);
 	gate->setPort(ID::B, sig_b);
 	gate->setPort(ID::Y, sig_y);
@@ -239,19 +252,22 @@ void simplemap_eqne(RTLIL::Module *module, RTLIL::Cell *cell)
 
 	RTLIL::SigSpec xor_out = module->addWire(NEW_ID, max(GetSize(sig_a), GetSize(sig_b)));
 	RTLIL::Cell *xor_cell = module->addXor(NEW_ID, sig_a, sig_b, xor_out, is_signed);
-	xor_cell->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
+	xor_cell->attributes[ID::src] = cell->attributes[ID::src];
+	// xor_cell->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
 	simplemap_bitop(module, xor_cell);
 	module->remove(xor_cell);
 
 	RTLIL::SigSpec reduce_out = is_ne ? sig_y : module->addWire(NEW_ID);
 	RTLIL::Cell *reduce_cell = module->addReduceOr(NEW_ID, xor_out, reduce_out);
-	reduce_cell->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
+	reduce_cell->attributes[ID::src] = cell->attributes[ID::src];
+	//	reduce_cell->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
 	simplemap_reduce(module, reduce_cell);
 	module->remove(reduce_cell);
 
 	if (!is_ne) {
 		RTLIL::Cell *not_cell = module->addLogicNot(NEW_ID, reduce_out, sig_y);
-		not_cell->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
+		not_cell->attributes[ID::src] = cell->attributes[ID::src];
+		//		not_cell->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
 		simplemap_lognot(module, not_cell);
 		module->remove(not_cell);
 	}
@@ -265,7 +281,7 @@ void simplemap_mux(RTLIL::Module *module, RTLIL::Cell *cell)
 
 	for (int i = 0; i < GetSize(sig_y); i++) {
 		RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_MUX_));
-		gate->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
+		gate->attributes[ID::src] = cell->attributes[ID::src];
 		gate->setPort(ID::A, sig_a[i]);
 		gate->setPort(ID::B, sig_b[i]);
 		gate->setPort(ID::S, cell->getPort(ID::S));
@@ -282,7 +298,7 @@ void simplemap_bwmux(RTLIL::Module *module, RTLIL::Cell *cell)
 
 	for (int i = 0; i < GetSize(sig_y); i++) {
 		RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_MUX_));
-		gate->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
+		gate->attributes[ID::src] = cell->attributes[ID::src];
 		gate->setPort(ID::A, sig_a[i]);
 		gate->setPort(ID::B, sig_b[i]);
 		gate->setPort(ID::S, sig_s[i]);
@@ -298,7 +314,7 @@ void simplemap_tribuf(RTLIL::Module *module, RTLIL::Cell *cell)
 
 	for (int i = 0; i < GetSize(sig_y); i++) {
 		RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_TBUF_));
-		gate->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
+		gate->attributes[ID::src] = cell->attributes[ID::src];
 		gate->setPort(ID::A, sig_a[i]);
 		gate->setPort(ID::E, sig_e);
 		gate->setPort(ID::Y, sig_y[i]);
@@ -312,15 +328,15 @@ void simplemap_bmux(RTLIL::Module *module, RTLIL::Cell *cell)
 	int width = GetSize(cell->getPort(ID::Y));
 
 	for (int idx = 0; idx < GetSize(sel); idx++) {
-		SigSpec new_data = module->addWire(NEW_ID, GetSize(data)/2);
+		SigSpec new_data = module->addWire(NEW_ID, GetSize(data) / 2);
 		for (int i = 0; i < GetSize(new_data); i += width) {
 			for (int k = 0; k < width; k++) {
 				RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_MUX_));
-				gate->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
-				gate->setPort(ID::A, data[i*2+k]);
-				gate->setPort(ID::B, data[i*2+width+k]);
+				gate->attributes[ID::src] = cell->attributes[ID::src];
+				gate->setPort(ID::A, data[i * 2 + k]);
+				gate->setPort(ID::B, data[i * 2 + width + k]);
 				gate->setPort(ID::S, sel[idx]);
-				gate->setPort(ID::Y, new_data[i+k]);
+				gate->setPort(ID::Y, new_data[i + k]);
 			}
 		}
 		data = new_data;
@@ -336,14 +352,14 @@ void simplemap_lut(RTLIL::Module *module, RTLIL::Cell *cell)
 	lut_data.extend_u0(1 << cell->getParam(ID::WIDTH).as_int());
 
 	for (int idx = 0; GetSize(lut_data) > 1; idx++) {
-		SigSpec new_lut_data = module->addWire(NEW_ID, GetSize(lut_data)/2);
+		SigSpec new_lut_data = module->addWire(NEW_ID, GetSize(lut_data) / 2);
 		for (int i = 0; i < GetSize(lut_data); i += 2) {
 			RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_MUX_));
-			gate->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
+			gate->attributes[ID::src] = cell->attributes[ID::src];
 			gate->setPort(ID::A, lut_data[i]);
-			gate->setPort(ID::B, lut_data[i+1]);
+			gate->setPort(ID::B, lut_data[i + 1]);
 			gate->setPort(ID::S, lut_ctrl[idx]);
-			gate->setPort(ID::Y, new_lut_data[i/2]);
+			gate->setPort(ID::Y, new_lut_data[i / 2]);
 		}
 		lut_data = new_lut_data;
 	}
@@ -365,11 +381,11 @@ void simplemap_sop(RTLIL::Module *module, RTLIL::Cell *cell)
 	for (int i = 0; i < depth; i++) {
 		SigSpec in, pat;
 		for (int j = 0; j < width; j++) {
-			if (table[2*i*width + 2*j + 0] == State::S1) {
+			if (table[2 * i * width + 2 * j + 0] == State::S1) {
 				in.append(ctrl[j]);
 				pat.append(State::S0);
 			}
-			if (table[2*i*width + 2*j + 1] == State::S1) {
+			if (table[2 * i * width + 2 * j + 1] == State::S1) {
 				in.append(ctrl[j]);
 				pat.append(State::S1);
 			}
@@ -407,56 +423,56 @@ void simplemap_ff(RTLIL::Module *, RTLIL::Cell *cell)
 	}
 }
 
-void simplemap_get_mappers(dict<IdString, void(*)(RTLIL::Module*, RTLIL::Cell*)> &mappers)
+void simplemap_get_mappers(dict<IdString, void (*)(RTLIL::Module *, RTLIL::Cell *)> &mappers)
 {
-	mappers[ID($not)]         = simplemap_not;
-	mappers[ID($pos)]         = simplemap_pos;
-	mappers[ID($and)]         = simplemap_bitop;
-	mappers[ID($or)]          = simplemap_bitop;
-	mappers[ID($xor)]         = simplemap_bitop;
-	mappers[ID($xnor)]        = simplemap_bitop;
-	mappers[ID($bweqx)]       = simplemap_bitop;
-	mappers[ID($reduce_and)]  = simplemap_reduce;
-	mappers[ID($reduce_or)]   = simplemap_reduce;
-	mappers[ID($reduce_xor)]  = simplemap_reduce;
+	mappers[ID($not)] = simplemap_not;
+	mappers[ID($pos)] = simplemap_pos;
+	mappers[ID($and)] = simplemap_bitop;
+	mappers[ID($or)] = simplemap_bitop;
+	mappers[ID($xor)] = simplemap_bitop;
+	mappers[ID($xnor)] = simplemap_bitop;
+	mappers[ID($bweqx)] = simplemap_bitop;
+	mappers[ID($reduce_and)] = simplemap_reduce;
+	mappers[ID($reduce_or)] = simplemap_reduce;
+	mappers[ID($reduce_xor)] = simplemap_reduce;
 	mappers[ID($reduce_xnor)] = simplemap_reduce;
 	mappers[ID($reduce_bool)] = simplemap_reduce;
-	mappers[ID($logic_not)]   = simplemap_lognot;
-	mappers[ID($logic_and)]   = simplemap_logbin;
-	mappers[ID($logic_or)]    = simplemap_logbin;
-	mappers[ID($eq)]          = simplemap_eqne;
-	mappers[ID($eqx)]         = simplemap_eqne;
-	mappers[ID($ne)]          = simplemap_eqne;
-	mappers[ID($nex)]         = simplemap_eqne;
-	mappers[ID($mux)]         = simplemap_mux;
-	mappers[ID($bwmux)]       = simplemap_bwmux;
-	mappers[ID($tribuf)]      = simplemap_tribuf;
-	mappers[ID($bmux)]        = simplemap_bmux;
-	mappers[ID($lut)]         = simplemap_lut;
-	mappers[ID($sop)]         = simplemap_sop;
-	mappers[ID($slice)]       = simplemap_slice;
-	mappers[ID($concat)]      = simplemap_concat;
-	mappers[ID($sr)]          = simplemap_ff;
-	mappers[ID($ff)]          = simplemap_ff;
-	mappers[ID($dff)]         = simplemap_ff;
-	mappers[ID($dffe)]        = simplemap_ff;
-	mappers[ID($dffsr)]       = simplemap_ff;
-	mappers[ID($dffsre)]      = simplemap_ff;
-	mappers[ID($adff)]        = simplemap_ff;
-	mappers[ID($sdff)]        = simplemap_ff;
-	mappers[ID($adffe)]       = simplemap_ff;
-	mappers[ID($sdffe)]       = simplemap_ff;
-	mappers[ID($sdffce)]      = simplemap_ff;
-	mappers[ID($aldff)]       = simplemap_ff;
-	mappers[ID($aldffe)]      = simplemap_ff;
-	mappers[ID($dlatch)]      = simplemap_ff;
-	mappers[ID($adlatch)]     = simplemap_ff;
-	mappers[ID($dlatchsr)]    = simplemap_ff;
+	mappers[ID($logic_not)] = simplemap_lognot;
+	mappers[ID($logic_and)] = simplemap_logbin;
+	mappers[ID($logic_or)] = simplemap_logbin;
+	mappers[ID($eq)] = simplemap_eqne;
+	mappers[ID($eqx)] = simplemap_eqne;
+	mappers[ID($ne)] = simplemap_eqne;
+	mappers[ID($nex)] = simplemap_eqne;
+	mappers[ID($mux)] = simplemap_mux;
+	mappers[ID($bwmux)] = simplemap_bwmux;
+	mappers[ID($tribuf)] = simplemap_tribuf;
+	mappers[ID($bmux)] = simplemap_bmux;
+	mappers[ID($lut)] = simplemap_lut;
+	mappers[ID($sop)] = simplemap_sop;
+	mappers[ID($slice)] = simplemap_slice;
+	mappers[ID($concat)] = simplemap_concat;
+	mappers[ID($sr)] = simplemap_ff;
+	mappers[ID($ff)] = simplemap_ff;
+	mappers[ID($dff)] = simplemap_ff;
+	mappers[ID($dffe)] = simplemap_ff;
+	mappers[ID($dffsr)] = simplemap_ff;
+	mappers[ID($dffsre)] = simplemap_ff;
+	mappers[ID($adff)] = simplemap_ff;
+	mappers[ID($sdff)] = simplemap_ff;
+	mappers[ID($adffe)] = simplemap_ff;
+	mappers[ID($sdffe)] = simplemap_ff;
+	mappers[ID($sdffce)] = simplemap_ff;
+	mappers[ID($aldff)] = simplemap_ff;
+	mappers[ID($aldffe)] = simplemap_ff;
+	mappers[ID($dlatch)] = simplemap_ff;
+	mappers[ID($adlatch)] = simplemap_ff;
+	mappers[ID($dlatchsr)] = simplemap_ff;
 }
 
 void simplemap(RTLIL::Module *module, RTLIL::Cell *cell)
 {
-	static dict<IdString, void(*)(RTLIL::Module*, RTLIL::Cell*)> mappers;
+	static dict<IdString, void (*)(RTLIL::Module *, RTLIL::Cell *)> mappers;
 	static bool initialized_mappers = false;
 
 	if (!initialized_mappers) {
@@ -471,7 +487,7 @@ YOSYS_NAMESPACE_END
 PRIVATE_NAMESPACE_BEGIN
 
 struct SimplemapPass : public Pass {
-	SimplemapPass() : Pass("simplemap", "mapping simple coarse-grain cells") { }
+	SimplemapPass() : Pass("simplemap", "mapping simple coarse-grain cells") {}
 	void help() override
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
@@ -493,13 +509,13 @@ struct SimplemapPass : public Pass {
 		log_header(design, "Executing SIMPLEMAP pass (map simple cells to gate primitives).\n");
 		extra_args(args, 1, design);
 
-		dict<IdString, void(*)(RTLIL::Module*, RTLIL::Cell*)> mappers;
+		dict<IdString, void (*)(RTLIL::Module *, RTLIL::Cell *)> mappers;
 		simplemap_get_mappers(mappers);
 
 		for (auto mod : design->modules()) {
 			if (!design->selected(mod) || mod->get_blackbox_attribute())
 				continue;
-			std::vector<RTLIL::Cell*> cells = mod->cells();
+			std::vector<RTLIL::Cell *> cells = mod->cells();
 			for (auto cell : cells) {
 				if (mappers.count(cell->type) == 0)
 					continue;

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -156,6 +156,8 @@ struct TechmapWorker
 		}
 
 		std::string orig_cell_name;
+		pool<string> extra_src_attrs = cell->get_strpool_attribute(ID::src);
+
 		orig_cell_name = cell->name.str();
 		for (auto tpl_cell : tpl->cells())
 			if (tpl_cell->name.ends_with("_TECHMAP_REPLACE_")) {
@@ -170,7 +172,7 @@ struct TechmapWorker
 			apply_prefix(cell->name, m_name);
 			RTLIL::Memory *m = module->addMemory(m_name, it.second);
 			if (m->attributes.count(ID::src))
-                          m->attributes[ID::src] = cell->attributes[ID::src];
+				m->add_strpool_attribute(ID::src, extra_src_attrs);
 			memory_renames[it.first] = m->name;
 			design->select(module, m);
 		}
@@ -215,7 +217,7 @@ struct TechmapWorker
 				if (tpl_w->get_bool_attribute(ID::_techmap_special_))
 					w->attributes.clear();
 				if (w->attributes.count(ID::src))
-                                  w->attributes[ID::src] = cell->attributes[ID::src];
+					w->add_strpool_attribute(ID::src, extra_src_attrs);
 			}
 			design->select(module, w);
 
@@ -373,7 +375,7 @@ struct TechmapWorker
 			}
 
 			if (c->attributes.count(ID::src))
-                          c->attributes[ID::src] = cell->attributes[ID::src];
+				c->add_strpool_attribute(ID::src, extra_src_attrs);
 
 			if (techmap_replace_cell) {
 				for (auto attr : cell->attributes)

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -17,14 +17,14 @@
  *
  */
 
-#include "kernel/yosys.h"
-#include "kernel/utils.h"
-#include "kernel/sigtools.h"
 #include "kernel/ffinit.h"
+#include "kernel/sigtools.h"
+#include "kernel/utils.h"
+#include "kernel/yosys.h"
 #include "libs/sha1/sha1.h"
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "simplemap.h"
@@ -42,7 +42,7 @@ PRIVATE_NAMESPACE_BEGIN
 void apply_prefix(IdString prefix, IdString &id)
 {
 	if (id[0] == '\\')
-		id = stringf("%s.%s", prefix.c_str(), id.c_str()+1);
+		id = stringf("%s.%s", prefix.c_str(), id.c_str() + 1);
 	else
 		id = stringf("$techmap%s.%s", prefix.c_str(), id.c_str());
 }
@@ -60,13 +60,12 @@ void apply_prefix(IdString prefix, RTLIL::SigSpec &sig, RTLIL::Module *module)
 	sig = chunks;
 }
 
-struct TechmapWorker
-{
-	dict<IdString, void(*)(RTLIL::Module*, RTLIL::Cell*)> simplemap_mappers;
-	dict<std::pair<IdString, dict<IdString, RTLIL::Const>>, RTLIL::Module*> techmap_cache;
-	dict<RTLIL::Module*, bool> techmap_do_cache;
-	pool<RTLIL::Module*> module_queue;
-	dict<Module*, SigMap> sigmaps;
+struct TechmapWorker {
+	dict<IdString, void (*)(RTLIL::Module *, RTLIL::Cell *)> simplemap_mappers;
+	dict<std::pair<IdString, dict<IdString, RTLIL::Const>>, RTLIL::Module *> techmap_cache;
+	dict<RTLIL::Module *, bool> techmap_do_cache;
+	pool<RTLIL::Module *> module_queue;
+	dict<Module *, SigMap> sigmaps;
 
 	pool<string> log_msg_cache;
 
@@ -98,9 +97,9 @@ struct TechmapWorker
 				} else if (connbits_map.count(bit)) {
 					if (verbose)
 						log("  Bit %d of port %s and bit %d of port %s are connected.\n", i, log_id(conn.first),
-								connbits_map.at(bit).second, log_id(connbits_map.at(bit).first));
-					constmap_info += stringf("|%s %d %s %d", log_id(conn.first), i,
-							log_id(connbits_map.at(bit).first), connbits_map.at(bit).second);
+						    connbits_map.at(bit).second, log_id(connbits_map.at(bit).first));
+					constmap_info += stringf("|%s %d %s %d", log_id(conn.first), i, log_id(connbits_map.at(bit).first),
+								 connbits_map.at(bit).second);
 				} else {
 					connbits_map.emplace(bit, std::make_pair(conn.first, i));
 					constmap_info += stringf("|%s %d", log_id(conn.first), i);
@@ -134,8 +133,8 @@ struct TechmapWorker
 		if (!result.empty()) {
 			SigMap sigmap(module);
 			for (auto &it1 : result)
-			for (auto &it2 : it1.second)
-				sigmap.apply(it2.value);
+				for (auto &it2 : it1.second)
+					sigmap.apply(it2.value);
 		}
 
 		return result;
@@ -146,7 +145,7 @@ struct TechmapWorker
 		if (tpl->processes.size() != 0) {
 			log("Technology map yielded processes:");
 			for (auto &it : tpl->processes)
-				log(" %s",log_id(it.first));
+				log(" %s", log_id(it.first));
 			log("\n");
 			if (autoproc_mode) {
 				Pass::call_on_module(tpl->design, tpl, "proc");
@@ -156,7 +155,6 @@ struct TechmapWorker
 		}
 
 		std::string orig_cell_name;
-		pool<string> extra_src_attrs = cell->get_strpool_attribute(ID::src);
 
 		orig_cell_name = cell->name.str();
 		for (auto tpl_cell : tpl->cells())
@@ -166,32 +164,28 @@ struct TechmapWorker
 			}
 
 		dict<IdString, IdString> memory_renames;
-
 		for (auto &it : tpl->memories) {
 			IdString m_name = it.first;
 			apply_prefix(cell->name, m_name);
 			RTLIL::Memory *m = module->addMemory(m_name, it.second);
 			if (m->attributes.count(ID::src))
-				m->add_strpool_attribute(ID::src, extra_src_attrs);
+				m->attributes[ID::src] = cell->attributes[ID::src];
 			memory_renames[it.first] = m->name;
 			design->select(module, m);
 		}
 
 		dict<IdString, IdString> positional_ports;
-		dict<Wire*, IdString> temp_renamed_wires;
+		dict<Wire *, IdString> temp_renamed_wires;
 		pool<SigBit> autopurge_tpl_bits;
 
-		for (auto tpl_w : tpl->wires())
-		{
-			if (tpl_w->port_id > 0)
-			{
+		for (auto tpl_w : tpl->wires()) {
+			if (tpl_w->port_id > 0) {
 				IdString posportname = stringf("$%d", tpl_w->port_id);
 				positional_ports.emplace(posportname, tpl_w->name);
 
 				if (tpl_w->get_bool_attribute(ID::techmap_autopurge) &&
-						(!cell->hasPort(tpl_w->name) || !GetSize(cell->getPort(tpl_w->name))) &&
-						(!cell->hasPort(posportname) || !GetSize(cell->getPort(posportname))))
-				{
+				    (!cell->hasPort(tpl_w->name) || !GetSize(cell->getPort(tpl_w->name))) &&
+				    (!cell->hasPort(posportname) || !GetSize(cell->getPort(posportname)))) {
 					if (sigmaps.count(tpl) == 0)
 						sigmaps[tpl].set(tpl);
 
@@ -217,7 +211,7 @@ struct TechmapWorker
 				if (tpl_w->get_bool_attribute(ID::_techmap_special_))
 					w->attributes.clear();
 				if (w->attributes.count(ID::src))
-					w->add_strpool_attribute(ID::src, extra_src_attrs);
+					w->attributes[ID::src] = cell->attributes[ID::src];
 			}
 			design->select(module, w);
 
@@ -230,24 +224,24 @@ struct TechmapWorker
 
 		pool<SigBit> tpl_written_bits;
 		for (auto tpl_cell : tpl->cells())
-		for (auto &conn : tpl_cell->connections())
-			if (tpl_cell->output(conn.first))
-				for (auto bit : conn.second)
-					tpl_written_bits.insert(bit);
+			for (auto &conn : tpl_cell->connections())
+				if (tpl_cell->output(conn.first))
+					for (auto bit : conn.second)
+						tpl_written_bits.insert(bit);
 		for (auto &conn : tpl->connections())
 			for (auto bit : conn.first)
 				tpl_written_bits.insert(bit);
 
 		SigMap port_signal_map;
 
-		for (auto &it : cell->connections())
-		{
+		for (auto &it : cell->connections()) {
 			IdString portname = it.first;
 			if (positional_ports.count(portname) > 0)
 				portname = positional_ports.at(portname);
 			if (tpl->wire(portname) == nullptr || tpl->wire(portname)->port_id == 0) {
 				if (portname.begins_with("$"))
-					log_error("Can't map port `%s' of cell `%s' to template `%s'!\n", portname.c_str(), cell->name.c_str(), tpl->name.c_str());
+					log_error("Can't map port `%s' of cell `%s' to template `%s'!\n", portname.c_str(), cell->name.c_str(),
+						  tpl->name.c_str());
 				continue;
 			}
 
@@ -297,8 +291,7 @@ struct TechmapWorker
 
 			if (w->port_output && !w->port_input) {
 				port_signal_map.add(c.second, c.first);
-			} else
-			if (!w->port_output && w->port_input) {
+			} else if (!w->port_output && w->port_input) {
 				port_signal_map.add(c.first, c.second);
 			} else {
 				module->connect(c);
@@ -311,16 +304,15 @@ struct TechmapWorker
 				auto lhs = GetSize(extra_connect.first);
 				auto rhs = GetSize(extra_connect.second);
 				if (lhs > rhs)
-					extra_connect.first.remove(rhs, lhs-rhs);
+					extra_connect.first.remove(rhs, lhs - rhs);
 				else if (rhs > lhs)
-					extra_connect.second.remove(lhs, rhs-lhs);
+					extra_connect.second.remove(lhs, rhs - lhs);
 				module->connect(extra_connect);
 				break;
 			}
 		}
 
-		for (auto tpl_cell : tpl->cells())
-		{
+		for (auto tpl_cell : tpl->cells()) {
 			IdString c_name = tpl_cell->name;
 			bool techmap_replace_cell = c_name.ends_with("_TECHMAP_REPLACE_");
 
@@ -339,8 +331,7 @@ struct TechmapWorker
 
 			vector<IdString> autopurge_ports;
 
-			for (auto &conn : c->connections())
-			{
+			for (auto &conn : c->connections()) {
 				bool autopurge = false;
 				if (!autopurge_tpl_bits.empty()) {
 					autopurge = GetSize(conn.second) != 0;
@@ -375,7 +366,7 @@ struct TechmapWorker
 			}
 
 			if (c->attributes.count(ID::src))
-				c->add_strpool_attribute(ID::src, extra_src_attrs);
+				c->attributes[ID::src] = cell->attributes[ID::src];
 
 			if (techmap_replace_cell) {
 				for (auto attr : cell->attributes)
@@ -396,8 +387,7 @@ struct TechmapWorker
 
 		module->remove(cell);
 
-		for (auto &it : temp_renamed_wires)
-		{
+		for (auto &it : temp_renamed_wires) {
 			Wire *w = it.first;
 			IdString name = it.second;
 			IdString altname = module->uniquify(name);
@@ -407,8 +397,8 @@ struct TechmapWorker
 		}
 	}
 
-	bool techmap_module(RTLIL::Design *design, RTLIL::Module *module, RTLIL::Design *map, pool<RTLIL::Cell*> &handled_cells,
-			const dict<IdString, pool<IdString>> &celltypeMap, bool in_recursion)
+	bool techmap_module(RTLIL::Design *design, RTLIL::Module *module, RTLIL::Design *map, pool<RTLIL::Cell *> &handled_cells,
+			    const dict<IdString, pool<IdString>> &celltypeMap, bool in_recursion)
 	{
 		std::string mapmsg_prefix = in_recursion ? "Recursively mapping" : "Mapping";
 
@@ -422,12 +412,11 @@ struct TechmapWorker
 		SigMap sigmap(module);
 		FfInitVals initvals(&sigmap, module);
 
-		TopoSort<RTLIL::Cell*, IdString::compare_ptr_by_name<RTLIL::Cell>> cells;
-		dict<RTLIL::Cell*, pool<RTLIL::SigBit>> cell_to_inbit;
-		dict<RTLIL::SigBit, pool<RTLIL::Cell*>> outbit_to_cell;
+		TopoSort<RTLIL::Cell *, IdString::compare_ptr_by_name<RTLIL::Cell>> cells;
+		dict<RTLIL::Cell *, pool<RTLIL::SigBit>> cell_to_inbit;
+		dict<RTLIL::SigBit, pool<RTLIL::Cell *>> outbit_to_cell;
 
-		for (auto cell : module->selected_cells())
-		{
+		for (auto cell : module->selected_cells()) {
 			if (handled_cells.count(cell) > 0)
 				continue;
 
@@ -441,8 +430,7 @@ struct TechmapWorker
 				continue;
 			}
 
-			for (auto &conn : cell->connections())
-			{
+			for (auto &conn : cell->connections()) {
 				RTLIL::SigSpec sig = sigmap(conn.second);
 				sig.remove_const();
 
@@ -464,14 +452,13 @@ struct TechmapWorker
 		}
 
 		for (auto &it_right : cell_to_inbit)
-		for (auto &it_sigbit : it_right.second)
-		for (auto &it_left : outbit_to_cell[it_sigbit])
-			cells.edge(it_left, it_right.first);
+			for (auto &it_sigbit : it_right.second)
+				for (auto &it_left : outbit_to_cell[it_sigbit])
+					cells.edge(it_left, it_right.first);
 
 		cells.sort();
 
-		for (auto cell : cells.sorted)
-		{
+		for (auto cell : cells.sorted) {
 			log_assert(handled_cells.count(cell) == 0);
 			log_assert(cell == module->cell(cell->name));
 			bool mapped_cell = false;
@@ -481,8 +468,7 @@ struct TechmapWorker
 			if (in_recursion && cell->type.begins_with("\\$"))
 				cell_type = cell_type.substr(1);
 
-			for (auto &tpl_name : celltypeMap.at(cell_type))
-			{
+			for (auto &tpl_name : celltypeMap.at(cell_type)) {
 				IdString derived_name = tpl_name;
 				RTLIL::Module *tpl = map->module(tpl_name);
 				dict<IdString, RTLIL::Const> parameters(cell->parameters);
@@ -501,12 +487,10 @@ struct TechmapWorker
 				if (tpl->attributes.count(ID::techmap_wrap))
 					extmapper_name = "wrap";
 
-				if (!extmapper_name.empty())
-				{
+				if (!extmapper_name.empty()) {
 					cell->type = cell_type;
 
-					if ((extern_mode && !in_recursion) || extmapper_name == "wrap")
-					{
+					if ((extern_mode && !in_recursion) || extmapper_name == "wrap") {
 						std::string m_name = stringf("$extern:%s:%s", extmapper_name.c_str(), log_id(cell->type));
 
 						for (auto &c : cell->parameters)
@@ -518,8 +502,7 @@ struct TechmapWorker
 						RTLIL::Design *extmapper_design = extern_mode && !in_recursion ? design : tpl->design;
 						RTLIL::Module *extmapper_module = extmapper_design->module(m_name);
 
-						if (extmapper_module == nullptr)
-						{
+						if (extmapper_module == nullptr) {
 							extmapper_module = extmapper_design->addModule(m_name);
 							RTLIL::Cell *extmapper_cell = extmapper_module->addCell(cell->type, cell);
 
@@ -542,7 +525,8 @@ struct TechmapWorker
 							if (extmapper_name == "simplemap") {
 								log("Creating %s with simplemap.\n", log_id(extmapper_module));
 								if (simplemap_mappers.count(extmapper_cell->type) == 0)
-									log_error("No simplemap mapper for cell type %s found!\n", log_id(extmapper_cell->type));
+									log_error("No simplemap mapper for cell type %s found!\n",
+										  log_id(extmapper_cell->type));
 								simplemap_mappers.at(extmapper_cell->type)(extmapper_module, extmapper_cell);
 								extmapper_module->remove(extmapper_cell);
 							}
@@ -550,7 +534,8 @@ struct TechmapWorker
 							if (extmapper_name == "maccmap") {
 								log("Creating %s with maccmap.\n", log_id(extmapper_module));
 								if (extmapper_cell->type != ID($macc))
-									log_error("The maccmap mapper can only map $macc (not %s) cells!\n", log_id(extmapper_cell->type));
+									log_error("The maccmap mapper can only map $macc (not %s) cells!\n",
+										  log_id(extmapper_cell->type));
 								maccmap(extmapper_module, extmapper_cell);
 								extmapper_module->remove(extmapper_cell);
 							}
@@ -572,21 +557,23 @@ struct TechmapWorker
 							goto use_wrapper_tpl;
 						}
 
-						auto msg = stringf("Using extmapper %s for cells of type %s.", log_id(extmapper_module), log_id(cell->type));
+						auto msg =
+						  stringf("Using extmapper %s for cells of type %s.", log_id(extmapper_module), log_id(cell->type));
 						if (!log_msg_cache.count(msg)) {
 							log_msg_cache.insert(msg);
 							log("%s\n", msg.c_str());
 						}
-						log_debug("%s %s.%s (%s) to %s.\n", mapmsg_prefix.c_str(), log_id(module), log_id(cell), log_id(cell->type), log_id(extmapper_module));
-					}
-					else
-					{
-						auto msg = stringf("Using extmapper %s for cells of type %s.", extmapper_name.c_str(), log_id(cell->type));
+						log_debug("%s %s.%s (%s) to %s.\n", mapmsg_prefix.c_str(), log_id(module), log_id(cell),
+							  log_id(cell->type), log_id(extmapper_module));
+					} else {
+						auto msg =
+						  stringf("Using extmapper %s for cells of type %s.", extmapper_name.c_str(), log_id(cell->type));
 						if (!log_msg_cache.count(msg)) {
 							log_msg_cache.insert(msg);
 							log("%s\n", msg.c_str());
 						}
-						log_debug("%s %s.%s (%s) with %s.\n", mapmsg_prefix.c_str(), log_id(module), log_id(cell), log_id(cell->type), extmapper_name.c_str());
+						log_debug("%s %s.%s (%s) with %s.\n", mapmsg_prefix.c_str(), log_id(module), log_id(cell),
+							  log_id(cell->type), extmapper_name.c_str());
 
 						if (extmapper_name == "simplemap") {
 							if (simplemap_mappers.count(cell->type) == 0)
@@ -596,7 +583,8 @@ struct TechmapWorker
 
 						if (extmapper_name == "maccmap") {
 							if (cell->type != ID($macc))
-								log_error("The maccmap mapper can only map $macc (not %s) cells!\n", log_id(cell->type));
+								log_error("The maccmap mapper can only map $macc (not %s) cells!\n",
+									  log_id(cell->type));
 							maccmap(module, cell);
 						}
 
@@ -614,13 +602,14 @@ struct TechmapWorker
 						continue;
 					if (tpl->wire(conn.first) != nullptr && tpl->wire(conn.first)->port_id > 0)
 						continue;
-					if (!conn.second.is_fully_const() || parameters.count(conn.first) > 0 || tpl->avail_parameters.count(conn.first) == 0)
+					if (!conn.second.is_fully_const() || parameters.count(conn.first) > 0 ||
+					    tpl->avail_parameters.count(conn.first) == 0)
 						goto next_tpl;
 					parameters[conn.first] = conn.second.as_const();
 				}
 
 				if (0) {
-		next_tpl:
+				next_tpl:
 					continue;
 				}
 
@@ -634,14 +623,16 @@ struct TechmapWorker
 						std::vector<RTLIL::SigBit> v = sigmap(conn.second).to_sigbit_vector();
 						for (auto &bit : v)
 							bit = RTLIL::SigBit(bit.wire == nullptr ? RTLIL::State::S1 : RTLIL::State::S0);
-						parameters.emplace(stringf("\\_TECHMAP_CONSTMSK_%s_", log_id(conn.first)), RTLIL::SigSpec(v).as_const());
+						parameters.emplace(stringf("\\_TECHMAP_CONSTMSK_%s_", log_id(conn.first)),
+								   RTLIL::SigSpec(v).as_const());
 					}
 					if (tpl->avail_parameters.count(stringf("\\_TECHMAP_CONSTVAL_%s_", log_id(conn.first))) != 0) {
 						std::vector<RTLIL::SigBit> v = sigmap(conn.second).to_sigbit_vector();
 						for (auto &bit : v)
 							if (bit.wire != nullptr)
 								bit = RTLIL::SigBit(RTLIL::State::Sx);
-						parameters.emplace(stringf("\\_TECHMAP_CONSTVAL_%s_", log_id(conn.first)), RTLIL::SigSpec(v).as_const());
+						parameters.emplace(stringf("\\_TECHMAP_CONSTVAL_%s_", log_id(conn.first)),
+								   RTLIL::SigSpec(v).as_const());
 					}
 					if (tpl->avail_parameters.count(stringf("\\_TECHMAP_WIREINIT_%s_", log_id(conn.first))) != 0) {
 						parameters.emplace(stringf("\\_TECHMAP_WIREINIT_%s_", log_id(conn.first)), initvals(conn.second));
@@ -666,7 +657,7 @@ struct TechmapWorker
 					// Find highest bit set
 					int bits = 0;
 					for (int i = 0; i < 32; i++)
-						if (((unique_bit_id_counter-1) & (1 << i)) != 0)
+						if (((unique_bit_id_counter - 1) & (1 << i)) != 0)
 							bits = i;
 					// Increment index by one to get number of bits
 					bits++;
@@ -688,7 +679,7 @@ struct TechmapWorker
 				}
 
 				if (0) {
-			use_wrapper_tpl:;
+				use_wrapper_tpl:;
 					// do not register techmap_wrap modules with techmap_cache
 				} else {
 					std::pair<IdString, dict<IdString, RTLIL::Const>> key(tpl_name, parameters);
@@ -710,15 +701,13 @@ struct TechmapWorker
 				if (constmapped_tpl != nullptr)
 					tpl = constmapped_tpl;
 
-				if (techmap_do_cache.count(tpl) == 0)
-				{
+				if (techmap_do_cache.count(tpl) == 0) {
 					bool keep_running = true;
 					techmap_do_cache[tpl] = true;
 
 					pool<IdString> techmap_wire_names;
 
-					while (keep_running)
-					{
+					while (keep_running) {
 						TechmapWires twd = techmap_find_special_wires(tpl);
 						keep_running = false;
 
@@ -731,8 +720,9 @@ struct TechmapWorker
 							for (const TechmapWireData &elem : it.second) {
 								RTLIL::SigSpec value = elem.value;
 								if (value.is_fully_const() && value.as_bool()) {
-									log("Not using module `%s' from techmap as it contains a %s marker wire with non-zero value %s.\n",
-											derived_name.c_str(), log_id(elem.wire->name), log_signal(value));
+									log("Not using module `%s' from techmap as it contains a %s marker wire with "
+									    "non-zero value %s.\n",
+									    derived_name.c_str(), log_id(elem.wire->name), log_signal(value));
 									techmap_do_cache[tpl] = false;
 								}
 							}
@@ -741,27 +731,26 @@ struct TechmapWorker
 						if (!techmap_do_cache[tpl])
 							break;
 
-						for (auto &it : twd)
-						{
+						for (auto &it : twd) {
 							if (!it.first.contains("_TECHMAP_DO_") || it.second.empty())
 								continue;
 
 							auto &data = it.second.front();
 
 							if (!data.value.is_fully_const())
-								log_error("Techmap yielded config wire %s with non-const value %s.\n", log_id(data.wire->name), log_signal(data.value));
+								log_error("Techmap yielded config wire %s with non-const value %s.\n",
+									  log_id(data.wire->name), log_signal(data.value));
 
 							techmap_wire_names.erase(it.first);
 
 							const char *p = data.wire->name.c_str();
-							const char *q = strrchr(p+1, '.');
-							q = q ? q+1 : p+1;
+							const char *q = strrchr(p + 1, '.');
+							q = q ? q + 1 : p + 1;
 
 							std::string cmd_string = data.value.as_const().decode_string();
 
 						restart_eval_cmd_string:
-							if (cmd_string.rfind("CONSTMAP; ", 0) == 0)
-							{
+							if (cmd_string.rfind("CONSTMAP; ", 0) == 0) {
 								cmd_string = cmd_string.substr(strlen("CONSTMAP; "));
 
 								log("Analyzing pattern of constant bits for this cell:\n");
@@ -780,8 +769,7 @@ struct TechmapWorker
 								dict<RTLIL::SigBit, RTLIL::SigBit> port_connmap;
 								dict<RTLIL::SigBit, RTLIL::SigBit> cellbits_to_tplbits;
 
-								for (auto wire : tpl->wires().to_vector())
-								{
+								for (auto wire : tpl->wires().to_vector()) {
 									if (!wire->port_input || wire->port_output)
 										continue;
 
@@ -793,14 +781,15 @@ struct TechmapWorker
 									wire->port_id = 0;
 
 									for (int i = 0; i < wire->width; i++) {
-										port_new2old_map.emplace(RTLIL::SigBit(new_wire, i), RTLIL::SigBit(wire, i));
-										port_connmap.emplace(RTLIL::SigBit(wire, i), RTLIL::SigBit(new_wire, i));
+										port_new2old_map.emplace(RTLIL::SigBit(new_wire, i),
+													 RTLIL::SigBit(wire, i));
+										port_connmap.emplace(RTLIL::SigBit(wire, i),
+												     RTLIL::SigBit(new_wire, i));
 									}
 								}
 
 								// Handle outputs first, as these cannot be remapped.
-								for (auto &conn : cell->connections())
-								{
+								for (auto &conn : cell->connections()) {
 									Wire *twire = tpl->wire(conn.first);
 									if (!twire->port_output)
 										continue;
@@ -813,28 +802,22 @@ struct TechmapWorker
 								}
 
 								// Now handle inputs, remapping as necessary.
-								for (auto &conn : cell->connections())
-								{
+								for (auto &conn : cell->connections()) {
 									Wire *twire = tpl->wire(conn.first);
 									if (twire->port_output)
 										continue;
 
-									for (int i = 0; i < GetSize(conn.second); i++)
-									{
+									for (int i = 0; i < GetSize(conn.second); i++) {
 										RTLIL::SigBit bit = sigmap(conn.second[i]);
 										RTLIL::SigBit tplbit(twire, i);
 
-										if (bit.wire == nullptr)
-										{
+										if (bit.wire == nullptr) {
 											RTLIL::SigBit oldbit = port_new2old_map.at(tplbit);
 											port_connmap.at(oldbit) = bit;
-										}
-										else if (cellbits_to_tplbits.count(bit))
-										{
+										} else if (cellbits_to_tplbits.count(bit)) {
 											RTLIL::SigBit oldbit = port_new2old_map.at(tplbit);
 											port_connmap.at(oldbit) = cellbits_to_tplbits[bit];
-										}
-										else
+										} else
 											cellbits_to_tplbits[bit] = tplbit;
 									}
 								}
@@ -850,17 +833,18 @@ struct TechmapWorker
 								goto restart_eval_cmd_string;
 							}
 
-							if (cmd_string.rfind("RECURSION; ", 0) == 0)
-							{
+							if (cmd_string.rfind("RECURSION; ", 0) == 0) {
 								cmd_string = cmd_string.substr(strlen("RECURSION; "));
-								while (techmap_module(map, tpl, map, handled_cells, celltypeMap, true)) { }
+								while (techmap_module(map, tpl, map, handled_cells, celltypeMap, true)) {
+								}
 								goto restart_eval_cmd_string;
 							}
 
 							Pass::call_on_module(map, tpl, cmd_string);
 
 							log_assert(!strncmp(q, "_TECHMAP_DO_", 12));
-							std::string new_name = data.wire->name.substr(0, q-p) + "_TECHMAP_DONE_" + data.wire->name.substr(q-p+12);
+							std::string new_name =
+							  data.wire->name.substr(0, q - p) + "_TECHMAP_DONE_" + data.wire->name.substr(q - p + 12);
 							while (tpl->wire(new_name) != nullptr)
 								new_name += "_";
 							tpl->rename(data.wire->name, new_name);
@@ -872,12 +856,15 @@ struct TechmapWorker
 
 					TechmapWires twd = techmap_find_special_wires(tpl);
 					for (auto &it : twd) {
-						if (!it.first.ends_with("_TECHMAP_FAIL_") && (!it.first.begins_with("\\_TECHMAP_REMOVEINIT_") || !it.first.ends_with("_")) && !it.first.contains("_TECHMAP_DO_") && !it.first.contains("_TECHMAP_DONE_"))
+						if (!it.first.ends_with("_TECHMAP_FAIL_") &&
+						    (!it.first.begins_with("\\_TECHMAP_REMOVEINIT_") || !it.first.ends_with("_")) &&
+						    !it.first.contains("_TECHMAP_DO_") && !it.first.contains("_TECHMAP_DONE_"))
 							log_error("Techmap yielded unknown config wire %s.\n", log_id(it.first));
 						if (techmap_do_cache[tpl])
 							for (auto &it2 : it.second)
 								if (!it2.value.is_fully_const())
-									log_error("Techmap yielded config wire %s with non-const value %s.\n", log_id(it2.wire->name), log_signal(it2.value));
+									log_error("Techmap yielded config wire %s with non-const value %s.\n",
+										  log_id(it2.wire->name), log_signal(it2.value));
 						techmap_wire_names.erase(it.first);
 					}
 
@@ -890,7 +877,8 @@ struct TechmapWorker
 							log_continue = false;
 							mkdebug.off();
 						}
-						while (techmap_module(map, tpl, map, handled_cells, celltypeMap, true)) { }
+						while (techmap_module(map, tpl, map, handled_cells, celltypeMap, true)) {
+						}
 					}
 				}
 
@@ -920,12 +908,10 @@ struct TechmapWorker
 					}
 				}
 
-				if (extern_mode && !in_recursion)
-				{
+				if (extern_mode && !in_recursion) {
 					std::string m_name = stringf("$extern:%s", log_id(tpl));
 
-					if (!design->module(m_name))
-					{
+					if (!design->module(m_name)) {
 						RTLIL::Module *m = design->addModule(m_name);
 						tpl->cloneInto(m);
 
@@ -940,15 +926,14 @@ struct TechmapWorker
 					log_debug("%s %s.%s to imported %s.\n", mapmsg_prefix.c_str(), log_id(module), log_id(cell), log_id(m_name));
 					cell->type = m_name;
 					cell->parameters.clear();
-				}
-				else
-				{
+				} else {
 					auto msg = stringf("Using template %s for cells of type %s.", log_id(tpl), log_id(cell->type));
 					if (!log_msg_cache.count(msg)) {
 						log_msg_cache.insert(msg);
 						log("%s\n", msg.c_str());
 					}
-					log_debug("%s %s.%s (%s) using %s.\n", mapmsg_prefix.c_str(), log_id(module), log_id(cell), log_id(cell->type), log_id(tpl));
+					log_debug("%s %s.%s (%s) using %s.\n", mapmsg_prefix.c_str(), log_id(module), log_id(cell),
+						  log_id(cell->type), log_id(tpl));
 					techmap_module_worker(design, module, cell, tpl);
 					cell = nullptr;
 				}
@@ -974,7 +959,7 @@ struct TechmapWorker
 };
 
 struct TechmapPass : public Pass {
-	TechmapPass() : Pass("techmap", "generic technology mapper") { }
+	TechmapPass() : Pass("techmap", "generic technology mapper") {}
 	void help() override
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
@@ -1155,19 +1140,19 @@ struct TechmapPass : public Pass {
 
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++) {
-			if (args[argidx] == "-map" && argidx+1 < args.size()) {
+			if (args[argidx] == "-map" && argidx + 1 < args.size()) {
 				map_files.push_back(args[++argidx]);
 				continue;
 			}
-			if (args[argidx] == "-max_iter" && argidx+1 < args.size()) {
+			if (args[argidx] == "-max_iter" && argidx + 1 < args.size()) {
 				max_iter = atoi(args[++argidx].c_str());
 				continue;
 			}
-			if (args[argidx] == "-D" && argidx+1 < args.size()) {
+			if (args[argidx] == "-D" && argidx + 1 < args.size()) {
 				verilog_frontend += " -D " + args[++argidx];
 				continue;
 			}
-			if (args[argidx] == "-I" && argidx+1 < args.size()) {
+			if (args[argidx] == "-I" && argidx + 1 < args.size()) {
 				verilog_frontend += " -I " + args[++argidx];
 				continue;
 			}
@@ -1203,13 +1188,15 @@ struct TechmapPass : public Pass {
 				if (fn.compare(0, 1, "%") == 0) {
 					if (!saved_designs.count(fn.substr(1))) {
 						delete map;
-						log_cmd_error("Can't open saved design `%s'.\n", fn.c_str()+1);
+						log_cmd_error("Can't open saved design `%s'.\n", fn.c_str() + 1);
 					}
 					for (auto mod : saved_designs.at(fn.substr(1))->modules())
 						if (!map->module(mod->name))
 							map->add(mod->clone());
 				} else {
-					Frontend::frontend_call(map, nullptr, fn, (fn.size() > 3 && fn.compare(fn.size()-3, std::string::npos, ".il") == 0 ? "rtlil" : verilog_frontend));
+					Frontend::frontend_call(
+					  map, nullptr, fn,
+					  (fn.size() > 3 && fn.compare(fn.size() - 3, std::string::npos, ".il") == 0 ? "rtlil" : verilog_frontend));
 				}
 		}
 
@@ -1235,15 +1222,15 @@ struct TechmapPass : public Pass {
 							if (epos == std::string::npos)
 								log_error("Malformed techmap_celltype pattern %s\n", q);
 							for (size_t i = pos + 1; i < epos; i++) {
-								queue.push_back(name.substr(0, pos) + name[i] + name.substr(epos + 1, std::string::npos));
+								queue.push_back(name.substr(0, pos) + name[i] +
+										name.substr(epos + 1, std::string::npos));
 							}
 						}
 					}
 				}
 				free(p);
 			} else {
-				IdString module_name = module->name.begins_with("\\$") ?
-						module->name.substr(1) : module->name.str();
+				IdString module_name = module->name.begins_with("\\$") ? module->name.substr(1) : module->name.str();
 				celltypeMap[module_name].insert(module->name);
 			}
 		}
@@ -1260,14 +1247,13 @@ struct TechmapPass : public Pass {
 		for (auto module : design->modules())
 			worker.module_queue.insert(module);
 
-		while (!worker.module_queue.empty())
-		{
+		while (!worker.module_queue.empty()) {
 			RTLIL::Module *module = *worker.module_queue.begin();
 			worker.module_queue.erase(module);
 
 			int module_max_iter = max_iter;
 			bool did_something = true;
-			pool<RTLIL::Cell*> handled_cells;
+			pool<RTLIL::Cell *> handled_cells;
 			while (did_something) {
 				did_something = false;
 				if (worker.techmap_module(design, module, map, handled_cells, celltypeMap, false))


### PR DESCRIPTION
This is accomplished by directly inserting the cell source attribute in the new object's 'attributes' map instead of creating a new attribute pool and then copying that. Based on a suggestion by Martin Poviser in a comment on https://github.com/YosysHQ/yosys/pull/3959

Topdown view before:
![image](https://github.com/YosysHQ/yosys/assets/16907534/b4d0ee80-9f79-420a-ad73-eec353fb44db)

Topdown view after:
![image](https://github.com/YosysHQ/yosys/assets/16907534/2be2f4b2-cc95-4118-b6b0-31f06ccb0a67)
