### PR TITLE
Fix `check-git-abc` Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -783,14 +783,14 @@ $(PROGRAM_PREFIX)yosys-config: misc/yosys-config.in
 .PHONY: check-git-abc
 
 check-git-abc:
-	@if [ ! -d "$(YOSYS_SRC)/abc" ]; then \
+	@if [ ! -d "$(YOSYS_SRC)/abc" ] || [ -z "$(git submodule status abc | grep '^-' )" ]; then \
 	    echo "Error: The 'abc' directory does not exist."; \
 			echo "Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule."; \
 	    exit 1; \
 	elif git -C "$(YOSYS_SRC)" submodule status abc 2>/dev/null | grep -q '^ '; then \
 	    echo "'abc' is a git submodule. Continuing."; \
 	    exit 0; \
-	elif ([ -f "$(YOSYS_SRC)/abc/.gitcommit" ] && grep -q '\$$Format:%h\$$' "$(YOSYS_SRC)/abc/.gitcommit") || [ -z "$(git submodule status abc | grep '^-' )" ]; then \
+	elif [ -f "$(YOSYS_SRC)/abc/.gitcommit" ] && grep -q '\$$Format:%h\$$' "$(YOSYS_SRC)/abc/.gitcommit"; then \
 	    echo "Error: 'abc' is not configured as a git submodule."; \
 	    echo "To resolve this:"; \
 	    echo "1. Back up your changes: Save any modifications from the 'abc' directory to another location."; \

--- a/Makefile
+++ b/Makefile
@@ -783,7 +783,7 @@ $(PROGRAM_PREFIX)yosys-config: misc/yosys-config.in
 .PHONY: check-git-abc
 
 check-git-abc:
-	@if [ ! -d "$(YOSYS_SRC)/abc" ] || [ -z "$(git submodule status abc | grep '^-' )" ]; then \
+	@if [ ! -d "$(YOSYS_SRC)/abc" ]; then \
 	    echo "Error: The 'abc' directory does not exist."; \
 			echo "Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule."; \
 	    exit 1; \
@@ -797,6 +797,10 @@ check-git-abc:
 	    echo "2. Remove the existing 'abc' directory: Delete the 'abc' directory and all its contents."; \
 	    echo "3. Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule."; \
 	    echo "4. Reapply your changes: Move your saved changes back to the 'abc' directory, if necessary."; \
+	    exit 1; \
+	elif [ -z "$(git submodule status abc | grep '^-' )" ]; then \
+	    echo "Error: The 'abc' directory does not exist."; \
+			echo "Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule."; \
 	    exit 1; \
 	else \
 	    echo "'abc' comes from a tarball. Continuing."; \

--- a/Makefile
+++ b/Makefile
@@ -790,7 +790,7 @@ check-git-abc:
 	elif git -C "$(YOSYS_SRC)" submodule status abc 2>/dev/null | grep -q '^ '; then \
 	    echo "'abc' is a git submodule. Continuing."; \
 	    exit 0; \
-	elif [ -f "$(YOSYS_SRC)/abc/.gitcommit" ] && grep -q '\$$Format:%h\$$' "$(YOSYS_SRC)/abc/.gitcommit"; then \
+	elif ([ -f "$(YOSYS_SRC)/abc/.gitcommit" ] && grep -q '\$$Format:%h\$$' "$(YOSYS_SRC)/abc/.gitcommit") || [ -z "$(git submodule status | grep '^-' )" ]; then \
 	    echo "Error: 'abc' is not configured as a git submodule."; \
 	    echo "To resolve this:"; \
 	    echo "1. Back up your changes: Save any modifications from the 'abc' directory to another location."; \

--- a/Makefile
+++ b/Makefile
@@ -790,7 +790,7 @@ check-git-abc:
 	elif git -C "$(YOSYS_SRC)" submodule status abc 2>/dev/null | grep -q '^ '; then \
 	    echo "'abc' is a git submodule. Continuing."; \
 	    exit 0; \
-	elif ([ -f "$(YOSYS_SRC)/abc/.gitcommit" ] && grep -q '\$$Format:%h\$$' "$(YOSYS_SRC)/abc/.gitcommit") || [ -z "$(git submodule status | grep '^-' )" ]; then \
+	elif ([ -f "$(YOSYS_SRC)/abc/.gitcommit" ] && grep -q '\$$Format:%h\$$' "$(YOSYS_SRC)/abc/.gitcommit") || [ -z "$(git submodule status abc | grep '^-' )" ]; then \
 	    echo "Error: 'abc' is not configured as a git submodule."; \
 	    echo "To resolve this:"; \
 	    echo "1. Back up your changes: Save any modifications from the 'abc' directory to another location."; \

--- a/Makefile
+++ b/Makefile
@@ -798,7 +798,7 @@ check-git-abc:
 	    echo "3. Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule."; \
 	    echo "4. Reapply your changes: Move your saved changes back to the 'abc' directory, if necessary."; \
 	    exit 1; \
-	elif [ -z "$(git submodule status abc | grep '^-' )" ]; then \
+	elif [ -n "$(git submodule status abc | grep '^-' )" ]; then \
 	    echo "Error: The 'abc' directory does not exist."; \
 			echo "Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule."; \
 	    exit 1; \

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Makefile.
 	$ vi Makefile            # ..or..
 	$ vi Makefile.conf
 
+Initialize the `abc` submodule with `git submodule update --init`.
+
 To build Yosys simply type 'make' in this directory.
 
 	$ make


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

https://github.com/YosysHQ/yosys/issues/4383

_Explain how this is achieved._

Add the condition that if `git submodule status abc` results in a string starting with `-` then the git submodule is uninitialized.

_If applicable, please suggest to reviewers how they can test the change._

Clone the repo, run `make` or `make check-git-abc`, examine instructions to initialize the submodule, `git submodule update --init`, re-run `make` or `make check-git-abc` and there should not be any error.