### PR TITLE
abc9: Make the default a non-mapping mode 

### DIFF
--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -228,7 +228,7 @@ struct Abc9Pass : public ScriptPass
 						/*arg == "-box" ||*/ arg == "-W") &&
 					argidx+1 < args.size()) {
 				if (arg == "-lut" || arg == "-luts")
-					lut_mode = false;
+					lut_mode = true;
 				exe_cmd << " " << arg << " " << args[++argidx];
 				continue;
 			}
@@ -272,6 +272,9 @@ struct Abc9Pass : public ScriptPass
 
 		if (maxlut && !lutlib_mode)
 			log_cmd_error("abc9 '-maxlut' option only applicable in conjunction with '-lutlib'.\n");
+
+		if (lut_mode && lutlib_mode)
+			log_cmd_error("abc9 '-lutlib' option is in conflict with '-lut' or '-luts'.\n");
 
 		log_assert(design);
 		if (design->selected_modules().empty()) {

--- a/passes/techmap/abc9_exe.cc
+++ b/passes/techmap/abc9_exe.cc
@@ -176,8 +176,6 @@ void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe
 		abc9_script += stringf("read_lut %s/lutdefs.txt; ", tempdir_name.c_str());
 	else if (!lut_file.empty())
 		abc9_script += stringf("read_lut \"%s\"; ", lut_file.c_str());
-	else
-		log_abort();
 
 	log_assert(!box_file.empty());
 	abc9_script += stringf("read_box \"%s\"; ", box_file.c_str());
@@ -197,8 +195,9 @@ void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe
 	} else if (!lut_costs.empty() || !lut_file.empty()) {
 		abc9_script += fast_mode ? RTLIL::constpad.at("abc9.script.default.fast").substr(1,std::string::npos)
 			: RTLIL::constpad.at("abc9.script.default").substr(1,std::string::npos);
-	} else
-		log_abort();
+	} else {
+		log_error("Without a target library, a script needs to be provided.\n");
+	}
 
 	for (size_t pos = abc9_script.find("{D}"); pos != std::string::npos; pos = abc9_script.find("{D}", pos))
 		abc9_script = abc9_script.substr(0, pos) + delay_target + abc9_script.substr(pos+3);

--- a/techlibs/ecp5/synth_ecp5.cc
+++ b/techlibs/ecp5/synth_ecp5.cc
@@ -388,7 +388,7 @@ struct SynthEcp5Pass : public ScriptPass
 					abc9_opts += " -maxlut 4";
 				if (dff)
 					abc9_opts += " -dff";
-				run("abc9" + abc9_opts);
+				run("abc9 -lutlib" + abc9_opts);
 			} else {
 				std::string abc_args = " -dress";
 				if (nowidelut)

--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -278,12 +278,12 @@ struct SynthGowinPass : public ScriptPass
 		{
 			if (nowidelut && abc9) {
 				run("read_verilog -icells -lib -specify +/abc9_model.v");
-				run("abc9 -maxlut 4 -W 500");
+				run("abc9 -lutlib -maxlut 4 -W 500");
 			} else if (nowidelut && !abc9) {
 				run("abc -lut 4");
 			} else if (!nowidelut && abc9) {
 				run("read_verilog -icells -lib -specify +/abc9_model.v");
-				run("abc9 -maxlut 8 -W 500");
+				run("abc9 -lutlib -maxlut 8 -W 500");
 			} else if (!nowidelut && !abc9) {
 				run("abc -lut 4:8");
 			}

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -424,7 +424,7 @@ struct SynthIce40Pass : public ScriptPass
 					}
 					if (dff)
 						abc9_opts += " -dff";
-					run("abc9 " + abc9_opts);
+					run("abc9 -lutlib" + abc9_opts);
 				}
 				else
 					run(stringf("abc -dress -lut 4 %s", dff ? "-dff" : ""), "(skip if -noabc)");

