### PR TITLE
Fix printf formats

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -204,8 +204,8 @@ void AstNode::annotateTypedEnums(AstNode *template_node)
 				log_assert(enum_item->children[1]->type == AST_RANGE);
 				is_signed = enum_item->children[1]->is_signed;
 			} else {
-				log_error("enum_item children size==%lu, expected 1 or 2 for %s (%s)\n",
-						  enum_item->children.size(),
+				log_error("enum_item children size==%zu, expected 1 or 2 for %s (%s)\n",
+						  (size_t) enum_item->children.size(),
 						  enum_item->str.c_str(), enum_node->str.c_str()
 				);
 			}

--- a/passes/memory/memory_libmap.cc
+++ b/passes/memory/memory_libmap.cc
@@ -690,7 +690,7 @@ bool apply_clock(MemConfig &cfg, const PortVariant &def, SigBit clk, bool clk_po
 
 // Perform write port assignment, validating clock options as we go.
 void MemMapping::assign_wr_ports() {
-	log_reject(stringf("Assigning write ports... (candidate configs: %lu)", cfgs.size()));
+	log_reject(stringf("Assigning write ports... (candidate configs: %zu)", (size_t) cfgs.size()));
 	for (auto &port: mem.wr_ports) {
 		if (!port.clk_enable) {
 			// Async write ports not supported.
@@ -739,7 +739,7 @@ void MemMapping::assign_wr_ports() {
 
 // Perform read port assignment, validating clock and rden options as we go.
 void MemMapping::assign_rd_ports() {
-	log_reject(stringf("Assigning read ports... (candidate configs: %lu)", cfgs.size()));
+	log_reject(stringf("Assigning read ports... (candidate configs: %zu)", (size_t) cfgs.size()));
 	for (int pidx = 0; pidx < GetSize(mem.rd_ports); pidx++) {
 		auto &port = mem.rd_ports[pidx];
 		MemConfigs new_cfgs;
@@ -900,7 +900,7 @@ void MemMapping::assign_rd_ports() {
 
 // Validate transparency restrictions, determine where to add soft transparency logic.
 void MemMapping::handle_trans() {
-	log_reject(stringf("Handling transparency... (candidate configs: %lu)", cfgs.size()));
+	log_reject(stringf("Handling transparency... (candidate configs: %zu)", (size_t) cfgs.size()));
 	if (mem.emulate_read_first_ok()) {
 		MemConfigs new_cfgs;
 		for (auto &cfg: cfgs) {

--- a/passes/sat/recover_names.cc
+++ b/passes/sat/recover_names.cc
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include <queue>
+#include <cinttypes>
 
 USING_YOSYS_NAMESPACE
 
@@ -623,7 +624,7 @@ struct RecoverNamesWorker {
         	if (pop == 1 || pop == (8*sizeof(equiv_cls_t) - 1))
         		continue;
 
-        	log_debug("equivalence class: %016lx\n", cls.first);
+        	log_debug("equivalence class: %016" PRIx64 "\n", cls.first);
             const pool<IdBit> &gold_bits = cls2bits.at(cls.first).first;
             const pool<InvBit> &gate_bits = cls2bits.at(cls.first).second;
             if (gold_bits.empty() || gate_bits.empty())


### PR DESCRIPTION
Just what compiler found. Uses proper types like %zu for size_t and %PRIx64 for uint64_t in hexadecimal.