### PR TITLE
´Use g++ and clang++ instead of gcc and clang as C++ compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ ABC_ARCHFLAGS += "-DABC_NO_RLIMIT"
 endif
 
 ifeq ($(CONFIG),clang)
-CXX = clang
+CXX = clang++
 LD = clang++
 CXXFLAGS += -std=$(CXXSTD) -Os
 ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H -Wno-c++11-narrowing $(ABC_ARCHFLAGS)"
@@ -238,8 +238,8 @@ endif
 endif
 
 else ifeq ($(CONFIG),gcc)
-CXX = gcc
-LD = gcc
+CXX = g++
+LD = g++
 CXXFLAGS += -std=$(CXXSTD) -Os
 ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H $(ABC_ARCHFLAGS)"
 
@@ -262,8 +262,8 @@ CXXFLAGS += -std=$(CXXSTD) -Os
 ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H"
 
 else ifeq ($(CONFIG),cygwin)
-CXX = gcc
-LD = gcc
+CXX = g++
+LD = g++
 CXXFLAGS += -std=gnu++11 -Os
 ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H"
 
@@ -309,13 +309,13 @@ yosys.html: misc/yosys.html
 
 else ifeq ($(CONFIG),wasi)
 ifeq ($(WASI_SDK),)
-CXX = clang
+CXX = clang++
 LD = clang++
 AR = llvm-ar
 RANLIB = llvm-ranlib
 WASIFLAGS := -target wasm32-wasi --sysroot $(WASI_SYSROOT) $(WASIFLAGS)
 else
-CXX = $(WASI_SDK)/bin/clang
+CXX = $(WASI_SDK)/bin/clang++
 LD = $(WASI_SDK)/bin/clang++
 AR = $(WASI_SDK)/bin/ar
 RANLIB = $(WASI_SDK)/bin/ranlib

--- a/Makefile
+++ b/Makefile
@@ -92,14 +92,14 @@ VPATH := $(YOSYS_SRC)
 
 CXXSTD ?= c++11
 CXXFLAGS := $(CXXFLAGS) -Wall -Wextra -ggdb -I. -I"$(YOSYS_SRC)" -MD -MP -D_YOSYS_ -fPIC -I$(PREFIX)/include
-LDLIBS := $(LDLIBS) -lstdc++ -lm
-PLUGIN_LDFLAGS :=
-PLUGIN_LDLIBS :=
-EXE_LDFLAGS :=
+LIBS := $(LIBS) -lstdc++ -lm
+PLUGIN_LINKFLAGS :=
+PLUGIN_LIBS :=
+EXE_LINKFLAGS :=
 ifeq ($(OS), MINGW)
-EXE_LDFLAGS := -Wl,--export-all-symbols -Wl,--out-implib,libyosys_exe.a
-PLUGIN_LDFLAGS += -L"$(LIBDIR)"
-PLUGIN_LDLIBS := -lyosys_exe
+EXE_LINKFLAGS := -Wl,--export-all-symbols -Wl,--out-implib,libyosys_exe.a
+PLUGIN_LINKFLAGS += -L"$(LIBDIR)"
+PLUGIN_LIBS := -lyosys_exe
 endif
 
 PKG_CONFIG ?= pkg-config
@@ -109,7 +109,7 @@ STRIP ?= strip
 AWK ?= awk
 
 ifeq ($(OS), Darwin)
-PLUGIN_LDFLAGS += -undefined dynamic_lookup
+PLUGIN_LINKFLAGS += -undefined dynamic_lookup
 
 # homebrew search paths
 ifneq ($(shell :; command -v brew),)
@@ -117,10 +117,10 @@ BREW_PREFIX := $(shell brew --prefix)/opt
 $(info $$BREW_PREFIX is [${BREW_PREFIX}])
 ifeq ($(ENABLE_PYOSYS),1)
 CXXFLAGS += -I$(BREW_PREFIX)/boost/include/boost
-LDFLAGS += -L$(BREW_PREFIX)/boost/lib
+LINKFLAGS += -L$(BREW_PREFIX)/boost/lib
 endif
 CXXFLAGS += -I$(BREW_PREFIX)/readline/include
