### PR TITLE
Apply patch for Makefile and begin supporting nix flakes build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ ABC_ARCHFLAGS += "-DABC_NO_RLIMIT"
 endif
 
 ifeq ($(CONFIG),clang)
-CXX = clang
+CXX = clang++
 LD = clang++
 CXXFLAGS += -std=$(CXXSTD) -Os
 ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H -Wno-c++11-narrowing $(ABC_ARCHFLAGS)"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1708475490,
+        "narHash": "sha256-g1v0TsWBQPX97ziznfJdWhgMyMGtoBFs102xSYO4syU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0e74ca98a74bc7270d28838369593635a5db3260",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "A nix flake for the Yosys synthesis suite";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+        customYosys = pkgs.clangStdenv.mkDerivation {
+          name = "yosys";
+          src = ./. ;
+          buildInputs = with pkgs; [ clang bison flex libffi tcl readline python3 llvmPackages.libcxxClang zlib git ];
+          checkInputs = with pkgs; [ gtest ];
+          propagatedBuildInputs = with pkgs; [ abc-verifier ];
+          preConfigure = "make config-clang";
+          checkTarget = "test";
+          installPhase = ''
+            make install PREFIX=$out
+          '';
+          meta = with pkgs.lib; {
+            description = "Yosys Open SYnthesis Suite";
+            homepage = "https://yosyshq.net/yosys/";
+            license = licenses.isc;
+            maintainers = with maintainers; [ ];
+          };
+        };
+      in {
+        packages.default = customYosys;
+        defaultPackage = customYosys;
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [ clang bison flex libffi tcl readline python3 llvmPackages.libcxxClang zlib git gtest abc-verifier ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
To build yosys in nixpkgs (https://github.com/NixOS/nixpkgs/blob/nixos-23.11/pkgs/development/compilers/yosys/default.nix), a patch is applied to Makefile. I applied that same patch to the Makefile and was surprised that all the pipelines pass (https://github.com/RCoeurjoly/yosys/actions).

This PR would fix https://github.com/YosysHQ/yosys/issues/2011.
