### PR TITLE
write_verilog: don't `assign` to a `reg`

### DIFF
--- a/tests/simple/.gitignore
+++ b/tests/simple/.gitignore
@@ -1,2 +1,3 @@
 *.log
 *.out
+*.err

--- a/tests/verilog/.gitignore
+++ b/tests/verilog/.gitignore
@@ -1,6 +1,10 @@
 /*.log
 /*.out
+/*.err
 /run-test.mk
 /const_arst.v
 /const_sr.v
 /doubleslash.v
+/roundtrip_proc_1.v
+/roundtrip_proc_2.v
+/assign_to_reg.v

--- a/tests/verilog/assign_to_reg.ys
+++ b/tests/verilog/assign_to_reg.ys
@@ -1,0 +1,22 @@
+# https://github.com/yosyshq/yosys/issues/2035
+
+read_ilang <<END
+module \top
+  wire width 1 input 0 \halfbrite
+  wire width 2 output 1 \r_on
+  process $1
+    assign \r_on [1:0] 2'00
+    assign \r_on [1:0] 2'11
+    switch \halfbrite [0]
+      case 1'1
+        assign \r_on [1] 1'0
+    end
+  end
+end
+END
+proc_prune
+write_verilog assign_to_reg.v
+design -reset
+
+logger -expect-no-warnings
+read_verilog assign_to_reg.v


### PR DESCRIPTION
Fixes #2035.