### PR TITLE
peepopt: handle offset too large in `shiftadd`

### DIFF
--- a/passes/pmgen/peepopt_shiftadd.pmg
+++ b/passes/pmgen/peepopt_shiftadd.pmg
@@ -103,8 +103,18 @@ code
 		new_a.append(old_a);
 	} else {
 		// data >> (...+c) transformed to data[MAX:c] >> (...)
-		new_a.append(old_a.extract_end(offset));
+		if(offset < GetSize(old_a)) // some signal bits left?
+			new_a.append(old_a.extract_end(offset));
+		else {
+			if(shift->type.in($shiftx))
+				log_warning("at %s: result of indexed part-selection is always constant (selecting from '%s' with index '%s + %d')\n", \
+							shift->get_src_attribute().c_str(), log_signal(old_a), log_signal(var_signal), offset);
+			else
+				log_warning("at %s: result of shift operation is always constant (shifting '%s' by '%s + %d'-bits)\n", \
+							shift->get_src_attribute().c_str(), log_signal(old_a), log_signal(var_signal), offset);
+		}
 
+		// is it fine to leave new_a empty? (size 0)
 	}
 
 	SigSpec new_b = {var_signal, SigSpec(State::S0, log2scale)};

--- a/passes/pmgen/peepopt_shiftadd.pmg
+++ b/passes/pmgen/peepopt_shiftadd.pmg
@@ -103,15 +103,19 @@ code
 		new_a.append(old_a);
 	} else {
 		// data >> (...+c) transformed to data[MAX:c] >> (...)
-		if(offset < GetSize(old_a)) // some signal bits left?
+		if(offset < GetSize(old_a)) { // some signal bits left?
 			new_a.append(old_a.extract_end(offset));
-		else {
+		} else {
+			// warn user in case data is empty (no bits left)
+			std::string location = shift->get_src_attribute();
+			if (location.empty())
+				location = shift->name.str();
 			if(shift->type.in($shiftx))
 				log_warning("at %s: result of indexed part-selection is always constant (selecting from '%s' with index '%s + %d')\n", \
-							shift->get_src_attribute().c_str(), log_signal(old_a), log_signal(var_signal), offset);
+							location.c_str(), log_signal(old_a), log_signal(var_signal), offset);
 			else
 				log_warning("at %s: result of shift operation is always constant (shifting '%s' by '%s + %d'-bits)\n", \
-							shift->get_src_attribute().c_str(), log_signal(old_a), log_signal(var_signal), offset);
+							location.c_str(), log_signal(old_a), log_signal(var_signal), offset);
 		}
 	}
 

--- a/passes/pmgen/peepopt_shiftadd.pmg
+++ b/passes/pmgen/peepopt_shiftadd.pmg
@@ -113,8 +113,6 @@ code
 				log_warning("at %s: result of shift operation is always constant (shifting '%s' by '%s + %d'-bits)\n", \
 							shift->get_src_attribute().c_str(), log_signal(old_a), log_signal(var_signal), offset);
 		}
-
-		// is it fine to leave new_a empty? (size 0)
 	}
 
 	SigSpec new_b = {var_signal, SigSpec(State::S0, log2scale)};


### PR DESCRIPTION
Fixes #4160 

If the offset is larger than the signal itself, meaning the signal is completely shifted out,
it tried to extract a negative amount of bits from the old signal.

This RTL pattern is suspicious since it is a complicated way of arriving at a constant value, so we warn the user.