### PR TITLE
Release build configuration improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ SANITIZER =
 
 # Prefer using ENABLE_DEBUG over setting these
 OPT_LEVEL := -O3
-GCC_LTO := -flto=auto
+GCC_LTO :=
 CLANG_LTO := -flto=thin
 
 PROGRAM_PREFIX :=

--- a/Makefile
+++ b/Makefile
@@ -441,11 +441,7 @@ CXXFLAGS := -O3 -DNDEBUG $(filter-out -Os -ggdb,$(CXXFLAGS))
 endif
 
 ifeq ($(ENABLE_DEBUG),1)
-ifeq ($(CONFIG),clang)
-CXXFLAGS := -O0 -DDEBUG $(filter-out -Os,$(CXXFLAGS))
-else
 CXXFLAGS := -Og -DDEBUG $(filter-out -Os,$(CXXFLAGS))
-endif
 endif
 
 ifeq ($(ENABLE_ABC),1)

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
         packages.default = yosys;
         defaultPackage = yosys;
         devShell = pkgs.mkShell {
-          buildInputs = with pkgs; [ clang bison flex libffi tcl readline python3 llvmPackages.libcxxClang zlib git gtest abc-verifier ];
+          buildInputs = with pkgs; [ clang llvmPackages.bintools bison flex libffi tcl readline python3 llvmPackages.libcxxClang zlib git gtest abc-verifier ];
         };
       }
     );


### PR DESCRIPTION
This PR sets the build optimization level to `-O3` for yosys. It doesn't change abc build flags. Clang now uses `-Og` on `ENABLE_DEBUG=1`.

## New Makefile variables

`ENABLE_LTO` - primary way of disabling LTO
`OPT_LEVEL` - allows `-O` opt level override
`GCC_LTO` - allows gcc-specific LTO flags override
`CLANG_LTO` - allows clang-specific LTO flags override

## clang LTO

For clang builds, which are the preferred release builds, it adds `lld`, and uses its thin LTO. Yosys is a small executable and stripped binary size changes are not significant (15 -> 19MB). In practice, this change brings about 5-10% improvements to the synthesis of various designs. This PR, when clean built on 24 threads with clang, increases the build time from 48 to 61 seconds and raises memory usage at build time from about 800MB to 3.3GB.

## gcc LTO

I don't understand gcc LTO, using `-flto=auto` *lowered* build time memory usage and made the resulting binary *slower*. This is why I'm not enabling LTO for gcc