### PR TITLE
CXXRTL: Allow capturing `$print` cell output

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -1079,7 +1079,10 @@ struct CxxrtlWorker {
 			f << indent << "};\n";
 			f << indent << "if (performer) {\n";
 			inc_indent();
-				f << indent << "performer->on_print(formatter(performer->time(), performer->realtime()));\n";
+				f << indent << "static const metadata_map attributes = ";
+				dump_metadata_map(cell->attributes);
+				f << ";\n";
+				f << indent << "performer->on_print(formatter(performer->time(), performer->realtime()), attributes);\n";
 			dec_indent();
 			f << indent << "} else {\n";
 			inc_indent();

--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -1072,9 +1072,12 @@ struct CxxrtlWorker {
 		dump_sigspec_rhs(cell->getPort(ID::EN));
 		f << " == value<1>{1u}) {\n";
 		inc_indent();
-			f << indent << print_output;
-			fmt.emit_cxxrtl(f, [this](const RTLIL::SigSpec &sig) { dump_sigspec_rhs(sig); });
-			f << ";\n";
+			f << indent << "auto formatter = [&](int64_t itime, double ftime) {\n";
+			inc_indent();
+				fmt.emit_cxxrtl(f, indent, [this](const RTLIL::SigSpec &sig) { dump_sigspec_rhs(sig); });
+			dec_indent();
+			f << indent << "};\n";
+			f << indent << print_output << " << formatter(steps, steps);\n";
 		dec_indent();
 		f << indent << "}\n";
 	}

--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -1077,7 +1077,7 @@ struct CxxrtlWorker {
 				fmt.emit_cxxrtl(f, indent, [this](const RTLIL::SigSpec &sig) { dump_sigspec_rhs(sig); });
 			dec_indent();
 			f << indent << "};\n";
-			f << indent << print_output << " << formatter(steps, steps);\n";
+			f << indent << print_output << " << formatter(0, 0.0);\n";
 		dec_indent();
 		f << indent << "}\n";
 	}

--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -1077,7 +1077,15 @@ struct CxxrtlWorker {
 				fmt.emit_cxxrtl(f, indent, [this](const RTLIL::SigSpec &sig) { dump_sigspec_rhs(sig); });
 			dec_indent();
 			f << indent << "};\n";
-			f << indent << print_output << " << formatter(0, 0.0);\n";
+			f << indent << "if (performer) {\n";
+			inc_indent();
+				f << indent << "performer->on_print(formatter(performer->time(), performer->realtime()));\n";
+			dec_indent();
+			f << indent << "} else {\n";
+			inc_indent();
+				f << indent << print_output << " << formatter(0, 0.0);\n";
+			dec_indent();
+			f << indent << "}\n";
 		dec_indent();
 		f << indent << "}\n";
 	}
@@ -1497,11 +1505,11 @@ struct CxxrtlWorker {
 			};
 			if (buffered_inputs) {
 				// If we have any buffered inputs, there's no chance of converging immediately.
-				f << indent << mangle(cell) << access << "eval();\n";
+				f << indent << mangle(cell) << access << "eval(performer);\n";
 				f << indent << "converged = false;\n";
 				assign_from_outputs(/*cell_converged=*/false);
 			} else {
-				f << indent << "if (" << mangle(cell) << access << "eval()) {\n";
+				f << indent << "if (" << mangle(cell) << access << "eval(performer)) {\n";
 				inc_indent();
 					assign_from_outputs(/*cell_converged=*/true);
 				dec_indent();
@@ -2384,7 +2392,8 @@ struct CxxrtlWorker {
 				dump_reset_method(module);
 				f << indent << "}\n";
 				f << "\n";
-				f << indent << "bool eval() override {\n";
+				// No default argument, to prevent unintentional `return bb_foo::eval();` calls that drop performer.
+				f << indent << "bool eval(performer *performer) override {\n";
 				dump_eval_method(module);
 				f << indent << "}\n";
 				f << "\n";
@@ -2481,7 +2490,7 @@ struct CxxrtlWorker {
 				f << "\n";
 				f << indent << "void reset() override;\n";
 				f << "\n";
-				f << indent << "bool eval() override;\n";
+				f << indent << "bool eval(performer *performer = nullptr) override;\n";
 				f << "\n";
 				f << indent << "template<class ObserverT>\n";
 				f << indent << "bool commit(ObserverT &observer) {\n";
@@ -2520,7 +2529,7 @@ struct CxxrtlWorker {
 		dump_reset_method(module);
 		f << indent << "}\n";
 		f << "\n";
-		f << indent << "bool " << mangle(module) << "::eval() {\n";
+		f << indent << "bool " << mangle(module) << "::eval(performer *performer) {\n";
 		dump_eval_method(module);
 		f << indent << "}\n";
 		if (debug_info) {
@@ -2544,7 +2553,6 @@ struct CxxrtlWorker {
 		RTLIL::Module *top_module = nullptr;
 		std::vector<RTLIL::Module*> modules;
 		TopoSort<RTLIL::Module*> topo_design;
-		bool has_prints = false;
 		for (auto module : design->modules()) {
 			if (!design->selected_module(module))
 				continue;
@@ -2557,8 +2565,6 @@ struct CxxrtlWorker {
 
 			topo_design.node(module);
 			for (auto cell : module->cells()) {
-				if (cell->type == ID($print))
-					has_prints = true;
 				if (is_internal_cell(cell->type) || is_cxxrtl_blackbox_cell(cell))
 					continue;
 				RTLIL::Module *cell_module = design->module(cell->type);
@@ -2617,8 +2623,6 @@ struct CxxrtlWorker {
 			f << "#include \"" << basename(intf_filename) << "\"\n";
 		else
 			f << "#include <cxxrtl/cxxrtl.h>\n";
-		if (has_prints)
-			f << "#include <iostream>\n";
 		f << "\n";
 		f << "#if defined(CXXRTL_INCLUDE_CAPI_IMPL) || \\\n";
 		f << "    defined(CXXRTL_INCLUDE_VCD_CAPI_IMPL)\n";
@@ -3296,7 +3300,7 @@ struct CxxrtlBackend : public Backend {
 		log("      value<8> p_i_data;\n");
 		log("      wire<8> p_o_data;\n");
 		log("\n");
-		log("      bool eval() override;\n");
+		log("      bool eval(performer *performer) override;\n");
 		log("      template<class ObserverT>\n");
 		log("      bool commit(ObserverT &observer);\n");
 		log("      bool commit() override;\n");
@@ -3311,11 +3315,11 @@ struct CxxrtlBackend : public Backend {
 		log("    namespace cxxrtl_design {\n");
 		log("\n");
 		log("    struct stderr_debug : public bb_p_debug {\n");
-		log("      bool eval() override {\n");
+		log("      bool eval(performer *performer) override {\n");
 		log("        if (posedge_p_clk() && p_en)\n");
 		log("          fprintf(stderr, \"debug: %%02x\\n\", p_i_data.data[0]);\n");
 		log("        p_o_data.next = p_i_data;\n");
-		log("        return bb_p_debug::eval();\n");
+		log("        return bb_p_debug::eval(performer);\n");
 		log("      }\n");
 		log("    };\n");
 		log("\n");
@@ -3416,7 +3420,7 @@ struct CxxrtlBackend : public Backend {
 		log("    -print-output <stream>\n");
 		log("        $print cells in the generated code direct their output to <stream>.\n");
 		log("        must be one of \"std::cout\", \"std::cerr\". if not specified,\n");
-		log("        \"std::cout\" is used.\n");
+		log("        \"std::cout\" is used. explicitly provided performer overrides this.\n");
 		log("\n");
 		log("    -nohierarchy\n");
 		log("        use design hierarchy as-is. in most designs, a top module should be\n");

--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -2391,7 +2391,7 @@ struct CxxrtlWorker {
 				f << indent << "}\n";
 				f << "\n";
 				f << indent << "bool commit() override {\n";
-				f << indent << indent << "null_observer observer;\n";
+				f << indent << indent << "observer observer;\n";
 				f << indent << indent << "return commit<>(observer);\n";
 				f << indent << "}\n";
 				if (debug_info) {
@@ -2486,7 +2486,7 @@ struct CxxrtlWorker {
 				f << indent << "}\n";
 				f << "\n";
 				f << indent << "bool commit() override {\n";
-				f << indent << indent << "null_observer observer;\n";
+				f << indent << indent << "observer observer;\n";
 				f << indent << indent << "return commit<>(observer);\n";
 				f << indent << "}\n";
 				if (debug_info) {

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -865,19 +865,12 @@ struct observer {
 	// Called when the `commit()` method for a wire is about to update the `chunks` chunks at `base` with `chunks` chunks
 	// at `value` that have a different bit pattern. It is guaranteed that `chunks` is equal to the wire chunk count and
 	// `base` points to the first chunk.
-	virtual void on_update(size_t chunks, const chunk_t *base, const chunk_t *value) = 0;
+	void on_update(size_t chunks, const chunk_t *base, const chunk_t *value) {}
 
 	// Called when the `commit()` method for a memory is about to update the `chunks` chunks at `&base[chunks * index]`
 	// with `chunks` chunks at `value` that have a different bit pattern. It is guaranteed that `chunks` is equal to
 	// the memory element chunk count and `base` points to the first chunk of the first element of the memory.
-	virtual void on_update(size_t chunks, const chunk_t *base, const chunk_t *value, size_t index) = 0;
-};
-
-// The `null_observer` class has the same interface as `observer`, but has no invocation overhead, since its methods
-// are final and have no implementation. This allows the observer feature to be zero-cost when not in use.
-struct null_observer final: observer {
-	void on_update(size_t chunks, const chunk_t *base, const chunk_t *value) override {}
-	void on_update(size_t chunks, const chunk_t *base, const chunk_t *value, size_t index) override {}
+	void on_update(size_t chunks, const chunk_t *base, const chunk_t *value, size_t index) {}
 };
 
 template<size_t Bits>
@@ -916,8 +909,7 @@ struct wire {
 
 	// This method intentionally takes a mandatory argument (to make it more difficult to misuse in
 	// black box implementations, leading to missed observer events). It is generic over its argument
-	// to make sure the `on_update` call is devirtualized. This is somewhat awkward but lets us keep
-	// a single implementation for both this method and the one in `memory`.
+	// to allow the `on_update` method to be non-virtual.
 	template<class ObserverT>
 	bool commit(ObserverT &observer) {
 		if (curr != next) {

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -892,33 +892,6 @@ struct fmt_part {
 	}
 };
 
-// An object that can be passed to a `eval()` method in order to act on side effects.
-struct performer {
-	// Called to evaluate a Verilog `$time` expression.
-	virtual int64_t time() const { return 0; }
-
-	// Called to evaluate a Verilog `$realtime` expression.
-	virtual double realtime() const { return time(); }
-
-	// Called when a `$print` cell is triggered.
-	virtual void on_print(const std::string &output) { std::cout << output; }
-};
-
-// An object that can be passed to a `commit()` method in order to produce a replay log of every state change in
-// the simulation. Unlike `performer`, `observer` does not use virtual calls as their overhead is unacceptable, and
-// a comparatively heavyweight template-based solution is justified.
-struct observer {
-	// Called when the `commit()` method for a wire is about to update the `chunks` chunks at `base` with `chunks` chunks
-	// at `value` that have a different bit pattern. It is guaranteed that `chunks` is equal to the wire chunk count and
-	// `base` points to the first chunk.
-	void on_update(size_t chunks, const chunk_t *base, const chunk_t *value) {}
-
-	// Called when the `commit()` method for a memory is about to update the `chunks` chunks at `&base[chunks * index]`
-	// with `chunks` chunks at `value` that have a different bit pattern. It is guaranteed that `chunks` is equal to
-	// the memory element chunk count and `base` points to the first chunk of the first element of the memory.
-	void on_update(size_t chunks, const chunk_t *base, const chunk_t *value, size_t index) {}
-};
-
 template<size_t Bits>
 struct wire {
 	static constexpr size_t bits = Bits;
@@ -1099,6 +1072,33 @@ struct metadata {
 };
 
 typedef std::map<std::string, metadata> metadata_map;
+
+// An object that can be passed to a `eval()` method in order to act on side effects.
+struct performer {
+	// Called to evaluate a Verilog `$time` expression.
+	virtual int64_t time() const { return 0; }
+
+	// Called to evaluate a Verilog `$realtime` expression.
+	virtual double realtime() const { return time(); }
+
+	// Called when a `$print` cell is triggered.
+	virtual void on_print(const std::string &output, const metadata_map &attributes) { std::cout << output; }
+};
+
+// An object that can be passed to a `commit()` method in order to produce a replay log of every state change in
+// the simulation. Unlike `performer`, `observer` does not use virtual calls as their overhead is unacceptable, and
+// a comparatively heavyweight template-based solution is justified.
+struct observer {
+	// Called when the `commit()` method for a wire is about to update the `chunks` chunks at `base` with `chunks` chunks
+	// at `value` that have a different bit pattern. It is guaranteed that `chunks` is equal to the wire chunk count and
+	// `base` points to the first chunk.
+	void on_update(size_t chunks, const chunk_t *base, const chunk_t *value) {}
+
+	// Called when the `commit()` method for a memory is about to update the `chunks` chunks at `&base[chunks * index]`
+	// with `chunks` chunks at `value` that have a different bit pattern. It is guaranteed that `chunks` is equal to
+	// the memory element chunk count and `base` points to the first chunk of the first element of the memory.
+	void on_update(size_t chunks, const chunk_t *base, const chunk_t *value, size_t index) {}
+};
 
 // Tag class to disambiguate values/wires and their aliases.
 struct debug_alias {};

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -1331,10 +1331,7 @@ struct module {
 	virtual bool eval() = 0;
 	virtual bool commit() = 0;
 
-	unsigned int steps = 0;
-
 	size_t step() {
-		++steps;
 		size_t deltas = 0;
 		bool converged = false;
 		do {

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl_replay.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl_replay.h
@@ -561,12 +561,12 @@ public:
 			spool::writer *writer;
 
 			CXXRTL_ALWAYS_INLINE
-			void on_commit(size_t chunks, const chunk_t *base, const chunk_t *value) override {
+			void on_update(size_t chunks, const chunk_t *base, const chunk_t *value) override {
 				writer->write_change(ident_lookup->at(base), chunks, value);
 			}
 
 			CXXRTL_ALWAYS_INLINE
-			void on_commit(size_t chunks, const chunk_t *base, const chunk_t *value, size_t index) override {
+			void on_update(size_t chunks, const chunk_t *base, const chunk_t *value, size_t index) override {
 				writer->write_change(ident_lookup->at(base), chunks, value, index);
 			}
 		} record_observer;

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl_replay.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl_replay.h
@@ -556,22 +556,20 @@ public:
 	bool record_incremental(ModuleT &module) {
 		assert(streaming);
 
-		struct : public observer {
+		struct {
 			std::unordered_map<const chunk_t*, spool::ident_t> *ident_lookup;
 			spool::writer *writer;
 
 			CXXRTL_ALWAYS_INLINE
-			void on_update(size_t chunks, const chunk_t *base, const chunk_t *value) override {
+			void on_update(size_t chunks, const chunk_t *base, const chunk_t *value) {
 				writer->write_change(ident_lookup->at(base), chunks, value);
 			}
 
 			CXXRTL_ALWAYS_INLINE
-			void on_update(size_t chunks, const chunk_t *base, const chunk_t *value, size_t index) override {
+			void on_update(size_t chunks, const chunk_t *base, const chunk_t *value, size_t index) {
 				writer->write_change(ident_lookup->at(base), chunks, value, index);
 			}
-		} record_observer;
-		record_observer.ident_lookup = &ident_lookup;
-		record_observer.writer = &writer;
+		} record_observer = { &ident_lookup, &writer };
 
 		writer.write_sample(/*incremental=*/true, pointer++, timestamp);
 		for (auto input_index : inputs) {

--- a/kernel/fmt.h
+++ b/kernel/fmt.h
@@ -50,6 +50,7 @@ struct VerilogFmtArg {
 
 // RTLIL format part, such as the substitutions in:
 //   "foo {4:> 4du} bar {2:<01hs}"
+// Must be kept in sync with `struct fmt_part` in backends/cxxrtl/runtime/cxxrtl/cxxrtl.h!
 struct FmtPart {
 	enum {
 		STRING  	= 0,
@@ -71,7 +72,7 @@ struct FmtPart {
 	} justify = RIGHT;
 	char padding = '\0';
 	size_t width = 0;
-	
+
 	// INTEGER type
 	unsigned base = 10;
 	bool signed_ = false;
@@ -93,7 +94,7 @@ public:
 	void parse_verilog(const std::vector<VerilogFmtArg> &args, bool sformat_like, int default_base, RTLIL::IdString task_name, RTLIL::IdString module_name);
 	std::vector<VerilogFmtArg> emit_verilog() const;
 
-	void emit_cxxrtl(std::ostream &f, std::function<void(const RTLIL::SigSpec &)> emit_sig) const;
+	void emit_cxxrtl(std::ostream &os, std::string indent, std::function<void(const RTLIL::SigSpec &)> emit_sig) const;
 
 	std::string render() const;
 

--- a/tests/fmt/always_full_tb.cc
+++ b/tests/fmt/always_full_tb.cc
@@ -2,8 +2,13 @@
 
 int main()
 {
+	struct : public performer {
+		int64_t time() const override { return 1; }
+		void on_print(const std::string &output, const cxxrtl::metadata_map &) override { std::cerr << output; }
+	} performer;
+
 	cxxrtl_design::p_always__full uut;
 	uut.p_clk.set(!uut.p_clk);
-	uut.step();
+	uut.step(&performer);
 	return 0;
 }


### PR DESCRIPTION
See individual commits for detailed explanation and rationale. Although there are a few changes that are strictly speaking breaking, I don't think any are controversial. I tried to keep backwards compatibility where it made sense, e.g. `-print-output` is preserved.