### PR TITLE
peepopt: avoid shift-amount underflow

### DIFF
--- a/passes/pmgen/peepopt_shiftadd.pmg
+++ b/passes/pmgen/peepopt_shiftadd.pmg
@@ -66,7 +66,8 @@ match add
 	define <bool> offset_negative ((port(add, constport).bits().back() == State::S1) ^ (is_sub && varport_A))
 
 	// checking some value boundaries as well:
-	// data[...-c +:W1] is fine for +/-var (pad at LSB, all data still accessible)
+	// data[...-c +:W1] is fine for any signed var (pad at LSB, all data still accessible)
+	// unsigned shift may underflow (eg var-3 with var<3) -> cannot be converted
 	// data[...+c +:W1] is only fine for +var(add) and var unsigned
 	// (+c cuts lower C bits, making them inaccessible, a signed var could try to access them)
 	// either its an add or the variable port is A (it must be positive)
@@ -74,6 +75,8 @@ match add
 
 	// -> data[var+c +:W1] (with var signed) is illegal
 	filter !(!offset_negative && varport_signed)
+	// -> data >> (var-c) (with var unsigned) is illegal
+	filter !(offset_negative && !varport_signed)
 
 	// state-variables are assigned at the end only:
 	// shift the log2scale offset in-front of add to get true value: (var+c)<<N -> (var<<N)+(c<<N)

--- a/passes/pmgen/peepopt_shiftadd.pmg
+++ b/passes/pmgen/peepopt_shiftadd.pmg
@@ -63,7 +63,8 @@ match add
 
 	define <bool> constport_signed param(add, !varport_A ? \A_SIGNED : \B_SIGNED).as_bool()
 	define <bool> varport_signed param(add, varport_A ? \A_SIGNED : \B_SIGNED).as_bool();
-	define <bool> offset_negative ((port(add, constport).bits().back() == State::S1) ^ (is_sub && varport_A))
+	define <bool> const_negative (constport_signed && (port(add, constport).bits().back() == State::S1))
+	define <bool> offset_negative ((is_sub && varport_A) ^ const_negative)
 
 	// checking some value boundaries as well:
 	// data[...-c +:W1] is fine for any signed var (pad at LSB, all data still accessible)

--- a/tests/opt/bug4413.ys
+++ b/tests/opt/bug4413.ys
@@ -1,0 +1,15 @@
+read_verilog <<EOT
+module top(
+	input wire shift,
+	input wire [4:0] data,
+	output wire out
+);
+
+	wire [1:0] shift2 = shift - 1'b1;
+
+	assign out = data >> shift2;
+endmodule
+
+EOT
+
+equiv_opt -assert peepopt


### PR DESCRIPTION
This solves issue #4413. `shiftadd` did not consider underflows for unsigned shift-amounts.  
Specifically the issue arises if peepopt receives an expression like 
```verilog
wire [6:0] shift;
wire [7:0] data, shift2;
assign shift2 = shift - 1'b1;
assign out = data >> shift2;
```
Here an _intended_ underflow occurs if `shift<1`. (by _intended_ I mean it is what the current network implies, no matter what the designer might have wanted).  
This adds a filter for the case described and adds the bug to the tests.