### PR TITLE
ABC: read_lib args and placeholders

### DIFF
--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -861,6 +861,7 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 		for (size_t pos = abc_script.find("dretime;"); pos != std::string::npos; pos = abc_script.find("dretime;", pos+1))
 			abc_script = abc_script.substr(0, pos) + "dretime; retime -o {D};" + abc_script.substr(pos+8);
 
+	// replace placeholders in abc.script and user.script
 	for (size_t pos = abc_script.find("{D}"); pos != std::string::npos; pos = abc_script.find("{D}", pos))
 		abc_script = abc_script.substr(0, pos) + delay_target + abc_script.substr(pos+3);
 
@@ -872,6 +873,25 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 
 	for (size_t pos = abc_script.find("{S}"); pos != std::string::npos; pos = abc_script.find("{S}", pos))
 		abc_script = abc_script.substr(0, pos) + lutin_shared + abc_script.substr(pos+3);
+
+	for (size_t pos = abc_script.find("{tmpdir}"); pos != std::string::npos; pos = abc_script.find("{tmpdir}", pos))
+		abc_script = abc_script.substr(0, pos) + tempdir_name.c_str() + abc_script.substr(pos+ std::strlen("{tmpdir}"));
+
+	for (size_t pos = user_script.find("{D}"); pos != std::string::npos; pos = user_script.find("{D}", pos))
+		user_script = user_script.substr(0, pos) + delay_target + user_script.substr(pos+3);
+
+	for (size_t pos = user_script.find("{I}"); pos != std::string::npos; pos = user_script.find("{I}", pos))
+		user_script = user_script.substr(0, pos) + sop_inputs + user_script.substr(pos+3);
+
+	for (size_t pos = user_script.find("{P}"); pos != std::string::npos; pos = user_script.find("{P}", pos))
+		user_script = user_script.substr(0, pos) + sop_products + user_script.substr(pos+3);
+
+	for (size_t pos = user_script.find("{S}"); pos != std::string::npos; pos = user_script.find("{S}", pos))
+		user_script = user_script.substr(0, pos) + lutin_shared + user_script.substr(pos+3);
+
+	for (size_t pos = user_script.find("{tmpdir}"); pos != std::string::npos; pos = user_script.find("{tmpdir}", pos))
+		user_script = user_script.substr(0, pos) + tempdir_name.c_str() + user_script.substr(pos+ std::strlen("{tmpdir}"));
+
 	if (abc_dress)
 		abc_script += stringf("; dress \"%s/input.blif\"", tempdir_name.c_str());
 	abc_script += stringf("; write_blif %s/output.blif", tempdir_name.c_str());

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -875,7 +875,7 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 		abc_script = abc_script.substr(0, pos) + lutin_shared + abc_script.substr(pos+3);
 
 	for (size_t pos = abc_script.find("{tmpdir}"); pos != std::string::npos; pos = abc_script.find("{tmpdir}", pos))
-		abc_script = abc_script.substr(0, pos) + tempdir_name.c_str() + abc_script.substr(pos+ std::strlen("{tmpdir}"));
+		abc_script = abc_script.substr(0, pos) + tempdir_name.c_str() + abc_script.substr(pos+ strlen("{tmpdir}"));
 
 	for (size_t pos = user_script.find("{D}"); pos != std::string::npos; pos = user_script.find("{D}", pos))
 		user_script = user_script.substr(0, pos) + delay_target + user_script.substr(pos+3);
@@ -890,7 +890,7 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 		user_script = user_script.substr(0, pos) + lutin_shared + user_script.substr(pos+3);
 
 	for (size_t pos = user_script.find("{tmpdir}"); pos != std::string::npos; pos = user_script.find("{tmpdir}", pos))
-		user_script = user_script.substr(0, pos) + tempdir_name.c_str() + user_script.substr(pos+ std::strlen("{tmpdir}"));
+		user_script = user_script.substr(0, pos) + tempdir_name.c_str() + user_script.substr(pos+ strlen("{tmpdir}"));
 
 	if (abc_dress)
 		abc_script += stringf("; dress \"%s/input.blif\"", tempdir_name.c_str());


### PR DESCRIPTION
Adds a way to give read_lib additional arguments. 

This can for example be used to define `-S <slew> -G <gain>` so ABC will calculate its internal delay model from the standard cells liberty data. Without this it uses a unit delay model, which may produce worse results.  
An example use:
```
abc -liberty "$tech_cells" -D $period -script "$script" -liberty_args "-S 20 -G 3" -showtmp
```

I changed it so the placeholders like `{D}` are also replaced in user provided scripts. This seems reasonable to me as OpenLane, OpenROAD-flow-scripts etc currently use the same placeholders but have to replace it themself.  
Additionally, there is a new placeholder called `{tmpdir}`, it contains the path to the yosys-abc directory currently being used. This allows users to temporarily store information from their user script.