### PR TITLE
Fix Windows build by forcing initialization order, fixes #4068

### DIFF
--- a/techlibs/quicklogic/ql_bram_merge.cc
+++ b/techlibs/quicklogic/ql_bram_merge.cc
@@ -31,9 +31,6 @@ PRIVATE_NAMESPACE_BEGIN
 
 struct QlBramMergeWorker {
 
-	const RTLIL::IdString split_cell_type = ID($__QLF_TDP36K);
-	const RTLIL::IdString merged_cell_type = ID($__QLF_TDP36K_MERGED);
-
 	// can be used to record parameter values that have to match on both sides
 	typedef dict<RTLIL::IdString, RTLIL::Const> MergeableGroupKeyType;
 
@@ -42,6 +39,8 @@ struct QlBramMergeWorker {
 
 	QlBramMergeWorker(RTLIL::Module* module) : module(module)
 	{
+		const RTLIL::IdString split_cell_type = ID($__QLF_TDP36K);
+
 		for (RTLIL::Cell* cell : module->selected_cells())
 		{
 			if(cell->type != split_cell_type) continue;
@@ -125,6 +124,7 @@ struct QlBramMergeWorker {
 
 	void merge_brams(RTLIL::Cell* bram1, RTLIL::Cell* bram2)
 	{
+		const RTLIL::IdString merged_cell_type = ID($__QLF_TDP36K_MERGED);
 
 		// Create the new cell
 		RTLIL::Cell* merged = module->addCell(NEW_ID, merged_cell_type);

--- a/techlibs/quicklogic/ql_dsp_io_regs.cc
+++ b/techlibs/quicklogic/ql_dsp_io_regs.cc
@@ -30,10 +30,6 @@ PRIVATE_NAMESPACE_BEGIN
 // ============================================================================
 
 struct QlDspIORegs : public Pass {
-	const std::vector<IdString> ports2del_mult = {ID(load_acc), ID(subtract), ID(acc_fir), ID(dly_b),
-													 ID(saturate_enable), ID(shift_right), ID(round)};
-	const std::vector<IdString> ports2del_mult_acc = {ID(acc_fir), ID(dly_b)};
-
 	SigMap sigmap;
 
 	// ..........................................
@@ -67,6 +63,11 @@ struct QlDspIORegs : public Pass {
 
 	void ql_dsp_io_regs_pass(RTLIL::Module *module)
 	{
+		static const std::vector<IdString> ports2del_mult = {ID(load_acc), ID(subtract), ID(acc_fir), ID(dly_b),
+														ID(saturate_enable), ID(shift_right), ID(round)};
+		static const std::vector<IdString> ports2del_mult_acc = {ID(acc_fir), ID(dly_b)};
+
+
 		sigmap.set(module);
 
 		for (auto cell : module->cells()) {


### PR DESCRIPTION
Windows build is crashing on start, since registering of passes crashed. IdString can not be used as variable default values since order of initialization is not guaranteed, and MinGW compiler always doing it in different order than Clang.
Using `static` is not strictly necessary but makes sure to do this only once per run.
Have tried to make this with less changes as possible, but guess `m_` prefix for variables should be removed since they are local.
FYI doing init as part of constructor initialization does not help, since that is actually same moment of execution as previous code.