### PR TITLE
stat: Add sequential area output to stat -liberty

### DIFF
--- a/passes/cmds/stat.cc
+++ b/passes/cmds/stat.cc
@@ -256,7 +256,7 @@ struct statdata_t
 		if (area != 0) {
 			log("\n");
 			log("   Chip area for %smodule '%s': %f\n", (top_mod) ? "top " : "", mod_name.c_str(), area);
-			log("   Sequential area for %smodule '%s': %f\n", (top_mod) ? "top " : "", mod_name.c_str(), sequential_area);
+			log("     of which used for sequential elements: %f (%.2f%%)\n", sequential_area, 100.0*sequential_area/area);
 		}
 
 		if (tech == "xilinx")

--- a/passes/cmds/stat.cc
+++ b/passes/cmds/stat.cc
@@ -28,9 +28,9 @@
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
-struct cell_data_t {
+struct cell_area_t {
 	double area;
-	bool is_flip_flop;
+	bool is_sequential;
 };
 
 struct statdata_t
@@ -80,7 +80,7 @@ struct statdata_t
 	#undef X
 	}
 
-	statdata_t(RTLIL::Design *design, RTLIL::Module *mod, bool width_mode, const dict<IdString, cell_data_t> &cell_properties, string techname)
+	statdata_t(RTLIL::Design *design, RTLIL::Module *mod, bool width_mode, const dict<IdString, cell_area_t> &cell_properties, string techname)
 	{
 		tech = techname;
 
@@ -139,8 +139,8 @@ struct statdata_t
 
 			if (!cell_properties.empty()) {
 				if (cell_properties.count(cell_type)) {
-					cell_data_t cell_data = cell_properties.at(cell_type);
-					if (cell_data.is_flip_flop) {
+					cell_area_t cell_data = cell_properties.at(cell_type);
+					if (cell_data.is_sequential) {
 						sequential_area += cell_data.area;
 					}
 					area += cell_data.area;
@@ -338,7 +338,7 @@ statdata_t hierarchy_worker(std::map<RTLIL::IdString, statdata_t> &mod_stat, RTL
 	return mod_data;
 }
 
-void read_liberty_cellarea(dict<IdString, cell_data_t> &cell_properties, string liberty_file)
+void read_liberty_cellarea(dict<IdString, cell_area_t> &cell_properties, string liberty_file)
 {
 	std::ifstream f;
 	f.open(liberty_file.c_str());
@@ -397,7 +397,7 @@ struct StatPass : public Pass {
 		bool width_mode = false, json_mode = false;
 		RTLIL::Module *top_mod = nullptr;
 		std::map<RTLIL::IdString, statdata_t> mod_stat;
-		dict<IdString, cell_data_t> cell_properties;
+		dict<IdString, cell_area_t> cell_properties;
 		string techname;
 
 		size_t argidx;


### PR DESCRIPTION
Checks to see if a cell is of type ff in the liberty, and keeps track of an additional area value.

```
   Chip area for module '\addr': 92.280720
   Sequential area for module '\addr': 38.814720
```