### PR TITLE
Issue a warning instead of a syntax error for blif delay constraints

### DIFF
--- a/frontends/blif/blifparse.cc
+++ b/frontends/blif/blifparse.cc
@@ -256,6 +256,16 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 				continue;
 			}
 
+			if (!strcmp(cmd, ".area") || !strcmp(cmd, ".delay") || !strcmp(cmd, ".wire_load_slope") || !strcmp(cmd, ".wire") ||
+			    !strcmp(cmd, ".input_arrival") || !strcmp(cmd, ".default_input_arrival") || !strcmp(cmd, ".output_required") ||
+			    !strcmp(cmd, ".default_output_required") || !strcmp(cmd, ".input_drive") || !strcmp(cmd, ".default_input_drive") ||
+			    !strcmp(cmd, ".max_input_load") || !strcmp(cmd, ".default_max_input_load") || !strcmp(cmd, ".output_load") ||
+			    !strcmp(cmd, ".default_output_load"))
+			{
+				log_warning("Blif delay constraints (%s) are not supported.", cmd);
+				continue;
+			}
+
 			if (!strcmp(cmd, ".inputs") || !strcmp(cmd, ".outputs"))
 			{
 				char *p;


### PR DESCRIPTION
Fix issue #4152 