### PR TITLE
cxxrtl: Add unit tests for runtime

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -31,7 +31,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install gperf build-essential bison flex libreadline-dev gawk tcl-dev libffi-dev git graphviz xdot pkg-config python python3 libboost-system-dev libboost-python-dev libboost-filesystem-dev zlib1g-dev
+          sudo apt-get install gperf build-essential bison flex libreadline-dev gawk tcl-dev libffi-dev git graphviz xdot pkg-config python python3 libboost-system-dev libboost-python-dev libboost-filesystem-dev zlib1g-dev libgtest-dev patchelf
 
       - name: Setup GCC
         if: startsWith(matrix.compiler, 'gcc')
@@ -115,3 +115,9 @@ jobs:
         shell: bash
         run: |
           make -j${{ env.procs }} test CXXSTD=${{ matrix.cpp_std }} CC=$CC CXX=$CC LD=$CC
+
+      - name: Run unit-tests
+        if: (matrix.cpp_std == 'c++14') && (matrix.compiler == 'gcc-11')
+        shell: bash
+        run: |
+          make -j${{ env.procs }} unit-test CXXSTD=${{ matrix.cpp_std }} CC=$CC CXX=$CC LD=$CC

--- a/Makefile
+++ b/Makefile
@@ -917,7 +917,7 @@ ystests: $(TARGETS) $(EXTRA_TARGETS)
 # Unit test
 unit-test: libyosys.so
 	@$(MAKE) -C $(UNITESTPATH) CXX="$(CXX)" CPPFLAGS="$(CPPFLAGS)" \
