### PR TITLE
cleanup: extra_args and argidx

### DIFF
--- a/passes/cmds/autoname.cc
+++ b/passes/cmds/autoname.cc
@@ -101,15 +101,7 @@ struct AutonamePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++)
-		{
-			// if (args[argidx] == "-foo") {
-			// 	foo = true;
-			// 	continue;
-			// }
-			break;
-		}
+		extra_args(args, 1, design);
 
 		log_header(design, "Executing AUTONAME pass.\n");
 

--- a/passes/cmds/blackbox.cc
+++ b/passes/cmds/blackbox.cc
@@ -36,15 +36,7 @@ struct BlackboxPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++)
-		{
-			// if (args[argidx] == "-???") {
-			// 	continue;
-			// }
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		for (auto module : design->selected_whole_modules_warn(true))
 		{

--- a/passes/cmds/clean_zerowidth.cc
+++ b/passes/cmds/clean_zerowidth.cc
@@ -52,12 +52,7 @@ struct CleanZeroWidthPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++)
-		{
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		CellTypes ct;
 		ct.setup();

--- a/passes/cmds/edgetypes.cc
+++ b/passes/cmds/edgetypes.cc
@@ -37,15 +37,7 @@ struct EdgetypePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++) {
-			// if (args[argidx] == "-ltr") {
-			// 	config.ltr = true;
-			// 	continue;
-			// }
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		pool<string> edge_cache;
 

--- a/passes/cmds/future.cc
+++ b/passes/cmds/future.cc
@@ -122,14 +122,7 @@ struct FuturePass : public Pass {
 		FutureOptions options;
 
 		log_header(design, "Executing FUTURE pass.\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++) {
-
-			break;
-		}
-
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		for (auto module : design->selected_modules()) {
 			FutureWorker worker(module, options);

--- a/passes/cmds/printattrs.cc
+++ b/passes/cmds/printattrs.cc
@@ -50,8 +50,7 @@ struct PrintAttrsPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
-		size_t argidx = 1;
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		unsigned int indent = 0;
 		for (auto mod : design->selected_modules())

--- a/passes/cmds/select.cc
+++ b/passes/cmds/select.cc
@@ -1713,8 +1713,7 @@ struct LsPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
-		size_t argidx = 1;
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		if (design->selected_active_module.empty())
 		{

--- a/passes/cmds/setattr.cc
+++ b/passes/cmds/setattr.cc
@@ -140,17 +140,7 @@ struct WbflipPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++)
-		{
-			std::string arg = args[argidx];
-			// if (arg == "-mod") {
-			// 	flag_mod = true;
-			// 	continue;
-			// }
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		for (Module *module : design->modules())
 		{

--- a/passes/cmds/sta.cc
+++ b/passes/cmds/sta.cc
@@ -289,16 +289,7 @@ struct StaPass : public Pass {
 	{
 		log_header(design, "Executing STA pass (static timing analysis).\n");
 
-		/*
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++) {
-			if (args[argidx] == "-TODO") {
-				continue;
-			}
-			break;
-		}
-		*/
-
+		// TODO: there was a commented out -TODO argument
 		extra_args(args, 1, design);
 
 		for (Module *module : design->selected_modules())

--- a/passes/cmds/trace.cc
+++ b/passes/cmds/trace.cc
@@ -72,13 +72,7 @@ struct TracePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++)
-		{
-			// .. parse options ..
-			break;
-		}
-
+		size_t argidx = 1;
 		TraceMonitor monitor;
 		design->monitors.insert(&monitor);
 
@@ -107,12 +101,7 @@ struct DebugPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++)
-		{
-			// .. parse options ..
-			break;
-		}
+		size_t argidx = 1;
 
 		log_force_debug++;
 

--- a/passes/equiv/equiv_mark.cc
+++ b/passes/equiv/equiv_mark.cc
@@ -219,15 +219,7 @@ struct EquivMarkPass : public Pass {
 	void execute(std::vector<std::string> args, Design *design) override
 	{
 		log_header(design, "Executing EQUIV_MARK pass.\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++) {
-			// if (args[argidx] == "-foobar") {
-			// 	continue;
-			// }
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		for (auto module : design->selected_whole_modules_warn()) {
 			EquivMarkWorker worker(module);

--- a/passes/equiv/equiv_purge.cc
+++ b/passes/equiv/equiv_purge.cc
@@ -190,15 +190,7 @@ struct EquivPurgePass : public Pass {
 	void execute(std::vector<std::string> args, Design *design) override
 	{
 		log_header(design, "Executing EQUIV_PURGE pass.\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++) {
-			// if (args[argidx] == "-foobar") {
-			// 	continue;
-			// }
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		for (auto module : design->selected_whole_modules_warn()) {
 			EquivPurgeWorker worker(module);

--- a/passes/hierarchy/uniquify.cc
+++ b/passes/hierarchy/uniquify.cc
@@ -44,17 +44,7 @@ struct UniquifyPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing UNIQUIFY pass (creating unique copies of modules).\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++)
-		{
-			// if (args[argidx] == "-check") {
-			// 	flag_check = true;
-			// 	continue;
-			// }
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		bool did_something = true;
 		int count = 0;

--- a/passes/memory/memory_bmux2rom.cc
+++ b/passes/memory/memory_bmux2rom.cc
@@ -38,12 +38,7 @@ struct MemoryBmux2RomPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing MEMORY_BMUX2ROM pass (converting muxes to ROMs).\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++) {
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		for (auto module : design->selected_modules()) {
 			for (auto cell : module->selected_cells()) {

--- a/passes/memory/memory_narrow.cc
+++ b/passes/memory/memory_narrow.cc
@@ -38,12 +38,7 @@ struct MemoryNarrowPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing MEMORY_NARROW pass (splitting up wide memory ports).\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++) {
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		for (auto module : design->selected_modules()) {
 			if (module->has_processes_warn())

--- a/passes/opt/muxpack.cc
+++ b/passes/opt/muxpack.cc
@@ -344,13 +344,7 @@ struct MuxpackPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing MUXPACK pass ($mux cell cascades to $pmux).\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++)
-		{
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		int mux_count = 0;
 		int pmux_count = 0;

--- a/passes/opt/opt_demorgan.cc
+++ b/passes/opt/opt_demorgan.cc
@@ -182,9 +182,7 @@ struct OptDemorganPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing OPT_DEMORGAN pass (push inverters through $reduce_* cells).\n");
-
-		int argidx = 0;
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		unsigned int cells_changed = 0;
 		for (auto module : design->selected_modules())

--- a/passes/opt/opt_ffinv.cc
+++ b/passes/opt/opt_ffinv.cc
@@ -246,13 +246,7 @@ struct OptFfInvPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing OPT_FFINV pass (push inverters through FFs).\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++)
-		{
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		int total_count = 0;
 		for (auto module : design->selected_modules())

--- a/passes/opt/opt_mem.cc
+++ b/passes/opt/opt_mem.cc
@@ -39,16 +39,7 @@ struct OptMemPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing OPT_MEM pass (optimize memories).\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++) {
-			// if (args[argidx] == "-nomux") {
-			// 	mode_nomux = true;
-			// 	continue;
-			// }
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		int total_count = 0;
 		for (auto module : design->selected_modules()) {

--- a/passes/opt/opt_mem_widen.cc
+++ b/passes/opt/opt_mem_widen.cc
@@ -38,16 +38,7 @@ struct OptMemWidenPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing OPT_MEM_WIDEN pass (optimize memories where all ports are wide).\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++) {
-			// if (args[argidx] == "-nomux") {
-			// 	mode_nomux = true;
-			// 	continue;
-			// }
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		int total_count = 0;
 		for (auto module : design->selected_modules()) {

--- a/passes/opt/rmports.cc
+++ b/passes/opt/rmports.cc
@@ -42,9 +42,7 @@ struct RmportsPassPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing RMPORTS pass (remove ports with no connections).\n");
-
-		size_t argidx = 1;
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		// The set of ports we removed
 		dict<IdString, pool<IdString>> removed_ports;

--- a/passes/pmgen/ice40_dsp.cc
+++ b/passes/pmgen/ice40_dsp.cc
@@ -299,17 +299,7 @@ struct Ice40DspPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing ICE40_DSP pass (map multipliers).\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++)
-		{
-			// if (args[argidx] == "-singleton") {
-			// 	singleton_mode = true;
-			// 	continue;
-			// }
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		for (auto module : design->selected_modules())
 			ice40_dsp_pm(module, module->selected_cells()).run_ice40_dsp(create_ice40_dsp);

--- a/passes/pmgen/peepopt.cc
+++ b/passes/pmgen/peepopt.cc
@@ -55,13 +55,7 @@ struct PeepoptPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing PEEPOPT pass (run peephole optimizers).\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++)
-		{
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		for (auto module : design->selected_modules())
 		{

--- a/passes/pmgen/test_pmgen.cc
+++ b/passes/pmgen/test_pmgen.cc
@@ -150,16 +150,7 @@ struct TestPmgenPass : public Pass {
 	{
 		log_header(design, "Executing TEST_PMGEN pass (-reduce_chain).\n");
 
-		size_t argidx;
-		for (argidx = 2; argidx < args.size(); argidx++)
-		{
-			// if (args[argidx] == "-singleton") {
-			// 	singleton_mode = true;
-			// 	continue;
-			// }
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 2, design);
 
 		for (auto module : design->selected_modules())
 			while (test_pmgen_pm(module, module->selected_cells()).run_reduce(reduce_chain)) {}
@@ -169,16 +160,7 @@ struct TestPmgenPass : public Pass {
 	{
 		log_header(design, "Executing TEST_PMGEN pass (-reduce_tree).\n");
 
-		size_t argidx;
-		for (argidx = 2; argidx < args.size(); argidx++)
-		{
-			// if (args[argidx] == "-singleton") {
-			// 	singleton_mode = true;
-			// 	continue;
-			// }
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 2, design);
 
 		for (auto module : design->selected_modules())
 			test_pmgen_pm(module, module->selected_cells()).run_reduce(reduce_tree);
@@ -188,16 +170,7 @@ struct TestPmgenPass : public Pass {
 	{
 		log_header(design, "Executing TEST_PMGEN pass (-eqpmux).\n");
 
-		size_t argidx;
-		for (argidx = 2; argidx < args.size(); argidx++)
-		{
-			// if (args[argidx] == "-singleton") {
-			// 	singleton_mode = true;
-			// 	continue;
-			// }
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 2, design);
 
 		for (auto module : design->selected_modules())
 			test_pmgen_pm(module, module->selected_cells()).run_eqpmux(opt_eqpmux);
@@ -207,15 +180,7 @@ struct TestPmgenPass : public Pass {
 	{
 		log_header(design, "Executing TEST_PMGEN pass (-generate).\n");
 
-		size_t argidx;
-		for (argidx = 2; argidx < args.size(); argidx++)
-		{
-			// if (args[argidx] == "-singleton") {
-			// 	singleton_mode = true;
-			// 	continue;
-			// }
-			break;
-		}
+		size_t argidx = 2;
 
 		if (argidx+1 != args.size())
 			log_cmd_error("Expected exactly one pattern.\n");

--- a/passes/sat/fmcombine.cc
+++ b/passes/sat/fmcombine.cc
@@ -340,7 +340,7 @@ struct FmcombinePass : public Pass {
 		{
 			log_cmd_error("Invalid number of arguments.\n");
 		}
-		// extra_args(args, argidx, design);
+		// No call to extra_args, we handle this manually
 
 		if (opts.nop && (opts.fwd || opts.bwd))
 			log_cmd_error("Option -nop can not be combined with -fwd and/or -bwd.\n");

--- a/passes/techmap/alumacc.cc
+++ b/passes/techmap/alumacc.cc
@@ -563,16 +563,7 @@ struct AlumaccPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing ALUMACC pass (create $alu and $macc cells).\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++) {
-			// if (args[argidx] == "-foobar") {
-			// 	foobar_mode = true;
-			// 	continue;
-			// }
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		for (auto mod : design->selected_modules())
 			if (!mod->has_processes_warn()) {

--- a/passes/techmap/bwmuxmap.cc
+++ b/passes/techmap/bwmuxmap.cc
@@ -36,16 +36,7 @@ struct BwmuxmapPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing BWMUXMAP pass.\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++) {
-			// if (args[argidx] == "-arg") {
-			// 	continue;
-			// }
-			break;
-		}
-
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		for (auto module : design->selected_modules())
 		for (auto cell : module->selected_cells())

--- a/passes/techmap/demuxmap.cc
+++ b/passes/techmap/demuxmap.cc
@@ -37,12 +37,7 @@ struct DemuxmapPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing DEMUXMAP pass.\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++) {
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		for (auto module : design->selected_modules())
 		for (auto cell : module->selected_cells())

--- a/passes/techmap/lut2mux.cc
+++ b/passes/techmap/lut2mux.cc
@@ -68,16 +68,7 @@ struct Lut2muxPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing LUT2MUX pass (convert $lut to $_MUX_).\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++)
-		{
-			// if (args[argidx] == "-v") {
-			// 	continue;
-			// }
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		for (auto module : design->selected_modules())
 		for (auto cell : module->selected_cells()) {

--- a/passes/techmap/pmuxtree.cc
+++ b/passes/techmap/pmuxtree.cc
@@ -79,12 +79,7 @@ struct PmuxtreePass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing PMUXTREE pass.\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++) {
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		for (auto module : design->selected_modules())
 		for (auto cell : module->selected_cells())

--- a/techlibs/anlogic/anlogic_fixcarry.cc
+++ b/techlibs/anlogic/anlogic_fixcarry.cc
@@ -48,8 +48,8 @@ static void fix_carry_chain(Module *module)
 				SigSpec o = cell->getPort(ID(o));
 				if (GetSize(o) == 2) {
 					SigBit bit_o = o[0];
-					ci_bits.insert(bit_ci);				
-					mapping_bits[bit_ci] = bit_o;				
+					ci_bits.insert(bit_ci);
+					mapping_bits[bit_ci] = bit_o;
 				}
 			}
 		}
@@ -64,8 +64,8 @@ static void fix_carry_chain(Module *module)
 			SigBit bit_i1 = get_bit_or_zero(cell->getPort(ID(b)));
 			SigBit canonical_bit = sigmap(bit_ci);
 			if (!ci_bits.count(canonical_bit))
-				continue;			
-			if (bit_i0 == State::S0 && bit_i1== State::S0) 
+				continue;
+			if (bit_i0 == State::S0 && bit_i1== State::S0)
 				continue;
 
 			adders_to_fix_cells.push_back(cell);
@@ -90,10 +90,10 @@ static void fix_carry_chain(Module *module)
 		c->setPort(ID(b), State::S0);
 		c->setPort(ID(c), State::S0);
 		c->setPort(ID(o), bits);
-		
+
 		cell->setPort(ID(c), new_bit);
 	}
-	
+
 }
 
 struct AnlogicCarryFixPass : public Pass {
@@ -110,20 +110,14 @@ struct AnlogicCarryFixPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing anlogic_fixcarry pass (fix invalid carry chain).\n");
-		
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++)
-		{
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		Module *module = design->top_module();
 
 		if (module == nullptr)
 			log_cmd_error("No top module found.\n");
 
-		fix_carry_chain(module);		
+		fix_carry_chain(module);
 	}
 } AnlogicCarryFixPass;
 

--- a/techlibs/efinix/efinix_fixcarry.cc
+++ b/techlibs/efinix/efinix_fixcarry.cc
@@ -45,12 +45,12 @@ static void fix_carry_chain(Module *module)
 			if (bit_i0 == State::S0 && bit_i1== State::S0) {
 				SigBit bit_ci = get_bit_or_zero(cell->getPort(ID::CI));
 				SigBit bit_o = sigmap(cell->getPort(ID::O));
-				ci_bits.insert(bit_ci);				
+				ci_bits.insert(bit_ci);
 				mapping_bits[bit_ci] = bit_o;
 			}
 		}
 	}
-	
+
 	vector<Cell*> adders_to_fix_cells;
 	for (auto cell : module->cells())
 	{
@@ -60,8 +60,8 @@ static void fix_carry_chain(Module *module)
 			SigBit bit_i1 = get_bit_or_zero(cell->getPort(ID(I1)));
 			SigBit canonical_bit = sigmap(bit_ci);
 			if (!ci_bits.count(canonical_bit))
-				continue;			
-			if (bit_i0 == State::S0 && bit_i1== State::S0) 
+				continue;
+			if (bit_i0 == State::S0 && bit_i1== State::S0)
 				continue;
 
 			adders_to_fix_cells.push_back(cell);
@@ -83,7 +83,7 @@ static void fix_carry_chain(Module *module)
 		c->setPort(ID(I1), State::S1);
 		c->setPort(ID::CI, State::S0);
 		c->setPort(ID::CO, new_bit);
-		
+
 		cell->setPort(ID::CI, new_bit);
 	}
 }
@@ -102,20 +102,14 @@ struct EfinixCarryFixPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing EFINIX_FIXCARRY pass (fix invalid carry chain).\n");
-		
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++)
-		{
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		Module *module = design->top_module();
 
 		if (module == nullptr)
 			log_cmd_error("No top module found.\n");
 
-		fix_carry_chain(module);		
+		fix_carry_chain(module);
 	}
 } EfinixCarryFixPass;
 

--- a/techlibs/gatemate/gatemate_foldinv.cc
+++ b/techlibs/gatemate/gatemate_foldinv.cc
@@ -205,8 +205,7 @@ struct GatemateFoldInvPass : public Pass {
     {
         log_header(design, "Executing GATEMATE_FOLDINV pass (folding LUT tree inverters).\n");
 
-        size_t argidx = 1;
-        extra_args(args, argidx, design);
+        extra_args(args, 1, design);
 
         for (Module *module : design->selected_modules()) {
             FoldInvWorker worker(module);

--- a/techlibs/greenpak4/greenpak4_dffinv.cc
+++ b/techlibs/greenpak4/greenpak4_dffinv.cc
@@ -102,17 +102,7 @@ struct Greenpak4DffInvPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing GREENPAK4_DFFINV pass (merge input/output inverters into FF/latch cells).\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++)
-		{
-			// if (args[argidx] == "-singleton") {
-			// 	singleton_mode = true;
-			// 	continue;
-			// }
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		pool<IdString> gp_dff_types;
 		gp_dff_types.insert(ID(GP_DFF));

--- a/techlibs/ice40/ice40_braminit.cc
+++ b/techlibs/ice40/ice40_braminit.cc
@@ -141,15 +141,7 @@ struct Ice40BRAMInitPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing ICE40_BRAMINIT pass.\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++) {
-			// if (args[argidx] == "-???") {
-			//  continue;
-			// }
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		for (auto module : design->selected_modules())
 			run_ice40_braminit(module);

--- a/techlibs/lattice/lattice_gsr.cc
+++ b/techlibs/lattice/lattice_gsr.cc
@@ -43,17 +43,7 @@ struct LatticeGsrPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing LATTICE_GSR pass (implement FF init values).\n");
-
-		size_t argidx;
-		for (argidx = 1; argidx < args.size(); argidx++)
-		{
-			// if (args[argidx] == "-singleton") {
-			// 	singleton_mode = true;
-			// 	continue;
-			// }
-			break;
-		}
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		for (auto module : design->selected_modules())
 		{

--- a/techlibs/quicklogic/ql_bram_merge.cc
+++ b/techlibs/quicklogic/ql_bram_merge.cc
@@ -199,9 +199,7 @@ struct QlBramMergePass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing QL_BRAM_MERGE pass.\n");
-
-		size_t argidx = 1;
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		for (RTLIL::Module* module : design->selected_modules())
 		{

--- a/techlibs/quicklogic/ql_bram_types.cc
+++ b/techlibs/quicklogic/ql_bram_types.cc
@@ -72,9 +72,7 @@ struct QlBramTypesPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing QL_BRAM_TYPES pass.\n");
-
-		size_t argidx = 1;
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 
 		for (RTLIL::Module* module : design->selected_modules())
 			for (RTLIL::Cell* cell: module->selected_cells())

--- a/tests/various/plugin.cc
+++ b/tests/various/plugin.cc
@@ -6,8 +6,7 @@ struct TestPass : public Pass {
 	TestPass() : Pass("test", "test") { }
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
-		size_t argidx = 1;
-		extra_args(args, argidx, design);
+		extra_args(args, 1, design);
 		log("Plugin test passed!\n");
 	}
 } TestPass;


### PR DESCRIPTION
This PR simplifies and unifies boilerplate by removing unused iteration over pass args which have been left in as placeholders. It also removes commented out arg checks that I think aren't relevant to the pass at hand and have only been copied from another pass.

Incidentally, by setting argidx correctly it also prevents the warning opt_demorgan would unconditionally throw: `Warning: Selection "opt_demorgan" did not match any module.`