### PR TITLE
rtlil: Fix handling of connections on wire deletion

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -2157,12 +2157,10 @@ void RTLIL::Module::remove(const pool<RTLIL::Wire*> &wires)
 		}
 
 		void operator()(RTLIL::SigSpec &lhs, RTLIL::SigSpec &rhs) {
-			// When a deleted wire occurs on the lhs we can just remove that part
+			// If a deleted wire occurs on the lhs or rhs we just remove that part
 			// of the assignment
 			lhs.remove2(*wires_p, &rhs);
-
-			// Then replace all rhs occurrences with a dummy wire
-			(*this)(rhs);
+			rhs.remove2(*wires_p, &lhs);
 		}
 	};
 

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -924,6 +924,7 @@ public:
 	void remove(const pool<RTLIL::SigBit> &pattern, RTLIL::SigSpec *other) const;
 	void remove2(const pool<RTLIL::SigBit> &pattern, RTLIL::SigSpec *other);
 	void remove2(const std::set<RTLIL::SigBit> &pattern, RTLIL::SigSpec *other);
+	void remove2(const pool<RTLIL::Wire*> &pattern, RTLIL::SigSpec *other);
 
 	void remove(int offset, int length = 1);
 	void remove_const();

--- a/tests/various/bug4082.ys
+++ b/tests/various/bug4082.ys
@@ -1,0 +1,8 @@
+read_verilog <<EOF
+module top;
+  wire a;
+  wire b;
+  assign a = b;
+endmodule
+EOF
+delete w:a


### PR DESCRIPTION
Ought to fix #4082

The issue here is we replace removed wires in assignments with x-bits on both the LHS and RHS of the assignment. This triggers an assertion later on because we cannot assign to a constant.