### PR TITLE
Use alternate location for VS build required files

### DIFF
--- a/misc/create_vcxsrc.sh
+++ b/misc/create_vcxsrc.sh
@@ -6,8 +6,8 @@ yosysver="$2"
 gitsha="$3"
 
 rm -rf YosysVS-Tpl-v2.zip YosysVS
-wget https://yosyshq.net/yosys/nogit/YosysVS-Tpl-v2.zip
-wget https://www.zlib.net/fossils/zlib-1.2.11.tar.gz
+wget https://github.com/YosysHQ/yosys/releases/download/resources/YosysVS-Tpl-v2.zip
+wget https://github.com/YosysHQ/yosys/releases/download/resources/zlib-1.2.11.tar.gz
 
 unzip YosysVS-Tpl-v2.zip
 rm -f YosysVS-Tpl-v2.zip


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
There were issues with unavailability of these download locations in past.

_Explain how this is achieved._
By using GitHub pre-release location as part of this repo, we got these files hosted on higher availability servers.

_If applicable, please suggest to reviewers how they can test the change._
CI process will already utilize this script and it is enough to confirm changes working