-LDFLAGS += -L$(BREW_PREFIX)/readline/lib
+LINKFLAGS += -L$(BREW_PREFIX)/readline/lib
 PKG_CONFIG_PATH := $(BREW_PREFIX)/libffi/lib/pkgconfig:$(PKG_CONFIG_PATH)
 PKG_CONFIG_PATH := $(BREW_PREFIX)/tcl-tk/lib/pkgconfig:$(PKG_CONFIG_PATH)
 export PATH := $(BREW_PREFIX)/bison/bin:$(BREW_PREFIX)/gettext/bin:$(BREW_PREFIX)/flex/bin:$(PATH)
@@ -129,15 +129,15 @@ export PATH := $(BREW_PREFIX)/bison/bin:$(BREW_PREFIX)/gettext/bin:$(BREW_PREFIX
 else ifneq ($(shell :; command -v port),)
 PORT_PREFIX := $(patsubst %/bin/port,%,$(shell :; command -v port))
 CXXFLAGS += -I$(PORT_PREFIX)/include
-LDFLAGS += -L$(PORT_PREFIX)/lib
+LINKFLAGS += -L$(PORT_PREFIX)/lib
 PKG_CONFIG_PATH := $(PORT_PREFIX)/lib/pkgconfig:$(PKG_CONFIG_PATH)
 export PATH := $(PORT_PREFIX)/bin:$(PATH)
 endif
 
 else
-LDFLAGS += -rdynamic
+LINKFLAGS += -rdynamic
 ifneq ($(OS), OpenBSD)
-LDLIBS += -lrt
+LIBS += -lrt
 endif
 endif
 
@@ -222,17 +222,17 @@ ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H -Wno-c++11-narrowing $(ABC_ARCHFLAGS)
 ifneq ($(SANITIZER),)
 $(info [Clang Sanitizer] $(SANITIZER))
 CXXFLAGS += -g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=$(SANITIZER)
-LDFLAGS += -g -fsanitize=$(SANITIZER)
+LINKFLAGS += -g -fsanitize=$(SANITIZER)
 ifneq ($(findstring address,$(SANITIZER)),)
 ENABLE_COVER := 0
 endif
 ifneq ($(findstring memory,$(SANITIZER)),)
 CXXFLAGS += -fPIE -fsanitize-memory-track-origins
-LDFLAGS += -fPIE -fsanitize-memory-track-origins
+LINKFLAGS += -fPIE -fsanitize-memory-track-origins
 endif
 ifneq ($(findstring cfi,$(SANITIZER)),)
 CXXFLAGS += -flto
-LDFLAGS += -flto
+LINKFLAGS += -flto
 endif
 endif
 
@@ -242,8 +242,8 @@ CXXFLAGS += -std=$(CXXSTD) -Os
 ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H $(ABC_ARCHFLAGS)"
 
 else ifeq ($(CONFIG),gcc-static)
-LDFLAGS := $(filter-out -rdynamic,$(LDFLAGS)) -static
-LDLIBS := $(filter-out -lrt,$(LDLIBS))
+LINKFLAGS := $(filter-out -rdynamic,$(LINKFLAGS)) -static
+LIBS := $(filter-out -lrt,$(LIBS))
 CXXFLAGS := $(filter-out -fPIC,$(CXXFLAGS))
 CXXFLAGS += -std=$(CXXSTD) -Os
 ABCMKARGS = CC="$(CC)" CXX="$(CXX)" LD="$(CXX)" ABC_USE_LIBSTDCXX=1 LIBS="-lm -lpthread -static" OPTFLAGS="-O" \
@@ -267,15 +267,15 @@ CXX = emcc
 CXXFLAGS := -std=$(CXXSTD) $(filter-out -fPIC -ggdb,$(CXXFLAGS))
 ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H -DABC_MEMALIGN=8 -Wno-c++11-narrowing"
 EMCC_CXXFLAGS := -Os -Wno-warn-absolute-paths
-EMCC_LDFLAGS := --memory-init-file 0 --embed-file share
-EMCC_LDFLAGS += -s NO_EXIT_RUNTIME=1
-EMCC_LDFLAGS += -s EXPORTED_FUNCTIONS="['_main','_run','_prompt','_errmsg','_memset']"
-EMCC_LDFLAGS += -s TOTAL_MEMORY=134217728
-EMCC_LDFLAGS += -s EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]'
+EMCC_LINKFLAGS := --memory-init-file 0 --embed-file share
+EMCC_LINKFLAGS += -s NO_EXIT_RUNTIME=1
+EMCC_LINKFLAGS += -s EXPORTED_FUNCTIONS="['_main','_run','_prompt','_errmsg','_memset']"
+EMCC_LINKFLAGS += -s TOTAL_MEMORY=134217728
+EMCC_LINKFLAGS += -s EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]'
 # https://github.com/kripken/emscripten/blob/master/src/settings.js
 CXXFLAGS += $(EMCC_CXXFLAGS)
