### PR TITLE
Fix memory leak in verific file parsing.

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3510,6 +3510,12 @@ struct VerificPass : public Pass {
 					verific_error_msg.clear();
 					log_cmd_error("Reading Verilog/SystemVerilog sources failed.\n");
 			}
+			char* fn;
+			int i = 0;
+
+			FOREACH_ARRAY_ITEM(&file_names, i, fn) {
+				free(fn);
+			}
 			set_modules_to_blackbox(map, work, flag_lib);
 			verific_import_pending = true;
 			goto check_error;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
Running AddressSanitizer on yosys when using verific uncovered a memory leak in a `file_names` Array, as the char* copy created by `strdup()` is not freed.

_Explain how this is achieved._
Manually iterate over the array and free the memory, similar to other instances in the `verific.cc` file.