### PR TITLE
cxxrtl: Prevent wires with input or output ports from being aliased

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -3263,6 +3263,7 @@ struct CxxrtlWorker {
 						debug_wire_type = wire_type; // wire is a member
 
 					if (!debug_alias) continue;
+					if (wire->port_input || wire->port_output) continue; // preserve input/output metadata in flags
 					const RTLIL::Wire *it = wire;
 					while (flow.is_inlinable(it)) {
 						log_assert(flow.wire_comb_defs[it].size() == 1);


### PR DESCRIPTION
As explained in #4405, having outputs or inputs aliased causes a loss of information in `debug_info`.

To prevent this behavior, we stop assigning debug information at the beginning of the `debug_alias` option corresponding logic if the wire is an input and/or an output.

One implementation choice here was to choose, for an input that is tied to a constant, whether we should generate:
```
items->add(path, "a0", "src\000sand_ti.v:1.18-1.20\000", p_a0, 0, debug_item::INPUT|debug_item::DRIVEN_COMB);
```
or
```
static const value<1> const_p_a0 = value<1>{0u};
items->add(path, "a0", "src\000sand_ti.v:1.18-1.20\000", const_p_a0);
```

This patch is an implementation for the first one, because we can still query the constant later in the first whereas we would loose the `INPUT` and `DRIVEN_COMB` flags in the second one.