### PR TITLE
Add YosysHQ/abc as a submodule located in abc.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,8 @@ jobs:
 
     - name: Checkout repository
       uses: actions/checkout@v4
-
+      with:
+       submodules: true
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:

--- a/.github/workflows/emcc.yml
+++ b/.github/workflows/emcc.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - uses: mymindstorm/setup-emsdk@v14
       - uses: actions/checkout@v4
+        with:
+         submodules: true
       - name: Build
         run: |
           make config-emcc

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -29,7 +29,8 @@ jobs:
 
       - name: Checkout Yosys
         uses: actions/checkout@v3
-
+        with:
+         submodules: true
       - name: Build yosys
         shell: bash
         run: |

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -80,7 +80,8 @@ jobs:
 
       - name: Checkout Yosys
         uses: actions/checkout@v4
-
+        with:
+         submodules: true
       - name: Get iverilog
         shell: bash
         run: |

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -36,7 +36,8 @@ jobs:
 
       - name: Checkout Yosys
         uses: actions/checkout@v4
-
+        with:
+         submodules: true
       - name: Get iverilog
         shell: bash
         run: |

--- a/.github/workflows/test-verific.yml
+++ b/.github/workflows/test-verific.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-
+          submodules: true
       - name: Runtime environment
         run: |
           echo "procs=$(nproc)" >> $GITHUB_ENV

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: true
       - name: Take last commit
         id: log
         run: echo "message=$(git log --no-merges -1 --oneline)" >> $GITHUB_OUTPUT

--- a/.github/workflows/vs.yml
+++ b/.github/workflows/vs.yml
@@ -7,17 +7,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+         submodules: true
       - name: Build
         run: make vcxsrc YOSYS_VER=latest
       - uses: actions/upload-artifact@v4
         with:
           name: vcxsrc
           path: yosys-win32-vcxsrc-latest.zip
-  
+
   build:
     runs-on: windows-2019
     needs: yosys-vcxsrc
-    steps:  
+    steps:
       - uses: actions/download-artifact@v4
         with:
           name: vcxsrc

--- a/.github/workflows/wasi.yml
+++ b/.github/workflows/wasi.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+         submodules: true
       - name: Build
         run: |
           WASI_SDK=wasi-sdk-19.0

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ __pycache__
 /coverage.info
 /coverage_html
 /Makefile.conf
-/abc
 /viz.js
 /yosys
 /yosys.exe
@@ -46,3 +45,4 @@ __pycache__
 /tests/unit/bintest/
 /tests/unit/objtest/
 /tests/ystests
+/build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "abc"]
+	path = abc
+	url = https://github.com/YosysHQ/abc

--- a/Makefile
+++ b/Makefile
@@ -787,10 +787,10 @@ abc/abc$(EXE) abc/libabc.a: $(ABC_SOURCES)
 	$(Q) mkdir -p abc && $(MAKE) -C $(PROGRAM_PREFIX)abc -f "$(realpath $(YOSYS_SRC)/abc/Makefile)" ABCSRC="$(realpath $(YOSYS_SRC)/abc/)" $(S) $(ABCMKARGS) $(if $(filter %.a,$@),PROG="abc",PROG="abc$(EXE)") MSG_PREFIX="$(eval P_OFFSET = 5)$(call P_SHOW)$(eval P_OFFSET = 10) ABC: " $(if $(filter %.a,$@),libabc.a)
 
 $(PROGRAM_PREFIX)yosys-abc$(EXE): abc/abc$(EXE)
-	$(P) cp abc/abc$(EXE) $(PROGRAM_PREFIX)yosys-abc$(EXE)
+	$(P) cp $< $(PROGRAM_PREFIX)yosys-abc$(EXE)
 
 $(PROGRAM_PREFIX)yosys-libabc.a: abc/libabc.a
-	$(P) cp abc/libabc.a $(PROGRAM_PREFIX)yosys-libabc.a
+	$(P) cp $< $(PROGRAM_PREFIX)yosys-libabc.a
 
 ifneq ($(SEED),)
 SEEDOPT="-S $(SEED)"

--- a/Makefile
+++ b/Makefile
@@ -783,12 +783,24 @@ $(PROGRAM_PREFIX)yosys-config: misc/yosys-config.in
 .PHONY: check-git-abc
 
 check-git-abc:
