### PR TITLE
ci: Fix mac builds

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          brew install bison flex gawk libffi pkg-config bash
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install bison flex gawk libffi pkg-config bash
 
       - name: Runtime environment
         shell: bash


### PR DESCRIPTION
Adds `HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1` to prevent brew trying to upgrade dependents, which is both a waste of time, and raises an error trying to symlink `bin/2to3`.