### PR TITLE
clk2fflogic: Fix handling of $check cells

### DIFF
--- a/passes/sat/clk2fflogic.cc
+++ b/passes/sat/clk2fflogic.cc
@@ -238,7 +238,8 @@ struct Clk2fflogicPass : public Pass {
 						cell->setPort(ID::EN, module->And(NEW_ID, sig_en_sampled, sig_trg_combined));
 						cell->setPort(ID::ARGS, sig_args_sampled);
 						if (cell->type == ID($check)) {
-							SigBit sig_a_sampled = sample_data(module, sig_en, State::S1, false, false).sampled;
+							SigBit sig_a = cell->getPort(ID::A);
+							SigBit sig_a_sampled = sample_data(module, sig_a, State::S1, false, false).sampled;
 							cell->setPort(ID::A, sig_a_sampled);
 						}
 					}

--- a/tests/various/clk2fflogic_effects.sv
+++ b/tests/various/clk2fflogic_effects.sv
@@ -7,7 +7,7 @@ reg clk = 0;
 always @(posedge gclk)
     clk <= !clk;
 
-reg [4:0] counter = 0;
+reg [5:0] counter = 0;
 
 reg eff_0_trg = '0;
 reg eff_0_en = '0;
@@ -19,6 +19,10 @@ reg eff_1_en = '0;
 reg eff_2_trgA = '0;
 reg eff_2_trgB = '0;
 reg eff_2_en = '0;
+
+reg eff_3_trg = '0;
+reg eff_3_en = '0;
+reg eff_3_a = '0;
 
 `ifdef FAST
 always @(posedge gclk) begin
@@ -37,6 +41,10 @@ always @(posedge clk) begin
     eff_2_trgA = counter[0];
     eff_2_trgB = !counter[0];
     eff_2_en  <= 32'b00000000000000000000001111111100 >> counter;
+
+    eff_3_trg  = 32'b10101010101010101010101010101010 >> counter;
+    eff_3_en  <= 32'b11101110010001001110111001000100 >> counter;
+    eff_3_a   <= 32'b11111010111110100101000001010000 >> counter;
 end
 
 always @(posedge eff_0_trg)
@@ -71,11 +79,22 @@ always @(posedge eff_2_trgA, posedge eff_2_trgB)
     if (eff_2_en)
         $display("repeated");
 
+always @(posedge eff_3_trg)
+    if (eff_3_en) begin
+        $display("%02d: eff3 vvv", counter);
+`ifdef NO_ASSERT
+        if (!eff_3_a)
+            $display("Failed assertion eff3 at");
+`else
+        eff3: assert(eff_3_a);
+`endif
+    end
+
 `ifdef __ICARUS__
 initial gclk = 0;
 always @(gclk) gclk <= #5 !gclk;
 always @(posedge gclk)
-    if (counter == 31)
+    if (counter == 32)
         $finish(0);
 `endif
 


### PR DESCRIPTION
Fixes a bug in the handling of the recently introduced $check cells. Both $check and $print cells in clk2fflogic are handled by the same code and the existing tests for that were only using $print cells. This missed a bug where the additional A signal of $check cells that is not present on $print cells was dropped due to a typo, rendering $check cells non-functional.

Also updates the tests to explicitly cover both cell types such that they would have detected the now fixed bug.