-	@if [ -f "$(YOSYS_SRC)/abc/.git" ]; then \
-	    echo "abc/.git exists"; \
-		  exit 0; \
-	else \
-	    echo "abc/.git does not exist. Please execute git submodule update --init"; \
+	@if [ ! -d "$(YOSYS_SRC)/abc" ]; then \
+	    echo "Error: The 'abc' directory does not exist."; \
+			echo "Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule."; \
 	    exit 1; \
+	elif git -C "$(YOSYS_SRC)" submodule status abc 2>/dev/null | grep -q '^ '; then \
+	    echo "'abc' is a git submodule. Continuing."; \
+	    exit 0; \
+	elif [ -f "$(YOSYS_SRC)/abc/.gitcommit" ] && grep -q '\$$Format:%h\$$' "$(YOSYS_SRC)/abc/.gitcommit"; then \
+	    echo "Error: 'abc' is not configured as a git submodule."; \
+	    echo "To resolve this:"; \
+	    echo "1. Back up your changes: Save any modifications from the 'abc' directory to another location."; \
+	    echo "2. Remove the existing 'abc' directory: Delete the 'abc' directory and all its contents."; \
+	    echo "3. Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule."; \
+	    echo "4. Reapply your changes: Move your saved changes back to the 'abc' directory, if necessary."; \
+	    exit 1; \
+	else \
+	    echo "'abc' comes from a tarball. Continuing."; \
+	    exit 0; \
 	fi
 
 ABC_SOURCES := $(wildcard $(YOSYS_SRC)/abc/*)

--- a/Makefile
+++ b/Makefile
@@ -780,9 +780,20 @@ $(PROGRAM_PREFIX)yosys-config: misc/yosys-config.in
 			-e 's#@BINDIR@#$(strip $(BINDIR))#;' -e 's#@DATDIR@#$(strip $(DATDIR))#;' < $< > $(PROGRAM_PREFIX)yosys-config
 	$(Q) chmod +x $(PROGRAM_PREFIX)yosys-config
 
+.PHONY: check-git-abc
+
+check-git-abc:
+	@if [ -f "$(YOSYS_SRC)/abc/.git" ]; then \
+	    echo "abc/.git exists"; \
+		  exit 0; \
+	else \
+	    echo "abc/.git does not exist. Please execute git submodule update --init"; \
+	    exit 1; \
+	fi
+
 ABC_SOURCES := $(wildcard $(YOSYS_SRC)/abc/*)
 
-abc/abc$(EXE) abc/libabc.a: $(ABC_SOURCES)
+abc/abc$(EXE) abc/libabc.a: $(ABC_SOURCES) check-git-abc
 	$(P)
 	$(Q) mkdir -p abc && $(MAKE) -C $(PROGRAM_PREFIX)abc -f "$(realpath $(YOSYS_SRC)/abc/Makefile)" ABCSRC="$(realpath $(YOSYS_SRC)/abc/)" $(S) $(ABCMKARGS) $(if $(filter %.a,$@),PROG="abc",PROG="abc$(EXE)") MSG_PREFIX="$(eval P_OFFSET = 5)$(call P_SHOW)$(eval P_OFFSET = 10) ABC: " $(if $(filter %.a,$@),libabc.a)
 


### PR DESCRIPTION
Add YosysHQ/abc as a submodule located in abc. Apart from cloning with submodules, no other modifications are made to github actions.

This would enable building yosys with abc fetched as tar.gz, as pointed out by @mmicko in  https://github.com/YosysHQ/yosys/pull/4238#issuecomment-1966067326

Before starting the compilation of abc, we check four cases:

1. abc directory does not exist. The compilation is stopped with the following error.

> Error: The 'abc' directory does not exist.
> Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule.

2. abc is a clone of abc (abc/.gitcommit content is Format). The compilation is stopped with the following error.

> Error: 'abc' is not configured as a git submodule.
> To resolve this:
> 1. Back up your changes: Save any modifications from the 'abc' directory to another location.
> 2. Remove the existing 'abc' directory: Delete the 'abc' directory and all its contents.
> 3. Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule.
> 4. Reapply your changes: Move your saved changes back to the 'abc' directory, if necessary.

3. abc comes from a tarball (abc/.gitcommit content is different than $Format:%h$). The compilation can continue.

> 'abc' comes from a tarball. Continuing.

4. abc is a git submodule (checked with `git submodule status`). The compilation can continue.

> 'abc' is a git submodule. Continuing.