### PR TITLE
rtlil.cc: Fix #4427

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -325,8 +325,7 @@ std::string RTLIL::Const::decode_string() const
 				ch |= 1 << j;
 			}
 		}
-		if (ch != 0)
-			s.append({ch});
+		s.append({ch});
 	}
 	i -= 8;
 	for (; i >= 0; i -= 8) {
@@ -336,10 +335,9 @@ std::string RTLIL::Const::decode_string() const
 				ch |= 1 << j;
 			}
 		}
-		if (ch != 0)
-			s.append({ch});
+		s.append({ch});
 	}
-	return s;
+	return s.substr(s.find_first_not_of('\0'));
 }
 
 bool RTLIL::Const::is_fully_zero() const


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

If a `RTLIL::Const` is composed of multiple strings, such as when using a ternary expression to select between two strings of different lengths, zero padding for the strings needs to be maintained.

_Explain how this is achieved._

Only leading (and trailing) null characters should be dropped from the decoded string, rather than all null characters.

_If applicable, please suggest to reviewers how they can test the change._
