### PR TITLE
MachXO3 QoR improvements

### DIFF
--- a/techlibs/lattice/synth_lattice.cc
+++ b/techlibs/lattice/synth_lattice.cc
@@ -409,6 +409,7 @@ struct SynthLatticePass : public ScriptPass
 				dfflegalize_args += " -cell $_DLATCH_?_ x";
 			}
 			run("dfflegalize" + dfflegalize_args, "($_ALDFF_*_ only if -asyncprld, $_DLATCH_* only if not -asyncprld, $_*DFFE_* only if not -nodffe)");
+			run("opt_merge");
 			if ((abc9 && dff) || help_mode)
 				run("zinit -all w:* t:$_DFF_?_ t:$_DFFE_??_ t:$_SDFF*", "(only if -abc9 and -dff)");
 			run("techmap -D NO_LUT -map +/lattice/cells_map.v");

--- a/techlibs/lattice/synth_lattice.cc
+++ b/techlibs/lattice/synth_lattice.cc
@@ -373,7 +373,7 @@ struct SynthLatticePass : public ScriptPass
 		{
 			run("opt -fast -mux_undef -undriven -fine");
 			run("memory_map");
-			run("opt -undriven -fine");
+			run("opt -undriven -fine -mux_undef");
 		}
 
 		if (check_label("map_gates"))


### PR DESCRIPTION
These two changes can shed more than 15 % of `TRELLIS_COMB` usage on a representative design with a picorv32 core and some user peripherals. See the commits for details.