### PR TITLE
booth: Fix vacancy check when summing down result

### DIFF
--- a/passes/techmap/booth.cc
+++ b/passes/techmap/booth.cc
@@ -533,7 +533,7 @@ struct BoothPassWorker {
 			// get the bits in this column.
 			SigSpec column_bits;
 			for (int row_ix = 0; row_ix < row_size; row_ix++) {
-				if (bits_to_reduce[row_ix][column_ix].wire)
+				if (bits_to_reduce[row_ix][column_ix] != State::S0)
 					column_bits.append(bits_to_reduce[row_ix][column_ix]);
 			}
 			for (auto c : carry_bits_to_add_to_next_column) {
@@ -750,7 +750,7 @@ struct BoothPassWorker {
 			SigSpec first_csa_ips;
 			// get the first 3 inputs, if possible
 			for (var_ix = 0; var_ix < column_bits.size() && first_csa_ips.size() != 3; var_ix++) {
-				if (column_bits[var_ix].is_wire())
+				if (column_bits[var_ix] != State::S0)
 					first_csa_ips.append(column_bits[var_ix]);
 			}
 
@@ -782,7 +782,7 @@ struct BoothPassWorker {
 					// get the next two variables to sum
 					for (; var_ix <= column_bits.size() - 1 && csa_ips.size() < 2;) {
 						// skip any empty bits
-						if (column_bits[var_ix].is_wire())
+						if (column_bits[var_ix] != State::S0)
 							csa_ips.append(column_bits[var_ix]);
 						var_ix++;
 					}

--- a/tests/techmap/booth.ys
+++ b/tests/techmap/booth.ys
@@ -1,1 +1,15 @@
+read_verilog <<EOF
+module test(clk, a, b, y);
+	input wire clk;
+	input wire [9:0] a;
+	input wire [6:0] b;
+	output wire [20:0] y;
+
+	assign y = a * b;
+endmodule
+EOF
+booth
+sat -verify -set a 0 -set b 0 -prove y 0
+design -reset
+
 test_cell -s 1694091355 -n 100 -script booth_map_script.ys_ $mul


### PR DESCRIPTION
In commit fedd12261 ("booth: Move away from explicit `Wire` pointers") a bug was introduced when checking for vacant slots in arrays holding some intermediate results. Non-wire SigBit values were taken to imply a vacant slot, but actually a constant one can make its way into those results, if the multiplier cell configuration is just right. Fix the vacancy check to address the bug.