### PR TITLE
equiv_simple: Take FFs into account for driver map

### DIFF
--- a/passes/equiv/equiv_simple.cc
+++ b/passes/equiv/equiv_simple.cc
@@ -339,6 +339,8 @@ struct EquivSimplePass : public Pass {
 		CellTypes ct;
 		ct.setup_internals();
 		ct.setup_stdcells();
+		ct.setup_internals_ff();
+		ct.setup_stdcells_mem();
 
 		for (auto module : design->selected_modules())
 		{


### PR DESCRIPTION
This fixes an issue introduced in commit 26644ea due to which flip-flops are inadvertently ignored when building up driver map. The mentioned commit wasn't without functional change after all.

Thanks to @ArkadyKlimov who pointed this out.