### PR TITLE
Only build yosys-abc usage docs when ABCEXTERNAL is not set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -946,7 +946,13 @@ define DOC_USAGE_STDERR
 docs/source/generated/$(1): $(PROGRAM_PREFIX)$(1) docs/source/generated
 	-$(Q) ./$$< --help 2> $$@
 endef
-DOCS_USAGE_STDERR := yosys-config yosys-filterlib yosys-abc
+DOCS_USAGE_STDERR := yosys-config yosys-filterlib
+
+# The in-tree ABC (yosys-abc) is only built when ABCEXTERNAL is not set.
+ifeq ($(ABCEXTERNAL),)
+DOCS_USAGE_STDERR += yosys-abc
+endif
+
 $(foreach usage,$(DOCS_USAGE_STDERR),$(eval $(call DOC_USAGE_STDERR,$(usage))))
 
 # others print to stdout


### PR DESCRIPTION
Since https://github.com/YosysHQ/yosys/pull/4334, when building docs with `ABCEXTERNAL` set, the rule for yosys-abc docs usage would attempt to build in-tree ABC.

This fix this regression by only including yosys-abc in `DOCS_USAGE_STDERR` when `ABCEXTERNAL` is not set.
