### PR TITLE
Redo internal cell memory layout

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "abc"]
 	path = abc
 	url = https://github.com/YosysHQ/abc
+[submodule "tracy"]
+	path = tracy
+	url = git@github.com:wolfpld/tracy.git

--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,9 @@ CXX = clang++
 CXXFLAGS += -std=$(CXXSTD) -Os
 ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H $(ABC_ARCHFLAGS)"
 
+CXXFLAGS += -g -fno-omit-frame-pointer -fno-optimize-sibling-calls
+LINKFLAGS += -g
+
 ifneq ($(SANITIZER),)
 $(info [Clang Sanitizer] $(SANITIZER))
 CXXFLAGS += -g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=$(SANITIZER)

--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,10 @@ DISABLE_SPAWN := 0
 DISABLE_ABC_THREADS := 0
 
 # clang sanitizers
-SANITIZER =
+# SANITIZER =
 # SANITIZER = address
 # SANITIZER = memory
-# SANITIZER = undefined
+SANITIZER = undefined
 # SANITIZER = cfi
 
 PROGRAM_PREFIX :=

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ YOSYS_SRC := $(dir $(firstword $(MAKEFILE_LIST)))
 VPATH := $(YOSYS_SRC)
 
 CXXSTD ?= c++11
-CXXFLAGS := $(CXXFLAGS) -Wall -Wextra -ggdb -I. -I"$(YOSYS_SRC)" -MD -MP -D_YOSYS_ -fPIC -I$(PREFIX)/include
+CXXFLAGS := $(CXXFLAGS) -Wall -Wextra -ggdb -I. -Itracy/public -I"$(YOSYS_SRC)" -MD -MP -D_YOSYS_ -fPIC -I$(PREFIX)/include
 LIBS := $(LIBS) -lstdc++ -lm
 PLUGIN_LINKFLAGS :=
 PLUGIN_LIBS :=
@@ -595,6 +595,8 @@ $(eval $(call add_include_file,frontends/ast/ast_binding.h))
 $(eval $(call add_include_file,frontends/blif/blifparse.h))
 $(eval $(call add_include_file,backends/rtlil/rtlil_backend.h))
 
+OBJS += tracy/public/TracyClient.o
+CXXFLAGS += -DTRACY_ENABLE
 OBJS += kernel/driver.o kernel/register.o kernel/rtlil.o kernel/log.o kernel/calc.o kernel/yosys.o
 OBJS += kernel/binding.o
 OBJS += kernel/cellaigs.o kernel/celledges.o kernel/satgen.o kernel/scopeinfo.o kernel/qcsat.o kernel/mem.o kernel/ffmerge.o kernel/ff.o kernel/yw.o kernel/json.o kernel/fmt.o

--- a/Makefile
+++ b/Makefile
@@ -210,9 +210,6 @@ CXX = clang++
 CXXFLAGS += -std=$(CXXSTD) -Os
 ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H $(ABC_ARCHFLAGS)"
 
-CXXFLAGS += -g -fno-omit-frame-pointer -fno-optimize-sibling-calls
-LINKFLAGS += -g
-
 ifneq ($(SANITIZER),)
 $(info [Clang Sanitizer] $(SANITIZER))
 CXXFLAGS += -g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=$(SANITIZER)
@@ -227,6 +224,15 @@ endif
 ifneq ($(findstring cfi,$(SANITIZER)),)
 CXXFLAGS += -flto
 LINKFLAGS += -flto
+endif
+endif
+
+ifneq ($(PROFILER),)
+$(info [Profiler] $(PROFILER))
+CXXFLAGS += -g -fno-omit-frame-pointer -fno-optimize-sibling-calls
+LINKFLAGS += -g
+ifneq ($(findstring tracy,$(PROFILER)),)
+CXXFLAGS += -DTRACY_ENABLE
 endif
 endif
 
@@ -598,8 +604,8 @@ $(eval $(call add_include_file,frontends/ast/ast_binding.h))
 $(eval $(call add_include_file,frontends/blif/blifparse.h))
 $(eval $(call add_include_file,backends/rtlil/rtlil_backend.h))
 
+# See -DTRACY_ENABLE
 OBJS += tracy/public/TracyClient.o
-CXXFLAGS += -DTRACY_ENABLE
 OBJS += kernel/driver.o kernel/register.o kernel/rtlil.o kernel/log.o kernel/calc.o kernel/yosys.o
 OBJS += kernel/binding.o
 OBJS += kernel/cellaigs.o kernel/celledges.o kernel/satgen.o kernel/scopeinfo.o kernel/qcsat.o kernel/mem.o kernel/ffmerge.o kernel/ff.o kernel/yw.o kernel/json.o kernel/fmt.o

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ all: top-all
 YOSYS_SRC := $(dir $(firstword $(MAKEFILE_LIST)))
 VPATH := $(YOSYS_SRC)
 
-CXXSTD ?= c++11
+CXXSTD ?= c++17
 CXXFLAGS := $(CXXFLAGS) -Wall -Wextra -ggdb -I. -Itracy/public -I"$(YOSYS_SRC)" -MD -MP -D_YOSYS_ -fPIC -I$(PREFIX)/include
 LIBS := $(LIBS) -lstdc++ -lm
 PLUGIN_LINKFLAGS :=

--- a/Makefile
+++ b/Makefile
@@ -566,6 +566,7 @@ $(eval $(call add_include_file,kernel/celledges.h))
 $(eval $(call add_include_file,kernel/celltypes.h))
 $(eval $(call add_include_file,kernel/consteval.h))
 $(eval $(call add_include_file,kernel/constids.inc))
+$(eval $(call add_include_file,kernel/compat.h))
 $(eval $(call add_include_file,kernel/cost.h))
 $(eval $(call add_include_file,kernel/ff.h))
 $(eval $(call add_include_file,kernel/ffinit.h))
@@ -606,7 +607,7 @@ $(eval $(call add_include_file,backends/rtlil/rtlil_backend.h))
 
 # See -DTRACY_ENABLE
 OBJS += tracy/public/TracyClient.o
-OBJS += kernel/driver.o kernel/register.o kernel/rtlil.o kernel/log.o kernel/calc.o kernel/yosys.o
+OBJS += kernel/driver.o kernel/register.o kernel/rtlil.o kernel/log.o kernel/calc.o kernel/yosys.o kernel/compat.o
 OBJS += kernel/binding.o
 OBJS += kernel/cellaigs.o kernel/celledges.o kernel/satgen.o kernel/scopeinfo.o kernel/qcsat.o kernel/mem.o kernel/ffmerge.o kernel/ff.o kernel/yw.o kernel/json.o kernel/fmt.o
 ifeq ($(ENABLE_ZLIB),1)

--- a/Makefile
+++ b/Makefile
@@ -607,7 +607,7 @@ $(eval $(call add_include_file,backends/rtlil/rtlil_backend.h))
 
 # See -DTRACY_ENABLE
 OBJS += tracy/public/TracyClient.o
-OBJS += kernel/driver.o kernel/register.o kernel/rtlil.o kernel/log.o kernel/calc.o kernel/yosys.o kernel/compat.o
+OBJS += kernel/driver.o kernel/register.o kernel/rtlil.o kernel/adds.shim.o kernel/log.o kernel/calc.o kernel/yosys.o kernel/compat.o
 OBJS += kernel/binding.o
 OBJS += kernel/cellaigs.o kernel/celledges.o kernel/satgen.o kernel/scopeinfo.o kernel/qcsat.o kernel/mem.o kernel/ffmerge.o kernel/ff.o kernel/yw.o kernel/json.o kernel/fmt.o
 ifeq ($(ENABLE_ZLIB),1)

--- a/backends/blif/blif.cc
+++ b/backends/blif/blif.cc
@@ -141,9 +141,10 @@ struct BlifDumper
 		return "subckt";
 	}
 
