### PR TITLE
ice40, ecp5: enable ABC9 by default

### DIFF
--- a/techlibs/ecp5/synth_ecp5.cc
+++ b/techlibs/ecp5/synth_ecp5.cc
@@ -93,8 +93,8 @@ struct SynthEcp5Pass : public ScriptPass
 		log("    -abc2\n");
 		log("        run two passes of 'abc' for slightly improved logic density\n");
 		log("\n");
-		log("    -abc9\n");
-		log("        use new ABC9 flow (EXPERIMENTAL)\n");
+		log("    -noabc9\n");
+		log("        disable use of new ABC9 flow\n");
 		log("\n");
 		log("    -vpr\n");
 		log("        generate an output netlist (and BLIF file) suitable for VPR\n");
@@ -137,7 +137,7 @@ struct SynthEcp5Pass : public ScriptPass
 		retime = false;
 		abc2 = false;
 		vpr = false;
-		abc9 = false;
+		abc9 = true;
 		iopad = false;
 		nodsp = false;
 		no_rw_check = false;
@@ -224,7 +224,11 @@ struct SynthEcp5Pass : public ScriptPass
 				continue;
 			}
 			if (args[argidx] == "-abc9") {
-				abc9 = true;
+				// removed, ABC9 is on by default.
+				continue;
+			}
+			if (args[argidx] == "-noabc9") {
+				abc9 = false;
 				continue;
 			}
 			if (args[argidx] == "-iopad") {

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -106,8 +106,8 @@ struct SynthIce40Pass : public ScriptPass
 		log("        generate an output netlist (and BLIF file) suitable for VPR\n");
 		log("        (this feature is experimental and incomplete)\n");
 		log("\n");
-		log("    -abc9\n");
-		log("        use new ABC9 flow (EXPERIMENTAL)\n");
+		log("    -noabc9\n");
+		log("        disable use of new ABC9 flow\n");
 		log("\n");
 		log("    -flowmap\n");
 		log("        use FlowMap LUT techmapping instead of abc (EXPERIMENTAL)\n");
@@ -144,7 +144,7 @@ struct SynthIce40Pass : public ScriptPass
 		noabc = false;
 		abc2 = false;
 		vpr = false;
-		abc9 = false;
+		abc9 = true;
 		flowmap = false;
 		device_opt = "hx";
 		no_rw_check = false;
@@ -235,7 +235,11 @@ struct SynthIce40Pass : public ScriptPass
 				continue;
 			}
 			if (args[argidx] == "-abc9") {
-				abc9 = true;
+				// removed, ABC9 is on by default.
+				continue;
+			}
+			if (args[argidx] == "-noabc9") {
+				abc9 = false;
 				continue;
 			}
 			if (args[argidx] == "-dff") {

--- a/tests/arch/ecp5/add_sub.ys
+++ b/tests/arch/ecp5/add_sub.ys
@@ -4,6 +4,9 @@ proc
 equiv_opt -assert -map +/ecp5/cells_sim.v synth_ecp5 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
-select -assert-count 10 t:LUT4
-select -assert-none t:LUT4 %% t:* %D
+select -assert-min 25 t:LUT4
+select -assert-max 26 t:LUT4
+select -assert-count 10 t:PFUMX
+select -assert-count 6 t:L6MUX21
+select -assert-none t:LUT4 t:PFUMX t:L6MUX21 %% t:* %D
 

--- a/tests/arch/ecp5/counter.ys
+++ b/tests/arch/ecp5/counter.ys
@@ -5,6 +5,7 @@ flatten
 equiv_opt -assert -multiclock -map +/ecp5/cells_sim.v synth_ecp5 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
+select -assert-count 1 t:LUT4
 select -assert-count 4 t:CCU2C
 select -assert-count 8 t:TRELLIS_FF
-select -assert-none t:CCU2C t:TRELLIS_FF %% t:* %D
+select -assert-none t:LUT4 t:CCU2C t:TRELLIS_FF %% t:* %D

--- a/tests/arch/ice40/add_sub.ys
+++ b/tests/arch/ice40/add_sub.ys
@@ -3,7 +3,7 @@ hierarchy -top top
 equiv_opt -assert -map +/ice40/cells_sim.v synth_ice40 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
-select -assert-count 11 t:SB_LUT4
+select -assert-count 10 t:SB_LUT4
 select -assert-count 6 t:SB_CARRY
 select -assert-none t:SB_LUT4 t:SB_CARRY %% t:* %D
 

--- a/tests/arch/ice40/mux.ys
+++ b/tests/arch/ice40/mux.ys
@@ -15,7 +15,7 @@ proc
 equiv_opt -assert -map +/ice40/cells_sim.v synth_ice40 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux4 # Constrain all select calls below inside the top module
-select -assert-count 2 t:SB_LUT4
+select -assert-count 3 t:SB_LUT4
 
 select -assert-none t:SB_LUT4 %% t:* %D
 
@@ -25,7 +25,7 @@ proc
 equiv_opt -assert -map +/ice40/cells_sim.v synth_ice40 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux8 # Constrain all select calls below inside the top module
-select -assert-count 5 t:SB_LUT4
+select -assert-count 6 t:SB_LUT4
 
 select -assert-none t:SB_LUT4 %% t:* %D
 
@@ -35,7 +35,7 @@ proc
 equiv_opt -assert -map +/ice40/cells_sim.v synth_ice40 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux16 # Constrain all select calls below inside the top module
-select -assert-min 11 t:SB_LUT4
-select -assert-max 12 t:SB_LUT4
+select -assert-min 13 t:SB_LUT4
+select -assert-max 14 t:SB_LUT4
 
 select -assert-none t:SB_LUT4 %% t:* %D


### PR DESCRIPTION
It's been [four years](https://github.com/YosysHQ/yosys/pull/1544) since ABC9 was last proposed to be used by default. The arguments made back then still apply: results are superior compared to the default ABC flow, and we seem to have gotten most of the bugs fixed or worked around.

So, I'm once again asking for ~~your financial support~~ ABC9 to be made the default on iCE40 and ECP5. I think using these two architectures as a baseline for wide adoption should quickly expose any other bugs in ABC9 that can then be fixed, given how popular they are over the others.