### PR TITLE
Let makefile run without git

### DIFF
--- a/.github/workflows/extra-builds.yml
+++ b/.github/workflows/extra-builds.yml
@@ -120,7 +120,13 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup-build-env
-      
+
+      - name: Check abc
+        shell: bash
+        run: |
+          ! make check-git-abc
+          make wget-abc
+
       - name: Build
         shell: bash
         run: |

--- a/.github/workflows/extra-builds.yml
+++ b/.github/workflows/extra-builds.yml
@@ -125,7 +125,7 @@ jobs:
         shell: bash
         run: |
           ! make check-git-abc
-          make wget-abc
+          make curl-abc
 
       - name: Build
         shell: bash

--- a/.github/workflows/extra-builds.yml
+++ b/.github/workflows/extra-builds.yml
@@ -108,6 +108,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
+            .github/actions
             .
             backends
             frontends

--- a/.github/workflows/extra-builds.yml
+++ b/.github/workflows/extra-builds.yml
@@ -95,3 +95,34 @@ jobs:
         with:
           install_url: https://releases.nixos.org/nix/nix-2.18.1/install
       - run: nix build .?submodules=1
+
+  sparse-build:
+    name: "Build without abc or git" # emulate build from release tarball
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+    steps:
+      - name: Sparse checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .
+            backends
+            frontends
+            kernel
+            libs
+            misc
+            passes
+            techlibs
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-build-env
+      
+      - name: Build
+        shell: bash
+        run: |
+          make config-$CC
+          make -j$procs
+

--- a/Makefile
+++ b/Makefile
@@ -790,9 +790,27 @@ check-git-abc:
 		echo "3. Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule."; \
 		echo "4. Reapply your changes: Move your saved changes back to the 'abc' directory, if necessary."; \
 		exit 1; \
+	elif git status 2>&1 | grep 'fatal: not a git repository'; then \
+		echo "Did 'yosys' come from a release tarball?  Try call 'make wget-abc' to download matching 'abc' tarball."; \
+		exit 1; \
 	else \
 		echo "Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule."; \
 		exit 1; \
+	fi
+
+.PHONY: wget-abc
+ABC_TAR := abc.tar.gz
+YOSYS_TAG := $(word 1,$(subst +, ,$(YOSYS_VER)))
+ABC_TAR_URL := https://github.com/YosysHQ/yosys/releases/download/yosys-$(YOSYS_TAG)/$(ABC_TAR)
+wget-abc:
+	@if [ -z "$$(find abc -type d -prune -empty 2>&1)" ]; then \
+		echo "Error: The 'abc' directory already has contents.  Clear 'abc' directory before continuing."; \
+		exit 1; \
+	else \
+		mkdir -p abc; \
+		wget -nc "$(ABC_TAR_URL)"; \
+		echo "Extracting '$(ABC_TAR)' contents."; \
+		tar xzf $(ABC_TAR) -C abc --strip-components=1; \
 	fi
 
 abc/abc$(EXE) abc/libabc.a: check-git-abc

--- a/Makefile
+++ b/Makefile
@@ -791,24 +791,24 @@ check-git-abc:
 		echo "4. Reapply your changes: Move your saved changes back to the 'abc' directory, if necessary."; \
 		exit 1; \
 	elif git status 2>&1 | grep 'fatal: not a git repository'; then \
-		echo "Did 'yosys' come from a release tarball?  Try call 'make wget-abc' to download matching 'abc' tarball."; \
+		echo "Did 'yosys' come from a release tarball?  Try call 'make curl-abc' to download matching 'abc' tarball."; \
 		exit 1; \
 	else \
 		echo "Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule."; \
 		exit 1; \
 	fi
 
-.PHONY: wget-abc
+.PHONY: curl-abc
 ABC_TAR := abc.tar.gz
 YOSYS_TAG := $(word 1,$(subst +, ,$(YOSYS_VER)))
 ABC_TAR_URL := https://github.com/YosysHQ/yosys/releases/download/yosys-$(YOSYS_TAG)/$(ABC_TAR)
-wget-abc:
+curl-abc:
 	@if [ -z "$$(find abc -type d -prune -empty 2>&1)" ]; then \
 		echo "Error: The 'abc' directory already has contents.  Clear 'abc' directory before continuing."; \
 		exit 1; \
 	else \
 		mkdir -p abc; \
-		wget -nc "$(ABC_TAR_URL)"; \
+		curl -O -J -L "$(ABC_TAR_URL)"; \
 		echo "Extracting '$(ABC_TAR)' contents."; \
 		tar xzf $(ABC_TAR) -C abc --strip-components=1; \
 	fi


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Fix #4470

_Explain how this is achieved._

Test if current directory is a git repository, if it's not suggest calling `make wget-abc`.
Add `wget-abc` target, which attempts to download and extract the corresponding ABC release archive.

_If applicable, please suggest to reviewers how they can test the change._

Check "Build without abc or git" should pass.