### PR TITLE
hashlib: Add missing `stdint.h` include

### DIFF
--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -17,6 +17,8 @@
 #include <string>
 #include <vector>
 
+#include <stdint.h>
+
 namespace hashlib {
 
 const int hashtable_size_trigger = 2;


### PR DESCRIPTION
We use `uint32_t` `uint64_t` etc. so add an explicit include.