### PR TITLE
ast: don't suggest use in external projects

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -20,10 +20,10 @@
  *
  *  This is the AST frontend library.
  *
- *  The AST frontend library is not a frontend on it's own but provides a
- *  generic abstract syntax tree (AST) abstraction for HDL code and can be
- *  used by HDL frontends. See "ast.h" for an overview of the API and the
- *  Verilog frontend for an usage example.
+ *  The AST frontend library is not a frontend on its own but provides an
+ *  abstract syntax tree (AST) abstraction for the open source Verilog frontend
+ *  at frontends/verilog.
+ *
  *
  */
 

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -17,7 +17,9 @@
  *
  *  ---
  *
- *  This is support code for the Verilog frontend at frontends/verilog
+ *  The AST frontend library is not a frontend on its own but provides an
+ *  abstract syntax tree (AST) abstraction for the open source Verilog frontend
+ *  at frontends/verilog.
  *
  */
 


### PR DESCRIPTION
Some external projects, like synlig, depend on `ast.h` which is valid but isn't generally necessary or advisable. The Verific frontend doesn't use it. This PR removes the suggestion that external yosys frontends other than the open source Verilog frontend can use this ast functionality