### PR TITLE
lattice: Fix mapping onto DP8KC for data width 1 or 2

### DIFF
--- a/techlibs/lattice/brams_8kc.txt
+++ b/techlibs/lattice/brams_8kc.txt
@@ -32,6 +32,10 @@ ram block $__PDPW8KC_ {
 	cost 64;
 	init no_undef;
 	port sr "R" {
+		# width 2 cannot be supported because of quirks
+		# of the primitive, and memlib requires us to
+		# remove width 1 as well
+		width 4 9 18;
 		clock posedge;
 		clken;
 		option "RESETMODE" "SYNC" {

--- a/techlibs/lattice/brams_map_8kc.v
+++ b/techlibs/lattice/brams_map_8kc.v
@@ -38,8 +38,20 @@ endfunction
 
 wire [8:0] DOA;
 wire [8:0] DOB;
-wire [8:0] DIA = PORT_A_WR_DATA;
-wire [8:0] DIB = PORT_B_WR_DATA;
+wire [8:0] DIA;
+wire [8:0] DIB;
+
+case(PORT_A_WIDTH)
+	1: assign DIA = {7'bx, PORT_A_WR_DATA[0], 1'bx};
+	2: assign DIA = {3'bx, PORT_A_WR_DATA[1], 2'bx, PORT_A_WR_DATA[0], 2'bx};
+	default: assign DIA = PORT_A_WR_DATA;
+endcase
+
+case(PORT_B_WIDTH)
+	1: assign DIB = {7'bx, PORT_B_WR_DATA[0], 1'bx};
+	2: assign DIB = {3'bx, PORT_B_WR_DATA[1], 2'bx, PORT_B_WR_DATA[0], 2'bx};
+	default: assign DIB = PORT_B_WR_DATA;
+endcase
 
 assign PORT_A_RD_DATA = DOA;
 assign PORT_B_RD_DATA = DOB;


### PR DESCRIPTION
This appears to be the right wiring of `DP8KC` per the MachXO3 simulation model I have at hand.

Some points:

 * I don't know if this applies to all `DP8KC`primitives across the Lattice families.

 * Reading into the simulation model, it seems one cannot map a memory with write port of width 18 and read port of width 2 onto `DP8KC`. This is because `DIB1`, which would be used for the 10th data bit input, gets ignored. If this is true, or even if it's just a bug of the simulation model, we may want to disable this configuration in libmap inference of `$__PDPW8KC_`. **UPDATE:** done in the second commit
