### PR TITLE
Simplify and correct array slice assignment

### DIFF
--- a/tests/simple/sign_part_assign.v
+++ b/tests/simple/sign_part_assign.v
@@ -1,0 +1,20 @@
+module test (
+	offset_i,
+	data_o,
+	data_ref_o
+);
+input wire  [ 2:0] offset_i;
+output reg  [15:0] data_o;
+output reg  [15:0] data_ref_o;
+
+always @(*) begin
+	// defaults
+	data_o = '0;
+	data_ref_o = '0;
+
+	// partial assigns
+	data_ref_o[offset_i+:4] = 4'b1111; // unsigned
+	data_o[offset_i+:4] 	= 1'sb1;   // sign extension to 4'b1111
+end
+
+endmodule


### PR DESCRIPTION
Simplify and correct AST for array slice assignment

Corrects sign extension of the right hand side, and hopefully
makes the code simpler to understand.

Fixes #4064