### PR TITLE
alumacc: alternative cmp unification implementation

### DIFF
--- a/passes/techmap/alumacc.cc
+++ b/passes/techmap/alumacc.cc
@@ -405,11 +405,6 @@ struct AlumaccWorker
 			RTLIL::SigSpec B = sigmap(cell->getPort(ID::B));
 			RTLIL::SigSpec Y = sigmap(cell->getPort(ID::Y));
 
-			if (B < A && GetSize(B)) {
-				cmp_less = !cmp_less;
-				std::swap(A, B);
-			}
-
 			alunode_t *n = nullptr;
 
 			for (auto node : sig_alu[RTLIL::SigSig(A, B)])
@@ -417,6 +412,16 @@ struct AlumaccWorker
 					n = node;
 					break;
 				}
+
+			if (n == nullptr) {
+				for (auto node : sig_alu[RTLIL::SigSig(B, A)])
+					if (node->invert_b && node->c == State::S1) {
+						n = node;
+						cmp_less = !cmp_less;
+						std::swap(A, B);
+						break;
+					}
+			}
 
 			if (n == nullptr) {
 				n = new alunode_t;
@@ -445,9 +450,6 @@ struct AlumaccWorker
 			RTLIL::SigSpec B = sigmap(cell->getPort(ID::B));
 			RTLIL::SigSpec Y = sigmap(cell->getPort(ID::Y));
 
-			if (B < A && GetSize(B))
-				std::swap(A, B);
-
 			alunode_t *n = nullptr;
 
 			for (auto node : sig_alu[RTLIL::SigSig(A, B)])
@@ -455,6 +457,14 @@ struct AlumaccWorker
 					n = node;
 					break;
 				}
+
+			if (n == nullptr) {
+				for (auto node : sig_alu[RTLIL::SigSig(B, A)])
+					if (node->invert_b && node->c == State::S1) {
+						n = node;
+						break;
+					}
+			}
 
 			if (n != nullptr) {
 				log("  creating $alu model for %s (%s): merged with %s.\n", log_id(cell), log_id(cell->type), log_id(n->cells.front()));

--- a/passes/techmap/alumacc.cc
+++ b/passes/techmap/alumacc.cc
@@ -415,7 +415,7 @@ struct AlumaccWorker
 
 			if (n == nullptr) {
 				for (auto node : sig_alu[RTLIL::SigSig(B, A)])
-					if (node->invert_b && node->c == State::S1) {
+					if (node->is_signed == is_signed && node->invert_b && node->c == State::S1) {
 						n = node;
 						cmp_less = !cmp_less;
 						std::swap(A, B);
@@ -460,7 +460,7 @@ struct AlumaccWorker
 
 			if (n == nullptr) {
 				for (auto node : sig_alu[RTLIL::SigSig(B, A)])
-					if (node->invert_b && node->c == State::S1) {
+					if (node->is_signed == is_signed && node->invert_b && node->c == State::S1) {
 						n = node;
 						break;
 					}


### PR DESCRIPTION
`$lt` and related are sometimes inhibited from unifying with `$sub` as when `B < A`, then the `$sub` cell is unable to swap inputs, but `$lt` does. This resolves this problem by instead considering `sig_alu` as an unordered pair mapping.

Addendum:
`$add` and `$sub` might still be unable to unify with `share -aggressive` but changing the behavior [1] causes [2] to fail, so I'm keeping it to `cmp` only.

[1] https://github.com/YosysHQ/yosys/commit/ded586c0485484996ea85f3eb596321582631345#diff-f5a16f8ab735a667cabcdd605b428eeaa92f223f044ef01a91d52141d404633bL334-L336
[2] https://github.com/YosysHQ/yosys/blob/ded586c/tests/opt/opt_expr.ys#L27