-		CXXFLAGS="$(CXXFLAGS)" LDLIBS="$(LDLIBS)" ROOTPATH="$(CURDIR)"
+		CXXFLAGS="$(CXXFLAGS)" LDLIBS="$(LDLIBS)" ROOTPATH="$(CURDIR)" YOSYSLIBDIR="$(LIBDIR)"
 
 clean-unit-test:
 	@$(MAKE) -C $(UNITESTPATH) clean

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -510,8 +510,8 @@ struct value : public expr_base<value<Bits>> {
 		size_t count = 0;
 		for (size_t n = 0; n < chunks; n++) {
 			chunk::type x = data[chunks - 1 - n];
-			// First add to `count` as if the chunk is zero
-			count += (n == 0 ? Bits % chunk::bits : chunk::bits);
+			constexpr size_t first_chunk_bits = Bits % chunk::bits != 0 ? Bits % chunk::bits : chunk::bits;
+			count += (n == 0 ? first_chunk_bits : chunk::bits);
 			// If the chunk isn't zero, correct the `count` value and return
 			if (x != 0) {
 				for (; x != 0; count--)

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -419,6 +419,7 @@ struct value : public expr_base<value<Bits>> {
 			carry = (shift_bits == 0) ? 0
 				: data[n] >> (chunk::bits - shift_bits);
 		}
+		result.data[result.chunks - 1] &= result.msb_mask;
 		return result;
 	}
 

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -1,6 +1,6 @@
 GTESTFLAG := -lgtest -lgtest_main
 RPATH := -Wl,-rpath
-EXTRAFLAGS := -lyosys -pthreads
+EXTRAFLAGS := -lyosys -pthread
 
 OBJTEST := objtest
 BINTEST := bintest
@@ -15,11 +15,12 @@ TESTS := $(addprefix $(BINTEST)/, $(basename $(ALLTESTFILE:%Test.cc=%Test.o)))
 all: prepare $(TESTS) run-tests
 
 $(BINTEST)/%: $(OBJTEST)/%.o
-	$(CXX) -L$(ROOTPATH) $(RPATH)=$(ROOTPATH) -o $@ $^ $(LDLIBS) \
+	$(CXX) $(RPATH)=$(ROOTPATH) -L$(ROOTPATH) -o $@ $^ $(LDLIBS) \
 		$(GTESTFLAG) $(EXTRAFLAGS)
+	patchelf --replace-needed $(YOSYSLIBDIR)/libyosys.so libyosys.so $@
 
 $(OBJTEST)/%.o: $(basename $(subst $(OBJTEST),.,%)).cc
-	$(CXX) -o $@ -c -I$(ROOTPATH) $(CPPFLAGS) $(CXXFLAGS) $^
+	$(CXX) -o $@ -c -I$(ROOTPATH) -I$(ROOTPATH)/backends/cxxrtl/runtime $(CPPFLAGS) $(CXXFLAGS) $^
 
 .PHONY: prepare run-tests clean
 

--- a/tests/unit/backends/cxxrtl/valueTest.cc
+++ b/tests/unit/backends/cxxrtl/valueTest.cc
@@ -69,6 +69,13 @@ void test_binary_operation(Lambda1 f1, Lambda2 f2) {
     test_binary_operation(f1, f2, [](uint64_t, uint64_t){});
 }
 
+TEST(CxxrtlValueTest, shl) {
+    test_binary_operation(
+        [](uint64_t a, uint64_t b) { return b >= 64 ? 0 : a << b; },
+        [](auto a, auto b) { return a.shl(b); },
+        [](uint64_t&, uint64_t& b) { b &= 0x7f; });
+}
+
 TEST(CxxrtlValueTest, add) {
 	test_binary_operation(
         [](uint64_t a, uint64_t b) { return a + b; },

--- a/tests/unit/backends/cxxrtl/valueTest.cc
+++ b/tests/unit/backends/cxxrtl/valueTest.cc
@@ -45,7 +45,7 @@ void test_binary_operation_for_bitsize(Lambda1 f1, Lambda2 f2, TweakInputLambda 
             vb.data[i] = (chunk_type)(ib >> (i * chunk_bits));
         }
 
-        uint64_t iresult = f1(ia, ib) & mask;
+        uint64_t iresult = f1(Bits, ia, ib) & mask;
         cxxrtl::value<Bits> vresult = f2(va, vb);
 
         for (size_t i = 0; i * chunk_bits < Bits; i++) {
@@ -71,26 +71,36 @@ void test_binary_operation(Lambda1 f1, Lambda2 f2) {
 
 TEST(CxxrtlValueTest, shl) {
     test_binary_operation(
-        [](uint64_t a, uint64_t b) { return b >= 64 ? 0 : a << b; },
+        [](size_t, uint64_t a, uint64_t b) { return b >= 64 ? 0 : a << b; },
         [](auto a, auto b) { return a.shl(b); },
         [](uint64_t&, uint64_t& b) { b &= 0x7f; });
 }
 
 TEST(CxxrtlValueTest, shr) {
     test_binary_operation(
-        [](uint64_t a, uint64_t b) { return b >= 64 ? 0 : a >> b; },
+        [](size_t, uint64_t a, uint64_t b) { return b >= 64 ? 0 : a >> b; },
         [](auto a, auto b) { return a.shr(b); },
+        [](uint64_t&, uint64_t& b) { b &= 0x7f; });
+}
+
+TEST(CxxrtlValueTest, sshr) {
+    test_binary_operation(
+        [](size_t bits, uint64_t a, uint64_t b) {
+            int64_t sa = (int64_t)(a << (64 - bits));
+            return sa >> (b >= bits ? 63 : (b + 64 - bits));
+        },
+        [](auto a, auto b) { return a.sshr(b); },
         [](uint64_t&, uint64_t& b) { b &= 0x7f; });
 }
 
 TEST(CxxrtlValueTest, add) {
 	test_binary_operation(
-        [](uint64_t a, uint64_t b) { return a + b; },
+        [](size_t, uint64_t a, uint64_t b) { return a + b; },
         [](auto a, auto b) { return a.add(b); });
 }
 
 TEST(CxxrtlValueTest, sub) {
     test_binary_operation(
-        [](uint64_t a, uint64_t b) { return a - b; },
+        [](size_t, uint64_t a, uint64_t b) { return a - b; },
         [](auto a, auto b) { return a.sub(b); });
 }

--- a/tests/unit/backends/cxxrtl/valueTest.cc
+++ b/tests/unit/backends/cxxrtl/valueTest.cc
@@ -69,6 +69,11 @@ void test_binary_operation(Lambda1 f1, Lambda2 f2) {
     test_binary_operation(f1, f2, [](uint64_t, uint64_t){});
 }
 
+template<typename Lambda1, typename Lambda2>
+void test_unary_operation(Lambda1 f1, Lambda2 f2) {
+    test_binary_operation([&f1](size_t bits, uint64_t a, uint64_t) { return f1(bits, a); }, [&f2](auto a, auto) { return f2(a); });
+}
+
 TEST(CxxrtlValueTest, shl) {
     test_binary_operation(
         [](size_t, uint64_t a, uint64_t b) { return b >= 64 ? 0 : a << b; },
@@ -103,4 +108,14 @@ TEST(CxxrtlValueTest, sub) {
     test_binary_operation(
         [](size_t, uint64_t a, uint64_t b) { return a - b; },
         [](auto a, auto b) { return a.sub(b); });
+}
+
+TEST(CxxrtlValueTest, ctlz) {
+    test_unary_operation(
+        [](size_t bits, uint64_t a) -> uint64_t {
+            if (a == 0)
+                return bits;
+            return __builtin_clzl(a) - (64 - bits);
+        },
+        [](auto a) { return decltype(a)((cxxrtl::chunk_t)a.ctlz()); });
 }

--- a/tests/unit/backends/cxxrtl/valueTest.cc
+++ b/tests/unit/backends/cxxrtl/valueTest.cc
@@ -1,0 +1,82 @@
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <random>
+#include <type_traits>
+
+#include "cxxrtl/cxxrtl.h"
+
+template<typename T>
+T rand_int(T min = std::numeric_limits<T>::min(), T max = std::numeric_limits<T>::max()) {
+	static_assert(std::is_integral<T>::value, "T must be an integral type.");
+	static_assert(!std::is_same<T, signed char>::value && !std::is_same<T, unsigned char>::value,
+		      "Using char with uniform_int_distribution is undefined behavior.");
+
+	static std::mt19937 generator = [] {
+		std::random_device rd;
+		std::mt19937 mt{rd()};
+		return mt;
+	}();
+
+	std::uniform_int_distribution<T> dist(min, max);
+	return dist(generator);
+}
+
+template<size_t Bits, typename Lambda1, typename Lambda2, typename TweakInputLambda>
+void test_binary_operation_for_bitsize(Lambda1 f1, Lambda2 f2, TweakInputLambda tweak_input) {
+	constexpr int iteration_count = 10'000'000;
+
+    constexpr uint64_t mask = std::numeric_limits<uint64_t>::max() >> (64 - Bits);
+
+    using chunk_type = typename cxxrtl::value<Bits>::chunk::type;
+    constexpr size_t chunk_bits = cxxrtl::value<Bits>::chunk::bits;
+
+    for (int iteration = 0; iteration < iteration_count; iteration++)
+    {
+        uint64_t ia = rand_int<uint64_t>() >> (64 - Bits);
+        uint64_t ib = rand_int<uint64_t>() >> (64 - Bits);
+        tweak_input(ia, ib);
+
+        cxxrtl::value<Bits> va, vb;
+        for (size_t i = 0; i * chunk_bits < Bits; i++) {
+            va.data[i] = (chunk_type)(ia >> (i * chunk_bits));
+            vb.data[i] = (chunk_type)(ib >> (i * chunk_bits));
+        }
+
+        uint64_t iresult = f1(ia, ib) & mask;
+        cxxrtl::value<Bits> vresult = f2(va, vb);
+
+        for (size_t i = 0; i * chunk_bits < Bits; i++) {
+            EXPECT_EQ((chunk_type)(iresult >> (i * chunk_bits)), vresult.data[i]);
+        }
+    }
+}
+
+template<typename Lambda1, typename Lambda2, typename TweakInputLambda>
+void test_binary_operation(Lambda1 f1, Lambda2 f2, TweakInputLambda tweak_input) {
+    // Test at a variety of bitwidths
+    test_binary_operation_for_bitsize<6>(f1, f2, tweak_input);
+    test_binary_operation_for_bitsize<32>(f1, f2, tweak_input);
+    test_binary_operation_for_bitsize<42>(f1, f2, tweak_input);
+    test_binary_operation_for_bitsize<63>(f1, f2, tweak_input);
+    test_binary_operation_for_bitsize<64>(f1, f2, tweak_input);
+}
+
+template<typename Lambda1, typename Lambda2>
+void test_binary_operation(Lambda1 f1, Lambda2 f2) {
+    test_binary_operation(f1, f2, [](uint64_t, uint64_t){});
+}
+
+TEST(CxxrtlValueTest, add) {
+	test_binary_operation(
+        [](uint64_t a, uint64_t b) { return a + b; },
+        [](auto a, auto b) { return a.add(b); });
+}
+
+TEST(CxxrtlValueTest, sub) {
+    test_binary_operation(
+        [](uint64_t a, uint64_t b) { return a - b; },
+        [](auto a, auto b) { return a.sub(b); });
+}

--- a/tests/unit/backends/cxxrtl/valueTest.cc
+++ b/tests/unit/backends/cxxrtl/valueTest.cc
@@ -76,6 +76,13 @@ TEST(CxxrtlValueTest, shl) {
         [](uint64_t&, uint64_t& b) { b &= 0x7f; });
 }
 
+TEST(CxxrtlValueTest, shr) {
+    test_binary_operation(
+        [](uint64_t a, uint64_t b) { return b >= 64 ? 0 : a >> b; },
+        [](auto a, auto b) { return a.shr(b); },
+        [](uint64_t&, uint64_t& b) { b &= 0x7f; });
+}
+
 TEST(CxxrtlValueTest, add) {
 	test_binary_operation(
         [](uint64_t a, uint64_t b) { return a + b; },


### PR DESCRIPTION
Proposed testing strategy for the cxxrtl runtime.
This PR also fixes a few bugs found with randomized unit testing.

Use of `patchelf` is requried in order to override `libyosys.so` SONAME. The SONAME provides an absolute path into system library directory, which is not what we want here as we would like to test the currently built library and not the installed system library.

