### PR TITLE
ice40, ecp5, gowin: enable ABC9 by default

### DIFF
--- a/techlibs/ecp5/synth_ecp5.cc
+++ b/techlibs/ecp5/synth_ecp5.cc
@@ -93,8 +93,8 @@ struct SynthEcp5Pass : public ScriptPass
 		log("    -abc2\n");
 		log("        run two passes of 'abc' for slightly improved logic density\n");
 		log("\n");
-		log("    -abc9\n");
-		log("        use new ABC9 flow (EXPERIMENTAL)\n");
+		log("    -noabc9\n");
+		log("        disable use of new ABC9 flow\n");
 		log("\n");
 		log("    -vpr\n");
 		log("        generate an output netlist (and BLIF file) suitable for VPR\n");
@@ -137,7 +137,7 @@ struct SynthEcp5Pass : public ScriptPass
 		retime = false;
 		abc2 = false;
 		vpr = false;
-		abc9 = false;
+		abc9 = true;
 		iopad = false;
 		nodsp = false;
 		no_rw_check = false;
@@ -224,7 +224,11 @@ struct SynthEcp5Pass : public ScriptPass
 				continue;
 			}
 			if (args[argidx] == "-abc9") {
-				abc9 = true;
+				// removed, ABC9 is on by default.
+				continue;
+			}
+			if (args[argidx] == "-noabc9") {
+				abc9 = false;
 				continue;
 			}
 			if (args[argidx] == "-iopad") {

--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -78,8 +78,8 @@ struct SynthGowinPass : public ScriptPass
 		log("    -noalu\n");
 		log("        do not use ALU cells\n");
 		log("\n");
-		log("    -abc9\n");
-		log("        use new ABC9 flow (EXPERIMENTAL)\n");
+		log("    -noabc9\n");
+		log("        disable use of new ABC9 flow\n");
 		log("\n");
 		log("    -no-rw-check\n");
 		log("        marks all recognized read ports as \"return don't-care value on\n");
@@ -106,7 +106,7 @@ struct SynthGowinPass : public ScriptPass
 		nodffe = false;
 		nolutram = false;
 		nowidelut = false;
-		abc9 = false;
+		abc9 = true;
 		noiopads = false;
 		noalu = false;
 		no_rw_check = false;
@@ -170,7 +170,11 @@ struct SynthGowinPass : public ScriptPass
 				continue;
 			}
 			if (args[argidx] == "-abc9") {
-				abc9 = true;
+				// removed, ABC9 is on by default.
+				continue;
+			}
+			if (args[argidx] == "-abc9") {
+				abc9 = false;
 				continue;
 			}
 			if (args[argidx] == "-noiopads") {

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -106,8 +106,8 @@ struct SynthIce40Pass : public ScriptPass
 		log("        generate an output netlist (and BLIF file) suitable for VPR\n");
 		log("        (this feature is experimental and incomplete)\n");
 		log("\n");
-		log("    -abc9\n");
-		log("        use new ABC9 flow (EXPERIMENTAL)\n");
+		log("    -noabc9\n");
+		log("        disable use of new ABC9 flow\n");
 		log("\n");
 		log("    -flowmap\n");
 		log("        use FlowMap LUT techmapping instead of abc (EXPERIMENTAL)\n");
@@ -144,7 +144,7 @@ struct SynthIce40Pass : public ScriptPass
 		noabc = false;
 		abc2 = false;
 		vpr = false;
-		abc9 = false;
+		abc9 = true;
 		flowmap = false;
 		device_opt = "hx";
 		no_rw_check = false;
@@ -235,6 +235,10 @@ struct SynthIce40Pass : public ScriptPass
 				continue;
 			}
 			if (args[argidx] == "-abc9") {
+				// removed, ABC9 is on by default.
+				continue;
+			}
+			if (args[argidx] == "-noabc9") {
 				abc9 = true;
 				continue;
 			}

--- a/tests/arch/ecp5/add_sub.ys
+++ b/tests/arch/ecp5/add_sub.ys
@@ -4,6 +4,9 @@ proc
 equiv_opt -assert -map +/ecp5/cells_sim.v synth_ecp5 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
-select -assert-count 10 t:LUT4
-select -assert-none t:LUT4 %% t:* %D
+select -assert-min 25 t:LUT4
+select -assert-max 26 t:LUT4
+select -assert-count 10 t:PFUMX
+select -assert-count 6 t:L6MUX21
+select -assert-none t:LUT4 t:PFUMX t:L6MUX21 %% t:* %D
 