-LDFLAGS += $(EMCC_LDFLAGS)
-LDLIBS =
+LINKFLAGS += $(EMCC_LINKFLAGS)
+LIBS =
 EXE = .js
 
 DISABLE_SPAWN := 1
@@ -314,8 +314,8 @@ RANLIB = $(WASI_SDK)/bin/ranlib
 WASIFLAGS := --sysroot $(WASI_SDK)/share/wasi-sysroot $(WASIFLAGS)
 endif
 CXXFLAGS := $(WASIFLAGS) -std=$(CXXSTD) -Os -D_WASI_EMULATED_PROCESS_CLOCKS $(filter-out -fPIC,$(CXXFLAGS))
-LDFLAGS := $(WASIFLAGS) -Wl,-z,stack-size=1048576 $(filter-out -rdynamic,$(LDFLAGS))
-LDLIBS := -lwasi-emulated-process-clocks $(filter-out -lrt,$(LDLIBS))
+LINKFLAGS := $(WASIFLAGS) -Wl,-z,stack-size=1048576 $(filter-out -rdynamic,$(LINKFLAGS))
+LIBS := -lwasi-emulated-process-clocks $(filter-out -lrt,$(LIBS))
 ABCMKARGS += AR="$(AR)" RANLIB="$(RANLIB)"
 ABCMKARGS += ARCHFLAGS="$(WASIFLAGS) -D_WASI_EMULATED_PROCESS_CLOCKS -DABC_USE_STDINT_H -DABC_NO_DYNAMIC_LINKING -DABC_NO_RLIMIT -Wno-c++11-narrowing"
 ABCMKARGS += OPTFLAGS="-Os"
@@ -333,19 +333,19 @@ PKG_CONFIG = /usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-pkg-config
 CXX = /usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-g++
 CXXFLAGS += -std=$(CXXSTD) -Os -D_POSIX_SOURCE -DYOSYS_MXE_HACKS -Wno-attributes
 CXXFLAGS := $(filter-out -fPIC,$(CXXFLAGS))
-LDFLAGS := $(filter-out -rdynamic,$(LDFLAGS)) -s
-LDLIBS := $(filter-out -lrt,$(LDLIBS))
+LINKFLAGS := $(filter-out -rdynamic,$(LINKFLAGS)) -s
+LIBS := $(filter-out -lrt,$(LIBS))
 ABCMKARGS += ARCHFLAGS="-DWIN32_NO_DLL -DHAVE_STRUCT_TIMESPEC -fpermissive -w"
 # TODO: Try to solve pthread linking issue in more appropriate way
-ABCMKARGS += LIBS="lib/x86/pthreadVC2.lib -s" LDFLAGS="-Wl,--allow-multiple-definition" ABC_USE_NO_READLINE=1 CC="/usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-gcc"
+ABCMKARGS += LIBS="lib/x86/pthreadVC2.lib -s" LINKFLAGS="-Wl,--allow-multiple-definition" ABC_USE_NO_READLINE=1 CC="/usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-gcc"
 EXE = .exe
 
 else ifeq ($(CONFIG),msys2-32)
 CXX = i686-w64-mingw32-g++
 CXXFLAGS += -std=$(CXXSTD) -Os -D_POSIX_SOURCE -DYOSYS_WIN32_UNIX_DIR
 CXXFLAGS := $(filter-out -fPIC,$(CXXFLAGS))
-LDFLAGS := $(filter-out -rdynamic,$(LDFLAGS)) -s
-LDLIBS := $(filter-out -lrt,$(LDLIBS))
+LINKFLAGS := $(filter-out -rdynamic,$(LINKFLAGS)) -s
+LIBS := $(filter-out -lrt,$(LIBS))
 ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H -DWIN32_NO_DLL -DHAVE_STRUCT_TIMESPEC -fpermissive -w"
 ABCMKARGS += LIBS="-lpthread -lshlwapi -s" ABC_USE_NO_READLINE=0 CC="i686-w64-mingw32-gcc" CXX="$(CXX)"
 EXE = .exe
