### PR TITLE
gowin: Change BYTE ENABLE handling.

### DIFF
--- a/techlibs/gowin/brams.txt
+++ b/techlibs/gowin/brams.txt
@@ -1,13 +1,11 @@
 ram block $__GOWIN_SP_ {
 	abits 14;
 	widths 1 2 4 9 18 36 per_port;
-	byte 9;
 	cost 128;
 	init no_undef;
 	port srsw "A" {
 		clock posedge;
 		clken;
-		wrbe_separate;
 		option "RESET_MODE" "SYNC" {
 			rdsrst zero ungated;
 		}
@@ -30,13 +28,11 @@ ram block $__GOWIN_SP_ {
 ram block $__GOWIN_DP_ {
 	abits 14;
 	widths 1 2 4 9 18 per_port;
-	byte 9;
 	cost 128;
 	init no_undef;
 	port srsw "A" "B" {
 		clock posedge;
 		clken;
-		wrbe_separate;
 		option "RESET_MODE" "SYNC" {
 			rdsrst zero ungated;
 		}
@@ -59,7 +55,6 @@ ram block $__GOWIN_DP_ {
 ram block $__GOWIN_SDP_ {
 	abits 14;
 	widths 1 2 4 9 18 36 per_port;
-	byte 9;
 	cost 128;
 	init no_undef;
 	port sr "R" {
@@ -76,6 +71,5 @@ ram block $__GOWIN_SDP_ {
 	port sw "W" {
 		clock posedge;
 		clken;
-		wrbe_separate;
 	}
 }

--- a/techlibs/gowin/brams_map.v
+++ b/techlibs/gowin/brams_map.v
@@ -14,8 +14,7 @@
 `define x8_width(width) (width / 9 * 8 + width % 9)
 `define x8_rd_data(data) {1'bx, data[31:24], 1'bx, data[23:16], 1'bx, data[15:8], 1'bx, data[7:0]}
 `define x8_wr_data(data) {data[34:27], data[25:18], data[16:9], data[7:0]}
-`define wre(width, wr_en, wr_be) (width < 18 ? wr_en | wr_be[0] : wr_en)
-`define addrbe(width, addr, wr_be) (width < 18 ? addr : {addr[13:4], wr_be})
+`define addrbe_always(width, addr) (width < 18 ? addr :  width == 18 ? {addr[13:4], 4'b0011} : {addr[13:5], 5'b01111})
 
 
 `define INIT(func) \
@@ -90,7 +89,6 @@ parameter INIT = 0;
 parameter OPTION_RESET_MODE = "SYNC";
 
 parameter PORT_A_WIDTH = 36;
-parameter PORT_A_WR_BE_WIDTH = 4;
 parameter PORT_A_OPTION_WRITE_MODE = 0;
 
 input PORT_A_CLK;
@@ -99,15 +97,13 @@ input PORT_A_WR_EN;
 input PORT_A_RD_SRST;
 input PORT_A_RD_ARST;
 input [13:0] PORT_A_ADDR;
-input [PORT_A_WR_BE_WIDTH-1:0] PORT_A_WR_BE;
 input [PORT_A_WIDTH-1:0] PORT_A_WR_DATA;
 output [PORT_A_WIDTH-1:0] PORT_A_RD_DATA;
 
 `DEF_FUNCS
 
 wire RST = OPTION_RESET_MODE == "SYNC" ? PORT_A_RD_SRST : PORT_A_RD_ARST;
-wire WRE = `wre(PORT_A_WIDTH, PORT_A_WR_EN, PORT_A_WR_BE);
-wire [13:0] AD = `addrbe(PORT_A_WIDTH, PORT_A_ADDR, PORT_A_WR_BE);
+wire [13:0] AD = `addrbe_always(PORT_A_WIDTH, PORT_A_ADDR);
 
 generate
 
@@ -129,7 +125,7 @@ if (PORT_A_WIDTH < 9) begin
 		.BLKSEL(3'b000),
 		.CLK(PORT_A_CLK),
 		.CE(PORT_A_CLK_EN),
-		.WRE(WRE),
+		.WRE(PORT_A_WR_EN),
 		.RESET(RST),
 		.OCE(1'b1),
 		.AD(AD),
@@ -155,7 +151,7 @@ end else begin
 		.BLKSEL(3'b000),
 		.CLK(PORT_A_CLK),
 		.CE(PORT_A_CLK_EN),
-		.WRE(WRE),
+		.WRE(PORT_A_WR_EN),
 		.RESET(RST),
 		.OCE(1'b1),
 		.AD(AD),
@@ -176,11 +172,9 @@ parameter INIT = 0;
 parameter OPTION_RESET_MODE = "SYNC";
 
 parameter PORT_A_WIDTH = 18;
-parameter PORT_A_WR_BE_WIDTH = 2;
 parameter PORT_A_OPTION_WRITE_MODE = 0;
 
 parameter PORT_B_WIDTH = 18;
-parameter PORT_B_WR_BE_WIDTH = 2;
 parameter PORT_B_OPTION_WRITE_MODE = 0;
 
 input PORT_A_CLK;
@@ -189,7 +183,6 @@ input PORT_A_WR_EN;
 input PORT_A_RD_SRST;
 input PORT_A_RD_ARST;
 input [13:0] PORT_A_ADDR;
-input [PORT_A_WR_BE_WIDTH-1:0] PORT_A_WR_BE;
 input [PORT_A_WIDTH-1:0] PORT_A_WR_DATA;
 output [PORT_A_WIDTH-1:0] PORT_A_RD_DATA;
 
@@ -199,7 +192,6 @@ input PORT_B_WR_EN;
 input PORT_B_RD_SRST;
 input PORT_B_RD_ARST;
 input [13:0] PORT_B_ADDR;
-input [PORT_A_WR_BE_WIDTH-1:0] PORT_B_WR_BE;
 input [PORT_A_WIDTH-1:0] PORT_B_WR_DATA;
 output [PORT_A_WIDTH-1:0] PORT_B_RD_DATA;
 
@@ -207,10 +199,8 @@ output [PORT_A_WIDTH-1:0] PORT_B_RD_DATA;
 
 wire RSTA = OPTION_RESET_MODE == "SYNC" ? PORT_A_RD_SRST : PORT_A_RD_ARST;
 wire RSTB = OPTION_RESET_MODE == "SYNC" ? PORT_B_RD_SRST : PORT_B_RD_ARST;
-wire WREA = `wre(PORT_A_WIDTH, PORT_A_WR_EN, PORT_A_WR_BE);
-wire WREB = `wre(PORT_B_WIDTH, PORT_B_WR_EN, PORT_B_WR_BE);
-wire [13:0] ADA = `addrbe(PORT_A_WIDTH, PORT_A_ADDR, PORT_A_WR_BE);
-wire [13:0] ADB = `addrbe(PORT_B_WIDTH, PORT_B_ADDR, PORT_B_WR_BE);
+wire [13:0] ADA = `addrbe_always(PORT_A_WIDTH, PORT_A_ADDR);
+wire [13:0] ADB = `addrbe_always(PORT_B_WIDTH, PORT_B_ADDR);
 
 generate
 
@@ -241,7 +231,7 @@ if (PORT_A_WIDTH < 9 || PORT_B_WIDTH < 9) begin
 
 		.CLKA(PORT_A_CLK),
 		.CEA(PORT_A_CLK_EN),
-		.WREA(WREA),
+		.WREA(PORT_A_WR_EN),
 		.RESETA(RSTA),
 		.OCEA(1'b1),
 		.ADA(ADA),
@@ -250,7 +240,7 @@ if (PORT_A_WIDTH < 9 || PORT_B_WIDTH < 9) begin
 
 		.CLKB(PORT_B_CLK),
 		.CEB(PORT_B_CLK_EN),
-		.WREB(WREB),
+		.WREB(PORT_B_WR_EN),
 		.RESETB(RSTB),
 		.OCEB(1'b1),
 		.ADB(ADB),
@@ -285,7 +275,7 @@ end else begin
 
 		.CLKA(PORT_A_CLK),
 		.CEA(PORT_A_CLK_EN),
-		.WREA(WREA),
+		.WREA(PORT_A_WR_EN),
 		.RESETA(RSTA),
 		.OCEA(1'b1),
 		.ADA(ADA),
@@ -294,7 +284,7 @@ end else begin
 
 		.CLKB(PORT_B_CLK),
 		.CEB(PORT_B_CLK_EN),
-		.WREB(WREB),
+		.WREB(PORT_B_WR_EN),
 		.RESETB(RSTB),
 		.OCEB(1'b1),
 		.ADB(ADB),
@@ -315,9 +305,7 @@ parameter INIT = 0;
 parameter OPTION_RESET_MODE = "SYNC";
 
 parameter PORT_R_WIDTH = 18;
-
 parameter PORT_W_WIDTH = 18;
-parameter PORT_W_WR_BE_WIDTH = 2;
 
 input PORT_R_CLK;
 input PORT_R_CLK_EN;
@@ -330,14 +318,12 @@ input PORT_W_CLK;
 input PORT_W_CLK_EN;
 input PORT_W_WR_EN;
 input [13:0] PORT_W_ADDR;
-input [PORT_W_WR_BE_WIDTH-1:0] PORT_W_WR_BE;
 input [PORT_W_WIDTH-1:0] PORT_W_WR_DATA;
 
 `DEF_FUNCS
 
 wire RST = OPTION_RESET_MODE == "SYNC" ? PORT_R_RD_SRST : PORT_R_RD_ARST;
-wire WRE = `wre(PORT_W_WIDTH, PORT_W_WR_EN, PORT_W_WR_BE);
-wire [13:0] ADW = `addrbe(PORT_W_WIDTH, PORT_W_ADDR, PORT_W_WR_BE);
+wire [13:0] ADW = `addrbe_always(PORT_W_WIDTH, PORT_W_ADDR);
 
 generate
 


### PR DESCRIPTION
When inferring we allow writing to all bytes for now.

In the Gowin documentation for BSRAM 2019, the byte_enable port and its operation and use in generating IP with pictures were described in detail, two years later in the same document the byte_enable port was listed as supported only for the NS-2 family, and finally in the 2023 edition, all references to both the NS-2 family and the byte_enable port were removed.
I don’t know, maybe it turned out that they forgot the transistor there and it works unstable or something else, but at the moment I’m thinking of using only fixed values when inferring. You can use anything manually - after all, these are just lsb addresses.
