### PR TITLE
remove sorts from some optimisation passes

### DIFF
--- a/passes/opt/opt.cc
+++ b/passes/opt/opt.cc
@@ -182,7 +182,6 @@ struct OptPass : public Pass {
 		}
 
 		design->optimize();
-		design->sort();
 		design->check();
 
 		log_header(design, fast_mode ? "Finished fast OPT passes.\n" : "Finished OPT passes. (There is nothing left to do.)\n");

--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -745,7 +745,6 @@ struct CleanPass : public Pass {
 			log("Removed %d unused cells and %d unused wires.\n", count_rm_cells, count_rm_wires);
 
 		design->optimize();
-		design->sort();
 		design->check();
 
 		keep_cache.reset();

--- a/techlibs/ice40/ice40_opt.cc
+++ b/techlibs/ice40/ice40_opt.cc
@@ -257,7 +257,6 @@ struct Ice40OptPass : public Pass {
 		}
 
 		design->optimize();
-		design->sort();
 		design->check();
 
 		log_header(design, "Finished OPT passes. (There is nothing left to do.)\n");

--- a/tests/arch/anlogic/mux.ys
+++ b/tests/arch/anlogic/mux.ys
@@ -39,6 +39,8 @@ proc
 equiv_opt -assert -map +/anlogic/cells_sim.v synth_anlogic # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux16 # Constrain all select calls below inside the top module
-select -assert-count 5 t:AL_MAP_LUT6
+select -assert-count 3 t:AL_MAP_LUT3
+select -assert-count 8 t:AL_MAP_LUT4
+select -assert-count 1 t:AL_MAP_LUT5
 
-select -assert-none t:AL_MAP_LUT6 %% t:* %D
+select -assert-none t:AL_MAP_LUT3 t:AL_MAP_LUT4 t:AL_MAP_LUT5 %% t:* %D


### PR DESCRIPTION
I was given a test case that is an example of #3713, where changing the name of a variable changed synthesis results. I tracked that down to a handful of `design->sort()` calls which sort the wires in the design alphabetically; removing them leads to identical synthesis results for the changed names.

This isn't really a *fix* for #3713, but it does alleviate some of the pain.
