### PR TITLE
verific: Fixes incorrect aldff inference in verific importer

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -343,36 +343,46 @@ void VerificImporter::import_attributes(dict<RTLIL::IdString, RTLIL::Const> &att
 	}
 }
 
+RTLIL::SigBit VerificImporter::netToSigBit(Verific::Net *net) {
+	if (net && net->IsGnd())
+		return RTLIL::State::S0;
+	else if (net && net->IsPwr())
+		return RTLIL::State::S1;
+	else if (net && net->IsX())
+		return RTLIL::State::Sx;
+	else if (net)
+			return net_map_at(net);
+	else
+		return RTLIL::State::Sz;
+}
+
 RTLIL::SigSpec VerificImporter::operatorInput(Instance *inst)
 {
 	RTLIL::SigSpec sig;
-	for (int i = int(inst->InputSize())-1; i >= 0; i--)
-		if (inst->GetInputBit(i))
-			sig.append(net_map_at(inst->GetInputBit(i)));
-		else
-			sig.append(RTLIL::State::Sz);
+	for (int i = int(inst->InputSize())-1; i >= 0; i--) {
+		Net *net = inst->GetInputBit(i);
+		sig.append(netToSigBit(net));
+	}
 	return sig;
 }
 
 RTLIL::SigSpec VerificImporter::operatorInput1(Instance *inst)
 {
 	RTLIL::SigSpec sig;
-	for (int i = int(inst->Input1Size())-1; i >= 0; i--)
-		if (inst->GetInput1Bit(i))
-			sig.append(net_map_at(inst->GetInput1Bit(i)));
-		else
-			sig.append(RTLIL::State::Sz);
+	for (int i = int(inst->Input1Size())-1; i >= 0; i--) {
+		Net *net = inst->GetInput1Bit(i);
+		sig.append(netToSigBit(net));
+	}
 	return sig;
 }
 
 RTLIL::SigSpec VerificImporter::operatorInput2(Instance *inst)
 {
 	RTLIL::SigSpec sig;
-	for (int i = int(inst->Input2Size())-1; i >= 0; i--)
-		if (inst->GetInput2Bit(i))
-			sig.append(net_map_at(inst->GetInput2Bit(i)));
-		else
-			sig.append(RTLIL::State::Sz);
+	for (int i = int(inst->Input2Size())-1; i >= 0; i--) {
+		Net *net = inst->GetInput2Bit(i);
+		sig.append(netToSigBit(net));
+	}
 	return sig;
 }
 

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -351,7 +351,7 @@ RTLIL::SigBit VerificImporter::netToSigBit(Verific::Net *net) {
 	else if (net && net->IsX())
 		return RTLIL::State::Sx;
 	else if (net)
-			return net_map_at(net);
+		return net_map_at(net);
 	else
 		return RTLIL::State::Sz;
 }

--- a/frontends/verific/verific.h
+++ b/frontends/verific/verific.h
@@ -83,6 +83,7 @@ struct VerificImporter
 	RTLIL::IdString new_verific_id(Verific::DesignObj *obj);
 	void import_attributes(dict<RTLIL::IdString, RTLIL::Const> &attributes, Verific::DesignObj *obj, Verific::Netlist  *nl = nullptr);
 
+	RTLIL::SigBit netToSigBit(Verific::Net *net);
 	RTLIL::SigSpec operatorInput(Verific::Instance *inst);
 	RTLIL::SigSpec operatorInput1(Verific::Instance *inst);
 	RTLIL::SigSpec operatorInput2(Verific::Instance *inst);


### PR DESCRIPTION
The following SV module at HEAD imported with verific,

```systemverilog
    module my_module(
      input logic [4:0] a,
      input logic clk,
      input logic enable,
      output logic [4:0] z
    );

    reg [4:0] pipeline_register;
    always @(posedge clk) begin
      pipeline_register <= enable ? a : pipeline_register;
    end
    assign z = pipeline_register;

    endmodule : my_module

```

results in the following output verilog

```systemverilog
/* Generated by 0.36 */

(* top =  1  *)
(* hdlname = "my_module" *)
(* src = "/tmp/temp_directory_zTwd0l/my_input.v:2.12-2.21" *)
module my_module(clk, enable, a, z);
  wire [4:0] _0_;
  (* src = "/tmp/temp_directory_zTwd0l/my_input.v:3.25-3.26" *)
  input [4:0] a;
  wire [4:0] a;
  (* src = "/tmp/temp_directory_zTwd0l/my_input.v:4.19-4.22" *)
  input clk;
  wire clk;
  (* src = "/tmp/temp_directory_zTwd0l/my_input.v:5.19-5.25" *)
  input enable;
  wire enable;
  (* src = "/tmp/temp_directory_zTwd0l/my_input.v:6.26-6.27" *)
  output [4:0] z;
  wire [4:0] z;
  (* src = "/tmp/temp_directory_zTwd0l/my_input.v:10.12-12.8" *)
  \$aldff  #(
    .ALOAD_POLARITY(32'd1),
    .CLK_POLARITY(32'd1),
    .WIDTH(32'd5)
  ) _1_ (
    .AD(5'hxx),
    .ALOAD(1'h0),
    .CLK(clk),
    .D(_0_),
    .Q(z)
  );
  (* src = "/tmp/temp_directory_zTwd0l/my_input.v:11.28-11.58" *)
  \$mux  #(
    .WIDTH(32'd5)
  ) _2_ (
    .A(z),
    .B(a),
    .S(enable),
    .Y(_0_)
  );
endmodule
```

Yosys is incorrectly infering aldffs due to an incorrect conversion of logical 1 and 0 SigBits.

My PR unifies the conversion of Verific::Net objects into SigBits using Yosys' internal representation of special signals like 0,1,x,z. After my PR these signals are correctly converted into DFFs.