### PR TITLE
Makefile: no LTO and lld by default

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -56,7 +56,7 @@ jobs:
           mkdir build
           cd build
           make -f ../Makefile config-$CC
-          make -f ../Makefile -j$procs
+          make -f ../Makefile -j$procs ENABLE_LTO=1
 
       - name: Log yosys-config output
         run: |

--- a/.github/workflows/test-verific.yml
+++ b/.github/workflows/test-verific.yml
@@ -41,7 +41,7 @@ jobs:
           echo "ENABLE_VERIFIC_LIBERTY := 1" >> Makefile.conf
           echo "ENABLE_VERIFIC_YOSYSHQ_EXTENSIONS := 1" >> Makefile.conf
           echo "ENABLE_CCACHE := 1" >> Makefile.conf
-          make -j${{ env.procs }}
+          make -j${{ env.procs }} ENABLE_LTO=1
 
       - name: Install Yosys
         run: |

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ENABLE_PYOSYS := 0
 ENABLE_GCOV := 0
 ENABLE_GPROF := 0
 ENABLE_DEBUG := 0
-ENABLE_LTO := 1
+ENABLE_LTO := 0
 ENABLE_CCACHE := 0
 # sccache is not always a drop-in replacement for ccache in practice
 ENABLE_SCCACHE := 0
@@ -223,7 +223,9 @@ LTOFLAGS := $(GCC_LTO)
 ifeq ($(CONFIG),clang)
 CXX = clang++
 CXXFLAGS += -std=$(CXXSTD) $(OPT_LEVEL)
+ifeq ($(ENABLE_LTO),1)
 LINKFLAGS += -fuse-ld=lld
+endif
 ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H $(ABC_ARCHFLAGS)"
 LTOFLAGS := $(CLANG_LTO)
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,17 @@ unless `CXX` is assigned in the call to make, e.g.
 
   $ make CXX=$CXX
 
+The Makefile has many variables influencing the build process. These can be
+adjusted by modifying the Makefile.conf file which is created at the
+`make config-...` step (see above), or they can be set by passing an option
+to the make command directly.
+
+For example, if you have clang, and (a compatible version of) `ld.lld`
+available in PATH, it's recommended to speed up incremental builds with
+lld by enabling LTO:
+
+ $ make ENABLE_LTO=1
+
 For other compilers and build configurations it might be
 necessary to make some changes to the config section of the
 Makefile.


### PR DESCRIPTION
On mac, there's problems with lld presence, compatibility, and detection with brew vs nixos. Disable lld and LTO by default and inform users in the README about the benefit of enabling both.