### PR TITLE
Gowin. Add the DCS primitive

### DIFF
--- a/techlibs/gowin/cells_sim.v
+++ b/techlibs/gowin/cells_sim.v
@@ -1901,3 +1901,14 @@ output OSCOUT;
 parameter FREQ_DIV = 100;
 parameter REGULATOR_EN = 1'b0;
 endmodule
+
+(* blackbox *)
+module DCS (CLK0, CLK1, CLK2, CLK3, CLKSEL, SELFORCE, CLKOUT);
+input CLK0, CLK1, CLK2, CLK3, SELFORCE;
+input [3:0] CLKSEL;
+output CLKOUT;
+parameter DCS_MODE = "RISING";
+endmodule
+
+
+

--- a/techlibs/gowin/cells_xtra.v
+++ b/techlibs/gowin/cells_xtra.v
@@ -1564,12 +1564,6 @@ parameter IDLE    =  4'd0,
 		  RD_S2   =  4'd12;
 endmodule
 
-module DCS (...);
-input CLK0, CLK1, CLK2, CLK3, SELFORCE;
-input [3:0] CLKSEL;
-output CLKOUT;
-endmodule
-
 module DQCE (...);
 input CLKIN;
 input CE;


### PR DESCRIPTION
Not so much adding the primitive itself, but only its DCS_MODE parameter, without which an error occurs.