-	void dump_params(const char *command, dict<IdString, Const> &params)
+	template <typename SmellsLikeDict>
+	void dump_params(const char *command, SmellsLikeDict &params)
 	{
-		for (auto &param : params) {
+		for (auto param : params) {
 			f << stringf("%s %s ", command, log_id(param.first));
 			if (param.second.flags & RTLIL::CONST_FLAG_STRING) {
 				std::string str = param.second.decode_string();

--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -2326,7 +2326,8 @@ struct CxxrtlWorker {
 		f << escape_c_string(data);
 	}
 
-	void dump_metadata_map(const dict<RTLIL::IdString, RTLIL::Const> &metadata_map) {
+	template <typename SmellsLikeDict>
+	void dump_metadata_map(const SmellsLikeDict &metadata_map) {
 		if (metadata_map.empty()) {
 			f << "metadata_map()";
 		} else {

--- a/backends/edif/edif.cc
+++ b/backends/edif/edif.cc
@@ -473,7 +473,7 @@ struct EdifBackend : public Backend {
 				*f << stringf("          (instance %s\n", EDIF_DEF(cell->name));
 				*f << stringf("            (viewRef VIEW_NETLIST (cellRef %s%s))", EDIF_REF(cell->type),
 						lib_cell_ports.count(cell->type) > 0 ? " (libraryRef LIB)" : "");
-				for (auto &p : cell->parameters)
+				for (auto p : cell->parameters)
 					add_prop(p.first, p.second);
 				if (attr_properties)
 					for (auto &p : cell->attributes)

--- a/backends/firrtl/firrtl.cc
+++ b/backends/firrtl/firrtl.cc
@@ -480,17 +480,17 @@ struct FirrtlWorker
 		wire_exprs.push_back(stringf("%s" "inst %s%s of %s %s", indent.c_str(), cell_name.c_str(), cell_name_comment.c_str(), instanceName.c_str(), cellFileinfo.c_str()));
 
 		for (auto it = cell->connections().begin(); it != cell->connections().end(); ++it) {
-			if (it->second.size() > 0) {
-				const SigSpec &secondSig = it->second;
-				const std::string firstName = cell_name + "." + make_id(it->first);
+			if ((*it).second.size() > 0) {
+				const SigSpec &secondSig = (*it).second;
+				const std::string firstName = cell_name + "." + make_id((*it).first);
 				const std::string secondExpr = make_expr(secondSig);
 				// Find the direction for this port.
-				FDirection dir = getPortFDirection(it->first, instModule);
+				FDirection dir = getPortFDirection((*it).first, instModule);
 				std::string sourceExpr, sinkExpr;
 				const SigSpec *sinkSig = nullptr;
 				switch (dir) {
 					case FD_INOUT:
-						log_warning("Instance port connection %s.%s is INOUT; treating as OUT\n", cell_type.c_str(), log_signal(it->second));
+						log_warning("Instance port connection %s.%s is INOUT; treating as OUT\n", cell_type.c_str(), log_signal((*it).second));
 						YS_FALLTHROUGH
 					case FD_OUT:
 						sourceExpr = firstName;
@@ -498,14 +498,14 @@ struct FirrtlWorker
 						sinkSig = &secondSig;
 						break;
 					case FD_NODIRECTION:
-						log_warning("Instance port connection %s.%s is NODIRECTION; treating as IN\n", cell_type.c_str(), log_signal(it->second));
+						log_warning("Instance port connection %s.%s is NODIRECTION; treating as IN\n", cell_type.c_str(), log_signal((*it).second));
 						YS_FALLTHROUGH
 					case FD_IN:
 						sourceExpr = secondExpr;
 						sinkExpr = firstName;
 						break;
 					default:
-						log_error("Instance port %s.%s unrecognized connection direction 0x%x !\n", cell_type.c_str(), log_signal(it->second), dir);
+						log_error("Instance port %s.%s unrecognized connection direction 0x%x !\n", cell_type.c_str(), log_signal((*it).second), dir);
 						break;
 				}
 				// Check for subfield assignment.
@@ -849,7 +849,7 @@ struct FirrtlWorker
 				}
 
 				auto it = cell->parameters.find(ID::B_SIGNED);
-				if (it == cell->parameters.end() || !it->second.as_bool()) {
+				if (it == cell->parameters.end() || !(*it).second.as_bool()) {
 					b_expr = "asUInt(" + b_expr + ")";
 				}
 
@@ -881,7 +881,7 @@ struct FirrtlWorker
 			if (cell->type.in(ID($mux), ID($_MUX_)))
 			{
 				auto it = cell->parameters.find(ID::WIDTH);
-				int width = it == cell->parameters.end()? 1 : it->second.as_int();
+				int width = it == cell->parameters.end()? 1 : (*it).second.as_int();
 				string a_expr = make_expr(cell->getPort(ID::A));
 				string b_expr = make_expr(cell->getPort(ID::B));
 				string s_expr = make_expr(cell->getPort(ID::S));

--- a/backends/intersynth/intersynth.cc
+++ b/backends/intersynth/intersynth.cc
@@ -175,7 +175,7 @@ struct IntersynthBackend : public Backend {
 						node_code += stringf(" %s %s", log_id(port.first), netname(conntypes_code, celltypes_code, constcells_code, sig).c_str());
 					}
 				}
-				for (auto &param : cell->parameters) {
+				for (auto &&param : cell->parameters) {
 					celltype_code += stringf(" cfg:%d %s", int(param.second.bits.size()), log_id(param.first));
 					if (param.second.bits.size() != 32) {
 						node_code += stringf(" %s '", log_id(param.first));

--- a/backends/intersynth/intersynth.cc
+++ b/backends/intersynth/intersynth.cc
@@ -175,7 +175,7 @@ struct IntersynthBackend : public Backend {
 						node_code += stringf(" %s %s", log_id(port.first), netname(conntypes_code, celltypes_code, constcells_code, sig).c_str());
 					}
 				}
-				for (auto &&param : cell->parameters) {
+				for (auto param : cell->parameters) {
 					celltype_code += stringf(" cfg:%d %s", int(param.second.bits.size()), log_id(param.first));
 					if (param.second.bits.size() != 32) {
 						node_code += stringf(" %s '", log_id(param.first));

--- a/backends/jny/jny.cc
+++ b/backends/jny/jny.cc
@@ -342,11 +342,12 @@ struct JnyWriter
         }
     }
 
-    void write_prams(dict<RTLIL::IdString, RTLIL::Const>& params, uint16_t indent_level = 0) {
+    template <typename SmellsLikeDict>
+    void write_prams(SmellsLikeDict& params, uint16_t indent_level = 0) {
         const auto _indent = gen_indent(indent_level);
 
         bool first_param{true};
-        for (auto& param : params) {
+        for (auto param : params) {
             if (!first_param)
                 f << stringf(",\n");
             const auto param_val = param.second;

--- a/backends/json/json.cc
+++ b/backends/json/json.cc
@@ -128,11 +128,11 @@ struct JsonWriter
 			f << get_string(value.as_string());
 		}
 	}
-
-	void write_parameters(const dict<IdString, Const> &parameters, bool for_module=false)
+	template <typename SmellsLikeDict>
+	void write_parameters(const SmellsLikeDict &parameters, bool for_module=false)
 	{
 		bool first = true;
-		for (auto &param : parameters) {
+		for (auto param : parameters) {
 			f << stringf("%s\n", first ? "" : ",");
 			f << stringf("        %s%s: ", for_module ? "" : "    ", get_name(param.first).c_str());
 			write_parameter_value(param.second);

--- a/backends/rtlil/rtlil_backend.cc
+++ b/backends/rtlil/rtlil_backend.cc
@@ -165,7 +165,7 @@ void RTLIL_BACKEND::dump_cell(std::ostream &f, std::string indent, const RTLIL::
 		f << stringf("\n");
 	}
 	f << stringf("%s" "cell %s %s\n", indent.c_str(), cell->type.c_str(), cell->name.c_str());
-	for (auto &it : cell->parameters) {
+	for (auto &&it : cell->parameters) {
 		f << stringf("%s  parameter%s%s %s ", indent.c_str(),
 				(it.second.flags & RTLIL::CONST_FLAG_SIGNED) != 0 ? " signed" : "",
 				(it.second.flags & RTLIL::CONST_FLAG_REAL) != 0 ? " real" : "",

--- a/backends/rtlil/rtlil_backend.cc
+++ b/backends/rtlil/rtlil_backend.cc
@@ -106,7 +106,7 @@ void RTLIL_BACKEND::dump_sigspec(std::ostream &f, const RTLIL::SigSpec &sig, boo
 	if (sig.is_chunk()) {
 		dump_sigchunk(f, sig.as_chunk(), autoint);
 	} else {
-		f << stringf("{ ");
+		f << stringf("{"); //FIXME this is a hack
 		for (auto it = sig.chunks().rbegin(); it != sig.chunks().rend(); ++it) {
 			dump_sigchunk(f, *it, false);
 			f << stringf(" ");

--- a/backends/rtlil/rtlil_backend.cc
+++ b/backends/rtlil/rtlil_backend.cc
@@ -165,7 +165,7 @@ void RTLIL_BACKEND::dump_cell(std::ostream &f, std::string indent, const RTLIL::
 		f << stringf("\n");
 	}
 	f << stringf("%s" "cell %s %s\n", indent.c_str(), cell->type.c_str(), cell->name.c_str());
-	for (auto &&it : cell->parameters) {
+	for (auto it : cell->parameters) {
 		f << stringf("%s  parameter%s%s %s ", indent.c_str(),
 				(it.second.flags & RTLIL::CONST_FLAG_SIGNED) != 0 ? " signed" : "",
 				(it.second.flags & RTLIL::CONST_FLAG_REAL) != 0 ? " real" : "",

--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -1895,9 +1895,9 @@ void dump_cell(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 		for (auto it = cell->parameters.begin(); it != cell->parameters.end(); ++it) {
 			if (it != cell->parameters.begin())
 				f << stringf(",");
-			f << stringf("\n%s  .%s(", indent.c_str(), id(it->first).c_str());
-			if (it->second.size() > 0)
-				dump_const(f, it->second);
+			f << stringf("\n%s  .%s(", indent.c_str(), id((*it).first).c_str());
+			if ((*it).second.size() > 0)
+				dump_const(f, (*it).second);
 			f << stringf(")");
 		}
 		f << stringf("\n%s" ")", indent.c_str());
@@ -1915,36 +1915,36 @@ void dump_cell(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 		char str[16];
 		snprintf(str, 16, "$%d", i);
 		for (auto it = cell->connections().begin(); it != cell->connections().end(); ++it) {
-			if (it->first != str)
+			if ((*it).first != str)
 				continue;
 			if (!first_arg)
 				f << stringf(",");
 			first_arg = false;
 			f << stringf("\n%s  ", indent.c_str());
-			dump_sigspec(f, it->second);
-			numbered_ports.insert(it->first);
+			dump_sigspec(f, (*it).second);
+			numbered_ports.insert((*it).first);
 			goto found_numbered_port;
 		}
 		break;
 	found_numbered_port:;
 	}
 	for (auto it = cell->connections().begin(); it != cell->connections().end(); ++it) {
-		if (numbered_ports.count(it->first))
+		if (numbered_ports.count((*it).first))
 			continue;
 		if (!first_arg)
 			f << stringf(",");
 		first_arg = false;
-		f << stringf("\n%s  .%s(", indent.c_str(), id(it->first).c_str());
-		if (it->second.size() > 0)
-			dump_sigspec(f, it->second);
+		f << stringf("\n%s  .%s(", indent.c_str(), id((*it).first).c_str());
+		if ((*it).second.size() > 0)
+			dump_sigspec(f, (*it).second);
 		f << stringf(")");
 	}
 	f << stringf("\n%s" ");\n", indent.c_str());
 
 	if (defparam && cell->parameters.size() > 0) {
 		for (auto it = cell->parameters.begin(); it != cell->parameters.end(); ++it) {
-			f << stringf("%sdefparam %s.%s = ", indent.c_str(), cell_name.c_str(), id(it->first).c_str());
-			dump_const(f, it->second);
+			f << stringf("%sdefparam %s.%s = ", indent.c_str(), cell_name.c_str(), id((*it).first).c_str());
+			dump_const(f, (*it).second);
 			f << stringf(";\n");
 		}
 	}

--- a/flake.nix
+++ b/flake.nix
@@ -14,11 +14,11 @@
         };
         # TODO: don't override src when ./abc is empty
         # which happens when the command used is `nix build` and not `nix build ?submodules=1`
-        abc-verifier = pkgs.abc-verifier.overrideAttrs(x: y: {src = ./abc;});
+        abc-verifier = pkgs.abc-verifier;
         yosys = pkgs.llvmPackages.libcxxStdenv.mkDerivation {
           name = "yosys";
           src = ./. ;
-          buildInputs = with pkgs; [ bison flex libffi tcl readline python3 llvmPackages.libcxxClang zlib git pkg-configUpstream tracy ];
+          buildInputs = with pkgs; [ stdenv.cc.cc bison flex libffi tcl readline python3 zlib git pkg-configUpstream tracy ];
           checkInputs = with pkgs; [ gtest ];
           propagatedBuildInputs = [ abc-verifier ];
           preConfigure = "make config-clang";
@@ -42,7 +42,7 @@
         packages.default = yosys;
         defaultPackage = yosys;
         devShell = pkgs.mkShell {
-          buildInputs = with pkgs; [ clang bison flex libffi tcl readline python3 llvmPackages.libcxxClang zlib git gtest abc-verifier tracy ];
+          buildInputs = with pkgs; [ stdenv.cc.cc bison flex libffi tcl readline python3 zlib git gtest abc-verifier tracy ];
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -15,10 +15,10 @@
         # TODO: don't override src when ./abc is empty
         # which happens when the command used is `nix build` and not `nix build ?submodules=1`
         abc-verifier = pkgs.abc-verifier.overrideAttrs(x: y: {src = ./abc;});
-        yosys = pkgs.clangStdenv.mkDerivation {
+        yosys = pkgs.llvmPackages.libcxxStdenv.mkDerivation {
           name = "yosys";
           src = ./. ;
-          buildInputs = with pkgs; [ clang bison flex libffi tcl readline python3 llvmPackages.libcxxClang zlib git pkg-configUpstream ];
+          buildInputs = with pkgs; [ bison flex libffi tcl readline python3 llvmPackages.libcxxClang zlib git pkg-configUpstream tracy ];
           checkInputs = with pkgs; [ gtest ];
           propagatedBuildInputs = [ abc-verifier ];
           preConfigure = "make config-clang";
@@ -41,7 +41,7 @@
         packages.default = yosys;
         defaultPackage = yosys;
         devShell = pkgs.mkShell {
-          buildInputs = with pkgs; [ clang bison flex libffi tcl readline python3 llvmPackages.libcxxClang zlib git gtest abc-verifier ];
+          buildInputs = with pkgs; [ clang bison flex libffi tcl readline python3 llvmPackages.libcxxClang zlib git gtest abc-verifier tracy ];
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
             ln -s ${abc-verifier}/bin/abc $out/bin/yosys-abc
           '';
 					buildPhase = ''
-            make -j$(nproc) ABCEXTERNAL=yosys-abc
+            make -j$(nproc) ABCEXTERNAL=yosys-abc PROFILER=tracy
           '';
           dontStrip = true;
           meta = with pkgs.lib; {

--- a/flake.nix
+++ b/flake.nix
@@ -24,12 +24,13 @@
           preConfigure = "make config-clang";
           checkTarget = "test";
           installPhase = ''
-            make install PREFIX=$out ABCEXTERNAL=yosys-abc
+            make install PREFIX=$out ABCEXTERNAL=yosys-abc STRIP=\#
             ln -s ${abc-verifier}/bin/abc $out/bin/yosys-abc
           '';
 					buildPhase = ''
             make -j$(nproc) ABCEXTERNAL=yosys-abc
           '';
+          dontStrip = true;
           meta = with pkgs.lib; {
             description = "Yosys Open SYnthesis Suite";
             homepage = "https://yosyshq.net/yosys/";

--- a/frontends/aiger/aigerparse.cc
+++ b/frontends/aiger/aigerparse.cc
@@ -766,7 +766,8 @@ void AigerReader::post_process()
 {
 	unsigned ci_count = 0, co_count = 0;
 	for (auto cell : boxes) {
-		for (auto &bit : cell->connections_.at(ID(i))) {
+		auto sig_inp = cell->connections_.at(ID(i));
+		for (auto &bit : sig_inp) {
 			log_assert(bit == State::S0);
 			log_assert(co_count < outputs.size());
 			bit = outputs[co_count++];
@@ -774,7 +775,8 @@ void AigerReader::post_process()
 			log_assert(bit.wire->port_output);
 			bit.wire->port_output = false;
 		}
-		for (auto &bit : cell->connections_.at(ID(o))) {
+		auto sig_outp = cell->connections_.at(ID(i));
+		for (auto &bit : sig_outp) {
 			log_assert(bit == State::S0);
 			log_assert((piNum + ci_count) < inputs.size());
 			bit = inputs[piNum + ci_count++];

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -2093,9 +2093,10 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 			for (auto it = children.begin(); it != children.end(); it++) {
 				AstNode *child = *it;
 				if (child->type == AST_CELLTYPE) {
-					cell->type = child->str;
-					if (flag_icells && cell->type.begins_with("\\$"))
-						cell->type = cell->type.substr(1);
+					auto type = IdString(child->str);
+					if (flag_icells && type.begins_with("\\$"))
+						type = type.substr(1);
+					cell = cell->module->morphCell(type, cell);
 					continue;
 				}
 				if (child->type == AST_PARASET) {

--- a/frontends/blif/blifparse.cc
+++ b/frontends/blif/blifparse.cc
@@ -125,7 +125,7 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 	};
 
 	dict<RTLIL::IdString, RTLIL::Const> *obj_attributes = nullptr;
-	dict<RTLIL::IdString, RTLIL::Const> *obj_parameters = nullptr;
+	RTLIL::Cell::FakeParams *obj_parameters = nullptr;
 
 	dict<RTLIL::IdString, std::pair<int, bool>> wideports_cache;
 

--- a/frontends/json/jsonparse.cc
+++ b/frontends/json/jsonparse.cc
@@ -274,7 +274,8 @@ Const json_parse_attr_param_value(JsonNode *node)
 	return value;
 }
 
-void json_parse_attr_param(dict<IdString, Const> &results, JsonNode *node)
+template <typename SmellsLikeDict>
+void json_parse_attr_param(SmellsLikeDict &results, JsonNode *node)
 {
 	if (node->type != 'D')
 		log_error("JSON attributes or parameters node is not a dictionary.\n");

--- a/frontends/liberty/liberty.cc
+++ b/frontends/liberty/liberty.cc
@@ -269,21 +269,21 @@ static void create_ff(RTLIL::Module *module, LibertyAst *node)
 	cell->setPort(ID::C, clk_sig);
 
 	if (clear_sig.size() == 0 && preset_sig.size() == 0) {
-		cell->type = stringf("$_DFF_%c_", clk_polarity ? 'P' : 'N');
+		cell = cell->module->morphCell(stringf("$_DFF_%c_", clk_polarity ? 'P' : 'N'), cell);
 	}
 
 	if (clear_sig.size() == 1 && preset_sig.size() == 0) {
-		cell->type = stringf("$_DFF_%c%c0_", clk_polarity ? 'P' : 'N', clear_polarity ? 'P' : 'N');
+		cell = cell->module->morphCell(stringf("$_DFF_%c%c0_", clk_polarity ? 'P' : 'N', clear_polarity ? 'P' : 'N'), cell);
 		cell->setPort(ID::R, clear_sig);
 	}
 
 	if (clear_sig.size() == 0 && preset_sig.size() == 1) {
-		cell->type = stringf("$_DFF_%c%c1_", clk_polarity ? 'P' : 'N', preset_polarity ? 'P' : 'N');
+		cell = cell->module->morphCell(stringf("$_DFF_%c%c1_", clk_polarity ? 'P' : 'N', preset_polarity ? 'P' : 'N'), cell);
 		cell->setPort(ID::R, preset_sig);
 	}
 
 	if (clear_sig.size() == 1 && preset_sig.size() == 1) {
-		cell->type = stringf("$_DFFSR_%c%c%c_", clk_polarity ? 'P' : 'N', preset_polarity ? 'P' : 'N', clear_polarity ? 'P' : 'N');
+		cell = cell->module->morphCell(stringf("$_DFFSR_%c%c%c_", clk_polarity ? 'P' : 'N', preset_polarity ? 'P' : 'N', clear_polarity ? 'P' : 'N'), cell);
 		cell->setPort(ID::S, preset_sig);
 		cell->setPort(ID::R, clear_sig);
 	}

--- a/frontends/rpc/rpc_frontend.cc
+++ b/frontends/rpc/rpc_frontend.cc
@@ -207,7 +207,7 @@ struct RpcModule : RTLIL::Module {
 			for (auto module : derived_design->modules())
 				for (auto cell : module->cells())
 					if (name_mangling.count(cell->type.str()))
-						cell->type = name_mangling[cell->type.str()];
+						cell = cell->module->morphCell(name_mangling[cell->type.str()], cell);
 
 			for (auto module : derived_design->modules_) {
 				std::string mangled_name = name_mangling[module.first.str()];

--- a/kernel/compat.cc
+++ b/kernel/compat.cc
@@ -1,0 +1,20 @@
+#include "hashlib.h"
+#include "rtlil.h"
+
+YOSYS_NAMESPACE_BEGIN
+
+/**
+ * not sure if I need this file but this couldn't go in either
+ * hashlib or rtlil without adding an include to the other header
+ */
+
+dict<RTLIL::IdString, RTLIL::Const> cell_to_mod_params (const RTLIL::Cell::FakeParams& cell_params) {
+    dict<RTLIL::IdString, RTLIL::Const> ret;
+    for (auto i : cell_params){
+        ret[i.first] = i.second;
+    }
+    return ret;
+
+}
+
+YOSYS_NAMESPACE_END

--- a/kernel/compat.h
+++ b/kernel/compat.h
@@ -2,5 +2,11 @@
 
 #ifndef COMPAT_H
 #define COMPAT_H
+
+YOSYS_NAMESPACE_BEGIN
+
 dict<RTLIL::IdString, RTLIL::Const> cell_to_mod_params (const RTLIL::Cell::FakeParams& cell_params);
+
+YOSYS_NAMESPACE_END
+
 #endif

--- a/kernel/compat.h
+++ b/kernel/compat.h
@@ -1,0 +1,6 @@
+// TODO header whatever
+
+#ifndef COMPAT_H
+#define COMPAT_H
+dict<RTLIL::IdString, RTLIL::Const> cell_to_mod_params (const RTLIL::Cell::FakeParams& cell_params);
+#endif

--- a/kernel/ffmerge.cc
+++ b/kernel/ffmerge.cc
@@ -345,7 +345,7 @@ void FfMergeHelper::set(FfInitVals *initvals_, RTLIL::Module *module_)
 			for (int i = 0; i < GetSize(q); i++)
 				dff_driver[q[i]] = std::make_pair(cell, i);
 		}
-		for (auto &conn : cell->connections())
+		for (auto &&conn : cell->connections_)
 			if (!cell->known() || cell->input(conn.first))
 				for (auto bit : (*sigmap)(conn.second))
 					sigbit_users_count[bit]++;

--- a/kernel/ffmerge.cc
+++ b/kernel/ffmerge.cc
@@ -345,7 +345,7 @@ void FfMergeHelper::set(FfInitVals *initvals_, RTLIL::Module *module_)
 			for (int i = 0; i < GetSize(q); i++)
 				dff_driver[q[i]] = std::make_pair(cell, i);
 		}
-		for (auto &&conn : cell->connections_)
+		for (auto conn : cell->connections_)
 			if (!cell->known() || cell->input(conn.first))
 				for (auto bit : (*sigmap)(conn.second))
 					sigbit_users_count[bit]++;

--- a/kernel/mem.cc
+++ b/kernel/mem.cc
@@ -280,7 +280,7 @@ void Mem::emit() {
 		for (auto &port : rd_ports) {
 			if (!port.cell)
 				port.cell = module->addCell(NEW_ID, ID($memrd_v2));
-			port.cell = cell->module->morphCell(ID($memrd_v2), cell);
+			port.cell = port.cell->module->morphCell(ID($memrd_v2), port.cell);
 			port.cell->attributes = port.attributes;
 			port.cell->parameters[ID::MEMID] = memid.str();
 			port.cell->parameters[ID::ABITS] = GetSize(port.addr);
@@ -305,7 +305,7 @@ void Mem::emit() {
 		for (auto &port : wr_ports) {
 			if (!port.cell)
 				port.cell = module->addCell(NEW_ID, ID($memwr_v2));
-			port.cell = cell->module->morphCell(ID($memwr_v2), cell);
+			port.cell = port.cell->module->morphCell(ID($memwr_v2), port.cell);
 			port.cell->attributes = port.attributes;
 			if (port.cell->parameters.count(ID::PRIORITY))
 				port.cell->parameters.erase(ID::PRIORITY);
@@ -327,7 +327,7 @@ void Mem::emit() {
 			if (!init.cell)
 				init.cell = module->addCell(NEW_ID, v2 ? ID($meminit_v2) : ID($meminit));
 			else
-				init.cell = cell->module->morphCell(v2 ? ID($meminit_v2) : ID($meminit), cell);
+				init.cell = init.cell->module->morphCell(v2 ? ID($meminit_v2) : ID($meminit), init.cell);
 			init.cell->attributes = init.attributes;
 			init.cell->parameters[ID::MEMID] = memid.str();
 			init.cell->parameters[ID::ABITS] = GetSize(init.addr);

--- a/kernel/mem.cc
+++ b/kernel/mem.cc
@@ -125,7 +125,7 @@ void Mem::emit() {
 				memid = NEW_ID;
 			cell = module->addCell(memid, ID($mem_v2));
 		}
-		cell->type = ID($mem_v2);
+		cell = cell->module->morphCell(ID($mem_v2), cell);
 		cell->attributes = attributes;
 		cell->parameters[ID::MEMID] = Const(memid.str());
 		cell->parameters[ID::WIDTH] = Const(width);
@@ -280,7 +280,7 @@ void Mem::emit() {
 		for (auto &port : rd_ports) {
 			if (!port.cell)
 				port.cell = module->addCell(NEW_ID, ID($memrd_v2));
-			port.cell->type = ID($memrd_v2);
+			port.cell = cell->module->morphCell(ID($memrd_v2), cell);
 			port.cell->attributes = port.attributes;
 			port.cell->parameters[ID::MEMID] = memid.str();
 			port.cell->parameters[ID::ABITS] = GetSize(port.addr);
@@ -305,7 +305,7 @@ void Mem::emit() {
 		for (auto &port : wr_ports) {
 			if (!port.cell)
 				port.cell = module->addCell(NEW_ID, ID($memwr_v2));
-			port.cell->type = ID($memwr_v2);
+			port.cell = cell->module->morphCell(ID($memwr_v2), cell);
 			port.cell->attributes = port.attributes;
 			if (port.cell->parameters.count(ID::PRIORITY))
 				port.cell->parameters.erase(ID::PRIORITY);
@@ -327,7 +327,7 @@ void Mem::emit() {
 			if (!init.cell)
 				init.cell = module->addCell(NEW_ID, v2 ? ID($meminit_v2) : ID($meminit));
 			else
-				init.cell->type = v2 ? ID($meminit_v2) : ID($meminit);
+				init.cell = cell->module->morphCell(v2 ? ID($meminit_v2) : ID($meminit), cell);
 			init.cell->attributes = init.attributes;
 			init.cell->parameters[ID::MEMID] = memid.str();
 			init.cell->parameters[ID::ABITS] = GetSize(init.addr);

--- a/kernel/mem.cc
+++ b/kernel/mem.cc
@@ -703,7 +703,7 @@ namespace {
 		res.packed = true;
 		res.cell = cell;
 		res.attributes = cell->attributes;
-		Const &init = cell->parameters.at(ID::INIT);
+		const Const &init = cell->parameters.at(ID::INIT);
 		if (!init.is_fully_undef()) {
 			int pos = 0;
 			while (pos < res.size) {

--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -314,6 +314,9 @@ void Pass::call(RTLIL::Design *design, std::vector<std::string> args)
 
 	size_t orig_sel_stack_pos = design->selection_stack.size();
 	auto state = pass_register[args[0]]->pre_execute();
+	ZoneScopedN(pass_name.c_str());
+	// ZoneText(pass_name.c_str(), pass_name.length());
+	ZoneColor((uint32_t)(size_t)pass_name.c_str());
 	pass_register[args[0]]->execute(args, design);
 	pass_register[args[0]]->post_execute(state);
 	while (design->selection_stack.size() > orig_sel_stack_pos)

--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -314,9 +314,6 @@ void Pass::call(RTLIL::Design *design, std::vector<std::string> args)
 
 	size_t orig_sel_stack_pos = design->selection_stack.size();
 	auto state = pass_register[args[0]]->pre_execute();
-	ZoneScopedN(pass_name.c_str());
-	// ZoneText(pass_name.c_str(), pass_name.length());
-	ZoneColor((uint32_t)(size_t)pass_name.c_str());
 	pass_register[args[0]]->execute(args, design);
 	pass_register[args[0]]->post_execute(state);
 	while (design->selection_stack.size() > orig_sel_stack_pos)

--- a/kernel/register.h
+++ b/kernel/register.h
@@ -23,6 +23,8 @@
 #include "kernel/yosys_common.h"
 #include "kernel/yosys.h"
 
+#include "tracy/public/tracy/Tracy.hpp"
+
 YOSYS_NAMESPACE_BEGIN
 
 struct Pass

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -2535,9 +2535,9 @@ RTLIL::Process *RTLIL::Module::addProcess(RTLIL::IdString name, const RTLIL::Pro
 		add ## _func(name, sig_a, sig_y, is_signed, src);   \
 		return sig_y;                                       \
 	}
-DEF_METHOD(Not,        sig_a.size(), ID($not))
-DEF_METHOD(Pos,        sig_a.size(), ID($pos))
-DEF_METHOD(Neg,        sig_a.size(), ID($neg))
+// DEF_METHOD(Not,        sig_a.size(), ID($not))
+// DEF_METHOD(Pos,        sig_a.size(), ID($pos))
+// DEF_METHOD(Neg,        sig_a.size(), ID($neg))
 DEF_METHOD(ReduceAnd,  1, ID($reduce_and))
 DEF_METHOD(ReduceOr,   1, ID($reduce_or))
 DEF_METHOD(ReduceXor,  1, ID($reduce_xor))

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1219,7 +1219,7 @@ namespace {
 				port(ID::B, param(ID::B_WIDTH));
 				port(ID::Y, param(ID::Y_WIDTH));
 				check_expected();
-				Macc().from_cell(cell->legacy);
+				Macc().from_cell(cell);
 				return;
 			}
 
@@ -1935,7 +1935,7 @@ void RTLIL::Module::check()
 #ifndef NDEBUG
 	std::vector<bool> ports_declared;
 	for (auto &it : wires_) {
-		log_assert(this == it.second->module);
+		// log_assert(this == it.second->module);
 		log_assert(it.first == it.second->name);
 		log_assert(!it.first.empty());
 		log_assert(it.second->width >= 0);
@@ -1969,11 +1969,11 @@ void RTLIL::Module::check()
 	pool<IdString> packed_memids;
 
 	for (auto &it : cells_) {
-		log_assert(this == it.second->module);
+		// log_assert(this == it.second->module);
 		log_assert(it.first == it.second->name);
 		log_assert(!it.first.empty());
 		log_assert(!it.second->type.empty());
-		for (auto &it2 : it.second->connections()) {
+		for (auto &it2 : it.second->connections_) {
 			log_assert(!it2.first.empty());
 			it2.second.check(this);
 		}

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -2475,7 +2475,7 @@ RTLIL::Process *RTLIL::Module::addProcess(RTLIL::IdString name, const RTLIL::Pro
 
 #define DEF_METHOD(_func, _y_size, _type) \
 	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_y, bool is_signed, const std::string &src) { \
-		RTLIL::OldCell *cell = addCell(name, _type);           \
+		RTLIL::Cell *cell = addCell(name, _type);           \
 		cell->parameters[ID::A_SIGNED] = is_signed;         \
 		cell->parameters[ID::A_WIDTH] = sig_a.size();       \
 		cell->parameters[ID::Y_WIDTH] = sig_y.size();       \
@@ -2502,7 +2502,7 @@ DEF_METHOD(LogicNot,   1, ID($logic_not))
 
 #define DEF_METHOD(_func, _y_size, _type) \
 	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, bool is_signed, const std::string &src) { \
-		RTLIL::OldCell *cell = addCell(name, _type);           \
+		RTLIL::Cell *cell = addCell(name, _type);           \
 		cell->parameters[ID::A_SIGNED] = is_signed;         \
 		cell->parameters[ID::B_SIGNED] = is_signed;         \
 		cell->parameters[ID::A_WIDTH] = sig_a.size();       \
@@ -2546,7 +2546,7 @@ DEF_METHOD(LogicOr,  1, ID($logic_or))
 
 #define DEF_METHOD(_func, _y_size, _type) \
 	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, bool is_signed, const std::string &src) { \
-		RTLIL::OldCell *cell = addCell(name, _type);           \
+		RTLIL::Cell *cell = addCell(name, _type);           \
 		cell->parameters[ID::A_SIGNED] = is_signed;         \
 		cell->parameters[ID::B_SIGNED] = false;             \
 		cell->parameters[ID::A_WIDTH] = sig_a.size();       \
@@ -2571,7 +2571,7 @@ DEF_METHOD(Sshr,     sig_a.size(), ID($sshr))
 
 #define DEF_METHOD(_func, _type, _pmux) \
 	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_s, const RTLIL::SigSpec &sig_y, const std::string &src) { \
-		RTLIL::OldCell *cell = addCell(name, _type);                 \
+		RTLIL::Cell *cell = addCell(name, _type);                 \
 		cell->parameters[ID::WIDTH] = sig_a.size();               \
 		if (_pmux) cell->parameters[ID::S_WIDTH] = sig_s.size();  \
 		cell->setPort(ID::A, sig_a);                              \
@@ -2593,7 +2593,7 @@ DEF_METHOD(Pmux,     ID($pmux),       1)
 
 #define DEF_METHOD(_func, _type, _demux) \
 	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_s, const RTLIL::SigSpec &sig_y, const std::string &src) { \
-		RTLIL::OldCell *cell = addCell(name, _type);                 \
+		RTLIL::Cell *cell = addCell(name, _type);                 \
 		cell->parameters[ID::WIDTH] = _demux ? sig_a.size() : sig_y.size(); \
 		cell->parameters[ID::S_WIDTH] = sig_s.size();             \
 		cell->setPort(ID::A, sig_a);                              \
@@ -2613,7 +2613,7 @@ DEF_METHOD(Demux,    ID($demux),      1)
 
 #define DEF_METHOD(_func, _type) \
 	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, const std::string &src) { \
-		RTLIL::OldCell *cell = addCell(name, _type);                 \
+		RTLIL::Cell *cell = addCell(name, _type);                 \
 		cell->parameters[ID::WIDTH] = sig_a.size();               \
 		cell->setPort(ID::A, sig_a);                              \
 		cell->setPort(ID::B, sig_b);                              \
@@ -2631,7 +2631,7 @@ DEF_METHOD(Bweqx,    ID($bweqx))
 
 #define DEF_METHOD_2(_func, _type, _P1, _P2) \
 	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigBit &sig1, const RTLIL::SigBit &sig2, const std::string &src) { \
-		RTLIL::OldCell *cell = addCell(name, _type);         \
+		RTLIL::Cell *cell = addCell(name, _type);         \
 		cell->setPort("\\" #_P1, sig1);                   \
 		cell->setPort("\\" #_P2, sig2);                   \
 		cell->set_src_attribute(src);                     \
@@ -2644,7 +2644,7 @@ DEF_METHOD(Bweqx,    ID($bweqx))
 	}
 #define DEF_METHOD_3(_func, _type, _P1, _P2, _P3) \
 	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigBit &sig1, const RTLIL::SigBit &sig2, const RTLIL::SigBit &sig3, const std::string &src) { \
-		RTLIL::OldCell *cell = addCell(name, _type);         \
+		RTLIL::Cell *cell = addCell(name, _type);         \
 		cell->setPort("\\" #_P1, sig1);                   \
 		cell->setPort("\\" #_P2, sig2);                   \
 		cell->setPort("\\" #_P3, sig3);                   \
@@ -2658,7 +2658,7 @@ DEF_METHOD(Bweqx,    ID($bweqx))
 	}
 #define DEF_METHOD_4(_func, _type, _P1, _P2, _P3, _P4) \
 	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigBit &sig1, const RTLIL::SigBit &sig2, const RTLIL::SigBit &sig3, const RTLIL::SigBit &sig4, const std::string &src) { \
-		RTLIL::OldCell *cell = addCell(name, _type);         \
+		RTLIL::Cell *cell = addCell(name, _type);         \
 		cell->setPort("\\" #_P1, sig1);                   \
 		cell->setPort("\\" #_P2, sig2);                   \
 		cell->setPort("\\" #_P3, sig3);                   \
@@ -2673,7 +2673,7 @@ DEF_METHOD(Bweqx,    ID($bweqx))
 	}
 #define DEF_METHOD_5(_func, _type, _P1, _P2, _P3, _P4, _P5) \
 	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigBit &sig1, const RTLIL::SigBit &sig2, const RTLIL::SigBit &sig3, const RTLIL::SigBit &sig4, const RTLIL::SigBit &sig5, const std::string &src) { \
-		RTLIL::OldCell *cell = addCell(name, _type);         \
+		RTLIL::Cell *cell = addCell(name, _type);         \
 		cell->setPort("\\" #_P1, sig1);                   \
 		cell->setPort("\\" #_P2, sig2);                   \
 		cell->setPort("\\" #_P3, sig3);                   \
@@ -2710,7 +2710,7 @@ DEF_METHOD_5(Oai4Gate,   ID($_OAI4_),   A, B, C, D, Y)
 
 RTLIL::Cell* RTLIL::Module::addPow(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, bool a_signed, bool b_signed, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($pow));
+	RTLIL::Cell *cell = addCell(name, ID($pow));
 	cell->parameters[ID::A_SIGNED] = a_signed;
 	cell->parameters[ID::B_SIGNED] = b_signed;
 	cell->parameters[ID::A_WIDTH] = sig_a.size();
@@ -2725,7 +2725,7 @@ RTLIL::Cell* RTLIL::Module::addPow(RTLIL::IdString name, const RTLIL::SigSpec &s
 
 RTLIL::Cell* RTLIL::Module::addFa(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_c, const RTLIL::SigSpec &sig_x, const RTLIL::SigSpec &sig_y, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($fa));
+	RTLIL::Cell *cell = addCell(name, ID($fa));
 	cell->parameters[ID::WIDTH] = sig_a.size();
 	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID::B, sig_b);
@@ -2738,7 +2738,7 @@ RTLIL::Cell* RTLIL::Module::addFa(RTLIL::IdString name, const RTLIL::SigSpec &si
 
 RTLIL::Cell* RTLIL::Module::addSlice(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_y, RTLIL::Const offset, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($slice));
+	RTLIL::Cell *cell = addCell(name, ID($slice));
 	cell->parameters[ID::A_WIDTH] = sig_a.size();
 	cell->parameters[ID::Y_WIDTH] = sig_y.size();
 	cell->parameters[ID::OFFSET] = offset;
@@ -2750,7 +2750,7 @@ RTLIL::Cell* RTLIL::Module::addSlice(RTLIL::IdString name, const RTLIL::SigSpec 
 
 RTLIL::Cell* RTLIL::Module::addConcat(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($concat));
+	RTLIL::Cell *cell = addCell(name, ID($concat));
 	cell->parameters[ID::A_WIDTH] = sig_a.size();
 	cell->parameters[ID::B_WIDTH] = sig_b.size();
 	cell->setPort(ID::A, sig_a);
@@ -2762,7 +2762,7 @@ RTLIL::Cell* RTLIL::Module::addConcat(RTLIL::IdString name, const RTLIL::SigSpec
 
 RTLIL::Cell* RTLIL::Module::addLut(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_y, RTLIL::Const lut, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($lut));
+	RTLIL::Cell *cell = addCell(name, ID($lut));
 	cell->parameters[ID::LUT] = lut;
 	cell->parameters[ID::WIDTH] = sig_a.size();
 	cell->setPort(ID::A, sig_a);
@@ -2773,7 +2773,7 @@ RTLIL::Cell* RTLIL::Module::addLut(RTLIL::IdString name, const RTLIL::SigSpec &s
 
 RTLIL::Cell* RTLIL::Module::addTribuf(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_y, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($tribuf));
+	RTLIL::Cell *cell = addCell(name, ID($tribuf));
 	cell->parameters[ID::WIDTH] = sig_a.size();
 	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID::EN, sig_en);
@@ -2784,7 +2784,7 @@ RTLIL::Cell* RTLIL::Module::addTribuf(RTLIL::IdString name, const RTLIL::SigSpec
 
 RTLIL::Cell* RTLIL::Module::addAssert(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_en, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($assert));
+	RTLIL::Cell *cell = addCell(name, ID($assert));
 	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID::EN, sig_en);
 	cell->set_src_attribute(src);
@@ -2793,7 +2793,7 @@ RTLIL::Cell* RTLIL::Module::addAssert(RTLIL::IdString name, const RTLIL::SigSpec
 
 RTLIL::Cell* RTLIL::Module::addAssume(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_en, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($assume));
+	RTLIL::Cell *cell = addCell(name, ID($assume));
 	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID::EN, sig_en);
 	cell->set_src_attribute(src);
@@ -2802,7 +2802,7 @@ RTLIL::Cell* RTLIL::Module::addAssume(RTLIL::IdString name, const RTLIL::SigSpec
 
 RTLIL::Cell* RTLIL::Module::addLive(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_en, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($live));
+	RTLIL::Cell *cell = addCell(name, ID($live));
 	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID::EN, sig_en);
 	cell->set_src_attribute(src);
@@ -2811,7 +2811,7 @@ RTLIL::Cell* RTLIL::Module::addLive(RTLIL::IdString name, const RTLIL::SigSpec &
 
 RTLIL::Cell* RTLIL::Module::addFair(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_en, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($fair));
+	RTLIL::Cell *cell = addCell(name, ID($fair));
 	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID::EN, sig_en);
 	cell->set_src_attribute(src);
@@ -2820,7 +2820,7 @@ RTLIL::Cell* RTLIL::Module::addFair(RTLIL::IdString name, const RTLIL::SigSpec &
 
 RTLIL::Cell* RTLIL::Module::addCover(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_en, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($cover));
+	RTLIL::Cell *cell = addCell(name, ID($cover));
 	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID::EN, sig_en);
 	cell->set_src_attribute(src);
@@ -2829,7 +2829,7 @@ RTLIL::Cell* RTLIL::Module::addCover(RTLIL::IdString name, const RTLIL::SigSpec 
 
 RTLIL::Cell* RTLIL::Module::addEquiv(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($equiv));
+	RTLIL::Cell *cell = addCell(name, ID($equiv));
 	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID::B, sig_b);
 	cell->setPort(ID::Y, sig_y);
@@ -2839,7 +2839,7 @@ RTLIL::Cell* RTLIL::Module::addEquiv(RTLIL::IdString name, const RTLIL::SigSpec 
 
 RTLIL::Cell* RTLIL::Module::addSr(RTLIL::IdString name, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr, const RTLIL::SigSpec &sig_q, bool set_polarity, bool clr_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($sr));
+	RTLIL::Cell *cell = addCell(name, ID($sr));
 	cell->parameters[ID::SET_POLARITY] = set_polarity;
 	cell->parameters[ID::CLR_POLARITY] = clr_polarity;
 	cell->parameters[ID::WIDTH] = sig_q.size();
@@ -2852,7 +2852,7 @@ RTLIL::Cell* RTLIL::Module::addSr(RTLIL::IdString name, const RTLIL::SigSpec &si
 
 RTLIL::Cell* RTLIL::Module::addFf(RTLIL::IdString name, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($ff));
+	RTLIL::Cell *cell = addCell(name, ID($ff));
 	cell->parameters[ID::WIDTH] = sig_q.size();
 	cell->setPort(ID::D, sig_d);
 	cell->setPort(ID::Q, sig_q);
@@ -2862,7 +2862,7 @@ RTLIL::Cell* RTLIL::Module::addFf(RTLIL::IdString name, const RTLIL::SigSpec &si
 
 RTLIL::Cell* RTLIL::Module::addDff(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($dff));
+	RTLIL::Cell *cell = addCell(name, ID($dff));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::WIDTH] = sig_q.size();
 	cell->setPort(ID::CLK, sig_clk);
@@ -2874,7 +2874,7 @@ RTLIL::Cell* RTLIL::Module::addDff(RTLIL::IdString name, const RTLIL::SigSpec &s
 
 RTLIL::Cell* RTLIL::Module::addDffe(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, bool en_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($dffe));
+	RTLIL::Cell *cell = addCell(name, ID($dffe));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::EN_POLARITY] = en_polarity;
 	cell->parameters[ID::WIDTH] = sig_q.size();
@@ -2889,7 +2889,7 @@ RTLIL::Cell* RTLIL::Module::addDffe(RTLIL::IdString name, const RTLIL::SigSpec &
 RTLIL::Cell* RTLIL::Module::addDffsr(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
 		RTLIL::SigSpec sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, bool set_polarity, bool clr_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($dffsr));
+	RTLIL::Cell *cell = addCell(name, ID($dffsr));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::SET_POLARITY] = set_polarity;
 	cell->parameters[ID::CLR_POLARITY] = clr_polarity;
@@ -2906,7 +2906,7 @@ RTLIL::Cell* RTLIL::Module::addDffsr(RTLIL::IdString name, const RTLIL::SigSpec 
 RTLIL::Cell* RTLIL::Module::addDffsre(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
 		RTLIL::SigSpec sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, bool en_polarity, bool set_polarity, bool clr_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($dffsre));
+	RTLIL::Cell *cell = addCell(name, ID($dffsre));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::EN_POLARITY] = en_polarity;
 	cell->parameters[ID::SET_POLARITY] = set_polarity;
@@ -2925,7 +2925,7 @@ RTLIL::Cell* RTLIL::Module::addDffsre(RTLIL::IdString name, const RTLIL::SigSpec
 RTLIL::Cell* RTLIL::Module::addAdff(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_arst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		RTLIL::Const arst_value, bool clk_polarity, bool arst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($adff));
+	RTLIL::Cell *cell = addCell(name, ID($adff));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::ARST_POLARITY] = arst_polarity;
 	cell->parameters[ID::ARST_VALUE] = arst_value;
@@ -2941,7 +2941,7 @@ RTLIL::Cell* RTLIL::Module::addAdff(RTLIL::IdString name, const RTLIL::SigSpec &
 RTLIL::Cell* RTLIL::Module::addAdffe(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_arst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		RTLIL::Const arst_value, bool clk_polarity, bool en_polarity, bool arst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($adffe));
+	RTLIL::Cell *cell = addCell(name, ID($adffe));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::EN_POLARITY] = en_polarity;
 	cell->parameters[ID::ARST_POLARITY] = arst_polarity;
@@ -2959,7 +2959,7 @@ RTLIL::Cell* RTLIL::Module::addAdffe(RTLIL::IdString name, const RTLIL::SigSpec 
 RTLIL::Cell* RTLIL::Module::addAldff(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_aload, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		const RTLIL::SigSpec &sig_ad, bool clk_polarity, bool aload_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($aldff));
+	RTLIL::Cell *cell = addCell(name, ID($aldff));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::ALOAD_POLARITY] = aload_polarity;
 	cell->parameters[ID::WIDTH] = sig_q.size();
@@ -2975,7 +2975,7 @@ RTLIL::Cell* RTLIL::Module::addAldff(RTLIL::IdString name, const RTLIL::SigSpec 
 RTLIL::Cell* RTLIL::Module::addAldffe(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_aload, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		const RTLIL::SigSpec &sig_ad, bool clk_polarity, bool en_polarity, bool aload_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($aldffe));
+	RTLIL::Cell *cell = addCell(name, ID($aldffe));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::EN_POLARITY] = en_polarity;
 	cell->parameters[ID::ALOAD_POLARITY] = aload_polarity;
@@ -2993,7 +2993,7 @@ RTLIL::Cell* RTLIL::Module::addAldffe(RTLIL::IdString name, const RTLIL::SigSpec
 RTLIL::Cell* RTLIL::Module::addSdff(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_srst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		RTLIL::Const srst_value, bool clk_polarity, bool srst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($sdff));
+	RTLIL::Cell *cell = addCell(name, ID($sdff));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::SRST_POLARITY] = srst_polarity;
 	cell->parameters[ID::SRST_VALUE] = srst_value;
@@ -3009,7 +3009,7 @@ RTLIL::Cell* RTLIL::Module::addSdff(RTLIL::IdString name, const RTLIL::SigSpec &
 RTLIL::Cell* RTLIL::Module::addSdffe(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_srst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		RTLIL::Const srst_value, bool clk_polarity, bool en_polarity, bool srst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($sdffe));
+	RTLIL::Cell *cell = addCell(name, ID($sdffe));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::EN_POLARITY] = en_polarity;
 	cell->parameters[ID::SRST_POLARITY] = srst_polarity;
@@ -3027,7 +3027,7 @@ RTLIL::Cell* RTLIL::Module::addSdffe(RTLIL::IdString name, const RTLIL::SigSpec 
 RTLIL::Cell* RTLIL::Module::addSdffce(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_srst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		RTLIL::Const srst_value, bool clk_polarity, bool en_polarity, bool srst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($sdffce));
+	RTLIL::Cell *cell = addCell(name, ID($sdffce));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::EN_POLARITY] = en_polarity;
 	cell->parameters[ID::SRST_POLARITY] = srst_polarity;
@@ -3044,7 +3044,7 @@ RTLIL::Cell* RTLIL::Module::addSdffce(RTLIL::IdString name, const RTLIL::SigSpec
 
 RTLIL::Cell* RTLIL::Module::addDlatch(RTLIL::IdString name, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, bool en_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($dlatch));
+	RTLIL::Cell *cell = addCell(name, ID($dlatch));
 	cell->parameters[ID::EN_POLARITY] = en_polarity;
 	cell->parameters[ID::WIDTH] = sig_q.size();
 	cell->setPort(ID::EN, sig_en);
@@ -3057,7 +3057,7 @@ RTLIL::Cell* RTLIL::Module::addDlatch(RTLIL::IdString name, const RTLIL::SigSpec
 RTLIL::Cell* RTLIL::Module::addAdlatch(RTLIL::IdString name, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_arst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		RTLIL::Const arst_value, bool en_polarity, bool arst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($adlatch));
+	RTLIL::Cell *cell = addCell(name, ID($adlatch));
 	cell->parameters[ID::EN_POLARITY] = en_polarity;
 	cell->parameters[ID::ARST_POLARITY] = arst_polarity;
 	cell->parameters[ID::ARST_VALUE] = arst_value;
@@ -3073,7 +3073,7 @@ RTLIL::Cell* RTLIL::Module::addAdlatch(RTLIL::IdString name, const RTLIL::SigSpe
 RTLIL::Cell* RTLIL::Module::addDlatchsr(RTLIL::IdString name, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
 		RTLIL::SigSpec sig_d, const RTLIL::SigSpec &sig_q, bool en_polarity, bool set_polarity, bool clr_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($dlatchsr));
+	RTLIL::Cell *cell = addCell(name, ID($dlatchsr));
 	cell->parameters[ID::EN_POLARITY] = en_polarity;
 	cell->parameters[ID::SET_POLARITY] = set_polarity;
 	cell->parameters[ID::CLR_POLARITY] = clr_polarity;
@@ -3090,7 +3090,7 @@ RTLIL::Cell* RTLIL::Module::addDlatchsr(RTLIL::IdString name, const RTLIL::SigSp
 RTLIL::Cell* RTLIL::Module::addSrGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
 		const RTLIL::SigSpec &sig_q, bool set_polarity, bool clr_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, stringf("$_SR_%c%c_", set_polarity ? 'P' : 'N', clr_polarity ? 'P' : 'N'));
+	RTLIL::Cell *cell = addCell(name, stringf("$_SR_%c%c_", set_polarity ? 'P' : 'N', clr_polarity ? 'P' : 'N'));
 	cell->setPort(ID::S, sig_set);
 	cell->setPort(ID::R, sig_clr);
 	cell->setPort(ID::Q, sig_q);
@@ -3100,7 +3100,7 @@ RTLIL::Cell* RTLIL::Module::addSrGate(RTLIL::IdString name, const RTLIL::SigSpec
 
 RTLIL::Cell* RTLIL::Module::addFfGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($_FF_));
+	RTLIL::Cell *cell = addCell(name, ID($_FF_));
 	cell->setPort(ID::D, sig_d);
 	cell->setPort(ID::Q, sig_q);
 	cell->set_src_attribute(src);
@@ -3109,7 +3109,7 @@ RTLIL::Cell* RTLIL::Module::addFfGate(RTLIL::IdString name, const RTLIL::SigSpec
 
 RTLIL::Cell* RTLIL::Module::addDffGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, stringf("$_DFF_%c_", clk_polarity ? 'P' : 'N'));
+	RTLIL::Cell *cell = addCell(name, stringf("$_DFF_%c_", clk_polarity ? 'P' : 'N'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::D, sig_d);
 	cell->setPort(ID::Q, sig_q);
@@ -3119,7 +3119,7 @@ RTLIL::Cell* RTLIL::Module::addDffGate(RTLIL::IdString name, const RTLIL::SigSpe
 
 RTLIL::Cell* RTLIL::Module::addDffeGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, bool en_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, stringf("$_DFFE_%c%c_", clk_polarity ? 'P' : 'N', en_polarity ? 'P' : 'N'));
+	RTLIL::Cell *cell = addCell(name, stringf("$_DFFE_%c%c_", clk_polarity ? 'P' : 'N', en_polarity ? 'P' : 'N'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::E, sig_en);
 	cell->setPort(ID::D, sig_d);
@@ -3131,7 +3131,7 @@ RTLIL::Cell* RTLIL::Module::addDffeGate(RTLIL::IdString name, const RTLIL::SigSp
 RTLIL::Cell* RTLIL::Module::addDffsrGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
 		RTLIL::SigSpec sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, bool set_polarity, bool clr_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, stringf("$_DFFSR_%c%c%c_", clk_polarity ? 'P' : 'N', set_polarity ? 'P' : 'N', clr_polarity ? 'P' : 'N'));
+	RTLIL::Cell *cell = addCell(name, stringf("$_DFFSR_%c%c%c_", clk_polarity ? 'P' : 'N', set_polarity ? 'P' : 'N', clr_polarity ? 'P' : 'N'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::S, sig_set);
 	cell->setPort(ID::R, sig_clr);
@@ -3144,7 +3144,7 @@ RTLIL::Cell* RTLIL::Module::addDffsrGate(RTLIL::IdString name, const RTLIL::SigS
 RTLIL::Cell* RTLIL::Module::addDffsreGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
 		RTLIL::SigSpec sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, bool en_polarity, bool set_polarity, bool clr_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, stringf("$_DFFSRE_%c%c%c%c_", clk_polarity ? 'P' : 'N', set_polarity ? 'P' : 'N', clr_polarity ? 'P' : 'N', en_polarity ? 'P' : 'N'));
+	RTLIL::Cell *cell = addCell(name, stringf("$_DFFSRE_%c%c%c%c_", clk_polarity ? 'P' : 'N', set_polarity ? 'P' : 'N', clr_polarity ? 'P' : 'N', en_polarity ? 'P' : 'N'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::S, sig_set);
 	cell->setPort(ID::R, sig_clr);
@@ -3158,7 +3158,7 @@ RTLIL::Cell* RTLIL::Module::addDffsreGate(RTLIL::IdString name, const RTLIL::Sig
 RTLIL::Cell* RTLIL::Module::addAdffGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_arst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		bool arst_value, bool clk_polarity, bool arst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, stringf("$_DFF_%c%c%c_", clk_polarity ? 'P' : 'N', arst_polarity ? 'P' : 'N', arst_value ? '1' : '0'));
+	RTLIL::Cell *cell = addCell(name, stringf("$_DFF_%c%c%c_", clk_polarity ? 'P' : 'N', arst_polarity ? 'P' : 'N', arst_value ? '1' : '0'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::R, sig_arst);
 	cell->setPort(ID::D, sig_d);
@@ -3170,7 +3170,7 @@ RTLIL::Cell* RTLIL::Module::addAdffGate(RTLIL::IdString name, const RTLIL::SigSp
 RTLIL::Cell* RTLIL::Module::addAdffeGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_arst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		bool arst_value, bool clk_polarity, bool en_polarity, bool arst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, stringf("$_DFFE_%c%c%c%c_", clk_polarity ? 'P' : 'N', arst_polarity ? 'P' : 'N', arst_value ? '1' : '0', en_polarity ? 'P' : 'N'));
+	RTLIL::Cell *cell = addCell(name, stringf("$_DFFE_%c%c%c%c_", clk_polarity ? 'P' : 'N', arst_polarity ? 'P' : 'N', arst_value ? '1' : '0', en_polarity ? 'P' : 'N'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::R, sig_arst);
 	cell->setPort(ID::E, sig_en);
@@ -3183,7 +3183,7 @@ RTLIL::Cell* RTLIL::Module::addAdffeGate(RTLIL::IdString name, const RTLIL::SigS
 RTLIL::Cell* RTLIL::Module::addAldffGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_aload, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		const RTLIL::SigSpec &sig_ad, bool clk_polarity, bool aload_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, stringf("$_ALDFF_%c%c_", clk_polarity ? 'P' : 'N', aload_polarity ? 'P' : 'N'));
+	RTLIL::Cell *cell = addCell(name, stringf("$_ALDFF_%c%c_", clk_polarity ? 'P' : 'N', aload_polarity ? 'P' : 'N'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::L, sig_aload);
 	cell->setPort(ID::D, sig_d);
@@ -3196,7 +3196,7 @@ RTLIL::Cell* RTLIL::Module::addAldffGate(RTLIL::IdString name, const RTLIL::SigS
 RTLIL::Cell* RTLIL::Module::addAldffeGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_aload, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		const RTLIL::SigSpec &sig_ad, bool clk_polarity, bool en_polarity, bool aload_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, stringf("$_ALDFFE_%c%c%c_", clk_polarity ? 'P' : 'N', aload_polarity ? 'P' : 'N', en_polarity ? 'P' : 'N'));
+	RTLIL::Cell *cell = addCell(name, stringf("$_ALDFFE_%c%c%c_", clk_polarity ? 'P' : 'N', aload_polarity ? 'P' : 'N', en_polarity ? 'P' : 'N'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::L, sig_aload);
 	cell->setPort(ID::E, sig_en);
@@ -3210,7 +3210,7 @@ RTLIL::Cell* RTLIL::Module::addAldffeGate(RTLIL::IdString name, const RTLIL::Sig
 RTLIL::Cell* RTLIL::Module::addSdffGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_srst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		bool srst_value, bool clk_polarity, bool srst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, stringf("$_SDFF_%c%c%c_", clk_polarity ? 'P' : 'N', srst_polarity ? 'P' : 'N', srst_value ? '1' : '0'));
+	RTLIL::Cell *cell = addCell(name, stringf("$_SDFF_%c%c%c_", clk_polarity ? 'P' : 'N', srst_polarity ? 'P' : 'N', srst_value ? '1' : '0'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::R, sig_srst);
 	cell->setPort(ID::D, sig_d);
@@ -3222,7 +3222,7 @@ RTLIL::Cell* RTLIL::Module::addSdffGate(RTLIL::IdString name, const RTLIL::SigSp
 RTLIL::Cell* RTLIL::Module::addSdffeGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_srst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		bool srst_value, bool clk_polarity, bool en_polarity, bool srst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, stringf("$_SDFFE_%c%c%c%c_", clk_polarity ? 'P' : 'N', srst_polarity ? 'P' : 'N', srst_value ? '1' : '0', en_polarity ? 'P' : 'N'));
+	RTLIL::Cell *cell = addCell(name, stringf("$_SDFFE_%c%c%c%c_", clk_polarity ? 'P' : 'N', srst_polarity ? 'P' : 'N', srst_value ? '1' : '0', en_polarity ? 'P' : 'N'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::R, sig_srst);
 	cell->setPort(ID::E, sig_en);
@@ -3235,7 +3235,7 @@ RTLIL::Cell* RTLIL::Module::addSdffeGate(RTLIL::IdString name, const RTLIL::SigS
 RTLIL::Cell* RTLIL::Module::addSdffceGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_srst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		bool srst_value, bool clk_polarity, bool en_polarity, bool srst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, stringf("$_SDFFCE_%c%c%c%c_", clk_polarity ? 'P' : 'N', srst_polarity ? 'P' : 'N', srst_value ? '1' : '0', en_polarity ? 'P' : 'N'));
+	RTLIL::Cell *cell = addCell(name, stringf("$_SDFFCE_%c%c%c%c_", clk_polarity ? 'P' : 'N', srst_polarity ? 'P' : 'N', srst_value ? '1' : '0', en_polarity ? 'P' : 'N'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::R, sig_srst);
 	cell->setPort(ID::E, sig_en);
@@ -3247,7 +3247,7 @@ RTLIL::Cell* RTLIL::Module::addSdffceGate(RTLIL::IdString name, const RTLIL::Sig
 
 RTLIL::Cell* RTLIL::Module::addDlatchGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, bool en_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, stringf("$_DLATCH_%c_", en_polarity ? 'P' : 'N'));
+	RTLIL::Cell *cell = addCell(name, stringf("$_DLATCH_%c_", en_polarity ? 'P' : 'N'));
 	cell->setPort(ID::E, sig_en);
 	cell->setPort(ID::D, sig_d);
 	cell->setPort(ID::Q, sig_q);
@@ -3258,7 +3258,7 @@ RTLIL::Cell* RTLIL::Module::addDlatchGate(RTLIL::IdString name, const RTLIL::Sig
 RTLIL::Cell* RTLIL::Module::addAdlatchGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_arst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		bool arst_value, bool en_polarity, bool arst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, stringf("$_DLATCH_%c%c%c_", en_polarity ? 'P' : 'N', arst_polarity ? 'P' : 'N', arst_value ? '1' : '0'));
+	RTLIL::Cell *cell = addCell(name, stringf("$_DLATCH_%c%c%c_", en_polarity ? 'P' : 'N', arst_polarity ? 'P' : 'N', arst_value ? '1' : '0'));
 	cell->setPort(ID::E, sig_en);
 	cell->setPort(ID::R, sig_arst);
 	cell->setPort(ID::D, sig_d);
@@ -3270,7 +3270,7 @@ RTLIL::Cell* RTLIL::Module::addAdlatchGate(RTLIL::IdString name, const RTLIL::Si
 RTLIL::Cell* RTLIL::Module::addDlatchsrGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
 		RTLIL::SigSpec sig_d, const RTLIL::SigSpec &sig_q, bool en_polarity, bool set_polarity, bool clr_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, stringf("$_DLATCHSR_%c%c%c_", en_polarity ? 'P' : 'N', set_polarity ? 'P' : 'N', clr_polarity ? 'P' : 'N'));
+	RTLIL::Cell *cell = addCell(name, stringf("$_DLATCHSR_%c%c%c_", en_polarity ? 'P' : 'N', set_polarity ? 'P' : 'N', clr_polarity ? 'P' : 'N'));
 	cell->setPort(ID::E, sig_en);
 	cell->setPort(ID::S, sig_set);
 	cell->setPort(ID::R, sig_clr);
@@ -3282,7 +3282,7 @@ RTLIL::Cell* RTLIL::Module::addDlatchsrGate(RTLIL::IdString name, const RTLIL::S
 
 RTLIL::Cell* RTLIL::Module::addAnyinit(RTLIL::IdString name, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($anyinit));
+	RTLIL::Cell *cell = addCell(name, ID($anyinit));
 	cell->parameters[ID::WIDTH] = sig_q.size();
 	cell->setPort(ID::D, sig_d);
 	cell->setPort(ID::Q, sig_q);
@@ -3380,7 +3380,7 @@ RTLIL::SigSpec RTLIL::Module::GetTag(RTLIL::IdString name, const std::string &ta
 
 RTLIL::Cell* RTLIL::Module::addOverwriteTag(RTLIL::IdString name, const std::string &tag, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_s, const RTLIL::SigSpec &sig_c, const std::string &src)
 {
-	RTLIL::OldCell *cell = addCell(name, ID($overwrite_tag));
+	RTLIL::Cell *cell = addCell(name, ID($overwrite_tag));
 	cell->parameters[ID::WIDTH] = sig_a.size();
 	cell->parameters[ID::TAG] = tag;
 	cell->setPort(ID::A, sig_a);

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -928,7 +928,6 @@ RTLIL::Module::Module()
 	design = nullptr;
 	refcount_wires_ = 0;
 	refcount_cells_ = 0;
-	TracyAllocN(this, sizeof(RTLIL::Module), "module");
 
 #ifdef WITH_PYTHON
 	RTLIL::Module::get_all_modules()->insert(std::pair<unsigned int, RTLIL::Module*>(hashidx_, this));
@@ -947,7 +946,6 @@ RTLIL::Module::~Module()
 		delete pr.second;
 	for (auto binding : bindings_)
 		delete binding;
-	TracyFree(this);
 #ifdef WITH_PYTHON
 	RTLIL::Module::get_all_modules()->erase(hashidx_);
 #endif
@@ -3460,17 +3458,11 @@ RTLIL::Memory::Memory()
 #endif
 }
 
-RTLIL::Process::~Process()
-{
-	TracyFree(this);
-}
-
 RTLIL::Process::Process() : module(nullptr)
 {
 	static unsigned int hashidx_count = 123456789;
 	hashidx_count = mkhash_xorshift(hashidx_count);
 	hashidx_ = hashidx_count;
-	TracyAllocN(this, sizeof(RTLIL::Process), "process");
 }
 
 RTLIL::Cell::Cell() : module(nullptr)

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -3580,22 +3580,6 @@ void RTLIL::Cell::setParam(const RTLIL::IdString &paramname, RTLIL::Const value)
 // 	}
 // }
 
-const RTLIL::Const& RTLIL::Cell::getParam(const RTLIL::IdString &paramname) {
-	if (is_legacy())
-		return legacy->getParam(paramname);
-
-	if (type == ID($not)) {
-		if (paramname == ID::A_WIDTH) {
-			return not_.a_width;
-		} else if (paramname == ID::Y_WIDTH) {
-			return not_.y_width;
-		} else {
-			throw std::out_of_range("Cell::getParam()");
-		}
-	} else {
-		throw std::out_of_range("Cell::getParam()");
-	}
-}
 const RTLIL::Const& RTLIL::Cell::getParam(const RTLIL::IdString &paramname) const {
 	if (is_legacy())
 		return legacy->getParam(paramname);

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -2473,7 +2473,9 @@ RTLIL::Cell *RTLIL::Module::morphCell(RTLIL::IdString type, RTLIL::Cell *old)
 	// 	old->type = type;
 	// 	return old;
 	// }
-	// TODO xtrace
+	if (old->type == type)
+		return old;
+
 	if (yosys_xtrace) {
 		log("#X# Morphing %s.%s from type %s to %s\n", log_id(this), log_id(old), log_id(old->type), log_id(type));
 		log_backtrace("-X- ", yosys_xtrace-1);
@@ -2487,7 +2489,7 @@ RTLIL::Cell *RTLIL::Module::morphCell(RTLIL::IdString type, RTLIL::Cell *old)
 	new_cell->name = old->name;
 	log_assert(refcount_cells_ == 0);
 	cells_[new_cell->name] = new_cell;
-	delete old;
+	remove(old);
 	return new_cell;
 }
 

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -2428,26 +2428,29 @@ RTLIL::Cell *RTLIL::Module::addCell(RTLIL::IdString name, RTLIL::IdString type)
 {
 	RTLIL::Cell *cell = new RTLIL::Cell;
 	// std::cout << "alloc " << (long long)cell << " called " << cell->name.c_str() << "\n";
+	cell->module = this;
 	cell->name = name;
 	cell->type = type;
 	if (RTLIL::Cell::is_legacy_type(type)) {
-		auto legOldCell = new RTLIL::OldCell;
-		legOldCell->name = name;
-		legOldCell->type = type;
+		std::cout << "new RTLIL::OldCell\n";
+		cell->legacy = new RTLIL::OldCell;
+		cell->legacy->name = name;
+		cell->legacy->type = type;
 	}
 	add(cell);
 	return cell;
 }
 
-// TODO ? brokey
-// RTLIL::Cell *RTLIL::Module::addCell(RTLIL::IdString name, const RTLIL::OldCell *other)
-// {
-// 	RTLIL::Cell *cell = addCell(name, other->type);
-// 	cell->connections_ = other->connections_;
-// 	cell->parameters = other->parameters;
-// 	cell->attributes = other->attributes;
-// 	return cell;
-// }
+RTLIL::Cell *RTLIL::Module::addCell(RTLIL::IdString name, const RTLIL::Cell *other)
+{
+	RTLIL::Cell *cell = addCell(name, other->type);
+	cell->module = this;
+	cell->connections_ = other->connections_;
+	cell->parameters = other->parameters;
+	cell->attributes = other->attributes;
+	add(cell);
+	return cell;
+}
 
 RTLIL::Memory *RTLIL::Module::addMemory(RTLIL::IdString name, const RTLIL::Memory *other)
 {
@@ -2493,9 +2496,9 @@ RTLIL::Process *RTLIL::Module::addProcess(RTLIL::IdString name, const RTLIL::Pro
 		add ## _func(name, sig_a, sig_y, is_signed, src);   \
 		return sig_y;                                       \
 	}
-// DEF_METHOD(Not,        sig_a.size(), ID($not))
-// DEF_METHOD(Pos,        sig_a.size(), ID($pos))
-// DEF_METHOD(Neg,        sig_a.size(), ID($neg))
+DEF_METHOD(Not,        sig_a.size(), ID($not))
+DEF_METHOD(Pos,        sig_a.size(), ID($pos))
+DEF_METHOD(Neg,        sig_a.size(), ID($neg))
 DEF_METHOD(ReduceAnd,  1, ID($reduce_and))
 DEF_METHOD(ReduceOr,   1, ID($reduce_or))
 DEF_METHOD(ReduceXor,  1, ID($reduce_xor))

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1018,13 +1018,13 @@ size_t RTLIL::Module::count_id(const RTLIL::IdString& id)
 
 #ifndef NDEBUG
 namespace {
-	struct InternalOldCellChecker
+	struct InternalCellChecker
 	{
 		RTLIL::Module *module;
 		RTLIL::Cell *cell;
 		pool<RTLIL::IdString> expected_params, expected_ports;
 
-		InternalOldCellChecker(RTLIL::Module *module, RTLIL::Cell *cell) : module(module), cell(cell) { }
+		InternalCellChecker(RTLIL::Module *module, RTLIL::Cell *cell) : module(module), cell(cell) { }
 
 		void error(int linenr)
 		{
@@ -1983,7 +1983,7 @@ void RTLIL::Module::check()
 		// 	log_assert(!it2.first.empty());
 		for (auto it2 : it.second->parameters)
 			log_assert(!it2.first.empty());
-		InternalOldCellChecker checker(this, it.second);
+		InternalCellChecker checker(this, it.second);
 		checker.check();
 		if (it.second->has_memid()) {
 			log_assert(memories.count(it.second->parameters.at(ID::MEMID).decode_string()));
@@ -3915,7 +3915,7 @@ void RTLIL::OldCell::sort()
 void RTLIL::Cell::check()
 {
 #ifndef NDEBUG
-	InternalOldCellChecker checker(NULL, this);
+	InternalCellChecker checker(NULL, this);
 	checker.check();
 #endif
 }

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -2458,6 +2458,7 @@ RTLIL::Cell *RTLIL::Module::addCell(RTLIL::IdString name, RTLIL::IdString type)
 
 RTLIL::Cell *RTLIL::Module::addCell(RTLIL::IdString name, const RTLIL::Cell *other)
 {
+	log_assert(other);
 	RTLIL::Cell *cell = addCell(name, other->type);
 	cell->connections_ = other->connections_;
 	cell->parameters = other->parameters;

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -2446,7 +2446,7 @@ RTLIL::Cell *RTLIL::Module::addCell(RTLIL::IdString name, RTLIL::IdString type)
 	log("ptr 0x%016X\n", cell);
 	cell->name = name;
 	cell->type = type;
-	scream("addCell pre", cell);
+	// scream("addCell pre", cell);
 	if (RTLIL::Cell::is_legacy_type(type)) {
 		cell->legacy = new RTLIL::OldCell;
 		cell->legacy->name = name;
@@ -2464,7 +2464,7 @@ RTLIL::Cell *RTLIL::Module::addCell(RTLIL::IdString name, RTLIL::IdString type)
 			new (&conn.second) SigSpec();
 		}
 	}
-	scream("addCell post", cell);
+	// scream("addCell post", cell);
 	add(cell);
 	return cell;
 }
@@ -3664,7 +3664,6 @@ void RTLIL::Cell::setParam(const RTLIL::IdString &paramname, RTLIL::Const value)
 }
 
 const RTLIL::Const& RTLIL::Cell::getParam(const RTLIL::IdString &paramname) const {
-	log_debug("paramname %s, type %s\n", paramname.c_str(), type.c_str());
 	if (is_legacy())
 		return legacy->getParam(paramname);
 	log_debug("fr");

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -3750,7 +3750,6 @@ void RTLIL::OldCell::sort()
 {
 	connections_.sort(sort_by_id_str());
 	parameters.sort(sort_by_id_str());
-	attributes.sort(sort_by_id_str());
 }
 
 void RTLIL::Cell::check()

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -3525,6 +3525,22 @@ const RTLIL::SigSpec &RTLIL::Cell::getPort(const RTLIL::IdString &portname) cons
 		throw std::out_of_range("Cell::setPort()");
 	}
 }
+const RTLIL::SigSpec &RTLIL::Cell::getPort(const RTLIL::IdString &portname) {
+	if (is_legacy())
+		return legacy->getPort(portname);
+
+	if (type == ID($not)) {
+		if (portname == ID::A) {
+			return not_.a;
+		} else if (portname == ID::Y) {
+			return not_.y;
+		} else {
+			throw std::out_of_range("Cell::setPort()");
+		}
+	} else {
+		throw std::out_of_range("Cell::setPort()");
+	}
+}
 
 // TODO autogen
 void RTLIL::Cell::setParam(const RTLIL::IdString &paramname, RTLIL::Const value) {

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <algorithm>
 #include <iostream>
+#include <iomanip>
 
 YOSYS_NAMESPACE_BEGIN
 
@@ -2424,6 +2425,20 @@ RTLIL::Wire *RTLIL::Module::addWire(RTLIL::IdString name, const RTLIL::Wire *oth
 	return wire;
 }
 
+template<typename AAAA>
+void scream(AAAA* aaa) {
+	unsigned char *ptr = reinterpret_cast<unsigned char*>(aaa);
+    for (size_t i = 0; i < sizeof(AAAA); ++i) {
+        std::cout << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(ptr[i]) << ' ';
+    }
+    std::cout << std::endl;
+}
+template<typename AAAA>
+void scream(const char* ctx, AAAA* aaa) {
+	log("%s\n", ctx);
+	scream(aaa); 
+}
+
 RTLIL::Cell *RTLIL::Module::addCell(RTLIL::IdString name, RTLIL::IdString type)
 {
 	RTLIL::Cell *cell = new RTLIL::Cell;
@@ -2431,6 +2446,7 @@ RTLIL::Cell *RTLIL::Module::addCell(RTLIL::IdString name, RTLIL::IdString type)
 	log("ptr 0x%016X\n", cell);
 	cell->name = name;
 	cell->type = type;
+	scream("addCell pre", cell);
 	if (RTLIL::Cell::is_legacy_type(type)) {
 		cell->legacy = new RTLIL::OldCell;
 		cell->legacy->name = name;
@@ -2448,6 +2464,7 @@ RTLIL::Cell *RTLIL::Module::addCell(RTLIL::IdString name, RTLIL::IdString type)
 			new (&conn.second) SigSpec();
 		}
 	}
+	scream("addCell post", cell);
 	add(cell);
 	return cell;
 }

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1087,7 +1087,7 @@ namespace {
 
 		void check_expected(bool check_matched_sign = false)
 		{
-			for (auto &&para : cell->parameters)
+			for (auto para : cell->parameters)
 				if (expected_params.count(para.first) == 0)
 					error(__LINE__);
 			for (auto conn : cell->connections_)
@@ -1973,14 +1973,14 @@ void RTLIL::Module::check()
 		log_assert(it.first == it.second->name);
 		log_assert(!it.first.empty());
 		log_assert(!it.second->type.empty());
-		for (auto &&it2 : it.second->connections_) {
+		for (auto it2 : it.second->connections_) {
 			log_assert(!it2.first.empty());
 			it2.second.check(this);
 		}
 		// TODO
 		// for (auto &&it2 : it.second->attributes)
 		// 	log_assert(!it2.first.empty());
-		for (auto &&it2 : it.second->parameters)
+		for (auto it2 : it.second->parameters)
 			log_assert(!it2.first.empty());
 		InternalOldCellChecker checker(this, it.second);
 		checker.check();
@@ -2493,9 +2493,9 @@ RTLIL::Process *RTLIL::Module::addProcess(RTLIL::IdString name, const RTLIL::Pro
 		add ## _func(name, sig_a, sig_y, is_signed, src);   \
 		return sig_y;                                       \
 	}
-DEF_METHOD(Not,        sig_a.size(), ID($not))
-DEF_METHOD(Pos,        sig_a.size(), ID($pos))
-DEF_METHOD(Neg,        sig_a.size(), ID($neg))
+// DEF_METHOD(Not,        sig_a.size(), ID($not))
+// DEF_METHOD(Pos,        sig_a.size(), ID($pos))
+// DEF_METHOD(Neg,        sig_a.size(), ID($neg))
 DEF_METHOD(ReduceAnd,  1, ID($reduce_and))
 DEF_METHOD(ReduceOr,   1, ID($reduce_or))
 DEF_METHOD(ReduceXor,  1, ID($reduce_xor))

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1090,7 +1090,7 @@ namespace {
 			for (auto &&para : cell->parameters)
 				if (expected_params.count(para.first) == 0)
 					error(__LINE__);
-			for (auto &&conn : cell->connections_)
+			for (auto conn : cell->connections_)
 				if (expected_ports.count(conn.first) == 0)
 					error(__LINE__);
 

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -2063,7 +2063,7 @@ void RTLIL::Module::cloneInto(RTLIL::Module *new_mod) const
 		new_mod->addMemory(it.first, it.second);
 
 	for (auto &it : cells_)
-		new_mod->addOldCell(it.first, it.second);
+		new_mod->addCell(it.first, it.second);
 
 	for (auto &it : processes)
 		new_mod->addProcess(it.first, it.second);
@@ -2421,7 +2421,7 @@ RTLIL::Wire *RTLIL::Module::addWire(RTLIL::IdString name, const RTLIL::Wire *oth
 	return wire;
 }
 
-RTLIL::Cell *RTLIL::Module::addOldCell(RTLIL::IdString name, RTLIL::IdString type)
+RTLIL::Cell *RTLIL::Module::addCell(RTLIL::IdString name, RTLIL::IdString type)
 {
 	RTLIL::Cell *cell = new RTLIL::Cell;
 	// std::cout << "alloc " << (long long)cell << " called " << cell->name.c_str() << "\n";
@@ -2436,9 +2436,9 @@ RTLIL::Cell *RTLIL::Module::addOldCell(RTLIL::IdString name, RTLIL::IdString typ
 	return cell;
 }
 
-RTLIL::Cell *RTLIL::Module::addOldCell(RTLIL::IdString name, const RTLIL::OldCell *other)
+RTLIL::Cell *RTLIL::Module::addCell(RTLIL::IdString name, const RTLIL::OldCell *other)
 {
-	RTLIL::Cell *cell = addOldCell(name, other->type);
+	RTLIL::Cell *cell = addCell(name, other->type);
 	cell->connections_ = other->connections_;
 	cell->parameters = other->parameters;
 	cell->attributes = other->attributes;
@@ -2474,8 +2474,8 @@ RTLIL::Process *RTLIL::Module::addProcess(RTLIL::IdString name, const RTLIL::Pro
 }
 
 #define DEF_METHOD(_func, _y_size, _type) \
-	RTLIL::OldCell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_y, bool is_signed, const std::string &src) { \
-		RTLIL::OldCell *cell = addOldCell(name, _type);           \
+	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_y, bool is_signed, const std::string &src) { \
+		RTLIL::OldCell *cell = addCell(name, _type);           \
 		cell->parameters[ID::A_SIGNED] = is_signed;         \
 		cell->parameters[ID::A_WIDTH] = sig_a.size();       \
 		cell->parameters[ID::Y_WIDTH] = sig_y.size();       \
@@ -2501,8 +2501,8 @@ DEF_METHOD(LogicNot,   1, ID($logic_not))
 #undef DEF_METHOD
 
 #define DEF_METHOD(_func, _y_size, _type) \
-	RTLIL::OldCell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, bool is_signed, const std::string &src) { \
-		RTLIL::OldCell *cell = addOldCell(name, _type);           \
+	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, bool is_signed, const std::string &src) { \
+		RTLIL::OldCell *cell = addCell(name, _type);           \
 		cell->parameters[ID::A_SIGNED] = is_signed;         \
 		cell->parameters[ID::B_SIGNED] = is_signed;         \
 		cell->parameters[ID::A_WIDTH] = sig_a.size();       \
@@ -2545,8 +2545,8 @@ DEF_METHOD(LogicOr,  1, ID($logic_or))
 #undef DEF_METHOD
 
 #define DEF_METHOD(_func, _y_size, _type) \
-	RTLIL::OldCell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, bool is_signed, const std::string &src) { \
-		RTLIL::OldCell *cell = addOldCell(name, _type);           \
+	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, bool is_signed, const std::string &src) { \
+		RTLIL::OldCell *cell = addCell(name, _type);           \
 		cell->parameters[ID::A_SIGNED] = is_signed;         \
 		cell->parameters[ID::B_SIGNED] = false;             \
 		cell->parameters[ID::A_WIDTH] = sig_a.size();       \
@@ -2570,8 +2570,8 @@ DEF_METHOD(Sshr,     sig_a.size(), ID($sshr))
 #undef DEF_METHOD
 
 #define DEF_METHOD(_func, _type, _pmux) \
-	RTLIL::OldCell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_s, const RTLIL::SigSpec &sig_y, const std::string &src) { \
-		RTLIL::OldCell *cell = addOldCell(name, _type);                 \
+	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_s, const RTLIL::SigSpec &sig_y, const std::string &src) { \
+		RTLIL::OldCell *cell = addCell(name, _type);                 \
 		cell->parameters[ID::WIDTH] = sig_a.size();               \
 		if (_pmux) cell->parameters[ID::S_WIDTH] = sig_s.size();  \
 		cell->setPort(ID::A, sig_a);                              \
@@ -2592,8 +2592,8 @@ DEF_METHOD(Pmux,     ID($pmux),       1)
 #undef DEF_METHOD
 
 #define DEF_METHOD(_func, _type, _demux) \
-	RTLIL::OldCell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_s, const RTLIL::SigSpec &sig_y, const std::string &src) { \
-		RTLIL::OldCell *cell = addOldCell(name, _type);                 \
+	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_s, const RTLIL::SigSpec &sig_y, const std::string &src) { \
+		RTLIL::OldCell *cell = addCell(name, _type);                 \
 		cell->parameters[ID::WIDTH] = _demux ? sig_a.size() : sig_y.size(); \
 		cell->parameters[ID::S_WIDTH] = sig_s.size();             \
 		cell->setPort(ID::A, sig_a);                              \
@@ -2612,8 +2612,8 @@ DEF_METHOD(Demux,    ID($demux),      1)
 #undef DEF_METHOD
 
 #define DEF_METHOD(_func, _type) \
-	RTLIL::OldCell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, const std::string &src) { \
-		RTLIL::OldCell *cell = addOldCell(name, _type);                 \
+	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, const std::string &src) { \
+		RTLIL::OldCell *cell = addCell(name, _type);                 \
 		cell->parameters[ID::WIDTH] = sig_a.size();               \
 		cell->setPort(ID::A, sig_a);                              \
 		cell->setPort(ID::B, sig_b);                              \
@@ -2630,8 +2630,8 @@ DEF_METHOD(Bweqx,    ID($bweqx))
 #undef DEF_METHOD
 
 #define DEF_METHOD_2(_func, _type, _P1, _P2) \
-	RTLIL::OldCell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigBit &sig1, const RTLIL::SigBit &sig2, const std::string &src) { \
-		RTLIL::OldCell *cell = addOldCell(name, _type);         \
+	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigBit &sig1, const RTLIL::SigBit &sig2, const std::string &src) { \
+		RTLIL::OldCell *cell = addCell(name, _type);         \
 		cell->setPort("\\" #_P1, sig1);                   \
 		cell->setPort("\\" #_P2, sig2);                   \
 		cell->set_src_attribute(src);                     \
@@ -2643,8 +2643,8 @@ DEF_METHOD(Bweqx,    ID($bweqx))
 		return sig2;                                      \
 	}
 #define DEF_METHOD_3(_func, _type, _P1, _P2, _P3) \
-	RTLIL::OldCell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigBit &sig1, const RTLIL::SigBit &sig2, const RTLIL::SigBit &sig3, const std::string &src) { \
-		RTLIL::OldCell *cell = addOldCell(name, _type);         \
+	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigBit &sig1, const RTLIL::SigBit &sig2, const RTLIL::SigBit &sig3, const std::string &src) { \
+		RTLIL::OldCell *cell = addCell(name, _type);         \
 		cell->setPort("\\" #_P1, sig1);                   \
 		cell->setPort("\\" #_P2, sig2);                   \
 		cell->setPort("\\" #_P3, sig3);                   \
@@ -2657,8 +2657,8 @@ DEF_METHOD(Bweqx,    ID($bweqx))
 		return sig3;                                      \
 	}
 #define DEF_METHOD_4(_func, _type, _P1, _P2, _P3, _P4) \
-	RTLIL::OldCell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigBit &sig1, const RTLIL::SigBit &sig2, const RTLIL::SigBit &sig3, const RTLIL::SigBit &sig4, const std::string &src) { \
-		RTLIL::OldCell *cell = addOldCell(name, _type);         \
+	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigBit &sig1, const RTLIL::SigBit &sig2, const RTLIL::SigBit &sig3, const RTLIL::SigBit &sig4, const std::string &src) { \
+		RTLIL::OldCell *cell = addCell(name, _type);         \
 		cell->setPort("\\" #_P1, sig1);                   \
 		cell->setPort("\\" #_P2, sig2);                   \
 		cell->setPort("\\" #_P3, sig3);                   \
@@ -2672,8 +2672,8 @@ DEF_METHOD(Bweqx,    ID($bweqx))
 		return sig4;                                      \
 	}
 #define DEF_METHOD_5(_func, _type, _P1, _P2, _P3, _P4, _P5) \
-	RTLIL::OldCell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigBit &sig1, const RTLIL::SigBit &sig2, const RTLIL::SigBit &sig3, const RTLIL::SigBit &sig4, const RTLIL::SigBit &sig5, const std::string &src) { \
-		RTLIL::OldCell *cell = addOldCell(name, _type);         \
+	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, const RTLIL::SigBit &sig1, const RTLIL::SigBit &sig2, const RTLIL::SigBit &sig3, const RTLIL::SigBit &sig4, const RTLIL::SigBit &sig5, const std::string &src) { \
+		RTLIL::OldCell *cell = addCell(name, _type);         \
 		cell->setPort("\\" #_P1, sig1);                   \
 		cell->setPort("\\" #_P2, sig2);                   \
 		cell->setPort("\\" #_P3, sig3);                   \
@@ -2708,9 +2708,9 @@ DEF_METHOD_5(Oai4Gate,   ID($_OAI4_),   A, B, C, D, Y)
 #undef DEF_METHOD_4
 #undef DEF_METHOD_5
 
-RTLIL::OldCell* RTLIL::Module::addPow(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, bool a_signed, bool b_signed, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addPow(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, bool a_signed, bool b_signed, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($pow));
+	RTLIL::OldCell *cell = addCell(name, ID($pow));
 	cell->parameters[ID::A_SIGNED] = a_signed;
 	cell->parameters[ID::B_SIGNED] = b_signed;
 	cell->parameters[ID::A_WIDTH] = sig_a.size();
@@ -2723,9 +2723,9 @@ RTLIL::OldCell* RTLIL::Module::addPow(RTLIL::IdString name, const RTLIL::SigSpec
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addFa(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_c, const RTLIL::SigSpec &sig_x, const RTLIL::SigSpec &sig_y, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addFa(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_c, const RTLIL::SigSpec &sig_x, const RTLIL::SigSpec &sig_y, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($fa));
+	RTLIL::OldCell *cell = addCell(name, ID($fa));
 	cell->parameters[ID::WIDTH] = sig_a.size();
 	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID::B, sig_b);
@@ -2736,9 +2736,9 @@ RTLIL::OldCell* RTLIL::Module::addFa(RTLIL::IdString name, const RTLIL::SigSpec 
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addSlice(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_y, RTLIL::Const offset, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addSlice(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_y, RTLIL::Const offset, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($slice));
+	RTLIL::OldCell *cell = addCell(name, ID($slice));
 	cell->parameters[ID::A_WIDTH] = sig_a.size();
 	cell->parameters[ID::Y_WIDTH] = sig_y.size();
 	cell->parameters[ID::OFFSET] = offset;
@@ -2748,9 +2748,9 @@ RTLIL::OldCell* RTLIL::Module::addSlice(RTLIL::IdString name, const RTLIL::SigSp
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addConcat(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addConcat(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($concat));
+	RTLIL::OldCell *cell = addCell(name, ID($concat));
 	cell->parameters[ID::A_WIDTH] = sig_a.size();
 	cell->parameters[ID::B_WIDTH] = sig_b.size();
 	cell->setPort(ID::A, sig_a);
@@ -2760,9 +2760,9 @@ RTLIL::OldCell* RTLIL::Module::addConcat(RTLIL::IdString name, const RTLIL::SigS
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addLut(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_y, RTLIL::Const lut, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addLut(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_y, RTLIL::Const lut, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($lut));
+	RTLIL::OldCell *cell = addCell(name, ID($lut));
 	cell->parameters[ID::LUT] = lut;
 	cell->parameters[ID::WIDTH] = sig_a.size();
 	cell->setPort(ID::A, sig_a);
@@ -2771,9 +2771,9 @@ RTLIL::OldCell* RTLIL::Module::addLut(RTLIL::IdString name, const RTLIL::SigSpec
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addTribuf(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_y, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addTribuf(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_y, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($tribuf));
+	RTLIL::OldCell *cell = addCell(name, ID($tribuf));
 	cell->parameters[ID::WIDTH] = sig_a.size();
 	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID::EN, sig_en);
@@ -2782,54 +2782,54 @@ RTLIL::OldCell* RTLIL::Module::addTribuf(RTLIL::IdString name, const RTLIL::SigS
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addAssert(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_en, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addAssert(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_en, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($assert));
+	RTLIL::OldCell *cell = addCell(name, ID($assert));
 	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID::EN, sig_en);
 	cell->set_src_attribute(src);
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addAssume(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_en, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addAssume(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_en, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($assume));
+	RTLIL::OldCell *cell = addCell(name, ID($assume));
 	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID::EN, sig_en);
 	cell->set_src_attribute(src);
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addLive(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_en, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addLive(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_en, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($live));
+	RTLIL::OldCell *cell = addCell(name, ID($live));
 	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID::EN, sig_en);
 	cell->set_src_attribute(src);
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addFair(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_en, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addFair(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_en, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($fair));
+	RTLIL::OldCell *cell = addCell(name, ID($fair));
 	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID::EN, sig_en);
 	cell->set_src_attribute(src);
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addCover(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_en, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addCover(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_en, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($cover));
+	RTLIL::OldCell *cell = addCell(name, ID($cover));
 	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID::EN, sig_en);
 	cell->set_src_attribute(src);
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addEquiv(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addEquiv(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($equiv));
+	RTLIL::OldCell *cell = addCell(name, ID($equiv));
 	cell->setPort(ID::A, sig_a);
 	cell->setPort(ID::B, sig_b);
 	cell->setPort(ID::Y, sig_y);
@@ -2837,9 +2837,9 @@ RTLIL::OldCell* RTLIL::Module::addEquiv(RTLIL::IdString name, const RTLIL::SigSp
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addSr(RTLIL::IdString name, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr, const RTLIL::SigSpec &sig_q, bool set_polarity, bool clr_polarity, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addSr(RTLIL::IdString name, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr, const RTLIL::SigSpec &sig_q, bool set_polarity, bool clr_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($sr));
+	RTLIL::OldCell *cell = addCell(name, ID($sr));
 	cell->parameters[ID::SET_POLARITY] = set_polarity;
 	cell->parameters[ID::CLR_POLARITY] = clr_polarity;
 	cell->parameters[ID::WIDTH] = sig_q.size();
@@ -2850,9 +2850,9 @@ RTLIL::OldCell* RTLIL::Module::addSr(RTLIL::IdString name, const RTLIL::SigSpec 
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addFf(RTLIL::IdString name, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addFf(RTLIL::IdString name, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($ff));
+	RTLIL::OldCell *cell = addCell(name, ID($ff));
 	cell->parameters[ID::WIDTH] = sig_q.size();
 	cell->setPort(ID::D, sig_d);
 	cell->setPort(ID::Q, sig_q);
@@ -2860,9 +2860,9 @@ RTLIL::OldCell* RTLIL::Module::addFf(RTLIL::IdString name, const RTLIL::SigSpec 
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addDff(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addDff(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($dff));
+	RTLIL::OldCell *cell = addCell(name, ID($dff));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::WIDTH] = sig_q.size();
 	cell->setPort(ID::CLK, sig_clk);
@@ -2872,9 +2872,9 @@ RTLIL::OldCell* RTLIL::Module::addDff(RTLIL::IdString name, const RTLIL::SigSpec
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addDffe(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, bool en_polarity, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addDffe(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, bool en_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($dffe));
+	RTLIL::OldCell *cell = addCell(name, ID($dffe));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::EN_POLARITY] = en_polarity;
 	cell->parameters[ID::WIDTH] = sig_q.size();
@@ -2886,10 +2886,10 @@ RTLIL::OldCell* RTLIL::Module::addDffe(RTLIL::IdString name, const RTLIL::SigSpe
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addDffsr(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
+RTLIL::Cell* RTLIL::Module::addDffsr(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
 		RTLIL::SigSpec sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, bool set_polarity, bool clr_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($dffsr));
+	RTLIL::OldCell *cell = addCell(name, ID($dffsr));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::SET_POLARITY] = set_polarity;
 	cell->parameters[ID::CLR_POLARITY] = clr_polarity;
@@ -2903,10 +2903,10 @@ RTLIL::OldCell* RTLIL::Module::addDffsr(RTLIL::IdString name, const RTLIL::SigSp
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addDffsre(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
+RTLIL::Cell* RTLIL::Module::addDffsre(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
 		RTLIL::SigSpec sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, bool en_polarity, bool set_polarity, bool clr_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($dffsre));
+	RTLIL::OldCell *cell = addCell(name, ID($dffsre));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::EN_POLARITY] = en_polarity;
 	cell->parameters[ID::SET_POLARITY] = set_polarity;
@@ -2922,10 +2922,10 @@ RTLIL::OldCell* RTLIL::Module::addDffsre(RTLIL::IdString name, const RTLIL::SigS
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addAdff(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_arst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
+RTLIL::Cell* RTLIL::Module::addAdff(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_arst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		RTLIL::Const arst_value, bool clk_polarity, bool arst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($adff));
+	RTLIL::OldCell *cell = addCell(name, ID($adff));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::ARST_POLARITY] = arst_polarity;
 	cell->parameters[ID::ARST_VALUE] = arst_value;
@@ -2938,10 +2938,10 @@ RTLIL::OldCell* RTLIL::Module::addAdff(RTLIL::IdString name, const RTLIL::SigSpe
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addAdffe(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_arst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
+RTLIL::Cell* RTLIL::Module::addAdffe(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_arst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		RTLIL::Const arst_value, bool clk_polarity, bool en_polarity, bool arst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($adffe));
+	RTLIL::OldCell *cell = addCell(name, ID($adffe));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::EN_POLARITY] = en_polarity;
 	cell->parameters[ID::ARST_POLARITY] = arst_polarity;
@@ -2956,10 +2956,10 @@ RTLIL::OldCell* RTLIL::Module::addAdffe(RTLIL::IdString name, const RTLIL::SigSp
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addAldff(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_aload, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
+RTLIL::Cell* RTLIL::Module::addAldff(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_aload, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		const RTLIL::SigSpec &sig_ad, bool clk_polarity, bool aload_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($aldff));
+	RTLIL::OldCell *cell = addCell(name, ID($aldff));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::ALOAD_POLARITY] = aload_polarity;
 	cell->parameters[ID::WIDTH] = sig_q.size();
@@ -2972,10 +2972,10 @@ RTLIL::OldCell* RTLIL::Module::addAldff(RTLIL::IdString name, const RTLIL::SigSp
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addAldffe(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_aload, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
+RTLIL::Cell* RTLIL::Module::addAldffe(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_aload, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		const RTLIL::SigSpec &sig_ad, bool clk_polarity, bool en_polarity, bool aload_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($aldffe));
+	RTLIL::OldCell *cell = addCell(name, ID($aldffe));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::EN_POLARITY] = en_polarity;
 	cell->parameters[ID::ALOAD_POLARITY] = aload_polarity;
@@ -2990,10 +2990,10 @@ RTLIL::OldCell* RTLIL::Module::addAldffe(RTLIL::IdString name, const RTLIL::SigS
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addSdff(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_srst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
+RTLIL::Cell* RTLIL::Module::addSdff(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_srst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		RTLIL::Const srst_value, bool clk_polarity, bool srst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($sdff));
+	RTLIL::OldCell *cell = addCell(name, ID($sdff));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::SRST_POLARITY] = srst_polarity;
 	cell->parameters[ID::SRST_VALUE] = srst_value;
@@ -3006,10 +3006,10 @@ RTLIL::OldCell* RTLIL::Module::addSdff(RTLIL::IdString name, const RTLIL::SigSpe
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addSdffe(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_srst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
+RTLIL::Cell* RTLIL::Module::addSdffe(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_srst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		RTLIL::Const srst_value, bool clk_polarity, bool en_polarity, bool srst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($sdffe));
+	RTLIL::OldCell *cell = addCell(name, ID($sdffe));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::EN_POLARITY] = en_polarity;
 	cell->parameters[ID::SRST_POLARITY] = srst_polarity;
@@ -3024,10 +3024,10 @@ RTLIL::OldCell* RTLIL::Module::addSdffe(RTLIL::IdString name, const RTLIL::SigSp
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addSdffce(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_srst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
+RTLIL::Cell* RTLIL::Module::addSdffce(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_srst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		RTLIL::Const srst_value, bool clk_polarity, bool en_polarity, bool srst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($sdffce));
+	RTLIL::OldCell *cell = addCell(name, ID($sdffce));
 	cell->parameters[ID::CLK_POLARITY] = clk_polarity;
 	cell->parameters[ID::EN_POLARITY] = en_polarity;
 	cell->parameters[ID::SRST_POLARITY] = srst_polarity;
@@ -3042,9 +3042,9 @@ RTLIL::OldCell* RTLIL::Module::addSdffce(RTLIL::IdString name, const RTLIL::SigS
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addDlatch(RTLIL::IdString name, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, bool en_polarity, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addDlatch(RTLIL::IdString name, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, bool en_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($dlatch));
+	RTLIL::OldCell *cell = addCell(name, ID($dlatch));
 	cell->parameters[ID::EN_POLARITY] = en_polarity;
 	cell->parameters[ID::WIDTH] = sig_q.size();
 	cell->setPort(ID::EN, sig_en);
@@ -3054,10 +3054,10 @@ RTLIL::OldCell* RTLIL::Module::addDlatch(RTLIL::IdString name, const RTLIL::SigS
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addAdlatch(RTLIL::IdString name, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_arst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
+RTLIL::Cell* RTLIL::Module::addAdlatch(RTLIL::IdString name, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_arst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		RTLIL::Const arst_value, bool en_polarity, bool arst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($adlatch));
+	RTLIL::OldCell *cell = addCell(name, ID($adlatch));
 	cell->parameters[ID::EN_POLARITY] = en_polarity;
 	cell->parameters[ID::ARST_POLARITY] = arst_polarity;
 	cell->parameters[ID::ARST_VALUE] = arst_value;
@@ -3070,10 +3070,10 @@ RTLIL::OldCell* RTLIL::Module::addAdlatch(RTLIL::IdString name, const RTLIL::Sig
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addDlatchsr(RTLIL::IdString name, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
+RTLIL::Cell* RTLIL::Module::addDlatchsr(RTLIL::IdString name, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
 		RTLIL::SigSpec sig_d, const RTLIL::SigSpec &sig_q, bool en_polarity, bool set_polarity, bool clr_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($dlatchsr));
+	RTLIL::OldCell *cell = addCell(name, ID($dlatchsr));
 	cell->parameters[ID::EN_POLARITY] = en_polarity;
 	cell->parameters[ID::SET_POLARITY] = set_polarity;
 	cell->parameters[ID::CLR_POLARITY] = clr_polarity;
@@ -3087,10 +3087,10 @@ RTLIL::OldCell* RTLIL::Module::addDlatchsr(RTLIL::IdString name, const RTLIL::Si
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addSrGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
+RTLIL::Cell* RTLIL::Module::addSrGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
 		const RTLIL::SigSpec &sig_q, bool set_polarity, bool clr_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, stringf("$_SR_%c%c_", set_polarity ? 'P' : 'N', clr_polarity ? 'P' : 'N'));
+	RTLIL::OldCell *cell = addCell(name, stringf("$_SR_%c%c_", set_polarity ? 'P' : 'N', clr_polarity ? 'P' : 'N'));
 	cell->setPort(ID::S, sig_set);
 	cell->setPort(ID::R, sig_clr);
 	cell->setPort(ID::Q, sig_q);
@@ -3098,18 +3098,18 @@ RTLIL::OldCell* RTLIL::Module::addSrGate(RTLIL::IdString name, const RTLIL::SigS
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addFfGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addFfGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($_FF_));
+	RTLIL::OldCell *cell = addCell(name, ID($_FF_));
 	cell->setPort(ID::D, sig_d);
 	cell->setPort(ID::Q, sig_q);
 	cell->set_src_attribute(src);
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addDffGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addDffGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, stringf("$_DFF_%c_", clk_polarity ? 'P' : 'N'));
+	RTLIL::OldCell *cell = addCell(name, stringf("$_DFF_%c_", clk_polarity ? 'P' : 'N'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::D, sig_d);
 	cell->setPort(ID::Q, sig_q);
@@ -3117,9 +3117,9 @@ RTLIL::OldCell* RTLIL::Module::addDffGate(RTLIL::IdString name, const RTLIL::Sig
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addDffeGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, bool en_polarity, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addDffeGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, bool en_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, stringf("$_DFFE_%c%c_", clk_polarity ? 'P' : 'N', en_polarity ? 'P' : 'N'));
+	RTLIL::OldCell *cell = addCell(name, stringf("$_DFFE_%c%c_", clk_polarity ? 'P' : 'N', en_polarity ? 'P' : 'N'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::E, sig_en);
 	cell->setPort(ID::D, sig_d);
@@ -3128,10 +3128,10 @@ RTLIL::OldCell* RTLIL::Module::addDffeGate(RTLIL::IdString name, const RTLIL::Si
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addDffsrGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
+RTLIL::Cell* RTLIL::Module::addDffsrGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
 		RTLIL::SigSpec sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, bool set_polarity, bool clr_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, stringf("$_DFFSR_%c%c%c_", clk_polarity ? 'P' : 'N', set_polarity ? 'P' : 'N', clr_polarity ? 'P' : 'N'));
+	RTLIL::OldCell *cell = addCell(name, stringf("$_DFFSR_%c%c%c_", clk_polarity ? 'P' : 'N', set_polarity ? 'P' : 'N', clr_polarity ? 'P' : 'N'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::S, sig_set);
 	cell->setPort(ID::R, sig_clr);
@@ -3141,10 +3141,10 @@ RTLIL::OldCell* RTLIL::Module::addDffsrGate(RTLIL::IdString name, const RTLIL::S
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addDffsreGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
+RTLIL::Cell* RTLIL::Module::addDffsreGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
 		RTLIL::SigSpec sig_d, const RTLIL::SigSpec &sig_q, bool clk_polarity, bool en_polarity, bool set_polarity, bool clr_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, stringf("$_DFFSRE_%c%c%c%c_", clk_polarity ? 'P' : 'N', set_polarity ? 'P' : 'N', clr_polarity ? 'P' : 'N', en_polarity ? 'P' : 'N'));
+	RTLIL::OldCell *cell = addCell(name, stringf("$_DFFSRE_%c%c%c%c_", clk_polarity ? 'P' : 'N', set_polarity ? 'P' : 'N', clr_polarity ? 'P' : 'N', en_polarity ? 'P' : 'N'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::S, sig_set);
 	cell->setPort(ID::R, sig_clr);
@@ -3155,10 +3155,10 @@ RTLIL::OldCell* RTLIL::Module::addDffsreGate(RTLIL::IdString name, const RTLIL::
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addAdffGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_arst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
+RTLIL::Cell* RTLIL::Module::addAdffGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_arst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		bool arst_value, bool clk_polarity, bool arst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, stringf("$_DFF_%c%c%c_", clk_polarity ? 'P' : 'N', arst_polarity ? 'P' : 'N', arst_value ? '1' : '0'));
+	RTLIL::OldCell *cell = addCell(name, stringf("$_DFF_%c%c%c_", clk_polarity ? 'P' : 'N', arst_polarity ? 'P' : 'N', arst_value ? '1' : '0'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::R, sig_arst);
 	cell->setPort(ID::D, sig_d);
@@ -3167,10 +3167,10 @@ RTLIL::OldCell* RTLIL::Module::addAdffGate(RTLIL::IdString name, const RTLIL::Si
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addAdffeGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_arst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
+RTLIL::Cell* RTLIL::Module::addAdffeGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_arst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		bool arst_value, bool clk_polarity, bool en_polarity, bool arst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, stringf("$_DFFE_%c%c%c%c_", clk_polarity ? 'P' : 'N', arst_polarity ? 'P' : 'N', arst_value ? '1' : '0', en_polarity ? 'P' : 'N'));
+	RTLIL::OldCell *cell = addCell(name, stringf("$_DFFE_%c%c%c%c_", clk_polarity ? 'P' : 'N', arst_polarity ? 'P' : 'N', arst_value ? '1' : '0', en_polarity ? 'P' : 'N'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::R, sig_arst);
 	cell->setPort(ID::E, sig_en);
@@ -3180,10 +3180,10 @@ RTLIL::OldCell* RTLIL::Module::addAdffeGate(RTLIL::IdString name, const RTLIL::S
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addAldffGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_aload, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
+RTLIL::Cell* RTLIL::Module::addAldffGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_aload, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		const RTLIL::SigSpec &sig_ad, bool clk_polarity, bool aload_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, stringf("$_ALDFF_%c%c_", clk_polarity ? 'P' : 'N', aload_polarity ? 'P' : 'N'));
+	RTLIL::OldCell *cell = addCell(name, stringf("$_ALDFF_%c%c_", clk_polarity ? 'P' : 'N', aload_polarity ? 'P' : 'N'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::L, sig_aload);
 	cell->setPort(ID::D, sig_d);
@@ -3193,10 +3193,10 @@ RTLIL::OldCell* RTLIL::Module::addAldffGate(RTLIL::IdString name, const RTLIL::S
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addAldffeGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_aload, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
+RTLIL::Cell* RTLIL::Module::addAldffeGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_aload, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		const RTLIL::SigSpec &sig_ad, bool clk_polarity, bool en_polarity, bool aload_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, stringf("$_ALDFFE_%c%c%c_", clk_polarity ? 'P' : 'N', aload_polarity ? 'P' : 'N', en_polarity ? 'P' : 'N'));
+	RTLIL::OldCell *cell = addCell(name, stringf("$_ALDFFE_%c%c%c_", clk_polarity ? 'P' : 'N', aload_polarity ? 'P' : 'N', en_polarity ? 'P' : 'N'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::L, sig_aload);
 	cell->setPort(ID::E, sig_en);
@@ -3207,10 +3207,10 @@ RTLIL::OldCell* RTLIL::Module::addAldffeGate(RTLIL::IdString name, const RTLIL::
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addSdffGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_srst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
+RTLIL::Cell* RTLIL::Module::addSdffGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_srst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		bool srst_value, bool clk_polarity, bool srst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, stringf("$_SDFF_%c%c%c_", clk_polarity ? 'P' : 'N', srst_polarity ? 'P' : 'N', srst_value ? '1' : '0'));
+	RTLIL::OldCell *cell = addCell(name, stringf("$_SDFF_%c%c%c_", clk_polarity ? 'P' : 'N', srst_polarity ? 'P' : 'N', srst_value ? '1' : '0'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::R, sig_srst);
 	cell->setPort(ID::D, sig_d);
@@ -3219,10 +3219,10 @@ RTLIL::OldCell* RTLIL::Module::addSdffGate(RTLIL::IdString name, const RTLIL::Si
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addSdffeGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_srst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
+RTLIL::Cell* RTLIL::Module::addSdffeGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_srst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		bool srst_value, bool clk_polarity, bool en_polarity, bool srst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, stringf("$_SDFFE_%c%c%c%c_", clk_polarity ? 'P' : 'N', srst_polarity ? 'P' : 'N', srst_value ? '1' : '0', en_polarity ? 'P' : 'N'));
+	RTLIL::OldCell *cell = addCell(name, stringf("$_SDFFE_%c%c%c%c_", clk_polarity ? 'P' : 'N', srst_polarity ? 'P' : 'N', srst_value ? '1' : '0', en_polarity ? 'P' : 'N'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::R, sig_srst);
 	cell->setPort(ID::E, sig_en);
@@ -3232,10 +3232,10 @@ RTLIL::OldCell* RTLIL::Module::addSdffeGate(RTLIL::IdString name, const RTLIL::S
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addSdffceGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_srst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
+RTLIL::Cell* RTLIL::Module::addSdffceGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_clk, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_srst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		bool srst_value, bool clk_polarity, bool en_polarity, bool srst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, stringf("$_SDFFCE_%c%c%c%c_", clk_polarity ? 'P' : 'N', srst_polarity ? 'P' : 'N', srst_value ? '1' : '0', en_polarity ? 'P' : 'N'));
+	RTLIL::OldCell *cell = addCell(name, stringf("$_SDFFCE_%c%c%c%c_", clk_polarity ? 'P' : 'N', srst_polarity ? 'P' : 'N', srst_value ? '1' : '0', en_polarity ? 'P' : 'N'));
 	cell->setPort(ID::C, sig_clk);
 	cell->setPort(ID::R, sig_srst);
 	cell->setPort(ID::E, sig_en);
@@ -3245,9 +3245,9 @@ RTLIL::OldCell* RTLIL::Module::addSdffceGate(RTLIL::IdString name, const RTLIL::
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addDlatchGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, bool en_polarity, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addDlatchGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, bool en_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, stringf("$_DLATCH_%c_", en_polarity ? 'P' : 'N'));
+	RTLIL::OldCell *cell = addCell(name, stringf("$_DLATCH_%c_", en_polarity ? 'P' : 'N'));
 	cell->setPort(ID::E, sig_en);
 	cell->setPort(ID::D, sig_d);
 	cell->setPort(ID::Q, sig_q);
@@ -3255,10 +3255,10 @@ RTLIL::OldCell* RTLIL::Module::addDlatchGate(RTLIL::IdString name, const RTLIL::
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addAdlatchGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_arst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
+RTLIL::Cell* RTLIL::Module::addAdlatchGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_arst, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q,
 		bool arst_value, bool en_polarity, bool arst_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, stringf("$_DLATCH_%c%c%c_", en_polarity ? 'P' : 'N', arst_polarity ? 'P' : 'N', arst_value ? '1' : '0'));
+	RTLIL::OldCell *cell = addCell(name, stringf("$_DLATCH_%c%c%c_", en_polarity ? 'P' : 'N', arst_polarity ? 'P' : 'N', arst_value ? '1' : '0'));
 	cell->setPort(ID::E, sig_en);
 	cell->setPort(ID::R, sig_arst);
 	cell->setPort(ID::D, sig_d);
@@ -3267,10 +3267,10 @@ RTLIL::OldCell* RTLIL::Module::addAdlatchGate(RTLIL::IdString name, const RTLIL:
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addDlatchsrGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
+RTLIL::Cell* RTLIL::Module::addDlatchsrGate(RTLIL::IdString name, const RTLIL::SigSpec &sig_en, const RTLIL::SigSpec &sig_set, const RTLIL::SigSpec &sig_clr,
 		RTLIL::SigSpec sig_d, const RTLIL::SigSpec &sig_q, bool en_polarity, bool set_polarity, bool clr_polarity, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, stringf("$_DLATCHSR_%c%c%c_", en_polarity ? 'P' : 'N', set_polarity ? 'P' : 'N', clr_polarity ? 'P' : 'N'));
+	RTLIL::OldCell *cell = addCell(name, stringf("$_DLATCHSR_%c%c%c_", en_polarity ? 'P' : 'N', set_polarity ? 'P' : 'N', clr_polarity ? 'P' : 'N'));
 	cell->setPort(ID::E, sig_en);
 	cell->setPort(ID::S, sig_set);
 	cell->setPort(ID::R, sig_clr);
@@ -3280,9 +3280,9 @@ RTLIL::OldCell* RTLIL::Module::addDlatchsrGate(RTLIL::IdString name, const RTLIL
 	return cell;
 }
 
-RTLIL::OldCell* RTLIL::Module::addAnyinit(RTLIL::IdString name, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addAnyinit(RTLIL::IdString name, const RTLIL::SigSpec &sig_d, const RTLIL::SigSpec &sig_q, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($anyinit));
+	RTLIL::OldCell *cell = addCell(name, ID($anyinit));
 	cell->parameters[ID::WIDTH] = sig_q.size();
 	cell->setPort(ID::D, sig_d);
 	cell->setPort(ID::Q, sig_q);
@@ -3293,7 +3293,7 @@ RTLIL::OldCell* RTLIL::Module::addAnyinit(RTLIL::IdString name, const RTLIL::Sig
 RTLIL::SigSpec RTLIL::Module::Anyconst(RTLIL::IdString name, int width, const std::string &src)
 {
 	RTLIL::SigSpec sig = addWire(NEW_ID, width);
-	OldCell *cell = addOldCell(name, ID($anyconst));
+	OldCell *cell = addCell(name, ID($anyconst));
 	cell->setParam(ID::WIDTH, width);
 	cell->setPort(ID::Y, sig);
 	cell->set_src_attribute(src);
@@ -3303,7 +3303,7 @@ RTLIL::SigSpec RTLIL::Module::Anyconst(RTLIL::IdString name, int width, const st
 RTLIL::SigSpec RTLIL::Module::Anyseq(RTLIL::IdString name, int width, const std::string &src)
 {
 	RTLIL::SigSpec sig = addWire(NEW_ID, width);
-	OldCell *cell = addOldCell(name, ID($anyseq));
+	OldCell *cell = addCell(name, ID($anyseq));
 	cell->setParam(ID::WIDTH, width);
 	cell->setPort(ID::Y, sig);
 	cell->set_src_attribute(src);
@@ -3313,7 +3313,7 @@ RTLIL::SigSpec RTLIL::Module::Anyseq(RTLIL::IdString name, int width, const std:
 RTLIL::SigSpec RTLIL::Module::Allconst(RTLIL::IdString name, int width, const std::string &src)
 {
 	RTLIL::SigSpec sig = addWire(NEW_ID, width);
-	OldCell *cell = addOldCell(name, ID($allconst));
+	OldCell *cell = addCell(name, ID($allconst));
 	cell->setParam(ID::WIDTH, width);
 	cell->setPort(ID::Y, sig);
 	cell->set_src_attribute(src);
@@ -3323,7 +3323,7 @@ RTLIL::SigSpec RTLIL::Module::Allconst(RTLIL::IdString name, int width, const st
 RTLIL::SigSpec RTLIL::Module::Allseq(RTLIL::IdString name, int width, const std::string &src)
 {
 	RTLIL::SigSpec sig = addWire(NEW_ID, width);
-	OldCell *cell = addOldCell(name, ID($allseq));
+	OldCell *cell = addCell(name, ID($allseq));
 	cell->setParam(ID::WIDTH, width);
 	cell->setPort(ID::Y, sig);
 	cell->set_src_attribute(src);
@@ -3333,7 +3333,7 @@ RTLIL::SigSpec RTLIL::Module::Allseq(RTLIL::IdString name, int width, const std:
 RTLIL::SigSpec RTLIL::Module::Initstate(RTLIL::IdString name, const std::string &src)
 {
 	RTLIL::SigSpec sig = addWire(NEW_ID);
-	OldCell *cell = addOldCell(name, ID($initstate));
+	OldCell *cell = addCell(name, ID($initstate));
 	cell->setPort(ID::Y, sig);
 	cell->set_src_attribute(src);
 	return sig;
@@ -3342,7 +3342,7 @@ RTLIL::SigSpec RTLIL::Module::Initstate(RTLIL::IdString name, const std::string 
 RTLIL::SigSpec RTLIL::Module::SetTag(RTLIL::IdString name, const std::string &tag, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_s, const RTLIL::SigSpec &sig_c, const std::string &src)
 {
 	RTLIL::SigSpec sig = addWire(NEW_ID, sig_a.size());
-	OldCell *cell = addOldCell(name, ID($set_tag));
+	OldCell *cell = addCell(name, ID($set_tag));
 	cell->parameters[ID::WIDTH] = sig_a.size();
 	cell->parameters[ID::TAG] = tag;
 	cell->setPort(ID::A, sig_a);
@@ -3353,9 +3353,9 @@ RTLIL::SigSpec RTLIL::Module::SetTag(RTLIL::IdString name, const std::string &ta
 	return sig;
 }
 
-RTLIL::OldCell* RTLIL::Module::addSetTag(RTLIL::IdString name, const std::string &tag, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_s, const RTLIL::SigSpec &sig_c, const RTLIL::SigSpec &sig_y, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addSetTag(RTLIL::IdString name, const std::string &tag, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_s, const RTLIL::SigSpec &sig_c, const RTLIL::SigSpec &sig_y, const std::string &src)
 {
-	OldCell *cell = addOldCell(name, ID($set_tag));
+	OldCell *cell = addCell(name, ID($set_tag));
 	cell->parameters[ID::WIDTH] = sig_a.size();
 	cell->parameters[ID::TAG] = tag;
 	cell->setPort(ID::A, sig_a);
@@ -3369,7 +3369,7 @@ RTLIL::OldCell* RTLIL::Module::addSetTag(RTLIL::IdString name, const std::string
 RTLIL::SigSpec RTLIL::Module::GetTag(RTLIL::IdString name, const std::string &tag, const RTLIL::SigSpec &sig_a, const std::string &src)
 {
 	RTLIL::SigSpec sig = addWire(NEW_ID, sig_a.size());
-	OldCell *cell = addOldCell(name, ID($get_tag));
+	OldCell *cell = addCell(name, ID($get_tag));
 	cell->parameters[ID::WIDTH] = sig_a.size();
 	cell->parameters[ID::TAG] = tag;
 	cell->setPort(ID::A, sig_a);
@@ -3378,9 +3378,9 @@ RTLIL::SigSpec RTLIL::Module::GetTag(RTLIL::IdString name, const std::string &ta
 	return sig;
 }
 
-RTLIL::OldCell* RTLIL::Module::addOverwriteTag(RTLIL::IdString name, const std::string &tag, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_s, const RTLIL::SigSpec &sig_c, const std::string &src)
+RTLIL::Cell* RTLIL::Module::addOverwriteTag(RTLIL::IdString name, const std::string &tag, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_s, const RTLIL::SigSpec &sig_c, const std::string &src)
 {
-	RTLIL::OldCell *cell = addOldCell(name, ID($overwrite_tag));
+	RTLIL::OldCell *cell = addCell(name, ID($overwrite_tag));
 	cell->parameters[ID::WIDTH] = sig_a.size();
 	cell->parameters[ID::TAG] = tag;
 	cell->setPort(ID::A, sig_a);
@@ -3393,7 +3393,7 @@ RTLIL::OldCell* RTLIL::Module::addOverwriteTag(RTLIL::IdString name, const std::
 RTLIL::SigSpec RTLIL::Module::OriginalTag(RTLIL::IdString name, const std::string &tag, const RTLIL::SigSpec &sig_a, const std::string &src)
 {
 	RTLIL::SigSpec sig = addWire(NEW_ID, sig_a.size());
-	OldCell *cell = addOldCell(name, ID($original_tag));
+	OldCell *cell = addCell(name, ID($original_tag));
 	cell->parameters[ID::WIDTH] = sig_a.size();
 	cell->parameters[ID::TAG] = tag;
 	cell->setPort(ID::A, sig_a);
@@ -3405,7 +3405,7 @@ RTLIL::SigSpec RTLIL::Module::OriginalTag(RTLIL::IdString name, const std::strin
 RTLIL::SigSpec RTLIL::Module::FutureFF(RTLIL::IdString name, const RTLIL::SigSpec &sig_e, const std::string &src)
 {
 	RTLIL::SigSpec sig = addWire(NEW_ID, sig_e.size());
-	OldCell *cell = addOldCell(name, ID($future_ff));
+	OldCell *cell = addCell(name, ID($future_ff));
 	cell->parameters[ID::WIDTH] = sig_e.size();
 	cell->setPort(ID::A, sig_e);
 	cell->setPort(ID::Y, sig);

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1087,10 +1087,10 @@ namespace {
 
 		void check_expected(bool check_matched_sign = false)
 		{
-			for (auto &para : cell->parameters)
+			for (auto &&para : cell->parameters)
 				if (expected_params.count(para.first) == 0)
 					error(__LINE__);
-			for (auto &conn : cell->connections_)
+			for (auto &&conn : cell->connections_)
 				if (expected_ports.count(conn.first) == 0)
 					error(__LINE__);
 
@@ -1973,13 +1973,14 @@ void RTLIL::Module::check()
 		log_assert(it.first == it.second->name);
 		log_assert(!it.first.empty());
 		log_assert(!it.second->type.empty());
-		for (auto &it2 : it.second->connections_) {
+		for (auto &&it2 : it.second->connections_) {
 			log_assert(!it2.first.empty());
 			it2.second.check(this);
 		}
-		for (auto &it2 : it.second->attributes)
-			log_assert(!it2.first.empty());
-		for (auto &it2 : it.second->parameters)
+		// TODO
+		// for (auto &&it2 : it.second->attributes)
+		// 	log_assert(!it2.first.empty());
+		for (auto &&it2 : it.second->parameters)
 			log_assert(!it2.first.empty());
 		InternalOldCellChecker checker(this, it.second);
 		checker.check();
@@ -3553,6 +3554,9 @@ const RTLIL::Const RTLIL::Cell::getParam(const RTLIL::IdString &paramname) {
 
 	if (type == ID($not)) {
 		if (paramname == ID::A_WIDTH) {
+			// Notice using the trivial default constructor
+			// This is to reduce code changes later when we replace Const
+			// with int/bool where possible in internal cell type variants
 			return RTLIL::Const(not_.a_width);
 		} else if (paramname == ID::Y_WIDTH) {
 			return RTLIL::Const(not_.y_width);
@@ -3739,15 +3743,15 @@ void RTLIL::OldCell::sort()
 	attributes.sort(sort_by_id_str());
 }
 
-void RTLIL::OldCell::check()
+void RTLIL::Cell::check()
 {
 #ifndef NDEBUG
 	InternalOldCellChecker checker(NULL, this);
 	checker.check();
 #endif
 }
-
-void RTLIL::OldCell::fixup_parameters(bool set_a_signed, bool set_b_signed)
+int bigboy() {return sizeof(RTLIL::Cell);}
+void RTLIL::Cell::fixup_parameters(bool set_a_signed, bool set_b_signed)
 {
 	if (!type.begins_with("$") || type.begins_with("$_") || type.begins_with("$paramod") || type.begins_with("$fmcombine") ||
 			type.begins_with("$verific$") || type.begins_with("$array:") || type.begins_with("$extern:"))

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1041,7 +1041,7 @@ namespace {
 			if (it == cell->parameters.end())
 				error(__LINE__);
 			expected_params.insert(name);
-			return it->second.as_int();
+			return (*it).second.as_int();
 		}
 
 		int param_bool(const RTLIL::IdString& name)
@@ -1080,7 +1080,7 @@ namespace {
 			auto it = cell->connections_.find(name);
 			if (it == cell->connections_.end())
 				error(__LINE__);
-			if (GetSize(it->second) != width)
+			if (GetSize((*it).second) != width)
 				error(__LINE__);
 			expected_ports.insert(name);
 		}

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1666,7 +1666,6 @@ public:
 
 	constexpr void setPort(const RTLIL::IdString &portname, RTLIL::SigSpec signal);
 	constexpr const RTLIL::SigSpec &getPort(const RTLIL::IdString &portname);
-	constexpr const RTLIL::Const getParam(const RTLIL::IdString &paramname);
 	constexpr void setParam(const RTLIL::IdString &paramname, RTLIL::Const value);
 	constexpr const RTLIL::Const getParam(const RTLIL::IdString &paramname);
 	bool hasParam(const RTLIL::IdString &paramname) {

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1691,7 +1691,7 @@ public:
 			return parent->getParam(name);
 		}
 		void sort() {}
-		void reserve() {}
+		void reserve(int n) { (void)n; }
 		// Watch out! This is different semantics than what dict has!
 		// but we rely on RTLIL::Cell always being constructed correctly
 		// since its layout is fixed as defined by InternalOldCellChecker
@@ -1903,7 +1903,7 @@ public:
 			return parent->getPort(name);
 		}
 		void sort() {}
-		void reserve() {}
+		void reserve(int n) { (void)n; }
 		// Watch out! This is different semantics than what dict has!
 		// but we rely on RTLIL::Cell always being constructed correctly
 		// since its layout is fixed as defined by InternalOldCellChecker

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1723,6 +1723,8 @@ public:
 					throw std::out_of_range("FakeParams.iterator::operator*()");
 				}
 			}
+			// std::pair<IdString, Const&> operator->() { return operator*(); }
+			// const std::pair<IdString, Const&> operator->() const { return operator*(); }
 			const std::pair<IdString, Const&> operator*() const {
 				if (parent->is_legacy()) {
 					auto it = parent->legacy->parameters.begin();
@@ -1893,6 +1895,8 @@ public:
 					throw std::out_of_range("FakeConns.iterator::operator*()");
 				}
 			}
+			// std::pair<IdString, SigSpec&> operator->() { return operator*(); }
+			// const std::pair<IdString, SigSpec&> operator->() const { return operator*(); }
 			const std::pair<IdString, SigSpec&> operator*() const {
 				if (parent->is_legacy()) {
 					auto it = parent->legacy->connections_.begin();
@@ -1914,6 +1918,12 @@ public:
 		};
 		iterator begin() {
 				return iterator(parent, 0);
+		}
+		// Stupid impl, but rarely used, so I don't want to think about it rn
+		iterator find(IdString name) {
+			auto it = iterator(parent, 0);
+			for (; it != end() && (*it).first != name; ++it) {}
+			return it;
 		}
 		iterator end() {
 			if (parent->is_legacy()) {

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1708,7 +1708,7 @@ public:
 		void reserve(int n) { (void)n; }
 		// Watch out! This is different semantics than what dict has!
 		// but we rely on RTLIL::Cell always being constructed correctly
-		// since its layout is fixed as defined by InternalOldCellChecker
+		// since its layout is fixed as defined by InternalCellChecker
 		RTLIL::Const& operator[](RTLIL::IdString name) {
 			// log("operator[] on %s type %s\n", name.c_str(), parent->type.c_str());
 			return parent->getMutParam(name);
@@ -1975,7 +1975,7 @@ public:
 		void reserve(int n) { (void)n; }
 		// Watch out! This is different semantics than what dict has!
 		// but we rely on RTLIL::Cell always being constructed correctly
-		// since its layout is fixed as defined by InternalOldCellChecker
+		// since its layout is fixed as defined by InternalCellChecker
 		RTLIL::SigSpec& operator[](RTLIL::IdString portname) {
 			// log("operator[] on %s type %s\n", portname.c_str(), parent->type.c_str());
 			return parent->getMutPort(portname);

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1602,28 +1602,11 @@ public:
 		}
 		int count(RTLIL::IdString portname) {
 			try {
-				parent->getParam(portname);
+				parent->getPort(portname);
 			} catch (const std::out_of_range& e) {
 				return 0;
 			}
 			return 1;
-		}
-		// const std::array<RTLIL::Const> make_array () {
-
-		// 	return std::array<RTLIL::Const>
-		// }
-		std::vector<int> fixed_data{1, 9, 100};
-
-		auto begin() {
-			if (parent->is_legacy())
-				return parent->legacy->connections_.begin();
-			if (parent->type.in(ID($pos))) {
-				return parent->pos.connections().begin();
-			}
-		}
-
-		auto end() {
-			return parent->is_legacy() ? parent->legacy->connections_.end() : fixed_data.end();
 		}
 	};
 	FakeParams parameters;

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1721,6 +1721,7 @@ public:
 		// but we rely on RTLIL::Cell always being constructed correctly
 		// since its layout is fixed as defined by InternalOldCellChecker
 		RTLIL::Const& operator[](RTLIL::IdString name) {
+			log("operator[] on %s type %s\n", name.c_str(), parent->type.c_str());
 			return parent->getMutParam(name);
 		}
 		void operator=(dict<IdString, Const> from) {
@@ -1965,6 +1966,7 @@ public:
 		// but we rely on RTLIL::Cell always being constructed correctly
 		// since its layout is fixed as defined by InternalOldCellChecker
 		RTLIL::SigSpec& operator[](RTLIL::IdString portname) {
+			log("operator[] on %s type %s\n", portname.c_str(), parent->type.c_str());
 			return parent->getMutPort(portname);
 		}
 		void operator=(dict<IdString, SigSpec> from) {
@@ -2225,7 +2227,8 @@ public:
 	const RTLIL::SigSpec &getPort(const RTLIL::IdString &portname) const;
 	RTLIL::SigSpec &getMutPort(const RTLIL::IdString &portname);
 	bool hasPort(const RTLIL::IdString &portname) const {
-		return connections_.count(portname);
+		// TODO hack?
+		return connections_.count(portname) && !getPort(portname).empty();
 	}
 	// The need for this function implies setPort will be used on incompat types
 	void unsetPort(const RTLIL::IdString& portname) { (void)portname; }
@@ -2234,7 +2237,7 @@ public:
 	const RTLIL::Const& getParam(const RTLIL::IdString &paramname) const;
 	RTLIL::Const& getMutParam(const RTLIL::IdString &paramname);
 	bool hasParam(const RTLIL::IdString &paramname) const {
-		return parameters.count(paramname);
+		return parameters.count(paramname) && !getParam(paramname).empty();
 	}
 	// The need for this function implies setPort will be used on incompat types
 	void unsetParam(const RTLIL::IdString& paramname) { (void)paramname; }

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1786,11 +1786,13 @@ public:
 				throw std::out_of_range("FakeParams::size()");
 			}
 		}
-		bool empty() const {
-			return !size();
-		}
+		bool empty() const { return !size(); }
 		// The need for this function implies setPort will be used on incompat types
-		void erase(const RTLIL::IdString& paramname) const { (void)paramname; }
+		void erase(const RTLIL::IdString &paramname) const
+		{
+			if (parent->is_legacy())
+				parent->legacy->parameters.erase(paramname);
+		}
 		// The need for this function implies setPort will be used on incompat types
 		void clear() const {}
 		// AAA

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1285,9 +1285,7 @@ public:
 
 	// The add* methods create a cell and return the created cell. All signals must exist in advance.
 
-	RTLIL::Cell* addNot (RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_y, bool is_signed = false, const std::string &src = "");
-	RTLIL::Cell* addPos (RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_y, bool is_signed = false, const std::string &src = "");
-	RTLIL::Cell* addNeg (RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_y, bool is_signed = false, const std::string &src = "");
+	#include "kernel/adds.shim.h"
 
 	RTLIL::Cell* addAnd  (RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, bool is_signed = false, const std::string &src = "");
 	RTLIL::Cell* addOr   (RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_y, bool is_signed = false, const std::string &src = "");

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1684,7 +1684,12 @@ public:
 			return !size();
 		}
 		// AAA
-		class iterator: public std::iterator<std::bidirectional_iterator_tag, std::pair<IdString, Const>> {
+		class iterator {
+			typedef std::bidirectional_iterator_tag iterator_category;
+			typedef std::pair<IdString, Const> value_type;
+			typedef ptrdiff_t difference_type;
+			typedef std::pair<IdString, Const>* pointer;
+			typedef std::pair<IdString, Const>& reference;
 			Cell* parent;
 			int position;
 		public:
@@ -1747,7 +1752,12 @@ public:
 			}
 		}
 		// AAA CONST ITERATOR
-		class const_iterator: public std::iterator<std::input_iterator_tag, std::pair<IdString, Const>> {
+		class const_iterator {
+			typedef std::input_iterator_tag iterator_category;
+			typedef std::pair<IdString, Const> value_type;
+			typedef ptrdiff_t difference_type;
+			typedef std::pair<IdString, Const>* pointer;
+			typedef std::pair<IdString, Const>& reference;
 			Cell* parent;
 			int position;
 		public:
@@ -1825,7 +1835,12 @@ public:
 			return !size();
 		}
 		// AAA
-		class iterator: public std::iterator<std::bidirectional_iterator_tag, std::pair<IdString, SigSpec>> {
+		class iterator {
+			typedef std::bidirectional_iterator_tag iterator_category;
+			typedef std::pair<IdString, SigSpec> value_type;
+			typedef ptrdiff_t difference_type;
+			typedef std::pair<IdString, SigSpec>* pointer;
+			typedef std::pair<IdString, SigSpec>& reference;
 			Cell* parent;
 			int position;
 		public:
@@ -1890,7 +1905,12 @@ public:
 			}
 		}
 		// AAA CONST ITERATOR
-		class const_iterator: public std::iterator<std::input_iterator_tag, std::pair<IdString, SigSpec>> {
+		class const_iterator {
+			typedef std::input_iterator_tag iterator_category;
+			typedef std::pair<IdString, SigSpec> value_type;
+			typedef ptrdiff_t difference_type;
+			typedef std::pair<IdString, SigSpec>* pointer;
+			typedef std::pair<IdString, SigSpec>& reference;
 			Cell* parent;
 			int position;
 		public:
@@ -1917,7 +1937,7 @@ public:
 				} else if (parent->type == ID($not)) {
 					return parent->not_.connections()[position];
 				} else {
-					log_assert(false && "malformed cell or code broke");
+					throw std::out_of_range("FakeConns.const_iterator::operator*() const");
 				}
 			}
 		};
@@ -1951,7 +1971,7 @@ public:
 	bool has_memid() { return is_legacy() && legacy->has_memid(); }
 	bool is_mem_cell() { return is_legacy() && legacy->is_mem_cell(); }
 	// TODO stub
-	void set_src_attribute(const std::string &src) { };
+	void set_src_attribute(const std::string &src) { (void)src; };
 
 	void setPort(const RTLIL::IdString &portname, RTLIL::SigSpec signal);
 	const RTLIL::SigSpec &getPort(const RTLIL::IdString &portname);
@@ -1967,7 +1987,7 @@ public:
 	}
 	template<typename T>
 	void rewrite_sigspecs(T &functor) {
-		for (auto &it : connections_)
+		for (std::pair<IdString, SigSpec> &it : connections_)
 			functor(it.second);
 	}
 	void sort() {

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -2030,14 +2030,11 @@ public:
 			return !operator==(other);
 		}
 		int count(const RTLIL::IdString& portname) const {
-			log("count this %d\n", this);
 			try {
 				parent->getPort(portname);
 			} catch (const std::out_of_range& e) {
-				log("count 0\n");
 				return 0;
 			}
-			log("count 1\n");
 			return 1;
 		}
 		size_t size() const {
@@ -2270,13 +2267,15 @@ public:
 			throw std::out_of_range("FakeParams::size()");
 		}
 	}
+	// TODO check
 	void unsetPort(const RTLIL::IdString& portname) {
 		if (is_legacy())
 			legacy->unsetPort(portname);
-		setPort(portname, SigSpec());
+		try {
+			setPort(portname, SigSpec());
+		} catch (const std::out_of_range& e) {}
 	}
 	void setParam(const RTLIL::IdString &paramname, RTLIL::Const value);
-	// TODO is this reasonable at all?
 	const RTLIL::Const& getParam(const RTLIL::IdString &paramname) const;
 	RTLIL::Const& getMutParam(const RTLIL::IdString &paramname);
 	bool hasParam(const RTLIL::IdString &paramname) const {
@@ -2288,18 +2287,16 @@ public:
 			throw std::out_of_range("FakeParams::size()");
 		}
 	}
+	// TODO check
 	void unsetParam(const RTLIL::IdString& paramname) {
 		if (is_legacy())
 			legacy->unsetParam(paramname);
-		setPort(paramname, Const());
+		try {
+			setPort(paramname, Const());
+		} catch (const std::out_of_range& e) {}
 	}
 	template<typename T>
 	void rewrite_sigspecs2(T &functor) {
-		// for(auto it = connections_.begin(); it != connections_.end(); ++it) {
-		// 	auto& thing = *it;
-		// 	functor(it.second);
-		// }
-		// TODO fix!!!
 		for (auto it : connections_)
 			functor(it.second);
 	}

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1852,13 +1852,13 @@ public:
 		}
 		iterator end() {
 			if (parent->is_legacy()) {
-				return iterator(parent, parent->legacy->connections_.size());
+				return iterator(parent, parent->legacy->parameters.size());
 			} else if (parent->type == ID($pos)) {
-				return iterator(parent, parent->pos.connections().size());
+				return iterator(parent, parent->pos.parameters().size());
 			} else if (parent->type == ID($neg)) {
-				return iterator(parent, parent->neg.connections().size());
+				return iterator(parent, parent->neg.parameters().size());
 			} else if (parent->type == ID($not)) {
-				return iterator(parent, parent->not_.connections().size());
+				return iterator(parent, parent->not_.parameters().size());
 			} else {
 				throw std::out_of_range("FakeParams::iterator::end()");
 			}
@@ -1914,13 +1914,13 @@ public:
 		}
 		const_iterator end() const {
 			if (parent->is_legacy()) {
-				return const_iterator(parent, parent->legacy->connections_.size());
+				return const_iterator(parent, parent->legacy->parameters.size());
 			} else if (parent->type == ID($pos)) {
-				return const_iterator(parent, parent->pos.connections().size());
+				return const_iterator(parent, parent->pos.parameters().size());
 			} else if (parent->type == ID($neg)) {
-				return const_iterator(parent, parent->neg.connections().size());
+				return const_iterator(parent, parent->neg.parameters().size());
 			} else if (parent->type == ID($not)) {
-				return const_iterator(parent, parent->not_.connections().size());
+				return const_iterator(parent, parent->not_.parameters().size());
 			} else {
 				throw std::out_of_range("FakeConns::end() const");
 			}

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1625,7 +1625,7 @@ struct RTLIL::Unary {
 		return {std::make_pair(ID::A, std::ref(a)), std::make_pair(ID::Y, std::ref(y))};
 	}
 	std::array<std::pair<IdString, Const&>, 3> parameters() {
-		return {std::make_pair(ID::A_WIDTH, std::ref(a_width)), std::make_pair(ID::Y_WIDTH, std::ref(y_width)), std::make_pair(ID::A_SIGNED, std::ref(y_width))};
+		return {std::make_pair(ID::A_WIDTH, std::ref(a_width)), std::make_pair(ID::Y_WIDTH, std::ref(y_width)), std::make_pair(ID::A_SIGNED, std::ref(is_signed))};
 	}
 	bool input(IdString portname) const {
 		return portname == ID::A;
@@ -1671,20 +1671,7 @@ public:
 	struct FakeParams {
 		RTLIL::Cell* parent;
 		RTLIL::Const& at(RTLIL::IdString paramname) {
-			if (parent->is_legacy())
-				return parent->legacy->parameters.at(paramname);
-
-			if (parent->type == ID($not)) {
-				if (paramname == ID::A_WIDTH) {
-					return parent->not_.a_width;
-				} else if (paramname == ID::Y_WIDTH) {
-					return parent->not_.y_width;
-				} else {
-					throw std::out_of_range("Cell::getParam()");
-				}
-			} else {
-				throw std::out_of_range("Cell::getParam()");
-			}
+			return parent->getMutParam(paramname);
 		}
 		const RTLIL::Const& at(RTLIL::IdString name) const {
 			return parent->getParam(name);

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1614,7 +1614,7 @@ public:
 };
 
 
-// $not
+// $not etc
 struct RTLIL::Unary {
 	SigSpec a;
 	SigSpec y;
@@ -1662,7 +1662,6 @@ public:
 	RTLIL::IdString type;
 	RTLIL::IdString name; // TODO delete?
 	RTLIL::Module* module; // TODO delete
-	bool has_attrs;
 	union {
 		RTLIL::Unary not_;
 		RTLIL::Unary pos;
@@ -1869,8 +1868,8 @@ public:
 			typedef std::input_iterator_tag iterator_category;
 			typedef std::pair<IdString, Const> value_type;
 			typedef ptrdiff_t difference_type;
-			typedef std::pair<IdString, Const*> pointer;
-			typedef std::pair<IdString, Const&> reference;
+			typedef std::pair<IdString, const Const*> pointer;
+			typedef std::pair<IdString, const Const&> reference;
 			Cell* parent;
 			int position;
 		public:
@@ -1885,7 +1884,7 @@ public:
 			bool operator!=(const const_iterator &other) const {
 				return !(*this == other);
 			}
-			const std::pair<IdString, Const&> operator*() const {
+			const std::pair<IdString, const Const&> operator*() const {
 				if (parent->is_legacy()) {
 					auto it = parent->legacy->parameters.begin();
 					it += position;
@@ -1902,8 +1901,8 @@ public:
 					throw std::out_of_range("FakeParams::const_iterator::operator*() const");
 				}
 			}
-			std::pair<IdString, Const&> operator->() { return operator*(); }
-			const std::pair<IdString, Const&> operator->() const { return operator*(); }
+			// std::pair<IdString, Const&> operator->() { return operator*(); }
+			const std::pair<IdString, const Const&> operator->() const { return operator*(); }
 		};
 		const_iterator begin() const {
 				return const_iterator(parent, 0);
@@ -2116,8 +2115,8 @@ public:
 			typedef std::input_iterator_tag iterator_category;
 			typedef std::pair<IdString, SigSpec> value_type;
 			typedef ptrdiff_t difference_type;
-			typedef std::pair<IdString, SigSpec*> pointer;
-			typedef std::pair<IdString, SigSpec&> reference;
+			typedef std::pair<IdString, const SigSpec*> pointer;
+			typedef std::pair<IdString, const SigSpec&> reference;
 			Cell* parent;
 			int position;
 		public:
@@ -2132,7 +2131,7 @@ public:
 			bool operator!=(const const_iterator &other) const {
 				return !(*this == other);
 			}
-			const std::pair<IdString, SigSpec&> operator*() const {
+			const std::pair<IdString, const SigSpec&> operator*() const {
 				if (parent->is_legacy()) {
 					auto it = parent->legacy->connections_.begin();
 					it += position;
@@ -2149,8 +2148,8 @@ public:
 					throw std::out_of_range("FakeConns::const_iterator::operator*() const");
 				}
 			}
-			std::pair<IdString, SigSpec&> operator->() { return operator*(); }
-			const std::pair<IdString, SigSpec&> operator->() const { return operator*(); }
+			// std::pair<IdString, const SigSpec&> operator->() { return operator*(); }
+			const std::pair<IdString, const SigSpec&> operator->() const { return operator*(); }
 		};
 		const_iterator begin() const {
 				return const_iterator(parent, 0);

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1776,13 +1776,13 @@ public:
 				throw std::out_of_range("FakeParams::size()");
 			}
 		}
-		bool empty() {
+		bool empty() const {
 			return !size();
 		}
 		// The need for this function implies setPort will be used on incompat types
-		void erase(const RTLIL::IdString& paramname) { (void)paramname; }
+		void erase(const RTLIL::IdString& paramname) const { (void)paramname; }
 		// The need for this function implies setPort will be used on incompat types
-		void clear() {}
+		void clear() const {}
 		// AAA
 		class iterator {
 			typedef std::bidirectional_iterator_tag iterator_category;
@@ -1821,8 +1821,8 @@ public:
 					throw std::out_of_range("FakeParams::iterator::operator*()");
 				}
 			}
-			// std::pair<IdString, Const&> operator->() { return operator*(); }
-			// const std::pair<IdString, Const&> operator->() const { return operator*(); }
+			std::pair<IdString, Const&> operator->() { return operator*(); }
+			const std::pair<IdString, Const&> operator->() const { return operator*(); }
 			const std::pair<IdString, Const&> operator*() const {
 				if (parent->is_legacy()) {
 					auto it = parent->legacy->parameters.begin();
@@ -1901,6 +1901,8 @@ public:
 					throw std::out_of_range("FakeParams::const_iterator::operator*() const");
 				}
 			}
+			std::pair<IdString, Const&> operator->() { return operator*(); }
+			const std::pair<IdString, Const&> operator->() const { return operator*(); }
 		};
 		const_iterator begin() const {
 				return const_iterator(parent, 0);
@@ -1926,7 +1928,7 @@ public:
 	};
 	struct FakeConns {
 		RTLIL::Cell* parent;
-		RTLIL::SigSpec at(RTLIL::IdString name) {
+		RTLIL::SigSpec& at(RTLIL::IdString name) {
 			return parent->getMutPort(name);
 		}
 		const RTLIL::SigSpec& at(RTLIL::IdString name) const {
@@ -2021,8 +2023,8 @@ public:
 		// The need for this function implies setPort will be used on incompat types
 		void erase(const RTLIL::IdString& portname) { (void)portname; }
 		// The need for this function implies setPort will be used on incompat types
-		void clear() {}
-		bool empty() {
+		void clear() const {}
+		bool empty() const {
 			return !size();
 		}
 		// AAA
@@ -2064,8 +2066,8 @@ public:
 					throw std::out_of_range("FakeConns::iterator::operator*()");
 				}
 			}
-			// std::pair<IdString, SigSpec&> operator->() { return operator*(); }
-			// const std::pair<IdString, SigSpec&> operator->() const { return operator*(); }
+			std::pair<IdString, SigSpec&> operator->() { return operator*(); }
+			const std::pair<IdString, SigSpec&> operator->() const { return operator*(); }
 			const std::pair<IdString, SigSpec&> operator*() const {
 				if (parent->is_legacy()) {
 					auto it = parent->legacy->connections_.begin();
@@ -2145,6 +2147,8 @@ public:
 					throw std::out_of_range("FakeConns::const_iterator::operator*() const");
 				}
 			}
+			std::pair<IdString, SigSpec&> operator->() { return operator*(); }
+			const std::pair<IdString, SigSpec&> operator->() const { return operator*(); }
 		};
 		const_iterator begin() const {
 				return const_iterator(parent, 0);
@@ -2175,7 +2179,7 @@ public:
 
 	// Canonical tag
 	bool is_legacy() const {
-		return has_attrs || is_legacy_type(type);
+		return is_legacy_type(type);
 	};
 
 	bool has_memid() { return is_legacy() && legacy->has_memid(); }
@@ -2186,7 +2190,7 @@ public:
 	}
 	// TODO stub
 	void set_src_attribute(const std::string &src) { (void)src; };
-	bool known () {
+	bool known () const {
 		return is_legacy() ? legacy->known() : true;
 	}
 	bool input(const RTLIL::IdString &portname) const {
@@ -2220,7 +2224,7 @@ public:
 	// TODO is this reasonable at all?
 	const RTLIL::SigSpec &getPort(const RTLIL::IdString &portname) const;
 	RTLIL::SigSpec &getMutPort(const RTLIL::IdString &portname);
-	bool hasPort(const RTLIL::IdString &portname) {
+	bool hasPort(const RTLIL::IdString &portname) const {
 		return connections_.count(portname);
 	}
 	// The need for this function implies setPort will be used on incompat types
@@ -2229,7 +2233,7 @@ public:
 	// TODO is this reasonable at all?
 	const RTLIL::Const& getParam(const RTLIL::IdString &paramname) const;
 	RTLIL::Const& getMutParam(const RTLIL::IdString &paramname);
-	bool hasParam(const RTLIL::IdString &paramname) {
+	bool hasParam(const RTLIL::IdString &paramname) const {
 		return parameters.count(paramname);
 	}
 	// The need for this function implies setPort will be used on incompat types

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1794,7 +1794,10 @@ public:
 				parent->legacy->parameters.erase(paramname);
 		}
 		// The need for this function implies setPort will be used on incompat types
-		void clear() const {}
+		void clear() const {
+			if (parent->is_legacy())
+				parent->legacy->parameters.clear();
+		}
 		// AAA
 		class iterator {
 			typedef std::bidirectional_iterator_tag iterator_category;
@@ -2056,9 +2059,16 @@ public:
 			}
 		}
 		// The need for this function implies setPort will be used on incompat types
-		void erase(const RTLIL::IdString& portname) { (void)portname; }
+		void erase(const RTLIL::IdString &portname) const
+		{
+			if (parent->is_legacy())
+				parent->legacy->connections_.erase(portname);
+		}
 		// The need for this function implies setPort will be used on incompat types
-		void clear() const {}
+		void clear() const {
+			if (parent->is_legacy())
+				parent->legacy->connections_.clear();
+		}
 		bool empty() const {
 			return !size();
 		}

--- a/kernel/shim.py
+++ b/kernel/shim.py
@@ -1,0 +1,183 @@
+from pathlib import Path
+
+with open("kernel/constids.inc") as f:
+    X = set([line[2:-2] for line in f.readlines() if len(line) > 2])
+
+# f.write(X)
+# ValidConstID = NewType('ValidConstID', str)
+
+
+class ValidConstID(str):
+    # https://stackoverflow.com/questions/69844072/why-isnt-python-newtype-compatible-with-isinstance-and-type
+    def __new__(cls, *args, **kwargs):
+        return str.__new__(cls, *args, **kwargs)
+
+
+def id(str):
+    assert str in X
+    return ValidConstID(str)
+
+
+class CellType():
+    name: str
+    inputs: list[ValidConstID, ValidConstID | int]
+    outputs = list[ValidConstID, ValidConstID | int]
+    other_params = list[ValidConstID, type]
+
+    def __init__(self, name, inputs, outputs, other_params, add_wire_width_expr):
+        self.name = name
+        self.inputs = inputs
+        self.outputs = outputs
+        self.other_params = other_params
+        self.add_wire_width_expr = add_wire_width_expr
+        self.inputs.sort()
+        self.outputs.sort()
+        self.other_params.sort()
+
+    def arg_inputs(self, call=False):
+        s = ""
+        if call:
+            s += "".join(map(
+                lambda inp: f"sig_{inp[0].lower()}, ", self.inputs))
+        else:
+            s += "".join(map(
+                lambda inp: f"const RTLIL::SigSpec &sig_{inp[0].lower()}, ", self.inputs))
+        return s
+
+    def arg_outputs(self, call=False):
+        s = ""
+        if call:
+            s += "".join(map(
+                lambda outp: f"sig_{outp[0].lower()}, ", self.outputs))
+        else:
+            s += "".join(map(
+                lambda outp: f"const RTLIL::SigSpec &sig_{outp[0].lower()}, ", self.outputs))
+        return s
+
+    def emit_add_h(self, filename):
+
+        def _argumentize_param(param):
+            is_only_one_param_signed = len(
+                list(filter(lambda x: "_SIGNED" in x[0], self.other_params))) == 1
+            if "_SIGNED" in param and is_only_one_param_signed:
+                return "is_signed = false"
+            else:
+                return param.lower()
+
+        with open(filename, 'a') as f:
+            f.write(
+                f"RTLIL::Cell* add{self.name.title()}(RTLIL::IdString name, ")
+            f.write(self.arg_inputs() + self.arg_outputs())
+            f.write("".join(
+                map(lambda par: f"{par[1].__name__} {_argumentize_param(par[0])}, ", self.other_params)))
+            f.write("const std::string &src = \"\");\n")
+
+    def emit_add_cc(self, filename):
+
+        def _argumentize_param(param):
+            is_only_one_param_signed = len(
+                list(filter(lambda x: "_SIGNED" in x[0], self.other_params))) == 1
+            if "_SIGNED" in param and is_only_one_param_signed:
+                return "is_signed"
+            else:
+                return param.lower()
+
+        with open(filename, 'a') as f:
+            f.write(
+                f"RTLIL::Cell* RTLIL::Module::add{self.name.title()}(RTLIL::IdString name, ")
+            f.write(self.arg_inputs() + self.arg_outputs())
+            f.write("".join(
+                map(lambda par: f"{par[1].__name__} {_argumentize_param(par[0])}, ", self.other_params)))
+            f.write("const std::string &src)\n")
+
+            f.write("{\n")
+            f.write(
+                f"\tRTLIL::Cell *cell = addCell(name, ID(${self.name}));\n")
+
+            for param in self.other_params:
+                f.write(
+                    f"\tcell->parameters[ID::{param[0]}] = {_argumentize_param(param[0])};\n")
+
+            for input, width in self.inputs:
+                if isinstance(width, ValidConstID):
+                    f.write(
+                        f"\tcell->parameters[ID::{width}] = sig_{input.lower()}.size();\n")
+
+            for output, width in self.outputs:
+                if isinstance(width, ValidConstID):
+                    f.write(
+                        f"\tcell->parameters[ID::{width}] = sig_{output.lower()}.size();\n")
+
+            for input, _ in self.inputs:
+                f.write(
+                    f"\tcell->setPort(ID::{input}, sig_{input.lower()});\n")
+            for output, _ in self.outputs:
+                f.write(
+                    f"\tcell->setPort(ID::{output}, sig_{output.lower()});\n")
+            f.write("\tcell->set_src_attribute(src);\n")
+            f.write("\treturn cell;\n")
+            f.write("}\n\n")
+
+            if self.add_wire_width_expr:
+                f.write(
+                    f"RTLIL::SigSpec RTLIL::Module::{self.name.title()}(RTLIL::IdString name, {self.arg_inputs()}")
+                f.write("".join(
+                    map(lambda par: f"{par[1].__name__} {_argumentize_param(par[0])}, ", self.other_params)))
+                f.write("const std::string &src) {\n")
+                f.write(
+                    f"\tRTLIL::SigSpec sig_y = addWire(NEW_ID, {self.add_wire_width_expr});\n")
+                f.write(
+                    f"\tadd{self.name.title()}(name, {self.arg_inputs(call=True)}{self.arg_outputs(call=True)}")
+                f.write("".join(
+                    map(lambda par: f"{_argumentize_param(par[0])}", self.other_params)))
+                f.write(f", src);\n")
+                f.write("\treturn sig_y;\n")
+                f.write("}\n\n")
+            # _func(const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, bool is_signed, const std::string &src) { \
+            #     RTLIL::SigSpec sig_y = addWire(NEW_ID, _y_size);         \
+            #     add ## _func(name, sig_a, sig_b, sig_y, is_signed, src); \
+            #     return sig_y;                                            \
+            # }
+
+
+def unary(name):
+    inputs = [(id("A"), id("A_WIDTH"))]
+    outputs = [(id("Y"), id("Y_WIDTH"))]
+    other_params = [(id("A_SIGNED"), bool)]
+    add_wire_width_expr = "sig_a.size()"
+    return CellType(name, inputs, outputs, other_params, add_wire_width_expr)
+
+
+celltypes = []
+celltypes += [unary("pos")]
+celltypes += [unary("neg")]
+celltypes += [unary("not")]
+
+shim_headers = Path("kernel/adds.shim.h")
+shim_headers.unlink(missing_ok=True)
+shim_src = Path("kernel/adds.shim.cc")
+shim_src.unlink(missing_ok=True)
+
+
+def emit_boilerplate():
+    warning = "/* Generated by shim.py, do not modify */\n"
+    with open(shim_headers, 'a') as f:
+        f.write(warning)
+        f.write('#ifndef SHIM_H\n')
+        f.write('#define SHIM_H\n')
+        f.write('#include "kernel/yosys.h"\n')
+        f.write('#endif /* SHIM_H */\n')
+
+    with open(shim_src, 'a') as f:
+        f.write(warning)
+        f.write('#include "kernel/yosys.h"\n')
+        f.write("USING_YOSYS_NAMESPACE\n")
+
+
+emit_boilerplate()
+
+for celltype in celltypes:
+    celltype.emit_add_h(shim_headers)
+
+for celltype in celltypes:
+    celltype.emit_add_cc(shim_src)

--- a/passes/cmds/add.cc
+++ b/passes/cmds/add.cc
@@ -152,6 +152,9 @@ struct AddPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		std::string command;
 		std::string arg_name;
 		std::string enable_name = "";

--- a/passes/cmds/autoname.cc
+++ b/passes/cmds/autoname.cc
@@ -101,6 +101,9 @@ struct AutonamePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
 		{

--- a/passes/cmds/blackbox.cc
+++ b/passes/cmds/blackbox.cc
@@ -36,6 +36,9 @@ struct BlackboxPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
 		{

--- a/passes/cmds/bugpoint.cc
+++ b/passes/cmds/bugpoint.cc
@@ -399,6 +399,9 @@ struct BugpointPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		string yosys_cmd = "yosys", yosys_arg, grep, runner;
 		bool fast = false, clean = false;
 		bool modules = false, ports = false, cells = false, connections = false, processes = false, assigns = false, updates = false, wires = false, has_part = false;

--- a/passes/cmds/check.cc
+++ b/passes/cmds/check.cc
@@ -62,6 +62,9 @@ struct CheckPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		int counter = 0;
 		bool noinit = false;
 		bool initdrv = false;

--- a/passes/cmds/chformal.cc
+++ b/passes/cmds/chformal.cc
@@ -128,6 +128,9 @@ struct ChformalPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool assert2assume = false;
 		bool assume2assert = false;
 		bool live2fair = false;

--- a/passes/cmds/chformal.cc
+++ b/passes/cmds/chformal.cc
@@ -46,7 +46,7 @@ static RTLIL::IdString formal_flavor(RTLIL::Cell *cell)
 static void set_formal_flavor(RTLIL::Cell *cell, RTLIL::IdString flavor)
 {
 	if (cell->type != ID($check)) {
-		cell->type = flavor;
+		cell = cell->module->morphCell(flavor, cell);
 		return;
 	}
 
@@ -423,7 +423,7 @@ struct ChformalPass : public Pass {
 					if (cell->getPort(ID::ARGS).empty()) {
 						module->remove(cell);
 					} else {
-						cell->type = ID($print);
+						cell = cell->module->morphCell(ID($print), cell);
 						cell->setPort(ID::EN, combined_en);
 						cell->unsetPort(ID::A);
 						cell->unsetParam(ID(FLAVOR));

--- a/passes/cmds/chtype.cc
+++ b/passes/cmds/chtype.cc
@@ -42,6 +42,9 @@ struct ChtypePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		IdString set_type;
 		dict<IdString, IdString> map_types;
 

--- a/passes/cmds/chtype.cc
+++ b/passes/cmds/chtype.cc
@@ -70,12 +70,12 @@ struct ChtypePass : public Pass {
 			for (auto cell : module->selected_cells())
 			{
 				if (map_types.count(cell->type)) {
-					cell->type = map_types.at(cell->type);
+					cell = cell->module->morphCell(map_types.at(cell->type), cell);
 					continue;
 				}
 
 				if (set_type != IdString()) {
-					cell->type = set_type;
+					cell = cell->module->morphCell(set_type, cell);
 					continue;
 				}
 			}

--- a/passes/cmds/clean_zerowidth.cc
+++ b/passes/cmds/clean_zerowidth.cc
@@ -52,6 +52,9 @@ struct CleanZeroWidthPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
 		{

--- a/passes/cmds/connect.cc
+++ b/passes/cmds/connect.cc
@@ -33,7 +33,7 @@ static void unset_drivers(RTLIL::Design *design, RTLIL::Module *module, SigMap &
 	RTLIL::Wire *dummy_wire = module->addWire(NEW_ID, sig.size());
 
 	for (auto cell : module->cells())
-	for (auto &&port : cell->connections_)
+	for (auto port : cell->connections_)
 		if (ct.cell_output(cell->type, port.first))
 			sigmap(port.second).replace(sig, dummy_wire, &port.second);
 

--- a/passes/cmds/connect.cc
+++ b/passes/cmds/connect.cc
@@ -80,6 +80,9 @@ struct ConnectPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool flag_nounset = false, flag_nomap = false, flag_assert = false;
 		std::string set_lhs, set_rhs, unset_expr;
 		std::string port_cell, port_port, port_expr;

--- a/passes/cmds/connect.cc
+++ b/passes/cmds/connect.cc
@@ -33,7 +33,7 @@ static void unset_drivers(RTLIL::Design *design, RTLIL::Module *module, SigMap &
 	RTLIL::Wire *dummy_wire = module->addWire(NEW_ID, sig.size());
 
 	for (auto cell : module->cells())
-	for (auto &port : cell->connections_)
+	for (auto &&port : cell->connections_)
 		if (ct.cell_output(cell->type, port.first))
 			sigmap(port.second).replace(sig, dummy_wire, &port.second);
 

--- a/passes/cmds/connwrappers.cc
+++ b/passes/cmds/connwrappers.cc
@@ -105,7 +105,7 @@ struct ConnwrappersWorker
 
 		for (auto cell : module->selected_cells())
 		{
-			for (auto &&conn : cell->connections_)
+			for (auto conn : cell->connections_)
 			{
 				std::vector<RTLIL::SigBit> sigbits = sigmap(conn.second).to_sigbit_vector();
 				RTLIL::SigSpec old_sig;

--- a/passes/cmds/connwrappers.cc
+++ b/passes/cmds/connwrappers.cc
@@ -167,6 +167,9 @@ struct ConnwrappersPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		ConnwrappersWorker worker;
 
 		size_t argidx;

--- a/passes/cmds/connwrappers.cc
+++ b/passes/cmds/connwrappers.cc
@@ -105,7 +105,7 @@ struct ConnwrappersWorker
 
 		for (auto cell : module->selected_cells())
 		{
-			for (auto &conn : cell->connections_)
+			for (auto &&conn : cell->connections_)
 			{
 				std::vector<RTLIL::SigBit> sigbits = sigmap(conn.second).to_sigbit_vector();
 				RTLIL::SigSpec old_sig;

--- a/passes/cmds/copy.cc
+++ b/passes/cmds/copy.cc
@@ -38,6 +38,9 @@ struct CopyPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		if (args.size() != 3)
 			log_cmd_error("Invalid number of arguments!\n");
 

--- a/passes/cmds/cover.cc
+++ b/passes/cmds/cover.cc
@@ -85,6 +85,9 @@ struct CoverPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		std::vector<FILE*> out_files;
 		std::vector<std::string> patterns;
 		bool do_log = true;

--- a/passes/cmds/delete.cc
+++ b/passes/cmds/delete.cc
@@ -42,6 +42,9 @@ struct DeletePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool flag_input = false;
 		bool flag_output = false;
 

--- a/passes/cmds/design.cc
+++ b/passes/cmds/design.cc
@@ -318,7 +318,7 @@ struct DesignPass : public Pass {
 						done[cell->type] = trg_name;
 					}
 
-					cell->type = done.at(cell->type);
+					cell = cell->module->morphCell(done.at(cell->type), cell);
 				}
 			}
 		}

--- a/passes/cmds/design.cc
+++ b/passes/cmds/design.cc
@@ -107,6 +107,9 @@ struct DesignPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool got_mode = false;
 		bool reset_mode = false;
 		bool reset_vlog_mode = false;

--- a/passes/cmds/dft_tag.cc
+++ b/passes/cmds/dft_tag.cc
@@ -109,7 +109,7 @@ struct DftTagWorker {
 			module->remove(cell);
 		}
 		for (auto cell : original_cells) {
-			cell->type = ID($get_tag);
+			cell = cell->module->morphCell(ID($get_tag), cell);
 		}
 
 		if (design_changed)

--- a/passes/cmds/dft_tag.cc
+++ b/passes/cmds/dft_tag.cc
@@ -972,6 +972,9 @@ struct DftTagPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		DftTagOptions options;
 
 		log_header(design, "Executing DFT_TAG pass.\n");

--- a/passes/cmds/edgetypes.cc
+++ b/passes/cmds/edgetypes.cc
@@ -37,6 +37,9 @@ struct EdgetypePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++) {
 			// if (args[argidx] == "-ltr") {

--- a/passes/cmds/exec.cc
+++ b/passes/cmds/exec.cc
@@ -73,6 +73,9 @@ struct ExecPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		std::string cmd = "";
 		char buf[1024] = {};
 		std::string linebuf = "";

--- a/passes/cmds/future.cc
+++ b/passes/cmds/future.cc
@@ -119,6 +119,9 @@ struct FuturePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		FutureOptions options;
 
 		log_header(design, "Executing FUTURE pass.\n");

--- a/passes/cmds/glift.cc
+++ b/passes/cmds/glift.cc
@@ -343,9 +343,9 @@ private:
 				//recurse to GLIFT model the child module. However, we need to augment the ports list
 				//with taint signals and connect the new ports to the corresponding taint signals.
 				RTLIL::Module *cell_module_def = module->design->module(cell->type);
-				dict<RTLIL::IdString, RTLIL::SigSpec> orig_ports = cell->connections();
+				auto orig_ports = cell->connections();
 				log("Adding cell %s\n", cell_module_def->name.c_str());
-				for (auto &it : orig_ports) {
+				for (auto &&it : orig_ports) {
 					RTLIL::SigSpec port = it.second;
 					RTLIL::SigSpec port_taint = get_corresponding_taint_signal(port);
 

--- a/passes/cmds/glift.cc
+++ b/passes/cmds/glift.cc
@@ -343,7 +343,7 @@ private:
 				//recurse to GLIFT model the child module. However, we need to augment the ports list
 				//with taint signals and connect the new ports to the corresponding taint signals.
 				RTLIL::Module *cell_module_def = module->design->module(cell->type);
-				auto orig_ports = cell->connections();
+				auto orig_ports = cell->connections().as_dict();
 				log("Adding cell %s\n", cell_module_def->name.c_str());
 				for (auto &&it : orig_ports) {
 					RTLIL::SigSpec port = it.second;

--- a/passes/cmds/glift.cc
+++ b/passes/cmds/glift.cc
@@ -517,6 +517,9 @@ struct GliftPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool opt_create_precise_model = false, opt_create_imprecise_model = false, opt_create_instrumented_model = false;
 		bool opt_taintconstants = false, opt_keepoutputs = false, opt_simplecostmodel = false, opt_nocostmodel = false;
 		bool opt_instrumentmore = false;

--- a/passes/cmds/logcmd.cc
+++ b/passes/cmds/logcmd.cc
@@ -65,6 +65,9 @@ struct LogPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design* design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		size_t argidx;
 		bool to_stdout = false;
 		bool to_stderr = false;

--- a/passes/cmds/logger.cc
+++ b/passes/cmds/logger.cc
@@ -73,6 +73,9 @@ struct LoggerPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design * design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
 		{

--- a/passes/cmds/ltp.cc
+++ b/passes/cmds/ltp.cc
@@ -156,6 +156,9 @@ struct LtpPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool noff = false;
 
 		log_header(design, "Executing LTP pass (find longest path).\n");

--- a/passes/cmds/plugin.cc
+++ b/passes/cmds/plugin.cc
@@ -142,6 +142,9 @@ struct PluginPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		std::string plugin_filename;
 		std::vector<std::string> plugin_aliases;
 		bool list_mode = false;

--- a/passes/cmds/portlist.cc
+++ b/passes/cmds/portlist.cc
@@ -41,6 +41,9 @@ struct PortlistPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool m_mode = false;
 
 		size_t argidx;

--- a/passes/cmds/printattrs.cc
+++ b/passes/cmds/printattrs.cc
@@ -50,6 +50,9 @@ struct PrintAttrsPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		size_t argidx = 1;
 		extra_args(args, argidx, design);
 

--- a/passes/cmds/qwp.cc
+++ b/passes/cmds/qwp.cc
@@ -810,6 +810,9 @@ struct QwpPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		QwpConfig config;
 		xorshift32_state = 123456789;
 

--- a/passes/cmds/rename.cc
+++ b/passes/cmds/rename.cc
@@ -256,6 +256,9 @@ struct RenamePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		std::string pattern_prefix = "_", pattern_suffix = "_";
 		std::string cell_suffix = "";
 		bool flag_src = false;

--- a/passes/cmds/scatter.cc
+++ b/passes/cmds/scatter.cc
@@ -43,6 +43,9 @@ struct ScatterPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		CellTypes ct(design);
 		extra_args(args, 1, design);
 

--- a/passes/cmds/scc.cc
+++ b/passes/cmds/scc.cc
@@ -294,6 +294,9 @@ struct SccPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		dict<std::string, std::string> setAttr;
 		bool allCellTypes = false;
 		bool selectMode = false;

--- a/passes/cmds/scratchpad.cc
+++ b/passes/cmds/scratchpad.cc
@@ -66,6 +66,9 @@ struct ScratchpadPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
 		{

--- a/passes/cmds/select.cc
+++ b/passes/cmds/select.cc
@@ -1254,6 +1254,9 @@ struct SelectPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool add_mode = false;
 		bool del_mode = false;
 		bool clear_mode = false;
@@ -1622,6 +1625,9 @@ struct CdPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		if (args.size() != 1 && args.size() != 2)
 			log_cmd_error("Invalid number of arguments.\n");
 
@@ -1713,6 +1719,9 @@ struct LsPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		size_t argidx = 1;
 		extra_args(args, argidx, design);
 

--- a/passes/cmds/select.cc
+++ b/passes/cmds/select.cc
@@ -106,7 +106,8 @@ static bool match_attr_val(const RTLIL::Const &value, const std::string &pattern
 	log_abort();
 }
 
-static bool match_attr(const dict<RTLIL::IdString, RTLIL::Const> &attributes, const std::string &name_pat, const std::string &value_pat, char match_op)
+template <typename SmellsLikeDict>
+static bool match_attr(const SmellsLikeDict &attributes, const std::string &name_pat, const std::string &value_pat, char match_op)
 {
 	if (name_pat.find('*') != std::string::npos || name_pat.find('?') != std::string::npos || name_pat.find('[') != std::string::npos) {
 		for (auto &it : attributes) {
@@ -124,7 +125,8 @@ static bool match_attr(const dict<RTLIL::IdString, RTLIL::Const> &attributes, co
 	return false;
 }
 
-static bool match_attr(const dict<RTLIL::IdString, RTLIL::Const> &attributes, const std::string &match_expr)
+template <typename SmellsLikeDict>
+static bool match_attr(const SmellsLikeDict &attributes, const std::string &match_expr)
 {
 	size_t pos = match_expr.find_first_of("<!=>");
 

--- a/passes/cmds/setattr.cc
+++ b/passes/cmds/setattr.cc
@@ -71,6 +71,9 @@ struct SetattrPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		std::vector<setunset_t> setunset_list;
 		bool flag_mod = false;
 
@@ -140,6 +143,9 @@ struct WbflipPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
 		{
@@ -181,6 +187,9 @@ struct SetparamPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		vector<setunset_t> setunset_list;
 		string new_cell_type;
 
@@ -236,6 +245,9 @@ struct ChparamPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		std::vector<setunset_t> setunset_list;
 		dict<RTLIL::IdString, RTLIL::Const> new_parameters;
 		bool list_mode = false;

--- a/passes/cmds/setattr.cc
+++ b/passes/cmds/setattr.cc
@@ -45,7 +45,8 @@ struct setunset_t
 	}
 };
 
-static void do_setunset(dict<RTLIL::IdString, RTLIL::Const> &attrs, const std::vector<setunset_t> &list)
+template <typename SmellsLikeDict>
+static void do_setunset(SmellsLikeDict &attrs, const std::vector<setunset_t> &list)
 {
 	for (auto &item : list)
 		if (item.unset)

--- a/passes/cmds/setattr.cc
+++ b/passes/cmds/setattr.cc
@@ -220,7 +220,7 @@ struct SetparamPass : public Pass {
 		{
 			for (auto cell : module->selected_cells()) {
 				if (!new_cell_type.empty())
-					cell->type = new_cell_type;
+					cell = cell->module->morphCell(new_cell_type, cell);
 				do_setunset(cell->parameters, setunset_list);
 			}
 		}

--- a/passes/cmds/setundef.cc
+++ b/passes/cmds/setundef.cc
@@ -245,7 +245,7 @@ struct SetundefPass : public Pass {
 			if (params_mode)
 			{
 				for (auto *cell : module->selected_cells()) {
-					for (auto &&parameter : cell->parameters) {
+					for (auto parameter : cell->parameters) {
 						for (auto &bit : parameter.second.bits) {
 							if (bit > RTLIL::State::S1)
 								bit = worker.next_bit();

--- a/passes/cmds/setundef.cc
+++ b/passes/cmds/setundef.cc
@@ -245,7 +245,7 @@ struct SetundefPass : public Pass {
 			if (params_mode)
 			{
 				for (auto *cell : module->selected_cells()) {
-					for (auto &parameter : cell->parameters) {
+					for (auto &&parameter : cell->parameters) {
 						for (auto &bit : parameter.second.bits) {
 							if (bit > RTLIL::State::S1)
 								bit = worker.next_bit();

--- a/passes/cmds/setundef.cc
+++ b/passes/cmds/setundef.cc
@@ -150,6 +150,9 @@ struct SetundefPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		int got_value = 0;
 		bool undriven_mode = false;
 		bool expose_mode = false;

--- a/passes/cmds/show.cc
+++ b/passes/cmds/show.cc
@@ -752,6 +752,9 @@ struct ShowPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Generating Graphviz representation of design.\n");
 		log_push();
 

--- a/passes/cmds/splice.cc
+++ b/passes/cmds/splice.cc
@@ -188,7 +188,7 @@ struct SpliceWorker
 		for (auto cell : mod_cells) {
 			if (!sel_by_wire && !design->selected(module, cell))
 				continue;
-			for (auto &&conn : cell->connections_)
+			for (auto conn : cell->connections_)
 				if (ct.cell_input(cell->type, conn.first)) {
 					if (ports.size() > 0 && !ports.count(conn.first))
 						continue;

--- a/passes/cmds/splice.cc
+++ b/passes/cmds/splice.cc
@@ -289,6 +289,9 @@ struct SplicePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool sel_by_cell = false;
 		bool sel_by_wire = false;
 		bool sel_any_bit = false;

--- a/passes/cmds/splice.cc
+++ b/passes/cmds/splice.cc
@@ -188,7 +188,7 @@ struct SpliceWorker
 		for (auto cell : mod_cells) {
 			if (!sel_by_wire && !design->selected(module, cell))
 				continue;
-			for (auto &conn : cell->connections_)
+			for (auto &&conn : cell->connections_)
 				if (ct.cell_input(cell->type, conn.first)) {
 					if (ports.size() > 0 && !ports.count(conn.first))
 						continue;

--- a/passes/cmds/splitcells.cc
+++ b/passes/cmds/splitcells.cc
@@ -220,6 +220,9 @@ struct SplitcellsPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		std::string format;
 
 		log_header(design, "Executing SPLITCELLS pass (splitting up multi-bit cells).\n");

--- a/passes/cmds/splitnets.cc
+++ b/passes/cmds/splitnets.cc
@@ -119,6 +119,9 @@ struct SplitnetsPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool flag_ports = false;
 		bool flag_driver = false;
 		std::string format = "[]:";

--- a/passes/cmds/sta.cc
+++ b/passes/cmds/sta.cc
@@ -21,6 +21,7 @@
 #include "kernel/yosys.h"
 #include "kernel/sigtools.h"
 #include "kernel/timinginfo.h"
+#include "kernel/compat.h"
 #include <deque>
 
 USING_YOSYS_NAMESPACE
@@ -74,7 +75,7 @@ struct StaWorker
 				continue;
 			}
 
-			IdString derived_type = inst_module->derive(design, cell->parameters);
+			IdString derived_type = inst_module->derive(design, cell_to_mod_params(cell->parameters));
 			inst_module = design->module(derived_type);
 			log_assert(inst_module);
 

--- a/passes/cmds/sta.cc
+++ b/passes/cmds/sta.cc
@@ -287,6 +287,9 @@ struct StaPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing STA pass (static timing analysis).\n");
 
 		/*

--- a/passes/cmds/stat.cc
+++ b/passes/cmds/stat.cc
@@ -404,6 +404,9 @@ struct StatPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool width_mode = false, json_mode = false;
 		RTLIL::Module *top_mod = nullptr;
 		std::map<RTLIL::IdString, statdata_t> mod_stat;

--- a/passes/cmds/tee.cc
+++ b/passes/cmds/tee.cc
@@ -54,6 +54,9 @@ struct TeePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		std::vector<FILE*> backup_log_files, files_to_close;
 		std::vector<std::ostream*> backup_log_streams;
 		std::vector<std::string> backup_log_scratchpads;

--- a/passes/cmds/torder.cc
+++ b/passes/cmds/torder.cc
@@ -45,6 +45,9 @@ struct TorderPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool noautostop = false;
 		dict<IdString, pool<IdString>> stop_db;
 

--- a/passes/cmds/trace.cc
+++ b/passes/cmds/trace.cc
@@ -72,6 +72,9 @@ struct TracePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
 		{
@@ -107,6 +110,9 @@ struct DebugPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
 		{

--- a/passes/cmds/viz.cc
+++ b/passes/cmds/viz.cc
@@ -889,6 +889,9 @@ struct VizPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Generating Graphviz representation of design.\n");
 		log_push();
 

--- a/passes/cmds/write_file.cc
+++ b/passes/cmds/write_file.cc
@@ -46,6 +46,9 @@ struct WriteFileFrontend : public Frontend {
 	}
 	void execute(std::istream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design*) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool append_mode = false;
 		std::string output_filename;
 

--- a/passes/cmds/xprop.cc
+++ b/passes/cmds/xprop.cc
@@ -1154,6 +1154,9 @@ struct XpropPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		XpropOptions options;
 
 		log_header(design, "Executing XPROP pass.\n");

--- a/passes/equiv/equiv_add.cc
+++ b/passes/equiv/equiv_add.cc
@@ -41,6 +41,9 @@ struct EquivAddPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool try_mode = false;
 
 		if (design->selected_active_module.empty())

--- a/passes/equiv/equiv_induct.cc
+++ b/passes/equiv/equiv_induct.cc
@@ -199,6 +199,9 @@ struct EquivInductPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		int success_counter = 0;
 		bool model_undef = false;
 		int max_seq = 4;

--- a/passes/equiv/equiv_make.cc
+++ b/passes/equiv/equiv_make.cc
@@ -457,6 +457,9 @@ struct EquivMakePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		EquivMakeWorker worker;
 		worker.ct.setup(design);
 		worker.inames = false;

--- a/passes/equiv/equiv_mark.cc
+++ b/passes/equiv/equiv_mark.cc
@@ -218,6 +218,9 @@ struct EquivMarkPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing EQUIV_MARK pass.\n");
 
 		size_t argidx;

--- a/passes/equiv/equiv_miter.cc
+++ b/passes/equiv/equiv_miter.cc
@@ -284,6 +284,9 @@ struct EquivMiterPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		EquivMiterWorker worker;
 		worker.ct.setup(design);
 		worker.mode_trigger = false;

--- a/passes/equiv/equiv_opt.cc
+++ b/passes/equiv/equiv_opt.cc
@@ -85,6 +85,9 @@ struct EquivOptPass:public ScriptPass
 
 	void execute(std::vector < std::string > args, RTLIL::Design * design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		string run_from, run_to;
 		clear_flags();
 

--- a/passes/equiv/equiv_purge.cc
+++ b/passes/equiv/equiv_purge.cc
@@ -189,6 +189,9 @@ struct EquivPurgePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing EQUIV_PURGE pass.\n");
 
 		size_t argidx;

--- a/passes/equiv/equiv_remove.cc
+++ b/passes/equiv/equiv_remove.cc
@@ -42,6 +42,9 @@ struct EquivRemovePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool mode_gold = false;
 		bool mode_gate = false;
 		int remove_count = 0;

--- a/passes/equiv/equiv_simple.cc
+++ b/passes/equiv/equiv_simple.cc
@@ -304,6 +304,9 @@ struct EquivSimplePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool verbose = false, short_cones = false, model_undef = false, nogroup = false;
 		int success_counter = 0;
 		int max_seq = 1;

--- a/passes/equiv/equiv_status.cc
+++ b/passes/equiv/equiv_status.cc
@@ -38,6 +38,9 @@ struct EquivStatusPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool assert_mode = false;
 		int unproven_count = 0;
 

--- a/passes/equiv/equiv_struct.cc
+++ b/passes/equiv/equiv_struct.cc
@@ -162,7 +162,7 @@ struct EquivStructWorker
 			Cell *cell = module->cell(cell_name);
 			key.type = cell->type;
 
-			for (auto &it : cell->parameters)
+			for (auto &&it : cell->parameters)
 				key.parameters.push_back(it);
 			std::sort(key.parameters.begin(), key.parameters.end());
 

--- a/passes/equiv/equiv_struct.cc
+++ b/passes/equiv/equiv_struct.cc
@@ -316,6 +316,9 @@ struct EquivStructPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		pool<IdString> fwonly_cells({ ID($equiv) });
 		bool mode_icells = false;
 		bool mode_fwd = false;

--- a/passes/equiv/equiv_struct.cc
+++ b/passes/equiv/equiv_struct.cc
@@ -162,7 +162,7 @@ struct EquivStructWorker
 			Cell *cell = module->cell(cell_name);
 			key.type = cell->type;
 
-			for (auto &&it : cell->parameters)
+			for (auto it : cell->parameters)
 				key.parameters.push_back(it);
 			std::sort(key.parameters.begin(), key.parameters.end());
 

--- a/passes/fsm/fsm.cc
+++ b/passes/fsm/fsm.cc
@@ -79,6 +79,9 @@ struct FsmPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool flag_nomap = false;
 		bool flag_norecode = false;
 		bool flag_nodetect = false;

--- a/passes/fsm/fsm_detect.cc
+++ b/passes/fsm/fsm_detect.cc
@@ -287,6 +287,9 @@ struct FsmDetectPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing FSM_DETECT pass (finding FSMs in design).\n");
 
 		bool ignore_self_reset = false;

--- a/passes/fsm/fsm_expand.cc
+++ b/passes/fsm/fsm_expand.cc
@@ -281,6 +281,9 @@ struct FsmExpandPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool full_mode = false;
 
 		log_header(design, "Executing FSM_EXPAND pass (merging auxiliary logic into FSMs).\n");

--- a/passes/fsm/fsm_export.cc
+++ b/passes/fsm/fsm_export.cc
@@ -145,6 +145,9 @@ struct FsmExportPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		dict<RTLIL::IdString, RTLIL::Const>::iterator attr_it;
 		std::string arg;
 		bool flag_noauto = false;

--- a/passes/fsm/fsm_extract.cc
+++ b/passes/fsm/fsm_extract.cc
@@ -395,7 +395,8 @@ static void extract_fsm(RTLIL::Wire *wire)
 		RTLIL::SigSpec port_sig = assign_map(cell->getPort(cellport.second));
 		RTLIL::SigSpec unconn_sig = port_sig.extract(ctrl_out);
 		RTLIL::Wire *unconn_wire = module->addWire(stringf("$fsm_unconnect$%d", autoidx++), unconn_sig.size());
-		port_sig.replace(unconn_sig, RTLIL::SigSpec(unconn_wire), &cell->connections_[cellport.second]);
+		auto &x = cell->connections_[cellport.second];
+		port_sig.replace(unconn_sig, RTLIL::SigSpec(unconn_wire), x);
 	}
 }
 

--- a/passes/fsm/fsm_extract.cc
+++ b/passes/fsm/fsm_extract.cc
@@ -419,6 +419,9 @@ struct FsmExtractPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing FSM_EXTRACT pass (extracting FSM from design).\n");
 		extra_args(args, 1, design);
 

--- a/passes/fsm/fsm_extract.cc
+++ b/passes/fsm/fsm_extract.cc
@@ -395,8 +395,7 @@ static void extract_fsm(RTLIL::Wire *wire)
 		RTLIL::SigSpec port_sig = assign_map(cell->getPort(cellport.second));
 		RTLIL::SigSpec unconn_sig = port_sig.extract(ctrl_out);
 		RTLIL::Wire *unconn_wire = module->addWire(stringf("$fsm_unconnect$%d", autoidx++), unconn_sig.size());
-		auto &x = cell->connections_[cellport.second];
-		port_sig.replace(unconn_sig, RTLIL::SigSpec(unconn_wire), x);
+		port_sig.replace(unconn_sig, RTLIL::SigSpec(unconn_wire), cell->connections_[cellport.second]);
 	}
 }
 

--- a/passes/fsm/fsm_info.cc
+++ b/passes/fsm/fsm_info.cc
@@ -43,6 +43,9 @@ struct FsmInfoPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing FSM_INFO pass (dumping all available information on FSM cells).\n");
 		extra_args(args, 1, design);
 

--- a/passes/fsm/fsm_map.cc
+++ b/passes/fsm/fsm_map.cc
@@ -333,6 +333,9 @@ struct FsmMapPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing FSM_MAP pass (mapping FSMs to basic logic).\n");
 		extra_args(args, 1, design);
 

--- a/passes/fsm/fsm_opt.cc
+++ b/passes/fsm/fsm_opt.cc
@@ -337,6 +337,9 @@ struct FsmOptPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing FSM_OPT pass (simple optimizations of FSMs).\n");
 		extra_args(args, 1, design);
 

--- a/passes/fsm/fsm_recode.cc
+++ b/passes/fsm/fsm_recode.cc
@@ -153,6 +153,9 @@ struct FsmRecodePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		FILE *fm_set_fsm_file = NULL;
 		FILE *encfile = NULL;
 		std::string default_encoding;

--- a/passes/fsm/fsmdata.h
+++ b/passes/fsm/fsmdata.h
@@ -48,7 +48,8 @@ struct FsmData
 		cell->parameters[ID::STATE_TABLE] = RTLIL::Const();
 
 		for (int i = 0; i < int(state_table.size()); i++) {
-			std::vector<RTLIL::State> &bits_table = cell->parameters[ID::STATE_TABLE].bits;
+			auto thing = cell->parameters[ID::STATE_TABLE];
+			std::vector<RTLIL::State> &bits_table = thing.bits;
 			std::vector<RTLIL::State> &bits_state = state_table[i].bits;
 			bits_table.insert(bits_table.end(), bits_state.begin(), bits_state.end());
 		}

--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -575,7 +575,7 @@ bool expand_module(RTLIL::Design *design, RTLIL::Module *module, bool flag_check
 
 		RTLIL::Module *mod = design->module(cell->type);
 
-		for (auto &&conn : cell->connections_) {
+		for (auto conn : cell->connections_) {
 			int conn_size = conn.second.size();
 			RTLIL::IdString portname = conn.first;
 			if (portname.begins_with("$")) {

--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -473,7 +473,7 @@ bool expand_module(RTLIL::Design *design, RTLIL::Module *module, bool flag_check
 			int idx = atoi(cell->type.substr(pos_idx + 1, pos_num).c_str());
 			int num = atoi(cell->type.substr(pos_num + 1, pos_type).c_str());
 			array_cells[cell] = std::pair<int, int>(idx, num);
-			cell->type = cell->type.substr(pos_type + 1);
+			cell = cell->module->morphCell(cell->type.substr(pos_type + 1), cell);
 		}
 
 		RTLIL::Module *mod = design->module(cell->type);

--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -819,6 +819,9 @@ struct HierarchyPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing HIERARCHY pass (managing design hierarchy).\n");
 
 		bool flag_check = false;

--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -70,7 +70,7 @@ void generate(RTLIL::Design *design, const std::vector<std::string> &celltypes, 
 						portnames.insert(conn.first);
 					portwidths[conn.first] = max(portwidths[conn.first], conn.second.size());
 				}
-				for (auto &&para : cell->parameters)
+				for (auto para : cell->parameters)
 					parameters.insert(para.first);
 			}
 

--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -574,7 +574,7 @@ bool expand_module(RTLIL::Design *design, RTLIL::Module *module, bool flag_check
 
 		RTLIL::Module *mod = design->module(cell->type);
 
-		for (auto &conn : cell->connections_) {
+		for (auto &&conn : cell->connections_) {
 			int conn_size = conn.second.size();
 			RTLIL::IdString portname = conn.first;
 			if (portname.begins_with("$")) {

--- a/passes/hierarchy/submod.cc
+++ b/passes/hierarchy/submod.cc
@@ -208,7 +208,7 @@ struct SubmodWorker
 
 		for (RTLIL::Cell *cell : submod.cells) {
 			RTLIL::Cell *new_cell = new_mod->addCell(cell->name, cell);
-			for (auto &conn : new_cell->connections_)
+			for (auto conn : new_cell->connections_)
 				for (auto &bit : conn.second)
 					if (bit.wire != nullptr) {
 						log_assert(wire_flags.count(bit.wire) > 0);

--- a/passes/hierarchy/submod.cc
+++ b/passes/hierarchy/submod.cc
@@ -354,6 +354,9 @@ struct SubmodPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing SUBMOD pass (moving cells to submodules as requested).\n");
 		log_push();
 

--- a/passes/hierarchy/uniquify.cc
+++ b/passes/hierarchy/uniquify.cc
@@ -89,7 +89,7 @@ struct UniquifyPass : public Pass {
 
 					auto smod = tmod->clone();
 					smod->name = newname;
-					cell->type = newname;
+					cell = cell->module->morphCell(newname, cell);
 					smod->set_bool_attribute(ID::unique);
 					if (smod->attributes.count(ID::hdlname) == 0)
 						smod->attributes[ID::hdlname] = string(log_id(tmod->name));

--- a/passes/hierarchy/uniquify.cc
+++ b/passes/hierarchy/uniquify.cc
@@ -43,6 +43,9 @@ struct UniquifyPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing UNIQUIFY pass (creating unique copies of modules).\n");
 
 		size_t argidx;

--- a/passes/memory/memory.cc
+++ b/passes/memory/memory.cc
@@ -55,6 +55,9 @@ struct MemoryPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool flag_norom = false;
 		bool flag_nomap = false;
 		bool flag_nordff = false;

--- a/passes/memory/memory_bmux2rom.cc
+++ b/passes/memory/memory_bmux2rom.cc
@@ -37,6 +37,9 @@ struct MemoryBmux2RomPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing MEMORY_BMUX2ROM pass (converting muxes to ROMs).\n");
 
 		size_t argidx;

--- a/passes/memory/memory_bram.cc
+++ b/passes/memory/memory_bram.cc
@@ -1306,6 +1306,9 @@ struct MemoryBramPass : public Pass {
 	}
 	void execute(vector<string> args, Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		rules_t rules;
 
 		log_header(design, "Executing MEMORY_BRAM pass (mapping $mem cells to block memories).\n");

--- a/passes/memory/memory_collect.cc
+++ b/passes/memory/memory_collect.cc
@@ -37,6 +37,9 @@ struct MemoryCollectPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override {
 		log_header(design, "Executing MEMORY_COLLECT pass (generating $mem cells).\n");
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		extra_args(args, 1, design);
 		for (auto module : design->selected_modules()) {
 			if (module->has_processes_warn())

--- a/passes/memory/memory_dff.cc
+++ b/passes/memory/memory_dff.cc
@@ -643,6 +643,9 @@ struct MemoryDffPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool flag_no_rw_check = false;
 		log_header(design, "Executing MEMORY_DFF pass (merging $dff cells to $memrd).\n");
 

--- a/passes/memory/memory_libmap.cc
+++ b/passes/memory/memory_libmap.cc
@@ -2182,6 +2182,9 @@ struct MemoryLibMapPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		std::vector<std::string> lib_files;
 		pool<std::string> defines;
 		PassOptions opts;

--- a/passes/memory/memory_map.cc
+++ b/passes/memory/memory_map.cc
@@ -432,6 +432,9 @@ struct MemoryMapPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool attr_icase = false;
 		bool rom_only = false;
 		bool keepdc = false;

--- a/passes/memory/memory_memx.cc
+++ b/passes/memory/memory_memx.cc
@@ -51,6 +51,9 @@ struct MemoryMemxPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override {
 		log_header(design, "Executing MEMORY_MEMX pass (emit soft logic for out-of-bounds handling).\n");
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		extra_args(args, 1, design);
 
 		for (auto module : design->selected_modules())

--- a/passes/memory/memory_narrow.cc
+++ b/passes/memory/memory_narrow.cc
@@ -37,6 +37,9 @@ struct MemoryNarrowPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing MEMORY_NARROW pass (splitting up wide memory ports).\n");
 
 		size_t argidx;

--- a/passes/memory/memory_nordff.cc
+++ b/passes/memory/memory_nordff.cc
@@ -38,6 +38,9 @@ struct MemoryNordffPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing MEMORY_NORDFF pass (extracting $dff cells from memories).\n");
 
 		size_t argidx;

--- a/passes/memory/memory_share.cc
+++ b/passes/memory/memory_share.cc
@@ -538,6 +538,9 @@ struct MemorySharePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override {
 		bool flag_widen = true;
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool flag_sat = true;
 		log_header(design, "Executing MEMORY_SHARE pass (consolidating $memrd/$memwr cells).\n");
 		size_t argidx;

--- a/passes/memory/memory_unpack.cc
+++ b/passes/memory/memory_unpack.cc
@@ -37,6 +37,9 @@ struct MemoryUnpackPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override {
 		log_header(design, "Executing MEMORY_UNPACK pass (generating $memrd/$memwr cells form $mem cells).\n");
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		extra_args(args, 1, design);
 		for (auto module : design->selected_modules()) {
 			for (auto &mem : Mem::get_selected_memories(module)) {

--- a/passes/opt/muxpack.cc
+++ b/passes/opt/muxpack.cc
@@ -343,6 +343,9 @@ struct MuxpackPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing MUXPACK pass ($mux cell cascades to $pmux).\n");
 
 		size_t argidx;

--- a/passes/opt/muxpack.cc
+++ b/passes/opt/muxpack.cc
@@ -269,7 +269,7 @@ struct MuxpackWorker
 			mux_count += cases;
 			pmux_count += 1;
 
-			first_cell->type = ID($pmux);
+			first_cell = first_cell->module->morphCell(ID($pmux), first_cell);
 			SigSpec b_sig = first_cell->getPort(ID::B);
 			SigSpec s_sig = first_cell->getPort(ID::S);
 

--- a/passes/opt/opt.cc
+++ b/passes/opt/opt.cc
@@ -66,6 +66,9 @@ struct OptPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		std::string opt_clean_args;
 		std::string opt_expr_args;
 		std::string opt_reduce_args;

--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -361,7 +361,7 @@ bool rmunused_module_signals(RTLIL::Module *module, bool purge_mode, bool verbos
 	// gather the usage information for cells
 	for (auto &it : module->cells_) {
 		RTLIL::Cell *cell = it.second;
-		for (auto &it2 : cell->connections_) {
+		for (auto it2 : cell->connections_) {
 			assign_map.apply(it2.second); // modify the cell connection in place
 			raw_used_signals.add(it2.second);
 			used_signals.add(it2.second);

--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -646,6 +646,9 @@ struct OptCleanPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool purge_mode = false;
 
 		log_header(design, "Executing OPT_CLEAN pass (remove unused cells and wires).\n");
@@ -711,6 +714,9 @@ struct CleanPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool purge_mode = false;
 
 		size_t argidx;

--- a/passes/opt/opt_demorgan.cc
+++ b/passes/opt/opt_demorgan.cc
@@ -155,9 +155,9 @@ void demorgan_worker(
 
 	//Change the cell type
 	if(cell->type == ID($reduce_and))
-		cell->type = ID($reduce_or);
+		cell = m->morphCell(ID($reduce_or), cell);
 	else if(cell->type == ID($reduce_or))
-		cell->type = ID($reduce_and);
+		cell = m->morphCell(ID($reduce_and), cell);
 	//don't change XOR
 
 	//Add an inverter to the output

--- a/passes/opt/opt_demorgan.cc
+++ b/passes/opt/opt_demorgan.cc
@@ -181,6 +181,9 @@ struct OptDemorganPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing OPT_DEMORGAN pass (push inverters through $reduce_* cells).\n");
 
 		int argidx = 1;

--- a/passes/opt/opt_dff.cc
+++ b/passes/opt/opt_dff.cc
@@ -882,6 +882,9 @@ struct OptDffPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing OPT_DFF pass (perform DFF optimizations).\n");
 		OptDffOptions opt;
 		opt.nodffe = false;

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -409,7 +409,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 	for (auto cell : module->cells())
 		if (design->selected(module, cell) && cell->type[0] == '$') {
 			if (cell->type.in(ID($_NOT_), ID($not), ID($logic_not)) &&
-					GetSize(cell->getPort(ID::A)) == 1 && GetSize(cell->getPort(ID::Y)) == 1)
+					GetSize(cell->getPort(ID::B)) == 1 && GetSize(cell->getPort(ID::Y)) == 1)
 				invert_map[assign_map(cell->getPort(ID::Y))] = assign_map(cell->getPort(ID::A));
 			if (cell->type.in(ID($mux), ID($_MUX_)) &&
 					cell->getPort(ID::A) == SigSpec(State::S1) && cell->getPort(ID::B) == SigSpec(State::S0))

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -409,7 +409,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 	for (auto cell : module->cells())
 		if (design->selected(module, cell) && cell->type[0] == '$') {
 			if (cell->type.in(ID($_NOT_), ID($not), ID($logic_not)) &&
-					GetSize(cell->getPort(ID::B)) == 1 && GetSize(cell->getPort(ID::Y)) == 1)
+					GetSize(cell->getPort(ID::A)) == 1 && GetSize(cell->getPort(ID::Y)) == 1)
 				invert_map[assign_map(cell->getPort(ID::Y))] = assign_map(cell->getPort(ID::A));
 			if (cell->type.in(ID($mux), ID($_MUX_)) &&
 					cell->getPort(ID::A) == SigSpec(State::S1) && cell->getPort(ID::B) == SigSpec(State::S0))

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -2252,6 +2252,9 @@ struct OptExprPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool mux_undef = false;
 		bool mux_bool = false;
 		bool undriven = false;

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -408,6 +408,8 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 	for (auto cell : module->cells())
 		if (design->selected(module, cell) && cell->type[0] == '$') {
+			log("%s\n", cell->name.c_str());
+			log_cell(cell, "inner ");
 			if (cell->type.in(ID($_NOT_), ID($not), ID($logic_not)) &&
 					GetSize(cell->getPort(ID::A)) == 1 && GetSize(cell->getPort(ID::Y)) == 1)
 				invert_map[assign_map(cell->getPort(ID::Y))] = assign_map(cell->getPort(ID::A));
@@ -2305,6 +2307,9 @@ struct OptExprPass : public Pass {
 		CellTypes ct(design);
 		for (auto module : design->selected_modules())
 		{
+			for (auto cell : module->cells()) {
+				log_cell(cell, "start ");
+			}
 			log("Optimizing module %s.\n", log_id(module));
 
 			if (undriven) {
@@ -2312,6 +2317,9 @@ struct OptExprPass : public Pass {
 				replace_undriven(module, ct);
 				if (did_something)
 					design->scratchpad_set_bool("opt.did_something", true);
+			}
+			for (auto cell : module->cells()) {
+				log_cell(cell, "mid ");
 			}
 
 			do {

--- a/passes/opt/opt_ffinv.cc
+++ b/passes/opt/opt_ffinv.cc
@@ -245,6 +245,9 @@ struct OptFfInvPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing OPT_FFINV pass (push inverters through FFs).\n");
 
 		size_t argidx;

--- a/passes/opt/opt_lut.cc
+++ b/passes/opt/opt_lut.cc
@@ -543,6 +543,9 @@ struct OptLutPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing OPT_LUT pass (optimize LUTs).\n");
 
 		std::vector<dlogic_t> dlogic;

--- a/passes/opt/opt_lut_ins.cc
+++ b/passes/opt/opt_lut_ins.cc
@@ -44,6 +44,9 @@ struct OptLutInsPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing OPT_LUT_INS pass (discard unused LUT inputs).\n");
 		string techname;
 

--- a/passes/opt/opt_lut_ins.cc
+++ b/passes/opt/opt_lut_ins.cc
@@ -244,17 +244,17 @@ struct OptLutInsPass : public Pass {
 						else
 							log_assert(GetSize(new_inputs) <= 4);
 						if (GetSize(new_inputs) == 1)
-							cell->type = ID(LUT1);
+							cell = cell->module->morphCell(ID(LUT1), cell);
 						else if (GetSize(new_inputs) == 2)
-							cell->type = ID(LUT2);
+							cell = cell->module->morphCell(ID(LUT2), cell);
 						else if (GetSize(new_inputs) == 3)
-							cell->type = ID(LUT3);
+							cell = cell->module->morphCell(ID(LUT3), cell);
 						else if (GetSize(new_inputs) == 4)
-							cell->type = ID(LUT4);
+							cell = cell->module->morphCell(ID(LUT4), cell);
 						else if (GetSize(new_inputs) == 5)
-							cell->type = ID(LUT5);
+							cell = cell->module->morphCell(ID(LUT5), cell);
 						else if (GetSize(new_inputs) == 6)
-							cell->type = ID(LUT6);
+							cell = cell->module->morphCell(ID(LUT6), cell);
 						else
 							log_assert(0);
 						cell->unsetPort(ID(I0));

--- a/passes/opt/opt_mem.cc
+++ b/passes/opt/opt_mem.cc
@@ -38,6 +38,9 @@ struct OptMemPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing OPT_MEM pass (optimize memories).\n");
 
 		size_t argidx;

--- a/passes/opt/opt_mem_feedback.cc
+++ b/passes/opt/opt_mem_feedback.cc
@@ -338,6 +338,9 @@ struct OptMemFeedbackPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override {
 		log_header(design, "Executing OPT_MEM_FEEDBACK pass (finding memory read-to-write feedback paths).\n");
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		extra_args(args, 1, design);
 		OptMemFeedbackWorker worker(design);
 

--- a/passes/opt/opt_mem_priority.cc
+++ b/passes/opt/opt_mem_priority.cc
@@ -42,6 +42,9 @@ struct OptMemPriorityPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override {
 		log_header(design, "Executing OPT_MEM_PRIORITY pass (removing unnecessary memory write priority relations).\n");
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		extra_args(args, 1, design);
 
 		ModWalker modwalker(design);

--- a/passes/opt/opt_mem_widen.cc
+++ b/passes/opt/opt_mem_widen.cc
@@ -37,6 +37,9 @@ struct OptMemWidenPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing OPT_MEM_WIDEN pass (optimize memories where all ports are wide).\n");
 
 		size_t argidx;

--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -167,7 +167,7 @@ struct OptMergeWorker
 			if (!cell2->connections_.count(it.first))
 				return false;
 
-		decltype(Cell::connections_) conn1, conn2;
+		dict<RTLIL::IdString, RTLIL::SigSpec> conn1, conn2;
 		conn1.reserve(cell1->connections_.size());
 		conn2.reserve(cell1->connections_.size());
 

--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -42,7 +42,8 @@ struct OptMergeWorker
 	CellTypes ct;
 	int total_count;
 
-	static void sort_pmux_conn(dict<RTLIL::IdString, RTLIL::SigSpec> &conn)
+	template <typename SmellsLikeDict>
+	static void sort_pmux_conn(SmellsLikeDict &conn)
 	{
 		SigSpec sig_s = conn.at(ID::S);
 		SigSpec sig_b = conn.at(ID::B);
@@ -82,7 +83,8 @@ struct OptMergeWorker
 		vector<string> hash_conn_strings;
 		std::string hash_string = cell->type.str() + "\n";
 
-		const dict<RTLIL::IdString, RTLIL::SigSpec> *conn = &cell->connections();
+		auto tmp = cell->connections_.as_dict();
+		dict<RTLIL::IdString, RTLIL::SigSpec>* conn = &tmp;
 		dict<RTLIL::IdString, RTLIL::SigSpec> alt_conn;
 
 		if (cell->type.in(ID($and), ID($or), ID($xor), ID($xnor), ID($add), ID($mul),
@@ -140,7 +142,7 @@ struct OptMergeWorker
 			hash_conn_strings.push_back(s + "\n");
 		}
 
-		for (auto &&it : cell->parameters)
+		for (auto it : cell->parameters)
 			hash_conn_strings.push_back("P " + it.first.str() + "=" + it.second.as_string() + "\n");
 
 		std::sort(hash_conn_strings.begin(), hash_conn_strings.end());

--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -336,6 +336,9 @@ struct OptMergePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing OPT_MERGE pass (detect identical cells).\n");
 
 		bool mode_nomux = false;

--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -140,7 +140,7 @@ struct OptMergeWorker
 			hash_conn_strings.push_back(s + "\n");
 		}
 
-		for (auto &it : cell->parameters)
+		for (auto &&it : cell->parameters)
 			hash_conn_strings.push_back("P " + it.first.str() + "=" + it.second.as_string() + "\n");
 
 		std::sort(hash_conn_strings.begin(), hash_conn_strings.end());

--- a/passes/opt/opt_muxtree.cc
+++ b/passes/opt/opt_muxtree.cc
@@ -487,6 +487,9 @@ struct OptMuxtreePass : public Pass {
 	}
 	void execute(vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing OPT_MUXTREE pass (detect dead branches in mux trees).\n");
 		extra_args(args, 1, design);
 

--- a/passes/opt/opt_muxtree.cc
+++ b/passes/opt/opt_muxtree.cc
@@ -259,7 +259,7 @@ struct OptMuxtreeWorker
 				mi.cell->setPort(ID::B, new_sig_b);
 				mi.cell->setPort(ID::S, new_sig_s);
 				if (GetSize(new_sig_s) == 1) {
-					mi.cell->type = ID($mux);
+					mi.cell = mi.cell->module->morphCell(ID($mux), mi.cell);
 					mi.cell->parameters.erase(ID::S_WIDTH);
 				} else {
 					mi.cell->parameters[ID::S_WIDTH] = RTLIL::Const(GetSize(new_sig_s));

--- a/passes/opt/opt_reduce.cc
+++ b/passes/opt/opt_reduce.cc
@@ -160,7 +160,7 @@ struct OptReduceWorker
 			if (new_sig_s.size() > 1) {
 				cell->parameters[ID::S_WIDTH] = RTLIL::Const(new_sig_s.size());
 			} else {
-				cell->type = ID($mux);
+				cell = cell->module->morphCell(ID($mux), cell);
 				cell->parameters.erase(ID::S_WIDTH);
 			}
 		}
@@ -228,7 +228,7 @@ struct OptReduceWorker
 
 		if (new_sig_s.size() == 1)
 		{
-			cell->type = ID($mux);
+			cell = cell->module->morphCell(ID($mux), cell);
 			cell->setPort(ID::A, new_sig_a.extract(0, width));
 			cell->setPort(ID::B, new_sig_a.extract(width, width));
 			cell->setPort(ID::S, new_sig_s);

--- a/passes/opt/opt_reduce.cc
+++ b/passes/opt/opt_reduce.cc
@@ -630,6 +630,9 @@ struct OptReducePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool do_fine = false;
 
 		log_header(design, "Executing OPT_REDUCE pass (consolidate $*mux and $reduce_* inputs).\n");

--- a/passes/opt/opt_share.cc
+++ b/passes/opt/opt_share.cc
@@ -354,6 +354,9 @@ struct OptSharePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 
 		log_header(design, "Executing OPT_SHARE pass.\n");
 

--- a/passes/opt/pmux2shiftx.cc
+++ b/passes/opt/pmux2shiftx.cc
@@ -218,6 +218,9 @@ struct Pmux2ShiftxPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		int min_density = 50;
 		int min_choices = 3;
 		bool allow_onehot = false;
@@ -742,6 +745,9 @@ struct OnehotPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool verbose = false;
 		bool verbose_onehot = false;
 

--- a/passes/opt/rmports.cc
+++ b/passes/opt/rmports.cc
@@ -41,6 +41,9 @@ struct RmportsPassPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing RMPORTS pass (remove ports with no connections).\n");
 
 		size_t argidx = 1;

--- a/passes/opt/share.cc
+++ b/passes/opt/share.cc
@@ -481,11 +481,11 @@ struct ShareWorker
 			return true;
 		}
 
-		for (auto &it : c1->parameters)
+		for (auto it : c1->parameters)
 			if (c2->parameters.count(it.first) == 0 || c2->parameters.at(it.first) != it.second)
 				return false;
 
-		for (auto &it : c2->parameters)
+		for (auto it : c2->parameters)
 			if (c1->parameters.count(it.first) == 0 || c1->parameters.at(it.first) != it.second)
 				return false;
 

--- a/passes/opt/share.cc
+++ b/passes/opt/share.cc
@@ -1442,6 +1442,9 @@ struct SharePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		ShareWorkerConfig config;
 
 		config.limit = -1;

--- a/passes/opt/wreduce.cc
+++ b/passes/opt/wreduce.cc
@@ -495,6 +495,9 @@ struct WreducePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		WreduceConfig config;
 		bool opt_memx = false;
 

--- a/passes/pmgen/ice40_dsp.cc
+++ b/passes/pmgen/ice40_dsp.cc
@@ -298,6 +298,9 @@ struct Ice40DspPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing ICE40_DSP pass (map multipliers).\n");
 
 		size_t argidx;

--- a/passes/pmgen/ice40_wrapcarry.cc
+++ b/passes/pmgen/ice40_wrapcarry.cc
@@ -93,6 +93,9 @@ struct Ice40WrapCarryPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool unwrap = false;
 
 		log_header(design, "Executing ICE40_WRAPCARRY pass (wrap carries).\n");

--- a/passes/pmgen/peepopt.cc
+++ b/passes/pmgen/peepopt.cc
@@ -54,6 +54,9 @@ struct PeepoptPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing PEEPOPT pass (run peephole optimizers).\n");
 
 		size_t argidx;

--- a/passes/pmgen/pmgen.py
+++ b/passes/pmgen/pmgen.py
@@ -5,6 +5,8 @@ import sys
 import pprint
 import getopt
 
+# TODO there's an invalid cell type assignment here that should be turned into morphCell
+
 pp = pprint.PrettyPrinter(indent=4)
 
 prefix = None

--- a/passes/pmgen/test_pmgen.cc
+++ b/passes/pmgen/test_pmgen.cc
@@ -241,6 +241,9 @@ struct TestPmgenPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		if (GetSize(args) > 1)
 		{
 			if (args[1] == "-reduce_chain")

--- a/passes/pmgen/xilinx_dsp.cc
+++ b/passes/pmgen/xilinx_dsp.cc
@@ -770,6 +770,9 @@ struct XilinxDspPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing XILINX_DSP pass (pack resources into DSPs).\n");
 
 		std::string family = "xc7";

--- a/passes/pmgen/xilinx_srl.cc
+++ b/passes/pmgen/xilinx_srl.cc
@@ -214,6 +214,9 @@ struct XilinxSrlPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing XILINX_SRL pass (Xilinx shift register extraction).\n");
 
 		bool fixed = false;

--- a/passes/proc/proc.cc
+++ b/passes/proc/proc.cc
@@ -72,6 +72,9 @@ struct ProcPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		std::string global_arst;
 		bool ifxmode = false;
 		bool nomux = false;

--- a/passes/proc/proc_arst.cc
+++ b/passes/proc/proc_arst.cc
@@ -265,6 +265,9 @@ struct ProcArstPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		std::string global_arst;
 		bool global_arst_neg = false;
 

--- a/passes/proc/proc_clean.cc
+++ b/passes/proc/proc_clean.cc
@@ -192,6 +192,9 @@ struct ProcCleanPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		int total_count = 0;
 		bool quiet = false;
 

--- a/passes/proc/proc_dff.cc
+++ b/passes/proc/proc_dff.cc
@@ -361,6 +361,9 @@ struct ProcDffPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing PROC_DFF pass (convert process syncs to FFs).\n");
 
 		extra_args(args, 1, design);

--- a/passes/proc/proc_dlatch.cc
+++ b/passes/proc/proc_dlatch.cc
@@ -293,10 +293,10 @@ struct proc_dlatch_db_t
 			cell->setPort(ID::A, sig_any_valid_b);
 
 		if (GetSize(sig_new_s) == 1) {
-			cell->type = ID($mux);
+			cell = cell->module->morphCell(ID($mux), cell);
 			cell->unsetParam(ID::S_WIDTH);
 		} else {
-			cell->type = ID($pmux);
+			cell = cell->module->morphCell(ID($pmux), cell);
 			cell->setParam(ID::S_WIDTH, GetSize(sig_new_s));
 		}
 

--- a/passes/proc/proc_dlatch.cc
+++ b/passes/proc/proc_dlatch.cc
@@ -460,6 +460,9 @@ struct ProcDlatchPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing PROC_DLATCH pass (convert process syncs to latches).\n");
 
 		extra_args(args, 1, design);

--- a/passes/proc/proc_init.cc
+++ b/passes/proc/proc_init.cc
@@ -87,6 +87,9 @@ struct ProcInitPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing PROC_INIT pass (extract init attributes).\n");
 
 		extra_args(args, 1, design);

--- a/passes/proc/proc_memwr.cc
+++ b/passes/proc/proc_memwr.cc
@@ -95,6 +95,9 @@ struct ProcMemWrPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing PROC_MEMWR pass (convert process memory writes to cells).\n");
 
 		extra_args(args, 1, design);

--- a/passes/proc/proc_mux.cc
+++ b/passes/proc/proc_mux.cc
@@ -252,7 +252,7 @@ RTLIL::SigSpec gen_mux(RTLIL::Module *mod, const RTLIL::SigSpec &signal, const s
 	return RTLIL::SigSpec(result_wire);
 }
 
-void append_pmux(RTLIL::Module *mod, const RTLIL::SigSpec &signal, const std::vector<RTLIL::SigSpec> &compare, RTLIL::SigSpec when_signal, RTLIL::Cell *last_mux_cell, RTLIL::SwitchRule *sw, RTLIL::CaseRule *cs, bool ifxmode)
+void append_pmux(RTLIL::Module *mod, const RTLIL::SigSpec &signal, const std::vector<RTLIL::SigSpec> &compare, RTLIL::SigSpec when_signal, RTLIL::Cell *&last_mux_cell, RTLIL::SwitchRule *sw, RTLIL::CaseRule *cs, bool ifxmode)
 {
 	log_assert(last_mux_cell != NULL);
 	log_assert(when_signal.size() == last_mux_cell->getPort(ID::A).size());

--- a/passes/proc/proc_mux.cc
+++ b/passes/proc/proc_mux.cc
@@ -262,7 +262,7 @@ void append_pmux(RTLIL::Module *mod, const RTLIL::SigSpec &signal, const std::ve
 
 	RTLIL::SigSpec ctrl_sig = gen_cmp(mod, signal, compare, sw, cs, ifxmode);
 	log_assert(ctrl_sig.size() == 1);
-	last_mux_cell->type = ID($pmux);
+	last_mux_cell = last_mux_cell->module->morphCell(ID($pmux), last_mux_cell);
 
 	RTLIL::SigSpec new_s = last_mux_cell->getPort(ID::S);
 	new_s.append(ctrl_sig);

--- a/passes/proc/proc_mux.cc
+++ b/passes/proc/proc_mux.cc
@@ -454,6 +454,9 @@ struct ProcMuxPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool ifxmode = false;
 		log_header(design, "Executing PROC_MUX pass (convert decision trees to multiplexers).\n");
 

--- a/passes/proc/proc_prune.cc
+++ b/passes/proc/proc_prune.cc
@@ -122,6 +122,9 @@ struct ProcPrunePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		int total_removed_count = 0, total_promoted_count = 0;
 		log_header(design, "Executing PROC_PRUNE pass (remove redundant assignments in processes).\n");
 

--- a/passes/proc/proc_rmdead.cc
+++ b/passes/proc/proc_rmdead.cc
@@ -142,6 +142,9 @@ struct ProcRmdeadPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing PROC_RMDEAD pass (remove dead branches from decision trees).\n");
 
 		extra_args(args, 1, design);

--- a/passes/proc/proc_rom.cc
+++ b/passes/proc/proc_rom.cc
@@ -232,6 +232,9 @@ struct ProcRomPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		int total_count = 0;
 		log_header(design, "Executing PROC_ROM pass (convert switches to ROMs).\n");
 

--- a/passes/sat/assertpmux.cc
+++ b/passes/sat/assertpmux.cc
@@ -201,6 +201,9 @@ struct AssertpmuxPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool flag_noinit = false;
 		bool flag_always = false;
 

--- a/passes/sat/async2sync.cc
+++ b/passes/sat/async2sync.cc
@@ -47,6 +47,9 @@ struct Async2syncPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool flag_nolower = false;
 
 		log_header(design, "Executing ASYNC2SYNC pass.\n");

--- a/passes/sat/clk2fflogic.cc
+++ b/passes/sat/clk2fflogic.cc
@@ -120,6 +120,9 @@ struct Clk2fflogicPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool flag_nolower = false;
 
 		log_header(design, "Executing CLK2FFLOGIC pass (convert clocked FFs to generic $ff cells).\n");

--- a/passes/sat/cutpoint.cc
+++ b/passes/sat/cutpoint.cc
@@ -40,6 +40,9 @@ struct CutpointPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		 bool flag_undef = false;
 
 		log_header(design, "Executing CUTPOINT pass.\n");

--- a/passes/sat/eval.cc
+++ b/passes/sat/eval.cc
@@ -384,6 +384,9 @@ struct EvalPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		std::vector<std::pair<std::string, std::string>> sets;
 		std::vector<std::string> shows, tables;
 		bool set_undef = false;

--- a/passes/sat/expose.cc
+++ b/passes/sat/expose.cc
@@ -498,7 +498,7 @@ struct ExposePass : public Pass {
 				for (auto cell : module->cells()) {
 					if (!ct.cell_known(cell->type))
 						continue;
-					for (auto &&conn : cell->connections_)
+					for (auto conn : cell->connections_)
 						if (ct.cell_output(cell->type, conn.first))
 							conn.second = out_to_in_map(sigmap(conn.second));
 				}
@@ -519,7 +519,7 @@ struct ExposePass : public Pass {
 				for (auto cell : module->cells()) {
 					if (!ct.cell_known(cell->type))
 						continue;
-					for (auto &&conn : cell->connections_)
+					for (auto conn : cell->connections_)
 						if (ct.cell_input(cell->type, conn.first))
 							conn.second = out_to_in_map(sigmap(conn.second));
 				}

--- a/passes/sat/expose.cc
+++ b/passes/sat/expose.cc
@@ -498,7 +498,7 @@ struct ExposePass : public Pass {
 				for (auto cell : module->cells()) {
 					if (!ct.cell_known(cell->type))
 						continue;
-					for (auto &conn : cell->connections_)
+					for (auto &&conn : cell->connections_)
 						if (ct.cell_output(cell->type, conn.first))
 							conn.second = out_to_in_map(sigmap(conn.second));
 				}
@@ -519,7 +519,7 @@ struct ExposePass : public Pass {
 				for (auto cell : module->cells()) {
 					if (!ct.cell_known(cell->type))
 						continue;
-					for (auto &conn : cell->connections_)
+					for (auto &&conn : cell->connections_)
 						if (ct.cell_input(cell->type, conn.first))
 							conn.second = out_to_in_map(sigmap(conn.second));
 				}

--- a/passes/sat/expose.cc
+++ b/passes/sat/expose.cc
@@ -256,6 +256,9 @@ struct ExposePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool flag_shared = false;
 		bool flag_evert = false;
 		bool flag_dff = false;

--- a/passes/sat/fmcombine.cc
+++ b/passes/sat/fmcombine.cc
@@ -276,6 +276,9 @@ struct FmcombinePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		opts_t opts;
 		Module *module = nullptr;
 		Cell *gold_cell = nullptr;

--- a/passes/sat/fminit.cc
+++ b/passes/sat/fminit.cc
@@ -49,6 +49,9 @@ struct FminitPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		vector<pair<string, vector<string>>> initdata;
 		vector<pair<string, string>> setdata;
 		string clocksignal;

--- a/passes/sat/formalff.cc
+++ b/passes/sat/formalff.cc
@@ -542,6 +542,9 @@ struct FormalFfPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool flag_clk2ff = false;
 		bool flag_ff2anyinit = false;
 		bool flag_anyinit2ff = false;

--- a/passes/sat/freduce.cc
+++ b/passes/sat/freduce.cc
@@ -794,6 +794,9 @@ struct FreducePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		reduce_counter = 0;
 		reduce_stop_at = 0;
 		verbose_level = 0;

--- a/passes/sat/freduce.cc
+++ b/passes/sat/freduce.cc
@@ -722,7 +722,7 @@ struct FreduceWorker
 
 				RTLIL::Cell *drv = drivers.at(grp[i].bit).first;
 				RTLIL::Wire *dummy_wire = module->addWire(NEW_ID);
-				for (auto &port : drv->connections_)
+				for (auto port : drv->connections_)
 					if (ct.cell_output(drv->type, port.first))
 						sigmap(port.second).replace(grp[i].bit, dummy_wire, &port.second);
 

--- a/passes/sat/miter.cc
+++ b/passes/sat/miter.cc
@@ -450,6 +450,9 @@ struct MiterPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		if (args.size() > 1 && args[1] == "-equiv") {
 			create_miter_equiv(this, args, design);
 			return;

--- a/passes/sat/mutate.cc
+++ b/passes/sat/mutate.cc
@@ -794,6 +794,9 @@ struct MutatePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		mutate_opts_t opts;
 		string filename;
 		string srcsfile;

--- a/passes/sat/qbfsat.cc
+++ b/passes/sat/qbfsat.cc
@@ -584,6 +584,9 @@ struct QbfSatPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing QBFSAT pass (solving QBF-SAT problems in the circuit).\n");
 		QbfSolveOptions opt = parse_args(args);
 		extra_args(args, opt.argidx, design);

--- a/passes/sat/recover_names.cc
+++ b/passes/sat/recover_names.cc
@@ -698,6 +698,9 @@ struct RecoverNamesPass : public Pass {
     }
     void execute(std::vector<std::string> args, RTLIL::Design *design) override
     {
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
         log_header(design, "Executing RECOVER_NAMES pass (run mapping and recover original names).\n");
         string command;
 

--- a/passes/sat/sat.cc
+++ b/passes/sat/sat.cc
@@ -1074,6 +1074,9 @@ struct SatPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		std::vector<std::pair<std::string, std::string>> sets, sets_init, prove, prove_x;
 		std::map<int, std::vector<std::pair<std::string, std::string>>> sets_at;
 		std::map<int, std::vector<std::string>> unsets_at, sets_def_at, sets_any_undef_at, sets_all_undef_at;

--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -2688,6 +2688,9 @@ struct SimPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		SimWorker worker;
 		int numcycles = 20;
 		int append = 0;
@@ -2932,6 +2935,9 @@ struct Fst2TbPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		SimWorker worker;
 		int numcycles = 20;
 		bool stop_set = false;

--- a/passes/sat/supercover.cc
+++ b/passes/sat/supercover.cc
@@ -37,6 +37,9 @@ struct SupercoverPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		// bool flag_noinit = false;
 
 		log_header(design, "Executing SUPERCOVER pass.\n");

--- a/passes/sat/synthprop.cc
+++ b/passes/sat/synthprop.cc
@@ -220,6 +220,9 @@ struct SyntProperties : public Pass {
 
 	virtual void execute(std::vector<std::string> args, RTLIL::Design* design)
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing SYNTHPROP pass.\n");
 		SynthPropWorker worker(design);
 		size_t argidx;

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1336,7 +1336,8 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 
 			if (c->type.in(ID(_const0_), ID(_const1_))) {
 				RTLIL::SigSig conn;
-				conn.first = module->wire(remap_name(c->connections().begin()->second.as_wire()->name));
+				auto it = c->connections().begin();
+				conn.first = module->wire(remap_name((*it).second.as_wire()->name));
 				conn.second = RTLIL::SigSpec(c->type == ID(_const0_) ? 0 : 1, 1);
 				module->connect(conn);
 				continue;

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1648,6 +1648,9 @@ struct AbcPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing ABC pass (technology mapping using ABC).\n");
 		log_push();
 

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -203,6 +203,9 @@ struct Abc9Pass : public ScriptPass
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		std::string run_from, run_to;
 		clear_flags();
 

--- a/passes/techmap/abc9_exe.cc
+++ b/passes/techmap/abc9_exe.cc
@@ -408,6 +408,9 @@ struct Abc9ExePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing ABC9_EXE pass (technology mapping using ABC9).\n");
 
 		std::string exe_file = yosys_abc_executable;

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -590,7 +590,7 @@ void break_scc(RTLIL::Module *module)
 		cell->attributes.erase(it);
 		if (!r.second)
 			continue;
-		for (auto &c : cell->connections_) {
+		for (auto c : cell->connections_) {
 			if (c.second.is_fully_const()) continue;
 			if (cell->output(c.first)) {
 				Wire *w = module->addWire(NEW_ID, GetSize(c.second));
@@ -1353,12 +1353,12 @@ void reintegrate(RTLIL::Module *module, bool dff_mode)
 
 			auto jt = mapped_cell->connections_.find(ID(i));
 			log_assert(jt != mapped_cell->connections_.end());
-			SigSpec inputs = std::move(jt->second);
-			mapped_cell->connections_.erase(jt);
+			SigSpec inputs = std::move((*jt).second);
+			mapped_cell->connections_.erase((*jt).first);
 			jt = mapped_cell->connections_.find(ID(o));
 			log_assert(jt != mapped_cell->connections_.end());
-			SigSpec outputs = std::move(jt->second);
-			mapped_cell->connections_.erase(jt);
+			SigSpec outputs = std::move((*jt).second);
+			mapped_cell->connections_.erase((*jt).first);
 
 			auto abc9_flop = box_module->get_bool_attribute(ID::abc9_flop);
 			if (abc9_flop) {

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -23,6 +23,7 @@
 #include "kernel/utils.h"
 #include "kernel/celltypes.h"
 #include "kernel/timinginfo.h"
+#include "kernel/compat.h"
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
@@ -113,7 +114,7 @@ void check(RTLIL::Design *design, bool dff_mode)
 					//   but not its existence)
 					if (!inst_module->has_attribute(ID::abc9_flop))
 						continue;
-					derived_type = inst_module->derive(design, cell->parameters);
+					derived_type = inst_module->derive(design, cell_to_mod_params(cell->parameters));
 					derived_module = design->module(derived_type);
 					log_assert(derived_module);
 				}
@@ -170,7 +171,7 @@ void prep_hier(RTLIL::Design *design, bool dff_mode)
 				derived_module = inst_module;
 			}
 			else {
-				derived_type = inst_module->derive(design, cell->parameters);
+				derived_type = inst_module->derive(design, cell_to_mod_params(cell->parameters));
 				derived_module = design->module(derived_type);
 				unused_derived.insert(derived_type);
 			}

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -1654,6 +1654,9 @@ struct Abc9OpsPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing ABC9_OPS pass (helper functions for ABC9).\n");
 
 		bool check_mode = false;

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -195,7 +195,7 @@ void prep_hier(RTLIL::Design *design, bool dff_mode)
 						// If derived_type is present in unmap_design, it means that it was processed previously, but found to be incompatible -- e.g. if
 						// it contained a non-zero initial state. In this case, continue to replace the cell type/parameters so that it has the same properties
 						// as a compatible type, yet will be safely unmapped later
-						cell->type = derived_type;
+						cell = cell->module->morphCell(derived_type, cell);
 						cell->parameters.clear();
 						unused_derived.erase(derived_type);
 					}
@@ -255,7 +255,7 @@ void prep_hier(RTLIL::Design *design, bool dff_mode)
 				}
 			}
 
-			cell->type = derived_type;
+			cell = cell->module->morphCell(derived_type, cell);
 			cell->parameters.clear();
 			unused_derived.erase(derived_type);
 		}
@@ -1344,7 +1344,7 @@ void reintegrate(RTLIL::Module *module, bool dff_mode)
 			RTLIL::Module* box_module = design->module(existing_cell->type);
 			log_assert(existing_cell->parameters.empty());
 			log_assert(mapped_cell->type == stringf("$__boxid%d", box_module->attributes.at(ID::abc9_box_id).as_int()));
-			mapped_cell->type = existing_cell->type;
+			mapped_cell = mapped_cell->module->morphCell(existing_cell->type, mapped_cell);
 
 			RTLIL::Cell *cell = module->addCell(remap_name(mapped_cell->name), mapped_cell->type);
 			cell->parameters = existing_cell->parameters;

--- a/passes/techmap/aigmap.cc
+++ b/passes/techmap/aigmap.cc
@@ -45,6 +45,9 @@ struct AigmapPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool nand_mode = false, select_mode = false;
 
 		log_header(design, "Executing AIGMAP pass (map logic to AIG).\n");

--- a/passes/techmap/alumacc.cc
+++ b/passes/techmap/alumacc.cc
@@ -562,6 +562,9 @@ struct AlumaccPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing ALUMACC pass (create $alu and $macc cells).\n");
 
 		size_t argidx;

--- a/passes/techmap/alumacc.cc
+++ b/passes/techmap/alumacc.cc
@@ -145,7 +145,9 @@ struct AlumaccWorker
 			Macc::port_t new_port;
 
 			n->cell = cell;
+			log("%s\n", log_signal(cell->getPort(ID::Y)));
 			n->y = sigmap(cell->getPort(ID::Y));
+			log("%s\n", log_signal(n->y));
 			n->users = 0;
 
 			for (auto bit : n->y)
@@ -181,6 +183,7 @@ struct AlumaccWorker
 				n->macc.ports.push_back(new_port);
 			}
 
+			log("%s\n", log_signal(n->y));
 			log_assert(sig_macc.count(n->y) == 0);
 			sig_macc[n->y] = n;
 		}
@@ -237,8 +240,12 @@ struct AlumaccWorker
 
 				for (int i = 0; i < GetSize(n->macc.ports); i++)
 				{
+					log("ports: size %d\n", n->macc.ports.size());
 					auto &port = n->macc.ports[i];
 
+					log("ports 2: size %d\n", port.in_b.size());
+					log("uuh: count %d\n", sig_macc.count(port.in_a));
+					log("%s\n", log_signal(port.in_a));
 					if (GetSize(port.in_b) > 0 || sig_macc.count(port.in_a) == 0)
 						continue;
 

--- a/passes/techmap/alumacc.cc
+++ b/passes/techmap/alumacc.cc
@@ -240,12 +240,8 @@ struct AlumaccWorker
 
 				for (int i = 0; i < GetSize(n->macc.ports); i++)
 				{
-					log("ports: size %d\n", n->macc.ports.size());
 					auto &port = n->macc.ports[i];
 
-					log("ports 2: size %d\n", port.in_b.size());
-					log("uuh: count %d\n", sig_macc.count(port.in_a));
-					log("%s\n", log_signal(port.in_a));
 					if (GetSize(port.in_b) > 0 || sig_macc.count(port.in_a) == 0)
 						continue;
 

--- a/passes/techmap/attrmap.cc
+++ b/passes/techmap/attrmap.cc
@@ -339,8 +339,10 @@ struct ParamapPass : public Pass {
 		extra_args(args, argidx, design);
 
 		for (auto module : design->selected_modules())
-		for (auto cell : module->selected_cells())
-			attrmap_apply(stringf("%s.%s", log_id(module), log_id(cell)), actions, cell->parameters);
+		for (auto cell : module->selected_cells()) {
+			auto params = cell->parameters.as_dict();
+			attrmap_apply(stringf("%s.%s", log_id(module), log_id(cell)), actions, params);
+		}
 	}
 } ParamapPass;
 

--- a/passes/techmap/attrmap.cc
+++ b/passes/techmap/attrmap.cc
@@ -243,6 +243,9 @@ struct AttrmapPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing ATTRMAP pass (move or copy attributes).\n");
 
 		bool modattr_mode = false;
@@ -319,6 +322,9 @@ struct ParamapPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing PARAMAP pass (move or copy cell parameters).\n");
 
 		vector<std::unique_ptr<AttrmapAction>> actions;

--- a/passes/techmap/attrmvcp.cc
+++ b/passes/techmap/attrmvcp.cc
@@ -55,6 +55,9 @@ struct AttrmvcpPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing ATTRMVCP pass (move or copy attributes).\n");
 
 		bool copy_mode = false;

--- a/passes/techmap/bmuxmap.cc
+++ b/passes/techmap/bmuxmap.cc
@@ -39,6 +39,9 @@ struct BmuxmapPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool pmux_mode = false;
 
 		log_header(design, "Executing BMUXMAP pass.\n");

--- a/passes/techmap/booth.cc
+++ b/passes/techmap/booth.cc
@@ -1155,6 +1155,9 @@ struct BoothPass : public Pass {
 	}
 	void execute(vector<string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing BOOTH pass (map to Booth multipliers).\n");
 
 		size_t argidx;

--- a/passes/techmap/bwmuxmap.cc
+++ b/passes/techmap/bwmuxmap.cc
@@ -35,6 +35,9 @@ struct BwmuxmapPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing BWMUXMAP pass.\n");
 
 		size_t argidx;

--- a/passes/techmap/cellmatch.cc
+++ b/passes/techmap/cellmatch.cc
@@ -158,6 +158,9 @@ struct CellmatchPass : Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *d) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(d, "Executing CELLMATCH pass. (match cells)\n");
 
 		size_t argidx;

--- a/passes/techmap/clkbufmap.cc
+++ b/passes/techmap/clkbufmap.cc
@@ -79,6 +79,9 @@ struct ClkbufmapPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing CLKBUFMAP pass (inserting clock buffers).\n");
 
 		std::string buf_celltype, buf_portname, buf_portname2;

--- a/passes/techmap/deminout.cc
+++ b/passes/techmap/deminout.cc
@@ -35,6 +35,9 @@ struct DeminoutPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing DEMINOUT pass (demote inout ports to input or output).\n");
 
 		size_t argidx;

--- a/passes/techmap/demuxmap.cc
+++ b/passes/techmap/demuxmap.cc
@@ -36,6 +36,9 @@ struct DemuxmapPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing DEMUXMAP pass.\n");
 
 		size_t argidx;

--- a/passes/techmap/dffinit.cc
+++ b/passes/techmap/dffinit.cc
@@ -57,6 +57,9 @@ struct DffinitPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing DFFINIT pass (set INIT param on FF cells).\n");
 
 		dict<IdString, dict<IdString, IdString>> ff_types;

--- a/passes/techmap/dfflegalize.cc
+++ b/passes/techmap/dfflegalize.cc
@@ -1013,6 +1013,9 @@ struct DffLegalizePass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 
 		log_header(design, "Executing DFFLEGALIZE pass (convert FFs to types supported by the target).\n");
 

--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -467,6 +467,9 @@ struct DfflibmapPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing DFFLIBMAP pass (mapping DFF cells to sequential cells from liberty file).\n");
 		log_push();
 

--- a/passes/techmap/dffunmap.cc
+++ b/passes/techmap/dffunmap.cc
@@ -45,6 +45,9 @@ struct DffunmapPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing DFFUNMAP pass (unmap clock enable and synchronous reset from FFs).\n");
 
 		bool ce_only = false;

--- a/passes/techmap/extract.cc
+++ b/passes/techmap/extract.cc
@@ -436,6 +436,9 @@ struct ExtractPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing EXTRACT pass (map subcircuits to cells).\n");
 		log_push();
 

--- a/passes/techmap/extract.cc
+++ b/passes/techmap/extract.cc
@@ -105,10 +105,10 @@ public:
 
 		if (!ignore_parameters) {
 			std::map<RTLIL::IdString, RTLIL::Const> needle_param, haystack_param;
-			for (auto &it : needleCell->parameters)
+			for (auto it : needleCell->parameters)
 				if (!ignored_parameters.count(std::pair<RTLIL::IdString, RTLIL::IdString>(needleCell->type, it.first)))
 					needle_param[it.first] = unified_param(needleCell->type, it.first, it.second);
-			for (auto &it : haystackCell->parameters)
+			for (auto it : haystackCell->parameters)
 				if (!ignored_parameters.count(std::pair<RTLIL::IdString, RTLIL::IdString>(haystackCell->type, it.first)))
 					haystack_param[it.first] = unified_param(haystackCell->type, it.first, it.second);
 			if (needle_param != haystack_param)

--- a/passes/techmap/extract_counter.cc
+++ b/passes/techmap/extract_counter.cc
@@ -788,6 +788,9 @@ struct ExtractCounterPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing EXTRACT_COUNTER pass (find counters in netlist).\n");
 
 		pool<RTLIL::IdString> _parallel_cells;

--- a/passes/techmap/extract_counter.cc
+++ b/passes/techmap/extract_counter.cc
@@ -628,7 +628,7 @@ void counter_worker(
 	cell->unsetParam(ID::Y_WIDTH);
 
 	//Change the cell type
-	cell->type = ID($__COUNT_);
+	cell = cell->module->morphCell(ID($__COUNT_), cell);
 
 	//Hook up resets
 	if(extract.has_reset)

--- a/passes/techmap/extract_fa.cc
+++ b/passes/techmap/extract_fa.cc
@@ -563,6 +563,9 @@ struct ExtractFaPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		ExtractFaConfig config;
 
 		log_header(design, "Executing EXTRACT_FA pass (find and extract full/half adders).\n");

--- a/passes/techmap/extract_reduce.cc
+++ b/passes/techmap/extract_reduce.cc
@@ -65,6 +65,9 @@ struct ExtractReducePass : public Pass
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing EXTRACT_REDUCE pass.\n");
 		log_push();
 

--- a/passes/techmap/extractinv.cc
+++ b/passes/techmap/extractinv.cc
@@ -59,6 +59,9 @@ struct ExtractinvPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing EXTRACTINV pass (extracting pin inverters).\n");
 
 		std::string inv_celltype, inv_portname, inv_portname2;

--- a/passes/techmap/extractinv.cc
+++ b/passes/techmap/extractinv.cc
@@ -102,9 +102,9 @@ struct ExtractinvPass : public Pass {
 				if (it2 == cell->parameters.end())
 					continue;
 				SigSpec sig = port.second;
-				if (it2->second.size() != sig.size())
+				if ((*it2).second.size() != sig.size())
 					log_error("The inversion parameter needs to be the same width as the port (%s.%s port %s parameter %s)", log_id(module->name), log_id(cell->type), log_id(port.first), log_id(param_name));
-				RTLIL::Const invmask = it2->second;
+				RTLIL::Const invmask = (*it2).second;
 				cell->parameters.erase(param_name);
 				if (invmask.is_fully_zero())
 					continue;

--- a/passes/techmap/flatten.cc
+++ b/passes/techmap/flatten.cc
@@ -348,6 +348,9 @@ struct FlattenPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing FLATTEN pass (flatten design).\n");
 		log_push();
 

--- a/passes/techmap/flowmap.cc
+++ b/passes/techmap/flowmap.cc
@@ -1514,6 +1514,9 @@ struct FlowmapPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		int order = 3;
 		int minlut = 1;
 		vector<string> cells;

--- a/passes/techmap/hilomap.cc
+++ b/passes/techmap/hilomap.cc
@@ -76,6 +76,9 @@ struct HilomapPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing HILOMAP pass (mapping to constant drivers).\n");
 
 		hicell_celltype = std::string();

--- a/passes/techmap/insbuf.cc
+++ b/passes/techmap/insbuf.cc
@@ -42,6 +42,9 @@ struct InsbufPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing INSBUF pass (insert buffer cells for connected wires).\n");
 
 		IdString celltype = ID($_BUF_), in_portname = ID::A, out_portname = ID::Y;

--- a/passes/techmap/iopadmap.cc
+++ b/passes/techmap/iopadmap.cc
@@ -101,6 +101,9 @@ struct IopadmapPass : public Pass {
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing IOPADMAP pass (mapping inputs/outputs to IO-PAD cells).\n");
 
 		std::string inpad_celltype, inpad_portname_o, inpad_portname_pad;

--- a/passes/techmap/lut2mux.cc
+++ b/passes/techmap/lut2mux.cc
@@ -67,6 +67,9 @@ struct Lut2muxPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing LUT2MUX pass (convert $lut to $_MUX_).\n");
 
 		size_t argidx;

--- a/passes/techmap/maccmap.cc
+++ b/passes/techmap/maccmap.cc
@@ -377,6 +377,9 @@ struct MaccmapPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool unmap_mode = false;
 
 		log_header(design, "Executing MACCMAP pass (map $macc cells).\n");

--- a/passes/techmap/muxcover.cc
+++ b/passes/techmap/muxcover.cc
@@ -655,6 +655,9 @@ struct MuxcoverPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing MUXCOVER pass (mapping to wider MUXes).\n");
 
 		bool use_mux4 = false;

--- a/passes/techmap/nlutmap.cc
+++ b/passes/techmap/nlutmap.cc
@@ -151,6 +151,9 @@ struct NlutmapPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		NlutmapConfig config;
 
 		log_header(design, "Executing NLUTMAP pass (mapping to constant drivers).\n");

--- a/passes/techmap/pmuxtree.cc
+++ b/passes/techmap/pmuxtree.cc
@@ -78,6 +78,9 @@ struct PmuxtreePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing PMUXTREE pass.\n");
 
 		size_t argidx;

--- a/passes/techmap/shregmap.cc
+++ b/passes/techmap/shregmap.cc
@@ -434,6 +434,9 @@ struct ShregmapPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		ShregmapOptions opts;
 		string clkpol, enpol;
 

--- a/passes/techmap/shregmap.cc
+++ b/passes/techmap/shregmap.cc
@@ -332,7 +332,7 @@ struct ShregmapWorker
 				if (opts.ffe) first_cell->setParam(ID(ENPOL), param_enpol);
 			}
 
-			first_cell->type = shreg_cell_type_str;
+			first_cell = first_cell->module->morphCell(shreg_cell_type_str, first_cell);
 			first_cell->setPort(q_port, last_cell->getPort(q_port));
 			first_cell->setParam(ID::DEPTH, depth);
 

--- a/passes/techmap/simplemap.cc
+++ b/passes/techmap/simplemap.cc
@@ -490,6 +490,9 @@ struct SimplemapPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing SIMPLEMAP pass (map simple cells to gate primitives).\n");
 		extra_args(args, 1, design);
 

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -490,7 +490,7 @@ struct TechmapWorker
 			{
 				IdString derived_name = tpl_name;
 				RTLIL::Module *tpl = map->module(tpl_name);
-				dict<IdString, RTLIL::Const> parameters(cell->parameters);
+				dict<IdString, RTLIL::Const> parameters(cell->parameters.as_dict());
 
 				if (tpl->get_blackbox_attribute(ignore_wb))
 					continue;
@@ -514,7 +514,7 @@ struct TechmapWorker
 					{
 						std::string m_name = stringf("$extern:%s:%s", extmapper_name.c_str(), log_id(cell->type));
 
-						for (auto &c : cell->parameters)
+						for (auto c : cell->parameters)
 							m_name += stringf(":%s=%s", log_id(c.first), log_signal(c.second));
 
 						if (extmapper_name == "wrap")
@@ -531,7 +531,7 @@ struct TechmapWorker
 							extmapper_cell->set_src_attribute(cell->get_src_attribute());
 
 							int port_counter = 1;
-							for (auto &c : extmapper_cell->connections_) {
+							for (auto c : extmapper_cell->connections_) {
 								RTLIL::Wire *w = extmapper_module->addWire(c.first, GetSize(c.second));
 								if (w->name.in(ID::Y, ID::Q))
 									w->port_output = true;
@@ -916,7 +916,7 @@ struct TechmapWorker
 							auto wirename = RTLIL::escape_id(it.first.substr(21, it.first.size() - 21 - 1));
 							auto it = cell->connections().find(wirename);
 							if (it != cell->connections().end()) {
-								auto sig = sigmap(it->second);
+								auto sig = sigmap((*it).second);
 								for (int i = 0; i < sig.size(); i++)
 									if (val[i] == State::S1)
 										initvals.remove_init(sig[i]);

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -1152,6 +1152,9 @@ struct TechmapPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		log_header(design, "Executing TECHMAP pass (map to technology primitives).\n");
 		log_push();
 

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -563,6 +563,7 @@ struct TechmapWorker
 							if (extmapper_name == "wrap") {
 								std::string cmd_string = tpl->attributes.at(ID::techmap_wrap).decode_string();
 								log("Running \"%s\" on wrapper %s.\n", cmd_string.c_str(), log_id(extmapper_module));
+								log_module(extmapper_module);
 								mkdebug.on();
 								Pass::call_on_module(extmapper_design, extmapper_module, cmd_string);
 								log_continue = true;

--- a/passes/techmap/tribuf.cc
+++ b/passes/techmap/tribuf.cc
@@ -86,7 +86,7 @@ struct TribufWorker {
 					cell->setPort(en_port, cell->getPort(ID::S));
 					cell->unsetPort(ID::B);
 					cell->unsetPort(ID::S);
-					cell->type = tri_type;
+					cell = cell->module->morphCell(tri_type, cell);
 					tribuf_cells[sigmap(cell->getPort(ID::Y))].push_back(cell);
 					module->design->scratchpad_set_bool("tribuf.added_something", true);
 					continue;
@@ -96,7 +96,7 @@ struct TribufWorker {
 					cell->setPort(en_port, module->Not(NEW_ID, cell->getPort(ID::S)));
 					cell->unsetPort(ID::B);
 					cell->unsetPort(ID::S);
-					cell->type = tri_type;
+					cell = cell->module->morphCell(tri_type, cell);
 					tribuf_cells[sigmap(cell->getPort(ID::Y))].push_back(cell);
 					module->design->scratchpad_set_bool("tribuf.added_something", true);
 					continue;

--- a/passes/techmap/tribuf.cc
+++ b/passes/techmap/tribuf.cc
@@ -201,6 +201,9 @@ struct TribufPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		TribufConfig config;
 
 		log_header(design, "Executing TRIBUF pass.\n");

--- a/passes/techmap/zinit.cc
+++ b/passes/techmap/zinit.cc
@@ -41,6 +41,9 @@ struct ZinitPass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
+		ZoneScoped;
+		ZoneText(pass_name.c_str(), pass_name.length());
+		ZoneColor((uint32_t)(size_t)pass_name.c_str());
 		bool all_mode = false;
 
 		log_header(design, "Executing ZINIT pass (make all FFs zero-initialized).\n");

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -344,7 +344,7 @@ static void create_gold_module(RTLIL::Design *design, RTLIL::IdString cell_type,
 
 	if (constmode)
 	{
-		auto conn_list = cell->connections();
+		auto conn_list = cell->connections().as_dict();
 		for (auto conn : conn_list)
 		{
 			RTLIL::SigSpec sig = conn.second;

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -41,10 +41,6 @@ static void create_gold_module(RTLIL::Design *design, RTLIL::IdString cell_type,
 {
 	RTLIL::Module *module = design->addModule(ID(gold));
 	RTLIL::Cell *cell = module->addCell(ID(UUT), cell_type);
-	for (auto para : cell->parameters)
-		log("param %s is %s\n", para.first.c_str(), para.second.as_string().c_str());
-	// for (auto para : cell->connections)
-	// 	log("param %s is %s\n", para.first.c_str(), para.second.as_string());
 	RTLIL::Wire *wire;
 
 	if (cell_type.in(ID($mux), ID($pmux)))

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -41,6 +41,10 @@ static void create_gold_module(RTLIL::Design *design, RTLIL::IdString cell_type,
 {
 	RTLIL::Module *module = design->addModule(ID(gold));
 	RTLIL::Cell *cell = module->addCell(ID(UUT), cell_type);
+	for (auto para : cell->parameters)
+		log("param %s is %s\n", para.first.c_str(), para.second.as_string().c_str());
+	// for (auto para : cell->connections)
+	// 	log("param %s is %s\n", para.first.c_str(), para.second.as_string());
 	RTLIL::Wire *wire;
 
 	if (cell_type.in(ID($mux), ID($pmux)))

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -973,9 +973,9 @@ struct TestCellPass : public Pass {
 					Frontend::frontend_call(design, NULL, std::string(), "rtlil " + rtlil_file);
 				else
 					create_gold_module(design, cell_type, cell_types.at(cell_type), constmode, muxdiv);
-				if (!write_prefix.empty()) {
+				if (!write_prefix.empty())
 					Pass::call(design, stringf("write_rtlil %s_%s_%05d.il", write_prefix.c_str(), cell_type.c_str()+1, i));
-				} else if (edges) {
+				if (edges) {
 					Pass::call(design, "dump gold");
 					run_edges_test(design, verbose);
 				} else {

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -345,7 +345,7 @@ static void create_gold_module(RTLIL::Design *design, RTLIL::IdString cell_type,
 	if (constmode)
 	{
 		auto conn_list = cell->connections();
-		for (auto &conn : conn_list)
+		for (auto conn : conn_list)
 		{
 			RTLIL::SigSpec sig = conn.second;
 

--- a/techlibs/coolrunner2/coolrunner2_sop.cc
+++ b/techlibs/coolrunner2/coolrunner2_sop.cc
@@ -170,14 +170,14 @@ struct Coolrunner2SopPass : public Pass {
 								if (has_invert)
 								{
 									auto cell = std::get<0>(x);
-									if (cell->type == ID(FDCP)) cell->type = ID(FDCP_N);
-									else if (cell->type == ID(FDCP_N)) cell->type = ID(FDCP);
-									else if (cell->type == ID(FTCP)) cell->type = ID(FTCP_N);
-									else if (cell->type == ID(FTCP_N)) cell->type = ID(FTCP);
-									else if (cell->type == ID(FDCPE)) cell->type = ID(FDCPE_N);
-									else if (cell->type == ID(FDCPE_N)) cell->type = ID(FDCPE);
-									else if (cell->type == ID(LDCP)) cell->type = ID(LDCP_N);
-									else if (cell->type == ID(LDCP_N)) cell->type = ID(LDCP);
+									if (cell->type == ID(FDCP)) cell = cell->module->morphCell(ID(FDCP_N), cell);
+									else if (cell->type == ID(FDCP_N)) cell = cell->module->morphCell(ID(FDCP), cell);
+									else if (cell->type == ID(FTCP)) cell = cell->module->morphCell(ID(FTCP_N), cell);
+									else if (cell->type == ID(FTCP_N)) cell = cell->module->morphCell(ID(FTCP), cell);
+									else if (cell->type == ID(FDCPE)) cell = cell->module->morphCell(ID(FDCPE_N), cell);
+									else if (cell->type == ID(FDCPE_N)) cell = cell->module->morphCell(ID(FDCPE), cell);
+									else if (cell->type == ID(LDCP)) cell = cell->module->morphCell(ID(LDCP_N), cell);
+									else if (cell->type == ID(LDCP_N)) cell = cell->module->morphCell(ID(LDCP), cell);
 									else log_assert(!"Internal error! Bad cell type!");
 								}
 							}

--- a/techlibs/greenpak4/greenpak4_dffinv.cc
+++ b/techlibs/greenpak4/greenpak4_dffinv.cc
@@ -81,9 +81,9 @@ void invert_gp_dff(Cell *cell, bool invert_input)
 	}
 
 	if(cell_type_latch)
-		cell->type = stringf("\\GP_DLATCH%s%s%s", cell_type_s ? "S" : "", cell_type_r ? "R" : "", cell_type_i ? "I" : "");
+		cell = cell->module->morphCell(stringf("\\GP_DLATCH%s%s%s", cell_type_s ? "S" : "", cell_type_r ? "R" : "", cell_type_i ? "I" : ""), cell);
 	else
-		cell->type = stringf("\\GP_DFF%s%s%s", cell_type_s ? "S" : "", cell_type_r ? "R" : "", cell_type_i ? "I" : "");
+		cell = cell->module->morphCell(stringf("\\GP_DFF%s%s%s", cell_type_s ? "S" : "", cell_type_r ? "R" : "", cell_type_i ? "I" : ""), cell);
 
 	log("Merged %s inverter into cell %s.%s: %s -> %s\n", invert_input ? "input" : "output",
 			log_id(cell->module), log_id(cell), cell_type.c_str()+1, log_id(cell->type));

--- a/techlibs/ice40/ice40_opt.cc
+++ b/techlibs/ice40/ice40_opt.cc
@@ -138,7 +138,7 @@ static void run_ice40_opts(Module *module)
 				module->design->scratchpad_set_bool("opt.did_something", true);
 				log("Optimized $__ICE40_CARRY_WRAPPER cell back to logic (without SB_CARRY) %s.%s: CO=%s\n",
 						log_id(module), log_id(cell), log_signal(replacement_output));
-				cell->type = ID($lut);
+				cell = cell->module->morphCell(ID($lut), cell);
 				auto I3 = get_bit_or_zero(cell->getPort(cell->getParam(ID(I3_IS_CI)).as_bool() ? ID::CI : ID(I3)));
 				cell->setPort(ID::A, { I3, inbit[1], inbit[0], get_bit_or_zero(cell->getPort(ID(I0))) });
 				cell->setPort(ID::Y, cell->getPort(ID::O));
@@ -177,7 +177,7 @@ static void run_ice40_opts(Module *module)
 		module->design->scratchpad_set_bool("opt.did_something", true);
 		log("Mapping SB_LUT4 cell %s.%s back to logic.\n", log_id(module), log_id(cell));
 
-		cell->type = ID($lut);
+		cell = cell->module->morphCell(ID($lut), cell);
 		cell->setParam(ID::WIDTH, 4);
 		cell->setParam(ID::LUT, cell->getParam(ID(LUT_INIT)));
 		cell->unsetParam(ID(LUT_INIT));

--- a/techlibs/quicklogic/ql_bram_types.cc
+++ b/techlibs/quicklogic/ql_bram_types.cc
@@ -154,7 +154,7 @@ struct QlBramTypesPass : public Pass {
 					type += "nonsplit";
 				}
 
-				cell->type = RTLIL::escape_id(type);
+				cell = cell->module->morphCell(RTLIL::escape_id(type), cell);
 				log_debug("Changed type of memory cell %s to %s\n", log_id(cell->name), log_id(cell->type));
 			}
 	}

--- a/techlibs/quicklogic/ql_dsp_io_regs.cc
+++ b/techlibs/quicklogic/ql_dsp_io_regs.cc
@@ -127,7 +127,7 @@ struct QlDspIORegs : public Pass {
 			}
 
 			// Set new type name
-			cell->type = RTLIL::IdString(new_type);
+			cell = cell->module->morphCell(RTLIL::IdString(new_type), cell);
 
 			std::vector<std::string> ports2del;
 


### PR DESCRIPTION
# Brief

_What are the reasons/motivation for this change?_
small is fast!
_Explain how this is achieved._
make cell small.
_If applicable, please suggest to reviewers how they can test the change._
right now, nothing works

# Full

## Core idea

Yosys is conceptually flexible in what a cell can be. This makes it easy to do odd custom things that match use cases. The way this is achieved is inefficient for commonly represented types. Each cell has a dict from [interned](https://en.wikipedia.org/wiki/String_interning) parameter name strings to parameter value constants. It also has a dict from port name strings to signals represented by `SigSpec`s. However, most cells that Yosys uses in common flows have a fixed set of ports and parameters. So instead of dynamically growing space for a dict and hashing to access the value stored in it, we can have preallocated space and a compile-time known mapping if we just use a struct specific to a given cell type:

```cpp
// $not etc
struct RTLIL::Unary {
	SigSpec a;
	SigSpec y;
	Const a_width;
	Const y_width;
	Const is_signed;
};
```

We can then use a [tagged union](https://en.wikipedia.org/wiki/Tagged_union) to construct a new, slimmer, faster to access cell type, with a fallback pointer to the old cell structure.

```cpp
struct RTLIL::Cell
{
	RTLIL::IdString type;
	RTLIL::IdString name;
	RTLIL::Module* module;
	union {
		RTLIL::Unary not_;
		RTLIL::Unary pos;
		RTLIL::Unary neg;
		RTLIL::OldCell* flexible;
	};
};
```

## Wait, wasn't this supposed to be a Yosys rewrite in Rust?

This isn't next generation Yosys (project nyan). Rust or Zig would be better to do what I'm doing, but Yosys is a C++ codebase, so C++ it is. This is a surgical, gradual transition to more efficient internals with minimal impact on stuff outside `kernel/rtlil.h` and `kernel/rtlil.cc`. The Yosys codebase (~200k LOC) and user plugins have a large number of code like `cell->getParam(ID::A_WIDTH)`, we have to reproduce these interfaces rather than change them all to `cell->not_.a_width`. There's a good number of such functions. The annoying part is mocking for example the `parameters` dictionary. Instead, there's `struct FakeParams` which provides iterators to hide this. Same goes for connections. Implementations of `getParam` etc are simple switches over the cell type so they should inline well.

However, there's a lot of "internal" cells we may want to be fast, and their struct layouts and methods are basically duplicating the same information. Manually writing these methods is also very error prone, accessing tagged unions incorrectly is common [UB](https://en.cppreference.com/w/cpp/language/ub). This is why, to add support for the various cell types, the next stage will get a bit weird:

## Writing a compiler

[Modern C++](https://www.youtube.com/watch?v=QTLn3goa3A8) offers multiple ways to have code that thinks about types. However, what we need here is to construct functions and construct their return types based on struct layouts. This level of [reflection](https://en.wikipedia.org/wiki/Reflective_programming) if possible seems too difficult to achieve with templates and constexpr and such. We don't have [Rust's proc_macro](https://doc.rust-lang.org/book/ch19-06-macros.html#procedural-macros-for-generating-code-from-attributes), we don't have [Zig's comptime](https://ziglang.org/documentation/master/#comptime), so one possible solution is a light Python utility which from information-dense Python or plain text structures emits generates C++ which is committed into the repository and checked with CI. Yosys already depends on Python in a similar way, see `passes/pmgen/pmgen.py`.

## Beyond the cell

It's possible that the changes outlined above alone won't make a huge difference. `RTLIL::Const` is fairly inefficient as well. Size is virtuous in a positive feedback loop: the fewer bytes per cell, the more it helps to save a single byte per cell.

## Size goals

The current flexible `RTLIL::Cell` is 192 bytes. The proposed one is a bit bigger while it supports only unary elements, but doesn't require external allocations. With the current flexible cell, this simple verilog eats 6kB memory per inverter-and-FF-bit:

```v
module invert_n_times #(parameter N = 10000) (
    input wire in,
    output wire out
);
    wire [N:0] intermediate;

    assign intermediate[0] = in;

    genvar i;
    generate
        for (i = 0; i < N; i = i + 1) begin : invert_loop
            assign intermediate[i+1] = ~intermediate[i];
        end
    endgenerate

    assign out = intermediate[N];
endmodule
```

This suggests that focused effort can bring it down by a significant factor.
