### PR TITLE
read_verilog: correctly format `hdlname` attribute value

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -1820,7 +1820,7 @@ std::string AstModule::derive_common(RTLIL::Design *design, const dict<RTLIL::Id
 
 	AstNode *new_ast = ast->clone();
 	if (!new_ast->attributes.count(ID::hdlname))
-		new_ast->set_attribute(ID::hdlname, AstNode::mkconst_str(stripped_name));
+		new_ast->set_attribute(ID::hdlname, AstNode::mkconst_str(stripped_name.substr(1)));
 
 	para_counter = 0;
 	for (auto child : new_ast->children) {

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -5662,7 +5662,7 @@ std::string AstNode::try_pop_module_prefix() const
 		if (current_scope.count(new_str)) {
 			std::string prefix = str.substr(0, pos);
 			auto it = current_scope_ast->attributes.find(ID::hdlname);
-			if ((it != current_scope_ast->attributes.end() && it->second->str == prefix)
+			if ((it != current_scope_ast->attributes.end() && it->second->str == prefix.substr(1))
 					|| prefix == current_scope_ast->str)
 				return new_str;
 		}


### PR DESCRIPTION
The leading slash is not a part of the attribute as it only concerns public values.

No idea why this fails tests. @povik, do you know?