### PR TITLE
Use cell edges data in `check`, improve messages

### DIFF
--- a/kernel/celledges.cc
+++ b/kernel/celledges.cc
@@ -341,6 +341,18 @@ void memrd_op(AbstractCellEdgesDatabase *db, RTLIL::Cell *cell)
 			db->add_edge(cell, ID::ADDR, j, ID::DATA, k, -1);
 }
 
+void mem_op(AbstractCellEdgesDatabase *db, RTLIL::Cell *cell)
+{
+	if (cell->type == ID($mem_v2))
+		packed_mem_op(db, cell);
+	else if (cell->type.in(ID($memrd), ID($memrd_v2)))
+		memrd_op(db, cell);
+	else if (cell->type.in(ID($memwr), ID($memwr_v2), ID($meminit)))
+		return; /* no edges here */
+	else
+		log_abort();
+}
+
 PRIVATE_NAMESPACE_END
 
 bool YOSYS_NAMESPACE_PREFIX AbstractCellEdgesDatabase::add_edges_from_cell(RTLIL::Cell *cell)
@@ -395,13 +407,8 @@ bool YOSYS_NAMESPACE_PREFIX AbstractCellEdgesDatabase::add_edges_from_cell(RTLIL
 		return true;
 	}
 
-	if (cell->type == ID($mem_v2)) {
-		packed_mem_op(this, cell);
-		return true;
-	}
-
-	if (cell->type.in(ID($memrd), ID($memrd_v2))) {
-		memrd_op(this, cell);
+	if (cell->type.in(ID($mem_v2), ID($memrd), ID($memrd_v2), ID($memwr), ID($memwr_v2), ID($meminit))) {
+		mem_op(this, cell);
 		return true;
 	}
 

--- a/kernel/utils.h
+++ b/kernel/utils.h
@@ -149,7 +149,7 @@ template <typename T, typename C = std::less<T>, typename OPS = hash_ops<T>> cla
 	std::map<T, int, C> node_to_index;
 	std::vector<std::set<int, IndirectCmp>> edges;
 	std::vector<T> sorted;
-	std::set<std::set<T, C>> loops;
+	std::set<std::vector<T>> loops;
 
 	TopoSort() : indirect_cmp(nodes)
 	{
@@ -220,10 +220,10 @@ template <typename T, typename C = std::less<T>, typename OPS = hash_ops<T>> cla
 		if (active_cells[root_index]) {
 			found_loops = true;
 			if (analyze_loops) {
-				std::set<T, C> loop;
+				std::vector<T> loop;
 				for (int i = GetSize(active_stack) - 1; i >= 0; i--) {
 					const int index = active_stack[i];
-					loop.insert(nodes[index]);
+					loop.push_back(nodes[index]);
 					if (index == root_index)
 						break;
 				}

--- a/passes/cmds/check.cc
+++ b/passes/cmds/check.cc
@@ -224,7 +224,8 @@ struct CheckPass : public Pass {
 					}
 				}
 
-				if (yosys_celltypes.cell_evaluable(cell->type) || cell->type.in(ID($mem_v2), ID($memrd), ID($memrd_v2)))
+				if (yosys_celltypes.cell_evaluable(cell->type) || cell->type.in(ID($mem_v2), ID($memrd), ID($memrd_v2)) \
+						|| RTLIL::builtin_ff_cell_types().count(cell->type))
 					edges_db.add_edges_from_cell(cell);
 			}
 

--- a/passes/cmds/check.cc
+++ b/passes/cmds/check.cc
@@ -220,7 +220,7 @@ struct CheckPass : public Pass {
 					}
 				}
 
-				if (yosys_celltypes.cell_evaluable(cell->type))
+				if (yosys_celltypes.cell_evaluable(cell->type) || cell->type.in(ID($mem_v2), ID($memrd), ID($memrd_v2)))
 					edges_db.add_edges_from_cell(cell);
 			}
 

