### PR TITLE
opt_demorgan: fix extra args warning

### DIFF
--- a/passes/opt/opt_demorgan.cc
+++ b/passes/opt/opt_demorgan.cc
@@ -183,7 +183,7 @@ struct OptDemorganPass : public Pass {
 	{
 		log_header(design, "Executing OPT_DEMORGAN pass (push inverters through $reduce_* cells).\n");
 
-		int argidx = 0;
+		int argidx = 1;
 		extra_args(args, argidx, design);
 
 		unsigned int cells_changed = 0;


### PR DESCRIPTION
By setting argidx correctly this PR prevents the warning opt_demorgan would unconditionally throw: `Warning: Selection "opt_demorgan" did not match any module.`