### PR TITLE
Add *.dwo files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *.d
+*.dwo
 .*.swp
 *.gch
 *.gcda


### PR DESCRIPTION
These files are generated in `-gsplit-dwarf` builds, which provide faster linking.