### PR TITLE
Change `booth` architecture for improved delay, similar signed/unsigned results

### DIFF
--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -921,6 +921,9 @@ public:
 	RTLIL::SigSpec extract(int offset, int length = 1) const;
 	RTLIL::SigSpec extract_end(int offset) const { return extract(offset, width_ - offset); }
 
+	RTLIL::SigBit lsb() const { log_assert(width_); return (*this)[0]; };
+	RTLIL::SigBit msb() const { log_assert(width_); return (*this)[width_ - 1]; };
+
 	void append(const RTLIL::SigSpec &signal);
 	inline void append(Wire *wire) { append(RTLIL::SigSpec(wire)); }
 	inline void append(const RTLIL::SigChunk &chunk) { append(RTLIL::SigSpec(chunk)); }

--- a/passes/techmap/booth.cc
+++ b/passes/techmap/booth.cc
@@ -307,7 +307,7 @@ struct BoothPassWorker {
 			      SigSpec Y, // multiplier
 			      SigSpec Z)
 	{ // result
-		int x_sz = X.size(), z_sz = Z.size();
+		int z_sz = Z.size();
 
 		SigSpec one_int, two_int, s_int, sb_int;
 		int encoder_count = 0;
@@ -376,7 +376,7 @@ struct BoothPassWorker {
 		for (int i = 0; i < encoder_count + 1; i++)
 			aligned_pp[i].extend_u0(z_sz);
 
-		AlignPP(x_sz, z_sz, ppij_int, aligned_pp);
+		AlignPP(z_sz, ppij_int, aligned_pp);
 
 		// Debug: dump out aligned partial products.
 		// Later on yosys will clean up unused constants
@@ -609,7 +609,7 @@ struct BoothPassWorker {
 	  Pad out rows with zeros and left the opt pass clean them up.
 
 	*/
-	void AlignPP(int x_sz, int z_sz, std::vector<std::tuple<SigSpec, int, SigBit>> &ppij_int,
+	void AlignPP(int z_sz, std::vector<std::tuple<SigSpec, int, SigBit>> &ppij_int,
 		     std::vector<SigSpec> &aligned_pp)
 	{
 		unsigned aligned_pp_ix = aligned_pp.size() - 1;
@@ -629,12 +629,10 @@ struct BoothPassWorker {
 		// in first column of the last partial product
 		// which is at index corresponding to size of multiplicand
 		{
+			int prior_row_idx = get<1>(ppij_int[aligned_pp_ix - 1]);
 			SigBit prior_row_sign = get<2>(ppij_int[aligned_pp_ix - 1]);
-			//if (prior_row_sign) {
-				log_assert(aligned_pp_ix < aligned_pp.size());
-				log_assert(x_sz - 1 < (int)(aligned_pp[aligned_pp_ix].size()));
-				aligned_pp[aligned_pp_ix][x_sz - 1] = prior_row_sign;
-			//}
+			if (prior_row_idx < z_sz)
+				aligned_pp[aligned_pp_ix][prior_row_idx] = prior_row_sign;
 		}
 
 		for (int row_ix = aligned_pp_ix - 1; row_ix >= 0; row_ix--) {

--- a/passes/techmap/booth.cc
+++ b/passes/techmap/booth.cc
@@ -1046,7 +1046,6 @@ struct BoothPassWorker {
 		//
 		// sum up the partial products
 		//
-		int fa_el_ix = 0;
 		int fa_row_ix = 0;
 		std::vector<SigSpec> fa_sum;
 		std::vector<SigSpec> fa_carry;
@@ -1074,7 +1073,7 @@ struct BoothPassWorker {
 		// special because these are driven by a decoder and prior fa.
 		for (fa_row_ix = 1; fa_row_ix < fa_row_count; fa_row_ix++) {
 			// end two bits: sign extension
-			SigBit d_inv = module->NotGate(NEW_ID_SUFFIX(stringf("bfa_se_inv_%d_%d_L", fa_row_ix, fa_el_ix)),
+			SigBit d_inv = module->NotGate(NEW_ID_SUFFIX(stringf("bfa_se_inv_%d_L", fa_row_ix)),
 						       PPij[((fa_row_ix + 1) * dec_count) + dec_count - 1]);
 
 			BuildBitwiseFa(module, NEW_ID_SUFFIX(stringf("fa_row_%d", fa_row_ix)).str(),

--- a/passes/techmap/booth.cc
+++ b/passes/techmap/booth.cc
@@ -1028,6 +1028,22 @@ struct BoothPassWorker {
 		}
 
 		//
+		// instantiate the quadrant 1 cell. This is the upper right
+		// quadrant which can be realized using non-booth encoded logic.
+		//
+		SigBit pp0_o_int, pp1_o_int, nxj_o_int, q1_carry_out;
+
+		BuildBoothQ1("icb_booth_q1_",
+			     negi_n_int[0], // negi
+			     cori_n_int[0], // cori
+			     X[0], X[1], Y[0], Y[1],
+			     nxj_o_int, q1_carry_out, pp0_o_int, pp1_o_int);
+
+		module->connect(Z[0], pp0_o_int);
+		module->connect(Z[1], pp1_o_int);
+		module->connect(nxj[(0 * dec_count) + 2], nxj_o_int);
+
+		//
 		// sum up the partial products
 		//
 		int fa_el_ix = 0;
@@ -1052,6 +1068,7 @@ struct BoothPassWorker {
 			/* X */ fa_carry[0].extract(2, x_sz + 2),
 			/* Y */ fa_sum[0].extract(2, x_sz + 2)
 		);
+		module->connect(fa_carry[0][1], q1_carry_out);
 
 		// step case: 2nd and rest of rows. (fa_row_ix == 1...n)
 		// special because these are driven by a decoder and prior fa.
@@ -1093,30 +1110,6 @@ struct BoothPassWorker {
 			BuildHa(cpa_name, fa_sum[fa_row_count - 1][cpa_ix - offset + 2], ci, op, cpa_carry[cpa_ix - offset]);
 			module->connect(Z[cpa_ix], op);
 		}
-
-		//
-		// instantiate the quadrant 1 cell. This is the upper right
-		// quadrant which can be realized using non-booth encoded logic.
-		//
-		std::string q1_name = "icb_booth_q1_";
-
-		SigBit pp0_o_int;
-		SigBit pp1_o_int;
-		SigBit nxj_o_int;
-		SigBit cor_o_int;
-
-		BuildBoothQ1(q1_name,
-			     negi_n_int[0], // negi
-			     cori_n_int[0], // cori
-
-			     X[0], X[1], Y[0], Y[1],
-
-			     nxj_o_int, cor_o_int, pp0_o_int, pp1_o_int);
-
-		module->connect(fa_sum[0][0], pp0_o_int);
-		module->connect(fa_sum[0][1], pp1_o_int);
-		module->connect(fa_carry[0][1], cor_o_int);
-		module->connect(nxj[(0 * dec_count) + 2], nxj_o_int);
 	}
 };
 

--- a/passes/techmap/booth.cc
+++ b/passes/techmap/booth.cc
@@ -337,9 +337,7 @@ struct BoothPassWorker {
 
 			BuildBoothUMultDecoderRowN(module,
 						   X, // multiplicand
-						   one_int[i], two_int[i], s_int[i], sb_int[i], ppij_row_n, i,
-						   false, // include sign
-						   false  // include constant
+						   one_int[i], two_int[i], s_int[i], sb_int[i], ppij_row_n, i
 			);
 			// data, shift, sign
 			ppij_int.push_back(std::make_tuple(ppij_row_n, i * 2, s_int[i]));
@@ -413,7 +411,7 @@ struct BoothPassWorker {
 	void BuildBoothUMultDecoderRowN(RTLIL::Module *module,
 					SigSpec X, // multiplicand
 					SigSpec one_int, SigSpec two_int, SigSpec s_int, SigSpec sb_int,
-					SigSpec &ppij_vec, int row_ix, bool no_sign, bool no_constant)
+					SigSpec &ppij_vec, int row_ix)
 	{
 		(void)module;
 		int x_sz = GetSize(X);
@@ -430,12 +428,10 @@ struct BoothPassWorker {
 		ppij_vec.append(Bur4d_msb("row_dec_red", X[x_sz - 1], two_int, s_int));
 
 		// sign bit
-		if (!no_sign) // if no sign is false then make a sign bit
-			ppij_vec.append(sb_int);
+		ppij_vec.append(sb_int);
 
 		// constant bit
-		if (!no_constant) // if non constant is false make a constant bit
-			ppij_vec.append(State::S1);
+		ppij_vec.append(State::S1);
 	}
 
 	void DebugDumpAlignPP(std::vector<std::vector<RTLIL::Wire *>> &aligned_pp)

--- a/passes/techmap/booth.cc
+++ b/passes/techmap/booth.cc
@@ -331,7 +331,7 @@ struct BoothPassWorker {
 		// data, shift, sign
 		ppij_int.push_back(std::make_tuple(ppij_row_0, 0, s_int[0]));
 
-		for (int i = 1; i < encoder_count - 2; i++) {
+		for (int i = 1; i < encoder_count; i++) {
 			// format 1,S.Data.shift = encoder_ix*2,sign = sb_int[i]
 			SigSpec ppij_row_n;
 
@@ -345,24 +345,6 @@ struct BoothPassWorker {
 			ppij_int.push_back(std::make_tuple(ppij_row_n, i * 2, s_int[i]));
 		}
 
-		// Build second to last row
-		// format S/,Data + sign bit
-		SigSpec ppij_row_em1;
-		BuildBoothUMultDecoderRowN(module, X, one_int[encoder_count - 2], two_int[encoder_count - 2], s_int[encoder_count - 2],
-					   sb_int[encoder_count - 2], ppij_row_em1, encoder_count - 2,
-					   false, // include sign
-					   true	  // no constant
-		);
-		ppij_int.push_back(std::make_tuple(ppij_row_em1, (encoder_count - 2) * 2, s_int[encoder_count - 2]));
-		// Build last row
-		// format Data + sign bit
-		SigSpec ppij_row_e;
-		BuildBoothUMultDecoderRowN(module, X, one_int[encoder_count - 1], two_int[encoder_count - 1], s_int[encoder_count - 1],
-					   sb_int[encoder_count - 1], ppij_row_e, encoder_count - 1,
-					   true, // no sign
-					   true	 // no constant
-		);
-		ppij_int.push_back(std::make_tuple(ppij_row_e, (encoder_count - 1) * 2, s_int[encoder_count - 1]));
 
 		//  Debug dump out partial products
 		//  DebugDumpPP(ppij_int);

--- a/passes/techmap/booth.cc
+++ b/passes/techmap/booth.cc
@@ -1104,21 +1104,13 @@ struct BoothPass : public Pass {
 		log("\n");
 		log("    booth [selection]\n");
 		log("\n");
-		log("This pass replaces multiplier cells with an implementation based on the Booth\n");
-		log("algorithm. It operates on $mul cells whose width of operands is at least 4x4\n");
-		log("and whose width of result is at least 8. The detailed architecture is selected\n");
-		log("from two options based on the signedness of the operands to the $mul cell.\n");
+		log("This pass replaces multiplier cells with a radix-4 Booth-encoded implementation.\n");
+		log("It operates on $mul cells whose width of operands is at least 4x4 and whose\n");
+		log("width of result is at least 8.\n");
 		log("\n");
-		log("See the references below for the description of the architectures.\n");
-		log("\n");
-		log("Signed-multiplier architecture:\n");
-		log("Y. J. Chang, Y. C. Cheng, S. C. Liao and C. H. Hsiao, \"A Low Power Radix-4 Booth\n");
-		log("Multiplier With Pre-Encoded Mechanism,\" in IEEE Access, vol. 8, pp. 114842-114853,\n");
-		log("2020, doi: 10.1109/ACCESS.2020.3003684\n");
-		log("\n");
-		log("Unsigned-multiplier architecture:\n");
-		log("G. W. Bewick, \"Fast Multiplication: Algorithms and Implementations,\" PhD Thesis,\n");
-		log("Department of Electrical Engineering, Stanford University, 1994\n");
+		log("    -lowpower\n");
+		log("        use an alternative low-power architecture for the generated multiplier\n");
+		log("        (signed multipliers only)\n");
 		log("\n");
 	}
 	void execute(vector<string> args, RTLIL::Design *design) override

--- a/techlibs/lattice/synth_lattice.cc
+++ b/techlibs/lattice/synth_lattice.cc
@@ -362,6 +362,8 @@ struct SynthLatticePass : public ScriptPass
 				run("techmap -map +/mul2dsp.v -map +/lattice/dsp_map" + dsp_map + ".v -D DSP_A_MAXWIDTH=18 -D DSP_B_MAXWIDTH=18  -D DSP_A_MINWIDTH=2 -D DSP_B_MINWIDTH=2  -D DSP_NAME=$__MUL18X18", "(unless -nodsp)");
 				run("chtype -set $mul t:$__soft_mul", "(unless -nodsp)");
 			}
+			if (family == "xo3" || help_mode)
+				run("booth", "(only if '-family xo3')");
 			run("alumacc");
 			run("opt");
 			run("memory -nomap" + no_rw_check_opt);


### PR DESCRIPTION
~~Implement Wallace tree summation as an option in `booth`. This significantly improves the propagation delay of the multiplier, at least for some dimensions of inputs and outputs. So far the Wallace tree option is only supported with the signed multiplier architecture, and is implemented in the most crude way possible. There's likely space for improvement.~~ Redo the selection of architectures: Have one classic Booth architecture for both signed and unsigned multiplication. Move what was formerly the signed architecture under a new `-lowpower` option. Also improve the balance of the Wallace tree generated.

With these changes, the Booth multiplier no longer has worse timing on MachXO3 than the baseline multiplier emitted by `maccmap`. Since Booth can use a lot less area, opt for it as the default on MachXO3, making that architecture the early adopter. (MachXO3 has no hard logic for multipliers.)