### PR TITLE
opt_mem, memory_*: Refuse to operate in presence of processes

### DIFF
--- a/passes/memory/memory_collect.cc
+++ b/passes/memory/memory_collect.cc
@@ -39,6 +39,9 @@ struct MemoryCollectPass : public Pass {
 		log_header(design, "Executing MEMORY_COLLECT pass (generating $mem cells).\n");
 		extra_args(args, 1, design);
 		for (auto module : design->selected_modules()) {
+			if (module->has_processes_warn())
+				continue;
+
 			for (auto &mem : Mem::get_selected_memories(module)) {
 				if (!mem.packed) {
 					mem.packed = true;

--- a/passes/memory/memory_libmap.cc
+++ b/passes/memory/memory_libmap.cc
@@ -2229,6 +2229,9 @@ struct MemoryLibMapPass : public Pass {
 		Library lib = parse_library(lib_files, defines);
 
 		for (auto module : design->selected_modules()) {
+			if (module->has_processes_warn())
+				continue;
+
 			MapWorker worker(module);
 			auto mems = Mem::get_selected_memories(module);
 			for (auto &mem : mems)

--- a/passes/memory/memory_map.cc
+++ b/passes/memory/memory_map.cc
@@ -493,6 +493,9 @@ struct MemoryMapPass : public Pass {
 		extra_args(args, argidx, design);
 
 		for (auto mod : design->selected_modules()) {
+			if (mod->has_processes_warn())
+				continue;
+
 			MemoryMapWorker worker(design, mod);
 			worker.attr_icase = attr_icase;
 			worker.attributes = attributes;

--- a/passes/memory/memory_memx.cc
+++ b/passes/memory/memory_memx.cc
@@ -50,7 +50,7 @@ struct MemoryMemxPass : public Pass {
 	}
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override {
-		log_header(design, "Executing MEMORY_MEMX pass (converting $mem cells to logic and flip-flops).\n");
+		log_header(design, "Executing MEMORY_MEMX pass (emit soft logic for out-of-bounds handling).\n");
 		extra_args(args, 1, design);
 
 		for (auto module : design->selected_modules())

--- a/passes/memory/memory_narrow.cc
+++ b/passes/memory/memory_narrow.cc
@@ -46,6 +46,9 @@ struct MemoryNarrowPass : public Pass {
 		extra_args(args, argidx, design);
 
 		for (auto module : design->selected_modules()) {
+			if (module->has_processes_warn())
+				continue;
+
 			for (auto &mem : Mem::get_selected_memories(module))
 			{
 				bool wide = false;

--- a/passes/memory/memory_share.cc
+++ b/passes/memory/memory_share.cc
@@ -558,8 +558,12 @@ struct MemorySharePass : public Pass {
 		extra_args(args, argidx, design);
 		MemoryShareWorker msw(design, flag_widen, flag_sat);
 
-		for (auto module : design->selected_modules())
+		for (auto module : design->selected_modules()) {
+			if (module->has_processes_warn())
+				continue;
+
 			msw(module);
+		}
 	}
 } MemorySharePass;
 

--- a/passes/opt/opt_mem.cc
+++ b/passes/opt/opt_mem.cc
@@ -52,6 +52,9 @@ struct OptMemPass : public Pass {
 
 		int total_count = 0;
 		for (auto module : design->selected_modules()) {
+			if (module->has_processes_warn())
+				continue;
+
 			SigMap sigmap(module);
 			FfInitVals initvals(&sigmap, module);
 			for (auto &mem : Mem::get_selected_memories(module)) {


### PR DESCRIPTION
Processes can contain `MemWriteAction` entries which are invisible to most passes operating on memories but which will be lowered to write ports later on by `proc_memwr`. For that reason we can get corrupted RTLIL if we sequence the memory passes before `proc`. Address that by making the affected memory passes ignore modules with processes.

Also correct the log header printed by `memoy_memx`.