### PR TITLE
ice40: fix -noabc9

### DIFF
--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -239,7 +239,7 @@ struct SynthIce40Pass : public ScriptPass
 				continue;
 			}
 			if (args[argidx] == "-noabc9") {
-				abc9 = true;
+				abc9 = false;
 				continue;
 			}
 			if (args[argidx] == "-dff") {


### PR DESCRIPTION
I really should have read over my ABC9 patch with a fresh set of eyes, huh.