### PR TITLE
Tests update for latest more strict iverilog

### DIFF
--- a/techlibs/efinix/cells_sim.v
+++ b/techlibs/efinix/cells_sim.v
@@ -113,7 +113,31 @@ module EFX_GBUFCE(
    
 endmodule
 
-module EFX_RAM_5K(
+module EFX_RAM_5K
+# (
+   parameter READ_WIDTH = 20,
+   parameter WRITE_WIDTH = 20,
+   localparam READ_ADDR_WIDTH = 
+			    (READ_WIDTH == 16) ? 8 :  // 256x16
+			    (READ_WIDTH == 8)  ? 9 :  // 512x8
+			    (READ_WIDTH == 4)  ? 10 : // 1024x4
+			    (READ_WIDTH == 2)  ? 11 : // 2048x2
+			    (READ_WIDTH == 1)  ? 12 : // 4096x1
+			    (READ_WIDTH == 20) ? 8 :  // 256x20
+			    (READ_WIDTH == 10) ? 9 :  // 512x10
+			    (READ_WIDTH == 5)  ? 10 : -1, // 1024x5
+   
+   localparam WRITE_ADDR_WIDTH = 
+			    (WRITE_WIDTH == 16) ? 8 :  // 256x16
+			    (WRITE_WIDTH == 8)  ? 9 :  // 512x8
+			    (WRITE_WIDTH == 4)  ? 10 : // 1024x4
+			    (WRITE_WIDTH == 2)  ? 11 : // 2048x2
+			    (WRITE_WIDTH == 1)  ? 12 : // 4096x1
+			    (WRITE_WIDTH == 20) ? 8 :  // 256x20
+			    (WRITE_WIDTH == 10) ? 9 :  // 512x10
+			    (WRITE_WIDTH == 5)  ? 10 : -1 // 1024x5
+)
+(
    input [WRITE_WIDTH-1:0] WDATA,
    input [WRITE_ADDR_WIDTH-1:0] WADDR,
    input WE, 
@@ -126,8 +150,6 @@ module EFX_RAM_5K(
    (* clkbuf_sink *)
    input RCLK
 );
-   parameter READ_WIDTH = 20;
-   parameter WRITE_WIDTH = 20;
    parameter OUTPUT_REG = 1'b0;
    parameter RCLK_POLARITY  = 1'b1;
    parameter RE_POLARITY    = 1'b1;
@@ -155,25 +177,4 @@ module EFX_RAM_5K(
    parameter INIT_11 = 256'h0000000000000000000000000000000000000000000000000000000000000000;
    parameter INIT_12 = 256'h0000000000000000000000000000000000000000000000000000000000000000;
    parameter INIT_13 = 256'h0000000000000000000000000000000000000000000000000000000000000000;
-
-   localparam READ_ADDR_WIDTH = 
-			    (READ_WIDTH == 16) ? 8 :  // 256x16
-			    (READ_WIDTH == 8)  ? 9 :  // 512x8
-			    (READ_WIDTH == 4)  ? 10 : // 1024x4
-			    (READ_WIDTH == 2)  ? 11 : // 2048x2
-			    (READ_WIDTH == 1)  ? 12 : // 4096x1
-			    (READ_WIDTH == 20) ? 8 :  // 256x20
-			    (READ_WIDTH == 10) ? 9 :  // 512x10
-			    (READ_WIDTH == 5)  ? 10 : -1; // 1024x5
-   
-   localparam WRITE_ADDR_WIDTH = 
-			    (WRITE_WIDTH == 16) ? 8 :  // 256x16
-			    (WRITE_WIDTH == 8)  ? 9 :  // 512x8
-			    (WRITE_WIDTH == 4)  ? 10 : // 1024x4
-			    (WRITE_WIDTH == 2)  ? 11 : // 2048x2
-			    (WRITE_WIDTH == 1)  ? 12 : // 4096x1
-			    (WRITE_WIDTH == 20) ? 8 :  // 256x20
-			    (WRITE_WIDTH == 10) ? 9 :  // 512x10
-			    (WRITE_WIDTH == 5)  ? 10 : -1; // 1024x5
-   
 endmodule

--- a/tests/arch/run-test.sh
+++ b/tests/arch/run-test.sh
@@ -16,7 +16,7 @@ for arch in ../../techlibs/*; do
 			done
 		else
 			echo -n "Test $path ->"
-			iverilog -t null -I$arch $path
+			iverilog -t null -I$arch -g2005-sv $path
 			echo " ok"
 		fi
 	done

--- a/tests/memlib/memlib_9b1B.v
+++ b/tests/memlib/memlib_9b1B.v
@@ -1,4 +1,14 @@
-module RAM_9b1B (
+module RAM_9b1B 
+#(
+	parameter INIT = 0,
+	parameter OPTION_INIT = "UNDEFINED",
+	parameter PORT_R_WIDTH = 9,
+	parameter PORT_W_WIDTH = 9,
+	parameter PORT_R_CLK_POL = 0,
+	parameter PORT_W_CLK_POL = 0,
+	parameter PORT_W_WR_EN_WIDTH = 1
+)
+(
 	input PORT_R_CLK,
 	input [6:0] PORT_R_ADDR,
 	output reg [PORT_R_WIDTH-1:0] PORT_R_RD_DATA,
@@ -7,14 +17,6 @@ module RAM_9b1B (
 	input [6:0] PORT_W_ADDR,
 	input [PORT_W_WIDTH-1:0] PORT_W_WR_DATA
 );
-
-parameter INIT = 0;
-parameter OPTION_INIT = "UNDEFINED";
-parameter PORT_R_WIDTH = 9;
-parameter PORT_W_WIDTH = 9;
-parameter PORT_R_CLK_POL = 0;
-parameter PORT_W_CLK_POL = 0;
-parameter PORT_W_WR_EN_WIDTH = 1;
 
 reg [8:0] mem [0:15];
 

--- a/tests/memlib/memlib_wren.v
+++ b/tests/memlib/memlib_wren.v
@@ -1,4 +1,11 @@
-module RAM_WREN (
+module RAM_WREN #(
+	parameter ABITS=4,
+	parameter WIDTH=8,
+	parameter PORT_A_WR_EN_WIDTH=1,
+	parameter PORT_A_WR_BE_WIDTH=0,
+	parameter OPTION_BYTESIZE=WIDTH,
+	parameter WB=OPTION_BYTESIZE
+)(
 	input PORT_A_CLK,
 	input [ABITS-1:0] PORT_A_ADDR,
 	input [WIDTH-1:0] PORT_A_WR_DATA,
@@ -6,13 +13,6 @@ module RAM_WREN (
 	input [PORT_A_WR_EN_WIDTH-1:0] PORT_A_WR_EN,
 	input [PORT_A_WR_BE_WIDTH-1:0] PORT_A_WR_BE
 );
-
-parameter ABITS=4;
-parameter WIDTH=8;
-parameter PORT_A_WR_EN_WIDTH=1;
-parameter PORT_A_WR_BE_WIDTH=0;
-parameter OPTION_BYTESIZE=WIDTH;
-parameter WB=OPTION_BYTESIZE;
 
 reg [WIDTH-1:0] mem [0:2**ABITS-1];
 

--- a/tests/memories/issue00335.v
+++ b/tests/memories/issue00335.v
@@ -2,13 +2,15 @@
 // expect-rd-ports 1
 // expect-rd-clk \clk
 
-module ram2 (input clk,
+module ram2 #(
+             parameter  SIZE = 5 // Address size
+          ) (input clk,
              input             sel,
              input             we, 
              input [SIZE-1:0]  adr, 
              input [63:0]      dat_i, 
              output reg [63:0] dat_o);
-   parameter  SIZE = 5; // Address size
+   
 
    reg [63:0] mem [0:(1 << SIZE)-1];
    integer    i;


### PR DESCRIPTION
After last change iverilog is more strict to "use before declaration" of parameters.

To use localparam in module declaration required use of SystemVerilog syntax, only affecting Efinix.
