### PR TITLE
cxxrtl: make blackbox `commit()` possible to override

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -2511,14 +2511,13 @@ struct CxxrtlWorker {
 				dump_eval_method(module);
 				f << indent << "}\n";
 				f << "\n";
-				f << indent << "template<class ObserverT>\n";
-				f << indent << "bool commit(ObserverT &observer) {\n";
+				f << indent << "virtual bool commit(observer &observer) {\n";
 				dump_commit_method(module);
 				f << indent << "}\n";
 				f << "\n";
 				f << indent << "bool commit() override {\n";
 				f << indent << indent << "observer observer;\n";
-				f << indent << indent << "return commit<>(observer);\n";
+				f << indent << indent << "return commit(observer);\n";
 				f << indent << "}\n";
 				if (debug_info) {
 					f << "\n";
@@ -3421,8 +3420,7 @@ struct CxxrtlBackend : public Backend {
 		log("      wire<8> p_o_data;\n");
 		log("\n");
 		log("      bool eval(performer *performer) override;\n");
-		log("      template<class ObserverT>\n");
-		log("      bool commit(ObserverT &observer);\n");
+		log("      virtual bool commit(observer &observer);\n");
 		log("      bool commit() override;\n");
 		log("\n");
 		log("      static std::unique_ptr<bb_p_debug>\n");

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl_replay.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl_replay.h
@@ -556,7 +556,7 @@ public:
 	bool record_incremental(ModuleT &module) {
 		assert(streaming);
 
-		struct {
+		struct : observer {
 			std::unordered_map<const chunk_t*, spool::ident_t> *ident_lookup;
 			spool::writer *writer;
 
@@ -569,7 +569,9 @@ public:
 			void on_update(size_t chunks, const chunk_t *base, const chunk_t *value, size_t index) {
 				writer->write_change(ident_lookup->at(base), chunks, value, index);
 			}
-		} record_observer = { &ident_lookup, &writer };
+		} record_observer;
+		record_observer.ident_lookup = &ident_lookup;
+		record_observer.writer = &writer;
 
 		writer.write_sample(/*incremental=*/true, pointer++, timestamp);
 		for (auto input_index : inputs) {


### PR DESCRIPTION
This fixes a regression introduced when commit observers were added.