### PR TITLE
Extend `log` command with `-push`, `-pop`, `-header` options

### DIFF
--- a/passes/cmds/logcmd.cc
+++ b/passes/cmds/logcmd.cc
@@ -31,7 +31,8 @@ struct LogPass : public Pass {
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
-		log("    log string\n");
+		log("    log [options] string\n");
+		log("    log [ -push | -pop ]\n");
 		log("\n");
 		log("Print the given string to the screen and/or the log file. This is useful for TCL\n");
 		log("scripts, because the TCL command \"puts\" only goes to stdout but not to\n");
@@ -52,14 +53,26 @@ struct LogPass : public Pass {
 		log("    -n\n");
 		log("        do not append a newline\n");
 		log("\n");
+		log("    -header\n");
+		log("        log a pass header\n");
+		log("\n");
+		log("    -push\n");
+		log("        push a new level on the pass counter\n");
+		log("\n");
+		log("    -push\n");
+		log("        pop from the pass counter\n");
+		log("\n");
 	}
-	void execute(std::vector<std::string> args, RTLIL::Design*) override
+	void execute(std::vector<std::string> args, RTLIL::Design* design) override
 	{
 		size_t argidx;
 		bool to_stdout = false;
 		bool to_stderr = false;
 		bool to_log    = true;
 		bool newline   = true;
+		bool header    = false;
+		bool push      = false;
+		bool pop       = false;
 		std::string text;
 
 		for (argidx = 1; argidx < args.size(); argidx++)
@@ -68,15 +81,30 @@ struct LogPass : public Pass {
 			else if (args[argidx] == "-stderr") to_stderr = true;
 			else if (args[argidx] == "-nolog")  to_log    = false;
 			else if (args[argidx] == "-n")      newline   = false;
+			else if (args[argidx] == "-header") header    = true;
+			else if (args[argidx] == "-push")   push      = true;
+			else if (args[argidx] == "-pop")    pop       = true;
 			else break;
 		}
+
+		if ((push || pop) && args.size() != 2)
+			log_cmd_error("Bad usage: 'log -push' or 'log -pop' must be used without other arguments.\n");
+
+		if (push) { log_push(); return; }
+		if (pop)  { log_pop(); return; }
+
 		for (; argidx < args.size(); argidx++)
 			text += args[argidx] + ' ';
 		if (!text.empty()) text.resize(text.size()-1);
 
-		if (to_stdout) fprintf(stdout, (newline ? "%s\n" : "%s"), text.c_str());
-		if (to_stderr) fprintf(stderr, (newline ? "%s\n" : "%s"), text.c_str());
-		if (to_log)    log    (        (newline ? "%s\n" : "%s"), text.c_str());
+		const char *fmtline = newline ? "%s\n" : "%s";
+
+		if (to_stdout) fprintf(stdout, fmtline, text.c_str());
+		if (to_stderr) fprintf(stderr, fmtline, text.c_str());
+		if (to_log) {
+			if (!header) log(fmtline, text.c_str());
+			else log_header(design, fmtline, text.c_str());
+		}
 	}
 } LogPass;
 


### PR DESCRIPTION
For usage in Tcl scripting, when one essentially writes a pass in Tcl by combining existing passes.