### PR TITLE
write_verilog: avoid emitting empty cases.

### DIFF
--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -2008,6 +2008,11 @@ void dump_proc_switch(std::ostream &f, std::string indent, RTLIL::SwitchRule *sw
 		dump_case_body(f, indent + "    ", *it);
 	}
 
+	if (sw->cases.empty()) {
+		// Verilog does not allow empty cases.
+		f << stringf("%s  default: ;\n", indent.c_str());
+	}
+
 	f << stringf("%s" "endcase\n", indent.c_str());
 }
 


### PR DESCRIPTION
The Verilog grammar does not allow an empty case.  Most synthesis tools are quite permissive about this, but Quartus is not.  This causes problems for amaranth with Quartus (see amaranth-lang/amaranth#931).