--- a/tests/arch/ecp5/counter.ys
+++ b/tests/arch/ecp5/counter.ys
@@ -5,6 +5,7 @@ flatten
 equiv_opt -assert -multiclock -map +/ecp5/cells_sim.v synth_ecp5 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
+select -assert-count 1 t:LUT4
 select -assert-count 4 t:CCU2C
 select -assert-count 8 t:TRELLIS_FF
-select -assert-none t:CCU2C t:TRELLIS_FF %% t:* %D
+select -assert-none t:LUT4 t:CCU2C t:TRELLIS_FF %% t:* %D

--- a/tests/arch/gowin/counter.ys
+++ b/tests/arch/gowin/counter.ys
@@ -6,10 +6,11 @@ equiv_opt -assert -multiclock -map +/gowin/cells_sim.v synth_gowin # equivalency
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
 
+select -assert-count 1 t:LUT1
 select -assert-count 8 t:DFFC
 select -assert-count 8 t:ALU
 select -assert-count 1 t:GND
 select -assert-count 1 t:VCC
 select -assert-count 2 t:IBUF
 select -assert-count 8 t:OBUF
-select -assert-none t:DFFC t:ALU t:GND t:VCC t:IBUF t:OBUF %% t:* %D
+select -assert-none t:LUT1 t:DFFC t:ALU t:GND t:VCC t:IBUF t:OBUF %% t:* %D

--- a/tests/arch/gowin/init.ys
+++ b/tests/arch/gowin/init.ys
@@ -1,5 +1,5 @@
 read_verilog init.v
-read_verilog -lib +/gowin/cells_sim.v
+read_verilog -lib -specify +/gowin/cells_sim.v
 design -save read
 
 proc

--- a/tests/arch/gowin/mux.ys
+++ b/tests/arch/gowin/mux.ys
@@ -32,10 +32,17 @@ proc
 equiv_opt -assert -map +/gowin/cells_sim.v synth_gowin # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux8 # Constrain all select calls below inside the top module
+select -assert-count 1 t:LUT1
+select -assert-count 10 t:LUT3
+select -assert-count 1 t:LUT4
+select -assert-count 5 t:MUX2_LUT5
+select -assert-count 2 t:MUX2_LUT6
+select -assert-count 1 t:MUX2_LUT7
 select -assert-count 11 t:IBUF
 select -assert-count 1 t:OBUF
+select -assert-count 1 t:GND
 
-select -assert-none t:LUT* t:MUX2_LUT6 t:MUX2_LUT5 t:IBUF t:OBUF %% t:* %D
+select -assert-none t:LUT* t:MUX2_LUT7 t:MUX2_LUT6 t:MUX2_LUT5 t:IBUF t:OBUF t:GND %% t:* %D
 
 design -load read
 hierarchy -top mux16

--- a/tests/arch/ice40/add_sub.ys
+++ b/tests/arch/ice40/add_sub.ys
@@ -3,7 +3,7 @@ hierarchy -top top
 equiv_opt -assert -map +/ice40/cells_sim.v synth_ice40 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
-select -assert-count 11 t:SB_LUT4
+select -assert-count 10 t:SB_LUT4
 select -assert-count 6 t:SB_CARRY
 select -assert-none t:SB_LUT4 t:SB_CARRY %% t:* %D
 

--- a/tests/arch/ice40/mux.ys
+++ b/tests/arch/ice40/mux.ys
@@ -15,7 +15,7 @@ proc
 equiv_opt -assert -map +/ice40/cells_sim.v synth_ice40 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux4 # Constrain all select calls below inside the top module
-select -assert-count 2 t:SB_LUT4
+select -assert-count 3 t:SB_LUT4
 
 select -assert-none t:SB_LUT4 %% t:* %D
 
@@ -25,7 +25,7 @@ proc
 equiv_opt -assert -map +/ice40/cells_sim.v synth_ice40 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux8 # Constrain all select calls below inside the top module
-select -assert-count 5 t:SB_LUT4
+select -assert-count 6 t:SB_LUT4
 
 select -assert-none t:SB_LUT4 %% t:* %D
 
@@ -35,7 +35,7 @@ proc
 equiv_opt -assert -map +/ice40/cells_sim.v synth_ice40 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux16 # Constrain all select calls below inside the top module
-select -assert-min 11 t:SB_LUT4
-select -assert-max 12 t:SB_LUT4
+select -assert-min 13 t:SB_LUT4
+select -assert-max 14 t:SB_LUT4
 
 select -assert-none t:SB_LUT4 %% t:* %D


### PR DESCRIPTION
#4019 again, but the Gowin team also wanted ABC9 enabled for their flow.