### PR TITLE
scc: Use hashlib instead of STL for deterministic behaviour

### DIFF
--- a/passes/cmds/scc.cc
+++ b/passes/cmds/scc.cc
@@ -27,7 +27,6 @@
 #include "kernel/log.h"
 #include <stdlib.h>
 #include <stdio.h>
-#include <set>
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
@@ -39,18 +38,18 @@ struct SccWorker
 	SigMap sigmap;
 	CellTypes ct, specifyCells;
 
-	std::set<RTLIL::Cell*> workQueue;
-	std::map<RTLIL::Cell*, std::set<RTLIL::Cell*>> cellToNextCell;
-	std::map<RTLIL::Cell*, RTLIL::SigSpec> cellToPrevSig, cellToNextSig;
+	pool<RTLIL::Cell*> workQueue;
+	dict<RTLIL::Cell*, pool<RTLIL::Cell*>> cellToNextCell;
+	dict<RTLIL::Cell*, RTLIL::SigSpec> cellToPrevSig, cellToNextSig;
 
-	std::map<RTLIL::Cell*, std::pair<int, int>> cellLabels;
-	std::map<RTLIL::Cell*, int> cellDepth;
-	std::set<RTLIL::Cell*> cellsOnStack;
+	dict<RTLIL::Cell*, std::pair<int, int>> cellLabels;
+	dict<RTLIL::Cell*, int> cellDepth;
+	pool<RTLIL::Cell*> cellsOnStack;
 	std::vector<RTLIL::Cell*> cellStack;
 	int labelCounter;
 
-	std::map<RTLIL::Cell*, int> cell2scc;
-	std::vector<std::set<RTLIL::Cell*>> sccList;
+	dict<RTLIL::Cell*, int> cell2scc;
+	std::vector<pool<RTLIL::Cell*>> sccList;
 
 	void run(RTLIL::Cell *cell, int depth, int maxDepth)
 	{
@@ -85,7 +84,7 @@ struct SccWorker
 			else
 			{
 				log("Found an SCC:");
-				std::set<RTLIL::Cell*> scc;
+				pool<RTLIL::Cell*> scc;
 				while (cellsOnStack.count(cell) > 0) {
 					RTLIL::Cell *c = cellStack.back();
 					cellStack.pop_back();
@@ -199,11 +198,11 @@ struct SccWorker
 
 		for (auto cell : workQueue)
 		{
-			cellToNextCell[cell] = sigToNextCells.find(cellToNextSig[cell]);
+			sigToNextCells.find(cellToNextSig[cell], cellToNextCell[cell]);
 
 			if (!nofeedbackMode && cellToNextCell[cell].count(cell)) {
 				log("Found an SCC:");
-				std::set<RTLIL::Cell*> scc;
+				pool<RTLIL::Cell*> scc;
 				log(" %s", RTLIL::id2cstr(cell->name));
 				cell2scc[cell] = sccList.size();
 				scc.insert(cell);
@@ -231,7 +230,7 @@ struct SccWorker
 	{
 		for (int i = 0; i < int(sccList.size()); i++)
 		{
-			std::set<RTLIL::Cell*> &cells = sccList[i];
+			pool<RTLIL::Cell*> &cells = sccList[i];
 			RTLIL::SigSpec prevsig, nextsig, sig;
 
 			for (auto cell : cells) {
@@ -295,7 +294,7 @@ struct SccPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
-		std::map<std::string, std::string> setAttr;
+		dict<std::string, std::string> setAttr;
 		bool allCellTypes = false;
 		bool selectMode = false;
 		bool nofeedbackMode = false;


### PR DESCRIPTION
I was getting diverging SCC reports for the exact same input depending on whether I ran on ppc64 or ppc64le.
With this change the result should be the same regardless of the operating environment.