### PR TITLE
gowin: fix typo

### DIFF
--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -173,7 +173,7 @@ struct SynthGowinPass : public ScriptPass
 				// removed, ABC9 is on by default.
 				continue;
 			}
-			if (args[argidx] == "-abc9") {
+			if (args[argidx] == "-noabc9") {
 				abc9 = false;
 				continue;
 			}


### PR DESCRIPTION
I forgot to change the flag name when copy-pasting the argument option, which leads to the unintended effect that specifying `-abc9` turns *off* ABC9 instead of having no effect. Oops.