### PR TITLE
Add support for packed multidimensional arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,13 @@ from SystemVerilog:
 - enums are supported (including inside packages)
 	- but are currently not strongly typed
 
-- packed structs and unions are supported.
+- packed structs and unions are supported
+	- arrays of packed structs/unions are currently not supported
+	- structure literals are currently not supported
+
+- multidimensional arrays are supported
+	- array assignment of unpacked arrays is currently not supported
+	- array literals are currently not supported
 
 - SystemVerilog interfaces (SVIs) are supported. Modports for specifying whether
   ports are inputs or outputs are supported.

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -488,6 +488,20 @@ void AstNode::dumpVlog(FILE *f, std::string indent) const
 		fprintf(f, ";\n");
 		break;
 
+	if (0) { case AST_MEMRD:   txt = "@memrd@";  }
+	if (0) { case AST_MEMINIT: txt = "@meminit@";  }
+	if (0) { case AST_MEMWR:   txt = "@memwr@";  }
+		fprintf(f, "%s%s", indent.c_str(), txt.c_str());
+		for (auto child : children) {
+			fprintf(f, first ? "(" : ", ");
+			child->dumpVlog(f, "");
+			first = false;
+		}
+		fprintf(f, ")");
+		if (type != AST_MEMRD)
+			fprintf(f, ";\n");
+		break;
+
 	case AST_RANGE:
 		if (range_valid) {
 			if (range_swapped)
@@ -554,6 +568,12 @@ void AstNode::dumpVlog(FILE *f, std::string indent) const
 		}
 		for (auto child : children)
 			child->dumpVlog(f, "");
+		break;
+
+	case AST_STRUCT:
+	case AST_UNION:
+	case AST_STRUCT_ITEM:
+		fprintf(f, "%s", id2vl(str).c_str());
 		break;
 
 	case AST_CONSTANT:

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -202,9 +202,17 @@ namespace AST
 		// set for IDs typed to an enumeration, not used
 		bool is_enum;
 
-		// if this is a multirange memory then this vector contains offset and length of each dimension
-		std::vector<int> multirange_dimensions;
-		std::vector<bool> multirange_swapped; // true if range is swapped
+		// Declared range for array dimension.
+		struct dimension_t {
+			int range_right;     // lsb in [msb:lsb]
+			int range_width;     // msb - lsb + 1
+			bool range_swapped;  // if the declared msb < lsb, msb and lsb above are swapped
+		};
+		// Packed and unpacked dimensions for arrays.
+		// Unpacked dimensions go first, to follow the order of indexing.
+		std::vector<dimension_t> dimensions;
+		// Number of unpacked dimensions.
+		int unpacked_dimensions;
 
 		// this is set by simplify and used during RTLIL generation
 		AstNode *id2ast;
@@ -371,6 +379,10 @@ namespace AST
 		// localized fixups after modifying children/attributes of a particular node
 		void fixup_hierarchy_flags(bool force_descend = false);
 
+		// helpers for indexing
+		AstNode *make_index_range(AstNode *node, bool unpacked_range = false);
+		AstNode *get_struct_member() const;
+
 		// helper to print errors from simplify/genrtlil code
 		[[noreturn]] void input_error(const char *format, ...) const YS_ATTRIBUTE(format(printf, 2, 3));
 	};
@@ -415,10 +427,6 @@ namespace AST
 
 	// Helper for setting the src attribute.
 	void set_src_attr(RTLIL::AttrObject *obj, const AstNode *ast);
-
-	// struct helper exposed from simplify for genrtlil
-	AstNode *make_struct_member_range(AstNode *node, AstNode *member_node);
-	AstNode *get_struct_member(const AstNode *node);
 
 	// generate standard $paramod... derived module name; parameters should be
 	// in the order they are declared in the instantiated module

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -960,7 +960,7 @@ void AstNode::detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *foun
 			if (children.size() > 1)
 				range = children[1];
 		} else if (id_ast->type == AST_STRUCT_ITEM || id_ast->type == AST_STRUCT || id_ast->type == AST_UNION) {
-			AstNode *tmp_range = make_struct_member_range(this, id_ast);
+			AstNode *tmp_range = make_index_range(id_ast);
 			this_width = tmp_range->range_left - tmp_range->range_right + 1;
 			delete tmp_range;
 		} else
@@ -1521,7 +1521,7 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 			chunk.width = wire->width;
 			chunk.offset = 0;
 