--- a/passes/cmds/check.cc
+++ b/passes/cmds/check.cc
@@ -338,12 +338,15 @@ struct CheckPass : public Pass {
 					MatchingEdgePrinter printer(message, sigmap, prev, bit);
 					printer.add_edges_from_cell(driver);
 
-					std::string wire_src;
-					if (wire->has_attribute(ID::src)) {
-						std::string src_attr = wire->get_src_attribute();
-						wire_src = stringf(" source: %s", src_attr.c_str());
+					if (wire->name.isPublic()) {
+						std::string wire_src;
+						if (wire->has_attribute(ID::src)) {
+							std::string src_attr = wire->get_src_attribute();
+							wire_src = stringf(" source: %s", src_attr.c_str());
+						}
+						message += stringf("    wire %s%s\n", log_signal(SigBit(wire, pair.second)), wire_src.c_str());						
 					}
-					message += stringf("    wire %s%s\n", log_signal(SigBit(wire, pair.second)), wire_src.c_str());
+
 					prev = bit;
 				}
 				log_warning("%s", message.c_str());

--- a/passes/cmds/check.cc
+++ b/passes/cmds/check.cc
@@ -104,8 +104,7 @@ struct CheckPass : public Pass {
 			dict<SigBit, vector<string>> wire_drivers;
 			dict<SigBit, int> wire_drivers_count;
 			pool<SigBit> used_wires;
-			TopoSort<string> topo;
-
+			TopoSort<std::pair<RTLIL::IdString, int>> topo;
 			for (auto &proc_it : module->processes)
 			{
 				std::vector<RTLIL::CaseRule*> all_cases = {&proc_it.second->root_case};
@@ -164,16 +163,16 @@ struct CheckPass : public Pass {
 					if (cell->input(conn.first))
 						for (auto bit : sig)
 							if (bit.wire) {
-								if (logic_cell)
-									topo.edge(stringf("wire %s", log_signal(bit)),
-											stringf("cell %s (%s)", log_id(cell), log_id(cell->type)));
+								if (logic_cell && bit.wire)
+									topo.edge(std::make_pair(bit.wire->name, bit.offset),
+											std::make_pair(cell->name, -1));
 								used_wires.insert(bit);
 							}
 					if (cell->output(conn.first))
 						for (int i = 0; i < GetSize(sig); i++) {
-							if (logic_cell)
-								topo.edge(stringf("cell %s (%s)", log_id(cell), log_id(cell->type)),
-										stringf("wire %s", log_signal(sig[i])));
+							if (logic_cell && sig[i].wire)
+								topo.edge(std::make_pair(cell->name, -1),
+										std::make_pair(sig[i].wire->name, sig[i].offset));
 
 							if (sig[i].wire || !cell->input(conn.first))
 								wire_drivers[sig[i]].push_back(stringf("port %s[%d] of cell %s (%s)",
@@ -239,8 +238,28 @@ struct CheckPass : public Pass {
 			topo.sort();
 			for (auto &loop : topo.loops) {
 				string message = stringf("found logic loop in module %s:\n", log_id(module));
-				for (auto &str : loop)
-					message += stringf("    %s\n", str.c_str());
+				for (auto &pair : loop) {
+					RTLIL::AttrObject *obj;
+					if (pair.second == -1)
+						obj = module->cell(pair.first);
+					else
+						obj = module->wire(pair.first);
+					log_assert(obj);
+					std::string src;
+					if (obj->has_attribute(ID::src)) {
+						std::string src_attr = obj->get_src_attribute();
+						src = stringf(" source: %s", src_attr.c_str());
+					}
+					if (pair.second == -1) {
+						Cell *cell = module->cell(pair.first);
+						log_assert(cell);
+						message += stringf("    cell %s (%s)%s\n", log_id(cell), log_id(cell->type), src.c_str());
+					} else {
+						Wire *wire = module->wire(pair.first);
+						log_assert(wire);
+						message += stringf("    wire %s%s\n", log_signal(SigBit(wire, pair.second)), src.c_str());
+					}
+				}
 				log_warning("%s", message.c_str());
 				counter++;
 			}

--- a/passes/cmds/check.cc
+++ b/passes/cmds/check.cc
@@ -160,8 +160,12 @@ struct CheckPass : public Pass {
 
 				void add_edge(RTLIL::Cell *cell, RTLIL::IdString from_port, int from_bit,
 							  RTLIL::IdString to_port, int to_bit, int) override {
-					SigBit from = sigmap(cell->getPort(from_port))[from_bit];
-					SigBit to = sigmap(cell->getPort(to_port))[to_bit];
+					SigSpec from_portsig = cell->getPort(from_port);
+					SigSpec to_portsig = cell->getPort(to_port);
+					log_assert(from_bit >= 0 && from_bit < from_portsig.size());
+					log_assert(to_bit >= 0 && to_bit < to_portsig.size());
+					SigBit from = sigmap(from_portsig[from_bit]);
+					SigBit to = sigmap(to_portsig[to_bit]);
 
 					if (from.wire && to.wire)
 						topo.edge(std::make_pair(from.wire->name, from.offset), std::make_pair(to.wire->name, to.offset));

--- a/tests/opt/opt_dff_qd.ys
+++ b/tests/opt/opt_dff_qd.ys
@@ -7,7 +7,7 @@ module top(...);
 input CLK;
 input EN;
 (* init = 24'h555555 *)
-output [19:0] Q;
+output [17:0] Q;
 input SRST;
 input ARST;
 input [1:0] CLR;
@@ -23,26 +23,20 @@ $sdffce #(.CLK_POLARITY(1'b1), .EN_POLARITY(1'b1), .SRST_POLARITY(1'b1), .SRST_V
 $dffsr #(.CLK_POLARITY(1'b1), .CLR_POLARITY(1'b1), .SET_POLARITY(1'b0), .WIDTH(2)) ff7 (.CLK(CLK), .SET(SET), .CLR(CLR), .D(Q[15:14]), .Q(Q[15:14]));
 $dffsre #(.CLK_POLARITY(1'b1), .EN_POLARITY(1'b0), .CLR_POLARITY(1'b1), .SET_POLARITY(1'b0), .WIDTH(2)) ff8 (.CLK(CLK), .EN(EN), .SET(SET), .CLR(CLR), .D(Q[17:16]), .Q(Q[17:16]));
 
-$dlatch #(.EN_POLARITY(1'b1), .WIDTH(2)) ff9 (.EN(EN), .D(Q[19:18]), .Q(Q[19:18]));
-$adlatch #(.EN_POLARITY(1'b0), .ARST_POLARITY(1'b1), .ARST_VALUE(2'h2), .WIDTH(2)) ff10 (.EN(EN), .ARST(ARST), .D(Q[21:20]), .Q(Q[21:20]));
-$dlatchsr #(.EN_POLARITY(1'b0), .CLR_POLARITY(1'b1), .SET_POLARITY(1'b0), .WIDTH(2)) ff11 (.EN(EN), .SET(SET), .CLR(CLR), .D(Q[23:22]), .Q(Q[23:22]));
-
 endmodule
 
 EOT
 
 design -save orig
 
-# Equivalence check will fail for unmapped adlatch and dlatchsr due to negative hold hack.
-delete top/ff10 top/ff11
 equiv_opt -undef -assert -multiclock opt_dff -keepdc
 
 design -load orig
 opt_dff -keepdc
 select -assert-count 1 t:$and
 select -assert-count 3 t:$dffe
-select -assert-count 3 t:$dlatch
-select -assert-count 3 t:$sr
+select -assert-count 2 t:$dlatch
+select -assert-count 2 t:$sr
 select -assert-none t:$and t:$dffe t:$dlatch t:$sr %% %n t:* %i
 
 design -load orig
@@ -50,7 +44,7 @@ simplemap
 opt_dff -keepdc
 select -assert-count 2 t:$_AND_
 select -assert-count 6 t:$_DFFE_??_
-select -assert-count 6 t:$_DLATCH_?_
-select -assert-count 6 t:$_SR_??_
+select -assert-count 4 t:$_DLATCH_?_
+select -assert-count 4 t:$_SR_??_
 select -assert-none t:$_AND_ t:$_DFFE_??_ t:$_DLATCH_?_ t:$_SR_??_ %% %n t:* %i
 

--- a/tests/various/check.ys
+++ b/tests/various/check.ys
@@ -1,0 +1,12 @@
+design -reset
+read_verilog <<EOF
+module top(input clk, input a, input b, output [9:0] x);
+	wire [9:0] ripple;
+	reg [9:0] prev_ripple = 9'b0;
+
+	always @(posedge clk) prev_ripple <= ripple;
+	assign ripple = {ripple[8:0], a} ^ prev_ripple; // only cyclic at the coarse-grain level
+	assign x = ripple[9] + b;
+endmodule
+EOF
+check -assert

--- a/tests/various/check.ys
+++ b/tests/various/check.ys
@@ -1,5 +1,5 @@
 design -reset
-read_verilog <<EOF
+read -vlog2k <<EOF
 module top(input clk, input a, input b, output [9:0] x);
 	wire [9:0] ripple;
 	reg [9:0] prev_ripple = 9'b0;
@@ -9,4 +9,35 @@ module top(input clk, input a, input b, output [9:0] x);
 	assign x = ripple[9] + b;
 endmodule
 EOF
+hierarchy -top top
+prep
+check -assert
+
+design -reset
+read -vlog2k <<EOF
+module top(clk, y, sideread_addr, sideread_data);
+	input wire clk;
+
+	reg [7:0] mem [255:0];
+	reg [8:0] i;
+	initial begin
+		for (i = 0; i < 256; i = i + 1)
+			mem[i] = i * 371;
+	end
+
+	output reg [7:0] y = 1;
+	always @(posedge clk)
+		y <= mem[y];
+
+	input wire [7:0] sideread_addr;
+	output wire [7:0] sideread_data;
+	assign sideread_data = mem[sideread_addr];
+endmodule
+EOF
+hierarchy -top top
+prep -rdff
+select -assert-count 1 t:$mem_v2
+check -assert
+memory_unpack
+select -assert-count 2 t:$memrd_v2
 check -assert

--- a/tests/various/check_2.ys
+++ b/tests/various/check_2.ys
@@ -1,0 +1,17 @@
+# just so slightly adjust the example from check.ys to induce a loop
+design -reset
+read -vlog2k <<EOF
+module top(input clk, input a, input b, output [9:0] x);
+	wire [9:0] ripple;
+	reg [9:0] prev_ripple = 9'b0;
+
+	always @(posedge clk) prev_ripple <= ripple;
+	assign ripple = {ripple[8:1], a, ripple[0]} ^ prev_ripple;
+	assign x = ripple[9] + b;
+endmodule
+EOF
+hierarchy -top top
+prep
+logger -expect warning "found logic loop in module top:" 1
+logger -expect error "Found 1 problems in 'check -assert'" 1
+check -assert

--- a/tests/various/check_3.ys
+++ b/tests/various/check_3.ys
@@ -1,0 +1,20 @@
+# loop involving asynchronous memory ports
+design -reset
+read -vlog2k <<EOF
+module pingpong(input wire [1:0] x, output wire [3:0] y1, output wire [3:0] y2);
+	reg [3:0] mem [15:0];
+	reg [5:0] i;
+	initial begin
+		for (i = 0; i < 16; i = i + 1)
+			mem[i] = i * 371;
+	end
+
+	assign y1 = mem[{y2[3:2], x}];
+	assign y2 = mem[y1];
+endmodule
+EOF
+hierarchy -top pingpong
+prep
+logger -nowarn "found logic loop in module pingpong:"
+logger -expect error "Found \d+ problems in 'check -assert'" 1
+check -assert

--- a/tests/various/check_3.ys
+++ b/tests/various/check_3.ys
@@ -16,5 +16,5 @@ EOF
 hierarchy -top pingpong
 prep
 logger -nowarn "found logic loop in module pingpong:"
-logger -expect error "Found \d+ problems in 'check -assert'" 1
+logger -expect error "Found [0-9]+ problems in 'check -assert'" 1
 check -assert

--- a/tests/various/check_4.ys
+++ b/tests/various/check_4.ys
@@ -1,0 +1,29 @@
+# loop involving the asynchronous reset on a memory port
+design -reset
+read -vlog2k <<EOF
+module top(input wire clk, input wire [3:0] addr, output reg [3:0] data);
+	reg [3:0] mem [15:0];
+	reg [5:0] i;
+	initial begin
+		for (i = 0; i < 16; i = i + 1)
+			mem[i] = i * 371;
+	end
+
+	wire arst = !data[0];
+
+	always @(posedge arst, posedge clk) begin
+		if (arst)		
+			data <= 4'hx;
+		else
+			data <= mem[addr];
+	end
+endmodule
+EOF
+hierarchy -top top
+proc
+opt -keepdc
+memory_dff
+opt_clean
+logger -nowarn "found logic loop in module pingpong:"
+logger -expect error "Found [0-9]+ problems in 'check -assert'" 1
+check -assert


### PR DESCRIPTION
Partially obsoletes #4178.

Sample:
```
module top(y);
	output wire [7:0] y;
	wire f = ~y[0];
	assign y = &{f, 2'h0, {4{f}}, 1'h0};
endmodule
```
outputs
```
3. Executing CHECK pass (checking for obvious problems).
Checking module top...
Warning: found logic loop in module top:
    cell $not$loop_test.v:3$1 ($not) source: loop_test.v:3.11-3.16
        A[0] --> Y[0]
    wire \f source: loop_test.v:3.7-3.8
    cell $reduce_and$loop_test.v:4$2 ($reduce_and) source: loop_test.v:4.13-4.37
        A[1] --> Y[0]
        A[2] --> Y[0]
        A[3] --> Y[0]
        ...
    wire \y [0] source: loop_test.v:2.20-2.21
Found and reported 1 problems.
```

