### PR TITLE
formalff -setundef: Fix handling for has_srst FFs

### DIFF
--- a/passes/sat/formalff.cc
+++ b/passes/sat/formalff.cc
@@ -237,7 +237,7 @@ struct InitValWorker
 					return true;
 				if (ff.has_ce && initconst(ff.sig_ce.as_bit()) == (ff.pol_ce ? State::S0 : State::S1))
 					continue;
-				if (ff.has_srst && initconst(ff.sig_ce.as_bit()) == (ff.pol_srst ? State::S1 : State::S0))
+				if (ff.has_srst && initconst(ff.sig_srst.as_bit()) == (ff.pol_srst ? State::S1 : State::S0))
 					continue;
 
 				return true;


### PR DESCRIPTION
The `has_srst` case was checking `sig_ce` instead of `sig_srst` due to a copy and paste error.

This would crash when `has_ce` was false and could incorrectly determine that an initial value is unused when `has_ce` and `has_srst` are both set.