### PR TITLE
Infrastructure to run a Sat solver as a command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -632,6 +632,7 @@ $(eval $(call add_include_file,kernel/yosys.h))
 $(eval $(call add_include_file,kernel/yw.h))
 $(eval $(call add_include_file,libs/ezsat/ezsat.h))
 $(eval $(call add_include_file,libs/ezsat/ezminisat.h))
+$(eval $(call add_include_file,libs/ezsat/ezcommand.h))
 ifeq ($(ENABLE_ZLIB),1)
 $(eval $(call add_include_file,libs/fst/fstapi.h))
 endif
@@ -672,6 +673,7 @@ OBJS += libs/json11/json11.o
 
 OBJS += libs/ezsat/ezsat.o
 OBJS += libs/ezsat/ezminisat.o
+OBJS += libs/ezsat/ezcommand.o
 
 OBJS += libs/minisat/Options.o
 OBJS += libs/minisat/SimpSolver.o

--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -979,18 +979,6 @@ struct EchoPass : public Pass {
 	}
 } EchoPass;
 
-SatSolver *yosys_satsolver_list;
-SatSolver *yosys_satsolver;
-
-struct MinisatSatSolver : public SatSolver {
-	MinisatSatSolver() : SatSolver("minisat") {
-		yosys_satsolver = this;
-	}
-	ezSAT *create() override {
-		return new ezMiniSAT();
-	}
-} MinisatSatSolver;
-
 struct LicensePass : public Pass {
 	LicensePass() : Pass("license", "print license terms") { }
 	void help() override

--- a/kernel/satgen.cc
+++ b/kernel/satgen.cc
@@ -19,8 +19,13 @@
 
 #include "kernel/satgen.h"
 #include "kernel/ff.h"
+#include "libs/ezsat/ezcommand.h"
+#include "libs/ezsat/ezminisat.h"
 
 USING_YOSYS_NAMESPACE
+
+ezSatPtr::ezSatPtr() : unique_ptr<ezSAT>(new ezMiniSAT()) {}
+ezSatPtr::ezSatPtr(const std::string &command) : unique_ptr<ezSAT>(new ezSATCommand(command)) {}
 
 bool SatGen::importCell(RTLIL::Cell *cell, int timestep)
 {

--- a/kernel/satgen.h
+++ b/kernel/satgen.h
@@ -25,12 +25,13 @@
 #include "kernel/celltypes.h"
 #include "kernel/macc.h"
 
-#include "libs/ezsat/ezminisat.h"
+#include "libs/ezsat/ezsat.h"
 
 YOSYS_NAMESPACE_BEGIN
 
 struct ezSatPtr : public std::unique_ptr<ezSAT> {
-	ezSatPtr(): unique_ptr<ezSAT>(new ezMiniSAT()) {}
+	ezSatPtr();
+	ezSatPtr(const std::string &command);
 };
 
 struct SatGen

--- a/kernel/satgen.h
+++ b/kernel/satgen.h
@@ -29,36 +29,8 @@
 
 YOSYS_NAMESPACE_BEGIN
 
-// defined in kernel/register.cc
-extern struct SatSolver *yosys_satsolver_list;
-extern struct SatSolver *yosys_satsolver;
-
-struct SatSolver
-{
-	string name;
-	SatSolver *next;
-	virtual ezSAT *create() = 0;
-
-	SatSolver(string name) : name(name) {
-		next = yosys_satsolver_list;
-		yosys_satsolver_list = this;
-	}
-
-	virtual ~SatSolver() {
-		auto p = &yosys_satsolver_list;
-		while (*p) {
-			if (*p == this)
-				*p = next;
-			else
-				p = &(*p)->next;
-		}
-		if (yosys_satsolver == this)
-			yosys_satsolver = yosys_satsolver_list;
-	}
-};
-
 struct ezSatPtr : public std::unique_ptr<ezSAT> {
-	ezSatPtr() : unique_ptr<ezSAT>(yosys_satsolver->create()) { }
+	ezSatPtr(): unique_ptr<ezSAT>(new ezMiniSAT()) {}
 };
 
 struct SatGen

--- a/libs/ezsat/ezcommand.cc
+++ b/libs/ezsat/ezcommand.cc
@@ -9,19 +9,20 @@ ezSATCommand::~ezSATCommand() {}
 
 bool ezSATCommand::solver(const std::vector<int> &modelExpressions, std::vector<bool> &modelValues, const std::vector<int> &assumptions)
 {
-	if (!assumptions.empty()) {
-		Yosys::log_error("Assumptions are not supported yet by command-based Sat solver\n");
-	}
 	const std::string tempdir_name = Yosys::make_temp_dir(Yosys::get_base_tmpdir() + "/yosys-sat-XXXXXX");
 	const std::string cnf_filename = Yosys::stringf("%s/problem.cnf", tempdir_name.c_str());
 	const std::string sat_command = Yosys::stringf("%s %s", command.c_str(), cnf_filename.c_str());
 	FILE *dimacs = fopen(cnf_filename.c_str(), "w");
-	printDIMACS(dimacs);
-	fclose(dimacs);
 
 	std::vector<int> modelIdx;
 	for (auto id : modelExpressions)
 		modelIdx.push_back(bind(id));
+	std::vector<std::vector<int>> extraClauses;
+	for (auto id : assumptions)
+		extraClauses.push_back({bind(id)});
+
+	printDIMACS(dimacs, false, extraClauses);
+	fclose(dimacs);
 
 	bool status_sat = false;
 	bool status_unsat = false;

--- a/libs/ezsat/ezcommand.cc
+++ b/libs/ezsat/ezcommand.cc
@@ -9,6 +9,7 @@ ezSATCommand::~ezSATCommand() {}
 
 bool ezSATCommand::solver(const std::vector<int> &modelExpressions, std::vector<bool> &modelValues, const std::vector<int> &assumptions)
 {
+#if !defined(YOSYS_DISABLE_SPAWN)
 	const std::string tempdir_name = Yosys::make_temp_dir(Yosys::get_base_tmpdir() + "/yosys-sat-XXXXXX");
 	const std::string cnf_filename = Yosys::stringf("%s/problem.cnf", tempdir_name.c_str());
 	const std::string sat_command = Yosys::stringf("%s %s", command.c_str(), cnf_filename.c_str());
@@ -79,4 +80,7 @@ bool ezSATCommand::solver(const std::vector<int> &modelExpressions, std::vector<
 		modelValues[i] = (values.at(idx - 1) == refvalue);
 	}
 	return true;
+#else
+	Yosys::log_error("SAT solver command not available in this build!\n");
+#endif
 }

--- a/libs/ezsat/ezcommand.cc
+++ b/libs/ezsat/ezcommand.cc
@@ -1,0 +1,81 @@
+
+#include "ezcommand.h"
+
+#include "../../kernel/yosys.h"
+
+ezSATCommand::ezSATCommand(const std::string &cmd) : command(cmd) {}
+
+ezSATCommand::~ezSATCommand() {}
+
+bool ezSATCommand::solver(const std::vector<int> &modelExpressions, std::vector<bool> &modelValues, const std::vector<int> &assumptions)
+{
+	if (!assumptions.empty()) {
+		Yosys::log_error("Assumptions are not supported yet by command-based Sat solver\n");
+	}
+	const std::string tempdir_name = Yosys::make_temp_dir(Yosys::get_base_tmpdir() + "/yosys-sat-XXXXXX");
+	const std::string cnf_filename = Yosys::stringf("%s/problem.cnf", tempdir_name.c_str());
+	const std::string sat_command = Yosys::stringf("%s %s", command.c_str(), cnf_filename.c_str());
+	FILE *dimacs = fopen(cnf_filename.c_str(), "w");
+	printDIMACS(dimacs);
+	fclose(dimacs);
+
+	std::vector<int> modelIdx;
+	for (auto id : modelExpressions)
+		modelIdx.push_back(bind(id));
+
+	bool status_sat = false;
+	bool status_unsat = false;
+	std::vector<bool> values;
+
+	auto line_callback = [&](const std::string &line) {
+		if (line.empty()) {
+			return;
+		}
+		if (line[0] == 's') {
+			if (line.substr(0, 5) == "s SAT") {
+				status_sat = true;
+			}
+			if (line.substr(0, 7) == "s UNSAT") {
+				status_unsat = true;
+			}
+			return;
+		}
+		if (line[0] == 'v') {
+			std::stringstream ss(line.substr(1));
+			int lit;
+			while (ss >> lit) {
+				if (lit == 0) {
+					return;
+				}
+				bool val = lit >= 0;
+				int ind = lit >= 0 ? lit - 1 : -lit - 1;
+				if (Yosys::GetSize(values) <= ind) {
+					values.resize(ind + 1);
+				}
+				values[ind] = val;
+			}
+		}
+	};
+	Yosys::run_command(sat_command, line_callback);
+
+	modelValues.clear();
+	modelValues.resize(modelIdx.size());
+
+	if (!status_sat && !status_unsat) {
+		solverTimoutStatus = true;
+	}
+	if (!status_sat) {
+		return false;
+	}
+
+	for (size_t i = 0; i < modelIdx.size(); i++) {
+		int idx = modelIdx[i];
+		bool refvalue = true;
+
+		if (idx < 0)
+			idx = -idx, refvalue = false;
+
+		modelValues[i] = (values.at(idx - 1) == refvalue);
+	}
+	return true;
+}

--- a/libs/ezsat/ezcommand.h
+++ b/libs/ezsat/ezcommand.h
@@ -1,0 +1,36 @@
+/*
+ *  ezSAT -- A simple and easy to use CNF generator for SAT solvers
+ *
+ *  Copyright (C) 2013  Claire Xenia Wolf <claire@yosyshq.com>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#ifndef EZSATCOMMAND_H
+#define EZSATCOMMAND_H
+
+#include "ezsat.h"
+
+class ezSATCommand : public ezSAT
+{
+private:
+	std::string command;
+
+public:
+	ezSATCommand(const std::string &cmd);
+	virtual ~ezSATCommand();
+	bool solver(const std::vector<int> &modelExpressions, std::vector<bool> &modelValues, const std::vector<int> &assumptions) override;
+};
+
+#endif

--- a/libs/ezsat/ezsat.cc
+++ b/libs/ezsat/ezsat.cc
@@ -1222,7 +1222,7 @@ ezSATvec ezSAT::vec(const std::vector<int> &vec)
 	return ezSATvec(*this, vec);
 }
 
-void ezSAT::printDIMACS(FILE *f, bool verbose) const
+void ezSAT::printDIMACS(FILE *f, bool verbose, const std::vector<std::vector<int>> &extraClauses) const
 {
 	if (cnfConsumed) {
 		fprintf(stderr, "Usage error: printDIMACS() must not be called after cnfConsumed()!");
@@ -1259,6 +1259,8 @@ void ezSAT::printDIMACS(FILE *f, bool verbose) const
 	std::vector<std::vector<int>> all_clauses;
 	getFullCnf(all_clauses);
 	assert(cnfClausesCount == int(all_clauses.size()));
+	for (auto c : extraClauses)
+		all_clauses.push_back(c);
 
 	fprintf(f, "p cnf %d %d\n", cnfVariableCount, cnfClausesCount);
 	int maxClauseLen = 0;

--- a/libs/ezsat/ezsat.h
+++ b/libs/ezsat/ezsat.h
@@ -295,7 +295,7 @@ public:
 
 	// printing CNF and internal state
 
-	void printDIMACS(FILE *f, bool verbose = false) const;
+	void printDIMACS(FILE *f, bool verbose = false, const std::vector<std::vector<int>> &extraClauses = std::vector<std::vector<int>>()) const;
 	void printInternalState(FILE *f) const;
 
 	// more sophisticated constraints (designed to be used directly with assume(..))


### PR DESCRIPTION
As discussed on the slack channel, here is a patch for a solver interface using an arbitrary command (I used kissat for my test).
It also removes some unused code that was supposed to register arbitrary solvers.

As the moment, it is only usable for experimental purposes from the C++. I didn't implement any direct access from the command line (sat, equiv, ...)