### PR TITLE
Address race in `xprop` tests

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -86,7 +86,6 @@ jobs:
         run: |
           git clone https://github.com/steveicarus/iverilog.git
           cd iverilog
-          git checkout 192b6aec96fde982e6ddcb28b346d5893aa8e874
           echo "IVERILOG_GIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       - name: Cache iverilog

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -42,7 +42,6 @@ jobs:
         run: |
           git clone https://github.com/steveicarus/iverilog.git
           cd iverilog
-          git checkout 192b6aec96fde982e6ddcb28b346d5893aa8e874
           echo "IVERILOG_GIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       - name: Cache iverilog

--- a/tests/xprop/test.py
+++ b/tests/xprop/test.py
@@ -271,7 +271,7 @@ if "prepare" in steps:
 
         for pattern in patterns:
             print(
-                f'    gclk = 1; #0; A[0] = 1\'b{pattern[-1]}; #0; A = {input_width}\'b{pattern}; #5; gclk = 0; $display("%b %b", A, Y); #5',
+                f'    #0; gclk = 1; #0; A[0] = 1\'b{pattern[-1]}; #0; A = {input_width}\'b{pattern}; #5; gclk = 0; $display("%b %b", A, Y); #5',
                 file=tb_file,
             )
 

--- a/tests/xprop/test.py
+++ b/tests/xprop/test.py
@@ -270,6 +270,7 @@ if "prepare" in steps:
         print("initial begin", file=tb_file)
 
         for pattern in patterns:
+            # A[0] might be the clock which requires special sequencing
             print(
                 f'    #0; gclk = 1; #0; A[0] = 1\'b{pattern[-1]}; #0; A = {input_width}\'b{pattern}; #5; gclk = 0; $display("%b %b", A, Y); #5',
                 file=tb_file,


### PR DESCRIPTION
Ought to fix the CI failures which prompted iverilog pinning in #4148 / ddfd867.