-			if ((member_node = get_struct_member(this))) {
+			if ((member_node = get_struct_member())) {
 				// Clamp wire chunk to range of member within struct/union.
 				chunk.width = member_node->range_left - member_node->range_right + 1;
 				chunk.offset = member_node->range_right;

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -3603,7 +3603,7 @@ skip_dynamic_range_lvalue_expansion:;
 				goto apply_newNode;
 			}
 
-			if (str == "\\$size" || str == "\\$bits" || str == "\\$high" || str == "\\$low" || str == "\\$left" || str == "\\$right")
+			if (str == "\\$increment" || str == "\\$size" || str == "\\$bits" || str == "\\$high" || str == "\\$low" || str == "\\$left" || str == "\\$right")
 			{
 				int dim = 1;
 				if (str == "\\$bits") {
@@ -3672,6 +3672,8 @@ skip_dynamic_range_lvalue_expansion:;
 					result = left;
 				else if (str == "\\$right")
 					result = right;
+				else if (str == "\\$increment")
+					result = left >= right ? 1 : -1;
 				else if (str == "\\$size")
 					result = width;
 				else { // str == "\\$bits"

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -1900,10 +1900,11 @@ struct_member_type: { astbuf1 = new AstNode(AST_STRUCT_ITEM); } member_type_toke
 	;
 
 member_type_token:
-	  member_type
-	| hierarchical_type_id {
-			addWiretypeNode($1, astbuf1);
-		}
+	member_type range_or_multirange {
+		AstNode *range = checkRange(astbuf1, $2);
+		if (range)
+			astbuf1->children.push_back(range);
+	}
 	| {
 		delete astbuf1;
 	} struct_union {
@@ -1919,7 +1920,8 @@ member_type_token:
 	;
 
 member_type: type_atom type_signing
-	| type_vec type_signing range_or_multirange	{ if ($3) astbuf1->children.push_back($3); }
+	| type_vec type_signing
+	| hierarchical_type_id { addWiretypeNode($1, astbuf1); }
 	;
 
 struct_var_list: struct_var

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -2122,7 +2122,7 @@ typedef_decl:
 			astbuf1->children.push_back(astbuf2);
 
 		if ($5 != NULL) {
-			if (!astbuf2) {
+			if (!astbuf2 && !astbuf1->is_custom_type) {
 				addRange(astbuf1, 0, 0, false);
 			}
 			rewriteAsMemoryNode(astbuf1, $5);

--- a/tests/sat/sizebits.sv
+++ b/tests/sat/sizebits.sv
@@ -16,17 +16,17 @@ assert property ($size({3{x}}) == 3*4);
 assert property ($size(y) == 6);
 assert property ($size(y, 1) == 6);
 assert property ($size(y, (1+1)) == 4);
+assert property ($size(y[2], 1) == 4);
 // This is unsupported at the moment
-//assert property ($size(y[2], 1) == 4);
 //assert property ($size(y[2][1], 1) == 1);
 
 assert property ($size(z) == 6);
 assert property ($size(z, 1) == 6);
 assert property ($size(z, 2) == 8);
 assert property ($size(z, 3) == 4);
-// This is unsupported at the moment
 assert property ($size(z[3], 1) == 8);
 assert property ($size(z[3][3], 1) == 4);
+// This is unsupported at the moment
 //assert property ($size(z[3][3][3], 1) == 1);
 // This should trigger an error if enabled (it does).
 //assert property ($size(z, 4) == 4);

--- a/tests/sat/sizebits.sv
+++ b/tests/sat/sizebits.sv
@@ -90,4 +90,17 @@ assert property ($right(z, 3) == 0);
 assert property ($right(z[3]) == 9);
 assert property ($right(z[3][3]) == 0);
 assert property ($right(z[3], 2) == 0);
+
+assert property ($increment(x) == 1);
+assert property ($increment(y) == -1);
+assert property ($increment(y, 1) == -1);
+assert property ($increment(y, (1+1)) == 1);
+
+assert property ($increment(z) == 1);
+assert property ($increment(z, 1) == 1);
+assert property ($increment(z, 2) == -1);
+assert property ($increment(z, 3) == 1);
+assert property ($increment(z[3]) == -1);
+assert property ($increment(z[3][3]) == 1);
+assert property ($increment(z[3], 2) == 1);
 endmodule

--- a/tests/sat/sizebits.sv
+++ b/tests/sat/sizebits.sv
@@ -10,6 +10,24 @@ wire [3:0]z[7:2][2:9];
 //wire [$size(y)-1:0]y_size;
 //wire [$size(z)-1:0]z_size;
 
+assert property ($dimensions(t) == 1);
+assert property ($dimensions(x) == 1);
+assert property ($dimensions({3{x}}) == 1);
+assert property ($dimensions(y) == 2);
+assert property ($dimensions(y[2]) == 1);
+assert property ($dimensions(z) == 3);
+assert property ($dimensions(z[3]) == 2);
+assert property ($dimensions(z[3][3]) == 1);
+
+assert property ($unpacked_dimensions(t) == 0);
+assert property ($unpacked_dimensions(x) == 0);
+assert property ($unpacked_dimensions({3{x}}) == 0);
+assert property ($unpacked_dimensions(y) == 1);
+assert property ($unpacked_dimensions(y[2]) == 0);
+assert property ($unpacked_dimensions(z) == 2);
+assert property ($unpacked_dimensions(z[3]) == 1);
+assert property ($unpacked_dimensions(z[3][3]) == 0);
+
 assert property ($size(t) == 1);
 assert property ($size(x) == 4);
 assert property ($size({3{x}}) == 3*4);

--- a/tests/simple/arrays03.sv
+++ b/tests/simple/arrays03.sv
@@ -1,0 +1,49 @@
+// Test multidimensional packed arrays
+
+typedef logic [0:3][7:0] reg2dim_t;
+typedef logic  [7:0] reg8_t;
+typedef reg8_t [0:3] reg2dim1_t;
+
+module pcktest1 (
+    input  logic  clk,
+    input  logic [0:3][7:0] in,
+    input  logic [1:0] ix,
+    output reg8_t out
+);
+    always_ff @(posedge clk) begin
+        out <= in[ix];
+    end
+endmodule
+
+module pcktest2 (
+    input  logic  clk,
+    input  reg8_t [0:3] in,
+    input  logic [1:0] ix,
+    output reg8_t out
+);
+    always_ff @(posedge clk) begin
+        out <= in[ix];
+    end
+endmodule
+
+module pcktest3 (
+    input  logic  clk,
+    input  reg2dim_t in,
+    input  logic [1:0] ix,
+    output reg8_t out
+);
+    always_ff @(posedge clk) begin
+        out <= in[ix];
+    end
+endmodule
+
+module pcktest4 (
+    input  logic  clk,
+    input  reg2dim1_t in,
+    input  logic [1:0] ix,
+    output reg8_t out
+);
+    always_ff @(posedge clk) begin
+        out <= in[ix];
+    end
+endmodule

--- a/tests/simple/memory.v
+++ b/tests/simple/memory.v
@@ -44,6 +44,7 @@ input [2:0] bit;
 output reg y1, y2;
 output y3, y4;
 
+(* nomem2reg *)
 reg [7:0] mem1 [3:0];
 
 (* mem2reg *)

--- a/tests/svtypes/multirange_array.sv
+++ b/tests/svtypes/multirange_array.sv
@@ -8,9 +8,21 @@ module top;
 	logic a [3];
 	logic b [3][5];
 	logic c [3][5][7];
+	logic [2:0] d;
+	logic [2:0][4:0] e;
+	logic [2:0][4:0][6:0] f;
+	logic [2:0] g [3];
+	logic [2:0][4:0] h [3][5];
+	logic [2:0][4:0][6:0] i [3][5][7];
 
 	`STATIC_ASSERT($bits(a) == 3);
 	`STATIC_ASSERT($bits(b) == 15);
 	`STATIC_ASSERT($bits(c) == 105);
+	`STATIC_ASSERT($bits(d) == 3);
+	`STATIC_ASSERT($bits(e) == 15);
+	`STATIC_ASSERT($bits(f) == 105);
+	`STATIC_ASSERT($bits(g) == 9);
+	`STATIC_ASSERT($bits(h) == 225);
+	`STATIC_ASSERT($bits(i) == 11025);
 
 endmodule

--- a/tests/svtypes/struct_array.sv
+++ b/tests/svtypes/struct_array.sv
@@ -23,6 +23,29 @@ module top;
 	always_comb assert(s.b[23:16]===8'hxx);
 	always_comb assert(s.b[19:12]===8'hxf);
 
+	// Same as s, but defining dimensions in stages with typedef
+	typedef bit [7:0] bit8_t;
+	struct packed {
+		bit8_t [5:0] a;		// 6 element packed array of bytes
+		bit [15:0] b;		// filler for non-zero offset
+	} s_s;
+
+	initial begin
+		s_s = '0;
+
+		s_s.a[2:1] = 16'h1234;
+		s_s.a[5] = 8'h42;
+		s_s.a[-1] = '0;
+
+		s_s.b = '1;
+		s_s.b[1:0] = '0;
+	end
+
+	always_comb assert(s_s==64'h4200_0012_3400_FFFC);
+	always_comb assert(s_s.a[0][3:-4]===8'h0x);
+	always_comb assert(s_s.b[23:16]===8'hxx);
+	always_comb assert(s_s.b[19:12]===8'hxf);
+
 	struct packed {
 		bit [7:0] [7:0] a;	// 8 element packed array of bytes
 		bit [15:0] b;		// filler for non-zero offset
@@ -124,6 +147,28 @@ module top;
 	end
 
 	always_comb assert(s3_lbl==80'hFC00_4200_0012_3400_FFFC);
+
+	// Same as s3_lbl, but defining dimensions in stages with typedef
+	typedef bit [0:3] bit3l_t;
+	struct packed {
+		bit3l_t [0:7] [1:0] a;
+		bit [0:15] b;		// filler for non-zero offset
+	} s3_lbl_s;
+
+	initial begin
+		s3_lbl_s = '0;
+
+		s3_lbl_s.a[5:6] = 16'h1234;
+		s3_lbl_s.a[2] = 8'h42;
+
+		s3_lbl_s.a[0] = '1;
+		s3_lbl_s.a[0][0][2:3] = '0;
+
+		s3_lbl_s.b = '1;
+		s3_lbl_s.b[14:15] = '0;
+	end
+
+	always_comb assert(s3_lbl_s==80'hFC00_4200_0012_3400_FFFC);
 
 	struct packed {
 		bit [0:7] [0:1] [3:0] a;

--- a/tests/svtypes/struct_sizebits.sv
+++ b/tests/svtypes/struct_sizebits.sv
@@ -25,6 +25,18 @@ struct packed {
 //wire [$bits({s.x, s.x})-1:0]xx_bits;
 
 always_comb begin
+	assert ($dimensions(s) == 1);
+	assert ($dimensions(s.t) == 1);
+	assert ($dimensions(s.x) == 1);
+`ifndef VERIFIC
+	assert ($dimensions({3{s.x}}) == 1);
+`endif
+	assert ($dimensions(s.sy.y) == 2);
+	assert ($dimensions(s.sy.y[2]) == 1);
+	assert ($dimensions(s.sz.z) == 3);
+	assert ($dimensions(s.sz.z[3]) == 2);
+	assert ($dimensions(s.sz.z[3][3]) == 1);
+
 	assert ($size(s) == $size(s.t) + $size(s.x) + $size(s.sy) + $size(s.sz));
 	assert ($size(s) == 1 + 4 + 6*4 + 6*8*4);
 

--- a/tests/svtypes/struct_sizebits.sv
+++ b/tests/svtypes/struct_sizebits.sv
@@ -107,6 +107,19 @@ always_comb begin
 	assert ($right(s.sz.z[3]) == 9);
 	assert ($right(s.sz.z[3][3]) == 4);
 	assert ($right(s.sz.z[3], 2) == 4);
+
+	assert ($increment(s.x) == 1);
+	assert ($increment(s.sy.y) == -1);
+	assert ($increment(s.sy.y, 1) == -1);
+	assert ($increment(s.sy.y, (1+1)) == 1);
+
+	assert ($increment(s.sz.z) == 1);
+	assert ($increment(s.sz.z, 1) == 1);
+	assert ($increment(s.sz.z, 2) == -1);
+	assert ($increment(s.sz.z, 3) == -1);
+	assert ($increment(s.sz.z[3]) == -1);
+	assert ($increment(s.sz.z[3][3]) == -1);
+	assert ($increment(s.sz.z[3], 2) == -1);
 end
 
 endmodule


### PR DESCRIPTION
* Generalization of dimensions metadata (also simplifies $size et al.)
* Parsing and elaboration of multidimensional packed arrays
* Implementation of $increment, $dimensions and $unpacked_dimensions
* Resolve multiple dimensions defined in stages with typedef

Fixes #667
Fixes #3776
