### PR TITLE
fix bug of check-git-abc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -751,10 +751,10 @@ check-git-abc:
 		exit 1; \
 	elif git -C "$(YOSYS_SRC)" submodule status abc 2>/dev/null | grep -q '^ '; then \
 		exit 0; \
-	elif [ -f "$(YOSYS_SRC)/abc/.gitcommit" ] && ! grep -q '\$$Format:%h\$$' "$(YOSYS_SRC)/abc/.gitcommit"; then \
+	elif [ -f "$(YOSYS_SRC)/abc/.gitcommit" ] && grep -q '\$$Format:%h\$$' "$(YOSYS_SRC)/abc/.gitcommit"; then \
 		echo "'abc' comes from a tarball. Continuing."; \
 		exit 0; \
-	elif [ -f "$(YOSYS_SRC)/abc/.gitcommit" ] && grep -q '\$$Format:%h\$$' "$(YOSYS_SRC)/abc/.gitcommit"; then \
+	elif [ -f "$(YOSYS_SRC)/abc/.gitcommit" ] && ! grep -q '\$$Format:%h\$$' "$(YOSYS_SRC)/abc/.gitcommit"; then \
 		echo "Error: 'abc' is not configured as a git submodule."; \
 		echo "To resolve this:"; \
 		echo "1. Back up your changes: Save any modifications from the 'abc' directory to another location."; \


### PR DESCRIPTION
This project distinguishes the yosyshq/abc and berkeley-abc by .gitcommit file that checked in check-git-abc function in Makefile.

However, the second and third "elif" branches' judgment conditions are reversed. And "grep -q '\$$Format:%h\$$' "$(YOSYS_SRC)/abc/.gitcommit" can check that there is a .gitcommit file in yosys/abc with the text "Format:%h".

This pull request aims to ensure that the second and third "elif" conditions produce the expected compilation results for using yosyshq/abc.