### PR TITLE
Do not map `$eqx` `$nex` `$bweqx`

### DIFF
--- a/passes/techmap/simplemap.cc
+++ b/passes/techmap/simplemap.cc
@@ -415,7 +415,6 @@ void simplemap_get_mappers(dict<IdString, void(*)(RTLIL::Module*, RTLIL::Cell*)>
 	mappers[ID($or)]          = simplemap_bitop;
 	mappers[ID($xor)]         = simplemap_bitop;
 	mappers[ID($xnor)]        = simplemap_bitop;
-	mappers[ID($bweqx)]       = simplemap_bitop;
 	mappers[ID($reduce_and)]  = simplemap_reduce;
 	mappers[ID($reduce_or)]   = simplemap_reduce;
 	mappers[ID($reduce_xor)]  = simplemap_reduce;
@@ -425,9 +424,7 @@ void simplemap_get_mappers(dict<IdString, void(*)(RTLIL::Module*, RTLIL::Cell*)>
 	mappers[ID($logic_and)]   = simplemap_logbin;
 	mappers[ID($logic_or)]    = simplemap_logbin;
 	mappers[ID($eq)]          = simplemap_eqne;
-	mappers[ID($eqx)]         = simplemap_eqne;
 	mappers[ID($ne)]          = simplemap_eqne;
-	mappers[ID($nex)]         = simplemap_eqne;
 	mappers[ID($mux)]         = simplemap_mux;
 	mappers[ID($bwmux)]       = simplemap_bwmux;
 	mappers[ID($tribuf)]      = simplemap_tribuf;

--- a/passes/techmap/simplemap.cc
+++ b/passes/techmap/simplemap.cc
@@ -478,11 +478,10 @@ struct SimplemapPass : public Pass {
 		log("This pass maps a small selection of simple coarse-grain cells to yosys gate\n");
 		log("primitives. The following internal cell types are mapped by this pass:\n");
 		log("\n");
-		log("  $not, $pos, $and, $or, $xor, $xnor\n");
-		log("  $reduce_and, $reduce_or, $reduce_xor, $reduce_xnor, $reduce_bool\n");
-		log("  $logic_not, $logic_and, $logic_or, $mux, $tribuf\n");
-		log("  $sr, $ff, $dff, $dffe, $dffsr, $dffsre, $adff, $adffe, $aldff, $aldffe, $sdff,\n");
-		log("  $sdffe, $sdffce, $dlatch, $adlatch, $dlatchsr\n");
+		dict<IdString, void(*)(RTLIL::Module*, RTLIL::Cell*)> mappers;
+		simplemap_get_mappers(mappers);
+		for (auto pair : mappers)
+			log("  - %s\n", log_id(pair.first));
 		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override

--- a/techlibs/common/techmap.v
+++ b/techlibs/common/techmap.v
@@ -54,12 +54,12 @@ module _90_simplemap_logic_ops;
 endmodule
 
 (* techmap_simplemap *)
-(* techmap_celltype = "$eq $eqx $ne $nex" *)
+(* techmap_celltype = "$eq $ne" *)
 module _90_simplemap_compare_ops;
 endmodule
 
 (* techmap_simplemap *)
-(* techmap_celltype = "$pos $slice $concat $mux $tribuf $bmux $bwmux $bweqx" *)
+(* techmap_celltype = "$pos $slice $concat $mux $tribuf $bmux $bwmux" *)
 module _90_simplemap_various;
 endmodule
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

If someone ingests Verilog code using the `===` operator, and tries to synthesize it, I would like for that to be caught by `check -mapped` rather than silently processed as an `==` operator.

_Explain how this is achieved._

We make `simplemap` and `techmap` ignore `$eqx` `$nex` `$bweqx`, instead those cells are left in the netlist unmapped.

Along the way I make `simplemap` generate its help message based on the actual mappers registered (I think notwithstanding the `$eqx` change that help message grew out of sync.)