### PR TITLE
proc_rom: don't assert on big actionless switch.

### DIFF
--- a/passes/proc/proc_rom.cc
+++ b/passes/proc/proc_rom.cc
@@ -66,6 +66,11 @@ struct RomWorker
 			}
 		}
 
+		if (lhs.empty()) {
+			log_debug("rejecting switch: lhs empty\n");
+			return;
+		}
+
 		int swsigbits = 0;
 		for (int i = 0; i < GetSize(sw->signal); i++)
 			if (sw->signal[i] != State::S0)

--- a/tests/proc/proc_rom.ys
+++ b/tests/proc/proc_rom.ys
@@ -186,4 +186,27 @@ design -stash preopt
 equiv_opt -assert -run prepare: dummy
 
 
+design -reset
 
+read_ilang <<EOT
+
+module \m
+  wire width 3 input 1 \a
+
+  process \p
+    switch \a
+      case 3'000
+      case 3'001
+      case 3'010
+      case 3'011
+      case 3'100
+      case 3'101
+      case 3'110
+      case 3'111
+    end
+  end
+end
+
+EOT
+
+proc_rom


### PR DESCRIPTION
See the test case.  PROC_ROM will consider this for evaluation, even though -- without any actions -- lhs is empty (but still "uniform"). A zero-width memory is constructed, which later fails check with:

```
ERROR: Assert `width != 0' failed in kernel/mem.cc:518.
```

Ensure we don't proceed if there's nothing to encode.

---

Alternatively, do we want to reject this switch as meaningless? This came up in an Amaranth (`188eb8d4`) project; I've yet to investigate deeply why it's produced this, but either way Yosys probably doesn't want to give the assert it currently does here.