### PR TITLE
Speed up OptMergePass by 1.75x.

### DIFF
--- a/kernel/celltypes.h
+++ b/kernel/celltypes.h
@@ -56,7 +56,7 @@ struct CellTypes
 		setup_stdcells_mem();
 	}
 
-	void setup_type(RTLIL::IdString type, const pool<RTLIL::IdString> &inputs, const pool<RTLIL::IdString> &outputs, bool is_evaluable = false)
+	void setup_type(const RTLIL::IdString& type, const pool<RTLIL::IdString> &inputs, const pool<RTLIL::IdString> &outputs, bool is_evaluable = false)
 	{
 		CellType ct = {type, inputs, outputs, is_evaluable};
 		cell_types[ct.type] = ct;
@@ -298,24 +298,24 @@ struct CellTypes
 		cell_types.clear();
 	}
 
-	bool cell_known(RTLIL::IdString type) const
+	bool cell_known(const RTLIL::IdString& type) const
 	{
 		return cell_types.count(type) != 0;
 	}
 
-	bool cell_output(RTLIL::IdString type, RTLIL::IdString port) const
+	bool cell_output(const RTLIL::IdString& type, const RTLIL::IdString& port) const
 	{
 		auto it = cell_types.find(type);
 		return it != cell_types.end() && it->second.outputs.count(port) != 0;
 	}
 
-	bool cell_input(RTLIL::IdString type, RTLIL::IdString port) const
+	bool cell_input(const RTLIL::IdString& type, const RTLIL::IdString& port) const
 	{
 		auto it = cell_types.find(type);
 		return it != cell_types.end() && it->second.inputs.count(port) != 0;
 	}
 
-	bool cell_evaluable(RTLIL::IdString type) const
+	bool cell_evaluable(const RTLIL::IdString& type) const
 	{
 		auto it = cell_types.find(type);
 		return it != cell_types.end() && it->second.is_evaluable;

--- a/kernel/celltypes.h
+++ b/kernel/celltypes.h
@@ -56,7 +56,7 @@ struct CellTypes
 		setup_stdcells_mem();
 	}
 
-	void setup_type(const RTLIL::IdString& type, const pool<RTLIL::IdString> &inputs, const pool<RTLIL::IdString> &outputs, bool is_evaluable = false)
+	void setup_type(RTLIL::IdString type, const pool<RTLIL::IdString> &inputs, const pool<RTLIL::IdString> &outputs, bool is_evaluable = false)
 	{
 		CellType ct = {type, inputs, outputs, is_evaluable};
 		cell_types[ct.type] = ct;
@@ -298,24 +298,24 @@ struct CellTypes
 		cell_types.clear();
 	}
 
-	bool cell_known(const RTLIL::IdString& type) const
+	bool cell_known(RTLIL::IdString type) const
 	{
 		return cell_types.count(type) != 0;
 	}
 
-	bool cell_output(const RTLIL::IdString& type, const RTLIL::IdString& port) const
+	bool cell_output(RTLIL::IdString type, RTLIL::IdString port) const
 	{
 		auto it = cell_types.find(type);
 		return it != cell_types.end() && it->second.outputs.count(port) != 0;
 	}
 
-	bool cell_input(const RTLIL::IdString& type, const RTLIL::IdString& port) const
+	bool cell_input(RTLIL::IdString type, RTLIL::IdString port) const
 	{
 		auto it = cell_types.find(type);
 		return it != cell_types.end() && it->second.inputs.count(port) != 0;
 	}
 
-	bool cell_evaluable(const RTLIL::IdString& type) const
+	bool cell_evaluable(RTLIL::IdString type) const
 	{
 		auto it = cell_types.find(type);
 		return it != cell_types.end() && it->second.is_evaluable;

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -90,6 +90,12 @@ template<> struct hash_ops<uint32_t> : hash_int_ops
 		return a;
 	}
 };
