### PR TITLE
cxxrtl: don't emit invalid code on unconnected outputs.

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -1138,7 +1138,7 @@ struct CxxrtlWorker {
 		f << indent << "// cell " << cell->name.str() << " syncs\n";
 		for (auto conn : cell->connections())
 			if (cell->output(conn.first))
-				if (is_cxxrtl_sync_port(cell, conn.first)) {
+				if (is_cxxrtl_sync_port(cell, conn.first) && !conn.second.empty()) {
 					f << indent;
 					dump_sigspec_lhs(conn.second, for_debug);
 					f << " = " << mangle(cell) << access << mangle_wire_name(conn.first) << ".curr;\n";

--- a/tests/cxxrtl/run-test.sh
+++ b/tests/cxxrtl/run-test.sh
@@ -11,3 +11,7 @@ run_subtest () {
 
 run_subtest value
 run_subtest value_fuzz
+
+# Compile-only test.
+../../yosys -p "read_verilog test_unconnected_output.v; proc; clean; write_cxxrtl cxxrtl-test-unconnected_output.cc"
+${CC:-gcc} -std=c++11 -c -o cxxrtl-test-unconnected_output -I../../backends/cxxrtl/runtime cxxrtl-test-unconnected_output.cc

--- a/tests/cxxrtl/test_unconnected_output.v
+++ b/tests/cxxrtl/test_unconnected_output.v
@@ -1,0 +1,24 @@
+(* cxxrtl_blackbox *)
+module blackbox(...);
+    (* cxxrtl_edge = "p" *)
+    input clk;
+
+    (* cxxrtl_sync *)
+    output [7:0] out1;
+
+    (* cxxrtl_sync *)
+    output [7:0] out2;
+endmodule
+
+module unconnected_output(
+    input  clk,
+           in,
+    output out
+);
+    blackbox bb (
+        .clock (clock),
+        .in    (in),
+        .out1  (out),
+        .out2  (/* unconnected */),
+    );
+endmodule


### PR DESCRIPTION
Unconnected sync outputs cause `dump_cell_sync` to emit an invalid assignment in the instantiating module, namely `value<0>() = …;`.

Ensure the LHS is not empty before emitting.