@@ -354,8 +354,8 @@ else ifeq ($(CONFIG),msys2-64)
 CXX = x86_64-w64-mingw32-g++
 CXXFLAGS += -std=$(CXXSTD) -Os -D_POSIX_SOURCE -DYOSYS_WIN32_UNIX_DIR
 CXXFLAGS := $(filter-out -fPIC,$(CXXFLAGS))
-LDFLAGS := $(filter-out -rdynamic,$(LDFLAGS)) -s
-LDLIBS := $(filter-out -lrt,$(LDLIBS))
+LINKFLAGS := $(filter-out -rdynamic,$(LINKFLAGS)) -s
+LIBS := $(filter-out -lrt,$(LIBS))
 ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H -DWIN32_NO_DLL -DHAVE_STRUCT_TIMESPEC -fpermissive -w"
 ABCMKARGS += LIBS="-lpthread -lshlwapi -s" ABC_USE_NO_READLINE=0 CC="x86_64-w64-mingw32-gcc" CXX="$(CXX)"
 EXE = .exe
@@ -382,9 +382,9 @@ ifeq ($(BOOST_PYTHON_LIB),)
 $(error BOOST_PYTHON_LIB could not be detected. Please define manually)
 endif
 
-LDLIBS += $(shell $(PYTHON_CONFIG) --libs) $(BOOST_PYTHON_LIB) -lboost_system -lboost_filesystem
-# python-config --ldflags includes LDLIBS for some reason
-LDFLAGS += $(filter-out -l%,$(shell $(PYTHON_CONFIG) --ldflags))
+LIBS += $(shell $(PYTHON_CONFIG) --libs) $(BOOST_PYTHON_LIB) -lboost_system -lboost_filesystem
+# python-config --ldflags includes LIBS for some reason
+LINKFLAGS += $(filter-out -l%,$(shell $(PYTHON_CONFIG) --ldflags))
 CXXFLAGS += $(shell $(PYTHON_CONFIG) --includes) -DWITH_PYTHON
 
 PY_WRAPPER_FILE = kernel/python_wrappers
@@ -398,22 +398,22 @@ CXXFLAGS += -DYOSYS_ENABLE_READLINE
 ifeq ($(OS), $(filter $(OS),FreeBSD OpenBSD NetBSD))
 CXXFLAGS += -I/usr/local/include
 endif
-LDLIBS += -lreadline
+LIBS += -lreadline
 ifeq ($(LINK_CURSES),1)
-LDLIBS += -lcurses
+LIBS += -lcurses
 ABCMKARGS += "ABC_READLINE_LIBRARIES=-lcurses -lreadline"
 endif
 ifeq ($(LINK_TERMCAP),1)
-LDLIBS += -ltermcap
+LIBS += -ltermcap
 ABCMKARGS += "ABC_READLINE_LIBRARIES=-lreadline -ltermcap"
 endif
 ifeq ($(CONFIG),mxe)
-LDLIBS += -ltermcap
+LIBS += -ltermcap
 endif
 else
 ifeq ($(ENABLE_EDITLINE),1)
 CXXFLAGS += -DYOSYS_ENABLE_EDITLINE
-LDLIBS += -ledit -ltinfo -lbsd
+LIBS += -ledit -ltinfo -lbsd
 else
 ABCMKARGS += "ABC_USE_NO_READLINE=1"
 endif
@@ -432,9 +432,9 @@ CXXFLAGS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-e
 ifeq ($(OS), MINGW)
 CXXFLAGS += -Ilibs/dlfcn-win32
 endif
-LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --libs libffi || echo -lffi)
+LIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --libs libffi || echo -lffi)
 ifneq ($(OS), $(filter $(OS),FreeBSD OpenBSD NetBSD MINGW))
-LDLIBS += -ldl
+LIBS += -ldl
 endif
 endif
 
@@ -444,7 +444,7 @@ endif
 
 ifeq ($(ENABLE_ZLIB),1)
 CXXFLAGS += -DYOSYS_ENABLE_ZLIB
