### PR TITLE
Quote stripping in log command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -861,6 +861,7 @@ endif
 	+cd tests/various && bash run-test.sh
 	+cd tests/select && bash run-test.sh
 	+cd tests/sat && bash run-test.sh
+	+cd tests/scripts && bash run-test.sh
 	+cd tests/sim && bash run-test.sh
 	+cd tests/svinterfaces && bash run-test.sh $(SEEDOPT)
 	+cd tests/svtypes && bash run-test.sh $(SEEDOPT)

--- a/docs/source/code_examples/fifo/fifo.out
+++ b/docs/source/code_examples/fifo/fifo.out
@@ -306,14 +306,15 @@ yosys> show -color maroon3 c:fifo_reader -color cornflowerblue @new_cells -notit
 Writing dot description to `rdata_proc.dot'.
 Dumping selected parts of module fifo to page 1.
 
-yosys> flatten
+yosys> echo off
+echo off
+yosys> flatten;;
 
 15. Executing FLATTEN pass (flatten design).
 Deleting now unused module $paramod\addr_gen\MAX_DATA=s32'00000000000000000000000100000000.
 <suppressed ~2 debug messages>
-
-yosys> clean
 Removed 3 unused cells and 25 unused wires.
+echo on
 
 yosys> select -set rdata_path o:rdata %ci*
 

--- a/docs/source/code_examples/fifo/fifo.ys
+++ b/docs/source/code_examples/fifo/fifo.ys
@@ -39,7 +39,10 @@ show -color maroon3 c:fifo_reader -color cornflowerblue @new_cells -notitle -for
 
 # ========================================================
 
+echo off
+log "yosys> flatten;;"
 flatten;;
+echo on
 select -set rdata_path o:rdata %ci*
 select -set new_cells @rdata_path o:rdata %ci3 %d i:* %d
 show -color maroon3 @new_cells -notitle -format dot -prefix rdata_flat @rdata_path

--- a/docs/source/getting_started/example_synth.rst
+++ b/docs/source/getting_started/example_synth.rst
@@ -292,8 +292,8 @@ optimizations between modules which would otherwise be missed.  Let's run
 
 .. literalinclude:: /code_examples/fifo/fifo.out
    :language: doscon
-   :start-at: yosys> flatten
-   :end-before: yosys> select
+   :start-at: yosys> flatten;;
+   :end-before: echo on
    :name: flat_clean
    :caption: output of :yoscrypt:`flatten;;`
 
@@ -312,13 +312,6 @@ also see that the ``addr`` output has been renamed to :file:`fifo_reader.addr`
 and merged with the ``raddr`` wire feeding into the ``$memrd`` cell.  This wire
 merging happened during the call to :cmd:ref:`clean` which we can see in the
 :ref:`flat_clean`.
-
-.. note:: 
-
-   :cmd:ref:`flatten` and :cmd:ref:`clean` would normally be combined into a
-   single :yoterm:`yosys> flatten;;` output, but they appear separately here as
-   a side effect of using :cmd:ref:`echo` for generating the terminal style
-   output.
 
 Depending on the target architecture, this stage of synthesis might also see
 commands such as :cmd:ref:`tribuf` with the ``-logic`` option and

--- a/passes/cmds/logcmd.cc
+++ b/passes/cmds/logcmd.cc
@@ -97,7 +97,7 @@ struct LogPass : public Pass {
 			text += args[argidx] + ' ';
 		if (!text.empty()) text.resize(text.size()-1);
 
-		if (text[0] == '"' && text[text.size()-1] == '"')
+		if (text.size() > 1 && text[0] == '"' && text[text.size()-1] == '"')
 			text = text.substr(1, text.size()-2);
 
 		const char *fmtline = newline ? "%s\n" : "%s";

--- a/passes/cmds/logcmd.cc
+++ b/passes/cmds/logcmd.cc
@@ -97,6 +97,9 @@ struct LogPass : public Pass {
 			text += args[argidx] + ' ';
 		if (!text.empty()) text.resize(text.size()-1);
 
+		if (text[0] == '"' && text[text.size()-1] == '"')
+			text = text.substr(1, text.size()-2);
+
 		const char *fmtline = newline ? "%s\n" : "%s";
 
 		if (to_stdout) fprintf(stdout, fmtline, text.c_str());

--- a/passes/cmds/logcmd.cc
+++ b/passes/cmds/logcmd.cc
@@ -93,12 +93,15 @@ struct LogPass : public Pass {
 		if (push) { log_push(); return; }
 		if (pop)  { log_pop(); return; }
 
-		for (; argidx < args.size(); argidx++)
-			text += args[argidx] + ' ';
-		if (!text.empty()) text.resize(text.size()-1);
-
-		if (text.size() > 1 && text[0] == '"' && text[text.size()-1] == '"')
-			text = text.substr(1, text.size()-2);
+		text = args[argidx++];
+		if (argidx < args.size()) {
+			for (; argidx < args.size(); argidx++) {
+				text += ' ' + args[argidx];
+			}
+		} else {
+			if (text.size() > 1 && text[0] == '"' && text[text.size()-1] == '"')
+				text = text.substr(1, text.size()-2);
+		}
 
 		const char *fmtline = newline ? "%s\n" : "%s";
 

--- a/tests/scripts/.gitignore
+++ b/tests/scripts/.gitignore
@@ -1,0 +1,3 @@
+*.err
+*.log
+run-test.mk

--- a/tests/scripts/run-test.sh
+++ b/tests/scripts/run-test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eu
+source ../gen-tests-makefile.sh
+run_tests --bash

--- a/tests/scripts/test_logging.sh
+++ b/tests/scripts/test_logging.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+var=0
+rm -f quotes-*.log quotes-*.err
+
+test_log()
+{
+    # Usage: test_log <log_str> <grep_str>
+    var=$((var + 1))
+    log_str="$1"
+    grep_str="$2"
+    log_file="quotes-$var.log"
+    ../../yosys -QTq -l $log_file -p "log $log_str"
+    if ! grep -qx "$grep_str" $log_file; then
+        echo "ERROR: Expected 'yosys> log $log_str' to log '$grep_str'." > "quotes-$var.err"
+        cat "quotes-$var.err"
+    fi
+}
+
+test_log "test" "test"
+test_log "test;" "test"
+test_log "test;;" "test"
+test_log "\"test" "\"test"
+test_log "test\"" "test\""
+test_log "\"test\"" "test"
+test_log "\"test;\"" "test;"
+test_log "\"test;;\"" "test;;"
+test_log "\"test\" abc" "\"test\" abc"
+
+if [ -f quotes-*.err ] ; then
+    exit 1
+fi

--- a/tests/scripts/test_logging.sh
+++ b/tests/scripts/test_logging.sh
@@ -26,6 +26,11 @@ test_log "\"test\"" "test"
 test_log "\"test;\"" "test;"
 test_log "\"test;;\"" "test;;"
 test_log "\"test\" abc" "\"test\" abc"
+test_log "\"#comments\" #123" "#comments"
+test_log "\"!bang\"" "!bang"
+test_log "\"spaces are cool too\"" "spaces are cool too"
+test_log "\"log a\"; log b" "log a"
+test_log "\"log a\"; log b" "b"
 
 if [ -f quotes-*.err ] ; then
     exit 1

--- a/tests/scripts/test_logging.sh
+++ b/tests/scripts/test_logging.sh
@@ -31,7 +31,10 @@ test_log "\"!bang\"" "!bang"
 test_log "\"spaces are cool too\"" "spaces are cool too"
 test_log "\"log a\"; log b" "log a"
 test_log "\"log a\"; log b" "b"
+test_log "\"" "\""
+test_log "\\\"" "\\\\\"" #\" == \"
 
-if [ -f quotes-*.err ] ; then
+errors=( quotes-*.err )
+if [ -f $errors ] ; then
     exit 1
 fi

--- a/tests/scripts/test_logging.sh
+++ b/tests/scripts/test_logging.sh
@@ -33,6 +33,7 @@ test_log "\"log a\"; log b" "log a"
 test_log "\"log a\"; log b" "b"
 test_log "\"" "\""
 test_log "\\\"" "\\\\\"" #\" == \"
+test_log "\"abc\" \"def\"" "\"abc\" \"def\"" # don't abbreviate to abc" "def
 
 errors=( quotes-*.err )
 if [ -f $errors ] ; then


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Allows e.g. `log "yosys> flatten;;"`, logging the unquoted text `yosys> flatten;;`.

_Explain how this is achieved._

If the text to log starts and ends with a quotation mark, drop the first and last characters.

_If applicable, please suggest to reviewers how they can test the change._
