### PR TITLE
Strip compilation date from doc outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -985,16 +985,27 @@ docs/gen_images:
 	$(Q) $(MAKE) -C docs images
 
 DOCS_GUIDELINE_FILES := GettingStarted CodingStyle
-docs/guidelines:
+docs/guidelines docs/source/temp:
 	$(Q) mkdir -p docs/source/temp
 	$(Q) cp -f $(addprefix guidelines/,$(DOCS_GUIDELINE_FILES)) docs/source/temp
 
-# many of these will return an error which can be safely ignored, so we prefix
-# the command with a '-'
-DOCS_USAGE_PROGS := yosys yosys-config yosys-filterlib yosys-abc yosys-smtbmc yosys-witness
-docs/usage: $(addprefix docs/source/temp/,$(DOCS_USAGE_PROGS))
-docs/source/temp/%: docs/guidelines
-	-$(Q) ./$(PROGRAM_PREFIX)$* --help > $@ 2>&1
+# some commands return an error and print the usage text to stderr
+define DOC_USAGE_STDERR
+docs/source/temp/$(1): $(PROGRAM_PREFIX)$(1) docs/source/temp
+	-$(Q) ./$$< --help 2> $$@
+endef
+DOCS_USAGE_STDERR := yosys-config yosys-filterlib yosys-abc
+$(foreach usage,$(DOCS_USAGE_STDERR),$(eval $(call DOC_USAGE_STDERR,$(usage))))
+
+# others print to stdout
+define DOC_USAGE_STDOUT
+docs/source/temp/$(1): $(PROGRAM_PREFIX)$(1) docs/source/temp
+	$(Q) ./$$< --help > $$@
+endef
+DOCS_USAGE_STDOUT := yosys yosys-smtbmc yosys-witness
+$(foreach usage,$(DOCS_USAGE_STDOUT),$(eval $(call DOC_USAGE_STDOUT,$(usage))))
+
+docs/usage: $(addprefix docs/source/temp/,$(DOCS_USAGE_STDOUT) $(DOCS_USAGE_STDERR))
 
 docs/reqs:
 	$(Q) $(MAKE) -C docs reqs

--- a/Makefile
+++ b/Makefile
@@ -985,13 +985,13 @@ docs/gen_images:
 	$(Q) $(MAKE) -C docs images
 
 DOCS_GUIDELINE_FILES := GettingStarted CodingStyle
-docs/guidelines docs/source/temp:
-	$(Q) mkdir -p docs/source/temp
-	$(Q) cp -f $(addprefix guidelines/,$(DOCS_GUIDELINE_FILES)) docs/source/temp
+docs/guidelines docs/source/generated:
+	$(Q) mkdir -p docs/source/generated
+	$(Q) cp -f $(addprefix guidelines/,$(DOCS_GUIDELINE_FILES)) docs/source/generated
 
 # some commands return an error and print the usage text to stderr
 define DOC_USAGE_STDERR
-docs/source/temp/$(1): $(PROGRAM_PREFIX)$(1) docs/source/temp
+docs/source/generated/$(1): $(PROGRAM_PREFIX)$(1) docs/source/generated
 	-$(Q) ./$$< --help 2> $$@
 endef
 DOCS_USAGE_STDERR := yosys-config yosys-filterlib yosys-abc
@@ -999,13 +999,13 @@ $(foreach usage,$(DOCS_USAGE_STDERR),$(eval $(call DOC_USAGE_STDERR,$(usage))))
 
 # others print to stdout
 define DOC_USAGE_STDOUT
-docs/source/temp/$(1): $(PROGRAM_PREFIX)$(1) docs/source/temp
+docs/source/generated/$(1): $(PROGRAM_PREFIX)$(1) docs/source/generated
 	$(Q) ./$$< --help > $$@
 endef
 DOCS_USAGE_STDOUT := yosys yosys-smtbmc yosys-witness
 $(foreach usage,$(DOCS_USAGE_STDOUT),$(eval $(call DOC_USAGE_STDOUT,$(usage))))
 
-docs/usage: $(addprefix docs/source/temp/,$(DOCS_USAGE_STDOUT) $(DOCS_USAGE_STDERR))
+docs/usage: $(addprefix docs/source/generated/,$(DOCS_USAGE_STDOUT) $(DOCS_USAGE_STDERR))
 
 docs/reqs:
 	$(Q) $(MAKE) -C docs reqs

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,6 +1,6 @@
 /build/
 /source/cmd