-LDLIBS += -lz
+LIBS += -lz
 endif
 
 
@@ -461,21 +461,21 @@ endif
 
 ifeq ($(CONFIG),mxe)
 CXXFLAGS += -DYOSYS_ENABLE_TCL
-LDLIBS += -ltcl86 -lwsock32 -lws2_32 -lnetapi32 -lz -luserenv
+LIBS += -ltcl86 -lwsock32 -lws2_32 -lnetapi32 -lz -luserenv
 else
 CXXFLAGS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --cflags tcl || echo -I$(TCL_INCLUDE)) -DYOSYS_ENABLE_TCL
-LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --libs tcl || echo $(TCL_LIBS))
+LIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --libs tcl || echo $(TCL_LIBS))
 endif
 endif
 
 ifeq ($(ENABLE_GCOV),1)
 CXXFLAGS += --coverage
-LDFLAGS += --coverage
+LINKFLAGS += --coverage
 endif
 
 ifeq ($(ENABLE_GPROF),1)
 CXXFLAGS += -pg
-LDFLAGS += -pg
+LINKFLAGS += -pg
 endif
 
 ifeq ($(ENABLE_NDEBUG),1)
@@ -495,7 +495,7 @@ CXXFLAGS += -DYOSYS_ENABLE_ABC
 ifeq ($(LINK_ABC),1)
 CXXFLAGS += -DYOSYS_LINK_ABC
 ifeq ($(DISABLE_ABC_THREADS),0)
-LDLIBS += -lpthread
+LIBS += -lpthread
 endif
 else
 ifeq ($(ABCEXTERNAL),)
@@ -509,10 +509,10 @@ GHDL_PREFIX ?= $(PREFIX)
 GHDL_INCLUDE_DIR ?= $(GHDL_PREFIX)/include
 GHDL_LIB_DIR ?= $(GHDL_PREFIX)/lib
 CXXFLAGS += -I$(GHDL_INCLUDE_DIR) -DYOSYS_ENABLE_GHDL
-LDLIBS += $(GHDL_LIB_DIR)/libghdl.a $(file <$(GHDL_LIB_DIR)/libghdl.link)
+LIBS += $(GHDL_LIB_DIR)/libghdl.a $(file <$(GHDL_LIB_DIR)/libghdl.link)
 endif
 
-LDLIBS_VERIFIC =
+LIBS_VERIFIC =
 ifeq ($(ENABLE_VERIFIC),1)
 VERIFIC_DIR ?= /usr/local/src/verific_lib
 VERIFIC_COMPONENTS ?= verilog database util containers hier_tree
@@ -538,9 +538,9 @@ CXXFLAGS += -DYOSYSHQ_VERIFIC_EXTENSIONS
 endif
 CXXFLAGS += $(patsubst %,-I$(VERIFIC_DIR)/%,$(VERIFIC_COMPONENTS)) -DYOSYS_ENABLE_VERIFIC
 ifeq ($(OS), Darwin)
