### PR TITLE
Dark theme images for docs

### DIFF
--- a/docs/source/_static/yosyshq.css
+++ b/docs/source/_static/yosyshq.css
@@ -24,3 +24,17 @@ a.external {
 th {
     text-align: left;
 }
+
+body[data-theme="dark"] {
+    .invert-helper {
+        filter: url("data:image/svg+xml,<svg xmlns='http%3A//www.w3.org/2000/svg'><filter id='f'><feColorMatrix color-interpolation-filters='sRGB' type='matrix' values='1.47 -1.73 -0.467 0 0.867 -0.733 0.467 -0.467 0 0.867 -0.667 -1.07 1.07 0 0.867 0 0 0 1.0 0'></feColorMatrix></filter></svg>#f");
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    body:not([data-theme="light"]) {
+        .invert-helper {
+            filter: url("data:image/svg+xml,<svg xmlns='http%3A//www.w3.org/2000/svg'><filter id='f'><feColorMatrix color-interpolation-filters='sRGB' type='matrix' values='1.47 -1.73 -0.467 0 0.867 -0.733 0.467 -0.467 0 0.867 -0.667 -1.07 1.07 0 0.867 0 0 0 1.0 0'></feColorMatrix></filter></svg>#f");
+        }
+    }
+}

--- a/docs/source/appendix/primer.rst
+++ b/docs/source/appendix/primer.rst
@@ -24,7 +24,7 @@ circuit to a functionally equivalent low-level representation of a circuit.
 abstraction and how they relate to different kinds of synthesis.
 
 .. figure:: /_images/primer/basics_abstractions.*
-	:class: width-helper
+	:class: width-helper invert-helper
 	:name: fig:Basics_abstractions
 
 	Different levels of abstraction and synthesis.
@@ -499,7 +499,7 @@ using a series of tools and the results are again verified using simulation.
 This process is illustrated in :numref:`Fig. %s <fig:Basics_flow>`.
 
 .. figure:: /_images/primer/basics_flow.*
-	:class: width-helper
+	:class: width-helper invert-helper
 	:name: fig:Basics_flow
 
 	Typical design flow.  Green boxes represent manually created models.
@@ -598,7 +598,7 @@ Let's consider the following BNF (in Bison syntax):
    expr: TOK_IDENTIFIER | TOK_NUMBER | expr TOK_PLUS expr;
 
 .. figure:: /_images/primer/basics_parsetree.*
-	:class: width-helper
+	:class: width-helper invert-helper
 	:name: fig:Basics_parsetree
 
 	Example parse tree for the Verilog expression 
@@ -627,7 +627,7 @@ suitable for further processing. In compilers this is often an assembler-like
 three-address-code intermediate representation. :cite:p:`Dragonbook`
 
 .. figure:: /_images/primer/basics_ast.*
-	:class: width-helper
+	:class: width-helper invert-helper
 	:name: fig:Basics_ast
 
 	Example abstract syntax tree for the Verilog expression 

--- a/docs/source/getting_started/example_synth.rst
+++ b/docs/source/getting_started/example_synth.rst
@@ -122,7 +122,7 @@ Since we're just getting started, let's instead begin with :yoscrypt:`hierarchy
 Our ``addr_gen`` circuit now looks like this:
 
 .. figure:: /_images/code_examples/fifo/addr_gen_hier.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: addr_gen_hier
 
    ``addr_gen`` module after :cmd:ref:`hierarchy`
@@ -145,7 +145,7 @@ we run it.  For now, we will call :yoscrypt:`proc -noopt` to prevent some
 automatic optimizations which would normally happen.
 
 .. figure:: /_images/code_examples/fifo/addr_gen_proc.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: addr_gen_proc
 
    ``addr_gen`` module after :yoscrypt:`proc -noopt`
@@ -166,7 +166,7 @@ the same time by separating them with a colon and space: :yoscrypt:`opt_expr;
 clean`.
 
 .. figure:: /_images/code_examples/fifo/addr_gen_clean.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: addr_gen_clean
 
    ``addr_gen`` module after :yoscrypt:`opt_expr; clean`
@@ -252,7 +252,7 @@ command only works with a single module, so you may need to call it with
 :doc:`/getting_started/scripting_intro` has more on how to use :cmd:ref:`show`.
 
 .. figure:: /_images/code_examples/fifo/rdata_proc.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: rdata_proc
 
    ``rdata`` output after :cmd:ref:`proc`
@@ -298,7 +298,7 @@ optimizations between modules which would otherwise be missed.  Let's run
    :caption: output of :yoscrypt:`flatten;;`
 
 .. figure:: /_images/code_examples/fifo/rdata_flat.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: rdata_flat
 
    ``rdata`` output after :yoscrypt:`flatten;;`
@@ -385,7 +385,7 @@ options is able to fold one of the ``$mux`` cells into the ``$adff`` to form an
    :caption: output of :cmd:ref:`opt_dff`
 
 .. figure:: /_images/code_examples/fifo/rdata_adffe.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: rdata_adffe
 
    ``rdata`` output after :cmd:ref:`opt_dff`
@@ -424,7 +424,7 @@ the schematic and see the output of that cell has now changed.
 .. todo:: pending bugfix in :cmd:ref:`wreduce` and/or :cmd:ref:`opt_clean`
 
 .. figure:: /_images/code_examples/fifo/rdata_wreduce.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: rdata_wreduce
 
    ``rdata`` output after :cmd:ref:`wreduce`
@@ -446,7 +446,7 @@ Our next command to run is
    :caption: output of :cmd:ref:`memory_dff`
 
 .. figure:: /_images/code_examples/fifo/rdata_memrdv2.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: rdata_memrdv2
 
    ``rdata`` output after :cmd:ref:`memory_dff`
@@ -535,7 +535,7 @@ example design:
    :caption: output of :cmd:ref:`alumacc`
 
 .. figure:: /_images/code_examples/fifo/rdata_alumacc.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: rdata_alumacc
 
    ``rdata`` output after :cmd:ref:`alumacc`
@@ -553,7 +553,7 @@ operating on the same memory only in the abstract. :cmd:ref:`memory_collect`
 combines all of the reads and writes for a memory block into a single cell.
 
 .. figure:: /_images/code_examples/fifo/rdata_coarse.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: rdata_coarse
 
    ``rdata`` output after :cmd:ref:`memory_collect`
@@ -604,7 +604,7 @@ Mapping to hard memory blocks uses a combination of :cmd:ref:`memory_libmap` and
    :caption: ``map_ram`` section
 
 .. figure:: /_images/code_examples/fifo/rdata_map_ram.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: rdata_map_ram
 
    ``rdata`` output after :ref:`map_ram`
@@ -646,7 +646,7 @@ into flip flops (the ``logic fallback``) with :cmd:ref:`memory_map`.
    :caption: ``map_ffram`` section
 
 .. figure:: /_images/code_examples/fifo/rdata_map_ffram.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: rdata_map_ffram
 
    ``rdata`` output after :ref:`map_ffram`
@@ -682,7 +682,7 @@ replaced with single-bit ``$_MUX_`` and ``$_DFFE_PP0P_`` cells, while the
    :caption: ``map_gates`` section
 
 .. figure:: /_images/code_examples/fifo/rdata_map_gates.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: rdata_map_gates
 
    ``rdata`` output after :ref:`map_gates`
@@ -711,7 +711,7 @@ instead with an ``$_AND_`` cell.
    :caption: ``map_ffs`` section
 
 .. figure:: /_images/code_examples/fifo/rdata_map_ffs.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: rdata_map_ffs
 
    ``rdata`` output after :ref:`map_ffs`
@@ -737,7 +737,7 @@ what the difference between these two commands are, refer to
    :caption: ``map_luts`` section
 
 .. figure:: /_images/code_examples/fifo/rdata_map_luts.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: rdata_map_luts
 
    ``rdata`` output after :ref:`map_luts`
@@ -754,7 +754,7 @@ Finally we use :cmd:ref:`techmap` to map the generic ``$lut`` cells to iCE40
    :caption: ``map_cells`` section
 
 .. figure:: /_images/code_examples/fifo/rdata_map_cells.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: rdata_map_cells
 
    ``rdata`` output after :ref:`map_cells`

--- a/docs/source/getting_started/scripting_intro.rst
+++ b/docs/source/getting_started/scripting_intro.rst
@@ -108,7 +108,7 @@ what the different symbols represent, see :ref:`interactive_show` and the
 :doc:`/using_yosys/more_scripting/interactive_investigation` page.
 
 .. figure:: /_images/code_examples/fifo/addr_gen_show.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: addr_gen_show
 
    Calling :yoscrypt:`show addr_gen` after :cmd:ref:`hierarchy`
@@ -158,7 +158,7 @@ selection<select_new_cells>` and called it ``new_cells``?  We saw in the
 ``$eq``.  We can call :cmd:ref:`show` on that selection just as easily:
 
 .. figure:: /_images/code_examples/fifo/new_cells_show.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: new_cells_show
 
    Calling :yoscrypt:`show -notitle @new_cells`
@@ -173,7 +173,7 @@ the two ``PROC`` blocks.  To achieve this highlight, we make use of the
 :yoscrypt:`-color` option:
 
 .. figure:: /_images/code_examples/fifo/addr_gen_hier.*
-   :class: width-helper
+   :class: width-helper invert-helper
 
    Calling :yoscrypt:`show -color maroon3 @new_cells -color cornflowerblue p:* -notitle`
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -151,7 +151,7 @@ extensible and therefore is a good basis for implementing custom synthesis tools
 for specialised tasks.
 
 .. figure:: /_images/primer/levels_of_abstraction.*
-    :class: width-helper
+    :class: width-helper invert-helper
     :name: fig:Levels_of_abstraction
 
     Where Yosys exists in the layers of abstraction

--- a/docs/source/using_yosys/more_scripting/interactive_investigation.rst
+++ b/docs/source/using_yosys/more_scripting/interactive_investigation.rst
@@ -56,7 +56,7 @@ is shown.
    ``xdot example_first.dot`` etc.
 
 .. figure:: /_images/code_examples/show/example_first.*
-   :class: width-helper
+   :class: width-helper invert-helper
    
    Output of the first :cmd:ref:`show` command in :numref:`example_ys`
 
@@ -88,7 +88,7 @@ The :cmd:ref:`proc` command transforms the process from the first diagram into a
 multiplexer and a d-type flip-flop, which brings us to the second diagram:
 
 .. figure:: /_images/code_examples/show/example_second.*
-   :class: width-helper
+   :class: width-helper invert-helper
    
    Output of the second :cmd:ref:`show` command in :numref:`example_ys`
 
@@ -110,7 +110,7 @@ In this script we directly call :cmd:ref:`opt` as the next step, which finally
 leads us to the third diagram: 
 
 .. figure:: /_images/code_examples/show/example_third.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: example_out
    
    Output of the third :cmd:ref:`show` command in :ref:`example_ys`
@@ -137,7 +137,7 @@ that operate on wide integers, it also introduces some additional complexity
 when the individual bits of of a signal vector are accessed.
 
 .. figure:: /_images/code_examples/show/splice.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: splice_dia
 
    Output of ``yosys -p 'prep -top splice_demo; show' splice.v``
@@ -165,7 +165,7 @@ Gate level netlists
 mapped to a cell library:
 
 .. figure:: /_images/code_examples/show/cmos_00.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: first_pitfall
 
    A half-adder built from simple CMOS gates, demonstrating common pitfalls when 
@@ -185,7 +185,7 @@ column. Secondly the two-bit vector ``y`` requires breakout-boxes for its
 individual bits, resulting in an unnecessary complex diagram.
 
 .. figure:: /_images/code_examples/show/cmos_01.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: second_pitfall
 
    Effects of :cmd:ref:`splitnets` command and of providing a cell library on 
@@ -358,10 +358,10 @@ reorganizing a module in Yosys and checking the resulting circuit.
    :end-before: cd ..
 
 .. figure:: /_images/code_examples/scrambler/scrambler_p01.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 .. figure:: /_images/code_examples/scrambler/scrambler_p02.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 Analyzing the resulting circuit with :doc:`/cmd/eval`:
 
@@ -442,7 +442,7 @@ if the circuit under investigation is encapsulated in a separate module.
 Recall the ``memdemo`` design from :ref:`advanced_logic_cones`:
 
 .. figure:: /_images/code_examples/selections/memdemo_00.*
-   :class: width-helper
+   :class: width-helper invert-helper
    
    ``memdemo``
 
@@ -463,18 +463,18 @@ name of the new cell in the current module. The resulting circuits are shown
 below.
 
 .. figure:: /_images/code_examples/selections/submod_02.*
-   :class: width-helper
+   :class: width-helper invert-helper
    
    ``outstage``
 
 .. figure:: /_images/code_examples/selections/submod_03.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: selstage
    
    ``selstage``
 
 .. figure:: /_images/code_examples/selections/submod_01.*
-   :class: width-helper
+   :class: width-helper invert-helper
    
    ``scramble``
 

--- a/docs/source/using_yosys/more_scripting/selections.rst
+++ b/docs/source/using_yosys/more_scripting/selections.rst
@@ -160,7 +160,7 @@ Selecting ``a:sumstuff`` in this module will yield the following circuit
 diagram:
 
 .. figure:: /_images/code_examples/selections/sumprod_00.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: sumprod_00
 
    Output of ``show a:sumstuff`` on :numref:`sumprod`
@@ -177,7 +177,7 @@ selected wire it selects all cells connected to the wire and vice versa. So
 :yoscrypt:`show a:sumstuff %x` yields the diagram shown in :numref:`sumprod_01`:
 
 .. figure:: /_images/code_examples/selections/sumprod_01.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: sumprod_01
 
    Output of ``show a:sumstuff %x`` on :numref:`sumprod`
@@ -200,22 +200,22 @@ input ports.
 The following sequence of diagrams demonstrates this step-wise expansion:
 
 .. figure:: /_images/code_examples/selections/sumprod_02.*
-   :class: width-helper
+   :class: width-helper invert-helper
 
    Output of :yoscrypt:`show prod` on :numref:`sumprod`
 
 .. figure:: /_images/code_examples/selections/sumprod_03.*
-   :class: width-helper
+   :class: width-helper invert-helper
 
    Output of :yoscrypt:`show prod %ci` on :numref:`sumprod`
 
 .. figure:: /_images/code_examples/selections/sumprod_04.*
-   :class: width-helper
+   :class: width-helper invert-helper
 
    Output of :yoscrypt:`show prod %ci %ci` on :numref:`sumprod`
 
 .. figure:: /_images/code_examples/selections/sumprod_05.*
-   :class: width-helper
+   :class: width-helper invert-helper
 
    Output of :yoscrypt:`show prod %ci %ci %ci` on :numref:`sumprod`
 
@@ -280,7 +280,7 @@ provided :file:`memdemo.v` is in the same directory. We can now change to the
 diagram in :numref:`memdemo_00`.
 
 .. figure:: /_images/code_examples/selections/memdemo_00.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: memdemo_00
    
    Complete circuit diagram for the design shown in :numref:`memdemo_src`
@@ -291,7 +291,7 @@ output signal, ``y``, and its immediate predecessors. Remember `Selecting logic
 cones`_ from above, we can use :yoscrypt:`show y %ci2`:
 
 .. figure:: /_images/code_examples/selections/memdemo_01.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: memdemo_01
    
    Output of :yoscrypt:`show y %ci2`
@@ -303,7 +303,7 @@ wire into the input ``D`` of the flip-flop cell (indicated by the ``$`` at the
 start of the name).  Let's go a bit further now and try :yoscrypt:`show y %ci5`:
 
 .. figure:: /_images/code_examples/selections/memdemo_02.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: memdemo_02
    
    Output of :yoscrypt:`show y %ci5`
@@ -317,7 +317,7 @@ brackets.  In this case, we want to exclude the ``S`` port of the ``$mux`` cell
 type with :yoscrypt:`show y %ci5:-$mux[S]`:
 
 .. figure:: /_images/code_examples/selections/memdemo_03.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: memdemo_03
    
    Output of :yoscrypt:`show y %ci5:-$mux[S]`
@@ -328,7 +328,7 @@ flip-flop and the 2nd action selects the entire input cone without going over
 multiplexer select inputs and flip-flop cells:
 
 .. figure:: /_images/code_examples/selections/memdemo_05.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: memdemo_05
    
    Output of ``show y %ci2:+$dff[Q,D] %ci*:-$mux[S]:-$dff``
@@ -340,7 +340,7 @@ ignoring any ports named ``CLK`` or ``S``:
 .. TODO:: pending discussion on whether rule ordering is a bug or a feature
 
 .. figure:: /_images/code_examples/selections/memdemo_04.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: memdemo_04
    
    Output of :yoscrypt:`show y %ci*:-[CLK,S]:+$dff,$mux`
@@ -417,6 +417,6 @@ Example code from |code_examples/selections|_:
    :name: select_ys
 
 .. figure:: /_images/code_examples/selections/select.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
     Circuit diagram produced by :numref:`select_ys`

--- a/docs/source/using_yosys/synthesis/cell_libs.rst
+++ b/docs/source/using_yosys/synthesis/cell_libs.rst
@@ -51,7 +51,7 @@ Loading the design
 Our circuit now looks like this:
 
 .. figure:: /_images/code_examples/intro/counter_00.*
-   :class: width-helper
+   :class: width-helper invert-helper
    :name: counter-hierarchy
 
    ``counter`` after :cmd:ref:`hierarchy`
@@ -66,7 +66,7 @@ Coarse-grain representation
    :caption: :file:`counter.ys` - the high-level stuff
 
 .. figure:: /_images/code_examples/intro/counter_01.*
-   :class: width-helper
+   :class: width-helper invert-helper
 
    Coarse-grain representation of the ``counter`` module
 
@@ -80,7 +80,7 @@ Logic gate mapping
    :caption: :file:`counter.ys` - mapping to internal cell library
 
 .. figure:: /_images/code_examples/intro/counter_02.*
-   :class: width-helper
+   :class: width-helper invert-helper
 
    ``counter`` after :cmd:ref:`techmap`
 
@@ -111,7 +111,7 @@ Recall that the Yosys built-in logic gate types are ``$_NOT_``, ``$_AND_``,
 The final version of our ``counter`` module looks like this:
 
 .. figure:: /_images/code_examples/intro/counter_03.*
-   :class: width-helper
+   :class: width-helper invert-helper
 
    ``counter`` after hardware cell mapping
 

--- a/docs/source/using_yosys/synthesis/extract.rst
+++ b/docs/source/using_yosys/synthesis/extract.rst
@@ -23,7 +23,7 @@ Example code can be found in |code_examples/macc|_.
     :lines: 1-2
 
 .. figure:: /_images/code_examples/macc/macc_simple_test_00a.*
-    :class: width-helper
+    :class: width-helper invert-helper
     
     before :cmd:ref:`extract`
 
@@ -32,7 +32,7 @@ Example code can be found in |code_examples/macc|_.
     :lines: 6
 
 .. figure:: /_images/code_examples/macc/macc_simple_test_00b.*
-    :class: width-helper
+    :class: width-helper invert-helper
     
     after :cmd:ref:`extract`
 
@@ -49,20 +49,20 @@ Example code can be found in |code_examples/macc|_.
    :caption: :file:`macc_simple_test_01.v`
 
 .. figure:: /_images/code_examples/macc/macc_simple_test_01a.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 .. figure:: /_images/code_examples/macc/macc_simple_test_01b.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 .. literalinclude:: /code_examples/macc/macc_simple_test_02.v
    :language: verilog
    :caption: :file:`macc_simple_test_02.v`
 
 .. figure:: /_images/code_examples/macc/macc_simple_test_02a.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 .. figure:: /_images/code_examples/macc/macc_simple_test_02b.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 The wrap-extract-unwrap method
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -149,10 +149,10 @@ Unwrapping adders: :file:`macc_xilinx_unwrap_map.v`
    :caption: ``test1`` of :file:`macc_xilinx_test.v`
 
 .. figure:: /_images/code_examples/macc/macc_xilinx_test1a.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 .. figure:: /_images/code_examples/macc/macc_xilinx_test1b.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 .. literalinclude:: /code_examples/macc/macc_xilinx_test.v
    :language: verilog
@@ -160,15 +160,15 @@ Unwrapping adders: :file:`macc_xilinx_unwrap_map.v`
    :caption: ``test2`` of :file:`macc_xilinx_test.v`
 
 .. figure:: /_images/code_examples/macc/macc_xilinx_test2a.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 .. figure:: /_images/code_examples/macc/macc_xilinx_test2b.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 Wrapping in ``test1``:
 
 .. figure:: /_images/code_examples/macc/macc_xilinx_test1b.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 .. literalinclude:: /code_examples/macc/macc_xilinx_test.ys
     :language: yoscrypt
@@ -176,12 +176,12 @@ Wrapping in ``test1``:
     :end-before: end part c
 
 .. figure:: /_images/code_examples/macc/macc_xilinx_test1c.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 Wrapping in ``test2``:
 
 .. figure:: /_images/code_examples/macc/macc_xilinx_test2b.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 .. literalinclude:: /code_examples/macc/macc_xilinx_test.ys
     :language: yoscrypt
@@ -189,12 +189,12 @@ Wrapping in ``test2``:
     :end-before: end part c
 
 .. figure:: /_images/code_examples/macc/macc_xilinx_test2c.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 Extract in ``test1``:
 
 .. figure:: /_images/code_examples/macc/macc_xilinx_test1c.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 .. literalinclude:: /code_examples/macc/macc_xilinx_test.ys
     :language: yoscrypt
@@ -202,12 +202,12 @@ Extract in ``test1``:
     :end-before: end part d
 
 .. figure:: /_images/code_examples/macc/macc_xilinx_test1d.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 Extract in ``test2``:
 
 .. figure:: /_images/code_examples/macc/macc_xilinx_test2c.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 .. literalinclude:: /code_examples/macc/macc_xilinx_test.ys
     :language: yoscrypt
@@ -215,12 +215,12 @@ Extract in ``test2``:
     :end-before: end part d
 
 .. figure:: /_images/code_examples/macc/macc_xilinx_test2d.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 Unwrap in ``test2``:
 
 .. figure:: /_images/code_examples/macc/macc_xilinx_test2d.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 .. literalinclude:: /code_examples/macc/macc_xilinx_test.ys
     :language: yoscrypt
@@ -228,4 +228,4 @@ Unwrap in ``test2``:
     :end-before: end part e
 
 .. figure:: /_images/code_examples/macc/macc_xilinx_test2e.*
-    :class: width-helper
+    :class: width-helper invert-helper

--- a/docs/source/using_yosys/synthesis/memory.rst
+++ b/docs/source/using_yosys/synthesis/memory.rst
@@ -39,7 +39,7 @@ Example
 .. _code_examples/synth_flow: https://github.com/YosysHQ/yosys/tree/main/docs/source/code_examples/synth_flow
 
 .. figure:: /_images/code_examples/synth_flow/memory_01.*
-   :class: width-helper
+   :class: width-helper invert-helper
 
 .. literalinclude:: /code_examples/synth_flow/memory_01.ys
    :language: yoscrypt
@@ -50,7 +50,7 @@ Example
    :caption: :file:`memory_01.v`
 
 .. figure:: /_images/code_examples/synth_flow/memory_02.*
-   :class: width-helper
+   :class: width-helper invert-helper
 
 .. literalinclude:: /code_examples/synth_flow/memory_02.v
    :language: verilog

--- a/docs/source/using_yosys/synthesis/opt.rst
+++ b/docs/source/using_yosys/synthesis/opt.rst
@@ -88,7 +88,7 @@ trees can interfere with other optimizations.
    :caption: example verilog for demonstrating :cmd:ref:`opt_expr`
 
 .. figure:: /_images/code_examples/opt/opt_expr.*
-   :class: width-helper
+   :class: width-helper invert-helper
 
    Before and after :cmd:ref:`opt_expr`
 
@@ -111,7 +111,7 @@ possible optimizations.
    :caption: example verilog for demonstrating :cmd:ref:`opt_merge`
 
 .. figure:: /_images/code_examples/opt/opt_merge.*
-   :class: width-helper
+   :class: width-helper invert-helper
 
    Before and after :cmd:ref:`opt_merge`
 
@@ -133,7 +133,7 @@ detects this contradiction and replaces the inner multiplexer with a constant 1,
 yielding the logic for ``y = a ? b : d``.
 
 .. figure:: /_images/code_examples/opt/opt_muxtree.*
-   :class: width-helper
+   :class: width-helper invert-helper
 
    Before and after :cmd:ref:`opt_muxtree`
 
@@ -172,7 +172,7 @@ multiplexing its output to multiplexing the non-shared input signals.
    :caption: example verilog for demonstrating :cmd:ref:`opt_share`
 
 .. figure:: /_images/code_examples/opt/opt_share.*
-   :class: width-helper
+   :class: width-helper invert-helper
 
    Before and after :cmd:ref:`opt_share`
 

--- a/docs/source/using_yosys/synthesis/proc.rst
+++ b/docs/source/using_yosys/synthesis/proc.rst
@@ -42,10 +42,10 @@ Example
    :caption: :file:`proc_01.ys`
 
 .. figure:: /_images/code_examples/synth_flow/proc_01.*
-   :class: width-helper
+   :class: width-helper invert-helper
 
 .. figure:: /_images/code_examples/synth_flow/proc_02.*
-   :class: width-helper
+   :class: width-helper invert-helper
 
 .. literalinclude:: /code_examples/synth_flow/proc_02.v
    :language: verilog
@@ -56,7 +56,7 @@ Example
    :caption: :file:`proc_02.ys`
 
 .. figure:: /_images/code_examples/synth_flow/proc_03.*
-   :class: width-helper
+   :class: width-helper invert-helper
 
 .. literalinclude:: /code_examples/synth_flow/proc_03.ys
    :language: yoscrypt

--- a/docs/source/yosys_internals/extending_yosys/extensions.rst
+++ b/docs/source/yosys_internals/extending_yosys/extensions.rst
@@ -38,7 +38,7 @@ This document will focus on the much simpler version of RTLIL left after the
 commands :cmd:ref:`proc` and :cmd:ref:`memory` (or :yoscrypt:`memory -nomap`):
 
 .. figure:: /_images/internals/simplified_rtlil.*
-    :class: width-helper
+    :class: width-helper invert-helper
     :name: fig:Simplified_RTLIL
 
     Simplified RTLIL entity-relationship diagram without memories and processes
@@ -140,7 +140,7 @@ We'll do the same as before and format it as a a ``Yosys::Pass``.
 And if we look at the schematic for this new module we see the following:
 
 .. figure:: /_images/code_examples/extensions/test1.*
-   :class: width-helper
+   :class: width-helper invert-helper
 
    Output of ``yosys -m ./my_cmd.so -p 'test1; show'``
 

--- a/docs/source/yosys_internals/flow/control_and_data.rst
+++ b/docs/source/yosys_internals/flow/control_and_data.rst
@@ -10,7 +10,7 @@ and generating the data for the next subsystem (see :numref:`Fig. %s
 <fig:approach_flow>`).
 
 .. figure:: /_images/internals/approach_flow.*
-	:class: width-helper
+	:class: width-helper invert-helper
 	:name: fig:approach_flow
 
 	General data- and control-flow of a synthesis tool

--- a/docs/source/yosys_internals/flow/overview.rst
+++ b/docs/source/yosys_internals/flow/overview.rst
@@ -42,7 +42,7 @@ possible it is key that (1) all passes operate on the same data structure
 design in different stages of the synthesis.
 
 .. figure:: /_images/internals/overview_flow.*
-	:class: width-helper
+	:class: width-helper invert-helper
 	:name: fig:Overview_flow
 
 	Yosys simplified data flow (ellipses: data structures, rectangles:

--- a/docs/source/yosys_internals/flow/verilog_frontend.rst
+++ b/docs/source/yosys_internals/flow/verilog_frontend.rst
@@ -10,7 +10,7 @@ is then passed to the AST frontend that converts it to RTLIL data, as
 illustrated in :numref:`Fig. %s <fig:Verilog_flow>`.
 
 .. figure:: /_images/internals/verilog_flow.*
-	:class: width-helper
+	:class: width-helper invert-helper
 	:name: fig:Verilog_flow
 
 	Simplified Verilog to RTLIL data flow

--- a/docs/source/yosys_internals/formats/rtlil_rep.rst
+++ b/docs/source/yosys_internals/formats/rtlil_rep.rst
@@ -24,7 +24,7 @@ create an additional ``RTLIL::Design`` object and call the Verilog frontend with
 this other object to parse the cell library.
 
 .. figure:: /_images/internals/overview_rtlil.*
-	:class: width-helper
+	:class: width-helper invert-helper
 	:name: fig:Overview_RTLIL
 
 	Simplified RTLIL Entity-Relationship Diagram

--- a/docs/source/yosys_internals/techmap.rst
+++ b/docs/source/yosys_internals/techmap.rst
@@ -34,7 +34,7 @@ Mapping OR3X1
    :caption: :file:`red_or3x1_map.v`
 
 .. figure:: /_images/code_examples/techmap/red_or3x1.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 .. literalinclude:: /code_examples/techmap/red_or3x1_test.ys
    :language: yoscrypt
@@ -61,7 +61,7 @@ Conditional techmap
 Example:
 
 .. figure:: /_images/code_examples/techmap/sym_mul.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 .. literalinclude:: /code_examples/techmap/sym_mul_map.v
    :language: verilog
@@ -100,7 +100,7 @@ Scripting in map modules
 Example:
 
 .. figure:: /_images/code_examples/techmap/mymul.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 .. literalinclude:: /code_examples/techmap/mymul_map.v
    :language: verilog
@@ -130,7 +130,7 @@ Handling constant inputs
 Example:
 
 .. figure:: /_images/code_examples/techmap/mulshift.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 .. literalinclude:: /code_examples/techmap/mulshift_map.v
    :language: verilog
@@ -162,7 +162,7 @@ Handling shorted inputs
 Example:
 
 .. figure:: /_images/code_examples/techmap/addshift.*
-    :class: width-helper
+    :class: width-helper invert-helper
 
 .. literalinclude:: /code_examples/techmap/addshift_map.v
    :language: verilog


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
#4385

_Explain how this is achieved._
New `invert-helper` css class uses svg color filter matrix from @jix (via https://github.com/YosysHQ/yosys/issues/4385#issuecomment-2102187927) to invert brightness for images when using dark theme.

_If applicable, please suggest to reviewers how they can test the change._
Make docs locally, check images in both light and dark mode, using both the forced light/dark mode selector and the auto mode with browser/OS selected light/dark mode.