### PR TITLE
frontend: Fixes verific import around range order

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -2156,15 +2156,15 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 			int port_offset = 0;
 			if (pr->GetPort()->Bus()) {
 				port_name = pr->GetPort()->Bus()->Name();
-				int msb = pr->GetPort()->Bus()->LeftIndex();
-				int lsb = pr->GetPort()->Bus()->RightIndex();
+				int msb_index = pr->GetPort()->Bus()->LeftIndex();
+				int lsb_index = pr->GetPort()->Bus()->RightIndex();
 				int index_of_port = pr->GetPort()->Bus()->IndexOf(pr->GetPort());
-				port_offset =  index_of_port - min(msb, lsb);
+				port_offset =  index_of_port - min(msb_index, lsb_index);
 				// In cases where the msb order is flipped we need to make sure
 				// that the indicies match LSB = 0 order to match the std::vector
 				// to SigSpec LSB = 0 precondition.
-				if (lsb > msb) {
-					port_offset = abs(port_offset - lsb);
+				if (lsb_index > msb_index) {
+					port_offset = abs(port_offset - lsb_index);
 				}
 			}
 			IdString port_name_id = RTLIL::escape_id(port_name);

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -2164,7 +2164,7 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 				// that the indicies match LSB = 0 order to match the std::vector
 				// to SigSpec LSB = 0 precondition.
 				if (lsb_index > msb_index) {
-					port_offset = abs(port_offset - lsb_index);
+					port_offset = abs(port_offset - (lsb_index - min(msb_index, lsb_index)));
 				}
 			}
 			IdString port_name_id = RTLIL::escape_id(port_name);

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -2156,8 +2156,16 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 			int port_offset = 0;
 			if (pr->GetPort()->Bus()) {
 				port_name = pr->GetPort()->Bus()->Name();
-				port_offset = pr->GetPort()->Bus()->IndexOf(pr->GetPort()) -
-						min(pr->GetPort()->Bus()->LeftIndex(), pr->GetPort()->Bus()->RightIndex());
+				int msb = pr->GetPort()->Bus()->LeftIndex();
+				int lsb = pr->GetPort()->Bus()->RightIndex();
+				int index_of_port = pr->GetPort()->Bus()->IndexOf(pr->GetPort());
+				port_offset =  index_of_port - min(msb, lsb);
+				// In cases where the msb order is flipped we need to make sure
+				// that the indicies match LSB = 0 order to match the std::vector
+				// to SigSpec LSB = 0 precondition.
+				if (lsb > msb) {
+					port_offset = abs(port_offset - lsb);
+				}
 			}
 			IdString port_name_id = RTLIL::escape_id(port_name);
 			auto &sigvec = cell_port_conns[port_name_id];


### PR DESCRIPTION
Test Case
```
module packed_dimensions_range_ordering (
    input  wire [0:4-1] in,
    output wire [4-1:0] out
);
  assign out = in;
endmodule : packed_dimensions_range_ordering

module instanciates_packed_dimensions_range_ordering (
    input  wire [4-1:0] in,
    output wire [4-1:0] out
);
  packed_dimensions_range_ordering U0 (
      .in (in),
      .out(out)
  );
endmodule : instanciates_packed_dimensions_range_ordering
```

```
// with verific, does not pass formal
module instanciates_packed_dimensions_range_ordering(in, out);
  input [3:0] in;
  wire [3:0] in;
  output [3:0] out;
  wire [3:0] out;

  assign out = { in[0], in[1], in[2], in[3] };
endmodule

// with surelog, passes formal
module instanciates_packed_dimensions_range_ordering(in, out);
  input [3:0] in;
  wire [3:0] in;
  output [3:0] out;
  wire [3:0] out;

  assign out = in;
endmodule
```

Script
```
verific -sv test.sv
verific -import -vv instanciates_packed_dimensions_range_ordering
hierarchy -top instanciates_packed_dimensions_range_ordering
flatten
opt
clean -purge
write_verilog -simple-lhs -noattr -noexpr result3.v
```