### PR TITLE
Tweaked the representation of nets and buffers in the Show command graph.

### DIFF
--- a/passes/cmds/show.cc
+++ b/passes/cmds/show.cc
@@ -429,7 +429,7 @@ struct ShowWorker
 
 		std::map<std::string, std::string> wires_on_demand;
 		for (auto wire : module->selected_wires()) {
-			const char *shape = "diamond";
+			const char *shape = "plaintext";
 			if (wire->port_input || wire->port_output)
 				shape = "octagon";
 			if (wire->name.isPublic()) {
@@ -584,7 +584,7 @@ struct ShowWorker
 				} else {
 					net_conn_map[right_node].in.insert({stringf("x%d", single_idx_count), GetSize(conn.first)});
 					net_conn_map[left_node].out.insert({stringf("x%d", single_idx_count), GetSize(conn.first)});
-					fprintf(f, "x%d [shape=point, %s];\n", single_idx_count++, findColor(conn).c_str());
+					fprintf(f, "x%d [shape=plaintext, label=\"[BUF]\", %s];\n", single_idx_count++, findColor(conn).c_str());
 				}
 			}
 		}

--- a/passes/cmds/show.cc
+++ b/passes/cmds/show.cc
@@ -584,7 +584,7 @@ struct ShowWorker
 				} else {
 					net_conn_map[right_node].in.insert({stringf("x%d", single_idx_count), GetSize(conn.first)});
 					net_conn_map[left_node].out.insert({stringf("x%d", single_idx_count), GetSize(conn.first)});
-					fprintf(f, "x%d [shape=plaintext, label=\"[BUF]\", %s];\n", single_idx_count++, findColor(conn).c_str());
+					fprintf(f, "x%d [shape=point, %s];\n", single_idx_count++, findColor(conn).c_str());
 				}
 			}
 		}


### PR DESCRIPTION
Two tweaks to the generated graph.

1. Nets changed from a diamond shapes to plain text with the net name. This provides the visual load of the nets while preserving their names.

2. Buffers changed from a period shape to a plain text with the label "[BUF]", providing hint what they are while keeping the visual load low

Before
![before](https://github.com/YosysHQ/yosys/assets/2184769/1dfc8f71-6715-4357-8c5b-07b1c7c73633)

After
![after](https://github.com/YosysHQ/yosys/assets/2184769/3f49e54c-3d93-4eed-8b96-924911c354ef)

Dot files
[Archive.zip](https://github.com/YosysHQ/yosys/files/14445442/Archive.zip)
