### PR TITLE
test-docs should not ignore docs changes

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -62,10 +62,6 @@ jobs:
         run: |
           ./yosys-config || true
 
-      - name: Log yosys-config output
-        run: |
-          ./yosys-config || true
-
       - name: Compress build
         shell: bash
         run: |

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -16,12 +16,23 @@ jobs:
           cancel_others: 'true'
           # only run on push *or* pull_request, not both
           concurrent_skipping: 'same_content_newer'
+  pre_docs_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          paths_ignore: '["**/README.md"]'
+          # cancel previous builds if a new commit is pushed
+          cancel_others: 'true'
+          # only run on push *or* pull_request, not both
+          concurrent_skipping: 'same_content_newer'
 
   build-yosys:
     name: Reusable build
     runs-on: ${{ matrix.os }}
-    needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
     env:
       CC: clang
     strategy:
@@ -137,8 +148,8 @@ jobs:
   test-docs:
     name: Run docs tests
     runs-on: ${{ matrix.os }}
-    needs: [build-yosys, pre_job]
-    if: needs.pre_job.outputs.should_skip != 'true'
+    needs: [build-yosys, pre_docs_job]
+    if: needs.pre_docs_job.outputs.should_skip != 'true'
     env:
       CC: clang
     strategy:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -33,6 +33,8 @@ jobs:
   build-yosys:
     name: Reusable build
     runs-on: ${{ matrix.os }}
+    needs: pre_docs_job
+    if: needs.pre_docs_job.outputs.should_skip != 'true'
     env:
       CC: clang
     strategy:


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
https://github.com/YosysHQ/yosys/actions/runs/9038879272 skipped test-docs because `pre_job` ignores changes to docs, but it should not.

_Explain how this is achieved._
Add a different skip check for the docs that doesn't ignore the docs directory.

_If applicable, please suggest to reviewers how they can test the change._