-LDLIBS_VERIFIC += $(foreach comp,$(patsubst %,$(VERIFIC_DIR)/%/*-mac.a,$(VERIFIC_COMPONENTS)),-Wl,-force_load $(comp)) -lz
+LIBS_VERIFIC += $(foreach comp,$(patsubst %,$(VERIFIC_DIR)/%/*-mac.a,$(VERIFIC_COMPONENTS)),-Wl,-force_load $(comp)) -lz
 else
-LDLIBS_VERIFIC += -Wl,--whole-archive $(patsubst %,$(VERIFIC_DIR)/%/*-linux.a,$(VERIFIC_COMPONENTS)) -Wl,--no-whole-archive -lz
+LIBS_VERIFIC += -Wl,--whole-archive $(patsubst %,$(VERIFIC_DIR)/%/*-linux.a,$(VERIFIC_COMPONENTS)) -Wl,--no-whole-archive -lz
 endif
 endif
 
@@ -741,13 +741,13 @@ yosys.js: $(filter-out yosysjs-$(YOSYS_VER).zip,$(EXTRA_TARGETS))
 endif
 
 $(PROGRAM_PREFIX)yosys$(EXE): $(OBJS)
-	$(P) $(CXX) -o $(PROGRAM_PREFIX)yosys$(EXE) $(EXE_LDFLAGS) $(LDFLAGS) $(OBJS) $(LDLIBS) $(LDLIBS_VERIFIC)
+	$(P) $(CXX) -o $(PROGRAM_PREFIX)yosys$(EXE) $(EXE_LINKFLAGS) $(LINKFLAGS) $(OBJS) $(LIBS) $(LIBS_VERIFIC)
 
 libyosys.so: $(filter-out kernel/driver.o,$(OBJS))
 ifeq ($(OS), Darwin)
-	$(P) $(CXX) -o libyosys.so -shared -Wl,-install_name,$(LIBDIR)/libyosys.so $(LDFLAGS) $^ $(LDLIBS) $(LDLIBS_VERIFIC)
+	$(P) $(CXX) -o libyosys.so -shared -Wl,-install_name,$(LIBDIR)/libyosys.so $(LINKFLAGS) $^ $(LIBS) $(LIBS_VERIFIC)
 else
-	$(P) $(CXX) -o libyosys.so -shared -Wl,-soname,$(LIBDIR)/libyosys.so $(LDFLAGS) $^ $(LDLIBS) $(LDLIBS_VERIFIC)
+	$(P) $(CXX) -o libyosys.so -shared -Wl,-soname,$(LIBDIR)/libyosys.so $(LINKFLAGS) $^ $(LIBS) $(LIBS_VERIFIC)
 endif
 
 %.o: %.cc
@@ -777,15 +777,15 @@ kernel/version_$(GIT_REV).cc: $(YOSYS_SRC)/Makefile
 
 ifeq ($(ENABLE_VERIFIC),1)
 CXXFLAGS_NOVERIFIC = $(foreach v,$(CXXFLAGS),$(if $(findstring $(VERIFIC_DIR),$(v)),,$(v)))
-LDLIBS_NOVERIFIC = $(foreach v,$(LDLIBS),$(if $(findstring $(VERIFIC_DIR),$(v)),,$(v)))
+LIBS_NOVERIFIC = $(foreach v,$(LIBS),$(if $(findstring $(VERIFIC_DIR),$(v)),,$(v)))
 else
 CXXFLAGS_NOVERIFIC = $(CXXFLAGS)
-LDLIBS_NOVERIFIC = $(LDLIBS)
+LIBS_NOVERIFIC = $(LIBS)
 endif
 
 $(PROGRAM_PREFIX)yosys-config: misc/yosys-config.in
 	$(P) $(SED) -e 's#@CXXFLAGS@#$(subst -Ilibs/dlfcn-win32,,$(subst -I. -I"$(YOSYS_SRC)",-I"$(DATDIR)/include",$(strip $(CXXFLAGS_NOVERIFIC))))#;' \
-			-e 's#@CXX@#$(strip $(CXX))#;' -e 's#@LDFLAGS@#$(strip $(LDFLAGS) $(PLUGIN_LDFLAGS))#;' -e 's#@LDLIBS@#$(strip $(LDLIBS_NOVERIFIC) $(PLUGIN_LDLIBS))#;' \
+			-e 's#@CXX@#$(strip $(CXX))#;' -e 's#@LINKFLAGS@#$(strip $(LINKFLAGS) $(PLUGIN_LINKFLAGS))#;' -e 's#@LIBS@#$(strip $(LIBS_NOVERIFIC) $(PLUGIN_LIBS))#;' \
 			-e 's#@BINDIR@#$(strip $(BINDIR))#;' -e 's#@DATDIR@#$(strip $(DATDIR))#;' < $< > $(PROGRAM_PREFIX)yosys-config
 	$(Q) chmod +x $(PROGRAM_PREFIX)yosys-config
 
@@ -924,7 +924,7 @@ ystests: $(TARGETS) $(EXTRA_TARGETS)
 # Unit test
 unit-test: libyosys.so
 	@$(MAKE) -C $(UNITESTPATH) CXX="$(CXX)" CPPFLAGS="$(CPPFLAGS)" \
-		CXXFLAGS="$(CXXFLAGS)" LDLIBS="$(LDLIBS)" ROOTPATH="$(CURDIR)"
+		CXXFLAGS="$(CXXFLAGS)" LIBS="$(LIBS)" ROOTPATH="$(CURDIR)"
 
 clean-unit-test:
 	@$(MAKE) -C $(UNITESTPATH) clean

--- a/libs/ezsat/Makefile
+++ b/libs/ezsat/Makefile
@@ -1,9 +1,9 @@
 
 CC = clang
-CXX = clang
+CXX = clang++
 CXXFLAGS = -MD -Wall -Wextra -ggdb
 CXXFLAGS += -std=c++11 -O0
-LDLIBS = ../minisat/Options.cc ../minisat/SimpSolver.cc ../minisat/Solver.cc ../minisat/System.cc -lm -lstdc++
+LIBS = ../minisat/Options.cc ../minisat/SimpSolver.cc ../minisat/Solver.cc ../minisat/System.cc -lm -lstdc++
 
 
 all: demo_vec demo_bit demo_cmp testbench puzzle3d
@@ -27,4 +27,3 @@ clean:
 .PHONY: all test clean
 
 -include *.d
-

--- a/libs/subcircuit/Makefile
+++ b/libs/subcircuit/Makefile
@@ -5,9 +5,9 @@ CONFIG := clang-debug
 # CONFIG := release
 
 CC = clang
-CXX = clang
+CXX = clang++
 CXXFLAGS = -MD -Wall -Wextra -ggdb
-LDLIBS = -lstdc++
+LIBS = -lstdc++
 
 ifeq ($(CONFIG),clang-debug)
 CXXFLAGS += -std=c++11 -O0
@@ -15,19 +15,19 @@ endif
 
 ifeq ($(CONFIG),gcc-debug)
 CC = gcc
-CXX = gcc
+CXX = g++
 CXXFLAGS += -std=gnu++0x -O0
 endif
 
 ifeq ($(CONFIG),profile)
 CC = gcc
-CXX = gcc
+CXX = g++
 CXXFLAGS += -std=gnu++0x -Os -DNDEBUG
 endif
 
 ifeq ($(CONFIG),release)
 CC = gcc
-CXX = gcc
+CXX = g++
 CXXFLAGS += -std=gnu++0x -march=native -O3 -DNDEBUG
 endif
 
@@ -50,4 +50,3 @@ clean:
 .PHONY: all test clean
 
 -include *.d
-

--- a/misc/yosys-config.in
+++ b/misc/yosys-config.in
@@ -9,8 +9,10 @@ help() {
 		echo "Replacement args:"
 		echo "    --cxx         @CXX@"
 		echo "    --cxxflags    $( echo '@CXXFLAGS@' | fmt -w60 | sed ':a;N;$!ba;s/\n/ \\\n                      /g' )"
-		echo "    --ldflags     @LINKFLAGS@"
-		echo "    --ldlibs      @LIBS@"
+		echo "    --linkflags   @LINKFLAGS@"
+		echo "    --ldflags     (alias of --linkflags)"
+		echo "    --libs        @LIBS@"
+		echo "    --ldlibs      (alias of --libs)"
 		echo "    --bindir      @BINDIR@"
 		echo "    --datdir      @DATDIR@"
 		echo ""
@@ -18,7 +20,7 @@ help() {
 		echo ""
 		echo "Use --exec to call a command instead of generating output. Example usage:"
 		echo ""
-		echo "  $0 --exec --cxx --cxxflags --ldflags -o plugin.so -shared plugin.cc --ldlibs"
+		echo "  $0 --exec --cxx --cxxflags --ldflags -o plugin.so -shared plugin.cc --libs"
 		echo ""
 		echo "The above command can be abbreviated as:"
 		echo ""
@@ -44,7 +46,7 @@ fi
 
 if [ "$1" == "--build" ]; then
 	modname="$2"; shift 2
-	set -- --exec --cxx --cxxflags --ldflags -o "$modname" -shared "$@" --ldlibs
+	set -- --exec --cxx --cxxflags --ldflags -o "$modname" -shared "$@" --libs
 fi
 
 prefix="--"
@@ -63,6 +65,10 @@ for opt; do
 			tokens=( "${tokens[@]}"  @CXX@       ) ;;
 		"$prefix"cxxflags)
 			tokens=( "${tokens[@]}"  @CXXFLAGS@  ) ;;
+		"$prefix"linkflags)
+			tokens=( "${tokens[@]}"  @LINKFLAGS@   ) ;;
+		"$prefix"libs)
+			tokens=( "${tokens[@]}"  @LIBS@    ) ;;
 		"$prefix"ldflags)
 			tokens=( "${tokens[@]}"  @LINKFLAGS@   ) ;;
 		"$prefix"ldlibs)

--- a/misc/yosys-config.in
+++ b/misc/yosys-config.in
@@ -9,8 +9,8 @@ help() {
 		echo "Replacement args:"
 		echo "    --cxx         @CXX@"
 		echo "    --cxxflags    $( echo '@CXXFLAGS@' | fmt -w60 | sed ':a;N;$!ba;s/\n/ \\\n                      /g' )"
-		echo "    --ldflags     @LDFLAGS@"
-		echo "    --ldlibs      @LDLIBS@"
+		echo "    --ldflags     @LINKFLAGS@"
+		echo "    --ldlibs      @LIBS@"
 		echo "    --bindir      @BINDIR@"
 		echo "    --datdir      @DATDIR@"
 		echo ""
@@ -64,9 +64,9 @@ for opt; do
 		"$prefix"cxxflags)
 			tokens=( "${tokens[@]}"  @CXXFLAGS@  ) ;;
 		"$prefix"ldflags)
-			tokens=( "${tokens[@]}"  @LDFLAGS@   ) ;;
+			tokens=( "${tokens[@]}"  @LINKFLAGS@   ) ;;
 		"$prefix"ldlibs)
-			tokens=( "${tokens[@]}"  @LDLIBS@    ) ;;
+			tokens=( "${tokens[@]}"  @LIBS@    ) ;;
 		"$prefix"bindir)
 			tokens=( "${tokens[@]}" '@BINDIR@'   ) ;;
 		"$prefix"datdir)
@@ -104,4 +104,3 @@ fi
 
 echo "${tokens[@]}"
 exit 0
-

--- a/passes/techmap/Makefile.inc
+++ b/passes/techmap/Makefile.inc
@@ -56,5 +56,5 @@ EXTRA_OBJS += passes/techmap/filterlib.o
 
 $(PROGRAM_PREFIX)yosys-filterlib$(EXE): passes/techmap/filterlib.o
 	$(Q) mkdir -p $(dir $@)
-	$(P) $(LD) -o $(PROGRAM_PREFIX)yosys-filterlib$(EXE) $(LDFLAGS) $^ $(LDLIBS)
+	$(P) $(CXX) -o $(PROGRAM_PREFIX)yosys-filterlib$(EXE) $(LDFLAGS) $^ $(LDLIBS)
 endif

--- a/passes/techmap/Makefile.inc
+++ b/passes/techmap/Makefile.inc
@@ -56,5 +56,5 @@ EXTRA_OBJS += passes/techmap/filterlib.o
 
 $(PROGRAM_PREFIX)yosys-filterlib$(EXE): passes/techmap/filterlib.o
 	$(Q) mkdir -p $(dir $@)
-	$(P) $(CXX) -o $(PROGRAM_PREFIX)yosys-filterlib$(EXE) $(LDFLAGS) $^ $(LDLIBS)
+	$(P) $(CXX) -o $(PROGRAM_PREFIX)yosys-filterlib$(EXE) $(LINKFLAGS) $^ $(LIBS)
 endif

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -15,7 +15,7 @@ TESTS := $(addprefix $(BINTEST)/, $(basename $(ALLTESTFILE:%Test.cc=%Test.o)))
 all: prepare $(TESTS) run-tests
 
 $(BINTEST)/%: $(OBJTEST)/%.o
-	$(CXX) -L$(ROOTPATH) $(RPATH)=$(ROOTPATH) -o $@ $^ $(LDLIBS) \
+	$(CXX) -L$(ROOTPATH) $(RPATH)=$(ROOTPATH) -o $@ $^ $(LIBS) \
 		$(GTESTFLAG) $(EXTRAFLAGS)
 
 $(OBJTEST)/%.o: $(basename $(subst $(OBJTEST),.,%)).cc


### PR DESCRIPTION
This would solve the CXX and LD points of https://github.com/YosysHQ/yosys/issues/2011.
LD is also changed to g++ when appropriate.

All pipelines pass in my fork (https://github.com/RCoeurjoly/yosys/actions).