### PR TITLE
python: Fix import in plugin example

### DIFF
--- a/examples/python-api/pass.py
+++ b/examples/python-api/pass.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from pyosys import libyosys as ys
+import libyosys as ys
 
 import matplotlib.pyplot as plt
 import numpy as np


### PR DESCRIPTION
When a plugin is being loaded from Python source, the binding will be available under

    import libyosys

That is unfortunately different from how a self-standing Python program would import the Yosys interface, which is

    from pyosys import libyosys

Until that is made consistent, at least fix the example to have it working as is.