### PR TITLE
Represent string constants as strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -930,8 +930,8 @@ ystests: $(TARGETS) $(EXTRA_TARGETS)
 
 # Unit test
 unit-test: libyosys.so
-	@$(MAKE) -C $(UNITESTPATH) CXX="$(CXX)" CPPFLAGS="$(CPPFLAGS)" \
-		CXXFLAGS="$(CXXFLAGS)" LIBS="$(LIBS)" ROOTPATH="$(CURDIR)"
+	@$(MAKE) -C $(UNITESTPATH) CXX="$(CXX)" CC="$(CC)" CPPFLAGS="$(CPPFLAGS)" \
+		CXXFLAGS="$(CXXFLAGS)" LINKFLAGS="$(LINKFLAGS)" LIBS="$(LIBS)" ROOTPATH="$(CURDIR)"
 
 clean-unit-test:
 	@$(MAKE) -C $(UNITESTPATH) clean

--- a/backends/blif/blif.cc
+++ b/backends/blif/blif.cc
@@ -387,7 +387,7 @@ struct BlifDumper
 				auto &inputs = cell->getPort(ID::A);
 				auto width = cell->parameters.at(ID::WIDTH).as_int();
 				auto depth = cell->parameters.at(ID::DEPTH).as_int();
-				vector<State> table = cell->parameters.at(ID::TABLE).bits;
+				vector<State> table = cell->parameters.at(ID::TABLE).to_bits();
 				while (GetSize(table) < 2*width*depth)
 					table.push_back(State::S0);
 				log_assert(inputs.size() == width);

--- a/backends/btor/btor.cc
+++ b/backends/btor/btor.cc
@@ -711,9 +711,9 @@ struct BtorWorker
 			Const initval;
 			for (int i = 0; i < GetSize(sig_q); i++)
 				if (initbits.count(sig_q[i]))
-					initval.bits.push_back(initbits.at(sig_q[i]) ? State::S1 : State::S0);
+					initval.bits().push_back(initbits.at(sig_q[i]) ? State::S1 : State::S0);
 				else
-					initval.bits.push_back(State::Sx);
+					initval.bits().push_back(State::Sx);
 
 			int nid_init_val = -1;
 
@@ -1042,7 +1042,7 @@ struct BtorWorker
 						Const c(bit.data);
 
 						while (i+GetSize(c) < GetSize(sig) && sig[i+GetSize(c)].wire == nullptr)
-							c.bits.push_back(sig[i+GetSize(c)].data);
+							c.bits().push_back(sig[i+GetSize(c)].data);
 
 						if (consts.count(c) == 0) {
 							int sid = get_bv_sid(GetSize(c));

--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -328,7 +328,7 @@ struct FlowGraph {
 					node_comb_defs[node].insert(chunk.wire);
 				}
 			}
