### PR TITLE
Makefile: do install `bitpattern.h`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -579,6 +579,7 @@ S =
 endif
 
 $(eval $(call add_include_file,kernel/binding.h))
+$(eval $(call add_include_file,kernel/bitpattern.h))
 $(eval $(call add_include_file,kernel/cellaigs.h))
 $(eval $(call add_include_file,kernel/celledges.h))
 $(eval $(call add_include_file,kernel/celltypes.h))


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

`bitpattern.h` is useful to plugins which process HDLs.