+template<> struct hash_ops<uint64_t> : hash_int_ops
+{
+	static inline unsigned int hash(uint64_t a) {
+		return mkhash((unsigned int)(a), (unsigned int)(a >> 32));
+	}
+};
 
 template<> struct hash_ops<std::string> {
 	static inline bool cmp(const std::string &a, const std::string &b) {

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -308,10 +308,14 @@ namespace RTLIL
 		bool operator!=(const char *rhs) const { return strcmp(c_str(), rhs) != 0; }
 
 		char operator[](size_t i) const {
-			const char *p = c_str();
+                  const char *p = c_str();
+#ifndef NDEBUG
 			for (; i != 0; i--, p++)
 				log_assert(*p != 0);
 			return *p;
+#else
+			return *(p + i);
+#endif
 		}
 
 		std::string substr(size_t pos = 0, size_t len = std::string::npos) const {

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -308,7 +308,7 @@ namespace RTLIL
 		bool operator!=(const char *rhs) const { return strcmp(c_str(), rhs) != 0; }
 
 		char operator[](size_t i) const {
-                  const char *p = c_str();
+                        const char *p = c_str();
 #ifndef NDEBUG
 			for (; i != 0; i--, p++)
 				log_assert(*p != 0);

--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -41,7 +41,6 @@ struct OptMergeWorker
 
 	CellTypes ct;
 	int total_count;
-        using FingerPrint = std::hash<std::string>::result_type;
 
 	static void sort_pmux_conn(dict<RTLIL::IdString, RTLIL::SigSpec> &conn)
 	{
@@ -78,7 +77,7 @@ struct OptMergeWorker
 		return str;
 	}
 
-        FingerPrint hash_cell_parameters_and_connections(const RTLIL::Cell *cell)
+        uint64_t hash_cell_parameters_and_connections(const RTLIL::Cell *cell)
 	{
 		vector<string> hash_conn_strings;
 		std::string hash_string = cell->type.str() + "\n";
@@ -267,13 +266,13 @@ struct OptMergeWorker
 			}
 
 			did_something = false;
-                        dict<FingerPrint, RTLIL::Cell*> sharemap;
+                        dict<uint64_t, RTLIL::Cell*> sharemap;
 			for (auto cell : cells)
 			{
 				if ((!mode_share_all && !ct.cell_known(cell->type)) || !cell->known())
 					continue;
 
-				FingerPrint hash = hash_cell_parameters_and_connections(cell);
+				uint64_t hash = hash_cell_parameters_and_connections(cell);
 				auto r = sharemap.insert(std::make_pair(hash, cell));
 				if (!r.second) {
 					if (compare_cell_parameters_and_connections(cell, r.first->second)) {

--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -267,7 +267,7 @@ struct OptMergeWorker
 			}
 
 			did_something = false;
-                        std::unordered_map<FingerPrint, RTLIL::Cell*> sharemap;
+                        dict<FingerPrint, RTLIL::Cell*> sharemap;
 			for (auto cell : cells)
 			{
 				if ((!mode_share_all && !ct.cell_known(cell->type)) || !cell->known())

--- a/passes/sat/recover_names.cc
+++ b/passes/sat/recover_names.cc
@@ -29,13 +29,6 @@
 
 USING_YOSYS_NAMESPACE
 
-template<> struct hashlib::hash_ops<uint64_t> : hashlib::hash_int_ops
-{
-	static inline unsigned int hash(uint64_t a) {
-		return mkhash((unsigned int)(a), (unsigned int)(a >> 32));
-	}
-};
-
 PRIVATE_NAMESPACE_BEGIN
 
 // xorshift128 params
@@ -453,7 +446,7 @@ struct RecoverNamesWorker {
     pool<IdString> comb_whiteboxes, buffer_types;
 
     // class -> (gold, (gate, inverted))
-    dict<equiv_cls_t, std::pair<pool<IdBit>, dict<IdBit, bool>>> cls2bits; 
+    dict<equiv_cls_t, std::pair<pool<IdBit>, dict<IdBit, bool>>> cls2bits;
 
     void analyse_boxes()
     {


### PR DESCRIPTION
The main speedup comes from switching away from using SHA1 hash to using `std::hash<std::string>` for fingerprinting cells. There is no need to use an expensive cryptographic hash for fingerprinting in this context.

Flamegraph of benchmark timings from synthesis of a representative circuit:

Before:
![image](https://github.com/YosysHQ/yosys/assets/16907534/13bccc3f-6468-475d-80ea-7eebe8f87b48)

After:
![image](https://github.com/YosysHQ/yosys/assets/16907534/e0f3b036-d63e-409b-a187-0ca1d6b90441)
