### PR TITLE
driver: Fix crashes on missing cli arguments

### DIFF
--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -92,8 +92,15 @@ int getopt(int argc, char **argv, const char *optstring)
 		return optopt;
 	}
 
-	optarg = argv[++optind];
+	if (++optind >= argc) {
+		fprintf(stderr, "%s: option '-%c' expects an argument\n", argv[0], optopt);
+		optopt = '?';
+		return optopt;
+	}
+
+	optarg = argv[optind];
 	optind++, optcur = 1;
+
 	return optopt;
 }
 


### PR DESCRIPTION
In #3973 we switched to using an internal `getopt` implementation unconditionally, but there turns out to be an issue with missing option arguments which lead to crashes. Address that.

Now we handle it gracefully:
```
$ ./yosys -p
./yosys: option '-p' expects an argument
Run './yosys -h' for help.
```