### PR TITLE
cxxrtl: reduce stack space used by the `debug_info()` function

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -615,10 +615,11 @@ std::string escape_cxx_string(const std::string &input)
 				output.push_back('\\');
 			output.push_back(c);
 		} else {
-			char l = c & 0xf, h = (c >> 4) & 0xf;
-			output.append("\\x");
-			output.push_back((h < 10 ? '0' + h : 'a' + h - 10));
-			output.push_back((l < 10 ? '0' + l : 'a' + l - 10));
+			char l = c & 0x3, m = (c >> 3) & 0x3, h = (c >> 6) & 0x3;
+			output.append("\\");
+			output.push_back('0' + h);
+			output.push_back('0' + m);
+			output.push_back('0' + l);
 		}
 	}
 	output.push_back('"');

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -1466,6 +1466,11 @@ struct debug_items {
 			});
 	}
 
+	// This overload exists to reduce excessive stack slot allocation in `CXXRTL_EXTREMELY_COLD void debug_info()`.
+	void add(const std::string &base_path, const char *path, debug_item &&item, const char *serialized_item_attrs) {
+		add(base_path + path, std::move(item), metadata::deserialize(serialized_item_attrs));
+	}
+
 	size_t count(const std::string &path) const {
 		if (table.count(path) == 0)
 			return 0;
@@ -1510,6 +1515,11 @@ struct debug_scopes {
 		scope.module_name = module_name;
 		scope.module_attrs = std::unique_ptr<debug_attrs>(new debug_attrs { module_attrs });
 		scope.cell_attrs = std::unique_ptr<debug_attrs>(new debug_attrs { cell_attrs });
+	}
+
+	// This overload exists to reduce excessive stack slot allocation in `CXXRTL_EXTREMELY_COLD void debug_info()`.
+	void add(const std::string &base_path, const char *path, const char *module_name, const char *serialized_module_attrs, const char *serialized_cell_attrs) {
+		add(base_path + path, module_name, metadata::deserialize(serialized_module_attrs), metadata::deserialize(serialized_cell_attrs));
 	}
 
 	size_t contains(const std::string &path) const {

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -1467,8 +1467,9 @@ struct debug_items {
 	}
 
 	// This overload exists to reduce excessive stack slot allocation in `CXXRTL_EXTREMELY_COLD void debug_info()`.
-	void add(const std::string &base_path, const char *path, debug_item &&item, const char *serialized_item_attrs) {
-		add(base_path + path, std::move(item), metadata::deserialize(serialized_item_attrs));
+	template<class... T>
+	void add(const std::string &base_path, const char *path, const char *serialized_item_attrs, T&&... args) {
+		add(base_path + path, debug_item(std::forward<T>(args)...), metadata::deserialize(serialized_item_attrs));
 	}
 
 	size_t count(const std::string &path) const {

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl_replay.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl_replay.h
@@ -512,9 +512,10 @@ public:
 	spool &operator=(const spool &) = delete;
 
 	~spool() {
-		if (int fd = writefd.exchange(-1))
+		int fd;
+		if ((fd = writefd.exchange(-1)) != -1)
 			close(fd);
-		if (int fd = readfd.exchange(-1))
+		if ((fd = readfd.exchange(-1)) != -1)
 			close(fd);
 	}
 


### PR DESCRIPTION
The large amount of stack space used by this function is problematic especially on macOS, where the default stack size is 512 KiB.