### PR TITLE
Add several new formatting features used by Amaranth to translate Python format strings

### DIFF
--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -1034,6 +1034,7 @@ struct fmt_part {
 	unsigned base; // = 10;
 	bool signed_; // = false;
 	bool plus; // = false;
+	bool hex_upper; // = false;
 
 	// VLOG_TIME type
 	bool realtime; // = false;
@@ -1085,7 +1086,7 @@ struct fmt_part {
 						uint8_t value = val.bit(index) | (val.bit(index + 1) << 1) | (val.bit(index + 2) << 2);
 						if (step == 4)
 							value |= val.bit(index + 3) << 3;
-						buf += "0123456789abcdef"[value];
+						buf += (hex_upper ? "0123456789ABCDEF" : "0123456789abcdef")[value];
 					}
 					std::reverse(buf.begin(), buf.end());
 				} else if (base == 10) {

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -1026,6 +1026,7 @@ struct fmt_part {
 	enum {
 		RIGHT	= 0,
 		LEFT	= 1,
+		NUMERIC	= 2,
 	} justify; // = RIGHT;
 	char padding; // = '\0';
 	size_t width; // = 0;
@@ -1131,9 +1132,9 @@ struct fmt_part {
 
 		std::string str;
 		assert(width == 0 || padding != '\0');
-		if (justify == RIGHT && buf.size() < width) {
+		if (justify != LEFT && buf.size() < width) {
 			size_t pad_width = width - buf.size();
-			if (padding == '0' && (buf.front() == '+' || buf.front() == '-')) {
+			if (justify == NUMERIC && (buf.front() == '+' || buf.front() == '-' || buf.front() == ' ')) {
 				str += buf.front();
 				buf.erase(0, 1);
 			}

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -1041,6 +1041,7 @@ struct fmt_part {
 		SPACE_MINUS	= 2,
 	} sign; // = MINUS;
 	bool hex_upper; // = false;
+	bool show_base; // = false;
 
 	// VLOG_TIME type
 	bool realtime; // = false;
@@ -1103,6 +1104,8 @@ struct fmt_part {
 				}
 
 				if (base == 2) {
+					if (show_base)
+						buf += "0b";
 					for (size_t i = width; i > 0; i--)
 						buf += (val.bit(i - 1) ? '1' : '0');
 				} else if (base == 8 || base == 16) {
@@ -1113,6 +1116,8 @@ struct fmt_part {
 							value |= val.bit(index + 3) << 3;
 						buf += (hex_upper ? "0123456789ABCDEF" : "0123456789abcdef")[value];
 					}
+					if (show_base)
+						buf += (base == 16) ? (hex_upper ? "X0" : "x0") : "o0";
 					std::reverse(buf.begin(), buf.end());
 				} else if (base == 10) {
 					bool negative = signed_ && val.is_neg();
@@ -1130,6 +1135,8 @@ struct fmt_part {
 						buf += '0' + remainder.template trunc<4>().template get<uint8_t>();
 						xval = quotient;
 					}
+					if (show_base)
+						buf += "d0";
 					switch (sign) {
 						case MINUS:       buf += negative ? "-" : "";  break;
 						case PLUS_MINUS:  buf += negative ? "-" : "+"; break;

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -1010,19 +1010,19 @@ struct observer {
 // Default member initializers would make this a non-aggregate-type in C++11, so they are commented out.
 struct fmt_part {
 	enum {
-		STRING    = 0,
+		LITERAL   = 0,
 		INTEGER   = 1,
-		CHARACTER = 2,
+		STRING    = 2,
 		VLOG_TIME = 3,
 	} type;
 
-	// STRING type
+	// LITERAL type
 	std::string str;
 
-	// INTEGER/CHARACTER types
+	// INTEGER/STRING types
 	// + value<Bits> val;
 
-	// INTEGER/CHARACTER/VLOG_TIME types
+	// INTEGER/STRING/VLOG_TIME types
 	enum {
 		RIGHT	= 0,
 		LEFT	= 1,
@@ -1050,10 +1050,10 @@ struct fmt_part {
 		// chunk access if it turns out to be slow enough to matter.
 		std::string buf;
 		switch (type) {
-			case STRING:
+			case LITERAL:
 				return str;
 
-			case CHARACTER: {
+			case STRING: {
 				buf.reserve(Bits/8);
 				for (int i = 0; i < Bits; i += 8) {
 					char ch = 0;

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -1109,28 +1109,27 @@ struct fmt_part {
 					}
 				}
 
-				size_t width = Bits;
+				size_t val_width = Bits;
 				if (base != 10) {
-					width = 1;
+					val_width = 1;
 					for (size_t index = 0; index < Bits; index++)
 						if (val.bit(index))
-							width = index + 1;
+							val_width = index + 1;
 				}
 
 				if (base == 2) {
 					if (show_base)
 						prefix += "0b";
-					for (size_t index = 0; index < width; index++) {
+					for (size_t index = 0; index < val_width; index++) {
 						if (group && index > 0 && index % 4 == 0)
 							buf += '_';
 						buf += (val.bit(index) ? '1' : '0');
 					}
-					std::reverse(buf.begin(), buf.end());
 				} else if (base == 8 || base == 16) {
 					if (show_base)
 						prefix += (base == 16) ? (hex_upper ? "0X" : "0x") : "0o";
 					size_t step = (base == 16) ? 4 : 3;
-					for (size_t index = 0; index < width; index += step) {
+					for (size_t index = 0; index < val_width; index += step) {
 						if (group && index > 0 && index % (4 * step) == 0)
 							buf += '_';
 						uint8_t value = val.bit(index) | (val.bit(index + 1) << 1) | (val.bit(index + 2) << 2);
@@ -1138,7 +1137,6 @@ struct fmt_part {
 							value |= val.bit(index + 3) << 3;
 						buf += (hex_upper ? "0123456789ABCDEF" : "0123456789abcdef")[value];
 					}
-					std::reverse(buf.begin(), buf.end());
 				} else if (base == 10) {
 					if (show_base)
 						prefix += "0d";
@@ -1158,8 +1156,16 @@ struct fmt_part {
 						xval = quotient;
 						index++;
 					}
-					std::reverse(buf.begin(), buf.end());
 				} else assert(false && "Unsupported base for fmt_part");
+				if (justify == NUMERIC && group && padding == '0') {
+					int group_size = base == 10 ? 3 : 4;
+					while (prefix.size() + buf.size() < width) {
+						if (buf.size() % (group_size + 1) == group_size)
+							buf += '_';
+						buf += '0';
+					}
+				}
+				std::reverse(buf.begin(), buf.end());
 				break;
 			}
 

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -1013,13 +1013,14 @@ struct fmt_part {
 		LITERAL   = 0,
 		INTEGER   = 1,
 		STRING    = 2,
-		VLOG_TIME = 3,
+		UNICHAR   = 3,
+		VLOG_TIME = 4,
 	} type;
 
 	// LITERAL type
 	std::string str;
 
-	// INTEGER/STRING types
+	// INTEGER/STRING/UNICHAR types
 	// + value<Bits> val;
 
 	// INTEGER/STRING/VLOG_TIME types
@@ -1070,6 +1071,25 @@ struct fmt_part {
 						buf.append({ch});
 				}
 				std::reverse(buf.begin(), buf.end());
+				break;
+			}
+
+			case UNICHAR: {
+				uint32_t codepoint = val.template get<uint32_t>();
+				if (codepoint >= 0x10000)
+					buf += (char)(0xf0 |  (codepoint >> 18));
+				else if (codepoint >= 0x800)
+					buf += (char)(0xe0 |  (codepoint >> 12));
+				else if (codepoint >= 0x80)
+					buf += (char)(0xc0 |  (codepoint >>  6));
+				else
+					buf += (char)codepoint;
+				if (codepoint >= 0x10000)
+					buf += (char)(0x80 | ((codepoint >> 12) & 0x3f));
+				if (codepoint >= 0x800)
+					buf += (char)(0x80 | ((codepoint >>  6) & 0x3f));
+				if (codepoint >= 0x80)
+					buf += (char)(0x80 | ((codepoint >>  0) & 0x3f));
 				break;
 			}
 

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -1033,7 +1033,11 @@ struct fmt_part {
 	// INTEGER type
 	unsigned base; // = 10;
 	bool signed_; // = false;
-	bool plus; // = false;
+	enum {
+		MINUS		= 0,
+		PLUS_MINUS	= 1,
+		SPACE_MINUS	= 2,
+	} sign; // = MINUS;
 	bool hex_upper; // = false;
 
 	// VLOG_TIME type
@@ -1105,8 +1109,11 @@ struct fmt_part {
 						buf += '0' + remainder.template trunc<4>().template get<uint8_t>();
 						xval = quotient;
 					}
-					if (negative || plus)
-						buf += negative ? '-' : '+';
+					switch (sign) {
+						case MINUS:       buf += negative ? "-" : "";  break;
+						case PLUS_MINUS:  buf += negative ? "-" : "+"; break;
+						case SPACE_MINUS: buf += negative ? "-" : " "; break;
+					}
 					std::reverse(buf.begin(), buf.end());
 				} else assert(false && "Unsupported base for fmt_part");
 				break;

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -790,7 +790,7 @@ struct AST_INTERNAL::ProcessGenerator
 				Fmt fmt;
 				fmt.parse_verilog(args, /*sformat_like=*/false, default_base, /*task_name=*/ast->str, current_module->name);
 				if (ast->str.substr(0, 8) == "$display")
-					fmt.append_string("\n");
+					fmt.append_literal("\n");
 				fmt.emit_rtlil(cell);
 			} else if (!ast->str.empty()) {
 				log_file_error(ast->filename, ast->location.first_line, "Found unsupported invocation of system task `%s'!\n", ast->str.c_str());

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1079,7 +1079,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 				// when $display()/$write() functions are used in an initial block, print them during synthesis
 				Fmt fmt = processFormat(stage, /*sformat_like=*/false, default_base, /*first_arg_at=*/0, /*may_fail=*/true);
 				if (str.substr(0, 8) == "$display")
-					fmt.append_string("\n");
+					fmt.append_literal("\n");
 				log("%s", fmt.render().c_str());
 			}
 

--- a/kernel/fmt.cc
+++ b/kernel/fmt.cc
@@ -91,10 +91,7 @@ void Fmt::parse_rtlil(const RTLIL::Cell *cell) {
 			if (++i == fmt.size())
 				log_assert(false && "Unexpected end in format substitution");
 
-			if (fmt[i] == '0' || fmt[i] == ' ')
-				part.padding = fmt[i];
-			else
-				log_assert(false && "Unexpected padding in format substitution");
+			part.padding = fmt[i];
 			if (++i == fmt.size())
 				log_assert(false && "Unexpected end in format substitution");
 
@@ -550,7 +547,6 @@ std::vector<VerilogFmtArg> Fmt::emit_verilog() const
 				if (part.width == 0) {
 					fmt.str += '0';
 				} else if (part.width > 0) {
-					log_assert(part.padding == ' ' || part.padding == '0');
 					if (part.base != 10 || part.padding == '0')
 						fmt.str += '0';
 					fmt.str += std::to_string(part.width);
@@ -576,7 +572,6 @@ std::vector<VerilogFmtArg> Fmt::emit_verilog() const
 					fmt.str += '-';
 				if (part.sig.size() == 8) {
 					if (part.width > 0) {
-						log_assert(part.padding == '0' || part.padding == ' ');
 						if (part.padding == '0')
 							fmt.str += part.padding;
 						fmt.str += std::to_string(part.width);
@@ -585,7 +580,6 @@ std::vector<VerilogFmtArg> Fmt::emit_verilog() const
 				} else {
 					log_assert(part.sig.size() % 8 == 0);
 					if (part.width > 0) {
-						log_assert(part.padding == ' '); // no zero padding
 						fmt.str += std::to_string(part.width);
 					}
 					fmt.str += 's';
@@ -616,7 +610,6 @@ std::vector<VerilogFmtArg> Fmt::emit_verilog() const
 					fmt.str += '+';
 				if (part.justify == FmtPart::LEFT)
 					fmt.str += '-';
-				log_assert(part.padding == ' ' || part.padding == '0');
 				if (part.padding == '0' && part.width > 0)
 					fmt.str += '0';
 				fmt.str += std::to_string(part.width);

--- a/kernel/fmt.cc
+++ b/kernel/fmt.cc
@@ -107,6 +107,10 @@ void Fmt::parse_rtlil(const RTLIL::Cell *cell) {
 				} else if (fmt[i] == 'h') {
 					part.type = FmtPart::INTEGER;
 					part.base = 16;
+				} else if (fmt[i] == 'H') {
+					part.type = FmtPart::INTEGER;
+					part.base = 16;
+					part.hex_upper = true;
 				} else if (fmt[i] == 'c') {
 					part.type = FmtPart::STRING;
 				} else if (fmt[i] == 't') {
@@ -197,7 +201,7 @@ void Fmt::emit_rtlil(RTLIL::Cell *cell) const {
 						case  2: fmt += 'b'; break;
 						case  8: fmt += 'o'; break;
 						case 10: fmt += 'd'; break;
-						case 16: fmt += 'h'; break;
+						case 16: fmt += part.hex_upper ? 'H' : 'h'; break;
 						default: log_abort();
 					}
 					if (part.plus)
@@ -507,7 +511,7 @@ std::vector<VerilogFmtArg> Fmt::emit_verilog() const
 					case  2: fmt.str += 'b'; break;
 					case  8: fmt.str += 'o'; break;
 					case 10: fmt.str += 'd'; break;
-					case 16: fmt.str += 'h'; break;
+					case 16: fmt.str += 'h'; break; // treat uppercase hex as lowercase
 					default: log_abort();
 				}
 				break;
@@ -617,6 +621,7 @@ void Fmt::emit_cxxrtl(std::ostream &os, std::string indent, std::function<void(c
 		os << part.base << ", ";
 		os << part.signed_ << ", ";
 		os << part.plus << ", ";
+		os << part.hex_upper << ", ";
 		os << part.realtime;
 		os << " }.render(";
 		emit_sig(part.sig);
@@ -676,7 +681,7 @@ std::string Fmt::render() const
 							else if (has_z)
 								buf += 'Z';
 							else
-								buf += "0123456789abcdef"[subvalue.as_int()];
+								buf += (part.hex_upper ? "0123456789ABCDEF" : "0123456789abcdef")[subvalue.as_int()];
 						}
 						std::reverse(buf.begin(), buf.end());
 					} else if (part.base == 10) {

--- a/kernel/fmt.cc
+++ b/kernel/fmt.cc
@@ -776,7 +776,6 @@ std::string Fmt::render() const
 							else /* if (bit == State::S0) */
 								buf += '0';
 						}
-						std::reverse(buf.begin(), buf.end());
 					} else if (part.base == 8 || part.base == 16) {
 						if (part.show_base)
 							prefix += (part.base == 16) ? (part.hex_upper ? "0X" : "0x") : "0o";
@@ -807,7 +806,6 @@ std::string Fmt::render() const
 							else
 								buf += (part.hex_upper ? "0123456789ABCDEF" : "0123456789abcdef")[subvalue.as_int()];
 						}
-						std::reverse(buf.begin(), buf.end());
 					} else if (part.base == 10) {
 						if (part.show_base)
 							prefix += "0d";
@@ -831,9 +829,17 @@ std::string Fmt::render() const
 								value = RTLIL::const_div(value, 10, false, false, value.size());
 								index++;
 							}
-							std::reverse(buf.begin(), buf.end());
 						}
 					} else log_abort();
+					if (part.justify == FmtPart::NUMERIC && part.group && part.padding == '0') {
+						int group_size = part.base == 10 ? 3 : 4;
+						while (prefix.size() + buf.size() < part.width) {
+							if (buf.size() % (group_size + 1) == group_size)
+								buf += '_';
+							buf += '0';
+						}
+					}
+					std::reverse(buf.begin(), buf.end());
 				} else if (part.type == FmtPart::STRING) {
 					buf = part.sig.as_const().decode_string();
 				} else if (part.type == FmtPart::VLOG_TIME) {

--- a/kernel/fmt.h
+++ b/kernel/fmt.h
@@ -53,19 +53,19 @@ struct VerilogFmtArg {
 // Must be kept in sync with `struct fmt_part` in backends/cxxrtl/runtime/cxxrtl/cxxrtl.h!
 struct FmtPart {
 	enum {
-		STRING  	= 0,
+		LITERAL  	= 0,
 		INTEGER 	= 1,
-		CHARACTER = 2,
+		STRING    = 2,
 		VLOG_TIME = 3,
 	} type;
 
-	// STRING type
+	// LITERAL type
 	std::string str;
 
-	// INTEGER/CHARACTER types
+	// INTEGER/STRING types
 	RTLIL::SigSpec sig;
 
-	// INTEGER/CHARACTER/VLOG_TIME types
+	// INTEGER/STRING/VLOG_TIME types
 	enum {
 		RIGHT	= 0,
 		LEFT	= 1,
@@ -86,7 +86,7 @@ struct Fmt {
 public:
 	std::vector<FmtPart> parts;
 
-	void append_string(const std::string &str);
+	void append_literal(const std::string &str);
 
 	void parse_rtlil(const RTLIL::Cell *cell);
 	void emit_rtlil(RTLIL::Cell *cell) const;

--- a/kernel/fmt.h
+++ b/kernel/fmt.h
@@ -84,6 +84,7 @@ struct FmtPart {
 		SPACE_MINUS	= 2,
 	} sign = MINUS;
 	bool hex_upper = false;
+	bool show_base = false;
 
 	// VLOG_TIME type
 	bool realtime = false;

--- a/kernel/fmt.h
+++ b/kernel/fmt.h
@@ -77,6 +77,7 @@ struct FmtPart {
 	unsigned base = 10;
 	bool signed_ = false;
 	bool plus = false;
+	bool hex_upper = false;
 
 	// VLOG_TIME type
 	bool realtime = false;

--- a/kernel/fmt.h
+++ b/kernel/fmt.h
@@ -85,6 +85,7 @@ struct FmtPart {
 	} sign = MINUS;
 	bool hex_upper = false;
 	bool show_base = false;
+	bool group = false;
 
 	// VLOG_TIME type
 	bool realtime = false;

--- a/kernel/fmt.h
+++ b/kernel/fmt.h
@@ -69,6 +69,7 @@ struct FmtPart {
 	enum {
 		RIGHT	= 0,
 		LEFT	= 1,
+		NUMERIC	= 2,
 	} justify = RIGHT;
 	char padding = '\0';
 	size_t width = 0;

--- a/kernel/fmt.h
+++ b/kernel/fmt.h
@@ -56,13 +56,14 @@ struct FmtPart {
 		LITERAL  	= 0,
 		INTEGER 	= 1,
 		STRING    = 2,
-		VLOG_TIME = 3,
+		UNICHAR   = 3,
+		VLOG_TIME = 4,
 	} type;
 
 	// LITERAL type
 	std::string str;
 
-	// INTEGER/STRING types
+	// INTEGER/STRING/UNICHAR types
 	RTLIL::SigSpec sig;
 
 	// INTEGER/STRING/VLOG_TIME types

--- a/kernel/fmt.h
+++ b/kernel/fmt.h
@@ -76,7 +76,11 @@ struct FmtPart {
 	// INTEGER type
 	unsigned base = 10;
 	bool signed_ = false;
-	bool plus = false;
+	enum {
+		MINUS		= 0,
+		PLUS_MINUS	= 1,
+		SPACE_MINUS	= 2,
+	} sign = MINUS;
 	bool hex_upper = false;
 
 	// VLOG_TIME type


### PR DESCRIPTION
This is a work-in-progress PR at the moment.
- [x] `H` format type (uppercase hex digits)
- [x] `c` format type (Unicode code point emitted as UTF-8)
- [x] `=` justification (align right, but after the padding)
- [x] arbitrary fill character
- [x] ` ` sign mode (either `-` or ` `, as opposed to either `-` or `+`)
- [x] `_` option (insert an underscore between each 3 decimal, 4 binary/octal/hex digits)
- [x] `#` option (insert `0x`/`0o`/`0b` after sign and before padding)
- [x] signed hex numbers
- [x] padding interacts poorly with base
- [x] consider combination of `0` padding and `_`
- [x] test integration with Amaranth