--- a/techlibs/intel_alm/synth_intel_alm.cc
+++ b/techlibs/intel_alm/synth_intel_alm.cc
@@ -289,7 +289,7 @@ struct SynthIntelALMPass : public ScriptPass {
 
 		if (check_label("map_luts")) {
 			run("techmap -map +/intel_alm/common/abc9_map.v");
-			run(stringf("abc9 %s -maxlut 6 -W 600", help_mode ? "[-dff]" : dff ? "-dff" : ""));
+			run(stringf("abc9 -lutlib %s -maxlut 6 -W 600", help_mode ? "[-dff]" : dff ? "-dff" : ""));
 			run("techmap -map +/intel_alm/common/abc9_unmap.v");
 			run("techmap -map +/intel_alm/common/alm_map.v");
 			run("opt -fast");

--- a/techlibs/lattice/synth_lattice.cc
+++ b/techlibs/lattice/synth_lattice.cc
@@ -454,7 +454,7 @@ struct SynthLatticePass : public ScriptPass
 					abc9_opts += " -maxlut 4";
 				if (dff)
 					abc9_opts += " -dff";
-				run("abc9" + abc9_opts);
+				run("abc9 -lutlib" + abc9_opts);
 			} else {
 				std::string abc_args = " -dress";
 				if (nowidelut)

--- a/techlibs/nexus/synth_nexus.cc
+++ b/techlibs/nexus/synth_nexus.cc
@@ -366,7 +366,7 @@ struct SynthNexusPass : public ScriptPass
 					abc9_opts += " -maxlut 4";
 				if (dff)
 					abc9_opts += " -dff";
-				run("abc9" + abc9_opts);
+				run("abc9 -lutlib" + abc9_opts);
 			} else {
 				std::string abc_args = " -dress";
 				if (nowidelut)

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -304,7 +304,7 @@ struct SynthQuickLogicPass : public ScriptPass {
 			if (abc9) {
 				run("read_verilog -lib -specify -icells " + lib_path + family + "/abc9_model.v");
 				run("techmap -map " + lib_path + family + "/abc9_map.v");
-				run("abc9 -maxlut 4 -dff");
+				run("abc9 -lutlib -maxlut 4 -dff");
 				run("techmap -map " + lib_path + family + "/abc9_unmap.v");
 			} else {
 				run("abc -luts 1,2,2,4 -dress");
@@ -314,7 +314,7 @@ struct SynthQuickLogicPass : public ScriptPass {
 
 		if (check_label("map_luts", "(for qlf_k6n10f)") && (help_mode || family == "qlf_k6n10f")) {
 			if (abc9) {
-				run("abc9 -maxlut 6");
+				run("abc9 -lutlib -maxlut 6");
 			} else {
 				run("abc -lut 6 -dress");
 			}

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -650,7 +650,7 @@ struct SynthXilinxPass : public ScriptPass
 					abc9_opts += stringf(" -maxlut %d", lut_size);
 				if (dff)
 					abc9_opts += " -dff";
-				run("abc9" + abc9_opts);
+				run("abc9 -lutlib" + abc9_opts);
 			}
 			else {
 				std::string abc_opts;

--- a/tests/arch/xilinx/bug3670.ys
+++ b/tests/arch/xilinx/bug3670.ys
@@ -1,3 +1,3 @@
 read_verilog bug3670.v
 read_verilog -lib -specify +/xilinx/cells_sim.v
-abc9
+abc9 -lutlib

--- a/tests/arch/xilinx/dsp_abc9.ys
+++ b/tests/arch/xilinx/dsp_abc9.ys
@@ -49,7 +49,7 @@ DSP48E1 #(.AREG(1)) u2(.A(A), .B(B), .PCIN(casc), .P(P));
 endmodule
 EOT
 synth_xilinx -run :prepare
-abc9
+abc9 -lutlib
 clean
 check
 logger -expect-no-warnings

--- a/tests/various/abc9.ys
+++ b/tests/various/abc9.ys
@@ -73,7 +73,7 @@ module abc9_test037(input [1:0] i, output o);
 LUT2 #(.mask(4'b0)) lut (.i(i), .o(o));
 endmodule
 EOT
-abc9
+abc9 -lutlib
 
 
 design -reset


### PR DESCRIPTION
Formerly when you didn't pass any options to `abc9` it would source a LUT library from the current design by considering any module with an `abc9_lut` attribute to be an available mapping primitive.

Make the change to condition this behavior on a `-lutlib` option, and instead make `abc9` without any options perform a non-mapping mode in which the netlist is reimported back into Yosys as an and-inverter graph.