### PR TITLE
tests: Support running `make test` with YOSYS_NOVERIFIC=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -848,9 +848,22 @@ else
 ABCOPT=""
 endif
 
+# When YOSYS_NOVERIFIC is set as a make variable, also export it to the
+# enviornment, so that `YOSYS_NOVERIFIC=1 make test` _and_
+# `make test YOSYS_NOVERIFIC=1` will run with verific disabled.
+ifeq ($(YOSYS_NOVERIFIC),1)
+export YOSYS_NOVERIFIC
+endif
+
 test: $(TARGETS) $(EXTRA_TARGETS)
 ifeq ($(ENABLE_VERIFIC),1)
+ifeq ($(YOSYS_NOVERIFIC),1)
+	@echo
+	@echo "Running tests without verific support due to YOSYS_NOVERIFIC=1"
+	@echo
+else
 	+cd tests/verific && bash run-test.sh $(SEEDOPT)
+endif
 endif
 	+cd tests/simple && bash run-test.sh $(SEEDOPT)
 	+cd tests/simple_abc9 && bash run-test.sh $(SEEDOPT)


### PR DESCRIPTION
A yosys build with verific support can act as a non-verific yosys with `YOSYS_NOVERIFIC=1` in the enviornment, which is useful for quickly testing code that works with either frontend without rebuilding yosys.

Before this change, this did not work with `make test` as it would only consider the build time configuration to decide whether to run tests that depend on verific support, immediately failing on those tests when the enviornment contains `YOSYS_NOVERIFIC=1`.

This adds logic to the makefile that checks this enviornment variable and also exports YOSYS_NOVERIFIC=1 to the enviornment when that is present as a make variable to support `make test YOSYS_NOVERIFIC=1` invocations.