### PR TITLE
read_blif: Represent sequential elements with gate cells

### DIFF
--- a/frontends/blif/blifparse.cc
+++ b/frontends/blif/blifparse.cc
@@ -352,17 +352,17 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 					goto no_latch_clock;
 
 				if (!strcmp(edge, "re"))
-					cell = module->addDff(NEW_ID, blif_wire(clock), blif_wire(d), blif_wire(q));
+					cell = module->addDffGate(NEW_ID, blif_wire(clock), blif_wire(d), blif_wire(q));
 				else if (!strcmp(edge, "fe"))
-					cell = module->addDff(NEW_ID, blif_wire(clock), blif_wire(d), blif_wire(q), false);
+					cell = module->addDffGate(NEW_ID, blif_wire(clock), blif_wire(d), blif_wire(q), false);
 				else if (!strcmp(edge, "ah"))
-					cell = module->addDlatch(NEW_ID, blif_wire(clock), blif_wire(d), blif_wire(q));
+					cell = module->addDlatchGate(NEW_ID, blif_wire(clock), blif_wire(d), blif_wire(q));
 				else if (!strcmp(edge, "al"))
-					cell = module->addDlatch(NEW_ID, blif_wire(clock), blif_wire(d), blif_wire(q), false);
+					cell = module->addDlatchGate(NEW_ID, blif_wire(clock), blif_wire(d), blif_wire(q), false);
 				else {
 			no_latch_clock:
 					if (dff_name.empty()) {
-						cell = module->addFf(NEW_ID, blif_wire(d), blif_wire(q));
+						cell = module->addFfGate(NEW_ID, blif_wire(d), blif_wire(q));
 					} else {
 						cell = module->addCell(NEW_ID, dff_name);
 						cell->setPort(ID::D, blif_wire(d));


### PR DESCRIPTION
When reading the BLIF input, represent the native sequential elements with fine-grained cells like `$_FF_` instead of the coarse-grained cells like `$ff` which we were using up to now.

There are two reasons for this:

 * The sequential elements in BLIF are always single-bit, so the gate cells are a better fit.

 * This makes it symmetrical to the BLIF backend which only understands the fine-grained cells, and only translates those to the native BLIF features.

Fix #4117.