### PR TITLE
Improve `opt_merge` performance

### DIFF
--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -39,16 +39,19 @@ inline unsigned int mkhash_add(unsigned int a, unsigned int b) {
 }
 
 inline unsigned int mkhash_xorshift(unsigned int a) {
-	if (sizeof(a) == 4) {
-		a ^= a << 13;
-		a ^= a >> 17;
-		a ^= a << 5;
-	} else if (sizeof(a) == 8) {
-		a ^= a << 13;
-		a ^= a >> 7;
-		a ^= a << 17;
-	} else
-		throw std::runtime_error("mkhash_xorshift() only implemented for 32 bit and 64 bit ints");
+	a ^= a << 13;
+	a ^= a >> 17;
+	a ^= a << 5;
+	return a;
+}
+
+inline unsigned long long mkhash_xorshift64(unsigned long long a) {
+	a ^= a << 13;
+	a ^= a >> 17;
+	a ^= a << 5;
+	a ^= a << 13;
+	a ^= a >> 7;
+	a ^= a << 17;
 	return a;
 }
 

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -21,10 +21,17 @@
 
 namespace hashlib {
 
+#if __cplusplus >= 201603L
+#  define HASHLIB_NODISCARD [[nodiscard]]
+#else
+#  define HASHLIB_NODISCARD
+#endif
+
 const int hashtable_size_trigger = 2;
 const int hashtable_size_factor = 3;
 
 // The XOR version of DJB2
+HASHLIB_NODISCARD
 inline unsigned int mkhash(unsigned int a, unsigned int b) {
 	return ((a << 5) + a) ^ b;
 }
@@ -34,10 +41,12 @@ const unsigned int mkhash_init = 5381;
 
 // The ADD version of DJB2
 // (use this version for cache locality in b)
+HASHLIB_NODISCARD
 inline unsigned int mkhash_add(unsigned int a, unsigned int b) {
 	return ((a << 5) + a) + b;
 }
 
+HASHLIB_NODISCARD
 inline unsigned int mkhash_xorshift(unsigned int a) {
 	a ^= a << 13;
 	a ^= a >> 17;
@@ -45,6 +54,7 @@ inline unsigned int mkhash_xorshift(unsigned int a) {
 	return a;
 }
 
+HASHLIB_NODISCARD
 inline unsigned long long mkhash_xorshift64(unsigned long long a) {
 	a ^= a << 13;
 	a ^= a >> 17;

--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -188,6 +188,7 @@ using hashlib::mkhash;
 using hashlib::mkhash_init;
 using hashlib::mkhash_add;
 using hashlib::mkhash_xorshift;
+using hashlib::mkhash_xorshift64;
 using hashlib::hash_ops;
 using hashlib::hash_cstr_ops;
 using hashlib::hash_ptr_ops;

--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -105,7 +105,7 @@ struct OptMergeWorker
 			}
 			conn_hash = mkhash_xorshift64(a.hash()) + acc;
 		} else {
-			for (auto conn : cell->connections())
+			for (const auto &conn : cell->connections())
 			if (!cell->output(conn.first))
 				conn_hash += mkhash_xorshift64(mkhash(conn.first.hash(), assign_map(conn.second).hash()));
 
@@ -114,7 +114,7 @@ struct OptMergeWorker
 		}
 
 		uint64_t param_hash = 0;
-		for (auto &it : cell->parameters)
+		for (const auto &it : cell->parameters)
 			param_hash += mkhash_xorshift64(mkhash(it.first.hash(), it.second.hash()));
 
 		return conn_hash + mkhash_xorshift64(param_hash + cell->type.hash());

--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -223,14 +223,14 @@ struct OptMergeWorker
 		while (did_something)
 		{
 			std::vector<RTLIL::Cell*> cells;
-			cells.reserve(module->cells_.size());
-			for (auto &it : module->cells_) {
-				if (!design->selected(module, it.second))
+			cells.reserve(module->cells().size());
+			for (auto cell : module->cells()) {
+				if (!design->selected(module, cell))
 					continue;
-				if (mode_keepdc && has_dont_care_initval(it.second))
+				if (mode_keepdc && has_dont_care_initval(cell))
 					continue;
-				if (ct.cell_known(it.second->type) || (mode_share_all && it.second->known()))
-					cells.push_back(it.second);
+				if (ct.cell_known(cell->type) || (mode_share_all && cell->known()))
+					cells.push_back(cell);
 			}
 
 			did_something = false;

--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -227,6 +227,11 @@ struct OptMergeWorker
 			for (auto cell : module->cells()) {
 				if (!design->selected(module, cell))
 					continue;
+				if (cell->type.in(ID($meminit), ID($meminit_v2), ID($mem), ID($mem_v2))) {
+					// Ignore those for performance: meminit can have an excessively large port,
+					// mem can have an excessively large parameter holding the init data
+					continue;
+				}
 				if (mode_keepdc && has_dont_care_initval(cell))
 					continue;
 				if (ct.cell_known(cell->type) || (mode_share_all && cell->known()))


### PR DESCRIPTION
See the commits. This replaces the hashing implementation, and makes it ignore cells holding memory initialization data.

Ping @rmlarsen since they were interested in `opt_merge` performance before.