### PR TITLE
do not override existing shell variable

### DIFF
--- a/tests/gen-tests-makefile.sh
+++ b/tests/gen-tests-makefile.sh
@@ -16,8 +16,8 @@ generate_target() {
 # $ generate_ys_test ys_file [yosys_args]
 generate_ys_test() {
 	ys_file=$1
-	yosys_args=${2:-}
-	generate_target "$ys_file" "\"$YOSYS_BASEDIR/yosys\" -ql ${ys_file%.*}.log $yosys_args $ys_file"
+	yosys_args_=${2:-}
+	generate_target "$ys_file" "\"$YOSYS_BASEDIR/yosys\" -ql ${ys_file%.*}.log $yosys_args_ $ys_file"
 }
 
 # $ generate_bash_test bash_file


### PR DESCRIPTION
Variable `yosys_args`  is used in other places in script and due to this ys tests in generated `run-test.mk` had yosys parameters repeated multiple times, each one  in list one time more.
This makes variable name unique