### PR TITLE
pmgen: Have a single make pattern

### DIFF
--- a/passes/pmgen/Makefile.inc
+++ b/passes/pmgen/Makefile.inc
@@ -1,5 +1,5 @@
 %_pm.h: passes/pmgen/pmgen.py %.pmg
-	$(P) mkdir -p passes/pmgen && $(PYTHON_EXECUTABLE) $< -o $@ -p $(subst _pm.h,,$(notdir $@)) $(filter-out $<,$^)
+	$(P) mkdir -p $(dir $@) && $(PYTHON_EXECUTABLE) $< -o $@ -p $(subst _pm.h,,$(notdir $@)) $(filter-out $<,$^)
 
 # --------------------------------------
 

--- a/techlibs/quicklogic/Makefile.inc
+++ b/techlibs/quicklogic/Makefile.inc
@@ -1,6 +1,3 @@
-%_pm.h: passes/pmgen/pmgen.py %.pmg
-	$(P) mkdir -p pmgen && $(PYTHON_EXECUTABLE) $< -o $@ -p $(subst _pm.h,,$(notdir $@)) $(filter-out $<,$^)
-
 techlibs/quicklogic/qlf_k6n10f/bram_types_sim.v: techlibs/quicklogic/qlf_k6n10f/generate_bram_types_sim.py
 	$(P) $(PYTHON_EXECUTABLE) $^ $@
 


### PR DESCRIPTION
Remove duplicate %.pmg -> %_pm.h pattern. One of the duplicates overrode the other, and in some conditions there were build races as to whether the target directory for the generated header would exist. Instead have a single rule which is properly generalized.