### PR TITLE
Run nix build also on macos. Build with more logs

### DIFF
--- a/.github/workflows/extra-builds.yml
+++ b/.github/workflows/extra-builds.yml
@@ -86,7 +86,11 @@ jobs:
     name: "Build nix flake"
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -94,4 +98,4 @@ jobs:
       - uses: cachix/install-nix-action@v26
         with:
           install_url: https://releases.nixos.org/nix/nix-2.18.1/install
-      - run: nix build .?submodules=1
+      - run: nix build .?submodules=1 -L


### PR DESCRIPTION
This is achieved by having a matrix build, where we build with nix under both ubuntu-latest and macos-latest.

We could also test that yosys builds locally with nix on macOS. Unfortunately I don't have the machine required to do that, so any help is 

Tested the action on my fork and it works (https://github.com/RCoeurjoly/yosys/actions/runs/10169394792).