### PR TITLE
Fix emcc build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ CXX = emcc
 CXXFLAGS := -std=$(CXXSTD) $(filter-out -fPIC -ggdb,$(CXXFLAGS))
 ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H -DABC_MEMALIGN=8 -Wno-c++11-narrowing"
 EMCC_CXXFLAGS := -Os -Wno-warn-absolute-paths
-EMCC_LINKFLAGS := --memory-init-file 0 --embed-file share
+EMCC_LINKFLAGS := --embed-file share
 EMCC_LINKFLAGS += -s NO_EXIT_RUNTIME=1
 EMCC_LINKFLAGS += -s EXPORTED_FUNCTIONS="['_main','_run','_prompt','_errmsg','_memset']"
 EMCC_LINKFLAGS += -s TOTAL_MEMORY=134217728


### PR DESCRIPTION
`--memory-init-file` is no longer supported as of emscripten version 3.1.55 (released 03/01/24).  It was previously taking a value of `0`, so I don't think it was actually doing anything for us and can be safely removed?