### PR TITLE
Avoid `module_not_derived` on internal cells in techmap result

### DIFF
--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -2087,8 +2087,6 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 			check_unique_id(current_module, id, this, "cell");
 			RTLIL::Cell *cell = current_module->addCell(id, "");
 			set_src_attr(cell, this);
-			// Set attribute 'module_not_derived' which will be cleared again after the hierarchy pass
-			cell->set_bool_attribute(ID::module_not_derived);
 
 			for (auto it = children.begin(); it != children.end(); it++) {
 				AstNode *child = *it;
@@ -2151,6 +2149,11 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 				}
 				log_abort();
 			}
+
+			// Set attribute 'module_not_derived' which will be cleared again after the hierarchy pass
+			if (cell->type.isPublic())
+				cell->set_bool_attribute(ID::module_not_derived);
+
 			for (auto &attr : attributes) {
 				if (attr.second->type != AST_CONSTANT)
 					input_error("Attribute `%s' with non-constant value.\n", attr.first.c_str());

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -334,9 +334,6 @@ struct TechmapWorker
 			RTLIL::Cell *c = module->addCell(c_name, tpl_cell);
 			design->select(module, c);
 
-			if (c->type.begins_with("\\$"))
-				c->type = c->type.substr(1);
-
 			vector<IdString> autopurge_ports;
 
 			for (auto &conn : c->connections())
@@ -431,13 +428,9 @@ struct TechmapWorker
 			if (handled_cells.count(cell) > 0)
 				continue;
 
-			std::string cell_type = cell->type.str();
-			if (in_recursion && cell->type.begins_with("\\$"))
-				cell_type = cell_type.substr(1);
-
-			if (celltypeMap.count(cell_type) == 0) {
-				if (assert_mode && cell_type.back() != '_')
-					log_error("(ASSERT MODE) No matching template cell for type %s found.\n", log_id(cell_type));
+			if (celltypeMap.count(cell->type) == 0) {
+				if (assert_mode && !cell->type.ends_with("_"))
+					log_error("(ASSERT MODE) No matching template cell for type %s found.\n", log_id(cell->type));
 				continue;
 			}
 
@@ -449,7 +442,7 @@ struct TechmapWorker
 				if (GetSize(sig) == 0)
 					continue;
 
-				for (auto &tpl_name : celltypeMap.at(cell_type)) {
+				for (auto &tpl_name : celltypeMap.at(cell->type)) {
 					RTLIL::Module *tpl = map->module(tpl_name);
 					RTLIL::Wire *port = tpl->wire(conn.first);
 					if (port && port->port_input)
@@ -476,12 +469,7 @@ struct TechmapWorker
 			log_assert(cell == module->cell(cell->name));
 			bool mapped_cell = false;
 
-			std::string cell_type = cell->type.str();
-
-			if (in_recursion && cell->type.begins_with("\\$"))
-				cell_type = cell_type.substr(1);
-
-			for (auto &tpl_name : celltypeMap.at(cell_type))
+			for (auto &tpl_name : celltypeMap.at(cell->type))
 			{
 				IdString derived_name = tpl_name;
 				RTLIL::Module *tpl = map->module(tpl_name);
@@ -503,8 +491,6 @@ struct TechmapWorker
 
 				if (!extmapper_name.empty())
 				{
-					cell->type = cell_type;
-
 					if ((extern_mode && !in_recursion) || extmapper_name == "wrap")
 					{
 						std::string m_name = stringf("$extern:%s:%s", extmapper_name.c_str(), log_id(cell->type));
@@ -929,11 +915,6 @@ struct TechmapWorker
 						RTLIL::Module *m = design->addModule(m_name);
 						tpl->cloneInto(m);
 
-						for (auto cell : m->cells()) {
-							if (cell->type.begins_with("\\$"))
-								cell->type = cell->type.substr(1);
-						}
-
 						module_queue.insert(m);
 					}
 
@@ -1150,7 +1131,7 @@ struct TechmapPass : public Pass {
 		simplemap_get_mappers(worker.simplemap_mappers);
 
 		std::vector<std::string> map_files;
-		std::string verilog_frontend = "verilog -nooverwrite -noblackbox";
+		std::string verilog_frontend = "verilog -nooverwrite -noblackbox -icells";
 		int max_iter = -1;
 
 		size_t argidx;


### PR DESCRIPTION
With the following

```
read_verilog <<EOF
module top(a, b, y);
	input wire [7:0] a;
	input wire [7:0] b;
	output wire [7:0] y;
	assign y = a + b;
endmodule
EOF
prep
alumacc
techmap -max_iter 1
dump t:$lcu
```

you get

```
  attribute \module_not_derived 1
  attribute \src "test.v:5.13-5.18|.../yosys/share/techmap.v:286.27-286.69"
  cell $lcu $auto$alumacc.cc:485:replace_alu$2.lcu
    parameter \WIDTH 8
    connect \CO $auto$alumacc.cc:502:replace_alu$4
    connect \CI 1'0
    connect \G $techmap$auto$alumacc.cc:485:replace_alu$2.$and$/Users/pk/repos/yosys/share/techmap.v:286$84_Y
    connect \P $auto$alumacc.cc:501:replace_alu$3
  end
```

where the `module_not_derived` attribute is misplaced. It doesn't make sense on an internall cell and `hierarchy` won't clean it.

To address this, we want `read_verilog -icells` not to place the attribute on internal cells, and `techmap` to use the frontend in the `-icells` mode instead of fixing up the cell types after the fact.