-/source/temp
+/source/generated
 /source/_images/**/*.log
 /source/_images/**/*.aux
 /source/_images/**/*.pdf

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -48,6 +48,7 @@ help:
 clean: clean-examples
 	rm -rf $(BUILDDIR)/*
 	rm -rf source/cmd util/__pycache__
+	rm -rf source/generated
 	$(MAKE) -C source/_images clean
 
 .PHONY: html

--- a/docs/source/appendix/auxprogs.rst
+++ b/docs/source/appendix/auxprogs.rst
@@ -11,7 +11,7 @@ The ``yosys-config`` tool (an auto-generated shell-script) can be used to query
 compiler options and other information needed for building loadable modules for
 Yosys. See :doc:`/yosys_internals/extending_yosys/extensions` for details.
 
-.. literalinclude:: /temp/yosys-config
+.. literalinclude:: /generated/yosys-config
     :start-at: Usage
 
 .. _sec:filterlib:
@@ -25,7 +25,7 @@ The ``yosys-filterlib`` tool is a small utility that can be used to strip or
 extract information from a Liberty file.  This can be useful for removing
 sensitive or proprietary information such as timing or other trade secrets.
 
-.. literalinclude:: /temp/yosys-filterlib
+.. literalinclude:: /generated/yosys-filterlib
     :start-at: Usage
 
 yosys-abc
@@ -36,7 +36,7 @@ been accepted upstream. Not all versions of Yosys work with all versions of ABC.
 So Yosys comes with its own yosys-abc to avoid compatibility issues between the
 two.
 
-.. literalinclude:: /temp/yosys-abc
+.. literalinclude:: /generated/yosys-abc
     :start-at: usage
 
 yosys-smtbmc
@@ -45,7 +45,7 @@ yosys-smtbmc
 The ``yosys-smtbmc`` tool is a utility used by SBY for interacting with smt
 solvers.
 
-.. literalinclude:: /temp/yosys-smtbmc
+.. literalinclude:: /generated/yosys-smtbmc
 
 yosys-witness
 -------------
@@ -54,7 +54,7 @@ yosys-witness
 This is used in SBY and SCY for producing traces in a consistent format
 independent of the solver.
 
-.. literalinclude:: /temp/yosys-witness
+.. literalinclude:: /generated/yosys-witness
     :start-at: Usage
 
 .. note:: ``yosys-witness`` requires `click`_ Python package for use.

--- a/docs/source/appendix/auxprogs.rst
+++ b/docs/source/appendix/auxprogs.rst
@@ -38,7 +38,6 @@ two.
 
 .. literalinclude:: /temp/yosys-abc
     :start-at: usage
-    :end-before: UC Berkeley
 
 yosys-smtbmc
 ------------

--- a/docs/source/cmd_ref.rst
+++ b/docs/source/cmd_ref.rst
@@ -4,7 +4,7 @@
 Command line reference
 ================================================================================
 
-.. literalinclude:: /temp/yosys
+.. literalinclude:: /generated/yosys
     :start-at: Usage
 
 .. toctree::

--- a/docs/source/code_examples/extensions/Makefile
+++ b/docs/source/code_examples/extensions/Makefile
@@ -13,18 +13,18 @@ my_cmd.so: my_cmd.cc
 	$(YOSYS)-config --exec --cxx $(subst $(DATDIR),../../../../share,$(CXXFLAGS)) --ldflags -o my_cmd.so -shared my_cmd.cc --ldlibs
 
 test0.log: my_cmd.so
-	$(YOSYS) -Ql test0.log_new -m ./my_cmd.so -p 'my_cmd foo bar' absval_ref.v
+	$(YOSYS) -QTl test0.log_new -m ./my_cmd.so -p 'my_cmd foo bar' absval_ref.v
 	mv test0.log_new test0.log
 
 test1.log: my_cmd.so
-	$(YOSYS) -Ql test1.log_new -m ./my_cmd.so -p 'clean; test1; dump' absval_ref.v
+	$(YOSYS) -QTl test1.log_new -m ./my_cmd.so -p 'clean; test1; dump' absval_ref.v
 	mv test1.log_new test1.log
 
 test1.dot: my_cmd.so
 	$(YOSYS) -m ./my_cmd.so -p 'test1; show -format dot -prefix test1'
 
 test2.log: my_cmd.so
-	$(YOSYS) -Ql test2.log_new -m ./my_cmd.so -p 'hierarchy -top test; test2' sigmap_test.v
+	$(YOSYS) -QTl test2.log_new -m ./my_cmd.so -p 'hierarchy -top test; test2' sigmap_test.v
 	mv test2.log_new test2.log
 
 .PHONY: clean

--- a/docs/source/code_examples/extensions/Makefile
+++ b/docs/source/code_examples/extensions/Makefile
@@ -13,18 +13,18 @@ my_cmd.so: my_cmd.cc
 	$(YOSYS)-config --exec --cxx $(subst $(DATDIR),../../../../share,$(CXXFLAGS)) --ldflags -o my_cmd.so -shared my_cmd.cc --ldlibs
 
 test0.log: my_cmd.so
-	$(YOSYS) -QTl test0.log_new -m ./my_cmd.so -p 'my_cmd foo bar' absval_ref.v
+	$(YOSYS) -QTl test0.log_new -m ./my_cmd.so -p 'my_cmd foo bar' -f verilog absval_ref.v
 	mv test0.log_new test0.log
 
 test1.log: my_cmd.so
-	$(YOSYS) -QTl test1.log_new -m ./my_cmd.so -p 'clean; test1; dump' absval_ref.v
+	$(YOSYS) -QTl test1.log_new -m ./my_cmd.so -p 'clean; test1; dump' -f verilog absval_ref.v
 	mv test1.log_new test1.log
 
 test1.dot: my_cmd.so
 	$(YOSYS) -m ./my_cmd.so -p 'test1; show -format dot -prefix test1'
 
 test2.log: my_cmd.so
-	$(YOSYS) -QTl test2.log_new -m ./my_cmd.so -p 'hierarchy -top test; test2' sigmap_test.v
+	$(YOSYS) -QTl test2.log_new -m ./my_cmd.so -p 'hierarchy -top test; test2' -f verilog sigmap_test.v
 	mv test2.log_new test2.log
 
 .PHONY: clean


### PR DESCRIPTION
- [x] Fix `yosys-abc` usage changing for every compile.
- [x] Fix `test*.log` changing for every compile.
- [x] Fix `test*.log` changing for every verific release.
- [x] Resolve ambiguity on source/temp by renaming to source/generated (i.e. the files should not be included in the Yosys repo, but they are needed for publishing the docs).