### PR TITLE
peepopt shiftadd: Only match for sufficiently small constant widths

### DIFF
--- a/passes/pmgen/peepopt_shiftadd.pmg
+++ b/passes/pmgen/peepopt_shiftadd.pmg
@@ -53,6 +53,11 @@ match add
 	select port(add, constport).is_fully_const()
 	define <IdString> varport (constport == \A ? \B : \A)
 
+	// only optimize for constants up to a fixed width. this prevents cases
+	// with a blowup in internal term size and prevents larger constants being
+	// casted to int incorrectly
+	select (GetSize(port(add, constport)) <= 24)
+
 	// if a value of var is able to wrap the output, the transformation might give wrong results
 	// an addition/substraction can at most flip one more bit than the largest operand (the carry bit)
 	// as long as the output can show this bit, no wrap should occur (assuming all signed-ness make sense)


### PR DESCRIPTION
This addresses issue #4445. There are two issues from that, one being that casting a constant of arbitrary size to an `int` can overflow, and the other being that the `shiftadd` peephole optimization creates logic that can be very large for large shift constants.

This is a simple fix to both that just disables the optimization for constants over a certain bitwidth. I have arbitrarily chosen 24 bits here but am happy to change that or discuss a more fine-grained solution than just disabling the optimization. I suspect most user code will not have offsets outside of this range.