### PR TITLE
cxxrtl: export wire attributes through the C API

### DIFF
--- a/backends/cxxrtl/cxxrtl_capi.cc
+++ b/backends/cxxrtl/cxxrtl_capi.cc
@@ -90,3 +90,46 @@ void cxxrtl_enum(cxxrtl_handle handle, void *data,
 void cxxrtl_outline_eval(cxxrtl_outline outline) {
 	outline->eval();
 }
+
+int cxxrtl_attr_type(cxxrtl_attr_set attrs_, const char *name) {
+	auto attrs = (cxxrtl::metadata_map*)attrs_;
+	if (!attrs->count(name))
+		return CXXRTL_ATTR_NONE;
+	switch (attrs->at(name).value_type) {
+		case cxxrtl::metadata::UINT:
+			return CXXRTL_ATTR_UNSIGNED_INT;
+		case cxxrtl::metadata::SINT:
+			return CXXRTL_ATTR_SIGNED_INT;
+		case cxxrtl::metadata::STRING:
+			return CXXRTL_ATTR_STRING;
+		case cxxrtl::metadata::DOUBLE:
+			return CXXRTL_ATTR_DOUBLE;
+		default:
+			// Present unsupported attribute type the same way as no attribute at all.
+			return CXXRTL_ATTR_NONE;
+	}
+}
+
+uint64_t cxxrtl_attr_get_unsigned_int(cxxrtl_attr_set attrs_, const char *name) {
+	auto &attrs = *(cxxrtl::metadata_map*)attrs_;
+	assert(attrs.count(name) && attrs.at(name).value_type == cxxrtl::metadata::UINT);
+	return attrs[name].as_uint();
+}
+
+int64_t cxxrtl_attr_get_signed_int(cxxrtl_attr_set attrs_, const char *name) {
+	auto &attrs = *(cxxrtl::metadata_map*)attrs_;
+	assert(attrs.count(name) && attrs.at(name).value_type == cxxrtl::metadata::SINT);
+	return attrs[name].as_sint();
+}
+
+const char *cxxrtl_attr_get_string(cxxrtl_attr_set attrs_, const char *name) {
+	auto &attrs = *(cxxrtl::metadata_map*)attrs_;
+	assert(attrs.count(name) && attrs.at(name).value_type == cxxrtl::metadata::STRING);
+	return attrs[name].as_string().c_str();
+}
+
+double cxxrtl_attr_get_double(cxxrtl_attr_set attrs_, const char *name) {
+	auto &attrs = *(cxxrtl::metadata_map*)attrs_;
+	assert(attrs.count(name) && attrs.at(name).value_type == cxxrtl::metadata::DOUBLE);
+	return attrs[name].as_double();
+}

--- a/backends/cxxrtl/cxxrtl_capi.h
+++ b/backends/cxxrtl/cxxrtl_capi.h
@@ -249,6 +249,15 @@ struct cxxrtl_object {
 	// this field to NULL.
 	struct _cxxrtl_outline *outline;
 
+	// Opaque reference to an attribute set.
+	//
+	// See the documentation of `cxxrtl_attr_set` for details. When creating a `cxxrtl_object`, set
+	// this field to NULL.
+	//
+	// The lifetime of the pointers returned by `cxxrtl_attr_*` family of functions is the same as
+	// the lifetime of this structure.
+	struct _cxxrtl_attr_set *attrs;
+
 	// More description fields may be added in the future, but the existing ones will never change.
 };
 
@@ -303,6 +312,62 @@ typedef struct _cxxrtl_outline *cxxrtl_outline;
 // causes every outline object to become stale, after which the corresponding outline must be
 // re-evaluated, otherwise the bits read from that object are meaningless.
 void cxxrtl_outline_eval(cxxrtl_outline outline);
+
+// Opaque reference to an attribute set.
+//
+// An attribute set is a map between attribute names (always strings) and values (which may have
+// several different types). To find out the type of an attribute, use `cxxrtl_attr_type`, and
+// to retrieve the value of an attribute, use `cxxrtl_attr_as_string`.
+typedef struct _cxxrtl_attr_set *cxxrtl_attr_set;
+
+// Type of an attribute.
+enum cxxrtl_attr_type {
+	// Attribute is not present.
+	CXXRTL_ATTR_NONE = 0,
+
+	// Attribute has an unsigned integer value.
+	CXXRTL_ATTR_UNSIGNED_INT = 1,
+
+	// Attribute has an unsigned integer value.
+	CXXRTL_ATTR_SIGNED_INT = 2,
+
+	// Attribute has a string value.
+	CXXRTL_ATTR_STRING = 3,
+
+	// Attribute has a double precision floating point value.
+	CXXRTL_ATTR_DOUBLE = 4,
+
+	// More attribute types may be defined in the future, but the existing values will never change.
+};
+
+// Determine the presence and type of an attribute in an attribute set.
+//
+// This function returns one of the possible `cxxrtl_attr_type` values.
+int cxxrtl_attr_type(cxxrtl_attr_set attrs, const char *name);
+
+// Retrieve an unsigned integer valued attribute from an attribute set.
+//
+// This function asserts that `cxxrtl_attr_type(attrs, name) == CXXRTL_ATTR_UNSIGNED_INT`.
+// If assertions are disabled, returns 0 if the attribute is missing or has an incorrect type.
+uint64_t cxxrtl_attr_get_unsigned_int(cxxrtl_attr_set attrs, const char *name);
+
+// Retrieve a signed integer valued attribute from an attribute set.
+//
+// This function asserts that `cxxrtl_attr_type(attrs, name) == CXXRTL_ATTR_SIGNED_INT`.
+// If assertions are disabled, returns 0 if the attribute is missing or has an incorrect type.
+int64_t cxxrtl_attr_get_signed_int(cxxrtl_attr_set attrs, const char *name);
+
+// Retrieve a string valued attribute from an attribute set. The returned string is zero-terminated.
+//
+// This function asserts that `cxxrtl_attr_type(attrs, name) == CXXRTL_ATTR_STRING`. If assertions
+// are disabled, returns NULL if the attribute is missing or has an incorrect type.
+const char *cxxrtl_attr_get_string(cxxrtl_attr_set attrs, const char *name);
+
+// Retrieve a double precision floating point valued attribute from an attribute set.
+//
+// This function asserts that `cxxrtl_attr_type(attrs, name) == CXXRTL_ATTR_DOUBLE`. If assertions
+// are disabled, returns NULL if the attribute is missing or has an incorrect type.
+double cxxrtl_attr_get_double(cxxrtl_attr_set attrs, const char *name);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Among other things this allows retrieving source locations for wires in the simulation, e.g.:

```c
void print_location_cb(void *, const char *name, struct cxxrtl_object *object, size_t parts) {
	printf("%s:\n", name);
	cxxrtl_attr_set attrs = object->attrs;
	if (cxxrtl_attr_type(attrs, "src") == CXXRTL_ATTR_STRING) {
		const char *src = cxxrtl_attr_get_string(attrs, "src");
		while (src) {
			char buf[256] = {0};
			const char *next = strchr(src, '|');
			if (!next) {
				printf("\t%s\n", src);
				src = NULL;
			} else {
				strncpy(buf, src, next - src);
				printf("\t%s\n", buf);
				src = next + 1;
			}
		}
	} else {
		printf("(missing!)\n");
	}
}

int main() {
	cxxrtl_handle top = cxxrtl_create_at(cxxrtl_design_create(), "toplevel");
	cxxrtl_reset(top);

	printf("Source location information for this simulation:\n");
	cxxrtl_enum(top, NULL, print_location_cb);

	return 0;
}
```