### PR TITLE
cxxxrtl: fix use of format specifiers in test

### DIFF
--- a/tests/cxxrtl/test_value_fuzz.cc
+++ b/tests/cxxrtl/test_value_fuzz.cc
@@ -1,3 +1,4 @@
+#include <cinttypes>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -62,17 +63,17 @@ void test_binary_operation_for_bitsize(Operation &op)
 		for (size_t i = 0; i * chunk_bits < Bits; i++) {
 			if ((chunk_type)(iresult >> (i * chunk_bits)) != vresult.data[i]) {
 				std::printf("Test failure:\n");
-				std::printf("Bits:    %i\n", Bits);
-				std::printf("a:       %016lx\n", ia);
-				std::printf("b:       %016lx\n", ib);
-				std::printf("iresult: %016lx\n", iresult);
-				std::printf("vresult: %016lx\n", vresult.template get<uint64_t>());
+				std::printf("Bits:    %zu\n", Bits);
+				std::printf("a:       %016" PRIx64 "\n", ia);
+				std::printf("b:       %016" PRIx64 "\n", ib);
+				std::printf("iresult: %016" PRIx64 "\n", iresult);
+				std::printf("vresult: %016" PRIx64 "\n", vresult.template get<uint64_t>());
 
 				std::terminate();
 			}
 		}
 	}
-	std::printf("Test passed @ Bits = %i.\n", Bits);
+	std::printf("Test passed @ Bits = %zu.\n", Bits);
 }
 
 template<typename Operation>


### PR DESCRIPTION
#### What are the reasons/motivation for this change?

Correct C++ code

#### Explain how this is achieved.

A few instances of incorrect (and non-portable) use of format specifiers have been fixed.

#### If applicable, please suggest to reviewers how they can test the change.

Compilation with `-Werror=format` of the changed file should now succeed.
