### PR TITLE
smtbmc: Fix two .yw handling related crashes

### DIFF
--- a/backends/smt2/smtbmc.py
+++ b/backends/smt2/smtbmc.py
@@ -719,6 +719,8 @@ def smt_extract_mask(smt_expr, mask):
     return combined_chunks, ''.join(mask_index_order[start:end] for start, end in chunks)[::-1]
 
 def smt_concat(exprs):
+    if not isinstance(exprs, (tuple, list)):
+        exprs = tuple(exprs)
     if not exprs:
         return ""
     if len(exprs) == 1:
@@ -817,6 +819,9 @@ def ywfile_constraints(inywfile, constr_assumes, map_steps=None, skip_x=False):
                     bits = bits.replace('x', '?')
                 if not bits_re.match(bits):
                     raise ValueError("unsupported bit value in Yosys witness file")
+
+                if bits.count('?') == len(bits):
+                    continue
 
                 smt_expr = ywfile_signal(sig, map_steps.get(t, t))
 


### PR DESCRIPTION
These came up when using the experimental incremental interface and are also in code that was recently refactored to support that interface.

_What are the reasons/motivation for this change?_

This fixes observed crashes when using the incremental interface. In both cases a special case was missed and the specific changes handle the missed special case. 

_Explain how this is achieved._

* Making `smt_concat` accept anything iterable in addition to tuples and lists, as it is sometimes called with generators.
* Avoiding calling `smt_extract_mask` with a completely empty mask and expecting a useful result, as it returns None in that case.

_If applicable, please suggest to reviewers how they can test the change._

The `check-sby` CI checks should be sufficient to ensure this doesn't regress anything.