### PR TITLE
cxxrtl: Mask `bmux` result appropriately

### DIFF
--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -475,6 +475,7 @@ struct value : public expr_base<value<Bits>> {
 			carry = (shift_bits == 0) ? 0
 				: data[result.chunks + shift_chunks - 1 - n] << (chunk::bits - shift_bits);
 		}
+		result.data[result.chunks - 1] &= result.msb_mask;
 		return result;
 	}
 

--- a/tests/cxxrtl/test_value.cc
+++ b/tests/cxxrtl/test_value.cc
@@ -42,4 +42,11 @@ int main()
         cxxrtl::value<32> a(0x00040000u);
         assert(a.ctlz() == 13);
     }
+
+    {
+        // bmux clears top bits of result
+        cxxrtl::value<8> val(0x1fu);
+        cxxrtl::value<1> sel(0u);
+        assert(val.template bmux<4>(sel).get<uint64_t>() == 0xfu);
+    }
 }


### PR DESCRIPTION
Fixes #4074 