### PR TITLE
smtbmc: Support skipping steps in cover mode

### DIFF
--- a/backends/smt2/smtbmc.py
+++ b/backends/smt2/smtbmc.py
@@ -1866,6 +1866,11 @@ elif covermode:
             smt_assert_antecedent("(|%s_t| s%d s%d)" % (topmod, step-1, step))
             smt_assert_antecedent("(not (|%s_is| s%d))" % (topmod, step))
 
+        if step < skip_steps:
+            print_msg("Skipping step %d.." % (step))
+            step += 1
+            continue
+
         while "1" in cover_mask:
             print_msg("Checking cover reachability in step %d.." % (step))
             smt_push()


### PR DESCRIPTION
SBY documentation currently says that `skip` is supported in `cover` and `bmc` mode, but skip steps are actually silently ignored in `cover` mode by `smtbmc`. This can cause confusion as in https://github.com/YosysHQ/sby/issues/283.

This change adds support for skipping steps to smtbmc and is implemented the same as the equivalent in `bmc` mode.