### PR TITLE
Stop unconditionally building abc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -805,7 +805,7 @@ check-git-abc:
 		exit 1; \
 	fi
 
-abc/abc$(EXE) abc/libabc.a: check-git-abc
+abc/abc$(EXE) abc/libabc.a: | check-git-abc
 	$(P)
 	$(Q) mkdir -p abc && $(MAKE) -C $(PROGRAM_PREFIX)abc -f "$(realpath $(YOSYS_SRC)/abc/Makefile)" ABCSRC="$(realpath $(YOSYS_SRC)/abc/)" $(S) $(ABCMKARGS) $(if $(filter %.a,$@),PROG="abc",PROG="abc$(EXE)") MSG_PREFIX="$(eval P_OFFSET = 5)$(call P_SHOW)$(eval P_OFFSET = 10) ABC: " $(if $(filter %.a,$@),libabc.a)
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
abc builds unconditional because `check-git-abc` is a phony prerequisite and therefore always runs, and since it always runs it will always trigger abc to rebuild.

_Explain how this is achieved._
Convert `check-git-abc` to an order-only prerequisite.  It still runs as before, but no longer triggers yosys-abc to rebuild when it does.

_If applicable, please suggest to reviewers how they can test the change._