### PR TITLE
Update workflows to Node.js 20

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,10 +14,10 @@ jobs:
       run: sudo apt-get install bison flex libreadline-dev tcl-dev libffi-dev
 
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: cpp
         queries: security-extended,security-and-quality
@@ -26,4 +26,4 @@ jobs:
       run: make yosys -j6
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/emcc.yml
+++ b/.github/workflows/emcc.yml
@@ -6,13 +6,13 @@ jobs:
   emcc:
     runs-on: ubuntu-latest
     steps:
-      - uses: mymindstorm/setup-emsdk@v11
-      - uses: actions/checkout@v3
+      - uses: mymindstorm/setup-emsdk@v14
+      - uses: actions/checkout@v4
       - name: Build
         run: |
           make config-emcc
           make YOSYS_VER=latest
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: yosysjs
           path: yosysjs-latest.zip

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -79,7 +79,7 @@ jobs:
           $CXX --version
 
       - name: Checkout Yosys
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get iverilog
         shell: bash
@@ -91,7 +91,7 @@ jobs:
 
       - name: Cache iverilog
         id: cache-iverilog
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .local/
           key: ${{ matrix.os.id }}-${{ env.IVERILOG_GIT }}

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -35,7 +35,7 @@ jobs:
           cc --version
 
       - name: Checkout Yosys
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get iverilog
         shell: bash
@@ -47,7 +47,7 @@ jobs:
 
       - name: Cache iverilog
         id: cache-iverilog
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .local/
           key: ${{ matrix.os.id }}-${{ env.IVERILOG_GIT }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Take last commit

--- a/.github/workflows/vs.yml
+++ b/.github/workflows/vs.yml
@@ -6,10 +6,10 @@ jobs:
   yosys-vcxsrc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build
         run: make vcxsrc YOSYS_VER=latest
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: vcxsrc
           path: yosys-win32-vcxsrc-latest.zip
@@ -18,7 +18,7 @@ jobs:
     runs-on: windows-2019
     needs: yosys-vcxsrc
     steps:  
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: vcxsrc
           path: .

--- a/.github/workflows/wasi.yml
+++ b/.github/workflows/wasi.yml
@@ -6,7 +6,7 @@ jobs:
   wasi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build
         run: |
           WASI_SDK=wasi-sdk-19.0


### PR DESCRIPTION
Node.js 16 actions are deprecated.  For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.