### PR TITLE
Make C++17 compiler required

### DIFF
--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -64,11 +64,11 @@ jobs:
           $CXX --version
 
       # minimum standard
-      - name: Build C++11
+      - name: Build C++17
         shell: bash
         run: |
           make config-$CC_SHORT
-          make -j$procs CXXSTD=c++11 compile-only
+          make -j$procs CXXSTD=c++17 compile-only
 
       # maximum standard, only on newest compilers
       - name: Build C++20

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ all: top-all
 YOSYS_SRC := $(dir $(firstword $(MAKEFILE_LIST)))
 VPATH := $(YOSYS_SRC)
 
-CXXSTD ?= c++11
+CXXSTD ?= c++17
 CXXFLAGS := $(CXXFLAGS) -Wall -Wextra -ggdb -I. -I"$(YOSYS_SRC)" -MD -MP -D_YOSYS_ -fPIC -I$(PREFIX)/include
 LIBS := $(LIBS) -lstdc++ -lm
 PLUGIN_LINKFLAGS :=
@@ -1015,7 +1015,7 @@ qtcreator:
 vcxsrc: $(GENFILES) $(EXTRA_TARGETS)
 	rm -rf yosys-win32-vcxsrc-$(YOSYS_VER){,.zip}
 	set -e; for f in `ls $(filter %.cc %.cpp,$(GENFILES)) $(addsuffix .cc,$(basename $(OBJS))) $(addsuffix .cpp,$(basename $(OBJS))) 2> /dev/null`; do \
-		echo "Analyse: $$f" >&2; cpp -std=c++11 -MM -I. -D_YOSYS_ $$f; done | sed 's,.*:,,; s,//*,/,g; s,/[^/]*/\.\./,/,g; y, \\,\n\n,;' | grep '^[^/]' | sort -u | grep -v kernel/version_ > srcfiles.txt
+		echo "Analyse: $$f" >&2; cpp -std=c++17 -MM -I. -D_YOSYS_ $$f; done | sed 's,.*:,,; s,//*,/,g; s,/[^/]*/\.\./,/,g; y, \\,\n\n,;' | grep '^[^/]' | sort -u | grep -v kernel/version_ > srcfiles.txt
 	bash misc/create_vcxsrc.sh yosys-win32-vcxsrc $(YOSYS_VER) $(GIT_REV)
 	echo "namespace Yosys { extern const char *yosys_version_str; const char *yosys_version_str=\"Yosys (Version Information Unavailable)\"; }" > kernel/version.cc
 	zip yosys-win32-vcxsrc-$(YOSYS_VER)/genfiles.zip $(GENFILES) kernel/version.cc

--- a/Makefile
+++ b/Makefile
@@ -736,7 +736,7 @@ CXXFLAGS_NOVERIFIC = $(CXXFLAGS)
 LIBS_NOVERIFIC = $(LIBS)
 endif
 
-$(PROGRAM_PREFIX)yosys-config: misc/yosys-config.in
+$(PROGRAM_PREFIX)yosys-config: misc/yosys-config.in $(YOSYS_SRC)/Makefile
 	$(P) $(SED) -e 's#@CXXFLAGS@#$(subst -Ilibs/dlfcn-win32,,$(subst -I. -I"$(YOSYS_SRC)",-I"$(DATDIR)/include",$(strip $(CXXFLAGS_NOVERIFIC))))#;' \
 			-e 's#@CXX@#$(strip $(CXX))#;' -e 's#@LINKFLAGS@#$(strip $(LINKFLAGS) $(PLUGIN_LINKFLAGS))#;' -e 's#@LIBS@#$(strip $(LIBS_NOVERIFIC) $(PLUGIN_LIBS))#;' \
 			-e 's#@BINDIR@#$(strip $(BINDIR))#;' -e 's#@DATDIR@#$(strip $(DATDIR))#;' < $< > $(PROGRAM_PREFIX)yosys-config

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Many Linux distributions also provide Yosys binaries, some more up to date than 
 Building from Source
 ====================
 
-You need a C++ compiler with C++11 support (up-to-date CLANG or GCC is
+You need a C++ compiler with C++17 support (up-to-date CLANG or GCC is
 recommended) and some standard tools such as GNU Flex, GNU Bison, and GNU Make.
 TCL, readline and libffi are optional (see ``ENABLE_*`` settings in Makefile).
 Xdot (graphviz) is used by the ``show`` command in yosys to display schematics.

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -84,7 +84,7 @@ not regularly tested:
 Build prerequisites
 ^^^^^^^^^^^^^^^^^^^
 
-A C++ compiler with C++11 support is required as well as some standard tools
+A C++ compiler with C++17 support is required as well as some standard tools
 such as GNU Flex, GNU Bison, Make and Python.  Some additional tools: readline,
 libffi, Tcl and zlib; are optional but enabled by default (see
 :makevar:`ENABLE_*` settings in Makefile). Graphviz and Xdot are used by the

--- a/docs/source/yosys_internals/index.rst
+++ b/docs/source/yosys_internals/index.rst
@@ -25,7 +25,7 @@ wide range of real-world designs, including the `OpenRISC 1200 CPU`_, the
 
 .. _k68 CPU: http://opencores.org/projects/k68
 
-Yosys is written in C++, targeting C++11 at minimum. This chapter describes some
+Yosys is written in C++, targeting C++17 at minimum. This chapter describes some
 of the fundamental Yosys data structures. For the sake of simplicity the C++
 type names used in the Yosys implementation are used in this chapter, even
 though the chapter only explains the conceptual idea behind it and can be used

--- a/guidelines/CodingStyle
+++ b/guidelines/CodingStyle
@@ -25,7 +25,7 @@ Formatting of code
 C++ Language
 -------------
 
-Yosys is written in C++11.
+Yosys is written in C++17.
 
 In general Yosys uses "int" instead of "size_t". To avoid compiler
 warnings for implicit type casts, always use "GetSize(foobar)" instead

--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -142,12 +142,8 @@ extern Tcl_Obj *Tcl_ObjSetVar2(Tcl_Interp *interp, Tcl_Obj *part1Ptr, Tcl_Obj *p
 
 #if __cplusplus >= 201703L
 #  define YS_FALLTHROUGH [[fallthrough]];
-#elif defined(__clang__)
-#  define YS_FALLTHROUGH [[clang::fallthrough]];
-#elif defined(__GNUC__)
-#  define YS_FALLTHROUGH [[gnu::fallthrough]];
 #else
-#  define YS_FALLTHROUGH
+#  error "C++17 or later compatible compiler is required"
 #endif
 
 

--- a/misc/create_vcxsrc.sh
+++ b/misc/create_vcxsrc.sh
@@ -30,6 +30,7 @@ popd
 	tail -n +$((n+1)) "$vcxsrc"/YosysVS/YosysVS.vcxproj
 } > "$vcxsrc"/YosysVS/YosysVS.vcxproj.new
 
+sed -i 's,</AdditionalIncludeDirectories>,</AdditionalIncludeDirectories>\n      <LanguageStandard>stdcpp17</LanguageStandard>\n      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>,g' "$vcxsrc"/YosysVS/YosysVS.vcxproj.new
 mv "$vcxsrc"/YosysVS/YosysVS.vcxproj.new "$vcxsrc"/YosysVS/YosysVS.vcxproj
 
 mkdir -p "$vcxsrc"/yosys


### PR DESCRIPTION
Team decided it is time to update minimal requirement for C++ compiler to be at least C++17 compliant.

Change in header file (that is used everywhere) makes sure that requirement is enforced.

Also updated workflow to run now tests with new minimal requirements.