### PR TITLE
Initial VAY draft

### DIFF
--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -166,6 +166,18 @@ extern Tcl_Obj *Tcl_ObjSetVar2(Tcl_Interp *interp, Tcl_Obj *part1Ptr, Tcl_Obj *p
 #  define YS_FALLTHROUGH
 #endif
 
+#define YS_COMMA ,
+
+#ifdef _YOSYS_VAY_
+#  define YS_VAY_VIRTUAL virtual
+#  define YS_VAY_ABSTRACT = 0
+#  define YS_NOVAY_CONSTREF(type) type
+#else
+#  define YS_VAY_VIRTUAL
+#  define YS_VAY_ABSTRACT
+#  define YS_NOVAY_CONSTREF(type) const type &
+#endif
+
 YOSYS_NAMESPACE_BEGIN
 
 // Note: All headers included in hashlib.h must be included


### PR DESCRIPTION
This adds the build config variable ENABLE_VIRTUAL_APIS. When enabled, the build will produce a `vay` executable instead of a `yosys` executable. (VAY stands for **V**irtual **A**PIs in **Y**osys, and is pronounced like "way".)

In a "vay" build, cells can be of different types, and the Cell API is providing virtual methods that the individual cell types can override.

The goal is to refactor most of yosys to use the virtual methods instead of accessing Cell members directly, or disable commands that would be hard to refactor. Especially coarse-grain front-end commands like `read_verilog` and `proc` would likely not be included in vay, because they represent a large code-base that would potentially be hard to refactor in that way.

In the end we want to have a `vay` command in `yosys`, that will exec `vay` to replace the yosys process, and automatically saves and restores the state, including passing open file handles for things like the script being executed. This allows us to switch from `yosys` to `vay` when going from coarse-grain to fine-grain synthesis, enabling more efficient representations of fine-grain netlists, at the cost of the overhead of virtual method call dispatch.