### PR TITLE
verific: expose library name as module attribute

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -1430,6 +1430,7 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 	}
 	import_attributes(module->attributes, nl, nl);
 	module->set_string_attribute(ID::hdlname, nl->CellBaseName());
+	module->set_string_attribute(ID(library), nl->Owner()->Owner()->Name());
 #ifdef VERIFIC_VHDL_SUPPORT
 	if (nl->IsFromVhdl()) {
 		NameSpace name_space(0);


### PR DESCRIPTION
Each module is represented by Netlist object in Verific. It's owner is Cell and it's owner is Library object, that matches "work" specified when reading Verilog or VHDL sources.

There is always such object so no need for NULL checks. 