### PR TITLE
fix hierarchy -generate mode handling of cells

### DIFF
--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -47,7 +47,7 @@ void generate(RTLIL::Design *design, const std::vector<std::string> &celltypes, 
 	{
 		if (design->module(cell->type) != nullptr)
 			continue;
-		if (cell->type.begins_with("$__"))
+		if (cell->type.begins_with("$") && !cell->type.begins_with("$__"))
 			continue;
 		for (auto &pattern : celltypes)
 			if (patmatch(pattern.c_str(), RTLIL::unescape_id(cell->type).c_str()))

--- a/tests/various/hierarchy_generate.ys
+++ b/tests/various/hierarchy_generate.ys
@@ -15,5 +15,6 @@ endmodule
 EOF
 hierarchy -generate unknown_sub i:a i:b o:y
 hierarchy -generate $__dunder_sub i:a i:b o:y
+hierarchy -generate $xor i:A i:B o:Y # this one is ignored
 hierarchy -top top -check
 check -assert

--- a/tests/various/hierarchy_generate.ys
+++ b/tests/various/hierarchy_generate.ys
@@ -1,0 +1,19 @@
+read_verilog -icells <<EOF
+module top(input [2:0] a, input [2:0] b, output [2:0] y);
+
+sub sub_i (.a(a[0]), .b(b[0]), .y(y[0]));
+
+unknown_sub sub_ii (.a(a[1]), .b(b[1]), .y(y[1]));
+
+$__dunder_sub sub_iii (.a(a[2]), .b(b[2]), .y(y[2]));
+
+endmodule
+
+module sub(input a, input b, output y);
+    assign y = a ^ b;
+endmodule
+EOF
+hierarchy -generate unknown_sub i:a i:b o:y
+hierarchy -generate $__dunder_sub i:a i:b o:y
+hierarchy -top top -check
+check -assert


### PR DESCRIPTION
This change in refactoring commit e38f40af5b7 (passes/hierarchy/hierarchy.cc:51) actually changed the behavior:
```
-		if (cell->type.substr(0, 1) == "$" && cell->type.substr(0, 3) != "$__")
+		if (cell->type.begins_with("$__"))
```

As far as I can tell, the intended behavior for `hierarchy -generate` is to only create the requested module if:
- the module is instantiated in the design
- the module is not defined in the design
- the module name is not an internal cell type (heuristically)?
The heuristic in the last point being, if the cell name starts with `$` it's ignored, unless it starts with `$__` (which is the recommended prefix for intermediate cell types in techmap rules, for which it might be desirable to generate a blackbox definition, e.g. to be able to correctly `show` or export the intermediate state for debugging purposes)

The testcase checks this behavior, but should the check perhaps be changed to use `yosys_celltypes.cell_known()` instead?