### PR TITLE
Gowin. Add an energy saving primitive

### DIFF
--- a/techlibs/gowin/cells_sim.v
+++ b/techlibs/gowin/cells_sim.v
@@ -867,8 +867,12 @@ module ODDRC(D0, D1, CLEAR, TX, CLK, Q0, Q1);
 	parameter INIT = 0;
 endmodule
 
+(* blackbox, keep *)
 module GSR (input GSRI);
-	wire GSRO = GSRI;
+endmodule
+
+(* blackbox, keep *)
+module BANDGAP (input BGEN);
 endmodule
 
 (* abc9_box, lib_whitebox *)

--- a/techlibs/gowin/cells_xtra.py
+++ b/techlibs/gowin/cells_xtra.py
@@ -13,7 +13,7 @@ class State(Enum):
     IN_MODULE = auto()
     IN_PARAMETER = auto()
 
-_skip = { 'ALU', 'DFF', 'DFFC', 'DFFCE', 'DFFE', 'DFFN', 'DFFNC', 'DFFNCE',
+_skip = { 'ALU', 'BANDGAP', 'DFF', 'DFFC', 'DFFCE', 'DFFE', 'DFFN', 'DFFNC', 'DFFNCE',
           'DFFNE', 'DFFNP', 'DFFNPE', 'DFFNR', 'DFFNRE', 'DFFNS', 'DFFNSE',
           'DFFP', 'DFFPE', 'DFFR', 'DFFRE', 'DFFS', 'DFFSE', 'DP', 'DPX9',
           'ELVDS_OBUF', 'GND', 'GSR', 'IBUF', 'IDDR', 'IDDRC', 'IDES10',

--- a/techlibs/gowin/cells_xtra.v
+++ b/techlibs/gowin/cells_xtra.v
@@ -1687,10 +1687,6 @@ endmodule
 module ADC (...);
 endmodule
 
-module BANDGAP (...);
-input BGEN;
-endmodule
-
 module CLKDIV2 (...);
 parameter GSREN = "false"; 
 input HCLKIN, RESETN;


### PR DESCRIPTION
We add a BANDGAP primitive used to turn off power to OSC, PLL and other things on some GOWIN chips.

We also mark this primitive and GSR as keep.

