### PR TITLE
quicklogic: Fix pp3 `dffs` test

### DIFF
--- a/tests/arch/quicklogic/dffs.ys
+++ b/tests/arch/quicklogic/dffs.ys
@@ -7,14 +7,27 @@ hierarchy -top my_dff
 proc
 equiv_opt -async2sync -assert -map +/quicklogic/pp3_cells_sim.v -map +/quicklogic/cells_sim.v synth_quicklogic # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
-cd dff # Constrain all select calls below inside the top module
-select -assert-none t:*
+cd my_dff # Constrain all select calls below inside the top module
+select -assert-count 1 t:ckpad
+select -assert-count 1 t:dffepc
+select -assert-count 1 t:inpad
+select -assert-count 1 t:logic_0
+select -assert-count 1 t:logic_1
+select -assert-count 1 t:outpad
+
+select -assert-none t:ckpad t:dffepc t:inpad t:logic_0 t:logic_1 t:outpad %% t:* %D
 
 design -load read
 hierarchy -top my_dffe
 proc
 equiv_opt -async2sync -assert -map +/quicklogic/pp3_cells_sim.v -map +/quicklogic/cells_sim.v synth_quicklogic # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
-cd dffe # Constrain all select calls below inside the top module
+cd my_dffe # Constrain all select calls below inside the top module
 
-select -assert-none t:*
+select -assert-count 1 t:ckpad
+select -assert-count 1 t:dffepc
+select -assert-count 2 t:inpad
+select -assert-count 1 t:logic_0
+select -assert-count 1 t:outpad
+
+select -assert-none t:ckpad t:dffepc t:inpad t:logic_0 t:outpad %% t:* %D


### PR DESCRIPTION
Fix name confusion which was making the test look into the vendor's cell blackbox rather than into the synthesis results.