-		for (auto bit : sig.bits())
+		for (auto bit : sig)
 			bit_has_state[bit] |= is_ff;
 		// Only comb defs of an entire wire in the right order can be inlined.
 		if (!is_ff && sig.is_wire()) {
@@ -864,7 +864,7 @@ struct CxxrtlWorker {
 		if (!module->has_attribute(ID(cxxrtl_template)))
 			return {};
 
-		if (module->attributes.at(ID(cxxrtl_template)).flags != RTLIL::CONST_FLAG_STRING)
+		if (!(module->attributes.at(ID(cxxrtl_template)).flags & RTLIL::CONST_FLAG_STRING))
 			log_cmd_error("Attribute `cxxrtl_template' of module `%s' is not a string.\n", log_id(module));
 
 		std::vector<std::string> param_names = split_by(module->get_string_attribute(ID(cxxrtl_template)), " \t");
@@ -1665,15 +1665,15 @@ struct CxxrtlWorker {
 							switch (bit) {
 								case RTLIL::S0:
 								case RTLIL::S1:
-									compare_mask.bits.push_back(RTLIL::S1);
-									compare_value.bits.push_back(bit);
+									compare_mask.bits().push_back(RTLIL::S1);
+									compare_value.bits().push_back(bit);
 									break;
 
 								case RTLIL::Sx:
 								case RTLIL::Sz:
 								case RTLIL::Sa:
-									compare_mask.bits.push_back(RTLIL::S0);
-									compare_value.bits.push_back(RTLIL::S0);
+									compare_mask.bits().push_back(RTLIL::S0);
+									compare_value.bits().push_back(RTLIL::S0);
 									break;
 
 								default:
@@ -3028,7 +3028,7 @@ struct CxxrtlWorker {
 								if (init == RTLIL::Const()) {
 									init = RTLIL::Const(State::Sx, GetSize(bit.wire));
 								}
-								init[bit.offset] = port.init_value[i];
+								init.bits()[bit.offset] = port.init_value[i];
 							}
 						}
 					}

--- a/backends/edif/edif.cc
+++ b/backends/edif/edif.cc
@@ -334,20 +334,20 @@ struct EdifBackend : public Backend {
 		auto add_prop = [&](IdString name, Const val) {
 			if ((val.flags & RTLIL::CONST_FLAG_STRING) != 0)
 				*f << stringf("\n            (property %s (string \"%s\"))", EDIF_DEF(name), val.decode_string().c_str());
-			else if (val.bits.size() <= 32 && RTLIL::SigSpec(val).is_fully_def())
+			else if (val.size() <= 32 && RTLIL::SigSpec(val).is_fully_def())
 				*f << stringf("\n            (property %s (integer %u))", EDIF_DEF(name), val.as_int());
 			else {
 				std::string hex_string = "";
-				for (size_t i = 0; i < val.bits.size(); i += 4) {
+				for (size_t i = 0; i < val.size(); i += 4) {
 					int digit_value = 0;
-					if (i+0 < val.bits.size() && val.bits.at(i+0) == RTLIL::State::S1) digit_value |= 1;
-					if (i+1 < val.bits.size() && val.bits.at(i+1) == RTLIL::State::S1) digit_value |= 2;
-					if (i+2 < val.bits.size() && val.bits.at(i+2) == RTLIL::State::S1) digit_value |= 4;
-					if (i+3 < val.bits.size() && val.bits.at(i+3) == RTLIL::State::S1) digit_value |= 8;
+					if (i+0 < val.size() && val.at(i+0) == RTLIL::State::S1) digit_value |= 1;
+					if (i+1 < val.size() && val.at(i+1) == RTLIL::State::S1) digit_value |= 2;
+					if (i+2 < val.size() && val.at(i+2) == RTLIL::State::S1) digit_value |= 4;
+					if (i+3 < val.size() && val.at(i+3) == RTLIL::State::S1) digit_value |= 8;
 					char digit_str[2] = { "0123456789abcdef"[digit_value], 0 };
 					hex_string = std::string(digit_str) + hex_string;
 				}
-				*f << stringf("\n            (property %s (string \"%d'h%s\"))", EDIF_DEF(name), GetSize(val.bits), hex_string.c_str());
+				*f << stringf("\n            (property %s (string \"%d'h%s\"))", EDIF_DEF(name), GetSize(val), hex_string.c_str());
 			}
 		};
 		for (auto module : sorted_modules)

--- a/backends/firrtl/firrtl.cc
+++ b/backends/firrtl/firrtl.cc
@@ -149,7 +149,7 @@ std::string dump_const(const RTLIL::Const &data)
 	// Numeric (non-real) parameter.
 	else
 	{
-		int width = data.bits.size();
+		int width = data.size();
 
 		// If a standard 32-bit int, then emit standard int value like "56" or
 		// "-56". Firrtl supports negative-valued int literals.
@@ -163,7 +163,7 @@ std::string dump_const(const RTLIL::Const &data)
 
 			for (int i = 0; i < width; i++)
 			{
-				switch (data.bits[i])
+				switch (data[i])
 				{
 					case State::S0:                      break;
 					case State::S1: int_val |= (1 << i); break;
@@ -205,7 +205,7 @@ std::string dump_const(const RTLIL::Const &data)
 			for (int i = width - 1; i >= 0; i--)
 			{
 				log_assert(i < width);
-				switch (data.bits[i])
+				switch (data[i])
 				{
 					case State::S0: res_str += "0"; break;
 					case State::S1: res_str += "1"; break;

--- a/backends/functional/test_generic.cc
+++ b/backends/functional/test_generic.cc
@@ -105,7 +105,7 @@ struct MemContentsTest {
 				RTLIL::Const values;
 				for(addr_t addr = low; addr <= high; addr++) {
 					RTLIL::Const word(data_dist(rnd), data_width);
-					values.bits.insert(values.bits.end(), word.bits.begin(), word.bits.end());
+					values.bits().insert(values.bits().end(), word.begin(), word.end());
 				}
 				insert_concatenated(low, values);
 			}

--- a/backends/intersynth/intersynth.cc
+++ b/backends/intersynth/intersynth.cc
@@ -176,11 +176,11 @@ struct IntersynthBackend : public Backend {
 					}
 				}
 				for (auto &param : cell->parameters) {
-					celltype_code += stringf(" cfg:%d %s", int(param.second.bits.size()), log_id(param.first));
-					if (param.second.bits.size() != 32) {
+					celltype_code += stringf(" cfg:%d %s", int(param.second.size()), log_id(param.first));
+					if (param.second.size() != 32) {
 						node_code += stringf(" %s '", log_id(param.first));
-						for (int i = param.second.bits.size()-1; i >= 0; i--)
-							node_code += param.second.bits[i] == State::S1 ? "1" : "0";
+						for (int i = param.second.size()-1; i >= 0; i--)
+							node_code += param.second[i] == State::S1 ? "1" : "0";
 					} else
 						node_code += stringf(" %s 0x%x", log_id(param.first), param.second.as_int());
 				}

--- a/backends/rtlil/rtlil_backend.cc
+++ b/backends/rtlil/rtlil_backend.cc
@@ -33,13 +33,13 @@ YOSYS_NAMESPACE_BEGIN
 void RTLIL_BACKEND::dump_const(std::ostream &f, const RTLIL::Const &data, int width, int offset, bool autoint)
 {
 	if (width < 0)
-		width = data.bits.size() - offset;
-	if ((data.flags & RTLIL::CONST_FLAG_STRING) == 0 || width != (int)data.bits.size()) {
+		width = data.size() - offset;
+	if ((data.flags & RTLIL::CONST_FLAG_STRING) == 0 || width != (int)data.size()) {
 		if (width == 32 && autoint) {
 			int32_t val = 0;
 			for (int i = 0; i < width; i++) {
-				log_assert(offset+i < (int)data.bits.size());
-				switch (data.bits[offset+i]) {
+				log_assert(offset+i < (int)data.size());
+				switch (data[offset+i]) {
 				case State::S0: break;
 				case State::S1: val |= 1 << i; break;
 				default: val = -1; break;
@@ -58,8 +58,8 @@ void RTLIL_BACKEND::dump_const(std::ostream &f, const RTLIL::Const &data, int wi
 			f << "x";
 		} else {
 			for (int i = offset+width-1; i >= offset; i--) {
-				log_assert(i < (int)data.bits.size());
-				switch (data.bits[i]) {
+				log_assert(i < (int)data.size());
+				switch (data[i]) {
 				case State::S0: f << stringf("0"); break;
 				case State::S1: f << stringf("1"); break;
 				case RTLIL::Sx: f << stringf("x"); break;

--- a/backends/simplec/simplec.cc
+++ b/backends/simplec/simplec.cc
@@ -657,7 +657,7 @@ struct SimplecWorker
 			{
 				SigSpec sig = sigmaps.at(module)(w);
 				Const val = w->attributes.at(ID::init);
-				val.bits.resize(GetSize(sig), State::Sx);
+				val.bits().resize(GetSize(sig), State::Sx);
 
 				for (int i = 0; i < GetSize(sig); i++)
 					if (val[i] == State::S0 || val[i] == State::S1) {

--- a/backends/smt2/smt2.cc
+++ b/backends/smt2/smt2.cc
@@ -1077,14 +1077,14 @@ struct Smt2Worker
 
 				RTLIL::SigSpec sig = sigmap(wire);
 				Const val = wire->attributes.at(ID::init);
-				val.bits.resize(GetSize(sig), State::Sx);
+				val.bits().resize(GetSize(sig), State::Sx);
 				if (bvmode && GetSize(sig) > 1) {
 					Const mask(State::S1, GetSize(sig));
 					bool use_mask = false;
 					for (int i = 0; i < GetSize(sig); i++)
 						if (val[i] != State::S0 && val[i] != State::S1) {
-							val[i] = State::S0;
-							mask[i] = State::S0;
+							val.bits()[i] = State::S0;
+							mask.bits()[i] = State::S0;
 							use_mask = true;
 						}
 					if (use_mask)
@@ -1359,10 +1359,10 @@ struct Smt2Worker
 					for (int k = 0; k < GetSize(initword); k++) {
 						if (initword[k] == State::S0 || initword[k] == State::S1) {
 							gen_init_constr = true;
-							initmask[k] = State::S1;
+							initmask.bits()[k] = State::S1;
 						} else {
-							initmask[k] = State::S0;
-							initword[k] = State::S0;
+							initmask.bits()[k] = State::S0;
+							initword.bits()[k] = State::S0;
 						}
 					}
 

--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -191,7 +191,7 @@ void dump_const(std::ostream &f, const RTLIL::Const &data, int width = -1, int o
 {
 	bool set_signed = (data.flags & RTLIL::CONST_FLAG_SIGNED) != 0;
 	if (width < 0)
-		width = data.bits.size() - offset;
+		width = data.size() - offset;
 	if (width == 0) {
 		// See IEEE 1364-2005 Clause 5.1.14.
 		f << "{0{1'b0}}";
@@ -199,14 +199,14 @@ void dump_const(std::ostream &f, const RTLIL::Const &data, int width = -1, int o
 	}
 	if (nostr)
 		goto dump_hex;
-	if ((data.flags & RTLIL::CONST_FLAG_STRING) == 0 || width != (int)data.bits.size()) {
+	if ((data.flags & RTLIL::CONST_FLAG_STRING) == 0 || width != (int)data.size()) {
 		if (width == 32 && !no_decimal && !nodec) {
 			int32_t val = 0;
 			for (int i = offset+width-1; i >= offset; i--) {
-				log_assert(i < (int)data.bits.size());
-				if (data.bits[i] != State::S0 && data.bits[i] != State::S1)
+				log_assert(i < (int)data.size());
+				if (data[i] != State::S0 && data[i] != State::S1)
 					goto dump_hex;
-				if (data.bits[i] == State::S1)
+				if (data[i] == State::S1)
 					val |= 1 << (i - offset);
 			}
 			if (decimal)
@@ -221,8 +221,8 @@ void dump_const(std::ostream &f, const RTLIL::Const &data, int width = -1, int o
 				goto dump_bin;
 			vector<char> bin_digits, hex_digits;
 			for (int i = offset; i < offset+width; i++) {
-				log_assert(i < (int)data.bits.size());
-				switch (data.bits[i]) {
+				log_assert(i < (int)data.size());
+				switch (data[i]) {
 				case State::S0: bin_digits.push_back('0'); break;
 				case State::S1: bin_digits.push_back('1'); break;
 				case RTLIL::Sx: bin_digits.push_back('x'); break;
@@ -275,8 +275,8 @@ void dump_const(std::ostream &f, const RTLIL::Const &data, int width = -1, int o
 			if (width == 0)
 				f << stringf("0");
 			for (int i = offset+width-1; i >= offset; i--) {
-				log_assert(i < (int)data.bits.size());
-				switch (data.bits[i]) {
+				log_assert(i < (int)data.size());
+				switch (data[i]) {
 				case State::S0: f << stringf("0"); break;
 				case State::S1: f << stringf("1"); break;
 				case RTLIL::Sx: f << stringf("x"); break;
@@ -318,10 +318,10 @@ void dump_reg_init(std::ostream &f, SigSpec sig)
 
 	for (auto bit : active_sigmap(sig)) {
 		if (active_initdata.count(bit)) {
-			initval.bits.push_back(active_initdata.at(bit));
+			initval.bits().push_back(active_initdata.at(bit));
 			gotinit = true;
 		} else {
-			initval.bits.push_back(State::Sx);
+			initval.bits().push_back(State::Sx);
 		}
 	}
 
@@ -751,7 +751,7 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 					if (port.wide_log2) {
 						Const addr_lo;
 						for (int i = 0; i < port.wide_log2; i++)
-							addr_lo.bits.push_back(State(sub >> i & 1));
+							addr_lo.bits().push_back(State(sub >> i & 1));
 						os << "{";
 						os << temp_id;
 						os << ", ";

--- a/frontends/aiger/aigerparse.cc
+++ b/frontends/aiger/aigerparse.cc
@@ -448,7 +448,7 @@ void AigerReader::parse_xaiger()
 					bool success = ce.eval(o);
 					log_assert(success);
 					log_assert(o.wire == nullptr);
-					lut_mask[gray] = o.data;
+					lut_mask.bits()[gray] = o.data;
 				}
 				RTLIL::Cell *output_cell = module->cell(stringf("$and$aiger%d$%d", aiger_autoidx, rootNodeID));
 				log_assert(output_cell);

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -735,10 +735,10 @@ struct AST_INTERNAL::ProcessGenerator
 				for (auto sync : proc->syncs) {
 					if (sync->type == RTLIL::STp) {
 						triggers.append(sync->signal);
-						polarity.bits.push_back(RTLIL::S1);
+						polarity.bits().push_back(RTLIL::S1);
 					} else if (sync->type == RTLIL::STn) {
 						triggers.append(sync->signal);
-						polarity.bits.push_back(RTLIL::S0);
+						polarity.bits().push_back(RTLIL::S0);
 					}
 				}
 
@@ -832,10 +832,10 @@ struct AST_INTERNAL::ProcessGenerator
 				for (auto sync : proc->syncs) {
 					if (sync->type == RTLIL::STp) {
 						triggers.append(sync->signal);
-						polarity.bits.push_back(RTLIL::S1);
+						polarity.bits().push_back(RTLIL::S1);
 					} else if (sync->type == RTLIL::STn) {
 						triggers.append(sync->signal);
-						polarity.bits.push_back(RTLIL::S0);
+						polarity.bits().push_back(RTLIL::S0);
 					}
 				}
 
@@ -892,7 +892,7 @@ struct AST_INTERNAL::ProcessGenerator
 				RTLIL::Const priority_mask = RTLIL::Const(0, cur_idx);
 				for (int i = 0; i < portid; i++) {
 					int new_bit = port_map[std::make_pair(memid, i)];
-					priority_mask.bits[new_bit] = orig_priority_mask.bits[i];
+					priority_mask.bits()[new_bit] = orig_priority_mask[i];
 				}
 				action.priority_mask = priority_mask;
 				sync->mem_write_actions.push_back(action);

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1718,8 +1718,8 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 					if (v->type == AST_CONSTANT && v->bits_only_01()) {
 						RTLIL::Const case_item_expr = v->bitsAsConst(width_hint, sign_hint);
 						RTLIL::Const match = const_eq(case_expr, case_item_expr, sign_hint, sign_hint, 1);
-						log_assert(match.bits.size() == 1);
-						if (match.bits.front() == RTLIL::State::S1) {
+						log_assert(match.size() == 1);
+						if (match.front() == RTLIL::State::S1) {
 							while (i+1 < GetSize(children))
 								delete children[++i];
 							goto keep_const_cond;
@@ -2021,7 +2021,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 		if (children[1]->type != AST_CONSTANT)
 			input_error("Right operand of to_bits expression is not constant!\n");
 		RTLIL::Const new_value = children[1]->bitsAsConst(children[0]->bitsAsConst().as_int(), children[1]->is_signed);
-		newNode = mkconst_bits(new_value.bits, children[1]->is_signed);
+		newNode = mkconst_bits(new_value.to_bits(), children[1]->is_signed);
 		goto apply_newNode;
 	}
 
@@ -2184,7 +2184,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 				log_file_warning(filename, location.first_line, "converting real value %e to binary %s.\n",
 						children[0]->realvalue, log_signal(constvalue));
 				delete children[0];
-				children[0] = mkconst_bits(constvalue.bits, sign_hint);
+				children[0] = mkconst_bits(constvalue.to_bits(), sign_hint);
 				fixup_hierarchy_flags();
 				did_something = true;
 			}
@@ -2193,7 +2193,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 					RTLIL::SigSpec sig(children[0]->bits);
 					sig.extend_u0(width, children[0]->is_signed);
 					AstNode *old_child_0 = children[0];
-					children[0] = mkconst_bits(sig.as_const().bits, is_signed);
+					children[0] = mkconst_bits(sig.as_const().to_bits(), is_signed);
 					delete old_child_0;
 					fixup_hierarchy_flags();
 				}
@@ -3493,8 +3493,8 @@ skip_dynamic_range_lvalue_expansion:;
 				delete buf;
 
 				uint32_t result = 0;
-				for (size_t i = 0; i < arg_value.bits.size(); i++)
-					if (arg_value.bits.at(i) == RTLIL::State::S1)
+				for (size_t i = 0; i < arg_value.size(); i++)
+					if (arg_value.at(i) == RTLIL::State::S1)
 						result = i + 1;
 
 				newNode = mkconst_int(result, true);
@@ -4173,14 +4173,14 @@ replace_fcall_later:;
 		case AST_BIT_NOT:
 			if (children[0]->type == AST_CONSTANT) {
 				RTLIL::Const y = RTLIL::const_not(children[0]->bitsAsConst(width_hint, sign_hint), dummy_arg, sign_hint, false, width_hint);
-				newNode = mkconst_bits(y.bits, sign_hint);
+				newNode = mkconst_bits(y.to_bits(), sign_hint);
 			}
 			break;
 		case AST_TO_SIGNED:
 		case AST_TO_UNSIGNED:
 			if (children[0]->type == AST_CONSTANT) {
 				RTLIL::Const y = children[0]->bitsAsConst(width_hint, sign_hint);
-				newNode = mkconst_bits(y.bits, type == AST_TO_SIGNED);
+				newNode = mkconst_bits(y.to_bits(), type == AST_TO_SIGNED);
 			}
 			break;
 		if (0) { case AST_BIT_AND:  const_func = RTLIL::const_and;  }
@@ -4190,7 +4190,7 @@ replace_fcall_later:;
 			if (children[0]->type == AST_CONSTANT && children[1]->type == AST_CONSTANT) {
 				RTLIL::Const y = const_func(children[0]->bitsAsConst(width_hint, sign_hint),
 						children[1]->bitsAsConst(width_hint, sign_hint), sign_hint, sign_hint, width_hint);
-				newNode = mkconst_bits(y.bits, sign_hint);
+				newNode = mkconst_bits(y.to_bits(), sign_hint);
 			}
 			break;
 		if (0) { case AST_REDUCE_AND:  const_func = RTLIL::const_reduce_and;  }
@@ -4200,13 +4200,13 @@ replace_fcall_later:;
 		if (0) { case AST_REDUCE_BOOL: const_func = RTLIL::const_reduce_bool; }
 			if (children[0]->type == AST_CONSTANT) {
 				RTLIL::Const y = const_func(RTLIL::Const(children[0]->bits), dummy_arg, false, false, -1);
-				newNode = mkconst_bits(y.bits, false);
+				newNode = mkconst_bits(y.to_bits(), false);
 			}
 			break;
 		case AST_LOGIC_NOT:
 			if (children[0]->type == AST_CONSTANT) {
 				RTLIL::Const y = RTLIL::const_logic_not(RTLIL::Const(children[0]->bits), dummy_arg, children[0]->is_signed, false, -1);
-				newNode = mkconst_bits(y.bits, false);
+				newNode = mkconst_bits(y.to_bits(), false);
 			} else
 			if (children[0]->isConst()) {
 				newNode = mkconst_int(children[0]->asReal(sign_hint) == 0, false, 1);
@@ -4217,7 +4217,7 @@ replace_fcall_later:;
 			if (children[0]->type == AST_CONSTANT && children[1]->type == AST_CONSTANT) {
 				RTLIL::Const y = const_func(RTLIL::Const(children[0]->bits), RTLIL::Const(children[1]->bits),
 						children[0]->is_signed, children[1]->is_signed, -1);
-				newNode = mkconst_bits(y.bits, false);
+				newNode = mkconst_bits(y.to_bits(), false);
 			} else
 			if (children[0]->isConst() && children[1]->isConst()) {
 				if (type == AST_LOGIC_AND)
@@ -4234,7 +4234,7 @@ replace_fcall_later:;
 			if (children[0]->type == AST_CONSTANT && children[1]->type == AST_CONSTANT) {
 				RTLIL::Const y = const_func(children[0]->bitsAsConst(width_hint, sign_hint),
 						RTLIL::Const(children[1]->bits), sign_hint, type == AST_POW ? children[1]->is_signed : false, width_hint);
-				newNode = mkconst_bits(y.bits, sign_hint);
+				newNode = mkconst_bits(y.to_bits(), sign_hint);
 			} else
 			if (type == AST_POW && children[0]->isConst() && children[1]->isConst()) {
 				newNode = new AstNode(AST_REALVALUE);
@@ -4254,7 +4254,7 @@ replace_fcall_later:;
 				bool cmp_signed = children[0]->is_signed && children[1]->is_signed;
 				RTLIL::Const y = const_func(children[0]->bitsAsConst(cmp_width, cmp_signed),
 						children[1]->bitsAsConst(cmp_width, cmp_signed), cmp_signed, cmp_signed, 1);
-				newNode = mkconst_bits(y.bits, false);
+				newNode = mkconst_bits(y.to_bits(), false);
 			} else
 			if (children[0]->isConst() && children[1]->isConst()) {
 				bool cmp_signed = (children[0]->type == AST_REALVALUE || children[0]->is_signed) && (children[1]->type == AST_REALVALUE || children[1]->is_signed);
@@ -4279,7 +4279,7 @@ replace_fcall_later:;
 			if (children[0]->type == AST_CONSTANT && children[1]->type == AST_CONSTANT) {
 				RTLIL::Const y = const_func(children[0]->bitsAsConst(width_hint, sign_hint),
 						children[1]->bitsAsConst(width_hint, sign_hint), sign_hint, sign_hint, width_hint);
-				newNode = mkconst_bits(y.bits, sign_hint);
+				newNode = mkconst_bits(y.to_bits(), sign_hint);
 			} else
 			if (children[0]->isConst() && children[1]->isConst()) {
 				newNode = new AstNode(AST_REALVALUE);
@@ -4298,7 +4298,7 @@ replace_fcall_later:;
 		if (0) { case AST_NEG: const_func = RTLIL::const_neg; }
 			if (children[0]->type == AST_CONSTANT) {
 				RTLIL::Const y = const_func(children[0]->bitsAsConst(width_hint, sign_hint), dummy_arg, sign_hint, false, width_hint);
-				newNode = mkconst_bits(y.bits, sign_hint);
+				newNode = mkconst_bits(y.to_bits(), sign_hint);
 			} else
 			if (children[0]->isConst()) {
 				newNode = new AstNode(AST_REALVALUE);
@@ -4326,10 +4326,10 @@ replace_fcall_later:;
 							newNode->realvalue = choice->asReal(sign_hint);
 						} else {
 							RTLIL::Const y = choice->bitsAsConst(width_hint, sign_hint);
-							if (choice->is_string && y.bits.size() % 8 == 0 && sign_hint == false)
-								newNode = mkconst_str(y.bits);
+							if (choice->is_string && y.size() % 8 == 0 && sign_hint == false)
+								newNode = mkconst_str(y.to_bits());
 							else
-								newNode = mkconst_bits(y.bits, sign_hint);
+								newNode = mkconst_bits(y.to_bits(), sign_hint);
 						}
 					} else
 					if (choice->isConst()) {
@@ -4338,11 +4338,11 @@ replace_fcall_later:;
 				} else if (children[1]->type == AST_CONSTANT && children[2]->type == AST_CONSTANT) {
 					RTLIL::Const a = children[1]->bitsAsConst(width_hint, sign_hint);
 					RTLIL::Const b = children[2]->bitsAsConst(width_hint, sign_hint);
-					log_assert(a.bits.size() == b.bits.size());
-					for (size_t i = 0; i < a.bits.size(); i++)
-						if (a.bits[i] != b.bits[i])
-							a.bits[i] = RTLIL::State::Sx;
-					newNode = mkconst_bits(a.bits, sign_hint);
+					log_assert(a.size() == b.size());
+					for (size_t i = 0; i < a.size(); i++)
+						if (a[i] != b[i])
+							a.bits()[i] = RTLIL::State::Sx;
+					newNode = mkconst_bits(a.to_bits(), sign_hint);
 				} else if (children[1]->isConst() && children[2]->isConst()) {
 					newNode = new AstNode(AST_REALVALUE);
 					if (children[1]->asReal(sign_hint) == children[2]->asReal(sign_hint))
@@ -4363,7 +4363,7 @@ replace_fcall_later:;
 					val = children[1]->bitsAsUnsizedConst(width);
 				else
 					val = children[1]->bitsAsConst(width);
-				newNode = mkconst_bits(val.bits, children[1]->is_signed);
+				newNode = mkconst_bits(val.to_bits(), children[1]->is_signed);
 			}
 			break;
 		case AST_CONCAT:
@@ -4948,7 +4948,7 @@ bool AstNode::mem2reg_as_needed_pass2(pool<AstNode*> &mem2reg_set, AstNode *mod,
 						target->str = str;
 						target->id2ast = id2ast;
 						target->was_checked = true;
-						block->children.push_back(new AstNode(AST_ASSIGN_EQ, target, mkconst_bits(data.extract(i*wordsz + pos, clen).bits, false)));
+						block->children.push_back(new AstNode(AST_ASSIGN_EQ, target, mkconst_bits(data.extract(i*wordsz + pos, clen).to_bits(), false)));
 						pos = epos;
 					}
 				}
@@ -5303,7 +5303,7 @@ bool AstNode::is_simple_const_expr()
 bool AstNode::replace_variables(std::map<std::string, AstNode::varinfo_t> &variables, AstNode *fcall, bool must_succeed)
 {
 	if (type == AST_IDENTIFIER && variables.count(str)) {
-		int offset = variables.at(str).offset, width = variables.at(str).val.bits.size();
+		int offset = variables.at(str).offset, width = variables.at(str).val.size();
 		if (!children.empty()) {
 			if (children.size() != 1 || children.at(0)->type != AST_RANGE) {
 				if (!must_succeed)
@@ -5326,7 +5326,7 @@ bool AstNode::replace_variables(std::map<std::string, AstNode::varinfo_t> &varia
 		offset -= variables.at(str).offset;
 		if (variables.at(str).range_swapped)
 			offset = -offset;
-		std::vector<RTLIL::State> &var_bits = variables.at(str).val.bits;
+		std::vector<RTLIL::State> &var_bits = variables.at(str).val.bits();
 		std::vector<RTLIL::State> new_bits(var_bits.begin() + offset, var_bits.begin() + offset + width);
 		AstNode *newNode = mkconst_bits(new_bits, variables.at(str).is_signed);
 		newNode->cloneInto(this);
@@ -5457,7 +5457,7 @@ AstNode *AstNode::eval_const_function(AstNode *fcall, bool must_succeed)
 			}
 
 			if (stmt->children.at(0)->children.empty()) {
-				variables[stmt->children.at(0)->str].val = stmt->children.at(1)->bitsAsConst(variables[stmt->children.at(0)->str].val.bits.size());
+				variables[stmt->children.at(0)->str].val = stmt->children.at(1)->bitsAsConst(variables[stmt->children.at(0)->str].val.size());
 			} else {
 				AstNode *range = stmt->children.at(0)->children.at(0);
 				if (!range->range_valid) {
@@ -5468,12 +5468,12 @@ AstNode *AstNode::eval_const_function(AstNode *fcall, bool must_succeed)
 				int offset = min(range->range_left, range->range_right);
 				int width = std::abs(range->range_left - range->range_right) + 1;
 				varinfo_t &v = variables[stmt->children.at(0)->str];
-				RTLIL::Const r = stmt->children.at(1)->bitsAsConst(v.val.bits.size());
+				RTLIL::Const r = stmt->children.at(1)->bitsAsConst(v.val.size());
 				for (int i = 0; i < width; i++) {
 					int index = i + offset - v.offset;
 					if (v.range_swapped)
 						index = -index;
-					v.val.bits.at(index) = r.bits.at(i);
+					v.val.bits().at(index) = r.at(i);
 				}
 			}
 
@@ -5616,7 +5616,7 @@ AstNode *AstNode::eval_const_function(AstNode *fcall, bool must_succeed)
 		log_abort();
 	}
 
-	result = AstNode::mkconst_bits(variables.at(str).val.bits, variables.at(str).is_signed);
+	result = AstNode::mkconst_bits(variables.at(str).val.to_bits(), variables.at(str).is_signed);
 
 finished:
 	delete block;

--- a/frontends/blif/blifparse.cc
+++ b/frontends/blif/blifparse.cc
@@ -149,7 +149,7 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 		if (buffer[0] == '.')
 		{
 			if (lutptr) {
-				for (auto &bit : lutptr->bits)
+				for (auto &bit : lutptr->bits())
 					if (bit == RTLIL::State::Sx)
 						bit = lut_default_state;
 				lutptr = NULL;
@@ -321,9 +321,9 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 					const_v = Const(str);
 				} else {
 					int n = strlen(v);
-					const_v.bits.resize(n);
+					const_v.bits().resize(n);
 					for (int i = 0; i < n; i++)
-						const_v.bits[i] = v[n-i-1] != '0' ? State::S1 : State::S0;
+						const_v.bits()[i] = v[n-i-1] != '0' ? State::S1 : State::S0;
 				}
 				if (!strcmp(cmd, ".attr")) {
 					if (obj_attributes == nullptr) {
@@ -566,16 +566,16 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 			for (int i = 0; i < input_len; i++)
 				switch (input[i]) {
 					case '0':
-						sopcell->parameters[ID::TABLE].bits.push_back(State::S1);
-						sopcell->parameters[ID::TABLE].bits.push_back(State::S0);
+						sopcell->parameters[ID::TABLE].bits().push_back(State::S1);
+						sopcell->parameters[ID::TABLE].bits().push_back(State::S0);
 						break;
 					case '1':
-						sopcell->parameters[ID::TABLE].bits.push_back(State::S0);
-						sopcell->parameters[ID::TABLE].bits.push_back(State::S1);
+						sopcell->parameters[ID::TABLE].bits().push_back(State::S0);
+						sopcell->parameters[ID::TABLE].bits().push_back(State::S1);
 						break;
 					default:
-						sopcell->parameters[ID::TABLE].bits.push_back(State::S0);
-						sopcell->parameters[ID::TABLE].bits.push_back(State::S0);
+						sopcell->parameters[ID::TABLE].bits().push_back(State::S0);
+						sopcell->parameters[ID::TABLE].bits().push_back(State::S0);
 						break;
 				}
 
@@ -605,7 +605,7 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 							goto try_next_value;
 					}
 				}
-				lutptr->bits.at(i) = !strcmp(output, "0") ? RTLIL::State::S0 : RTLIL::State::S1;
+				lutptr->bits().at(i) = !strcmp(output, "0") ? RTLIL::State::S0 : RTLIL::State::S1;
 			try_next_value:;
 			}
 

--- a/frontends/rtlil/rtlil_parser.y
+++ b/frontends/rtlil/rtlil_parser.y
@@ -447,7 +447,7 @@ constant:
 			bits.pop_back();
 		$$ = new RTLIL::Const;
 		for (auto it = bits.begin(); it != bits.end(); it++)
-			$$->bits.push_back(*it);
+			$$->bits().push_back(*it);
 		if (is_signed) {
 			$$->flags |= RTLIL::CONST_FLAG_SIGNED;
 		}

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -236,23 +236,6 @@ RTLIL::IdString VerificImporter::new_verific_id(Verific::DesignObj *obj)
 	return s;
 }
 
-RTLIL::Const mkconst_str(const std::string &str)
-{
-	RTLIL::Const val;
-	std::vector<RTLIL::State> data;
-	data.reserve(str.size() * 8);
-	for (size_t i = 0; i < str.size(); i++) {
-		unsigned char ch = str[str.size() - i - 1];
-		for (int j = 0; j < 8; j++) {
-			data.push_back((ch & 1) ? State::S1 : State::S0);
-			ch = ch >> 1;
-		}
-	}
-	val.bits = data;
-	val.flags |= RTLIL::CONST_FLAG_STRING;
-	return val;
-}
-
 static const RTLIL::Const extract_vhdl_boolean(std::string &val)
 {
 	if (val == "false")
@@ -295,7 +278,7 @@ static const RTLIL::Const extract_vhdl_char(std::string &val)
 
 static const RTLIL::Const extract_real_value(std::string &val)
 {
-	RTLIL::Const c = mkconst_str(val);
+	RTLIL::Const c(val);
 	c.flags |= RTLIL::CONST_FLAG_REAL;
 	return c;
 }
@@ -333,7 +316,7 @@ static const  RTLIL::Const extract_vhdl_const(const char *value, bool output_sig
 	} else if (val == "true") {
 		c = RTLIL::Const::from_string("1");
 	} else {
-		c = mkconst_str(val);
+		c = RTLIL::Const(val);
 		log_warning("encoding value '%s' as string.\n", value);
 	}
 	if (is_signed)
@@ -364,7 +347,7 @@ static const  RTLIL::Const extract_verilog_const(const char *value, bool allow_s
 	} else if (allow_string) {
 		c = RTLIL::Const(val);
 	} else {
-		c = mkconst_str(val);
+		c = RTLIL::Const(val);
 		log_warning("encoding value '%s' as string.\n", value);
 	}
 	if (is_signed)
@@ -1634,7 +1617,7 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 						if (*ascii_initdata == 0)
 							break;
 						if (*ascii_initdata == '0' || *ascii_initdata == '1') {
-							initval[bit_idx] = (*ascii_initdata == '0') ? State::S0 : State::S1;
+							initval.bits()[bit_idx] = (*ascii_initdata == '0') ? State::S0 : State::S1;
 							initval_valid = true;
 						}
 						ascii_initdata++;
@@ -1756,9 +1739,9 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 
 					if (init_nets.count(net)) {
 						if (init_nets.at(net) == '0')
-							initval.bits.at(bitidx) = State::S0;
+							initval.bits().at(bitidx) = State::S0;
 						if (init_nets.at(net) == '1')
-							initval.bits.at(bitidx) = State::S1;
+							initval.bits().at(bitidx) = State::S1;
 						initval_valid = true;
 						init_nets.erase(net);
 					}
@@ -1832,12 +1815,12 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 			initval = bit.wire->attributes.at(ID::init);
 
 		while (GetSize(initval) < GetSize(bit.wire))
-			initval.bits.push_back(State::Sx);
+			initval.bits().push_back(State::Sx);
 
 		if (it.second == '0')
-			initval.bits.at(bit.offset) = State::S0;
+			initval.bits().at(bit.offset) = State::S0;
 		if (it.second == '1')
-			initval.bits.at(bit.offset) = State::S1;
+			initval.bits().at(bit.offset) = State::S1;
 
 		bit.wire->attributes[ID::init] = initval;
 	}
@@ -2024,7 +2007,7 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 			}
 
 			Const qx_init = Const(State::S1, width);
-			qx_init.bits.resize(2 * width, State::S0);
+			qx_init.bits().resize(2 * width, State::S0);
 
 			clocking.addDff(new_verific_id(inst), sig_dx, sig_qx, qx_init);
 			module->addXnor(new_verific_id(inst), sig_dx, sig_qx, sig_ox);
@@ -2295,7 +2278,7 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 					continue;
 
 				if (non_ff_bits.count(SigBit(wire, i)))
-					initval[i] = State::Sx;
+					initval.bits()[i] = State::Sx;
 			}
 
 			if (wire->port_input) {
@@ -2482,7 +2465,7 @@ Cell *VerificClocking::addDff(IdString name, SigSpec sig_d, SigSpec sig_q, Const
 				if (c.wire && c.wire->attributes.count(ID::init)) {
 					Const val = c.wire->attributes.at(ID::init);
 					for (int i = 0; i < GetSize(c); i++)
-						initval[offset+i] = val[c.offset+i];
+						initval.bits()[offset+i] = val[c.offset+i];
 				}
 				offset += GetSize(c);
 			}
@@ -2553,7 +2536,7 @@ Cell *VerificClocking::addAldff(IdString name, RTLIL::SigSpec sig_aload, RTLIL::
 			if (c.wire && c.wire->attributes.count(ID::init)) {
 				Const val = c.wire->attributes.at(ID::init);
 				for (int i = 0; i < GetSize(c); i++)
-					initval[offset+i] = val[c.offset+i];
+					initval.bits()[offset+i] = val[c.offset+i];
 			}
 			offset += GetSize(c);
 		}

--- a/frontends/verific/verificsva.cc
+++ b/frontends/verific/verificsva.cc
@@ -575,7 +575,7 @@ struct SvaFsm
 
 				if (delta_pos >= 0 && i_within_j && j_within_i) {
 					did_something = true;
-					values[i][delta_pos] = State::Sa;
+					values[i].bits()[delta_pos] = State::Sa;
 					values[j] = values.back();
 					values.pop_back();
 					goto next_pair;

--- a/kernel/bitpattern.h
+++ b/kernel/bitpattern.h
@@ -80,7 +80,7 @@ struct BitPatternPool
 	bits_t sig2bits(RTLIL::SigSpec sig)
 	{
 		bits_t bits;
-		bits.bitdata = sig.as_const().bits;
+		bits.bitdata = sig.as_const().bits();
 		for (auto &b : bits.bitdata)
 			if (b > RTLIL::State::S1)
 				b = RTLIL::State::Sa;

--- a/kernel/calc.cc
+++ b/kernel/calc.cc
@@ -30,13 +30,13 @@ static void extend_u0(RTLIL::Const &arg, int width, bool is_signed)
 {
 	RTLIL::State padding = RTLIL::State::S0;
 
-	if (arg.bits.size() > 0 && is_signed)
-		padding = arg.bits.back();
+	if (arg.size() > 0 && is_signed)
+		padding = arg.back();
 
-	while (int(arg.bits.size()) < width)
-		arg.bits.push_back(padding);
+	while (int(arg.size()) < width)
+		arg.bits().push_back(padding);
 
-	arg.bits.resize(width);
+	arg.bits().resize(width);
 }
 
 static BigInteger const2big(const RTLIL::Const &val, bool as_signed, int &undef_bit_pos)
@@ -45,17 +45,17 @@ static BigInteger const2big(const RTLIL::Const &val, bool as_signed, int &undef_
 
 	BigInteger::Sign sign = BigInteger::positive;
 	State inv_sign_bit = RTLIL::State::S1;
-	size_t num_bits = val.bits.size();
+	size_t num_bits = val.size();
 
-	if (as_signed && num_bits && val.bits[num_bits-1] == RTLIL::State::S1) {
+	if (as_signed && num_bits && val[num_bits-1] == RTLIL::State::S1) {
 		inv_sign_bit = RTLIL::State::S0;
 		sign = BigInteger::negative;
 		num_bits--;
 	}
 
 	for (size_t i = 0; i < num_bits; i++)
-		if (val.bits[i] == RTLIL::State::S0 || val.bits[i] == RTLIL::State::S1)
-			mag.setBit(i, val.bits[i] == inv_sign_bit);
+		if (val[i] == RTLIL::State::S0 || val[i] == RTLIL::State::S1)
+			mag.setBit(i, val[i] == inv_sign_bit);
 		else if (undef_bit_pos < 0)
 			undef_bit_pos = i;
 
@@ -79,19 +79,19 @@ static RTLIL::Const big2const(const BigInteger &val, int result_len, int undef_b
 		{
 			mag--;
 			for (int i = 0; i < result_len; i++)
-				result.bits[i] = mag.getBit(i) ? RTLIL::State::S0 : RTLIL::State::S1;
+				result.bits()[i] = mag.getBit(i) ? RTLIL::State::S0 : RTLIL::State::S1;
 		}
 		else
 		{
 			for (int i = 0; i < result_len; i++)
-				result.bits[i] = mag.getBit(i) ? RTLIL::State::S1 : RTLIL::State::S0;
+				result.bits()[i] = mag.getBit(i) ? RTLIL::State::S1 : RTLIL::State::S0;
 		}
 	}
 
 #if 0
 	if (undef_bit_pos >= 0)
 		for (int i = undef_bit_pos; i < result_len; i++)
-			result.bits[i] = RTLIL::State::Sx;
+			result[i] = RTLIL::State::Sx;
 #endif
 
 	return result;
@@ -132,19 +132,19 @@ static RTLIL::State logic_xnor(RTLIL::State a, RTLIL::State b)
 RTLIL::Const RTLIL::const_not(const RTLIL::Const &arg1, const RTLIL::Const&, bool signed1, bool, int result_len)
 {
 	if (result_len < 0)
-		result_len = arg1.bits.size();
+		result_len = arg1.size();
 
 	RTLIL::Const arg1_ext = arg1;
 	extend_u0(arg1_ext, result_len, signed1);
 
 	RTLIL::Const result(RTLIL::State::Sx, result_len);
 	for (size_t i = 0; i < size_t(result_len); i++) {
-		if (i >= arg1_ext.bits.size())
-			result.bits[i] = RTLIL::State::S0;
-		else if (arg1_ext.bits[i] == RTLIL::State::S0)
-			result.bits[i] = RTLIL::State::S1;
-		else if (arg1_ext.bits[i] == RTLIL::State::S1)
-			result.bits[i] = RTLIL::State::S0;
+		if (i >= arg1_ext.size())
+			result.bits()[i] = RTLIL::State::S0;
+		else if (arg1_ext.bits()[i] == RTLIL::State::S0)
+			result.bits()[i] = RTLIL::State::S1;
+		else if (arg1_ext.bits()[i] == RTLIL::State::S1)
+			result.bits()[i] = RTLIL::State::S0;
 	}
 
 	return result;
@@ -154,16 +154,16 @@ static RTLIL::Const logic_wrapper(RTLIL::State(*logic_func)(RTLIL::State, RTLIL:
 		RTLIL::Const arg1, RTLIL::Const arg2, bool signed1, bool signed2, int result_len = -1)
 {
 	if (result_len < 0)
-		result_len = max(arg1.bits.size(), arg2.bits.size());
+		result_len = max(arg1.size(), arg2.size());
 
 	extend_u0(arg1, result_len, signed1);
 	extend_u0(arg2, result_len, signed2);
 
 	RTLIL::Const result(RTLIL::State::Sx, result_len);
 	for (size_t i = 0; i < size_t(result_len); i++) {
-		RTLIL::State a = i < arg1.bits.size() ? arg1.bits[i] : RTLIL::State::S0;
-		RTLIL::State b = i < arg2.bits.size() ? arg2.bits[i] : RTLIL::State::S0;
-		result.bits[i] = logic_func(a, b);
+		RTLIL::State a = i < arg1.size() ? arg1.bits()[i] : RTLIL::State::S0;
+		RTLIL::State b = i < arg2.size() ? arg2.bits()[i] : RTLIL::State::S0;
+		result.bits()[i] = logic_func(a, b);
 	}
 
 	return result;
@@ -193,12 +193,12 @@ static RTLIL::Const logic_reduce_wrapper(RTLIL::State initial, RTLIL::State(*log
 {
 	RTLIL::State temp = initial;
 
-	for (size_t i = 0; i < arg1.bits.size(); i++)
-		temp = logic_func(temp, arg1.bits[i]);
+	for (size_t i = 0; i < arg1.size(); i++)
+		temp = logic_func(temp, arg1[i]);
 
 	RTLIL::Const result(temp);
-	while (int(result.bits.size()) < result_len)
-		result.bits.push_back(RTLIL::State::S0);
+	while (int(result.size()) < result_len)
+		result.bits().push_back(RTLIL::State::S0);
 	return result;
 }
 
@@ -220,11 +220,11 @@ RTLIL::Const RTLIL::const_reduce_xor(const RTLIL::Const &arg1, const RTLIL::Cons
 RTLIL::Const RTLIL::const_reduce_xnor(const RTLIL::Const &arg1, const RTLIL::Const&, bool, bool, int result_len)
 {
 	RTLIL::Const buffer = logic_reduce_wrapper(RTLIL::State::S0, logic_xor, arg1, result_len);
-	if (!buffer.bits.empty()) {
-		if (buffer.bits.front() == RTLIL::State::S0)
-			buffer.bits.front() = RTLIL::State::S1;
-		else if (buffer.bits.front() == RTLIL::State::S1)
-			buffer.bits.front() = RTLIL::State::S0;
+	if (!buffer.empty()) {
+		if (buffer.front() == RTLIL::State::S0)
+			buffer.bits().front() = RTLIL::State::S1;
+		else if (buffer.front() == RTLIL::State::S1)
+			buffer.bits().front() = RTLIL::State::S0;
 	}
 	return buffer;
 }
@@ -240,8 +240,8 @@ RTLIL::Const RTLIL::const_logic_not(const RTLIL::Const &arg1, const RTLIL::Const
 	BigInteger a = const2big(arg1, signed1, undef_bit_pos_a);
 	RTLIL::Const result(a.isZero() ? undef_bit_pos_a >= 0 ? RTLIL::State::Sx : RTLIL::State::S1 : RTLIL::State::S0);
 
-	while (int(result.bits.size()) < result_len)
-		result.bits.push_back(RTLIL::State::S0);
+	while (int(result.size()) < result_len)
+		result.bits().push_back(RTLIL::State::S0);
 	return result;
 }
 
@@ -255,8 +255,8 @@ RTLIL::Const RTLIL::const_logic_and(const RTLIL::Const &arg1, const RTLIL::Const
 	RTLIL::State bit_b = b.isZero() ? undef_bit_pos_b >= 0 ? RTLIL::State::Sx : RTLIL::State::S0 : RTLIL::State::S1;
 	RTLIL::Const result(logic_and(bit_a, bit_b));
 
-	while (int(result.bits.size()) < result_len)
-		result.bits.push_back(RTLIL::State::S0);
+	while (int(result.size()) < result_len)
+		result.bits().push_back(RTLIL::State::S0);
 	return result;
 }
 
@@ -270,8 +270,8 @@ RTLIL::Const RTLIL::const_logic_or(const RTLIL::Const &arg1, const RTLIL::Const 
 	RTLIL::State bit_b = b.isZero() ? undef_bit_pos_b >= 0 ? RTLIL::State::Sx : RTLIL::State::S0 : RTLIL::State::S1;
 	RTLIL::Const result(logic_or(bit_a, bit_b));
 
-	while (int(result.bits.size()) < result_len)
-		result.bits.push_back(RTLIL::State::S0);
+	while (int(result.size()) < result_len)
+		result.bits().push_back(RTLIL::State::S0);
 	return result;
 }
 
@@ -286,7 +286,7 @@ static RTLIL::Const const_shift_worker(const RTLIL::Const &arg1, const RTLIL::Co
 	BigInteger offset = const2big(arg2, signed2, undef_bit_pos) * direction;
 
 	if (result_len < 0)
-		result_len = arg1.bits.size();
+		result_len = arg1.size();
 
 	RTLIL::Const result(RTLIL::State::Sx, result_len);
 	if (undef_bit_pos >= 0)
@@ -295,11 +295,11 @@ static RTLIL::Const const_shift_worker(const RTLIL::Const &arg1, const RTLIL::Co
 	for (int i = 0; i < result_len; i++) {
 		BigInteger pos = BigInteger(i) + offset;
 		if (pos < 0)
-			result.bits[i] = vacant_bits;
-		else if (pos >= BigInteger(int(arg1.bits.size())))
-			result.bits[i] = sign_ext ? arg1.bits.back() : vacant_bits;
+			result.bits()[i] = vacant_bits;
+		else if (pos >= BigInteger(int(arg1.size())))
+			result.bits()[i] = sign_ext ? arg1.back() : vacant_bits;
 		else
-			result.bits[i] = arg1.bits[pos.toInt()];
+			result.bits()[i] = arg1[pos.toInt()];
 	}
 
 	return result;
@@ -347,8 +347,8 @@ RTLIL::Const RTLIL::const_lt(const RTLIL::Const &arg1, const RTLIL::Const &arg2,
 	bool y = const2big(arg1, signed1, undef_bit_pos) < const2big(arg2, signed2, undef_bit_pos);
 	RTLIL::Const result(undef_bit_pos >= 0 ? RTLIL::State::Sx : y ? RTLIL::State::S1 : RTLIL::State::S0);
 
-	while (int(result.bits.size()) < result_len)
-		result.bits.push_back(RTLIL::State::S0);
+	while (int(result.size()) < result_len)
+		result.bits().push_back(RTLIL::State::S0);
 	return result;
 }
 
@@ -358,8 +358,8 @@ RTLIL::Const RTLIL::const_le(const RTLIL::Const &arg1, const RTLIL::Const &arg2,
 	bool y = const2big(arg1, signed1, undef_bit_pos) <= const2big(arg2, signed2, undef_bit_pos);
 	RTLIL::Const result(undef_bit_pos >= 0 ? RTLIL::State::Sx : y ? RTLIL::State::S1 : RTLIL::State::S0);
 
-	while (int(result.bits.size()) < result_len)
-		result.bits.push_back(RTLIL::State::S0);
+	while (int(result.size()) < result_len)
+		result.bits().push_back(RTLIL::State::S0);
 	return result;
 }
 
@@ -369,31 +369,31 @@ RTLIL::Const RTLIL::const_eq(const RTLIL::Const &arg1, const RTLIL::Const &arg2,
 	RTLIL::Const arg2_ext = arg2;
 	RTLIL::Const result(RTLIL::State::S0, result_len);
 
-	int width = max(arg1_ext.bits.size(), arg2_ext.bits.size());
+	int width = max(arg1_ext.size(), arg2_ext.size());
 	extend_u0(arg1_ext, width, signed1 && signed2);
 	extend_u0(arg2_ext, width, signed1 && signed2);
 
 	RTLIL::State matched_status = RTLIL::State::S1;
-	for (size_t i = 0; i < arg1_ext.bits.size(); i++) {
-		if (arg1_ext.bits.at(i) == RTLIL::State::S0 && arg2_ext.bits.at(i) == RTLIL::State::S1)
+	for (size_t i = 0; i < arg1_ext.size(); i++) {
+		if (arg1_ext.at(i) == RTLIL::State::S0 && arg2_ext.at(i) == RTLIL::State::S1)
 			return result;
-		if (arg1_ext.bits.at(i) == RTLIL::State::S1 && arg2_ext.bits.at(i) == RTLIL::State::S0)
+		if (arg1_ext.at(i) == RTLIL::State::S1 && arg2_ext.at(i) == RTLIL::State::S0)
 			return result;
-		if (arg1_ext.bits.at(i) > RTLIL::State::S1 || arg2_ext.bits.at(i) > RTLIL::State::S1)
+		if (arg1_ext.at(i) > RTLIL::State::S1 || arg2_ext.at(i) > RTLIL::State::S1)
 			matched_status = RTLIL::State::Sx;
 	}
 
-	result.bits.front() = matched_status;
+	result.bits().front() = matched_status;
 	return result;
 }
 
 RTLIL::Const RTLIL::const_ne(const RTLIL::Const &arg1, const RTLIL::Const &arg2, bool signed1, bool signed2, int result_len)
 {
 	RTLIL::Const result = RTLIL::const_eq(arg1, arg2, signed1, signed2, result_len);
-	if (result.bits.front() == RTLIL::State::S0)
-		result.bits.front() = RTLIL::State::S1;
-	else if (result.bits.front() == RTLIL::State::S1)
-		result.bits.front() = RTLIL::State::S0;
+	if (result.front() == RTLIL::State::S0)
+		result.bits().front() = RTLIL::State::S1;
+	else if (result.front() == RTLIL::State::S1)
+		result.bits().front() = RTLIL::State::S0;
 	return result;
 }
 
@@ -403,26 +403,26 @@ RTLIL::Const RTLIL::const_eqx(const RTLIL::Const &arg1, const RTLIL::Const &arg2
 	RTLIL::Const arg2_ext = arg2;
 	RTLIL::Const result(RTLIL::State::S0, result_len);
 
-	int width = max(arg1_ext.bits.size(), arg2_ext.bits.size());
+	int width = max(arg1_ext.size(), arg2_ext.size());
 	extend_u0(arg1_ext, width, signed1 && signed2);
 	extend_u0(arg2_ext, width, signed1 && signed2);
 
-	for (size_t i = 0; i < arg1_ext.bits.size(); i++) {
-		if (arg1_ext.bits.at(i) != arg2_ext.bits.at(i))
+	for (size_t i = 0; i < arg1_ext.size(); i++) {
+		if (arg1_ext.at(i) != arg2_ext.at(i))
 			return result;
 	}
 
-	result.bits.front() = RTLIL::State::S1;
+	result.bits().front() = RTLIL::State::S1;
 	return result;
 }
 
 RTLIL::Const RTLIL::const_nex(const RTLIL::Const &arg1, const RTLIL::Const &arg2, bool signed1, bool signed2, int result_len)
 {
 	RTLIL::Const result = RTLIL::const_eqx(arg1, arg2, signed1, signed2, result_len);
-	if (result.bits.front() == RTLIL::State::S0)
-		result.bits.front() = RTLIL::State::S1;
-	else if (result.bits.front() == RTLIL::State::S1)
-		result.bits.front() = RTLIL::State::S0;
+	if (result.front() == RTLIL::State::S0)
+		result.bits().front() = RTLIL::State::S1;
+	else if (result.front() == RTLIL::State::S1)
+		result.bits().front() = RTLIL::State::S0;
 	return result;
 }
 
@@ -432,8 +432,8 @@ RTLIL::Const RTLIL::const_ge(const RTLIL::Const &arg1, const RTLIL::Const &arg2,
 	bool y = const2big(arg1, signed1, undef_bit_pos) >= const2big(arg2, signed2, undef_bit_pos);
 	RTLIL::Const result(undef_bit_pos >= 0 ? RTLIL::State::Sx : y ? RTLIL::State::S1 : RTLIL::State::S0);
 
-	while (int(result.bits.size()) < result_len)
-		result.bits.push_back(RTLIL::State::S0);
+	while (int(result.size()) < result_len)
+		result.bits().push_back(RTLIL::State::S0);
 	return result;
 }
 
@@ -443,8 +443,8 @@ RTLIL::Const RTLIL::const_gt(const RTLIL::Const &arg1, const RTLIL::Const &arg2,
 	bool y = const2big(arg1, signed1, undef_bit_pos) > const2big(arg2, signed2, undef_bit_pos);
 	RTLIL::Const result(undef_bit_pos >= 0 ? RTLIL::State::Sx : y ? RTLIL::State::S1 : RTLIL::State::S0);
 
-	while (int(result.bits.size()) < result_len)
-		result.bits.push_back(RTLIL::State::S0);
+	while (int(result.size()) < result_len)
+		result.bits().push_back(RTLIL::State::S0);
 	return result;
 }
 
@@ -452,21 +452,21 @@ RTLIL::Const RTLIL::const_add(const RTLIL::Const &arg1, const RTLIL::Const &arg2
 {
 	int undef_bit_pos = -1;
 	BigInteger y = const2big(arg1, signed1, undef_bit_pos) + const2big(arg2, signed2, undef_bit_pos);
-	return big2const(y, result_len >= 0 ? result_len : max(arg1.bits.size(), arg2.bits.size()), undef_bit_pos);
+	return big2const(y, result_len >= 0 ? result_len : max(arg1.size(), arg2.size()), undef_bit_pos);
 }
 
 RTLIL::Const RTLIL::const_sub(const RTLIL::Const &arg1, const RTLIL::Const &arg2, bool signed1, bool signed2, int result_len)
 {
 	int undef_bit_pos = -1;
 	BigInteger y = const2big(arg1, signed1, undef_bit_pos) - const2big(arg2, signed2, undef_bit_pos);
-	return big2const(y, result_len >= 0 ? result_len : max(arg1.bits.size(), arg2.bits.size()), undef_bit_pos);
+	return big2const(y, result_len >= 0 ? result_len : max(arg1.size(), arg2.size()), undef_bit_pos);
 }
 
 RTLIL::Const RTLIL::const_mul(const RTLIL::Const &arg1, const RTLIL::Const &arg2, bool signed1, bool signed2, int result_len)
 {
 	int undef_bit_pos = -1;
 	BigInteger y = const2big(arg1, signed1, undef_bit_pos) * const2big(arg2, signed2, undef_bit_pos);
-	return big2const(y, result_len >= 0 ? result_len : max(arg1.bits.size(), arg2.bits.size()), min(undef_bit_pos, 0));
+	return big2const(y, result_len >= 0 ? result_len : max(arg1.size(), arg2.size()), min(undef_bit_pos, 0));
 }
 
 // truncating division
@@ -480,7 +480,7 @@ RTLIL::Const RTLIL::const_div(const RTLIL::Const &arg1, const RTLIL::Const &arg2
 	bool result_neg = (a.getSign() == BigInteger::negative) != (b.getSign() == BigInteger::negative);
 	a = a.getSign() == BigInteger::negative ? -a : a;
 	b = b.getSign() == BigInteger::negative ? -b : b;
-	return big2const(result_neg ? -(a / b) : (a / b), result_len >= 0 ? result_len : max(arg1.bits.size(), arg2.bits.size()), min(undef_bit_pos, 0));
+	return big2const(result_neg ? -(a / b) : (a / b), result_len >= 0 ? result_len : max(arg1.size(), arg2.size()), min(undef_bit_pos, 0));
 }
 
 // truncating modulo
@@ -494,7 +494,7 @@ RTLIL::Const RTLIL::const_mod(const RTLIL::Const &arg1, const RTLIL::Const &arg2
 	bool result_neg = a.getSign() == BigInteger::negative;
 	a = a.getSign() == BigInteger::negative ? -a : a;
 	b = b.getSign() == BigInteger::negative ? -b : b;
-	return big2const(result_neg ? -(a % b) : (a % b), result_len >= 0 ? result_len : max(arg1.bits.size(), arg2.bits.size()), min(undef_bit_pos, 0));
+	return big2const(result_neg ? -(a % b) : (a % b), result_len >= 0 ? result_len : max(arg1.size(), arg2.size()), min(undef_bit_pos, 0));
 }
 
 RTLIL::Const RTLIL::const_divfloor(const RTLIL::Const &arg1, const RTLIL::Const &arg2, bool signed1, bool signed2, int result_len)
@@ -516,7 +516,7 @@ RTLIL::Const RTLIL::const_divfloor(const RTLIL::Const &arg1, const RTLIL::Const 
 		// bigint division with negative numbers is wonky, make sure we only negate at the very end
 		result = -((a + b - 1) / b);
 	}
-	return big2const(result, result_len >= 0 ? result_len : max(arg1.bits.size(), arg2.bits.size()), min(undef_bit_pos, 0));
+	return big2const(result, result_len >= 0 ? result_len : max(arg1.size(), arg2.size()), min(undef_bit_pos, 0));
 }
 
 RTLIL::Const RTLIL::const_modfloor(const RTLIL::Const &arg1, const RTLIL::Const &arg2, bool signed1, bool signed2, int result_len)
@@ -539,7 +539,7 @@ RTLIL::Const RTLIL::const_modfloor(const RTLIL::Const &arg1, const RTLIL::Const 
 	} else {
 		modulo = b_sign == BigInteger::negative ? truncated - b : truncated + b;
 	}
-	return big2const(modulo, result_len >= 0 ? result_len : max(arg1.bits.size(), arg2.bits.size()), min(undef_bit_pos, 0));
+	return big2const(modulo, result_len >= 0 ? result_len : max(arg1.size(), arg2.size()), min(undef_bit_pos, 0));
 }
 
 RTLIL::Const RTLIL::const_pow(const RTLIL::Const &arg1, const RTLIL::Const &arg2, bool signed1, bool signed2, int result_len)
@@ -590,7 +590,7 @@ RTLIL::Const RTLIL::const_pow(const RTLIL::Const &arg1, const RTLIL::Const &arg2
 			y *= -1;
 	}
 
-	return big2const(y, result_len >= 0 ? result_len : max(arg1.bits.size(), arg2.bits.size()), min(undef_bit_pos, 0));
+	return big2const(y, result_len >= 0 ? result_len : max(arg1.size(), arg2.size()), min(undef_bit_pos, 0));
 }
 
 RTLIL::Const RTLIL::const_pos(const RTLIL::Const &arg1, const RTLIL::Const&, bool signed1, bool, int result_len)
@@ -628,7 +628,7 @@ RTLIL::Const RTLIL::const_mux(const RTLIL::Const &arg1, const RTLIL::Const &arg2
 	RTLIL::Const ret = arg1;
 	for (int i = 0; i < ret.size(); i++)
 		if (ret[i] != arg2[i])
-			ret[i] = State::Sx;
+			ret.bits()[i] = State::Sx;
 	return ret;
 }
 
@@ -642,18 +642,18 @@ RTLIL::Const RTLIL::const_pmux(const RTLIL::Const &arg1, const RTLIL::Const &arg
 
 	for (int i = 0; i < arg3.size(); i++)
 		if (arg3[i] == State::S1)
-			return RTLIL::Const(std::vector<RTLIL::State>(arg2.bits.begin() + i*arg1.bits.size(), arg2.bits.begin() + (i+1)*arg1.bits.size()));
+			return RTLIL::Const(std::vector<RTLIL::State>(arg2.begin() + i*arg1.size(), arg2.begin() + (i+1)*arg1.size()));
 
 	log_abort(); // unreachable
 }
 
 RTLIL::Const RTLIL::const_bmux(const RTLIL::Const &arg1, const RTLIL::Const &arg2)
 {
-	std::vector<RTLIL::State> t = arg1.bits;
+	std::vector<State> t = arg1.to_bits();
 
 	for (int i = GetSize(arg2)-1; i >= 0; i--)
 	{
-		RTLIL::State sel = arg2.bits.at(i);
+		RTLIL::State sel = arg2.at(i);
 		std::vector<RTLIL::State> new_t;
 		if (sel == State::S0)
 			new_t = std::vector<RTLIL::State>(t.begin(), t.begin() + GetSize(t)/2);
@@ -689,10 +689,10 @@ RTLIL::Const RTLIL::const_demux(const RTLIL::Const &arg1, const RTLIL::Const &ar
 				res.push_back(State::S0);
 		} else if (x) {
 			for (int j = 0; j < width; j++)
-				res.push_back(arg1.bits[j] == State::S0 ? State::S0 : State::Sx);
+				res.push_back(arg1[j] == State::S0 ? State::S0 : State::Sx);
 		} else {
 			for (int j = 0; j < width; j++)
-				res.push_back(arg1.bits[j]);
+				res.push_back(arg1[j]);
 		}
 	}
 	return res;
@@ -703,7 +703,7 @@ RTLIL::Const RTLIL::const_bweqx(const RTLIL::Const &arg1, const RTLIL::Const &ar
 	log_assert(arg2.size() == arg1.size());
 	RTLIL::Const result(RTLIL::State::S0, arg1.size());
 	for (int i = 0; i < arg1.size(); i++)
-		result[i] = arg1[i] == arg2[i] ? State::S1 : State::S0;
+		result.bits()[i] = arg1[i] == arg2[i] ? State::S1 : State::S0;
 
 	return result;
 }
@@ -715,7 +715,7 @@ RTLIL::Const RTLIL::const_bwmux(const RTLIL::Const &arg1, const RTLIL::Const &ar
 	RTLIL::Const result(RTLIL::State::Sx, arg1.size());
 	for (int i = 0; i < arg1.size(); i++) {
 		if (arg3[i] != State::Sx || arg1[i] == arg2[i])
-			result[i] = arg3[i] == State::S1 ? arg2[i] : arg1[i];
+			result.bits()[i] = arg3[i] == State::S1 ? arg2[i] : arg1[i];
 	}
 
 	return result;

--- a/kernel/celltypes.h
+++ b/kernel/celltypes.h
@@ -325,7 +325,7 @@ struct CellTypes
 
 	static RTLIL::Const eval_not(RTLIL::Const v)
 	{
-		for (auto &bit : v.bits)
+		for (auto &bit : v.bits())
 			if (bit == State::S0) bit = State::S1;
 			else if (bit == State::S1) bit = State::S0;
 		return v;
@@ -419,13 +419,13 @@ struct CellTypes
 			RTLIL::Const ret;
 			int width = cell->parameters.at(ID::Y_WIDTH).as_int();
 			int offset = cell->parameters.at(ID::OFFSET).as_int();
-			ret.bits.insert(ret.bits.end(), arg1.bits.begin()+offset, arg1.bits.begin()+offset+width);
+			ret.bits().insert(ret.bits().end(), arg1.begin()+offset, arg1.begin()+offset+width);
 			return ret;
 		}
 
 		if (cell->type == ID($concat)) {
 			RTLIL::Const ret = arg1;
-			ret.bits.insert(ret.bits.end(), arg2.bits.begin(), arg2.bits.end());
+			ret.bits().insert(ret.bits().end(), arg2.begin(), arg2.end());
 			return ret;
 		}
 
@@ -448,7 +448,7 @@ struct CellTypes
 		{
 			int width = cell->parameters.at(ID::WIDTH).as_int();
 
-			std::vector<RTLIL::State> t = cell->parameters.at(ID::LUT).bits;
+			std::vector<RTLIL::State> t = cell->parameters.at(ID::LUT).to_bits();
 			while (GetSize(t) < (1 << width))
 				t.push_back(State::S0);
 			t.resize(1 << width);
@@ -460,7 +460,7 @@ struct CellTypes
 		{
 			int width = cell->parameters.at(ID::WIDTH).as_int();
 			int depth = cell->parameters.at(ID::DEPTH).as_int();
-			std::vector<RTLIL::State> t = cell->parameters.at(ID::TABLE).bits;
+			std::vector<RTLIL::State> t = cell->parameters.at(ID::TABLE).to_bits();
 
 			while (GetSize(t) < width*depth*2)
 				t.push_back(State::S0);
@@ -473,7 +473,7 @@ struct CellTypes
 				bool match_x = true;
 
 				for (int j = 0; j < width; j++) {
-					RTLIL::State a = arg1.bits.at(j);
+					RTLIL::State a = arg1.at(j);
 					if (t.at(2*width*i + 2*j + 0) == State::S1) {
 						if (a == State::S1) match_x = false;
 						if (a != State::S0) match = false;
@@ -513,7 +513,7 @@ struct CellTypes
 		if (cell->type == ID($_OAI3_))
 			return eval_not(const_and(const_or(arg1, arg2, false, false, 1), arg3, false, false, 1));
 
-		log_assert(arg3.bits.size() == 0);
+		log_assert(arg3.size() == 0);
 		return eval(cell, arg1, arg2, errp);
 	}
 
@@ -524,7 +524,7 @@ struct CellTypes
 		if (cell->type == ID($_OAI4_))
 			return eval_not(const_and(const_or(arg1, arg2, false, false, 1), const_or(arg3, arg4, false, false, 1), false, false, 1));
 
-		log_assert(arg4.bits.size() == 0);
+		log_assert(arg4.size() == 0);
 		return eval(cell, arg1, arg2, arg3, errp);
 	}
 };

--- a/kernel/consteval.h
+++ b/kernel/consteval.h
@@ -76,7 +76,7 @@ struct ConstEval
 #ifndef NDEBUG
 		RTLIL::SigSpec current_val = values_map(sig);
 		for (int i = 0; i < GetSize(current_val); i++)
-			log_assert(current_val[i].wire != NULL || current_val[i] == value.bits[i]);
+			log_assert(current_val[i].wire != NULL || current_val[i] == value[i]);
 #endif
 		values_map.add(sig, RTLIL::SigSpec(value));
 	}
@@ -115,7 +115,7 @@ struct ConstEval
 
 				for (int i = 0; i < GetSize(coval); i++) {
 					carry = (sig_g[i] == State::S1) || (sig_p[i] == RTLIL::S1 && carry);
-					coval.bits[i] = carry ? State::S1 : State::S0;
+					coval.bits()[i] = carry ? State::S1 : State::S0;
 				}
 
 				set(sig_co, coval);
@@ -153,7 +153,7 @@ struct ConstEval
 
 			for (int i = 0; i < sig_s.size(); i++)
 			{
-				RTLIL::State s_bit = sig_s.extract(i, 1).as_const().bits.at(0);
+				RTLIL::State s_bit = sig_s.extract(i, 1).as_const().at(0);
 				RTLIL::SigSpec b_slice = sig_b.extract(sig_y.size()*i, sig_y.size());
 
 				if (s_bit == RTLIL::State::Sx || s_bit == RTLIL::State::S1)
@@ -180,10 +180,10 @@ struct ConstEval
 
 			if (y_values.size() > 1)
 			{
-				std::vector<RTLIL::State> master_bits = y_values.at(0).bits;
+				std::vector<RTLIL::State> master_bits = y_values.at(0).to_bits();
 
 				for (size_t i = 1; i < y_values.size(); i++) {
-					std::vector<RTLIL::State> &slave_bits = y_values.at(i).bits;
+					std::vector<RTLIL::State> slave_bits = y_values.at(i).to_bits();
 					log_assert(master_bits.size() == slave_bits.size());
 					for (size_t j = 0; j < master_bits.size(); j++)
 						if (master_bits[j] != slave_bits[j])
@@ -248,8 +248,8 @@ struct ConstEval
 			RTLIL::Const val_x = const_or(t2, t3, false, false, width);
 
 			for (int i = 0; i < GetSize(val_y); i++)
-				if (val_y.bits[i] == RTLIL::Sx)
-					val_x.bits[i] = RTLIL::Sx;
+				if (val_y[i] == RTLIL::Sx)
+					val_x.bits()[i] = RTLIL::Sx;
 
 			set(sig_y, val_y);
 			set(sig_x, val_x);

--- a/kernel/drivertools.cc
+++ b/kernel/drivertools.cc
@@ -260,7 +260,7 @@ bool DriveChunkMultiple::try_append(DriveBitMultiple const &bit)
 		switch (single.type())
 		{
 			case DriveType::CONSTANT: {
-				single.constant().bits.push_back(constant);
+				single.constant().bits().push_back(constant);
 			} break;
 			case DriveType::WIRE: {
 				single.wire().width += 1;
@@ -295,8 +295,8 @@ bool DriveChunkMultiple::try_append(DriveChunkMultiple const &chunk)
 		switch (single.type())
 		{
 			case DriveType::CONSTANT: {
-				auto &bits = single.constant().bits;
-				bits.insert(bits.end(), constant.bits.begin(), constant.bits.end());
+				auto &bits = single.constant().bits();
+				bits.insert(bits.end(), constant.bits().begin(), constant.bits().end());
 			} break;
 			case DriveType::WIRE: {
 				single.wire().width += width;
@@ -349,7 +349,7 @@ bool DriveChunk::try_append(DriveBit const &bit)
 			none_ += 1;
 			return true;
 		case DriveType::CONSTANT:
-			constant_.bits.push_back(bit.constant());
+			constant_.bits().push_back(bit.constant());
 			return true;
 		case DriveType::WIRE:
 			return wire_.try_append(bit.wire());
@@ -375,7 +375,7 @@ bool DriveChunk::try_append(DriveChunk const &chunk)
 			none_ += chunk.none_;
 			return true;
 		case DriveType::CONSTANT:
-			constant_.bits.insert(constant_.bits.end(), chunk.constant_.bits.begin(), chunk.constant_.bits.end());
+			constant_.bits().insert(constant_.bits().end(), chunk.constant_.begin(), chunk.constant_.end());
 			return true;
 		case DriveType::WIRE:
 			return wire_.try_append(chunk.wire());

--- a/kernel/ff.cc
+++ b/kernel/ff.cc
@@ -298,11 +298,11 @@ FfData FfData::slice(const std::vector<int> &bits) {
 			res.sig_set.append(sig_set[i]);
 		}
 		if (has_arst)
-			res.val_arst.bits.push_back(val_arst[i]);
+			res.val_arst.bits().push_back(val_arst[i]);
 		if (has_srst)
-			res.val_srst.bits.push_back(val_srst[i]);
+			res.val_srst.bits().push_back(val_srst[i]);
 		if (initvals)
-			res.val_init.bits.push_back(val_init[i]);
+			res.val_init.bits().push_back(val_init[i]);
 	}
 	res.width = GetSize(res.sig_q);
 	return res;
@@ -688,10 +688,10 @@ void FfData::flip_rst_bits(const pool<int> &bits) {
 
 	for (auto bit: bits) {
 		if (has_arst)
-			val_arst[bit] = invert(val_arst[bit]);
+			val_arst.bits()[bit] = invert(val_arst[bit]);
 		if (has_srst)
-			val_srst[bit] = invert(val_srst[bit]);
-		val_init[bit] = invert(val_init[bit]);
+			val_srst.bits()[bit] = invert(val_srst[bit]);
+		val_init.bits()[bit] = invert(val_init[bit]);
 	}
 }
 
@@ -760,7 +760,7 @@ void FfData::flip_bits(const pool<int> &bits) {
 
 		Const mask = Const(State::S0, width);
 		for (auto bit: bits)
-			mask.bits[bit] = State::S1;
+			mask.bits()[bit] = State::S1;
 
 		if (has_clk || has_gclk)
 			sig_d = module->Xor(NEW_ID, sig_d, mask);

--- a/kernel/ffinit.h
+++ b/kernel/ffinit.h
@@ -76,7 +76,7 @@ struct FfInitVals
 	{
 		RTLIL::Const res;
 		for (auto bit : sig)
-			res.bits.push_back((*this)(bit));
+			res.bits().push_back((*this)(bit));
 		return res;
 	}
 
@@ -93,12 +93,12 @@ struct FfInitVals
 		initbits[mbit] = std::make_pair(val,abit);
 		auto it2 = abit.wire->attributes.find(ID::init);
 		if (it2 != abit.wire->attributes.end()) {
-			it2->second[abit.offset] = val;
+			it2->second.bits()[abit.offset] = val;
 			if (it2->second.is_fully_undef())
 				abit.wire->attributes.erase(it2);
 		} else if (val != State::Sx) {
 			Const cval(State::Sx, GetSize(abit.wire));
-			cval[abit.offset] = val;
+			cval.bits()[abit.offset] = val;
 			abit.wire->attributes[ID::init] = cval;
 		}
 	}

--- a/kernel/ffmerge.cc
+++ b/kernel/ffmerge.cc
@@ -42,9 +42,9 @@ bool FfMergeHelper::find_output_ff(RTLIL::SigSpec sig, FfData &ff, pool<std::pai
 			ff.sig_d.append(bit);
 			ff.sig_clr.append(State::Sx);
 			ff.sig_set.append(State::Sx);
-			ff.val_init.bits.push_back(State::Sx);
-			ff.val_srst.bits.push_back(State::Sx);
-			ff.val_arst.bits.push_back(State::Sx);
+			ff.val_init.bits().push_back(State::Sx);
+			ff.val_srst.bits().push_back(State::Sx);
+			ff.val_arst.bits().push_back(State::Sx);
 			continue;
 		}
 
@@ -147,9 +147,9 @@ bool FfMergeHelper::find_output_ff(RTLIL::SigSpec sig, FfData &ff, pool<std::pai
 		ff.sig_q.append(cur_ff.sig_q[idx]);
 		ff.sig_clr.append(ff.has_sr ? cur_ff.sig_clr[idx] : State::S0);
 		ff.sig_set.append(ff.has_sr ? cur_ff.sig_set[idx] : State::S0);
-		ff.val_arst.bits.push_back(ff.has_arst ? cur_ff.val_arst[idx] : State::Sx);
-		ff.val_srst.bits.push_back(ff.has_srst ? cur_ff.val_srst[idx] : State::Sx);
-		ff.val_init.bits.push_back(cur_ff.val_init[idx]);
+		ff.val_arst.bits().push_back(ff.has_arst ? cur_ff.val_arst[idx] : State::Sx);
+		ff.val_srst.bits().push_back(ff.has_srst ? cur_ff.val_srst[idx] : State::Sx);
+		ff.val_init.bits().push_back(cur_ff.val_init[idx]);
 		found = true;
 	}
 
@@ -174,9 +174,9 @@ bool FfMergeHelper::find_input_ff(RTLIL::SigSpec sig, FfData &ff, pool<std::pair
 			// These two will be fixed up later.
 			ff.sig_clr.append(State::Sx);
 			ff.sig_set.append(State::Sx);
-			ff.val_init.bits.push_back(bit.data);
-			ff.val_srst.bits.push_back(bit.data);
-			ff.val_arst.bits.push_back(bit.data);
+			ff.val_init.bits().push_back(bit.data);
+			ff.val_srst.bits().push_back(bit.data);
+			ff.val_arst.bits().push_back(bit.data);
 			continue;
 		}
 
@@ -274,9 +274,9 @@ bool FfMergeHelper::find_input_ff(RTLIL::SigSpec sig, FfData &ff, pool<std::pair
 		ff.sig_q.append(cur_ff.sig_q[idx]);
 		ff.sig_clr.append(ff.has_sr ? cur_ff.sig_clr[idx] : State::S0);
 		ff.sig_set.append(ff.has_sr ? cur_ff.sig_set[idx] : State::S0);
-		ff.val_arst.bits.push_back(ff.has_arst ? cur_ff.val_arst[idx] : State::Sx);
-		ff.val_srst.bits.push_back(ff.has_srst ? cur_ff.val_srst[idx] : State::Sx);
-		ff.val_init.bits.push_back(cur_ff.val_init[idx]);
+		ff.val_arst.bits().push_back(ff.has_arst ? cur_ff.val_arst[idx] : State::Sx);
+		ff.val_srst.bits().push_back(ff.has_srst ? cur_ff.val_srst[idx] : State::Sx);
+		ff.val_init.bits().push_back(cur_ff.val_init[idx]);
 		found = true;
 	}
 

--- a/kernel/functional.h
+++ b/kernel/functional.h
@@ -537,7 +537,8 @@ namespace Functional {
 			return add(Fn::memory_write, mem.sort(), {mem, addr, data});
 		}
 		Node constant(RTLIL::Const value) {
-			return add(IR::NodeData(Fn::constant, std::move(value)), Sort(value.size()), {});
+			int s = value.size();
+			return add(IR::NodeData(Fn::constant, std::move(value)), Sort(s), {});
 		}
 		Node create_pending(int width) {
 			return add(Fn::buf, Sort(width), {});

--- a/kernel/macc.h
+++ b/kernel/macc.h
@@ -104,7 +104,7 @@ struct Macc
 		ports.clear();
 		bit_ports = cell->getPort(ID::B);
 
-		std::vector<RTLIL::State> config_bits = cell->getParam(ID::CONFIG).bits;
+		auto config_bits = cell->getParam(ID::CONFIG);
 		int config_cursor = 0;
 
 		int config_width = cell->getParam(ID::CONFIG_WIDTH).as_int();
@@ -199,7 +199,7 @@ struct Macc
 
 	bool eval(RTLIL::Const &result) const
 	{
-		for (auto &bit : result.bits)
+		for (auto &bit : result.bits())
 			bit = State::S0;
 
 		for (auto &port : ports)

--- a/kernel/mem.cc
+++ b/kernel/mem.cc
@@ -157,10 +157,10 @@ void Mem::emit() {
 			}
 			for (int sub = 0; sub < (1 << port.wide_log2); sub++)
 			{
-				rd_wide_continuation.bits.push_back(State(sub != 0));
-				rd_clk_enable.bits.push_back(State(port.clk_enable));
-				rd_clk_polarity.bits.push_back(State(port.clk_polarity));
-				rd_ce_over_srst.bits.push_back(State(port.ce_over_srst));
+				rd_wide_continuation.bits().push_back(State(sub != 0));
+				rd_clk_enable.bits().push_back(State(port.clk_enable));
+				rd_clk_polarity.bits().push_back(State(port.clk_polarity));
+				rd_ce_over_srst.bits().push_back(State(port.ce_over_srst));
 				rd_clk.append(port.clk);
 				rd_arst.append(port.arst);
 				rd_srst.append(port.srst);
@@ -170,17 +170,17 @@ void Mem::emit() {
 				rd_addr.append(addr);
 				log_assert(GetSize(addr) == abits);
 				for (auto idx : wr_port_xlat) {
-					rd_transparency_mask.bits.push_back(State(bool(port.transparency_mask[idx])));
-					rd_collision_x_mask.bits.push_back(State(bool(port.collision_x_mask[idx])));
+					rd_transparency_mask.bits().push_back(State(bool(port.transparency_mask[idx])));
+					rd_collision_x_mask.bits().push_back(State(bool(port.collision_x_mask[idx])));
 				}
 			}
 			rd_data.append(port.data);
-			for (auto &bit : port.arst_value)
-				rd_arst_value.bits.push_back(bit);
-			for (auto &bit : port.srst_value)
-				rd_srst_value.bits.push_back(bit);
-			for (auto &bit : port.init_value)
-				rd_init_value.bits.push_back(bit);
+			for (auto bit : port.arst_value)
+				rd_arst_value.bits().push_back(bit);
+			for (auto bit : port.srst_value)
+				rd_srst_value.bits().push_back(bit);
+			for (auto bit : port.init_value)
+				rd_init_value.bits().push_back(bit);
 		}
 		if (rd_ports.empty()) {
 			rd_wide_continuation = State::S0;
@@ -222,12 +222,12 @@ void Mem::emit() {
 			}
 			for (int sub = 0; sub < (1 << port.wide_log2); sub++)
 			{
-				wr_wide_continuation.bits.push_back(State(sub != 0));
-				wr_clk_enable.bits.push_back(State(port.clk_enable));
-				wr_clk_polarity.bits.push_back(State(port.clk_polarity));
+				wr_wide_continuation.bits().push_back(State(sub != 0));
+				wr_clk_enable.bits().push_back(State(port.clk_enable));
+				wr_clk_polarity.bits().push_back(State(port.clk_polarity));
 				wr_clk.append(port.clk);
 				for (auto idx : wr_port_xlat)
-					wr_priority_mask.bits.push_back(State(bool(port.priority_mask[idx])));
+					wr_priority_mask.bits().push_back(State(bool(port.priority_mask[idx])));
 				SigSpec addr = port.sub_addr(sub);
 				addr.extend_u0(abits, false);
 				wr_addr.append(addr);
@@ -414,7 +414,7 @@ void Mem::coalesce_inits() {
 			if (!init.en.is_fully_ones()) {
 				for (int i = 0; i < GetSize(init.data); i++)
 					if (init.en[i % width] != State::S1)
-						init.data[i] = State::Sx;
+						init.data.bits()[i] = State::Sx;
 				init.en = Const(State::S1, width);
 			}
 			continue;
@@ -427,7 +427,7 @@ void Mem::coalesce_inits() {
 			log_assert(offset + GetSize(init.data) <= GetSize(cdata));
 			for (int i = 0; i < GetSize(init.data); i++)
 				if (init.en[i % width] == State::S1)
-					cdata.bits[i+offset] = init.data.bits[i];
+					cdata.bits()[i+offset] = init.data[i];
 			init.removed = true;
 		}
 		MemInit new_init;
@@ -446,7 +446,7 @@ Const Mem::get_init_data() const {
 		int offset = (init.addr.as_int() - start_offset) * width;
 		for (int i = 0; i < GetSize(init.data); i++)
 			if (0 <= i+offset && i+offset < GetSize(init_data) && init.en[i % width] == State::S1)
-				init_data.bits[i+offset] = init.data.bits[i];
+				init_data.bits()[i+offset] = init.data[i];
 	}
 	return init_data;
 }
@@ -1702,7 +1702,7 @@ MemContents::MemContents(Mem *mem) :
 				RTLIL::Const previous = (*this)[addr + i];
 				for(int j = 0; j < _data_width; j++)
 					if(init.en[j] != State::S1)
-						data[_data_width * i + j] = previous[j];
+						data.bits()[_data_width * i + j] = previous[j];
 			}
 			insert_concatenated(init.addr.as_int(), data);
 		}
@@ -1848,7 +1848,7 @@ std::map<addr_t, RTLIL::Const>::iterator MemContents::_reserve_range(addr_t begi
 		// we have two different ranges touching at either end, we need to merge them
 		auto upper_end = _range_end(upper_it);
 		// make range bigger (maybe reserve here instead of resize?)
-		lower_it->second.bits.resize(_range_offset(lower_it, upper_end), State::Sx);
+		lower_it->second.bits().resize(_range_offset(lower_it, upper_end), State::Sx);
 		// copy only the data beyond our range
 		std::copy(_range_data(upper_it, end_addr), _range_data(upper_it, upper_end), _range_data(lower_it, end_addr));
 		// keep lower_it, but delete upper_it
@@ -1856,7 +1856,7 @@ std::map<addr_t, RTLIL::Const>::iterator MemContents::_reserve_range(addr_t begi
 		return lower_it;
 	} else if (lower_touch) {
 		// we have a range to the left, just make it bigger and delete any other that may exist.
-		lower_it->second.bits.resize(_range_offset(lower_it, end_addr), State::Sx);
+		lower_it->second.bits().resize(_range_offset(lower_it, end_addr), State::Sx);
 		// keep lower_it and upper_it
 		_values.erase(std::next(lower_it), upper_it);
 		return lower_it;
@@ -1865,7 +1865,7 @@ std::map<addr_t, RTLIL::Const>::iterator MemContents::_reserve_range(addr_t begi
 		// since we need to erase and reinsert to a new address, steal the data
 		RTLIL::Const data = std::move(upper_it->second);
 		// note that begin_addr is not in upper_it, otherwise the whole range covered check would have tripped
-		data.bits.insert(data.bits.begin(), (_range_begin(upper_it) - begin_addr) * _data_width, State::Sx);
+		data.bits().insert(data.bits().begin(), (_range_begin(upper_it) - begin_addr) * _data_width, State::Sx);
 		// delete lower_it and upper_it, then reinsert
 		_values.erase(lower_it, std::next(upper_it));
 		return _values.emplace(begin_addr, std::move(data)).first;
@@ -1883,14 +1883,14 @@ void MemContents::insert_concatenated(addr_t addr, RTLIL::Const const &values) {
 	log_assert(words <= (addr_t)(1<<_addr_width) - addr);
 	auto it = _reserve_range(addr, addr + words);
 	auto to_begin = _range_data(it, addr);
-	std::copy(values.bits.begin(), values.bits.end(), to_begin);
+	std::copy(values.begin(), values.end(), to_begin);
 	// if values is not word-aligned, fill any missing bits with 0
 	std::fill(to_begin + values.size(), to_begin + words * _data_width, State::S0);
 }
 
 std::vector<State>::iterator MemContents::_range_write(std::vector<State>::iterator it, RTLIL::Const const &word) {
-	auto from_end = word.size() <= _data_width ? word.bits.end() : word.bits.begin() + _data_width;
-	auto to_end = std::copy(word.bits.begin(), from_end, it);
+	auto from_end = word.size() <= _data_width ? word.end() : word.begin() + _data_width;
+	auto to_end = std::copy(word.begin(), from_end, it);
 	auto it_next = std::next(it, _data_width);
 	std::fill(to_end, it_next, State::S0);
 	return it_next;

--- a/kernel/mem.h
+++ b/kernel/mem.h
@@ -255,7 +255,7 @@ private:
 	// return the offset the addr would have in the range at `it`
 	size_t _range_offset(std::map<addr_t, RTLIL::Const>::iterator it, addr_t addr) const { return (addr - it->first) * _data_width; }
 	// assuming _range_contains(it, addr), return an iterator pointing to the data at addr
-	std::vector<State>::iterator _range_data(std::map<addr_t, RTLIL::Const>::iterator it, addr_t addr) { return it->second.bits.begin() + _range_offset(it, addr); }
+	std::vector<State>::iterator _range_data(std::map<addr_t, RTLIL::Const>::iterator it, addr_t addr) { return it->second.bits().begin() + _range_offset(it, addr); }
 	// internal version of reserve_range that returns an iterator to the range
 	std::map<addr_t, RTLIL::Const>::iterator _reserve_range(addr_t begin_addr, addr_t end_addr);
 	// write a single word at addr, return iterator to next word

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -202,25 +202,34 @@ const pool<IdString> &RTLIL::builtin_ff_cell_types() {
 	return res;
 }
 
+#define check(condition) log_assert(condition && "malformed Const union")
+
+Const::bitvectype& Const::get_bits() const {
+	check(is_bits());
+	return *get_if_bits();
+}
+
+std::string& Const::get_str() const {
+	check(is_str());
+	return *get_if_str();
+}
+
 RTLIL::Const::Const(const std::string &str)
 {
 	flags = RTLIL::CONST_FLAG_STRING;
-	bits.reserve(str.size() * 8);
-	for (int i = str.size()-1; i >= 0; i--) {
-		unsigned char ch = str[i];
-		for (int j = 0; j < 8; j++) {
-			bits.push_back((ch & 1) != 0 ? State::S1 : State::S0);
-			ch = ch >> 1;
-		}
-	}
+	new ((void*)&str_) std::string(str);
+	tag = backing_tag::string;
 }
 
 RTLIL::Const::Const(long long val, int width)
 {
 	flags = RTLIL::CONST_FLAG_NONE;
-	bits.reserve(width);
+	new ((void*)&bits_) bitvectype();
+	tag = backing_tag::bits;
+	bitvectype& bv = get_bits();
+	bv.reserve(width);
 	for (int i = 0; i < width; i++) {
-		bits.push_back((val & 1) != 0 ? State::S1 : State::S0);
+		bv.push_back((val & 1) != 0 ? State::S1 : State::S0);
 		val = val >> 1;
 	}
 }
@@ -228,77 +237,167 @@ RTLIL::Const::Const(long long val, int width)
 RTLIL::Const::Const(RTLIL::State bit, int width)
 {
 	flags = RTLIL::CONST_FLAG_NONE;
-	bits.reserve(width);
+	new ((void*)&bits_) bitvectype();
+	tag = backing_tag::bits;
+	bitvectype& bv = get_bits();
+	bv.reserve(width);
 	for (int i = 0; i < width; i++)
-		bits.push_back(bit);
+		bv.push_back(bit);
 }
 
 RTLIL::Const::Const(const std::vector<bool> &bits)
 {
 	flags = RTLIL::CONST_FLAG_NONE;
-	this->bits.reserve(bits.size());
+	new ((void*)&bits_) bitvectype();
+	tag = backing_tag::bits;
+	bitvectype& bv = get_bits();
+	bv.reserve(bits.size());
 	for (const auto &b : bits)
-		this->bits.emplace_back(b ? State::S1 : State::S0);
+		bv.emplace_back(b ? State::S1 : State::S0);
 }
 
-bool RTLIL::Const::operator <(const RTLIL::Const &other) const
+RTLIL::Const::Const(const RTLIL::Const &other) {
+	tag = other.tag;
+	flags = other.flags;
+	if (is_str())
+		new ((void*)&str_) std::string(other.get_str());
+	else if (is_bits())
+		new ((void*)&bits_) bitvectype(other.get_bits());
+	else
+		check(false);
+}
+
+RTLIL::Const::Const(RTLIL::Const &&other) {
+	tag = other.tag;
+	flags = other.flags;
+	if (is_str())
+		new ((void*)&str_) std::string(std::move(other.get_str()));
+	else if (is_bits())
+		new ((void*)&bits_) bitvectype(std::move(other.get_bits()));
+	else
+		check(false);
+}
+
+RTLIL::Const &RTLIL::Const::operator =(const RTLIL::Const &other) {
+	flags = other.flags;
+	if (other.is_str()) {
+		if (!is_str()) {
+			// sketchy zone
+			check(is_bits());
+			bits_.~bitvectype();
+			(void)new ((void*)&str_) std::string();
+		}
+		tag = other.tag;
+		get_str() = other.get_str();
+	} else if (other.is_bits()) {
+		if (!is_bits()) {
+			// sketchy zone
+			check(is_str());
+			str_.~string();
+			(void)new ((void*)&bits_) bitvectype();
+		}
+		tag = other.tag;
+		get_bits() = other.get_bits();
+	} else {
+		check(false);
+	}
+	return *this;
+}
+
+RTLIL::Const::~Const() {
+	if (is_bits())
+		bits_.~bitvectype();
+	else if (is_str())
+		str_.~string();
+	else
+		check(false);
+}
+
+bool RTLIL::Const::operator<(const RTLIL::Const &other) const
 {
-	if (bits.size() != other.bits.size())
-		return bits.size() < other.bits.size();
-	for (size_t i = 0; i < bits.size(); i++)
-		if (bits[i] != other.bits[i])
-			return bits[i] < other.bits[i];
+	if (size() != other.size())
+		return size() < other.size();
+
+	for (int i = 0; i < size(); i++)
+		if ((*this)[i] != other[i])
+			return (*this)[i] < other[i];
+
 	return false;
 }
 
 bool RTLIL::Const::operator ==(const RTLIL::Const &other) const
 {
-	return bits == other.bits;
+	if (size() != other.size())
+		return false;
+
+	for (int i = 0; i < size(); i++)
+	if ((*this)[i] != other[i])
+		return false;
+
+	return true;
 }
 
 bool RTLIL::Const::operator !=(const RTLIL::Const &other) const
 {
-	return bits != other.bits;
+	return !(*this == other);
+}
+
+std::vector<RTLIL::State>& RTLIL::Const::bits()
+{
+	bitvectorize();
+	return get_bits();
+}
+
+std::vector<RTLIL::State> RTLIL::Const::to_bits() const
+{
+	std::vector<State> v;
+	for (auto bit : *this)
+		v.push_back(bit);
+	return v;
 }
 
 bool RTLIL::Const::as_bool() const
 {
-	for (size_t i = 0; i < bits.size(); i++)
-		if (bits[i] == State::S1)
+	bitvectorize();
+	bitvectype& bv = get_bits();
+	for (size_t i = 0; i < bv.size(); i++)
+		if (bv[i] == State::S1)
 			return true;
 	return false;
 }
 
 int RTLIL::Const::as_int(bool is_signed) const
 {
+	bitvectorize();
+	bitvectype& bv = get_bits();
 	int32_t ret = 0;
-	for (size_t i = 0; i < bits.size() && i < 32; i++)
-		if (bits[i] == State::S1)
+	for (size_t i = 0; i < bv.size() && i < 32; i++)
+		if (bv[i] == State::S1)
 			ret |= 1 << i;
-	if (is_signed && bits.back() == State::S1)
-		for (size_t i = bits.size(); i < 32; i++)
+	if (is_signed && bv.back() == State::S1)
+		for (size_t i = bv.size(); i < 32; i++)
 			ret |= 1 << i;
 	return ret;
 }
 
 size_t RTLIL::Const::get_min_size(bool is_signed) const
 {
-	if (bits.empty()) return 0;
+	if (empty()) return 0;
 
 	// back to front (MSB to LSB)
 	RTLIL::State leading_bit;
 	if (is_signed)
-		leading_bit = (bits.back() == RTLIL::State::Sx) ? RTLIL::State::S0 : bits.back();
+		leading_bit = (back() == RTLIL::State::Sx) ? RTLIL::State::S0 : back();
 	else
 		leading_bit = RTLIL::State::S0;
 
-	size_t idx = bits.size();
-	while (idx > 0 && bits[idx -1] == leading_bit) {
+	size_t idx = size();
+	while (idx > 0 && (*this)[idx -1] == leading_bit) {
 		idx--;
 	}
 
 	// signed needs one leading bit
-	if (is_signed && idx < bits.size()) {
+	if (is_signed && idx < size()) {
 		idx++;
 	}
 	// must be at least one bit
@@ -308,7 +407,7 @@ size_t RTLIL::Const::get_min_size(bool is_signed) const
 void RTLIL::Const::compress(bool is_signed)
 {
 	size_t idx = get_min_size(is_signed);
-	bits.erase(bits.begin() + idx, bits.end());
+	bits().erase(bits().begin() + idx, bits().end());
 }
 
 std::optional<int> RTLIL::Const::as_int_compress(bool is_signed) const
@@ -316,28 +415,30 @@ std::optional<int> RTLIL::Const::as_int_compress(bool is_signed) const
 	size_t size = get_min_size(is_signed);
 	if(size == 0 || size > 32)
 		return std::nullopt;
-		
+
 	int32_t ret = 0;
 	for (size_t i = 0; i < size && i < 32; i++)
-		if (bits[i] == State::S1)
+		if ((*this)[i] == State::S1)
 			ret |= 1 << i;
-	if (is_signed && bits[size-1] == State::S1)
+	if (is_signed && (*this)[size-1] == State::S1)
 		for (size_t i = size; i < 32; i++)
 			ret |= 1 << i;
 	return ret;
 }
 
-std::string RTLIL::Const::as_string() const
+std::string RTLIL::Const::as_string(const char* any) const
 {
+	bitvectorize();
+	bitvectype& bv = get_bits();
 	std::string ret;
-	ret.reserve(bits.size());
-	for (size_t i = bits.size(); i > 0; i--)
-		switch (bits[i-1]) {
+	ret.reserve(bv.size());
+	for (size_t i = bv.size(); i > 0; i--)
+		switch (bv[i-1]) {
 			case S0: ret += "0"; break;
 			case S1: ret += "1"; break;
 			case Sx: ret += "x"; break;
 			case Sz: ret += "z"; break;
-			case Sa: ret += "-"; break;
+			case Sa: ret += any; break;
 			case Sm: ret += "m"; break;
 		}
 	return ret;
@@ -346,22 +447,28 @@ std::string RTLIL::Const::as_string() const
 RTLIL::Const RTLIL::Const::from_string(const std::string &str)
 {
 	Const c;
-	c.bits.reserve(str.size());
+	bitvectype& bv = c.get_bits();
+	bv.reserve(str.size());
 	for (auto it = str.rbegin(); it != str.rend(); it++)
 		switch (*it) {
-			case '0': c.bits.push_back(State::S0); break;
-			case '1': c.bits.push_back(State::S1); break;
-			case 'x': c.bits.push_back(State::Sx); break;
-			case 'z': c.bits.push_back(State::Sz); break;
-			case 'm': c.bits.push_back(State::Sm); break;
-			default: c.bits.push_back(State::Sa);
+			case '0': bv.push_back(State::S0); break;
+			case '1': bv.push_back(State::S1); break;
+			case 'x': bv.push_back(State::Sx); break;
+			case 'z': bv.push_back(State::Sz); break;
+			case 'm': bv.push_back(State::Sm); break;
+			default: bv.push_back(State::Sa);
 		}
 	return c;
 }
 
 std::string RTLIL::Const::decode_string() const
 {
-	const int n = GetSize(bits);
+	if (auto str = get_if_str())
+		return *str;
+
+	bitvectorize();
+	bitvectype& bv = get_bits();
+	const int n = GetSize(bv);
 	const int n_over_8 = n / 8;
 	std::string s;
 	s.reserve(n_over_8);
@@ -369,7 +476,7 @@ std::string RTLIL::Const::decode_string() const
 	if (i < n) {
 		char ch = 0;
 		for (int j = 0; j < (n - i); j++) {
-			if (bits[i + j] == RTLIL::State::S1) {
+			if (bv[i + j] == RTLIL::State::S1) {
 				ch |= 1 << j;
 			}
 		}
@@ -380,7 +487,7 @@ std::string RTLIL::Const::decode_string() const
 	for (; i >= 0; i -= 8) {
 		char ch = 0;
 		for (int j = 0; j < 8; j++) {
-			if (bits[i + j] == RTLIL::State::S1) {
+			if (bv[i + j] == RTLIL::State::S1) {
 				ch |= 1 << j;
 			}
 		}
@@ -390,11 +497,65 @@ std::string RTLIL::Const::decode_string() const
 	return s;
 }
 
+int RTLIL::Const::size() const {
+	if (is_str())
+		return 8 * str_.size();
+	else {
+		check(is_bits());
+		return bits_.size();
+	}
+}
+
+bool RTLIL::Const::empty() const {
+	if (is_str())
+		return str_.empty();
+	else {
+		check(is_bits());
+		return bits_.empty();
+	}
+}
+
+void RTLIL::Const::bitvectorize() const {
+	if (tag == backing_tag::bits)
+		return;
+
+	check(is_str());
+
+	bitvectype new_bits;
+
+	new_bits.reserve(str_.size() * 8);
+	for (int i = str_.size() - 1; i >= 0; i--) {
+		unsigned char ch = str_[i];
+		for (int j = 0; j < 8; j++) {
+			new_bits.push_back((ch & 1) != 0 ? State::S1 : State::S0);
+			ch = ch >> 1;
+		}
+	}
+
+	{
+		// sketchy zone
+		str_.~string();
+		(void)new ((void*)&bits_) bitvectype(std::move(new_bits));
+		tag = backing_tag::bits;
+	}
+}
+
+RTLIL::State RTLIL::Const::const_iterator::operator*() const {
+	if (auto bv = parent.get_if_bits())
+		return (*bv)[idx];
+
+	int char_idx = parent.get_str().size() - idx / 8 - 1;
+	bool bit = (parent.get_str()[char_idx] & (1 << (idx % 8)));
+	return bit ? State::S1 : State::S0;
+}
+
 bool RTLIL::Const::is_fully_zero() const
 {
+	bitvectorize();
+	bitvectype& bv = get_bits();
 	cover("kernel.rtlil.const.is_fully_zero");
 
-	for (const auto &bit : bits)
+	for (const auto &bit : bv)
 		if (bit != RTLIL::State::S0)
 			return false;
 
@@ -403,9 +564,11 @@ bool RTLIL::Const::is_fully_zero() const
 
 bool RTLIL::Const::is_fully_ones() const
 {
+	bitvectorize();
+	bitvectype& bv = get_bits();
 	cover("kernel.rtlil.const.is_fully_ones");
 
-	for (const auto &bit : bits)
+	for (const auto &bit : bv)
 		if (bit != RTLIL::State::S1)
 			return false;
 
@@ -416,7 +579,10 @@ bool RTLIL::Const::is_fully_def() const
 {
 	cover("kernel.rtlil.const.is_fully_def");
 
-	for (const auto &bit : bits)
+	bitvectorize();
+	bitvectype& bv = get_bits();
+
+	for (const auto &bit : bv)
 		if (bit != RTLIL::State::S0 && bit != RTLIL::State::S1)
 			return false;
 
@@ -427,7 +593,10 @@ bool RTLIL::Const::is_fully_undef() const
 {
 	cover("kernel.rtlil.const.is_fully_undef");
 
-	for (const auto &bit : bits)
+	bitvectorize();
+	bitvectype& bv = get_bits();
+
+	for (const auto &bit : bv)
 		if (bit != RTLIL::State::Sx && bit != RTLIL::State::Sz)
 			return false;
 
@@ -438,7 +607,10 @@ bool RTLIL::Const::is_fully_undef_x_only() const
 {
 	cover("kernel.rtlil.const.is_fully_undef_x_only");
 
-	for (const auto &bit : bits)
+	bitvectorize();
+	bitvectype& bv = get_bits();
+
+	for (const auto &bit : bv)
 		if (bit != RTLIL::State::Sx)
 			return false;
 
@@ -449,9 +621,12 @@ bool RTLIL::Const::is_onehot(int *pos) const
 {
 	cover("kernel.rtlil.const.is_onehot");
 
+	bitvectorize();
+	bitvectype& bv = get_bits();
+
 	bool found = false;
 	for (int i = 0; i < GetSize(*this); i++) {
-		auto &bit = bits[i];
+		auto &bit = bv[i];
 		if (bit != RTLIL::State::S0 && bit != RTLIL::State::S1)
 			return false;
 		if (bit == RTLIL::State::S1) {
@@ -464,6 +639,15 @@ bool RTLIL::Const::is_onehot(int *pos) const
 	}
 	return found;
 }
+
+RTLIL::Const RTLIL::Const::extract(int offset, int len, RTLIL::State padding) const {
+	bitvectype ret_bv;
+	ret_bv.reserve(len);
+	for (int i = offset; i < offset + len; i++)
+		ret_bv.push_back(i < GetSize(*this) ? (*this)[i] : padding);
+	return RTLIL::Const(ret_bv);
+}
+#undef check /* check(condition) for Const */
 
 bool RTLIL::AttrObject::has_attribute(const RTLIL::IdString &id) const
 {
@@ -1112,7 +1296,7 @@ namespace {
 		void param_bits(const RTLIL::IdString& name, int width)
 		{
 			param(name);
-			if (GetSize(cell->parameters.at(name).bits) != width)
+			if (GetSize(cell->parameters.at(name)) != width)
 				error(__LINE__);
 		}
 
@@ -3940,7 +4124,7 @@ RTLIL::SigChunk::SigChunk(const RTLIL::SigBit &bit)
 	wire = bit.wire;
 	offset = 0;
 	if (wire == NULL)
-		data = RTLIL::Const(bit.data).bits;
+		data = {bit.data};
 	else
 		offset = bit.offset;
 	width = 1;

--- a/kernel/satgen.cc
+++ b/kernel/satgen.cc
@@ -922,7 +922,7 @@ bool SatGen::importCell(RTLIL::Cell *cell, int timestep)
 		std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 
 		std::vector<int> lut;
-		for (auto bit : cell->getParam(ID::LUT).bits)
+		for (auto bit : cell->getParam(ID::LUT))
 			lut.push_back(bit == State::S1 ? ez->CONST_TRUE : ez->CONST_FALSE);
 		while (GetSize(lut) < (1 << GetSize(a)))
 			lut.push_back(ez->CONST_FALSE);
@@ -974,7 +974,7 @@ bool SatGen::importCell(RTLIL::Cell *cell, int timestep)
 		int width = cell->getParam(ID::WIDTH).as_int();
 		int depth = cell->getParam(ID::DEPTH).as_int();
 
-		vector<State> table_raw = cell->getParam(ID::TABLE).bits;
+		vector<State> table_raw = cell->getParam(ID::TABLE).to_bits();
 		while (GetSize(table_raw) < 2*width*depth)
 			table_raw.push_back(State::S0);
 

--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -62,6 +62,9 @@
          defines the Yosys Makefile would set for your build configuration.
 #endif
 
+#define FRIEND_TEST(test_case_name, test_name) \
+  friend class test_case_name##_##test_name##_Test
+
 #ifdef YOSYS_ENABLE_TCL
 #  include <tcl.h>
 #  ifdef YOSYS_MXE_HACKS

--- a/kernel/yw.cc
+++ b/kernel/yw.cc
@@ -185,7 +185,7 @@ RTLIL::Const ReadWitness::get_bits(int t, int bits_offset, int width) const
 	const std::string &bits = steps[t].bits;
 
 	RTLIL::Const result(State::Sa, width);
-	result.bits.reserve(width);
+	result.bits().reserve(width);
 
 	int read_begin = GetSize(bits) - 1 - bits_offset;
 	int read_end = max(-1, read_begin - width);
@@ -200,7 +200,7 @@ RTLIL::Const ReadWitness::get_bits(int t, int bits_offset, int width) const
 			default:
 				log_abort();
 		}
-		result.bits[j] = bit;
+		result.bits()[j] = bit;
 	}
 
 	return result;

--- a/passes/cmds/bugpoint.cc
+++ b/passes/cmds/bugpoint.cc
@@ -354,7 +354,7 @@ struct BugpointPass : public Pass {
 								for (auto it2 = sy->mem_write_actions.begin(); it2 != sy->mem_write_actions.end(); ++it2) {
 									auto &mask = it2->priority_mask;
 									if (GetSize(mask) > i) {
-										mask.bits.erase(mask.bits.begin() + i);
+										mask.bits().erase(mask.bits().begin() + i);
 									}
 								}
 								return design_copy;

--- a/passes/cmds/clean_zerowidth.cc
+++ b/passes/cmds/clean_zerowidth.cc
@@ -160,7 +160,7 @@ struct CleanZeroWidthPass : public Pass {
 							memwr.address = State::S0;
 						Const priority_mask;
 						for (auto x : swizzle) {
-							priority_mask.bits.push_back(memwr.priority_mask.bits[x]);
+							priority_mask.bits().push_back(memwr.priority_mask[x]);
 						}
 						memwr.priority_mask = priority_mask;
 						swizzle.push_back(i);

--- a/passes/cmds/dft_tag.cc
+++ b/passes/cmds/dft_tag.cc
@@ -883,7 +883,7 @@ struct DftTagWorker {
 	{
 		if (sig_a.is_fully_const()) {
 			auto const_val = sig_a.as_const();
-			for (auto &bit : const_val.bits)
+			for (auto bit : const_val)
 				bit = bit == State::S0 ? State::S1 : bit == State::S1 ? State::S0 : bit;
 			return const_val;
 		}

--- a/passes/cmds/printattrs.cc
+++ b/passes/cmds/printattrs.cc
@@ -40,12 +40,12 @@ struct PrintAttrsPass : public Pass {
 	}
 
 	static void log_const(const RTLIL::IdString &s, const RTLIL::Const &x, const unsigned int indent) {
-		if (x.flags == RTLIL::CONST_FLAG_STRING)
+		if (x.flags & RTLIL::CONST_FLAG_STRING)
 			log("%s(* %s=\"%s\" *)\n", get_indent_str(indent).c_str(), log_id(s), x.decode_string().c_str());
 		else if (x.flags == RTLIL::CONST_FLAG_NONE || x.flags == RTLIL::CONST_FLAG_SIGNED)
 			log("%s(* %s=%s *)\n", get_indent_str(indent).c_str(), log_id(s), x.as_string().c_str());
 		else
-			log_assert(x.flags == RTLIL::CONST_FLAG_STRING || x.flags == RTLIL::CONST_FLAG_NONE); //intended to fail
+			log_assert(x.flags & RTLIL::CONST_FLAG_STRING || x.flags == RTLIL::CONST_FLAG_NONE); //intended to fail
 	}
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override

--- a/passes/cmds/setundef.cc
+++ b/passes/cmds/setundef.cc
@@ -243,7 +243,7 @@ struct SetundefPass : public Pass {
 			{
 				for (auto *cell : module->selected_cells()) {
 					for (auto &parameter : cell->parameters) {
-						for (auto &bit : parameter.second.bits) {
+						for (auto bit : parameter.second) {
 							if (bit > RTLIL::State::S1)
 								bit = worker.next_bit();
 						}
@@ -390,12 +390,12 @@ struct SetundefPass : public Pass {
 					for (auto wire : initwires)
 					{
 						Const &initval = wire->attributes[ID::init];
-						initval.bits.resize(GetSize(wire), State::Sx);
+						initval.bits().resize(GetSize(wire), State::Sx);
 
 						for (int i = 0; i < GetSize(wire); i++) {
 							SigBit bit = sigmap(SigBit(wire, i));
 							if (initval[i] == State::Sx && ffbits.count(bit)) {
-								initval[i] = worker.next_bit();
+								initval.bits()[i] = worker.next_bit();
 								ffbits.erase(bit);
 							}
 						}
@@ -421,7 +421,7 @@ struct SetundefPass : public Pass {
 								continue;
 
 							Const &initval = wire->attributes[ID::init];
-							initval.bits.resize(GetSize(wire), State::Sx);
+							initval.bits().resize(GetSize(wire), State::Sx);
 
 							if (initval.is_fully_undef()) {
 								wire->attributes.erase(ID::init);

--- a/passes/cmds/splitnets.cc
+++ b/passes/cmds/splitnets.cc
@@ -77,7 +77,7 @@ struct SplitnetsWorker
 		if (it != wire->attributes.end()) {
 			Const old_init = it->second, new_init;
 			for (int i = offset; i < offset+width; i++)
-				new_init.bits.push_back(i < GetSize(old_init) ? old_init.bits.at(i) : State::Sx);
+				new_init.bits().push_back(i < GetSize(old_init) ? old_init.at(i) : State::Sx);
 			new_wire->attributes.emplace(ID::init, new_init);
 		}
 

--- a/passes/cmds/xprop.cc
+++ b/passes/cmds/xprop.cc
@@ -827,9 +827,9 @@ struct XpropWorker
 			auto init_q_is_1 = init_q;
 			auto init_q_is_x = init_q;
 
-			for (auto &bit : init_q_is_1)
+			for (auto &bit : init_q_is_1.bits())
 				bit = bit == State::S1 ? State::S1 : State::S0;
-			for (auto &bit : init_q_is_x)
+			for (auto &bit : init_q_is_x.bits())
 				bit = bit == State::Sx ? State::S1 : State::S0;
 
 			initvals.remove_init(sig_q);
@@ -864,14 +864,14 @@ struct XpropWorker
 					auto init_q_is_x = init_q;
 
 					if (ff.is_anyinit) {
-						for (auto &bit : init_q_is_1)
+						for (auto &bit : init_q_is_1.bits())
 							bit = State::Sx;
-						for (auto &bit : init_q_is_x)
+						for (auto &bit : init_q_is_x.bits())
 							bit = State::S0;
 					} else {
-						for (auto &bit : init_q_is_1)
+						for (auto &bit : init_q_is_1.bits())
 							bit = bit == State::S1 ? State::S1 : State::S0;
-						for (auto &bit : init_q_is_x)
+						for (auto &bit : init_q_is_x.bits())
 							bit = bit == State::Sx ? State::S1 : State::S0;
 					}
 

--- a/passes/fsm/fsm_extract.cc
+++ b/passes/fsm/fsm_extract.cc
@@ -168,10 +168,10 @@ undef_bit_in_next_state:
 			ctrl_in_bit_indices[ctrl_in[i]] = i;
 
 		for (auto &it : ctrl_in_bit_indices)
-			if (tr.ctrl_in.bits.at(it.second) == State::S1 && exclusive_ctrls.count(it.first) != 0)
+			if (tr.ctrl_in.at(it.second) == State::S1 && exclusive_ctrls.count(it.first) != 0)
 				for (auto &dc_bit : exclusive_ctrls.at(it.first))
 					if (ctrl_in_bit_indices.count(dc_bit))
-						tr.ctrl_in.bits.at(ctrl_in_bit_indices.at(dc_bit)) = RTLIL::State::Sa;
+						tr.ctrl_in.bits().at(ctrl_in_bit_indices.at(dc_bit)) = RTLIL::State::Sa;
 
 		RTLIL::Const log_state_in = RTLIL::Const(RTLIL::State::Sx, fsm_data.state_bits);
 		if (state_in >= 0)

--- a/passes/fsm/fsm_opt.cc
+++ b/passes/fsm/fsm_opt.cc
@@ -106,11 +106,11 @@ struct FsmOpt
 			for (int i = 0; i < ctrl_in.size(); i++) {
 				RTLIL::SigSpec ctrl_bit = ctrl_in.extract(i, 1);
 				if (ctrl_bit.is_fully_const()) {
-					if (tr.ctrl_in.bits[i] <= RTLIL::State::S1 && RTLIL::SigSpec(tr.ctrl_in.bits[i]) != ctrl_bit)
+					if (tr.ctrl_in[i] <= RTLIL::State::S1 && RTLIL::SigSpec(tr.ctrl_in[i]) != ctrl_bit)
 						goto delete_this_transition;
 					continue;
 				}
-				if (tr.ctrl_in.bits[i] <= RTLIL::State::S1)
+				if (tr.ctrl_in[i] <= RTLIL::State::S1)
 					ctrl_in_used[i] = true;
 			}
 			new_transition_table.push_back(tr);
@@ -169,8 +169,8 @@ struct FsmOpt
 
 				for (auto tr : fsm_data.transition_table)
 				{
-					RTLIL::State &si = tr.ctrl_in.bits[i];
-					RTLIL::State &sj = tr.ctrl_in.bits[j];
+					RTLIL::State &si = tr.ctrl_in.bits()[i];
+					RTLIL::State &sj = tr.ctrl_in.bits()[j];
 
 					if (si > RTLIL::State::S1)
 						si = sj;
@@ -207,8 +207,8 @@ struct FsmOpt
 
 				for (auto tr : fsm_data.transition_table)
 				{
-					RTLIL::State &si = tr.ctrl_in.bits[i];
-					RTLIL::State &sj = tr.ctrl_out.bits[j];
+					RTLIL::State &si = tr.ctrl_in.bits()[i];
+					RTLIL::State &sj = tr.ctrl_out.bits()[j];
 
 					if (si > RTLIL::State::S1 || si == sj) {
 						RTLIL::SigSpec tmp(tr.ctrl_in);
@@ -232,22 +232,22 @@ struct FsmOpt
 
 		for (auto &pattern : set)
 		{
-			if (pattern.bits[bit] > RTLIL::State::S1) {
+			if (pattern[bit] > RTLIL::State::S1) {
 				new_set.insert(pattern);
 				continue;
 			}
 
 			RTLIL::Const other_pattern = pattern;
 
-			if (pattern.bits[bit] == RTLIL::State::S1)
-				other_pattern.bits[bit] = RTLIL::State::S0;
+			if (pattern[bit] == RTLIL::State::S1)
+				other_pattern.bits()[bit] = RTLIL::State::S0;
 			else
-				other_pattern.bits[bit] = RTLIL::State::S1;
+				other_pattern.bits()[bit] = RTLIL::State::S1;
 
 			if (set.count(other_pattern) > 0) {
 				log("  Merging pattern %s and %s from group (%d %d %s).\n", log_signal(pattern), log_signal(other_pattern),
 						tr.state_in, tr.state_out, log_signal(tr.ctrl_out));
-				other_pattern.bits[bit] = RTLIL::State::Sa;
+				other_pattern.bits()[bit] = RTLIL::State::Sa;
 				new_set.insert(other_pattern);
 				did_something = true;
 				continue;

--- a/passes/fsm/fsm_recode.cc
+++ b/passes/fsm/fsm_recode.cc
@@ -43,8 +43,8 @@ static void fm_set_fsm_print(RTLIL::Cell *cell, RTLIL::Module *module, FsmData &
 	fprintf(f, "set_fsm_encoding {");
 	for (int i = 0; i < GetSize(fsm_data.state_table); i++) {
 		fprintf(f, " s%d=2#", i);
-		for (int j = GetSize(fsm_data.state_table[i].bits)-1; j >= 0; j--)
-			fprintf(f, "%c", fsm_data.state_table[i].bits[j] == RTLIL::State::S1 ? '1' : '0');
+		for (int j = GetSize(fsm_data.state_table[i])-1; j >= 0; j--)
+			fprintf(f, "%c", fsm_data.state_table[i][j] == RTLIL::State::S1 ? '1' : '0');
 	}
 	fprintf(f, " } -name {%s_%s} {%s:/WORK/%s}\n",
 			prefix, RTLIL::unescape_id(name).c_str(),
@@ -105,7 +105,7 @@ static void fsm_recode(RTLIL::Cell *cell, RTLIL::Module *module, FILE *fm_set_fs
 
 		if (encoding == "one-hot") {
 			new_code = RTLIL::Const(RTLIL::State::Sa, fsm_data.state_bits);
-			new_code.bits[state_idx] = RTLIL::State::S1;
+			new_code.bits()[state_idx] = RTLIL::State::S1;
 		} else
 		if (encoding == "binary") {
 			new_code = RTLIL::Const(state_idx, fsm_data.state_bits);

--- a/passes/fsm/fsmdata.h
+++ b/passes/fsm/fsmdata.h
@@ -48,8 +48,8 @@ struct FsmData
 		cell->parameters[ID::STATE_TABLE] = RTLIL::Const();
 
 		for (int i = 0; i < int(state_table.size()); i++) {
-			std::vector<RTLIL::State> &bits_table = cell->parameters[ID::STATE_TABLE].bits;
-			std::vector<RTLIL::State> &bits_state = state_table[i].bits;
+			std::vector<RTLIL::State> &bits_table = cell->parameters[ID::STATE_TABLE].bits();
+			std::vector<RTLIL::State> &bits_state = state_table[i].bits();
 			bits_table.insert(bits_table.end(), bits_state.begin(), bits_state.end());
 		}
 
@@ -57,16 +57,16 @@ struct FsmData
 		cell->parameters[ID::TRANS_TABLE] = RTLIL::Const();
 		for (int i = 0; i < int(transition_table.size()); i++)
 		{
-			std::vector<RTLIL::State> &bits_table = cell->parameters[ID::TRANS_TABLE].bits;
+			std::vector<RTLIL::State> &bits_table = cell->parameters[ID::TRANS_TABLE].bits();
 			transition_t &tr = transition_table[i];
 
 			RTLIL::Const const_state_in = RTLIL::Const(tr.state_in, state_num_log2);
 			RTLIL::Const const_state_out = RTLIL::Const(tr.state_out, state_num_log2);
-			std::vector<RTLIL::State> &bits_state_in = const_state_in.bits;
-			std::vector<RTLIL::State> &bits_state_out = const_state_out.bits;
+			std::vector<RTLIL::State> &bits_state_in = const_state_in.bits();
+			std::vector<RTLIL::State> &bits_state_out = const_state_out.bits();
 
-			std::vector<RTLIL::State> &bits_ctrl_in = tr.ctrl_in.bits;
-			std::vector<RTLIL::State> &bits_ctrl_out = tr.ctrl_out.bits;
+			std::vector<RTLIL::State> &bits_ctrl_in = tr.ctrl_in.bits();
+			std::vector<RTLIL::State> &bits_ctrl_out = tr.ctrl_out.bits();
 
 			// append lsb first
 			bits_table.insert(bits_table.end(), bits_ctrl_out.begin(), bits_ctrl_out.end());
@@ -97,23 +97,23 @@ struct FsmData
 		for (int i = 0; i < state_num; i++) {
 			RTLIL::Const state_code;
 			int off_begin = i*state_bits, off_end = off_begin + state_bits;
-			state_code.bits.insert(state_code.bits.begin(), state_table.bits.begin()+off_begin, state_table.bits.begin()+off_end);
+			state_code.bits().insert(state_code.bits().begin(), state_table.begin()+off_begin, state_table.begin()+off_end);
 			this->state_table.push_back(state_code);
 		}
 
 		for (int i = 0; i < trans_num; i++)
 		{
-			auto off_ctrl_out = trans_table.bits.begin() + i*(num_inputs+num_outputs+2*state_num_log2);
+			auto off_ctrl_out = trans_table.begin() + i*(num_inputs+num_outputs+2*state_num_log2);
 			auto off_state_out = off_ctrl_out + num_outputs;
 			auto off_ctrl_in = off_state_out + state_num_log2;
 			auto off_state_in = off_ctrl_in + num_inputs;
 			auto off_end = off_state_in + state_num_log2;
 
 			RTLIL::Const state_in, state_out, ctrl_in, ctrl_out;
-			ctrl_out.bits.insert(state_in.bits.begin(), off_ctrl_out, off_state_out);
-			state_out.bits.insert(state_out.bits.begin(), off_state_out, off_ctrl_in);
-			ctrl_in.bits.insert(ctrl_in.bits.begin(), off_ctrl_in, off_state_in);
-			state_in.bits.insert(state_in.bits.begin(), off_state_in, off_end);
+			ctrl_out.bits().insert(ctrl_out.bits().begin(), off_ctrl_out, off_state_out);
+			state_out.bits().insert(state_out.bits().begin(), off_state_out, off_ctrl_in);
+			ctrl_in.bits().insert(ctrl_in.bits().begin(), off_ctrl_in, off_state_in);
+			state_in.bits().insert(state_in.bits().begin(), off_state_in, off_end);
 
 			transition_t tr;
 			tr.state_in = state_in.as_int();

--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -219,7 +219,7 @@ struct IFExpander
 	                  const RTLIL::SigSpec &conn_signals)
 	{
 		// Check if the connected wire is a potential interface in the parent module
-		std::string interface_name_str = conn_signals.bits()[0].wire->name.str();
+		std::string interface_name_str = conn_signals[0].wire->name.str();
 		// Strip the prefix '$dummywireforinterface' from the dummy wire to get the name
 		interface_name_str.replace(0,23,"");
 		interface_name_str = "\\" + interface_name_str;
@@ -289,7 +289,7 @@ struct IFExpander
 			return;
 
 		// If the connection looks like an interface, handle it.
-		const auto &bits = conn_signals.bits();
+		const auto &bits = conn_signals;
 		if (bits.size() == 1 && bits[0].wire->get_bool_attribute(ID::is_interface))
 			on_interface(submodule, conn_name, conn_signals);
 	}

--- a/passes/hierarchy/submod.cc
+++ b/passes/hierarchy/submod.cc
@@ -79,7 +79,7 @@ struct SubmodWorker
 				flag_wire(c.wire, create, set_int_used, set_ext_driven, set_ext_used);
 				if (set_int_driven)
 					for (int i = c.offset; i < c.offset+c.width; i++) {
-						wire_flags.at(c.wire).is_int_driven[i] = State::S1;
+						wire_flags.at(c.wire).is_int_driven.bits()[i] = State::S1;
 						flag_found_something = true;
 					}
 			}
@@ -185,8 +185,8 @@ struct SubmodWorker
 					auto it = sig[i].wire->attributes.find(ID::init);
 					if (it != sig[i].wire->attributes.end()) {
 						auto jt = new_wire->attributes.insert(std::make_pair(ID::init, Const(State::Sx, GetSize(sig)))).first;
-						jt->second[i] = it->second[sig[i].offset];
-						it->second[sig[i].offset] = State::Sx;
+						jt->second.bits()[i] = it->second[sig[i].offset];
+						it->second.bits()[sig[i].offset] = State::Sx;
 					}
 				}
 			}
@@ -279,7 +279,7 @@ struct SubmodWorker
 
 			for (auto cell : module->cells())
 			{
-				if (cell->attributes.count(ID::submod) == 0 || cell->attributes[ID::submod].bits.size() == 0) {
+				if (cell->attributes.count(ID::submod) == 0 || cell->attributes[ID::submod].size() == 0) {
 					cell->attributes.erase(ID::submod);
 					continue;
 				}

--- a/passes/memory/memory_bram.cc
+++ b/passes/memory/memory_bram.cc
@@ -848,9 +848,9 @@ grow_read_ports:;
 		for (int i = 0; i < mem.width; i++)
 			if (shuffle_map[i] != -1) {
 				module->connect(port.data[shuffle_map[i]], new_data[i]);
-				new_init_value[i] = port.init_value[shuffle_map[i]];
-				new_arst_value[i] = port.arst_value[shuffle_map[i]];
-				new_srst_value[i] = port.srst_value[shuffle_map[i]];
+				new_init_value.bits()[i] = port.init_value[shuffle_map[i]];
+				new_arst_value.bits()[i] = port.arst_value[shuffle_map[i]];
+				new_srst_value.bits()[i] = port.srst_value[shuffle_map[i]];
 			}
 		port.data = new_data;
 		port.init_value = new_init_value;
@@ -887,9 +887,9 @@ grow_read_ports:;
 				for (int i = 0; i < init_size; i++)
 					for (int j = 0; j < bram.dbits; j++)
 						if (init_offset+i < GetSize(initdata) && init_offset+i >= 0)
-							initparam[i*bram.dbits+j] = initdata[init_offset+i][init_shift+j];
+							initparam.bits()[i*bram.dbits+j] = initdata[init_offset+i][init_shift+j];
 						else
-							initparam[i*bram.dbits+j] = State::Sx;
+							initparam.bits()[i*bram.dbits+j] = State::Sx;
 				c->setParam(ID::INIT, initparam);
 			}
 

--- a/passes/memory/memory_libmap.cc
+++ b/passes/memory/memory_libmap.cc
@@ -1019,7 +1019,7 @@ void MemMapping::handle_priority() {
 }
 
 bool is_all_zero(const Const &val) {
-	for (auto bit: val.bits)
+	for (auto bit: val)
 		if (bit == State::S1)
 			return false;
 	return true;
@@ -1913,7 +1913,7 @@ void MemMapping::emit_port(const MemConfig &cfg, std::vector<Cell*> &cells, cons
 							if (!bit.valid) {
 								hw_val.push_back(State::Sx);
 							} else {
-								hw_val.push_back(val.bits[bit.bit]);
+								hw_val.push_back(val[bit.bit]);
 							}
 						}
 						if (pdef.rdinitval == ResetValKind::NoUndef)
@@ -1926,7 +1926,7 @@ void MemMapping::emit_port(const MemConfig &cfg, std::vector<Cell*> &cells, cons
 							if (!bit.valid) {
 								hw_val.push_back(State::Sx);
 							} else {
-								hw_val.push_back(rport.arst_value.bits[bit.bit]);
+								hw_val.push_back(rport.arst_value[bit.bit]);
 							}
 						}
 						if (pdef.rdarstval == ResetValKind::NoUndef)
@@ -1939,7 +1939,7 @@ void MemMapping::emit_port(const MemConfig &cfg, std::vector<Cell*> &cells, cons
 							if (!bit.valid) {
 								hw_val.push_back(State::Sx);
 							} else {
-								hw_val.push_back(rport.srst_value.bits[bit.bit]);
+								hw_val.push_back(rport.srst_value[bit.bit]);
 							}
 						}
 						if (pdef.rdsrstval == ResetValKind::NoUndef)
@@ -2103,7 +2103,7 @@ void MemMapping::emit(const MemConfig &cfg) {
 								if (hwa & 1 << i)
 									addr += 1 << hw_addr_swizzle[i];
 							if (addr >= mem.start_offset && addr < mem.start_offset + mem.size)
-								initval.push_back(init_data.bits[(addr - mem.start_offset) * mem.width + bit.bit]);
+								initval.push_back(init_data[(addr - mem.start_offset) * mem.width + bit.bit]);
 							else
 								initval.push_back(State::Sx);
 						}

--- a/passes/memory/memory_share.cc
+++ b/passes/memory/memory_share.cc
@@ -60,11 +60,11 @@ struct MemoryShareWorker
 	bool merge_rst_value(Mem &mem, Const &res, int wide_log2, const Const &src1, int sub1, const Const &src2, int sub2) {
 		res = Const(State::Sx, mem.width << wide_log2);
 		for (int i = 0; i < GetSize(src1); i++)
-			res[i + sub1 * mem.width] = src1[i];
+			res.bits()[i + sub1 * mem.width] = src1[i];
 		for (int i = 0; i < GetSize(src2); i++) {
 			if (src2[i] == State::Sx)
 				continue;
-			auto &dst = res[i + sub2 * mem.width];
+			auto &dst = res.bits()[i + sub2 * mem.width];
 			if (dst == src2[i])
 				continue;
 			if (dst != State::Sx)

--- a/passes/opt/muxpack.cc
+++ b/passes/opt/muxpack.cc
@@ -94,7 +94,7 @@ struct ExclusiveDatabase
 		SigSpec nonconst_sig;
 		pool<Const> const_values;
 
-		for (auto bit : sig.bits()) {
+		for (auto bit : sig) {
 			auto it = sig_cmp_prev.find(bit);
 			if (it == sig_cmp_prev.end())
 				return false;
@@ -152,7 +152,7 @@ struct MuxpackWorker
 				SigSpec y_sig = sigmap(cell->getPort(ID::Y));
    
 				if (sig_chain_next.count(a_sig))
-					for (auto a_bit : a_sig.bits())
+					for (auto a_bit : a_sig)
 						sigbit_with_non_chain_users.insert(a_bit);
 				else {
 					sig_chain_next[a_sig] = cell;
@@ -161,7 +161,7 @@ struct MuxpackWorker
 
 				if (!b_sig.empty()) {
 					if (sig_chain_next.count(b_sig))
-						for (auto b_bit : b_sig.bits())
+						for (auto b_bit : b_sig)
 							sigbit_with_non_chain_users.insert(b_bit);
 					else {
 						sig_chain_next[b_sig] = cell;
@@ -201,7 +201,7 @@ struct MuxpackWorker
 			}
 			else log_abort();
 
-			for (auto bit : a_sig.bits())
+			for (auto bit : a_sig)
 				if (sigbit_with_non_chain_users.count(bit))
 					goto start_cell;
 

--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -393,8 +393,8 @@ bool rmunused_module_signals(RTLIL::Module *module, bool purge_mode, bool verbos
 			RTLIL::Const &val = it2->second;
 			SigSpec sig = assign_map(wire);
 			for (int i = 0; i < GetSize(val) && i < GetSize(sig); i++)
-				if (val.bits[i] != State::Sx)
-					init_bits[sig[i]] = val.bits[i];
+				if (val[i] != State::Sx)
+					init_bits[sig[i]] = val[i];
 			wire->attributes.erase(it2);
 		}
 	}
@@ -406,7 +406,7 @@ bool rmunused_module_signals(RTLIL::Module *module, bool purge_mode, bool verbos
 		for (int i = 0; i < wire->width; i++) {
 			auto it = init_bits.find(RTLIL::SigBit(wire, i));
 			if (it != init_bits.end()) {
-				val.bits[i] = it->second;
+				val.bits()[i] = it->second;
 				found = true;
 			}
 		}
@@ -425,7 +425,7 @@ bool rmunused_module_signals(RTLIL::Module *module, bool purge_mode, bool verbos
 		if (wire->attributes.count(ID::init))
 			initval = wire->attributes.at(ID::init);
 		if (GetSize(initval) != GetSize(wire))
-			initval.bits.resize(GetSize(wire), State::Sx);
+			initval.bits().resize(GetSize(wire), State::Sx);
 		if (initval.is_fully_undef())
 			wire->attributes.erase(ID::init);
 
@@ -457,7 +457,7 @@ bool rmunused_module_signals(RTLIL::Module *module, bool purge_mode, bool verbos
 				if (s1[i] != s2[i]) {
 					if (s2[i] == State::Sx && (initval[i] == State::S0 || initval[i] == State::S1)) {
 						s2[i] = initval[i];
-						initval[i] = State::Sx;
+						initval.bits()[i] = State::Sx;
 					}
 					new_conn.first.append(s1[i]);
 					new_conn.second.append(s2[i]);

--- a/passes/opt/opt_dff.cc
+++ b/passes/opt/opt_dff.cc
@@ -361,9 +361,9 @@ struct OptDffWorker
 					bool failed = false;
 					for (int i = 0; i < ff.width; i++) {
 						if (ff.sig_clr[i] == sig_arst && ff.sig_set[i] == val_neutral)
-							val_arst.bits.push_back(State::S0);
+							val_arst.bits().push_back(State::S0);
 						else if (ff.sig_set[i] == sig_arst && ff.sig_clr[i] == val_neutral)
-							val_arst.bits.push_back(State::S1);
+							val_arst.bits().push_back(State::S1);
 						else
 							failed = true;
 					}
@@ -626,7 +626,7 @@ struct OptDffWorker
 							groups[resets].push_back(i);
 						} else
 							remaining_indices.push_back(i);
-						val_srst.bits.push_back(reset_val);
+						val_srst.bits().push_back(reset_val);
 					}
 
 					for (auto &it : groups) {
@@ -634,7 +634,7 @@ struct OptDffWorker
 						new_ff.val_srst = Const();
 						for (int i = 0; i < new_ff.width; i++) {
 							int j = it.second[i];
-							new_ff.val_srst.bits.push_back(val_srst[j]);
+							new_ff.val_srst.bits().push_back(val_srst[j]);
 						}
 						ctrl_t srst = combine_resets(it.first, ff.is_fine);
 

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -83,7 +83,7 @@ void replace_undriven(RTLIL::Module *module, const CellTypes &ct)
 			auto cursor = initbits.find(bit);
 			if (cursor != initbits.end()) {
 				revisit_initwires.insert(cursor->second.first);
-				val[i] = cursor->second.second;
+				val.bits()[i] = cursor->second.second;
 			}
 		}
 
@@ -101,7 +101,7 @@ void replace_undriven(RTLIL::Module *module, const CellTypes &ct)
 			Const initval = wire->attributes.at(ID::init);
 			for (int i = 0; i < GetSize(initval) && i < GetSize(wire); i++) {
 				if (SigBit(initval[i]) == sig[i])
-					initval[i] = State::Sx;
+					initval.bits()[i] = State::Sx;
 			}
 			if (initval.is_fully_undef()) {
 				log_debug("Removing init attribute from %s/%s.\n", log_id(module), log_id(wire));
@@ -351,21 +351,21 @@ bool is_one_or_minus_one(const Const &value, bool is_signed, bool &is_negative)
 	bool all_bits_one = true;
 	bool last_bit_one = true;
 
-	if (GetSize(value.bits) < 1)
+	if (GetSize(value) < 1)
 		return false;
 
-	if (GetSize(value.bits) == 1) {
-		if (value.bits[0] != State::S1)
+	if (GetSize(value) == 1) {
+		if (value[0] != State::S1)
 			return false;
 		if (is_signed)
 			is_negative = true;
 		return true;
 	}
 
-	for (int i = 0; i < GetSize(value.bits); i++) {
-		if (value.bits[i] != State::S1)
+	for (int i = 0; i < GetSize(value); i++) {
+		if (value[i] != State::S1)
 			all_bits_one = false;
-		if (value.bits[i] != (i ? State::S0 : State::S1))
+		if (value[i] != (i ? State::S0 : State::S1))
 			last_bit_one = false;
 	}
 

--- a/passes/opt/opt_ffinv.cc
+++ b/passes/opt/opt_ffinv.cc
@@ -98,7 +98,7 @@ struct OptFfInvWorker
 				Const mask = lut->getParam(ID::LUT);
 				Const new_mask;
 				for (int j = 0; j < (1 << GetSize(sig_a)); j++) {
-					new_mask.bits.push_back(mask.bits[j ^ flip_mask]);
+					new_mask.bits().push_back(mask[j ^ flip_mask]);
 				}
 				if (GetSize(sig_a) == 1 && new_mask.as_int() == 2) {
 					module->connect(lut->getPort(ID::Y), ff.sig_q);
@@ -180,10 +180,10 @@ struct OptFfInvWorker
 			Const mask = d_lut->getParam(ID::LUT);
 			Const new_mask;
 			for (int i = 0; i < GetSize(mask); i++) {
-				if (mask.bits[i] == State::S0)
-					new_mask.bits.push_back(State::S1);
+				if (mask[i] == State::S0)
+					new_mask.bits().push_back(State::S1);
 				else
-					new_mask.bits.push_back(State::S0);
+					new_mask.bits().push_back(State::S0);
 			}
 			d_lut->setParam(ID::LUT, new_mask);
 			if (d_lut->getParam(ID::WIDTH) == 1 && new_mask.as_int() == 2) {

--- a/passes/opt/opt_lut.cc
+++ b/passes/opt/opt_lut.cc
@@ -493,7 +493,7 @@ struct OptLutWorker
 							eval_inputs[lutM_new_inputs[i]] = (eval >> i) & 1;
 						}
 						eval_inputs[lutA_output] = evaluate_lut(lutA, eval_inputs);
-						lutM_new_table[eval] = (RTLIL::State) evaluate_lut(lutB, eval_inputs);
+						lutM_new_table.bits()[eval] = (RTLIL::State) evaluate_lut(lutB, eval_inputs);
 					}
 
 					log_debug("  Cell A truth table: %s.\n", lutA->getParam(ID::LUT).as_string().c_str());

--- a/passes/opt/opt_lut_ins.cc
+++ b/passes/opt/opt_lut_ins.cc
@@ -78,7 +78,7 @@ struct OptLutInsPass : public Pass {
 				if (techname == "") {
 					if (cell->type != ID($lut))
 						continue;
-					inputs = cell->getPort(ID::A).bits();
+					inputs = cell->getPort(ID::A);
 					output = cell->getPort(ID::Y);
 					lut = cell->getParam(ID::LUT);
 				} else if (techname == "xilinx" || techname == "gowin") {
@@ -213,7 +213,7 @@ struct OptLutInsPass : public Pass {
 						}
 						lidx |= val << j;
 					}
-					new_lut[i] = lut[lidx];
+					new_lut.bits()[i] = lut[lidx];
 				}
 				// For lattice, and gowin do not replace with a const driver — the nextpnr
 				// packer requires a complete set of LUTs for wide LUT muxes.

--- a/passes/opt/opt_mem.cc
+++ b/passes/opt/opt_mem.cc
@@ -90,7 +90,7 @@ struct OptMemPass : public Pass {
 				}
 				for (auto &init : mem.inits) {
 					for (int i = 0; i < GetSize(init.data); i++) {
-						State bit = init.data.bits[i];
+						State bit = init.data[i];
 						int lane = i % mem.width;
 						if (bit != State::Sx && bit != State::S0) {
 							always_0[lane] = false;
@@ -182,9 +182,9 @@ struct OptMemPass : public Pass {
 							for (auto i: swizzle) {
 								int bidx = sub * mem.width + i;
 								new_data.append(port.data[bidx]);
-								new_init.bits.push_back(port.init_value.bits[bidx]);
-								new_arst.bits.push_back(port.arst_value.bits[bidx]);
-								new_srst.bits.push_back(port.srst_value.bits[bidx]);
+								new_init.bits().push_back(port.init_value[bidx]);
+								new_arst.bits().push_back(port.arst_value[bidx]);
+								new_srst.bits().push_back(port.srst_value[bidx]);
 							}
 						}
 						port.data = new_data;
@@ -197,11 +197,11 @@ struct OptMemPass : public Pass {
 						Const new_en;
 						for (int s = 0; s < GetSize(init.data); s += mem.width) {
 							for (auto i: swizzle) {
-								new_data.bits.push_back(init.data.bits[s + i]);
+								new_data.bits().push_back(init.data[s + i]);
 							}
 						}
 						for (auto i: swizzle) {
-							new_en.bits.push_back(init.en.bits[i]);
+							new_en.bits().push_back(init.en[i]);
 						}
 						init.data = new_data;
 						init.en = new_en;

--- a/passes/opt/pmux2shiftx.cc
+++ b/passes/opt/pmux2shiftx.cc
@@ -323,7 +323,7 @@ struct Pmux2ShiftxPass : public Pass {
 
 					for (auto it : bits) {
 						entry.first.append(it.first);
-						entry.second.bits.push_back(it.second);
+						entry.second.bits().push_back(it.second);
 					}
 
 					eqdb[sigmap(cell->getPort(ID::Y)[0])] = entry;
@@ -344,7 +344,7 @@ struct Pmux2ShiftxPass : public Pass {
 
 					for (auto it : bits) {
 						entry.first.append(it.first);
-						entry.second.bits.push_back(it.second);
+						entry.second.bits().push_back(it.second);
 					}
 
 					eqdb[sigmap(cell->getPort(ID::Y)[0])] = entry;
@@ -411,7 +411,7 @@ struct Pmux2ShiftxPass : public Pass {
 					for (int i : seldb.at(sig)) {
 						Const val = eqdb.at(S[i]).second;
 						int onebits = 0;
-						for (auto b : val.bits)
+						for (auto b : val)
 							if (b == State::S1)
 								onebits++;
 						if (onebits > 1)
@@ -590,7 +590,7 @@ struct Pmux2ShiftxPass : public Pass {
 
 							used_src_columns[best_src_col] = true;
 							perm_new_from_old[dst_col] = best_src_col;
-							perm_xormask[dst_col] = best_inv ? State::S1 : State::S0;
+							perm_xormask.bits()[dst_col] = best_inv ? State::S1 : State::S0;
 						}
 					}
 
@@ -613,7 +613,7 @@ struct Pmux2ShiftxPass : public Pass {
 						Const new_c(State::S0, GetSize(old_c));
 
 						for (int i = 0; i < GetSize(old_c); i++)
-							new_c[i] = old_c[perm_new_from_old[i]];
+							new_c.bits()[i] = old_c[perm_new_from_old[i]];
 
 						Const new_c_before_xor = new_c;
 						new_c = const_xor(new_c, perm_xormask, false, false, GetSize(new_c));
@@ -686,7 +686,7 @@ struct Pmux2ShiftxPass : public Pass {
 					if (!full_case) {
 						Const enable_mask(State::S0, max_choice+1);
 						for (auto &it : perm_choices)
-							enable_mask[it.first.as_int()] = State::S1;
+							enable_mask.bits()[it.first.as_int()] = State::S1;
 						en = module->addWire(NEW_ID);
 						module->addShift(NEW_ID, enable_mask, cmp, en, false, src);
 					}

--- a/passes/opt/share.cc
+++ b/passes/opt/share.cc
@@ -781,18 +781,18 @@ struct ShareWorker
 		std::vector<RTLIL::SigBit> p_first_bits = p.first;
 		for (int i = 0; i < GetSize(p_first_bits); i++) {
 			RTLIL::SigBit b = p_first_bits[i];
-			RTLIL::State v = p.second.bits[i];
+			RTLIL::State v = p.second[i];
 			if (p_bits.count(b) && p_bits.at(b) != v)
 				return false;
 			p_bits[b] = v;
 		}
 
 		p.first = RTLIL::SigSpec();
-		p.second.bits.clear();
+		p.second.bits().clear();
 
 		for (auto &it : p_bits) {
 			p.first.append(it.first);
-			p.second.bits.push_back(it.second);
+			p.second.bits().push_back(it.second);
 		}
 
 		return true;
@@ -815,10 +815,10 @@ struct ShareWorker
 			{
 				auto otherval = val;
 
-				if (otherval.bits[i] == State::S0)
-					otherval.bits[i] = State::S1;
-				else if (otherval.bits[i] == State::S1)
-					otherval.bits[i] = State::S0;
+				if (otherval[i] == State::S0)
+					otherval.bits()[i] = State::S1;
+				else if (otherval[i] == State::S1)
+					otherval.bits()[i] = State::S0;
 				else
 					continue;
 
@@ -828,7 +828,7 @@ struct ShareWorker
 					newsig.remove(i);
 
 					auto newval = val;
-					newval.bits.erase(newval.bits.begin() + i);
+					newval.bits().erase(newval.bits().begin() + i);
 
 					db[newsig].insert(newval);
 					db[sig].erase(otherval);
@@ -907,14 +907,14 @@ struct ShareWorker
 			if (used_in_a)
 				for (auto p : c_patterns) {
 					for (int i = 0; i < GetSize(sig_s); i++)
-						p.first.append(sig_s[i]), p.second.bits.push_back(RTLIL::State::S0);
+						p.first.append(sig_s[i]), p.second.bits().push_back(RTLIL::State::S0);
 					if (sort_check_activation_pattern(p))
 						activation_patterns_cache[cell].insert(p);
 				}
 
 			for (int idx : used_in_b_parts)
 				for (auto p : c_patterns) {
-					p.first.append(sig_s[idx]), p.second.bits.push_back(RTLIL::State::S1);
+					p.first.append(sig_s[idx]), p.second.bits().push_back(RTLIL::State::S1);
 					if (sort_check_activation_pattern(p))
 						activation_patterns_cache[cell].insert(p);
 				}
@@ -965,7 +965,7 @@ struct ShareWorker
 			for (int i = 0; i < GetSize(p_first); i++)
 				if (filter_bits.count(p_first[i]) == 0) {
 					new_p.first.append(p_first[i]);
-					new_p.second.bits.push_back(p.second.bits.at(i));
+					new_p.second.bits().push_back(p.second.at(i));
 				}
 
 			out.insert(new_p);

--- a/passes/opt/wreduce.cc
+++ b/passes/opt/wreduce.cc
@@ -219,10 +219,10 @@ struct WreduceWorker
 
 		// Narrow ARST_VALUE parameter to new size.
 		if (cell->parameters.count(ID::ARST_VALUE)) {
-			rst_value.bits.resize(GetSize(sig_q));
+			rst_value.bits().resize(GetSize(sig_q));
 			cell->setParam(ID::ARST_VALUE, rst_value);
 		} else if (cell->parameters.count(ID::SRST_VALUE)) {
-			rst_value.bits.resize(GetSize(sig_q));
+			rst_value.bits().resize(GetSize(sig_q));
 			cell->setParam(ID::SRST_VALUE, rst_value);
 		}
 

--- a/passes/pmgen/microchip_dsp.cc
+++ b/passes/pmgen/microchip_dsp.cc
@@ -128,7 +128,7 @@ void microchip_dsp_pack(microchip_dsp_pm &pm)
 					continue;
 				for (int i = c.offset; i < c.offset + c.width; i++) {
 					log_assert(it->second[i] == State::S0 || it->second[i] == State::Sx);
-					it->second[i] = State::Sx;
+					it->second.bits()[i] = State::Sx;
 				}
 			}
 		};
@@ -244,7 +244,7 @@ void microchip_dsp_packC(microchip_dsp_CREG_pm &pm)
 					continue;
 				for (int i = c.offset; i < c.offset + c.width; i++) {
 					log_assert(it->second[i] == State::S0 || it->second[i] == State::Sx);
-					it->second[i] = State::Sx;
+					it->second.bits()[i] = State::Sx;
 				}
 			}
 		};

--- a/passes/pmgen/xilinx_dsp.cc
+++ b/passes/pmgen/xilinx_dsp.cc
@@ -339,11 +339,11 @@ void xilinx_dsp_pack(xilinx_dsp_pm &pm)
 
 		if (st.overflow->type == ID($ge)) {
 			Const B = st.overflow->getPort(ID::B).as_const();
-			log_assert(std::count(B.bits.begin(), B.bits.end(), State::S1) == 1);
+			log_assert(std::count(B.begin(), B.end(), State::S1) == 1);
 			// Since B is an exact power of 2, subtract 1
 			//   by inverting all bits up until hitting
 			//   that one hi bit
-			for (auto &b : B.bits)
+			for (auto &b : B.bits())
 				if (b == State::S0) b = State::S1;
 				else if (b == State::S1) {
 					b = State::S0;
@@ -392,7 +392,7 @@ void xilinx_dsp_pack(xilinx_dsp_pm &pm)
 					continue;
 				for (int i = c.offset; i < c.offset+c.width; i++) {
 					log_assert(it->second[i] == State::S0 || it->second[i] == State::Sx);
-					it->second[i] = State::Sx;
+					it->second.bits()[i] = State::Sx;
 				}
 			}
 		};
@@ -579,7 +579,7 @@ void xilinx_dsp48a_pack(xilinx_dsp48a_pm &pm)
 					continue;
 				for (int i = c.offset; i < c.offset+c.width; i++) {
 					log_assert(it->second[i] == State::S0 || it->second[i] == State::Sx);
-					it->second[i] = State::Sx;
+					it->second.bits()[i] = State::Sx;
 				}
 			}
 		};
@@ -702,7 +702,7 @@ void xilinx_dsp_packC(xilinx_dsp_CREG_pm &pm)
 					continue;
 				for (int i = c.offset; i < c.offset+c.width; i++) {
 					log_assert(it->second[i] == State::S0 || it->second[i] == State::Sx);
-					it->second[i] = State::Sx;
+					it->second.bits()[i] = State::Sx;
 				}
 			}
 		};

--- a/passes/pmgen/xilinx_dsp.pmg
+++ b/passes/pmgen/xilinx_dsp.pmg
@@ -363,7 +363,7 @@ match overflow
 	select GetSize(port(overflow, \Y)) <= 48
 	select port(overflow, \B).is_fully_const()
 	define <Const> B port(overflow, \B).as_const()
-	select std::count(B.bits.begin(), B.bits.end(), State::S1) == 1
+	select std::count(B.begin(), B.end(), State::S1) == 1
 	index <SigSpec> port(overflow, \A) === sigP
 	optional
 endmatch

--- a/passes/pmgen/xilinx_srl.cc
+++ b/passes/pmgen/xilinx_srl.cc
@@ -40,7 +40,7 @@ void run_fixed(xilinx_srl_pm &pm)
 			log_assert(Q.wire);
 			auto it = Q.wire->attributes.find(ID::init);
 			if (it != Q.wire->attributes.end()) {
-				auto &i = it->second[Q.offset];
+				auto &i = it->second.bits()[Q.offset];
 				initval.append(i);
 				i = State::Sx;
 			}
@@ -121,7 +121,7 @@ void run_variable(xilinx_srl_pm &pm)
 			log_assert(Q.wire);
 			auto it = Q.wire->attributes.find(ID::init);
 			if (it != Q.wire->attributes.end()) {
-				auto &i = it->second[Q.offset];
+				auto &i = it->second.bits()[Q.offset];
 				initval.append(i);
 				i = State::Sx;
 			}

--- a/passes/proc/proc_init.cc
+++ b/passes/proc/proc_init.cc
@@ -53,11 +53,11 @@ void proc_init(RTLIL::Module *mod, SigMap &sigmap, RTLIL::Process *proc)
 						Const value = valuesig.as_const();
 						Const &wireinit = lhs_c.wire->attributes[ID::init];
 
-						while (GetSize(wireinit.bits) < lhs_c.wire->width)
-							wireinit.bits.push_back(State::Sx);
+						while (GetSize(wireinit) < lhs_c.wire->width)
+							wireinit.bits().push_back(State::Sx);
 
 						for (int i = 0; i < lhs_c.width; i++) {
-							auto &initbit = wireinit.bits[i + lhs_c.offset];
+							auto &initbit = wireinit.bits()[i + lhs_c.offset];
 							if (initbit != State::Sx && initbit != value[i])
 								log_cmd_error("Conflicting initialization values for %s.\n", log_signal(lhs_c));
 							initbit = value[i];

--- a/passes/proc/proc_memwr.cc
+++ b/passes/proc/proc_memwr.cc
@@ -39,7 +39,7 @@ void proc_memwr(RTLIL::Module *mod, RTLIL::Process *proc, dict<IdString, int> &n
 			Const priority_mask(State::S0, port_id);
 			for (int i = 0; i < GetSize(prev_port_ids); i++)
 				if (memwr.priority_mask[i] == State::S1)
-					priority_mask[prev_port_ids[i]] = State::S1;
+					priority_mask.bits()[prev_port_ids[i]] = State::S1;
 			prev_port_ids.push_back(port_id);
 
 			RTLIL::Cell *cell = mod->addCell(NEW_ID, ID($memwr_v2));

--- a/passes/proc/proc_rom.cc
+++ b/passes/proc/proc_rom.cc
@@ -97,10 +97,10 @@ struct RomWorker
 						log_debug("rejecting switch: lhs not uniform\n");
 						return;
 					}
-					val[it2->second] = it.second[i].data;
+					val.bits()[it2->second] = it.second[i].data;
 				}
 			}
-			for (auto bit: val.bits) {
+			for (auto bit: val) {
 				if (bit == State::Sm) {
 					log_debug("rejecting switch: lhs not uniform\n");
 					return;
@@ -113,8 +113,8 @@ struct RomWorker
 					return;
 				}
 				Const c = addr.as_const();
-				while (GetSize(c) && c.bits.back() == State::S0)
-					c.bits.pop_back();
+				while (GetSize(c) && c.back() == State::S0)
+					c.bits().pop_back();
 				if (GetSize(c) > swsigbits)
 					continue;
 				if (GetSize(c) > 30) {
@@ -160,11 +160,11 @@ struct RomWorker
 			auto it = vals.find(i);
 			if (it == vals.end()) {
 				log_assert(got_default);
-				for (auto bit: default_val.bits)
-					init_data.bits.push_back(bit);
+				for (auto bit: default_val)
+					init_data.bits().push_back(bit);
 			} else {
-				for (auto bit: it->second.bits)
-					init_data.bits.push_back(bit);
+				for (auto bit: it->second)
+					init_data.bits().push_back(bit);
 			}
 		}
 

--- a/passes/sat/eval.cc
+++ b/passes/sat/eval.cc
@@ -250,13 +250,13 @@ struct VlogHammerReporter
 				std::string module_name = module_names[mod].c_str();
 				ConstEval ce(module);
 
-				std::vector<RTLIL::State> bits(patterns[idx].bits.begin(), patterns[idx].bits.begin() + total_input_width);
+				std::vector<RTLIL::State> bits(patterns[idx].begin(), patterns[idx].begin() + total_input_width);
 				for (int i = 0; i < int(inputs.size()); i++) {
 					RTLIL::Wire *wire = module->wire(inputs[i]);
 					for (int j = input_widths[i]-1; j >= 0; j--) {
 						ce.set(RTLIL::SigSpec(wire, j), bits.back());
 						recorded_set_vars.append(RTLIL::SigSpec(wire, j));
-						recorded_set_vals.bits.push_back(bits.back());
+						recorded_set_vals.bits().push_back(bits.back());
 						bits.pop_back();
 					}
 					if (module == modules.front()) {
@@ -346,7 +346,7 @@ struct VlogHammerReporter
 				log_error("Pattern %s is to short!\n", pattern.c_str());
 			patterns.push_back(sig.as_const());
 			if (invert_pattern) {
-				for (auto &bit : patterns.back().bits)
+				for (auto &bit : patterns.back().bits())
 					if (bit == RTLIL::State::S0)
 						bit = RTLIL::State::S1;
 					else if (bit == RTLIL::State::S1)
@@ -557,7 +557,7 @@ struct EvalPass : public Pass {
 				tab_line.clear();
 				ce.pop();
 
-				tabvals = RTLIL::const_add(tabvals, RTLIL::Const(1), false, false, tabvals.bits.size());
+				tabvals = RTLIL::const_add(tabvals, RTLIL::Const(1), false, false, tabvals.size());
 			}
 			while (tabvals.as_bool());
 

--- a/passes/sat/expose.cc
+++ b/passes/sat/expose.cc
@@ -131,7 +131,7 @@ void create_dff_dq_map(std::map<RTLIL::IdString, dff_map_info_t> &map, RTLIL::Mo
 			info.arst_polarity = info.cell->parameters.at(ID::ARST_POLARITY).as_bool();
 			std::vector<RTLIL::SigBit> sig_d = sigmap(info.cell->getPort(ID::D)).to_sigbit_vector();
 			std::vector<RTLIL::SigBit> sig_q = sigmap(info.cell->getPort(ID::Q)).to_sigbit_vector();
-			std::vector<RTLIL::State> arst_value = info.cell->parameters.at(ID::ARST_VALUE).bits;
+			std::vector<RTLIL::State> arst_value = info.cell->parameters.at(ID::ARST_VALUE).to_bits();
 			for (size_t i = 0; i < sig_d.size(); i++) {
 				info.bit_d = sig_d.at(i);
 				info.arst_value = arst_value.at(i);

--- a/passes/sat/formalff.cc
+++ b/passes/sat/formalff.cc
@@ -363,7 +363,7 @@ struct PropagateWorker
 
 		for (auto wire : module->wires())
 			if (wire->has_attribute(ID::replaced_by_gclk))
-				replace_clk_bit(SigBit(wire), wire->attributes[ID::replaced_by_gclk].bits.at(0) == State::S1, false);
+				replace_clk_bit(SigBit(wire), wire->attributes[ID::replaced_by_gclk].at(0) == State::S1, false);
 
 		for (auto cell : module->cells()) {
 			if (cell->type.in(ID($not), ID($_NOT_))) {
@@ -622,7 +622,7 @@ struct FormalFfPass : public Pass {
 						auto before = ff.val_init;
 						for (int i = 0; i < ff.width; i++)
 							if (ff.val_init[i] == State::Sx && !worker.is_initval_used(ff.sig_q[i]))
-								ff.val_init[i] = State::S0;
+								ff.val_init.bits()[i] = State::S0;
 
 						if (ff.val_init != before) {
 							log("Setting unused undefined initial value of %s.%s (%s) from %s to %s\n",
@@ -745,7 +745,7 @@ struct FormalFfPass : public Pass {
 				for (auto wire : module->wires()) {
 					if (!wire->has_attribute(ID::replaced_by_gclk))
 						continue;
-					bool clk_pol = wire->attributes[ID::replaced_by_gclk].bits.at(0) == State::S1;
+					bool clk_pol = wire->attributes[ID::replaced_by_gclk].at(0) == State::S1;
 
 					found.emplace_back(SigSpec(wire), clk_pol);
 				}

--- a/passes/sat/sat.cc
+++ b/passes/sat/sat.cc
@@ -629,9 +629,9 @@ struct SatHelper
 			bool found_undef = false;
 
 			for (int i = 0; i < info.width; i++) {
-				value.bits.push_back(modelValues.at(info.offset+i) ? RTLIL::State::S1 : RTLIL::State::S0);
+				value.bits().push_back(modelValues.at(info.offset+i) ? RTLIL::State::S1 : RTLIL::State::S0);
 				if (enable_undef && modelValues.at(modelExpressions.size()/2 + info.offset + i))
-					value.bits.back() = RTLIL::State::Sx, found_undef = true;
+					value.bits().back() = RTLIL::State::Sx, found_undef = true;
 			}
 
 			if (info.timestep != last_timestep) {
@@ -740,9 +740,9 @@ struct SatHelper
 			RTLIL::Const value;
 
 			for (int i = 0; i < info.width; i++) {
-				value.bits.push_back(modelValues.at(info.offset+i) ? RTLIL::State::S1 : RTLIL::State::S0);
+				value.bits().push_back(modelValues.at(info.offset+i) ? RTLIL::State::S1 : RTLIL::State::S0);
 				if (enable_undef && modelValues.at(modelExpressions.size()/2 + info.offset + i))
-					value.bits.back() = RTLIL::State::Sx;
+					value.bits().back() = RTLIL::State::Sx;
 			}
 
 			if (info.timestep != last_timestep) {
@@ -754,11 +754,11 @@ struct SatHelper
 			}
 
 			if(info.width == 1) {
-				fprintf(f, "%c%s\n", bitvals[value.bits[0]], vcdnames[info.description].c_str());
+				fprintf(f, "%c%s\n", bitvals[value[0]], vcdnames[info.description].c_str());
 			} else {
 				fprintf(f, "b");
 				for(int k=info.width-1; k >= 0; k --)	//need to flip bit ordering for VCD
-					fprintf(f, "%c", bitvals[value.bits[k]]);
+					fprintf(f, "%c", bitvals[value[k]]);
 				fprintf(f, " %s\n", vcdnames[info.description].c_str());
 			}
 		}
@@ -786,9 +786,9 @@ struct SatHelper
 		{
 			Const value;
 			for (int i = 0; i < info.width; i++) {
-				value.bits.push_back(modelValues.at(info.offset+i) ? RTLIL::State::S1 : RTLIL::State::S0);
+				value.bits().push_back(modelValues.at(info.offset+i) ? RTLIL::State::S1 : RTLIL::State::S0);
 				if (enable_undef && modelValues.at(modelExpressions.size()/2 + info.offset + i))
-					value.bits.back() = RTLIL::State::Sx;
+					value.bits().back() = RTLIL::State::Sx;
 			}
 
 			wavedata[info.description].first = info.width;

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -1217,7 +1217,7 @@ void reintegrate(RTLIL::Module *module, bool dff_mode)
 			auto Qi = initmap(Q);
 			auto it = Qi.wire->attributes.find(ID::init);
 			if (it != Qi.wire->attributes.end())
-				it->second[Qi.offset] = State::Sx;
+				it->second.bits()[Qi.offset] = State::Sx;
 		}
 		else if (cell->type.in(ID($_AND_), ID($_NOT_)))
 			module->remove(cell);
@@ -1528,7 +1528,7 @@ void reintegrate(RTLIL::Module *module, bool dff_mode)
 			int i = 0;
 			while (i < GetSize(mask)) {
 				for (int j = 0; j < (1 << index); j++)
-					std::swap(mask[i+j], mask[i+j+(1 << index)]);
+					std::swap(mask.bits()[i+j], mask.bits()[i+j+(1 << index)]);
 				i += 1 << (index+1);
 			}
 			A[index] = y_bit;
@@ -1543,7 +1543,7 @@ void reintegrate(RTLIL::Module *module, bool dff_mode)
 		// and get cleaned away
 clone_lut:
 		driver_mask = driver_lut->getParam(ID::LUT);
-		for (auto &b : driver_mask.bits) {
+		for (auto &b : driver_mask.bits()) {
 			if (b == RTLIL::State::S0) b = RTLIL::State::S1;
 			else if (b == RTLIL::State::S1) b = RTLIL::State::S0;
 		}

--- a/passes/techmap/dffinit.cc
+++ b/passes/techmap/dffinit.cc
@@ -118,13 +118,13 @@ struct DffinitPass : public Pass {
 					for (int i = 0; i < GetSize(sig); i++) {
 						if (initval[i] == State::Sx)
 							continue;
-						while (GetSize(value.bits) <= i)
-							value.bits.push_back(State::S0);
-						if (noreinit && value.bits[i] != State::Sx && value.bits[i] != initval[i])
+						while (GetSize(value) <= i)
+							value.bits().push_back(State::S0);
+						if (noreinit && value[i] != State::Sx && value[i] != initval[i])
 							log_error("Trying to assign a different init value for %s.%s.%s which technically "
 									"have a conflicted init value.\n",
 									log_id(module), log_id(cell), log_id(it.second));
-						value.bits[i] = initval[i];
+						value.bits()[i] = initval[i];
 					}
 
 					if (highlow_mode && GetSize(value) != 0) {

--- a/passes/techmap/dfflegalize.cc
+++ b/passes/techmap/dfflegalize.cc
@@ -869,17 +869,17 @@ struct DffLegalizePass : public Pass {
 			if (ff.has_arst) {
 				if (ff.val_arst[i] == State::Sx) {
 					if (!(supported & (mask << 8)))
-						ff.val_arst[i] = State::S0;
+						ff.val_arst.bits()[i] = State::S0;
 					if (!(supported & (mask << 4)))
-						ff.val_arst[i] = State::S1;
+						ff.val_arst.bits()[i] = State::S1;
 				}
 			}
 			if (ff.has_srst) {
 				if (ff.val_srst[i] == State::Sx) {
 					if (!(supported & (mask << 8)))
-						ff.val_srst[i] = State::S0;
+						ff.val_srst.bits()[i] = State::S0;
 					if (!(supported & (mask << 4)))
-						ff.val_srst[i] = State::S1;
+						ff.val_srst.bits()[i] = State::S1;
 				}
 			}
 		}

--- a/passes/techmap/flowmap.cc
+++ b/passes/techmap/flowmap.cc
@@ -1399,7 +1399,7 @@ struct FlowmapWorker
 					          log_signal(node), log_signal(undef), env.c_str());
 				}
 
-				lut_table[i] = value.as_bool() ? State::S1 : State::S0;
+				lut_table.bits()[i] = value.as_bool() ? State::S1 : State::S0;
 				ce.pop();
 			}
 

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -684,7 +684,7 @@ struct TechmapWorker
 							for (auto &bit : sigmap(conn.second)) {
 								int val = unique_bit_id.at(bit);
 								for (int i = 0; i < bits; i++) {
-									value.bits.push_back((val & 1) != 0 ? State::S1 : State::S0);
+									value.bits().push_back((val & 1) != 0 ? State::S1 : State::S0);
 									val = val >> 1;
 								}
 							}
@@ -1226,7 +1226,7 @@ struct TechmapPass : public Pass {
 
 		dict<IdString, pool<IdString>> celltypeMap;
 		for (auto module : map->modules()) {
-			if (module->attributes.count(ID::techmap_celltype) && !module->attributes.at(ID::techmap_celltype).bits.empty()) {
+			if (module->attributes.count(ID::techmap_celltype) && !module->attributes.at(ID::techmap_celltype).empty()) {
 				char *p = strdup(module->attributes.at(ID::techmap_celltype).decode_string().c_str());
 				for (char *q = strtok(p, " \t\r\n"); q; q = strtok(nullptr, " \t\r\n")) {
 					std::vector<std::string> queue;

--- a/passes/techmap/zinit.cc
+++ b/passes/techmap/zinit.cc
@@ -73,10 +73,10 @@ struct ZinitPass : public Pass {
 
 				pool<int> bits;
 				for (int i = 0; i < ff.width; i++) {
-					if (ff.val_init.bits[i] == State::S1)
+					if (ff.val_init[i] == State::S1)
 						bits.insert(i);
-					else if (ff.val_init.bits[i] != State::S0 && all_mode)
-						ff.val_init.bits[i] = State::S0;
+					else if (ff.val_init[i] != State::S0 && all_mode)
+						ff.val_init.bits()[i] = State::S0;
 				}
 				ff.flip_bits(bits);
 				ff.emit();

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -544,13 +544,13 @@ static void run_eval_test(RTLIL::Design *design, bool verbose, bool nosat, std::
 
 			RTLIL::Const in_value;
 			for (int i = 0; i < GetSize(gold_wire); i++)
-				in_value.bits.push_back(xorshift32(2) ? State::S1 : State::S0);
+				in_value.bits().push_back(xorshift32(2) ? State::S1 : State::S0);
 
 			if (xorshift32(4) == 0) {
 				int inv_chance = 1 + xorshift32(8);
 				for (int i = 0; i < GetSize(gold_wire); i++)
 					if (xorshift32(inv_chance) == 0)
-						in_value.bits[i] = RTLIL::Sx;
+						in_value.bits()[i] = RTLIL::Sx;
 			}
 
 			if (verbose)

--- a/techlibs/gatemate/gatemate_foldinv.cc
+++ b/techlibs/gatemate/gatemate_foldinv.cc
@@ -82,7 +82,7 @@ struct FoldInvWorker {
         Const result(State::S0, GetSize(lut));
         for (int i = 0; i < GetSize(lut); i++) {
             int j = i ^ (1 << bit);
-            result[j] = lut[i];
+            result.bits()[j] = lut[i];
         }
         return result;
     }
@@ -91,7 +91,7 @@ struct FoldInvWorker {
     {
         Const result(State::S0, GetSize(lut));
         for (int i = 0; i < GetSize(lut); i++)
-            result[i] = (lut[i] == State::S1) ? State::S0 : State::S1;
+            result.bits()[i] = (lut[i] == State::S1) ? State::S0 : State::S1;
         return result;
     }
 

--- a/techlibs/greenpak4/greenpak4_dffinv.cc
+++ b/techlibs/greenpak4/greenpak4_dffinv.cc
@@ -35,10 +35,10 @@ void invert_gp_dff(Cell *cell, bool invert_input)
 	{
 		Const initval = cell->getParam(ID::INIT);
 		if (GetSize(initval) >= 1) {
-			if (initval.bits[0] == State::S0)
-				initval.bits[0] = State::S1;
-			else if (initval.bits[0] == State::S1)
-				initval.bits[0] = State::S0;
+			if (initval[0] == State::S0)
+				initval.bits()[0] = State::S1;
+			else if (initval[0] == State::S1)
+				initval.bits()[0] = State::S0;
 			cell->setParam(ID::INIT, initval);
 		}
 
@@ -46,10 +46,10 @@ void invert_gp_dff(Cell *cell, bool invert_input)
 		{
 			Const srmode = cell->getParam(ID(SRMODE));
 			if (GetSize(srmode) >= 1) {
-				if (srmode.bits[0] == State::S0)
-					srmode.bits[0] = State::S1;
-				else if (srmode.bits[0] == State::S1)
-					srmode.bits[0] = State::S0;
+				if (srmode[0] == State::S0)
+					srmode.bits()[0] = State::S1;
+				else if (srmode[0] == State::S1)
+					srmode.bits()[0] = State::S0;
 				cell->setParam(ID(SRMODE), srmode);
 			}
 		}

--- a/techlibs/microchip/microchip_dffopt.cc
+++ b/techlibs/microchip/microchip_dffopt.cc
@@ -80,7 +80,7 @@ bool merge_lut(LutData &result, const LutData &data, const LutData select, bool 
 		for (int j = 0; j < GetSize(select.second); j++)
 			if (i & 1 << idx_sel[j])
 				sel_lut_idx |= 1 << j;
-		bool select_val = (select.first.bits[sel_lut_idx] == State::S1);
+		bool select_val = (select.first[sel_lut_idx] == State::S1);
 		bool new_bit;
 		if (select_val ^ select_inv) {
 			// Use alt_data.
@@ -91,9 +91,9 @@ bool merge_lut(LutData &result, const LutData &data, const LutData select, bool 
 		} else {
 			// Use original LUT.
 			int lut_idx = i >> idx_data & ((1 << GetSize(data.second)) - 1);
-			new_bit = data.first.bits[lut_idx] == State::S1;
+			new_bit = data.first[lut_idx] == State::S1;
 		}
-		result.first.bits[i] = new_bit ? State::S1 : State::S0;
+		result.first.bits()[i] = new_bit ? State::S1 : State::S0;
 	}
 	return true;
 }

--- a/techlibs/quicklogic/ql_dsp_simd.cc
+++ b/techlibs/quicklogic/ql_dsp_simd.cc
@@ -60,7 +60,7 @@ struct QlDspSimdPass : public Pass {
 
 	// ..........................................
 
-	const int m_ModeBitsSize = 80;
+	const size_t m_ModeBitsSize = 80;
 
 	// DSP parameters
 	const std::vector<std::string> m_DspParams = {"COEFF_3", "COEFF_2", "COEFF_1", "COEFF_0"};
@@ -176,7 +176,7 @@ struct QlDspSimdPass : public Pass {
 								sigspec.append(sig);
 							}
 
-							int padding = width / 2 - sigspec.bits().size();
+							int padding = width / 2 - sigspec.size();
 
 							if (padding) {
 								if (!isOutput)
@@ -200,8 +200,10 @@ struct QlDspSimdPass : public Pass {
 						auto val_a = dsp_a->getParam(it);
 						auto val_b = dsp_b->getParam(it);
 
-						mode_bits.bits.insert(mode_bits.end(), val_a.begin(), val_a.end());
-						mode_bits.bits.insert(mode_bits.end(), val_b.begin(), val_b.end());
+						mode_bits.bits().insert(mode_bits.bits().end(),
+							val_a.begin(), val_a.end());
+						mode_bits.bits().insert(mode_bits.bits().end(),
+							val_b.begin(), val_b.end());
 					}
 
 					// Enable the fractured mode by connecting the control

--- a/techlibs/xilinx/xilinx_dffopt.cc
+++ b/techlibs/xilinx/xilinx_dffopt.cc
@@ -79,7 +79,7 @@ bool merge_lut(LutData &result, const LutData &data, const LutData select, bool 
 		for (int j = 0; j < GetSize(select.second); j++)
 			if (i & 1 << idx_sel[j])
 				sel_lut_idx |= 1 << j;
-		bool select_val = (select.first.bits[sel_lut_idx] == State::S1);
+		bool select_val = (select.first[sel_lut_idx] == State::S1);
 		bool new_bit;
 		if (select_val ^ select_inv) {
 			// Use alt_data.
@@ -90,9 +90,9 @@ bool merge_lut(LutData &result, const LutData &data, const LutData select, bool 
 		} else {
 			// Use original LUT.
 			int lut_idx = i >> idx_data & ((1 << GetSize(data.second)) - 1);
-			new_bit = data.first.bits[lut_idx] == State::S1;
+			new_bit = data.first[lut_idx] == State::S1;
 		}
-		result.first.bits[i] = new_bit ? State::S1 : State::S0;
+		result.first.bits()[i] = new_bit ? State::S1 : State::S0;
 	}
 	return true;
 }
@@ -212,7 +212,7 @@ lut_sigin_done:
 				if (cell->hasParam(ID(IS_D_INVERTED)) && cell->getParam(ID(IS_D_INVERTED)).as_bool()) {
 					// Flip all bits in the LUT.
 					for (int i = 0; i < GetSize(lut_d.first); i++)
-						lut_d.first.bits[i] = (lut_d.first.bits[i] == State::S1) ? State::S0 : State::S1;
+						lut_d.first.bits()[i] = (lut_d.first[i] == State::S1) ? State::S0 : State::S1;
 				}
 
 				LutData lut_d_post_ce;

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -15,7 +15,7 @@ TESTS := $(addprefix $(BINTEST)/, $(basename $(ALLTESTFILE:%Test.cc=%Test.o)))
 all: prepare $(TESTS) run-tests
 
 $(BINTEST)/%: $(OBJTEST)/%.o
-	$(CXX) -L$(ROOTPATH) $(RPATH)=$(ROOTPATH) -o $@ $^ $(LIBS) \
+	$(CXX) -L$(ROOTPATH) $(RPATH)=$(ROOTPATH) $(LINKFLAGS) -o $@ $^ $(LIBS) \
 		$(GTESTFLAG) $(EXTRAFLAGS)
 
 $(OBJTEST)/%.o: $(basename $(subst $(OBJTEST),.,%)).cc

--- a/tests/unit/kernel/rtlilTest.cc
+++ b/tests/unit/kernel/rtlilTest.cc
@@ -1,14 +1,79 @@
 #include <gtest/gtest.h>
-
-#include "kernel/yosys.h"
 #include "kernel/rtlil.h"
 
 YOSYS_NAMESPACE_BEGIN
 
-TEST(KernelRtlilTest, getReferenceValid)
-{
-	//TODO: Implement rtlil test
-	EXPECT_EQ(33, 33);
+namespace RTLIL {
+
+	class KernelRtlilTest : public testing::Test {};
+
+	TEST_F(KernelRtlilTest, ConstAssignCompare)
+	{
+		Const c1;
+		Const c2;
+		c2 = c1;
+		Const c3(c2);
+		EXPECT_TRUE(c2 == c3);
+		EXPECT_FALSE(c2 < c3);
+	}
+
+	TEST_F(KernelRtlilTest, ConstStr) {
+		// We have multiple distinct sections since it's annoying
+		// to list multiple testcases as friends of Const in kernel/rtlil.h
+		{
+			std::string foo = "foo";
+			Const c1 = foo;
+			Const c2;
+			c2 = c1;
+			Const c3(c2);
+			EXPECT_TRUE(c1.is_str());
+			EXPECT_TRUE(c2.is_str());
+			EXPECT_TRUE(c3.is_str());
+		}
+
+		{
+			// A binary constant is bitvec backed
+			Const cb1(0, 10);
+			Const cb2(1, 10);
+			Const cb3(cb2);
+			std::vector<bool> v1 {false, true};
+			std::vector<State> v2 {State::S0, State::S1};
+			Const cb4(v1);
+			Const cb5(v2);
+			EXPECT_TRUE(cb4 == cb5);
+			EXPECT_TRUE(cb1.is_bits());
+			EXPECT_TRUE(cb2.is_bits());
+			EXPECT_TRUE(cb3.is_bits());
+			EXPECT_TRUE(cb4.is_bits());
+			EXPECT_TRUE(cb5.is_bits());
+			EXPECT_EQ(cb1.size(), 10);
+			EXPECT_EQ(cb2.size(), 10);
+			EXPECT_EQ(cb3.size(), 10);
+		}
+
+		{
+			// A string constructed Const starts off packed
+			std::string foo = "foo";
+			Const cs1 = foo;
+			EXPECT_TRUE(cs1.is_str());
+
+			// It can be iterated without mutating
+			int i = 0;
+			for (auto bit : cs1) {
+				i += bit;
+			}
+			EXPECT_EQ(i, 16);
+			EXPECT_TRUE(cs1.is_str());
+
+			// It can be mutated with the bits() view
+			// and decays into unpacked
+			for (auto& bit : cs1.bits()) {
+				bit = State::Sx;
+			}
+			EXPECT_TRUE(cs1.is_bits());
+		}
+
+	}
 }
 
 YOSYS_NAMESPACE_END


### PR DESCRIPTION
Currently, a `RTLIL::Const` representing a string will use `std::vector<RTLIL::State>`, encoding the string into a vector of individual bits. This increases the memory consumption of string attributes, such as `src` and `hdlname`, by a factor of 8.

As of this PR, the structure now holds data represented with ~~an `std::variant<bitvectype, std::string>` named `backing`~~ a union. The `bits` vector is no longer accessible and instead `std::vector<RTLIL::State>& bits()` has to be used. When a Const is constructed from a string, it is represented with the string alternative. When its `bits()` method is used, the string is encoded into the bit vector alternative as prior to this PR, see `Const::bitvectorize()`. This is similar to how `RTLIL::SigSpec` "unpacks" into bits.

In the initial implementation, when `bits()` were being accessed, I asserted that the Const isn't represented with a string. This found some places in Yosys that access string attributes bit-by-bit. As a result, this PR comes with bonus content:

+ `kernel/cellaigs.cc`
+ `frontends/ast/ast.cc`
+ `Const::pretty_fmt`
+ cell checker `is_param` that doesn't try return bits

It's possible to split these now necessary changes out to a separate PR, but it will be heavy on git conflicts. Please advise.

This PR does not affect constant `SigChunk`s which also have an `std::vector<RTLIL::State>` each.

- [X] clean my desk (TODO, log_debug, did_something_hook, unwrap `std::get` from `assert_get_bits` etc)
- [x] ~~add some way of debugging how much unpacking we're doing~~ requires unrelated changes in followup PR

Please comment what memory usage changes you see with this PR. I've observed memory savings of 0-20% depending on the design with negligible runtime improvements. The open source Verilog frontend often dominates memory usage, so flows that use Verific may more readily show these improvements.