### PR TITLE
add support for using ABCs library merging when providing multiple liberty files

### DIFF
--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -804,8 +804,10 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 		for (std::string dont_use_cell : dont_use_cells) {
 			dont_use_args += stringf("-X \"%s\" ", dont_use_cell.c_str());
 		}
+		bool first_lib = true;
 		for (std::string liberty_file : liberty_files) {
-			abc_script += stringf("read_lib %s -w \"%s\" ; ", dont_use_args.c_str(), liberty_file.c_str());
+			abc_script += stringf("read_lib %s %s -w \"%s\" ; ", dont_use_args.c_str(), first_lib ? "" : "-m", liberty_file.c_str());
+			first_lib = false;
 		}
 		for (std::string liberty_file : genlib_files)
 			abc_script += stringf("read_library \"%s\"; ", liberty_file.c_str());


### PR DESCRIPTION
Changes:
- adds the `-m` flag to the ABC script when multiple liberty files are specified to indicate to ABC that is should merge the libraries, this solves the issue of only the last liberty file specified getting used for synthesis.

Requirements:
- needs the abc fork to be synced with the main abc to get the new flag.
