### PR TITLE
cxxrtl: Use the base name of the interface file for the include directive

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -630,18 +630,16 @@ std::string escape_cxx_string(const std::string &input)
 
 std::string basename(const std::string &filepath)
 {
-#ifndef _WIN32
-	const std::string dir_seps = "/";
-#else
+#ifdef _WIN32
 	const std::string dir_seps = "\\/";
+#else
+	const std::string dir_seps = "/";
 #endif
 	size_t sep_pos = filepath.find_last_of(dir_seps);
-	if (sep_pos != std::string::npos) {
+	if (sep_pos != std::string::npos)
 		return filepath.substr(sep_pos + 1);
-	}
-	else {
+	else
 		return filepath;
-	}
 }
 
 template<class T>

--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -628,6 +628,22 @@ std::string escape_cxx_string(const std::string &input)
 	return output;
 }
 
+std::string basename(const std::string &filepath)
+{
+#ifndef _WIN32
+	const std::string dir_seps = "/";
+#else
+	const std::string dir_seps = "\\/";
+#endif
+	size_t sep_pos = filepath.find_last_of(dir_seps);
+	if (sep_pos != std::string::npos && sep_pos + 1 < filepath.length()) {
+		return filepath.substr(sep_pos + 1);
+	}
+	else {
+		return filepath;
+	}
+}
+
 template<class T>
 std::string get_hdl_name(T *object)
 {
@@ -2571,7 +2587,7 @@ struct CxxrtlWorker {
 		}
 
 		if (split_intf)
-			f << "#include \"" << intf_filename << "\"\n";
+			f << "#include \"" << basename(intf_filename) << "\"\n";
 		else
 			f << "#include <cxxrtl/cxxrtl.h>\n";
 		if (has_prints)

--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -636,7 +636,7 @@ std::string basename(const std::string &filepath)
 	const std::string dir_seps = "\\/";
 #endif
 	size_t sep_pos = filepath.find_last_of(dir_seps);
-	if (sep_pos != std::string::npos && sep_pos + 1 < filepath.length()) {
+	if (sep_pos != std::string::npos) {
 		return filepath.substr(sep_pos + 1);
 	}
 	else {


### PR DESCRIPTION
This pull request addresses an issue where an incorrect include file name is generated for the `.cc` file when using the `-header` flag and the filename includes folders.

For example:
```verilog
// top.v
module top ();
endmodule
```

```bash
$ mkdir -p build && yosys -p "read_verilog top.v; write_cxxrtl -header build/top.cc"
```

The following files are created: `build/top.h` and `build/top.cc`. The `top.cc` has the following include directive to include the `top.h`:

```c++
#include "build/top.h"
```

It should instead be:

```c++
#include "top.h"
```