### PR TITLE
Reproducible git hash

### DIFF
--- a/.gitcommit
+++ b/.gitcommit
@@ -1,1 +1,1 @@
-$Format:%h$
+$Format:%H$

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ YOSYS_VER := 0.43+3
 # will have this file in its unexpanded form tough, in which case we fall
 # back to calling git directly.
 TARBALL_GIT_REV := $(shell cat $(YOSYS_SRC)/.gitcommit)
-ifneq ($(findstring "Format:",$(TARBALL_GIT_REV)),)
+ifneq ($(findstring Format:,$(TARBALL_GIT_REV)),)
 GIT_REV := $(shell GIT_DIR=$(YOSYS_SRC)/.git git rev-parse --short=9 HEAD || echo UNKNOWN)
 else
 GIT_REV := $(TARBALL_GIT_REV)

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ YOSYS_VER := 0.43+3
 # will have this file in its unexpanded form tough, in which case we fall
 # back to calling git directly.
 TARBALL_GIT_REV := $(shell cat $(YOSYS_SRC)/.gitcommit)
-ifeq ($(TARBALL_GIT_REV),$$Format:%h$$)
+ifneq ($(findstring "Format:",$(TARBALL_GIT_REV)),)
 GIT_REV := $(shell GIT_DIR=$(YOSYS_SRC)/.git git rev-parse --short=9 HEAD || echo UNKNOWN)
 else
 GIT_REV := $(TARBALL_GIT_REV)
@@ -773,10 +773,10 @@ check-git-abc:
 		exit 1; \
 	elif git -C "$(YOSYS_SRC)" submodule status abc 2>/dev/null | grep -q '^ '; then \
 		exit 0; \
-	elif [ -f "$(YOSYS_SRC)/abc/.gitcommit" ] && ! grep -q '\$$Format:%h\$$' "$(YOSYS_SRC)/abc/.gitcommit"; then \
+	elif [ -f "$(YOSYS_SRC)/abc/.gitcommit" ] && ! grep -q '\$$Format:%[hH]\$$' "$(YOSYS_SRC)/abc/.gitcommit"; then \
 		echo "'abc' comes from a tarball. Continuing."; \
 		exit 0; \
-	elif [ -f "$(YOSYS_SRC)/abc/.gitcommit" ] && grep -q '\$$Format:%h\$$' "$(YOSYS_SRC)/abc/.gitcommit"; then \
+	elif [ -f "$(YOSYS_SRC)/abc/.gitcommit" ] && grep -q '\$$Format:%[hH]\$$' "$(YOSYS_SRC)/abc/.gitcommit"; then \
 		echo "Error: 'abc' is not configured as a git submodule."; \
 		echo "To resolve this:"; \
 		echo "1. Back up your changes: Save any modifications from the 'abc' directory to another location."; \


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

See https://github.com/YosysHQ/abc/pull/35

_Explain how this is achieved._

abc submodule is bumped. abc .gitcommit checks for `Format:%h` are replaced with checks for either  `Format:%h` or  `Format:%H`. Yosys .gitcommit is changed also to ` Format:%H`. The yosys .gitcommit check for `Format:%h` is replaced with a check for a substring check for `Format:`

_If applicable, please suggest to reviewers how they can test the change._

Modify .gitcommit files at will to simulate tarballs instead of git checkouts and observe build success and errors to match intended behavior