### PR TITLE
Neater hashing interface

### DIFF
--- a/docs/source/yosys_internals/hashing.rst
+++ b/docs/source/yosys_internals/hashing.rst
@@ -9,7 +9,9 @@ The hash function
 
 The hash function generally used in Yosys is the XOR version of DJB2:
 
-``state = ((state << 5) + state) ^ value``
+::
+
+   state = ((state << 5) + state) ^ value
 
 This is an old-school hash designed to hash ASCII characters. Yosys doesn't hash
 a lot of ASCII text, but it still happens to be a local optimum due to factors

--- a/docs/source/yosys_internals/hashing.rst
+++ b/docs/source/yosys_internals/hashing.rst
@@ -1,0 +1,45 @@
+Hashing and associative data structures in Yosys
+------------------------------------------------
+
+Yosys heavily relies on custom data structures such as dict or pool
+defined in kernel/hashlib.h. There are various reasons for this.
+
+The hash function
+~~~~~~~~~~~~~~~~~
+
+The hash function generally used in Yosys is the XOR version of DJB2:
+
+``state = ((state << 5) + state) ^ value``
+
+This is an old-school hash designed to hash ASCII characters. Yosys doesn't hash a lot of ASCII text, but it still happens to be a local optimum due to factors described later.
+
+Hash function quality is multi-faceted and highly dependent on what is being hashed. Yosys isn't concerned by any cryptographic qualities, instead the goal is minimizing total hashing collision risk given the data patterns within Yosys.
+In general, a good hash function typically folds values into a state accumulator with a mathematical function that is fast to compute and has some beneficial properties. One of these is the avalanche property, which demands that a small change such as flipping a bit or incrementing by one in the input produces a large, unpredictable change in the output. Additionally, the bit independence criterion states that any pair of output bits should change independently when any single input bit is inverted. These properties are important for avoiding hash collision on data patterns like the hash of a sequence not colliding with its permutation, not losing from the state the information added by hashing preceding elements, etc.
+
+DJB2 lacks these properties. Instead, since Yosys hashes large numbers of data structures composed of incrementing integer IDs, Yosys abuses the predictability of DJB2 to get lower hash collisions, with regular nature of the hashes surviving through the interaction with the "modulo prime" operations in the associative data structures. For example, some most common objects in Yosys are interned ``IdString``s of incrementing indices or ``SigBit``s with bit offsets into wire (represented by its unique ``IdString`` name) as the typical case. This is what makes DJB2 a local optimum. Additionally, the ADD version of DJB2 (like above but with addition instead of XOR) is used to this end for some types, abandoning the general pattern of folding values into a state value.
+
+Making a type hashable
+~~~~~~~~~~~~~~~~~~~~~~
+
+Let's first take a look at the external interface on a simplified level. Generally, to get the hash for ``T obj``, you would call the utility function ``run_hash<T>(const T& obj)``, corresponding to ``hash_top_ops<T>::hash(obj)``, the default implementation of which is ``hash_ops<T>::hash_acc(Hasher(), obj)``. ``Hasher`` is the class actually implementing the hash function, hiding its initialized internal state, and passing it out on ``hash_t yield()`` with perhaps some finalization steps.
+
+``hash_ops<T>`` is the star of the show. By default it pulls the ``Hasher h`` through a ``Hasher T::hash_acc(Hasher h)`` method. That's the method you have to implement to make a record (class or struct) type easily hashable with Yosys hashlib associative data structures.
+
+``hash_ops<T>`` is specialized for built-in types like ``int`` or ``bool`` and treats pointers the same as integers, so it doesn't dereference pointers. Since many RTLIL data structures like ``RTLIL::Wire`` carry their own unique index ``Hasher::hash_t hashidx_;``, there are specializations for ``hash_ops<Wire*>`` and others in ``kernel/hashlib.h`` that actually dereference the pointers and call ``hash_acc`` on the instances pointed to.
+
+``hash_ops<T>`` is also specialized for simple compound types like ``std::pair<U>`` by calling hash_acc in sequence on its members. For flexible size containers like ``std::vector<U>`` the size of the container is hashed first. That is also how implementing hashing for a custom record data type should be - unless there is strong reason to do otherwise, call ``h.acc(m)`` on the ``Hasher h`` you have received for each member in sequence and ``return h;``. If you do have a strong reason to do so, look at how ``hash_top_ops<RTLIL::SigBit>`` is implemented in ``kernel/rtlil.h``.
+
+Porting plugins from the legacy interface
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously, the interface to implement hashing on custom types was just ``unsigned int T::hash() const``. This meant hashes for members were computed independently and then ad-hoc combined with the hash function with some xorshift operations thrown in to mix bits together somewhat. A plugin can stay compatible with both versions prior and after the break by implementing the aforementioned current interface and redirecting the legacy one:
+
+``void Hasher::acc(const T& t)`` hashes ``t`` into its internal state by also redirecting to ``hash_ops<T>``
+
+.. code-block:: cpp
+    :caption: Example hash compatibility wrapper
+    :name: hash_plugin_compat
+    inline unsigned int T::hash() const {
+        Hasher h;
+        return (unsigned int)hash_acc(h).yield();
+    }

--- a/docs/source/yosys_internals/hashing.rst
+++ b/docs/source/yosys_internals/hashing.rst
@@ -98,13 +98,13 @@ Making a type hashable
 Let's first take a look at the external interface on a simplified level.
 Generally, to get the hash for ``T obj``, you would call the utility function
 ``run_hash<T>(const T& obj)``, corresponding to ``hash_top_ops<T>::hash(obj)``,
-the default implementation of which is ``hash_ops<T>::hash_eat(Hasher(), obj)``.
+the default implementation of which is ``hash_ops<T>::hash_into(Hasher(), obj)``.
 ``Hasher`` is the class actually implementing the hash function, hiding its
 initialized internal state, and passing it out on ``hash_t yield()`` with
 perhaps some finalization steps.
 
 ``hash_ops<T>`` is the star of the show. By default it pulls the ``Hasher h``
-through a ``Hasher T::hash_eat(Hasher h)`` method. That's the method you have to
+through a ``Hasher T::hash_into(Hasher h)`` method. That's the method you have to
 implement to make a record (class or struct) type easily hashable with Yosys
 hashlib associative data structures.
 
@@ -113,10 +113,10 @@ treats pointers the same as integers, so it doesn't dereference pointers. Since
 many RTLIL data structures like ``RTLIL::Wire`` carry their own unique index
 ``Hasher::hash_t hashidx_;``, there are specializations for ``hash_ops<Wire*>``
 and others in ``kernel/hashlib.h`` that actually dereference the pointers and
-call ``hash_eat`` on the instances pointed to.
+call ``hash_into`` on the instances pointed to.
 
 ``hash_ops<T>`` is also specialized for simple compound types like
-``std::pair<U>`` by calling hash_eat in sequence on its members. For flexible
+``std::pair<U>`` by calling hash_into in sequence on its members. For flexible
 size containers like ``std::vector<U>`` the size of the container is hashed
 first. That is also how implementing hashing for a custom record data type
 should be - unless there is strong reason to do otherwise, call ``h.eat(m)`` on
@@ -143,7 +143,7 @@ based on the existance and value of `YS_HASHING_VERSION`.
       return mkhash(a, b);
    }
    #elif YS_HASHING_VERSION == 1
-   Hasher T::hash_eat(Hasher h) const {
+   Hasher T::hash_into(Hasher h) const {
       h.eat(a);
       h.eat(b);
       return h;

--- a/docs/source/yosys_internals/hashing.rst
+++ b/docs/source/yosys_internals/hashing.rst
@@ -1,8 +1,8 @@
 Hashing and associative data structures in Yosys
 ------------------------------------------------
 
-Yosys heavily relies on custom data structures such as dict or pool
-defined in kernel/hashlib.h. There are various reasons for this.
+Yosys heavily relies on custom data structures such as dict or pool defined in
+kernel/hashlib.h. There are various reasons for this.
 
 The hash function
 ~~~~~~~~~~~~~~~~~
@@ -11,35 +11,85 @@ The hash function generally used in Yosys is the XOR version of DJB2:
 
 ``state = ((state << 5) + state) ^ value``
 
-This is an old-school hash designed to hash ASCII characters. Yosys doesn't hash a lot of ASCII text, but it still happens to be a local optimum due to factors described later.
+This is an old-school hash designed to hash ASCII characters. Yosys doesn't hash
+a lot of ASCII text, but it still happens to be a local optimum due to factors
+described later.
 
-Hash function quality is multi-faceted and highly dependent on what is being hashed. Yosys isn't concerned by any cryptographic qualities, instead the goal is minimizing total hashing collision risk given the data patterns within Yosys.
-In general, a good hash function typically folds values into a state accumulator with a mathematical function that is fast to compute and has some beneficial properties. One of these is the avalanche property, which demands that a small change such as flipping a bit or incrementing by one in the input produces a large, unpredictable change in the output. Additionally, the bit independence criterion states that any pair of output bits should change independently when any single input bit is inverted. These properties are important for avoiding hash collision on data patterns like the hash of a sequence not colliding with its permutation, not losing from the state the information added by hashing preceding elements, etc.
+Hash function quality is multi-faceted and highly dependent on what is being
+hashed. Yosys isn't concerned by any cryptographic qualities, instead the goal
+is minimizing total hashing collision risk given the data patterns within Yosys.
+In general, a good hash function typically folds values into a state accumulator
+with a mathematical function that is fast to compute and has some beneficial
+properties. One of these is the avalanche property, which demands that a small
+change such as flipping a bit or incrementing by one in the input produces a
+large, unpredictable change in the output. Additionally, the bit independence
+criterion states that any pair of output bits should change independently when
+any single input bit is inverted. These properties are important for avoiding
+hash collision on data patterns like the hash of a sequence not colliding with
+its permutation, not losing from the state the information added by hashing
+preceding elements, etc.
 
-DJB2 lacks these properties. Instead, since Yosys hashes large numbers of data structures composed of incrementing integer IDs, Yosys abuses the predictability of DJB2 to get lower hash collisions, with regular nature of the hashes surviving through the interaction with the "modulo prime" operations in the associative data structures. For example, some most common objects in Yosys are interned ``IdString``s of incrementing indices or ``SigBit``s with bit offsets into wire (represented by its unique ``IdString`` name) as the typical case. This is what makes DJB2 a local optimum. Additionally, the ADD version of DJB2 (like above but with addition instead of XOR) is used to this end for some types, abandoning the general pattern of folding values into a state value.
+DJB2 lacks these properties. Instead, since Yosys hashes large numbers of data
+structures composed of incrementing integer IDs, Yosys abuses the predictability
+of DJB2 to get lower hash collisions, with regular nature of the hashes
+surviving through the interaction with the "modulo prime" operations in the
+associative data structures. For example, some most common objects in Yosys are
+interned ``IdString``\ s of incrementing indices or ``SigBit``\ s with bit
+offsets into wire (represented by its unique ``IdString`` name) as the typical
+case. This is what makes DJB2 a local optimum. Additionally, the ADD version of
+DJB2 (like above but with addition instead of XOR) is used to this end for some
+types, abandoning the general pattern of folding values into a state value.
 
 Making a type hashable
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Let's first take a look at the external interface on a simplified level. Generally, to get the hash for ``T obj``, you would call the utility function ``run_hash<T>(const T& obj)``, corresponding to ``hash_top_ops<T>::hash(obj)``, the default implementation of which is ``hash_ops<T>::hash_acc(Hasher(), obj)``. ``Hasher`` is the class actually implementing the hash function, hiding its initialized internal state, and passing it out on ``hash_t yield()`` with perhaps some finalization steps.
+Let's first take a look at the external interface on a simplified level.
+Generally, to get the hash for ``T obj``, you would call the utility function
+``run_hash<T>(const T& obj)``, corresponding to ``hash_top_ops<T>::hash(obj)``,
+the default implementation of which is ``hash_ops<T>::hash_acc(Hasher(), obj)``.
+``Hasher`` is the class actually implementing the hash function, hiding its
+initialized internal state, and passing it out on ``hash_t yield()`` with
+perhaps some finalization steps.
 
-``hash_ops<T>`` is the star of the show. By default it pulls the ``Hasher h`` through a ``Hasher T::hash_acc(Hasher h)`` method. That's the method you have to implement to make a record (class or struct) type easily hashable with Yosys hashlib associative data structures.
+``hash_ops<T>`` is the star of the show. By default it pulls the ``Hasher h``
+through a ``Hasher T::hash_acc(Hasher h)`` method. That's the method you have to
+implement to make a record (class or struct) type easily hashable with Yosys
+hashlib associative data structures.
 
-``hash_ops<T>`` is specialized for built-in types like ``int`` or ``bool`` and treats pointers the same as integers, so it doesn't dereference pointers. Since many RTLIL data structures like ``RTLIL::Wire`` carry their own unique index ``Hasher::hash_t hashidx_;``, there are specializations for ``hash_ops<Wire*>`` and others in ``kernel/hashlib.h`` that actually dereference the pointers and call ``hash_acc`` on the instances pointed to.
+``hash_ops<T>`` is specialized for built-in types like ``int`` or ``bool`` and
+treats pointers the same as integers, so it doesn't dereference pointers. Since
+many RTLIL data structures like ``RTLIL::Wire`` carry their own unique index
+``Hasher::hash_t hashidx_;``, there are specializations for ``hash_ops<Wire*>``
+and others in ``kernel/hashlib.h`` that actually dereference the pointers and
+call ``hash_acc`` on the instances pointed to.
 
-``hash_ops<T>`` is also specialized for simple compound types like ``std::pair<U>`` by calling hash_acc in sequence on its members. For flexible size containers like ``std::vector<U>`` the size of the container is hashed first. That is also how implementing hashing for a custom record data type should be - unless there is strong reason to do otherwise, call ``h.acc(m)`` on the ``Hasher h`` you have received for each member in sequence and ``return h;``. If you do have a strong reason to do so, look at how ``hash_top_ops<RTLIL::SigBit>`` is implemented in ``kernel/rtlil.h``.
+``hash_ops<T>`` is also specialized for simple compound types like
+``std::pair<U>`` by calling hash_acc in sequence on its members. For flexible
+size containers like ``std::vector<U>`` the size of the container is hashed
+first. That is also how implementing hashing for a custom record data type
+should be - unless there is strong reason to do otherwise, call ``h.acc(m)`` on
+the ``Hasher h`` you have received for each member in sequence and ``return
+h;``. If you do have a strong reason to do so, look at how
+``hash_top_ops<RTLIL::SigBit>`` is implemented in ``kernel/rtlil.h``.
 
 Porting plugins from the legacy interface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Previously, the interface to implement hashing on custom types was just ``unsigned int T::hash() const``. This meant hashes for members were computed independently and then ad-hoc combined with the hash function with some xorshift operations thrown in to mix bits together somewhat. A plugin can stay compatible with both versions prior and after the break by implementing the aforementioned current interface and redirecting the legacy one:
+Previously, the interface to implement hashing on custom types was just
+``unsigned int T::hash() const``. This meant hashes for members were computed
+independently and then ad-hoc combined with the hash function with some xorshift
+operations thrown in to mix bits together somewhat. A plugin can stay compatible
+with both versions prior and after the break by implementing the aforementioned
+current interface and redirecting the legacy one:
 
-``void Hasher::acc(const T& t)`` hashes ``t`` into its internal state by also redirecting to ``hash_ops<T>``
+``void Hasher::acc(const T& t)`` hashes ``t`` into its internal state by also
+redirecting to ``hash_ops<T>``
 
 .. code-block:: cpp
-    :caption: Example hash compatibility wrapper
-    :name: hash_plugin_compat
-    inline unsigned int T::hash() const {
-        Hasher h;
-        return (unsigned int)hash_acc(h).yield();
-    }
+   :caption: Example hash compatibility wrapper
+   :name: hash_plugin_compat
+
+   inline unsigned int T::hash() const {
+       Hasher h;
+       return (unsigned int)hash_acc(h).yield();
+   }

--- a/docs/source/yosys_internals/hashing.rst
+++ b/docs/source/yosys_internals/hashing.rst
@@ -145,3 +145,9 @@ redirecting to ``hash_ops<T>``
        Hasher h;
        return (unsigned int)hash_acc(h).yield();
    }
+
+To get hashes for Yosys types, you can temporarily use the templated deprecated
+``mkhash`` function until the majority of your plugin's users switch to a newer
+version and live with the warnings, or set up a custom ``#ifdef``-based solution
+if you really need to.
+Feel free to contact Yosys maintainers with related issues.

--- a/docs/source/yosys_internals/index.rst
+++ b/docs/source/yosys_internals/index.rst
@@ -39,3 +39,4 @@ as reference to implement a similar system in any language.
    extending_yosys/index
    techmap
    verilog
+   hashing

--- a/examples/cxx-api/scopeinfo_example.cc
+++ b/examples/cxx-api/scopeinfo_example.cc
@@ -90,7 +90,7 @@ struct ScopeinfoExamplePass : public Pass {
 
 				// Shuffle wires so this example produces more interesting outputs
 				std::sort(wires.begin(), wires.end(), [](Wire *a, Wire *b) {
-					return mkhash_xorshift(a->name.hash() * 0x2c9277b5) < mkhash_xorshift(b->name.hash() * 0x2c9277b5);
+					return mkhash_xorshift(run_hash(a->name) * 0x2c9277b5) < mkhash_xorshift(run_hash(b->name) * 0x2c9277b5);
 				});
 
 				ModuleHdlnameIndex index(module);

--- a/flake.nix
+++ b/flake.nix
@@ -14,15 +14,15 @@
         };
         # TODO: don't override src when ./abc is empty
         # which happens when the command used is `nix build` and not `nix build ?submodules=1`
-        abc-verifier = pkgs.abc-verifier.overrideAttrs(x: y: {src = ./abc;});
+        abc-verifier = pkgs.abc-verifier;
         yosys = pkgs.clangStdenv.mkDerivation {
           name = "yosys";
           src = ./. ;
-          buildInputs = with pkgs; [ clang bison flex libffi tcl readline python3 llvmPackages.libcxxClang zlib git pkg-configUpstream llvmPackages.bintools ];
+          buildInputs = with pkgs; [ clang bison flex libffi tcl readline python3 zlib git pkg-configUpstream llvmPackages.bintools ];
           checkInputs = with pkgs; [ gtest ];
           propagatedBuildInputs = [ abc-verifier ];
           preConfigure = "make config-clang";
-          checkTarget = "test";
+          checkTarget = "unit-test";
           installPhase = ''
             make install PREFIX=$out ABCEXTERNAL=yosys-abc
             ln -s ${abc-verifier}/bin/abc $out/bin/yosys-abc
@@ -41,7 +41,7 @@
         packages.default = yosys;
         defaultPackage = yosys;
         devShell = pkgs.mkShell {
-          buildInputs = with pkgs; [ clang llvmPackages.bintools bison flex libffi tcl readline python3 llvmPackages.libcxxClang zlib git gtest abc-verifier ];
+          buildInputs = with pkgs; [ clang llvmPackages.bintools gcc bison flex libffi tcl readline python3 zlib git gtest abc-verifier verilog boost python3Packages.boost ];
         };
       }
     );

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -177,7 +177,7 @@ namespace AST
 	{
 		// for dict<> and pool<>
 		unsigned int hashidx_;
-		Hasher hash_acc(Hasher h) const { h.acc(hashidx_); return h; }
+		Hasher hash_eat(Hasher h) const { h.eat(hashidx_); return h; }
 
 		// this nodes type
 		AstNodeType type;

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -177,7 +177,7 @@ namespace AST
 	{
 		// for dict<> and pool<>
 		unsigned int hashidx_;
-		unsigned int hash() const { return hashidx_; }
+		Hasher hash_acc(Hasher h) const { h.acc(hashidx_); return h; }
 
 		// this nodes type
 		AstNodeType type;

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -177,7 +177,7 @@ namespace AST
 	{
 		// for dict<> and pool<>
 		unsigned int hashidx_;
-		Hasher hash_eat(Hasher h) const { h.eat(hashidx_); return h; }
+		Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
 
 		// this nodes type
 		AstNodeType type;

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -619,7 +619,7 @@ RTLIL::SigSpec VerificImporter::operatorInportCase(Instance *inst, const char *p
 	}
 }
 
-RTLIL::SigSpec VerificImporter::operatorOutput(Instance *inst, const pool<Net*, hash_ptr_ops> *any_all_nets)
+RTLIL::SigSpec VerificImporter::operatorOutput(Instance *inst, const pool<Net*> *any_all_nets)
 {
 	RTLIL::SigSpec sig;
 	RTLIL::Wire *dummy_wire = NULL;
@@ -1576,9 +1576,9 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 
 	module->fixup_ports();
 
-	dict<Net*, char, hash_ptr_ops> init_nets;
-	pool<Net*, hash_ptr_ops> anyconst_nets, anyseq_nets;
-	pool<Net*, hash_ptr_ops> allconst_nets, allseq_nets;
+	dict<Net*, char> init_nets;
+	pool<Net*> anyconst_nets, anyseq_nets;
+	pool<Net*> allconst_nets, allseq_nets;
 	any_all_nets.clear();
 
 	FOREACH_NET_OF_NETLIST(nl, mi, net)
@@ -1841,10 +1841,10 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 		module->connect(net_map_at(net), module->Anyseq(new_verific_id(net)));
 
 #ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
-	pool<Instance*, hash_ptr_ops> sva_asserts;
-	pool<Instance*, hash_ptr_ops> sva_assumes;
-	pool<Instance*, hash_ptr_ops> sva_covers;
-	pool<Instance*, hash_ptr_ops> sva_triggers;
+	pool<Instance*> sva_asserts;
+	pool<Instance*> sva_assumes;
+	pool<Instance*> sva_covers;
+	pool<Instance*> sva_triggers;
 #endif
 
 	pool<RTLIL::Cell*> past_ffs;

--- a/frontends/verific/verific.h
+++ b/frontends/verific/verific.h
@@ -71,7 +71,7 @@ struct VerificImporter
 
 	std::map<Verific::Net*, RTLIL::SigBit> net_map;
 	std::map<Verific::Net*, Verific::Net*> sva_posedge_map;
-	pool<Verific::Net*, hash_ptr_ops> any_all_nets;
+	pool<Verific::Net*> any_all_nets;
 
 	bool mode_gates, mode_keep, mode_nosva, mode_names, mode_verific;
 	bool mode_autocover, mode_fullinit;
@@ -89,7 +89,7 @@ struct VerificImporter
 	RTLIL::SigSpec operatorInput2(Verific::Instance *inst);
 	RTLIL::SigSpec operatorInport(Verific::Instance *inst, const char *portname);
 	RTLIL::SigSpec operatorInportCase(Verific::Instance *inst, const char *portname);
-	RTLIL::SigSpec operatorOutput(Verific::Instance *inst, const pool<Verific::Net*, hash_ptr_ops> *any_all_nets = nullptr);
+	RTLIL::SigSpec operatorOutput(Verific::Instance *inst, const pool<Verific::Net*> *any_all_nets = nullptr);
 
 	bool import_netlist_instance_gates(Verific::Instance *inst, RTLIL::IdString inst_name);
 	bool import_netlist_instance_cells(Verific::Instance *inst, RTLIL::IdString inst_name);

--- a/frontends/verific/verificsva.cc
+++ b/frontends/verific/verificsva.cc
@@ -1051,7 +1051,7 @@ struct VerificSvaImporter
 				msg.c_str(), inst->View()->Owner()->Name(), inst->Name()), inst->Linefile());
 	}
 
-	dict<Net*, bool, hash_ptr_ops> check_expression_cache;
+	dict<Net*, bool> check_expression_cache;
 
 	bool check_expression(Net *net, bool raise_error = false)
 	{

--- a/guidelines/GettingStarted
+++ b/guidelines/GettingStarted
@@ -37,57 +37,15 @@ And then executed using the following command:
 Yosys Data Structures
 ---------------------
 
-Here is a short list of data structures that you should make yourself familiar
-with before you write C++ code for Yosys. The following data structures are all
-defined when "kernel/yosys.h" is included and USING_YOSYS_NAMESPACE is used.
+  1. Container classes based on hashing
 
-  1. Yosys Container Classes
+Yosys heavily relies on custom container data structures such as dict or pool
+defined in kernel/hashlib.h.
+dict<K, T> is essentially a replacement for std::unordered_map<K, T>
+and pool<T> is a replacement for std::unordered_set<T>. Please refer to
+docs/source/yosys_internals/hashing.rst for more information on those.
 
-Yosys uses dict<K, T> and pool<T> as main container classes. dict<K, T> is
-essentially a replacement for std::unordered_map<K, T> and pool<T> is a
-replacement for std::unordered_set<T>. The main characteristics are:
-
-	- dict<K, T> and pool<T> are about 2x faster than the std containers
-
-	- references to elements in a dict<K, T> or pool<T> are invalidated by
-	  insert and remove operations (similar to std::vector<T> on push_back()).
-
-	- some iterators are invalidated by erase(). specifically, iterators
-	  that have not passed the erased element yet are invalidated. (erase()
-	  itself returns valid iterator to the next element.)
-
-	- no iterators are invalidated by insert(). elements are inserted at
-	  begin(). i.e. only a new iterator that starts at begin() will see the
-	  inserted elements.
-
-	- the method .count(key, iterator) is like .count(key) but only
-	  considers elements that can be reached via the iterator.
-
-	- iterators can be compared. it1 < it2 means that the position of t2
-	  can be reached via t1 but not vice versa.
-
-	- the method .sort() can be used to sort the elements in the container
-	  the container stays sorted until elements are added or removed.
-
-	- dict<K, T> and pool<T> will have the same order of iteration across
-	  all compilers, standard libraries and architectures.
-
-In addition to dict<K, T> and pool<T> there is also an idict<K> that
-creates a bijective map from K to the integers. For example:
-
-	idict<string, 42> si;
-	log("%d\n", si("hello"));      // will print 42
-	log("%d\n", si("world"));      // will print 43
-	log("%d\n", si.at("world"));   // will print 43
-	log("%d\n", si.at("dummy"));   // will throw exception
-	log("%s\n", si[42].c_str()));  // will print hello
-	log("%s\n", si[43].c_str()));  // will print world
-	log("%s\n", si[44].c_str()));  // will throw exception
-
-It is not possible to remove elements from an idict.
-
-Finally mfp<K> implements a merge-find set data structure (aka. disjoint-set or
-union-find) over the type K ("mfp" = merge-find-promote).
+Otherwise, Yosys makes use of the following:
 
   2. Standard STL data types
 

--- a/kernel/bitpattern.h
+++ b/kernel/bitpattern.h
@@ -30,7 +30,7 @@ struct BitPatternPool
 	int width;
 	struct bits_t {
 		std::vector<RTLIL::State> bitdata;
-		mutable unsigned int cached_hash;
+		mutable Hasher::hash_t cached_hash;
 		bits_t(int width = 0) : bitdata(width), cached_hash(0) { }
 		RTLIL::State &operator[](int index) {
 			return bitdata[index];
@@ -39,14 +39,15 @@ struct BitPatternPool
 			return bitdata[index];
 		}
 		bool operator==(const bits_t &other) const {
-			if (hash() != other.hash())
+			if (run_hash(*this) != run_hash(other))
 				return false;
 			return bitdata == other.bitdata;
 		}
-		unsigned int hash() const {
+		Hasher hash_acc(Hasher h) const {
 			if (!cached_hash)
-				cached_hash = hash_ops<std::vector<RTLIL::State>>::hash(bitdata);
-			return cached_hash;
+				cached_hash = run_hash(bitdata);
+			h.acc(cached_hash);
+			return h;
 		}
 	};
 	pool<bits_t> database;

--- a/kernel/bitpattern.h
+++ b/kernel/bitpattern.h
@@ -43,7 +43,7 @@ struct BitPatternPool
 				return false;
 			return bitdata == other.bitdata;
 		}
-		Hasher hash_eat(Hasher h) const {
+		Hasher hash_into(Hasher h) const {
 			if (!cached_hash)
 				cached_hash = run_hash(bitdata);
 			h.eat(cached_hash);

--- a/kernel/bitpattern.h
+++ b/kernel/bitpattern.h
@@ -43,10 +43,10 @@ struct BitPatternPool
 				return false;
 			return bitdata == other.bitdata;
 		}
-		Hasher hash_acc(Hasher h) const {
+		Hasher hash_eat(Hasher h) const {
 			if (!cached_hash)
 				cached_hash = run_hash(bitdata);
-			h.acc(cached_hash);
+			h.eat(cached_hash);
 			return h;
 		}
 	};

--- a/kernel/cellaigs.cc
+++ b/kernel/cellaigs.cc
@@ -39,7 +39,7 @@ bool AigNode::operator==(const AigNode &other) const
 	return true;
 }
 
-Hasher AigNode::hash_eat(Hasher h) const
+Hasher AigNode::hash_into(Hasher h) const
 {
 	h.eat(portname);
 	h.eat(portbit);
@@ -54,7 +54,7 @@ bool Aig::operator==(const Aig &other) const
 	return name == other.name;
 }
 
-Hasher Aig::hash_eat(Hasher h) const
+Hasher Aig::hash_into(Hasher h) const
 {
 	h.eat(name);
 	return h;

--- a/kernel/cellaigs.cc
+++ b/kernel/cellaigs.cc
@@ -39,13 +39,13 @@ bool AigNode::operator==(const AigNode &other) const
 	return true;
 }
 
-Hasher AigNode::hash_acc(Hasher h) const
+Hasher AigNode::hash_eat(Hasher h) const
 {
-	h.acc(portname);
-	h.acc(portbit);
-	h.acc(inverter);
-	h.acc(left_parent);
-	h.acc(right_parent);
+	h.eat(portname);
+	h.eat(portbit);
+	h.eat(inverter);
+	h.eat(left_parent);
+	h.eat(right_parent);
 	return h;
 }
 
@@ -54,9 +54,9 @@ bool Aig::operator==(const Aig &other) const
 	return name == other.name;
 }
 
-Hasher Aig::hash_acc(Hasher h) const
+Hasher Aig::hash_eat(Hasher h) const
 {
-	h.acc(name);
+	h.eat(name);
 	return h;
 }
 

--- a/kernel/cellaigs.cc
+++ b/kernel/cellaigs.cc
@@ -39,13 +39,13 @@ bool AigNode::operator==(const AigNode &other) const
 	return true;
 }
 
-unsigned int AigNode::hash() const
+Hasher AigNode::hash_acc(Hasher h) const
 {
-	unsigned int h = mkhash_init;
-	h = mkhash(portname.hash(), portbit);
-	h = mkhash(h, inverter);
-	h = mkhash(h, left_parent);
-	h = mkhash(h, right_parent);
+	h.acc(portname);
+	h.acc(portbit);
+	h.acc(inverter);
+	h.acc(left_parent);
+	h.acc(right_parent);
 	return h;
 }
 
@@ -54,9 +54,10 @@ bool Aig::operator==(const Aig &other) const
 	return name == other.name;
 }
 
-unsigned int Aig::hash() const
+Hasher Aig::hash_acc(Hasher h) const
 {
-	return hash_ops<std::string>::hash(name);
+	h.acc(name);
+	return h;
 }
 
 struct AigMaker

--- a/kernel/cellaigs.h
+++ b/kernel/cellaigs.h
@@ -34,7 +34,7 @@ struct AigNode
 
 	AigNode();
 	bool operator==(const AigNode &other) const;
-	Hasher hash_acc(Hasher h) const;
+	Hasher hash_eat(Hasher h) const;
 };
 
 struct Aig
@@ -44,7 +44,7 @@ struct Aig
 	Aig(Cell *cell);
 
 	bool operator==(const Aig &other) const;
-	Hasher hash_acc(Hasher h) const;
+	Hasher hash_eat(Hasher h) const;
 };
 
 YOSYS_NAMESPACE_END

--- a/kernel/cellaigs.h
+++ b/kernel/cellaigs.h
@@ -34,7 +34,7 @@ struct AigNode
 
 	AigNode();
 	bool operator==(const AigNode &other) const;
-	unsigned int hash() const;
+	Hasher hash_acc(Hasher h) const;
 };
 
 struct Aig
@@ -44,7 +44,7 @@ struct Aig
 	Aig(Cell *cell);
 
 	bool operator==(const Aig &other) const;
-	unsigned int hash() const;
+	Hasher hash_acc(Hasher h) const;
 };
 
 YOSYS_NAMESPACE_END

--- a/kernel/cellaigs.h
+++ b/kernel/cellaigs.h
@@ -34,7 +34,7 @@ struct AigNode
 
 	AigNode();
 	bool operator==(const AigNode &other) const;
-	Hasher hash_eat(Hasher h) const;
+	Hasher hash_into(Hasher h) const;
 };
 
 struct Aig
@@ -44,7 +44,7 @@ struct Aig
 	Aig(Cell *cell);
 
 	bool operator==(const Aig &other) const;
-	Hasher hash_eat(Hasher h) const;
+	Hasher hash_into(Hasher h) const;
 };
 
 YOSYS_NAMESPACE_END

--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -18,6 +18,7 @@
  */
 
 #include "kernel/yosys.h"
+#include "kernel/hashlib.h"
 #include "libs/sha1/sha1.h"
 #include "libs/cxxopts/include/cxxopts.hpp"
 #include <iostream>
@@ -282,6 +283,8 @@ int main(int argc, char **argv)
 		("M,randomize-pointers", "will slightly randomize allocated pointer addresses. for debugging")
 		("autoidx", "start counting autoidx up from <seed>, similar effect to --hash-seed",
 			cxxopts::value<uint64_t>(), "<idx>")
+		("hash-seed", "mix up hashing values with <seed>, for extreme optimization and testing",
+			cxxopts::value<uint64_t>(), "<seed>")
 		("A,abort", "will call abort() at the end of the script. for debugging")
 		("x,experimental", "do not print warnings for the experimental <feature>",
 			cxxopts::value<std::vector<std::string>>(), "<feature>")
@@ -436,6 +439,10 @@ int main(int argc, char **argv)
 		if (result.count("autoidx")) {
 			int idx = result["autoidx"].as<uint64_t>();
 			autoidx = idx;
+		}
+		if (result.count("hash-seed")) {
+			int seed = result["hash-seed"].as<uint64_t>();
+			Hasher::set_fudge((Hasher::hash_t)seed);
 		}
 
 		if (log_errfile == NULL) {

--- a/kernel/drivertools.h
+++ b/kernel/drivertools.h
@@ -863,39 +863,7 @@ public:
 	bool try_append(DriveBit const &bit);
 	bool try_append(DriveChunk const &chunk);
 
-<<<<<<< HEAD
-	unsigned int hash() const
-	{
-		unsigned int inner = 0;
-		switch (type_)
-		{
-			case DriveType::NONE:
-				inner = 0;
-				break;
-			case DriveType::CONSTANT:
-				inner = constant_.hash();
-				break;
-			case DriveType::WIRE:
-				inner = wire_.hash();
-				break;
-			case DriveType::PORT:
-				inner = port_.hash();
-				break;
-			case DriveType::MARKER:
-				inner = marker_.hash();
-				break;
-			case DriveType::MULTIPLE:
-				inner = multiple_.hash();
-				break;
-			default:
-				log_abort();
-				break;
-		}
-		return mkhash((unsigned int)type_, inner);
-	}
-=======
 	Hasher hash_acc(Hasher h) const;
->>>>>>> 898d04260 (hashlib: redo interface for flexibility)
 
 	bool operator==(const DriveChunk &other) const
 	{

--- a/kernel/drivertools.h
+++ b/kernel/drivertools.h
@@ -1067,10 +1067,11 @@ public:
 	DriveSpec &operator=(DriveBitMultiple const &bit) { return *this = DriveBit(bit); }
 
 	void updhash() const {
-		DriveSpec *that = (DriveSpec*)this;
+		if (hash_ != 0)
+			return;
 		pack();
-		that->hash_ = run_hash(chunks_);
-		that->hash_ |= (that->hash_ == 0);
+		hash_ = run_hash(chunks_);
+		hash_ |= (hash_ == 0);
 	}
 
 	Hasher hash_into(Hasher h) const;
@@ -1372,9 +1373,7 @@ inline Hasher DriveChunk::hash_into(Hasher h) const
 
 inline Hasher DriveSpec::hash_into(Hasher h) const
 {
-	if (hash_ == 0)
-		updhash();
-
+	updhash();
 	h.eat(hash_);
 	return h;
 }

--- a/kernel/drivertools.h
+++ b/kernel/drivertools.h
@@ -74,7 +74,7 @@ struct DriveBitWire
 		return offset < other.offset;
 	}
 
-	Hasher hash_acc(Hasher h) const;
+	Hasher hash_eat(Hasher h) const;
 
 
 	operator SigBit() const
@@ -105,7 +105,7 @@ struct DriveBitPort
 		return offset < other.offset;
 	}
 
-	Hasher hash_acc(Hasher h) const;
+	Hasher hash_eat(Hasher h) const;
 
 };
 
@@ -129,7 +129,7 @@ struct DriveBitMarker
 		return offset < other.offset;
 	}
 
-	Hasher hash_acc(Hasher h) const;
+	Hasher hash_eat(Hasher h) const;
 
 };
 
@@ -164,7 +164,7 @@ public:
 		return multiple_ == other.multiple_;
 	}
 
-	Hasher hash_acc(Hasher h) const;
+	Hasher hash_eat(Hasher h) const;
 };
 
 struct DriveBit
@@ -352,7 +352,7 @@ public:
 		return *this;
 	}
 
-	Hasher hash_acc(Hasher h) const;
+	Hasher hash_eat(Hasher h) const;
 
 	bool operator==(const DriveBit &other) const
 	{
@@ -473,7 +473,7 @@ struct DriveChunkWire
 		return offset < other.offset;
 	}
 
-	Hasher hash_acc(Hasher h) const;
+	Hasher hash_eat(Hasher h) const;
 
 	explicit operator SigChunk() const
 	{
@@ -531,7 +531,7 @@ struct DriveChunkPort
 		return offset < other.offset;
 	}
 
-	Hasher hash_acc(Hasher h) const;
+	Hasher hash_eat(Hasher h) const;
 };
 
 
@@ -572,7 +572,7 @@ struct DriveChunkMarker
 		return offset < other.offset;
 	}
 
-	Hasher hash_acc(Hasher h) const;
+	Hasher hash_eat(Hasher h) const;
 };
 
 struct DriveChunkMultiple
@@ -612,7 +612,7 @@ public:
 		return false; // TODO implement, canonicalize order
 	}
 
-	Hasher hash_acc(Hasher h) const;
+	Hasher hash_eat(Hasher h) const;
 };
 
 struct DriveChunk
@@ -863,7 +863,7 @@ public:
 	bool try_append(DriveBit const &bit);
 	bool try_append(DriveChunk const &chunk);
 
-	Hasher hash_acc(Hasher h) const;
+	Hasher hash_eat(Hasher h) const;
 
 	bool operator==(const DriveChunk &other) const
 	{
@@ -1073,7 +1073,7 @@ public:
 		that->hash_ |= (that->hash_ == 0);
 	}
 
-	Hasher hash_acc(Hasher h) const;
+	Hasher hash_eat(Hasher h) const;
 
 	bool operator==(DriveSpec const &other) const {
 		updhash();
@@ -1112,7 +1112,7 @@ private:
 		bool operator!=(const DriveBitId &other) const { return id != other.id; }
 		bool operator<(const DriveBitId &other) const { return id < other.id; }
 		// unsigned int hash() const { return id; }
-		Hasher hash_acc(Hasher h) const;
+		Hasher hash_eat(Hasher h) const;
 	};
 	// Essentially a dict<DriveBitId, pool<DriveBitId>> but using less memory
 	// and fewer allocations
@@ -1258,130 +1258,130 @@ private:
 	}
 };
 
-inline Hasher DriveBitWire::hash_acc(Hasher h) const
+inline Hasher DriveBitWire::hash_eat(Hasher h) const
 {
-	h.acc(wire->name);
-	h.acc(offset);
+	h.eat(wire->name);
+	h.eat(offset);
 	return h;
 }
 
-inline Hasher DriveBitPort::hash_acc(Hasher h) const
+inline Hasher DriveBitPort::hash_eat(Hasher h) const
 {
-	h.acc(cell->name);
-	h.acc(port);
-	h.acc(offset);
+	h.eat(cell->name);
+	h.eat(port);
+	h.eat(offset);
 	return h;
 }
 
-inline Hasher DriveBitMarker::hash_acc(Hasher h) const
+inline Hasher DriveBitMarker::hash_eat(Hasher h) const
 {
-	h.acc(marker);
-	h.acc(offset);
+	h.eat(marker);
+	h.eat(offset);
 	return h;
 }
 
-inline Hasher DriveBitMultiple::hash_acc(Hasher h) const
+inline Hasher DriveBitMultiple::hash_eat(Hasher h) const
 {
-	h.acc(multiple_);
+	h.eat(multiple_);
 	return h;
 }
 
-inline Hasher DriveBit::hash_acc(Hasher h) const
-{
-	switch (type_) {
-	case DriveType::NONE:
-		h.acc(0);
-		break;
-	case DriveType::CONSTANT:
-		h.acc(constant_);
-		break;
-	case DriveType::WIRE:
-		h.acc(wire_);
-		break;
-	case DriveType::PORT:
-		h.acc(port_);
-		break;
-	case DriveType::MARKER:
-		h.acc(marker_);
-		break;
-	case DriveType::MULTIPLE:
-		h.acc(multiple_);
-		break;
-	}
-	h.acc(type_);
-	return h;
-}
-
-inline Hasher DriveChunkWire::hash_acc(Hasher h) const
-{
-	h.acc(wire->name);
-	h.acc(width);
-	h.acc(offset);
-	return h;
-}
-
-inline Hasher DriveChunkPort::hash_acc(Hasher h) const
-{
-	h.acc(cell->name);
-	h.acc(port);
-	h.acc(width);
-	h.acc(offset);
-	return h;
-}
-
-inline Hasher DriveChunkMarker::hash_acc(Hasher h) const
-{
-	h.acc(marker);
-	h.acc(width);
-	h.acc(offset);
-	return h;
-}
-
-inline Hasher DriveChunkMultiple::hash_acc(Hasher h) const
-{
-	h.acc(width_);
-	h.acc(multiple_);
-	return h;
-}
-
-inline Hasher DriveChunk::hash_acc(Hasher h) const
+inline Hasher DriveBit::hash_eat(Hasher h) const
 {
 	switch (type_) {
 	case DriveType::NONE:
-		h.acc(0);
+		h.eat(0);
 		break;
 	case DriveType::CONSTANT:
-		h.acc(constant_);
+		h.eat(constant_);
 		break;
 	case DriveType::WIRE:
-		h.acc(wire_);
+		h.eat(wire_);
 		break;
 	case DriveType::PORT:
-		h.acc(port_);
+		h.eat(port_);
 		break;
 	case DriveType::MARKER:
-		h.acc(marker_);
+		h.eat(marker_);
 		break;
 	case DriveType::MULTIPLE:
-		h.acc(multiple_);
+		h.eat(multiple_);
 		break;
 	}
-	h.acc(type_);
+	h.eat(type_);
 	return h;
 }
 
-inline Hasher DriveSpec::hash_acc(Hasher h) const
+inline Hasher DriveChunkWire::hash_eat(Hasher h) const
+{
+	h.eat(wire->name);
+	h.eat(width);
+	h.eat(offset);
+	return h;
+}
+
+inline Hasher DriveChunkPort::hash_eat(Hasher h) const
+{
+	h.eat(cell->name);
+	h.eat(port);
+	h.eat(width);
+	h.eat(offset);
+	return h;
+}
+
+inline Hasher DriveChunkMarker::hash_eat(Hasher h) const
+{
+	h.eat(marker);
+	h.eat(width);
+	h.eat(offset);
+	return h;
+}
+
+inline Hasher DriveChunkMultiple::hash_eat(Hasher h) const
+{
+	h.eat(width_);
+	h.eat(multiple_);
+	return h;
+}
+
+inline Hasher DriveChunk::hash_eat(Hasher h) const
+{
+	switch (type_) {
+	case DriveType::NONE:
+		h.eat(0);
+		break;
+	case DriveType::CONSTANT:
+		h.eat(constant_);
+		break;
+	case DriveType::WIRE:
+		h.eat(wire_);
+		break;
+	case DriveType::PORT:
+		h.eat(port_);
+		break;
+	case DriveType::MARKER:
+		h.eat(marker_);
+		break;
+	case DriveType::MULTIPLE:
+		h.eat(multiple_);
+		break;
+	}
+	h.eat(type_);
+	return h;
+}
+
+inline Hasher DriveSpec::hash_eat(Hasher h) const
 {
 	if (hash_ == 0)
 		updhash();
 
-	h.acc(hash_);
+	h.eat(hash_);
 	return h;
 }
 
-inline Hasher DriverMap::DriveBitId::hash_acc(Hasher h) const
+inline Hasher DriverMap::DriveBitId::hash_eat(Hasher h) const
 {
-	h.acc(id);
+	h.eat(id);
 	return h;
 }
 

--- a/kernel/drivertools.h
+++ b/kernel/drivertools.h
@@ -1112,7 +1112,6 @@ private:
 		bool operator==(const DriveBitId &other) const { return id == other.id; }
 		bool operator!=(const DriveBitId &other) const { return id != other.id; }
 		bool operator<(const DriveBitId &other) const { return id < other.id; }
-		// unsigned int hash() const { return id; }
 		Hasher hash_into(Hasher h) const;
 	};
 	// Essentially a dict<DriveBitId, pool<DriveBitId>> but using less memory

--- a/kernel/drivertools.h
+++ b/kernel/drivertools.h
@@ -74,7 +74,7 @@ struct DriveBitWire
 		return offset < other.offset;
 	}
 
-	Hasher hash_eat(Hasher h) const;
+	Hasher hash_into(Hasher h) const;
 
 
 	operator SigBit() const
@@ -105,7 +105,7 @@ struct DriveBitPort
 		return offset < other.offset;
 	}
 
-	Hasher hash_eat(Hasher h) const;
+	Hasher hash_into(Hasher h) const;
 
 };
 
@@ -129,7 +129,7 @@ struct DriveBitMarker
 		return offset < other.offset;
 	}
 
-	Hasher hash_eat(Hasher h) const;
+	Hasher hash_into(Hasher h) const;
 
 };
 
@@ -164,7 +164,7 @@ public:
 		return multiple_ == other.multiple_;
 	}
 
-	Hasher hash_eat(Hasher h) const;
+	Hasher hash_into(Hasher h) const;
 };
 
 struct DriveBit
@@ -352,7 +352,7 @@ public:
 		return *this;
 	}
 
-	Hasher hash_eat(Hasher h) const;
+	Hasher hash_into(Hasher h) const;
 
 	bool operator==(const DriveBit &other) const
 	{
@@ -473,7 +473,7 @@ struct DriveChunkWire
 		return offset < other.offset;
 	}
 
-	Hasher hash_eat(Hasher h) const;
+	Hasher hash_into(Hasher h) const;
 
 	explicit operator SigChunk() const
 	{
@@ -531,7 +531,7 @@ struct DriveChunkPort
 		return offset < other.offset;
 	}
 
-	Hasher hash_eat(Hasher h) const;
+	Hasher hash_into(Hasher h) const;
 };
 
 
@@ -572,7 +572,7 @@ struct DriveChunkMarker
 		return offset < other.offset;
 	}
 
-	Hasher hash_eat(Hasher h) const;
+	Hasher hash_into(Hasher h) const;
 };
 
 struct DriveChunkMultiple
@@ -612,7 +612,7 @@ public:
 		return false; // TODO implement, canonicalize order
 	}
 
-	Hasher hash_eat(Hasher h) const;
+	Hasher hash_into(Hasher h) const;
 };
 
 struct DriveChunk
@@ -863,7 +863,7 @@ public:
 	bool try_append(DriveBit const &bit);
 	bool try_append(DriveChunk const &chunk);
 
-	Hasher hash_eat(Hasher h) const;
+	Hasher hash_into(Hasher h) const;
 
 	bool operator==(const DriveChunk &other) const
 	{
@@ -1073,7 +1073,7 @@ public:
 		that->hash_ |= (that->hash_ == 0);
 	}
 
-	Hasher hash_eat(Hasher h) const;
+	Hasher hash_into(Hasher h) const;
 
 	bool operator==(DriveSpec const &other) const {
 		updhash();
@@ -1112,7 +1112,7 @@ private:
 		bool operator!=(const DriveBitId &other) const { return id != other.id; }
 		bool operator<(const DriveBitId &other) const { return id < other.id; }
 		// unsigned int hash() const { return id; }
-		Hasher hash_eat(Hasher h) const;
+		Hasher hash_into(Hasher h) const;
 	};
 	// Essentially a dict<DriveBitId, pool<DriveBitId>> but using less memory
 	// and fewer allocations
@@ -1258,14 +1258,14 @@ private:
 	}
 };
 
-inline Hasher DriveBitWire::hash_eat(Hasher h) const
+inline Hasher DriveBitWire::hash_into(Hasher h) const
 {
 	h.eat(wire->name);
 	h.eat(offset);
 	return h;
 }
 
-inline Hasher DriveBitPort::hash_eat(Hasher h) const
+inline Hasher DriveBitPort::hash_into(Hasher h) const
 {
 	h.eat(cell->name);
 	h.eat(port);
@@ -1273,20 +1273,20 @@ inline Hasher DriveBitPort::hash_eat(Hasher h) const
 	return h;
 }
 
-inline Hasher DriveBitMarker::hash_eat(Hasher h) const
+inline Hasher DriveBitMarker::hash_into(Hasher h) const
 {
 	h.eat(marker);
 	h.eat(offset);
 	return h;
 }
 
-inline Hasher DriveBitMultiple::hash_eat(Hasher h) const
+inline Hasher DriveBitMultiple::hash_into(Hasher h) const
 {
 	h.eat(multiple_);
 	return h;
 }
 
-inline Hasher DriveBit::hash_eat(Hasher h) const
+inline Hasher DriveBit::hash_into(Hasher h) const
 {
 	switch (type_) {
 	case DriveType::NONE:
@@ -1312,7 +1312,7 @@ inline Hasher DriveBit::hash_eat(Hasher h) const
 	return h;
 }
 
-inline Hasher DriveChunkWire::hash_eat(Hasher h) const
+inline Hasher DriveChunkWire::hash_into(Hasher h) const
 {
 	h.eat(wire->name);
 	h.eat(width);
@@ -1320,7 +1320,7 @@ inline Hasher DriveChunkWire::hash_eat(Hasher h) const
 	return h;
 }
 
-inline Hasher DriveChunkPort::hash_eat(Hasher h) const
+inline Hasher DriveChunkPort::hash_into(Hasher h) const
 {
 	h.eat(cell->name);
 	h.eat(port);
@@ -1329,7 +1329,7 @@ inline Hasher DriveChunkPort::hash_eat(Hasher h) const
 	return h;
 }
 
-inline Hasher DriveChunkMarker::hash_eat(Hasher h) const
+inline Hasher DriveChunkMarker::hash_into(Hasher h) const
 {
 	h.eat(marker);
 	h.eat(width);
@@ -1337,14 +1337,14 @@ inline Hasher DriveChunkMarker::hash_eat(Hasher h) const
 	return h;
 }
 
-inline Hasher DriveChunkMultiple::hash_eat(Hasher h) const
+inline Hasher DriveChunkMultiple::hash_into(Hasher h) const
 {
 	h.eat(width_);
 	h.eat(multiple_);
 	return h;
 }
 
-inline Hasher DriveChunk::hash_eat(Hasher h) const
+inline Hasher DriveChunk::hash_into(Hasher h) const
 {
 	switch (type_) {
 	case DriveType::NONE:
@@ -1370,7 +1370,7 @@ inline Hasher DriveChunk::hash_eat(Hasher h) const
 	return h;
 }
 
-inline Hasher DriveSpec::hash_eat(Hasher h) const
+inline Hasher DriveSpec::hash_into(Hasher h) const
 {
 	if (hash_ == 0)
 		updhash();
@@ -1379,7 +1379,7 @@ inline Hasher DriveSpec::hash_eat(Hasher h) const
 	return h;
 }
 
-inline Hasher DriverMap::DriveBitId::hash_eat(Hasher h) const
+inline Hasher DriverMap::DriveBitId::hash_into(Hasher h) const
 {
 	h.eat(id);
 	return h;

--- a/kernel/drivertools.h
+++ b/kernel/drivertools.h
@@ -74,10 +74,8 @@ struct DriveBitWire
 		return offset < other.offset;
 	}
 
-	unsigned int hash() const
-	{
-		return mkhash_add(wire->name.hash(), offset);
-	}
+	Hasher hash_acc(Hasher h) const;
+
 
 	operator SigBit() const
 	{
@@ -107,10 +105,8 @@ struct DriveBitPort
 		return offset < other.offset;
 	}
 
-	unsigned int hash() const
-	{
-		return mkhash_add(mkhash(cell->name.hash(), port.hash()), offset);
-	}
+	Hasher hash_acc(Hasher h) const;
+
 };
 
 
@@ -133,10 +129,7 @@ struct DriveBitMarker
 		return offset < other.offset;
 	}
 
-	unsigned int hash() const
-	{
-		return mkhash_add(marker, offset);
-	}
+	Hasher hash_acc(Hasher h) const;
 
 };
 
@@ -171,10 +164,7 @@ public:
 		return multiple_ == other.multiple_;
 	}
 
-	unsigned int hash() const
-	{
-	   return multiple_.hash();
-	}
+	Hasher hash_acc(Hasher h) const;
 };
 
 struct DriveBit
@@ -362,35 +352,7 @@ public:
 		return *this;
 	}
 
-	unsigned int hash() const
-	{
-		unsigned int inner = 0;
-		switch (type_)
-		{
-			case DriveType::NONE:
-				inner = 0;
-				break;
-			case DriveType::CONSTANT:
-				inner = constant_;
-				break;
-			case DriveType::WIRE:
-				inner = wire_.hash();
-				break;
-			case DriveType::PORT:
-				inner = port_.hash();
-				break;
-			case DriveType::MARKER:
-				inner = marker_.hash();
-				break;
-			case DriveType::MULTIPLE:
-				inner = multiple_.hash();
-				break;
-			default:
-				log_abort();
-				break;
-		}
-		return mkhash((unsigned int)type_, inner);
-	}
+	Hasher hash_acc(Hasher h) const;
 
 	bool operator==(const DriveBit &other) const
 	{
@@ -511,10 +473,7 @@ struct DriveChunkWire
 		return offset < other.offset;
 	}
 
-	unsigned int hash() const
-	{
-		return mkhash_add(mkhash(wire->name.hash(), width), offset);
-	}
+	Hasher hash_acc(Hasher h) const;
 
 	explicit operator SigChunk() const
 	{
@@ -572,10 +531,7 @@ struct DriveChunkPort
 		return offset < other.offset;
 	}
 
-	unsigned int hash() const
-	{
-		return mkhash_add(mkhash(mkhash(cell->name.hash(), port.hash()), width), offset);
-	}
+	Hasher hash_acc(Hasher h) const;
 };
 
 
@@ -616,10 +572,7 @@ struct DriveChunkMarker
 		return offset < other.offset;
 	}
 
-	unsigned int hash() const
-	{
-		return mkhash_add(mkhash(marker, width), offset);
-	}
+	Hasher hash_acc(Hasher h) const;
 };
 
 struct DriveChunkMultiple
@@ -659,10 +612,7 @@ public:
 		return false; // TODO implement, canonicalize order
 	}
 
-	unsigned int hash() const
-	{
-	   return mkhash(width_, multiple_.hash());
-	}
+	Hasher hash_acc(Hasher h) const;
 };
 
 struct DriveChunk
@@ -913,6 +863,7 @@ public:
 	bool try_append(DriveBit const &bit);
 	bool try_append(DriveChunk const &chunk);
 
+<<<<<<< HEAD
 	unsigned int hash() const
 	{
 		unsigned int inner = 0;
@@ -942,6 +893,9 @@ public:
 		}
 		return mkhash((unsigned int)type_, inner);
 	}
+=======
+	Hasher hash_acc(Hasher h) const;
+>>>>>>> 898d04260 (hashlib: redo interface for flexibility)
 
 	bool operator==(const DriveChunk &other) const
 	{
@@ -1144,17 +1098,19 @@ public:
 	DriveSpec &operator=(DriveBitMarker const &bit) { return *this = DriveBit(bit); }
 	DriveSpec &operator=(DriveBitMultiple const &bit) { return *this = DriveBit(bit); }
 
-	unsigned int hash() const {
-		if (hash_ != 0) return hash_;
-
+	void updhash() const {
+		DriveSpec *that = (DriveSpec*)this;
 		pack();
-		hash_ = hash_ops<std::vector<DriveChunk>>().hash(chunks_);
-		hash_ |= (hash_ == 0);
-		return hash_;
+		that->hash_ = run_hash(chunks_);
+		that->hash_ |= (that->hash_ == 0);
 	}
 
+	Hasher hash_acc(Hasher h) const;
+
 	bool operator==(DriveSpec const &other) const {
-		if (size() != other.size() || hash() != other.hash())
+		updhash();
+		other.updhash();
+		if (size() != other.size() || hash_ != other.hash_)
 			return false;
 		return chunks() == other.chunks();
 	}
@@ -1187,7 +1143,8 @@ private:
 		bool operator==(const DriveBitId &other) const { return id == other.id; }
 		bool operator!=(const DriveBitId &other) const { return id != other.id; }
 		bool operator<(const DriveBitId &other) const { return id < other.id; }
-		unsigned int hash() const { return id; }
+		// unsigned int hash() const { return id; }
+		Hasher hash_acc(Hasher h) const;
 	};
 	// Essentially a dict<DriveBitId, pool<DriveBitId>> but using less memory
 	// and fewer allocations
@@ -1332,6 +1289,133 @@ private:
 		return wire->has_attribute(ID(keep));
 	}
 };
+
+inline Hasher DriveBitWire::hash_acc(Hasher h) const
+{
+	h.acc(wire->name);
+	h.acc(offset);
+	return h;
+}
+
+inline Hasher DriveBitPort::hash_acc(Hasher h) const
+{
+	h.acc(cell->name);
+	h.acc(port);
+	h.acc(offset);
+	return h;
+}
+
+inline Hasher DriveBitMarker::hash_acc(Hasher h) const
+{
+	h.acc(marker);
+	h.acc(offset);
+	return h;
+}
+
+inline Hasher DriveBitMultiple::hash_acc(Hasher h) const
+{
+	h.acc(multiple_);
+	return h;
+}
+
+inline Hasher DriveBit::hash_acc(Hasher h) const
+{
+	switch (type_) {
+	case DriveType::NONE:
+		h.acc(0);
+		break;
+	case DriveType::CONSTANT:
+		h.acc(constant_);
+		break;
+	case DriveType::WIRE:
+		h.acc(wire_);
+		break;
+	case DriveType::PORT:
+		h.acc(port_);
+		break;
+	case DriveType::MARKER:
+		h.acc(marker_);
+		break;
+	case DriveType::MULTIPLE:
+		h.acc(multiple_);
+		break;
+	}
+	h.acc(type_);
+	return h;
+}
+
+inline Hasher DriveChunkWire::hash_acc(Hasher h) const
+{
+	h.acc(wire->name);
+	h.acc(width);
+	h.acc(offset);
+	return h;
+}
+
+inline Hasher DriveChunkPort::hash_acc(Hasher h) const
+{
+	h.acc(cell->name);
+	h.acc(port);
+	h.acc(width);
+	h.acc(offset);
+	return h;
+}
+
+inline Hasher DriveChunkMarker::hash_acc(Hasher h) const
+{
+	h.acc(marker);
+	h.acc(width);
+	h.acc(offset);
+	return h;
+}
+
+inline Hasher DriveChunkMultiple::hash_acc(Hasher h) const
+{
+	h.acc(width_);
+	h.acc(multiple_);
+	return h;
+}
+
+inline Hasher DriveChunk::hash_acc(Hasher h) const
+{
+	switch (type_) {
+	case DriveType::NONE:
+		h.acc(0);
+		break;
+	case DriveType::CONSTANT:
+		h.acc(constant_);
+		break;
+	case DriveType::WIRE:
+		h.acc(wire_);
+		break;
+	case DriveType::PORT:
+		h.acc(port_);
+		break;
+	case DriveType::MARKER:
+		h.acc(marker_);
+		break;
+	case DriveType::MULTIPLE:
+		h.acc(multiple_);
+		break;
+	}
+	h.acc(type_);
+	return h;
+}
+
+inline Hasher DriveSpec::hash_acc(Hasher h) const
+{
+	if (hash_ == 0)
+		updhash();
+
+	h.acc(hash_);
+	return h;
+}
+
+inline Hasher DriverMap::DriveBitId::hash_acc(Hasher h) const
+{
+	h.acc(id);
+	return h;
+}
 
 YOSYS_NAMESPACE_END
 

--- a/kernel/functional.h
+++ b/kernel/functional.h
@@ -151,7 +151,7 @@ namespace Functional {
 		// returns the data width of a bitvector sort, errors out for other sorts
 		int data_width() const { return std::get<1>(_v).second; }
 		bool operator==(Sort const& other) const { return _v == other._v; }
-		Hasher hash_acc(Hasher h) const { h.acc(_v); return h; }
+		Hasher hash_eat(Hasher h) const { h.eat(_v); return h; }
 	};
 	class IR;
 	class Factory;
@@ -225,9 +225,9 @@ namespace Functional {
 			const RTLIL::Const &as_const() const { return std::get<RTLIL::Const>(_extra); }
 			std::pair<IdString, IdString> as_idstring_pair() const { return std::get<std::pair<IdString, IdString>>(_extra); }
 			int as_int() const { return std::get<int>(_extra); }
-			Hasher hash_acc(Hasher h) const {
-				h.acc((unsigned int) _fn);
-				h.acc(_extra);
+			Hasher hash_eat(Hasher h) const {
+				h.eat((unsigned int) _fn);
+				h.eat(_extra);
 				return h;
 			}
 			bool operator==(NodeData const &other) const {

--- a/kernel/functional.h
+++ b/kernel/functional.h
@@ -151,7 +151,7 @@ namespace Functional {
 		// returns the data width of a bitvector sort, errors out for other sorts
 		int data_width() const { return std::get<1>(_v).second; }
 		bool operator==(Sort const& other) const { return _v == other._v; }
-		unsigned int hash() const { return mkhash(_v); }
+		Hasher hash_acc(Hasher h) const { h.acc(_v); return h; }
 	};
 	class IR;
 	class Factory;
@@ -225,8 +225,10 @@ namespace Functional {
 			const RTLIL::Const &as_const() const { return std::get<RTLIL::Const>(_extra); }
 			std::pair<IdString, IdString> as_idstring_pair() const { return std::get<std::pair<IdString, IdString>>(_extra); }
 			int as_int() const { return std::get<int>(_extra); }
-			int hash() const {
-				return mkhash((unsigned int) _fn, mkhash(_extra));
+			Hasher hash_acc(Hasher h) const {
+				h.acc((unsigned int) _fn);
+				h.acc(_extra);
+				return h;
 			}
 			bool operator==(NodeData const &other) const {
 				return _fn == other._fn && _extra == other._extra;

--- a/kernel/functional.h
+++ b/kernel/functional.h
@@ -151,7 +151,7 @@ namespace Functional {
 		// returns the data width of a bitvector sort, errors out for other sorts
 		int data_width() const { return std::get<1>(_v).second; }
 		bool operator==(Sort const& other) const { return _v == other._v; }
-		Hasher hash_eat(Hasher h) const { h.eat(_v); return h; }
+		Hasher hash_into(Hasher h) const { h.eat(_v); return h; }
 	};
 	class IR;
 	class Factory;
@@ -225,7 +225,7 @@ namespace Functional {
 			const RTLIL::Const &as_const() const { return std::get<RTLIL::Const>(_extra); }
 			std::pair<IdString, IdString> as_idstring_pair() const { return std::get<std::pair<IdString, IdString>>(_extra); }
 			int as_int() const { return std::get<int>(_extra); }
-			Hasher hash_eat(Hasher h) const {
+			Hasher hash_into(Hasher h) const {
 				h.eat((unsigned int) _fn);
 				h.eat(_extra);
 				return h;

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -81,13 +81,20 @@ class Hasher {
 		// traditionally 5381 is used as starting value for the djb2 hash
 		state = 5381;
 	}
+	static void set_fudge(uint32_t f) {
+		fudge = f;
+	}
 
 	private:
 	uint32_t state;
+	static uint32_t fudge;
 	// The XOR version of DJB2
 	[[nodiscard]]
 	static uint32_t mkhash(uint32_t a, uint32_t b) {
-		return ((a << 5) + a) ^ b;
+		uint32_t hash = ((a << 5) + a) ^ b;
+		if (fudge)
+			hash = fudge ^ mkhash_xorshift(hash);
+		return hash;
 	}
 	public:
 	void hash32(uint32_t i) {

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -34,6 +34,8 @@ namespace hashlib {
  * Hashlib doesn't know how to hash silly Yosys-specific types.
  * Hashlib doesn't depend on Yosys and can be used standalone.
  * Please don't use hashlib standalone for new projects.
+ * Never directly include kernel/hashlib.h in Yosys code.
+ * Instead include kernel/yosys_common.h
  *
  * The hash_ops type is now always left to its default value, derived
  * from templated functions through SFINAE. Providing custom ops is

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -54,7 +54,7 @@ const int hashtable_size_trigger = 2;
 const int hashtable_size_factor = 3;
 
 namespace legacy {
-	inline uint32_t mkhash_add(uint32_t a, uint32_t b) {
+	inline uint32_t djb2_add(uint32_t a, uint32_t b) {
 		return ((a << 5) + a) + b;
 	}
 };

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -99,8 +99,7 @@ class Hasher {
 	[[nodiscard]]
 	static uint32_t mkhash(uint32_t a, uint32_t b) {
 		uint32_t hash = ((a << 5) + a) ^ b;
-		if (fudge)
-			hash = fudge ^ mkhash_xorshift(hash);
+		hash = mkhash_xorshift(fudge ^ hash);
 		return hash;
 	}
 	public:

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -111,7 +111,12 @@ class Hasher {
 	}
 
 	template<typename T>
-	void acc(T t) {
+	void acc(T&& t) {
+		*this = hash_ops<std::remove_cv_t<std::remove_reference_t<T>>>::hash_acc(std::forward<T>(t), *this);
+	}
+
+	template<typename T>
+	void acc(const T& t) {
 		*this = hash_ops<T>::hash_acc(t, *this);
 	}
 

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -132,6 +132,13 @@ class Hasher {
 		state ^= t;
 	}
 
+	void force(hash_t new_state) {
+		state = new_state;
+	}
+
+	bool is_new() const {
+		return state == Hasher().state;
+	}
 };
 
 template<typename T>

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -103,19 +103,19 @@ private:
 	static uint32_t fudge;
 	// The XOR version of DJB2
 	[[nodiscard]]
-	static uint32_t mkhash(uint32_t a, uint32_t b) {
+	static uint32_t djb2_xor(uint32_t a, uint32_t b) {
 		uint32_t hash = ((a << 5) + a) ^ b;
 		return hash;
 	}
 	public:
 	void hash32(uint32_t i) {
-		state = mkhash(i, state);
+		state = djb2_xor(i, state);
 		state = mkhash_xorshift(fudge ^ state);
 		return;
 	}
 	void hash64(uint64_t i) {
-		state = mkhash((uint32_t)(i % (1ULL << 32ULL)), state);
-		state = mkhash((uint32_t)(i >> 32ULL), state);
+		state = djb2_xor((uint32_t)(i % (1ULL << 32ULL)), state);
+		state = djb2_xor((uint32_t)(i >> 32ULL), state);
 		state = mkhash_xorshift(fudge ^ state);
 		return;
 	}
@@ -281,6 +281,14 @@ template<typename T>
 [[nodiscard]]
 Hasher::hash_t run_hash(const T& obj) {
 	return hash_top_ops<T>::hash(obj).yield();
+}
+
+/** Refer to docs/source/yosys_internals/hashing.rst */
+template<typename T>
+[[nodiscard]]
+[[deprecated]]
+inline unsigned int mkhash(const T &v) {
+	return (unsigned int) run_hash<T>(v);
 }
 
 template<> struct hash_ops<std::monostate> {

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -20,6 +20,8 @@
 #include <type_traits>
 #include <stdint.h>
 
+#define YS_HASHING_VERSION 1
+
 namespace hashlib {
 
 /**

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -278,17 +278,8 @@ struct hash_obj_ops {
 template<typename T>
 [[nodiscard]]
 Hasher::hash_t run_hash(const T& obj) {
-	Hasher h;
-	h.acc(obj);
-	return h.yield();
+	return hash_top_ops<T>::hash(obj).yield();
 }
-
-// #ifdef OTHER_HASH...
-
-// [[deprecated]]
-// inline unsigned int mkhash_add(unsigned int a, unsigned int b) {
-// 	return mkhash(a, b);
-// }
 
 template<> struct hash_ops<std::monostate> {
 	static inline bool cmp(std::monostate a, std::monostate b) {

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -264,7 +264,11 @@ struct hash_obj_ops {
 	}
 	template<typename T>
 	static inline Hasher hash_into(const T *a, Hasher h) {
-		return a ? a->hash_into(h) : h;
+		if (a)
+			a->hash_into(h);
+		else
+			h.eat(0);
+		return h;
 	}
 };
 /**
@@ -785,13 +789,13 @@ public:
 	}
 
 	Hasher hash_into(Hasher h) const {
-		h.eat(entries.size());
 		for (auto &it : entries) {
 			Hasher entry_hash;
 			entry_hash.eat(it.udata.first);
 			entry_hash.eat(it.udata.second);
 			h.commutative_eat(entry_hash.yield());
 		}
+		h.eat(entries.size());
 		return h;
 	}
 
@@ -1155,10 +1159,10 @@ public:
 	}
 
 	Hasher hash_into(Hasher h) const {
-		h.eat(entries.size());
 		for (auto &it : entries) {
 			h.commutative_eat(ops.hash(it.udata).yield());
 		}
+		h.eat(entries.size());
 		return h;
 	}
 

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -48,13 +48,8 @@ namespace hashlib {
  * instead of pointers.
  */
 
-// TODO describe how comparison hashes are special
-// TODO draw the line between generic and hash function specific code
-
 const int hashtable_size_trigger = 2;
 const int hashtable_size_factor = 3;
-
-#define DJB2_32
 
 namespace legacy {
 	inline uint32_t mkhash_add(uint32_t a, uint32_t b) {
@@ -89,16 +84,11 @@ inline unsigned int mkhash_xorshift(unsigned int a) {
 	return a;
 }
 
-class Hasher {
-	public:
-	#ifdef DJB2_32
+class HasherDJB32 {
+public:
 	using hash_t = uint32_t;
-	#endif
-	#ifdef DJB2_64
-	using hash_t = uint64_t;
-	#endif
 
-	Hasher() {
+	HasherDJB32() {
 		// traditionally 5381 is used as starting value for the djb2 hash
 		state = 5381;
 	}
@@ -106,7 +96,7 @@ class Hasher {
 		fudge = f;
 	}
 
-	private:
+private:
 	uint32_t state;
 	static uint32_t fudge;
 	// The XOR version of DJB2
@@ -142,18 +132,16 @@ class Hasher {
 		*this = hash_ops<T>::hash_acc(t, *this);
 	}
 
-	void commutative_acc(uint32_t t) {
+	void commutative_acc(hash_t t) {
 		state ^= t;
 	}
 
 	void force(hash_t new_state) {
 		state = new_state;
 	}
-
-	bool is_new() const {
-		return state == Hasher().state;
-	}
 };
+
+using Hasher = HasherDJB32;
 
 template<typename T>
 struct hash_top_ops {

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -25,6 +25,8 @@ namespace hashlib {
 /**
  * HASHING
  *
+ * Also refer to docs/source/yosys_internals/hashing.rst
+ *
  * The Hasher knows how to hash 32 and 64-bit integers. That's it.
  * In the future, it could be expanded to do vectors with SIMD.
  *

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -99,17 +99,18 @@ class Hasher {
 	[[nodiscard]]
 	static uint32_t mkhash(uint32_t a, uint32_t b) {
 		uint32_t hash = ((a << 5) + a) ^ b;
-		hash = mkhash_xorshift(fudge ^ hash);
 		return hash;
 	}
 	public:
 	void hash32(uint32_t i) {
 		state = mkhash(i, state);
+		state = mkhash_xorshift(fudge ^ state);
 		return;
 	}
 	void hash64(uint64_t i) {
 		state = mkhash((uint32_t)(i % (1ULL << 32ULL)), state);
 		state = mkhash((uint32_t)(i >> 32ULL), state);
+		state = mkhash_xorshift(fudge ^ state);
 		return;
 	}
 	[[nodiscard]]

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -363,13 +363,13 @@ void log_dump_val_worker(RTLIL::IdString v);
 void log_dump_val_worker(RTLIL::SigSpec v);
 void log_dump_val_worker(RTLIL::State v);
 
-template<typename K, typename T, typename OPS> static inline void log_dump_val_worker(dict<K, T, OPS> &v);
-template<typename K, typename OPS> static inline void log_dump_val_worker(pool<K, OPS> &v);
+template<typename K, typename T> static inline void log_dump_val_worker(dict<K, T> &v);
+template<typename K> static inline void log_dump_val_worker(pool<K> &v);
 template<typename K> static inline void log_dump_val_worker(std::vector<K> &v);
 template<typename T> static inline void log_dump_val_worker(T *ptr);
 
-template<typename K, typename T, typename OPS>
-static inline void log_dump_val_worker(dict<K, T, OPS> &v) {
+template<typename K, typename T>
+static inline void log_dump_val_worker(dict<K, T> &v) {
 	log("{");
 	bool first = true;
 	for (auto &it : v) {
@@ -382,8 +382,8 @@ static inline void log_dump_val_worker(dict<K, T, OPS> &v) {
 	log(" }");
 }
 
-template<typename K, typename OPS>
-static inline void log_dump_val_worker(pool<K, OPS> &v) {
+template<typename K>
+static inline void log_dump_val_worker(pool<K> &v) {
 	log("{");
 	bool first = true;
 	for (auto &it : v) {

--- a/kernel/modtools.h
+++ b/kernel/modtools.h
@@ -48,8 +48,11 @@ struct ModIndex : public RTLIL::Monitor
 			return cell == other.cell && port == other.port && offset == other.offset;
 		}
 
-		unsigned int hash() const {
-			return mkhash_add(mkhash(cell->name.hash(), port.hash()), offset);
+		Hasher hash_acc(Hasher h) const {
+			h.acc(cell->name);
+			h.acc(port);
+			h.acc(offset);
+			return h;
 		}
 	};
 
@@ -57,6 +60,8 @@ struct ModIndex : public RTLIL::Monitor
 	{
 		bool is_input, is_output;
 		pool<PortInfo> ports;
+		// SigBitInfo() : SigBitInfo{} {}
+		// SigBitInfo& operator=(const SigBitInfo&) = default;
 
 		SigBitInfo() : is_input(false), is_output(false) { }
 
@@ -304,6 +309,8 @@ struct ModWalker
 		RTLIL::Cell *cell;
 		RTLIL::IdString port;
 		int offset;
+		PortBit(Cell* c, IdString p, int o) : cell(c), port(p), offset(o) {}
+		// PortBit& operator=(const PortBit&) = default;
 
 		bool operator<(const PortBit &other) const {
 			if (cell != other.cell)
@@ -317,8 +324,11 @@ struct ModWalker
 			return cell == other.cell && port == other.port && offset == other.offset;
 		}
 
-		unsigned int hash() const {
-			return mkhash_add(mkhash(cell->name.hash(), port.hash()), offset);
+		Hasher hash_acc(Hasher h) const {
+			h.acc(cell->name);
+			h.acc(port);
+			h.acc(offset);
+			return h;
 		}
 	};
 
@@ -355,7 +365,7 @@ struct ModWalker
 	{
 		for (int i = 0; i < int(bits.size()); i++)
 			if (bits[i].wire != NULL) {
-				PortBit pbit = { cell, port, i };
+				PortBit pbit {cell, port, i};
 				if (is_output) {
 					signal_drivers[bits[i]].insert(pbit);
 					cell_outputs[cell].insert(bits[i]);

--- a/kernel/modtools.h
+++ b/kernel/modtools.h
@@ -48,10 +48,10 @@ struct ModIndex : public RTLIL::Monitor
 			return cell == other.cell && port == other.port && offset == other.offset;
 		}
 
-		Hasher hash_acc(Hasher h) const {
-			h.acc(cell->name);
-			h.acc(port);
-			h.acc(offset);
+		Hasher hash_eat(Hasher h) const {
+			h.eat(cell->name);
+			h.eat(port);
+			h.eat(offset);
 			return h;
 		}
 	};
@@ -324,10 +324,10 @@ struct ModWalker
 			return cell == other.cell && port == other.port && offset == other.offset;
 		}
 
-		Hasher hash_acc(Hasher h) const {
-			h.acc(cell->name);
-			h.acc(port);
-			h.acc(offset);
+		Hasher hash_eat(Hasher h) const {
+			h.eat(cell->name);
+			h.eat(port);
+			h.eat(offset);
 			return h;
 		}
 	};

--- a/kernel/modtools.h
+++ b/kernel/modtools.h
@@ -60,8 +60,6 @@ struct ModIndex : public RTLIL::Monitor
 	{
 		bool is_input, is_output;
 		pool<PortInfo> ports;
-		// SigBitInfo() : SigBitInfo{} {}
-		// SigBitInfo& operator=(const SigBitInfo&) = default;
 
 		SigBitInfo() : is_input(false), is_output(false) { }
 
@@ -310,7 +308,6 @@ struct ModWalker
 		RTLIL::IdString port;
 		int offset;
 		PortBit(Cell* c, IdString p, int o) : cell(c), port(p), offset(o) {}
-		// PortBit& operator=(const PortBit&) = default;
 
 		bool operator<(const PortBit &other) const {
 			if (cell != other.cell)

--- a/kernel/modtools.h
+++ b/kernel/modtools.h
@@ -48,7 +48,7 @@ struct ModIndex : public RTLIL::Monitor
 			return cell == other.cell && port == other.port && offset == other.offset;
 		}
 
-		Hasher hash_eat(Hasher h) const {
+		Hasher hash_into(Hasher h) const {
 			h.eat(cell->name);
 			h.eat(port);
 			h.eat(offset);
@@ -324,7 +324,7 @@ struct ModWalker
 			return cell == other.cell && port == other.port && offset == other.offset;
 		}
 
-		Hasher hash_eat(Hasher h) const {
+		Hasher hash_into(Hasher h) const {
 			h.eat(cell->name);
 			h.eat(port);
 			h.eat(offset);

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -4480,11 +4480,11 @@ void RTLIL::SigSpec::updhash() const
 	for (auto &c : that->chunks_)
 		if (c.wire == NULL) {
 			for (auto &v : c.data)
-				h.acc(v);
+				h.eat(v);
 		} else {
-			h.acc(c.wire->name.index_);
-			h.acc(c.offset);
-			h.acc(c.width);
+			h.eat(c.wire->name.index_);
+			h.eat(c.offset);
+			h.eat(c.width);
 		}
 	that->hash_ = h.yield();
 	if (that->hash_ == 0)

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -35,7 +35,7 @@ YOSYS_NAMESPACE_BEGIN
 bool RTLIL::IdString::destruct_guard_ok = false;
 RTLIL::IdString::destruct_guard_t RTLIL::IdString::destruct_guard;
 std::vector<char*> RTLIL::IdString::global_id_storage_;
-dict<char*, int, hash_cstr_ops> RTLIL::IdString::global_id_index_;
+dict<char*, int> RTLIL::IdString::global_id_index_;
 #ifndef YOSYS_NO_IDS_REFCNT
 std::vector<int> RTLIL::IdString::global_refcount_storage_;
 std::vector<int> RTLIL::IdString::global_free_idx_list_;
@@ -4476,17 +4476,17 @@ void RTLIL::SigSpec::updhash() const
 	cover("kernel.rtlil.sigspec.hash");
 	that->pack();
 
-	that->hash_ = mkhash_init;
+	Hasher h;
 	for (auto &c : that->chunks_)
 		if (c.wire == NULL) {
 			for (auto &v : c.data)
-				that->hash_ = mkhash(that->hash_, v);
+				h.acc(v);
 		} else {
-			that->hash_ = mkhash(that->hash_, c.wire->name.index_);
-			that->hash_ = mkhash(that->hash_, c.offset);
-			that->hash_ = mkhash(that->hash_, c.width);
+			h.acc(c.wire->name.index_);
+			h.acc(c.offset);
+			h.acc(c.width);
 		}
-
+	that->hash_ = h.yield();
 	if (that->hash_ == 0)
 		that->hash_ = 1;
 }

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1824,8 +1824,10 @@ inline bool RTLIL::SigBit::operator!=(const RTLIL::SigBit &other) const {
 
 inline Hasher RTLIL::SigBit::hash_acc(Hasher h) const {
 	if (wire) {
-		h = wire->name.hash_acc(h);
 		h.acc(offset);
+		// hash_acc isn't allowed to come first, or it might hash trivially
+		// and possibly ruin things
+		h = wire->name.hash_acc(h);
 		return h;
 	}
 	h.acc(data);

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -361,6 +361,12 @@ namespace RTLIL
 		}
 
 		Hasher hash_acc(Hasher h) const {
+			// If we're starting a hashing sequence, simply start with unhashed ID
+			if (h.is_new()) {
+				h.force((Hasher::hash_t) index_);
+				return h;
+			}
+
 			return hash_ops<int>::hash_acc(index_, h);
 		}
 

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -76,335 +76,348 @@ namespace RTLIL
 	struct SyncRule;
 	struct Process;
 	struct Binding;
+	struct IdString;
 
 	typedef std::pair<SigSpec, SigSpec> SigSig;
+};
 
-	struct IdString
+struct RTLIL::IdString
+{
+	#undef YOSYS_XTRACE_GET_PUT
+	#undef YOSYS_SORT_ID_FREE_LIST
+	#undef YOSYS_USE_STICKY_IDS
+	#undef YOSYS_NO_IDS_REFCNT
+
+	// the global id string cache
+
+	static bool destruct_guard_ok; // POD, will be initialized to zero
+	static struct destruct_guard_t {
+		destruct_guard_t() { destruct_guard_ok = true; }
+		~destruct_guard_t() { destruct_guard_ok = false; }
+	} destruct_guard;
+
+	static std::vector<char*> global_id_storage_;
+	static dict<char*, int> global_id_index_;
+#ifndef YOSYS_NO_IDS_REFCNT
+	static std::vector<int> global_refcount_storage_;
+	static std::vector<int> global_free_idx_list_;
+#endif
+
+#ifdef YOSYS_USE_STICKY_IDS
+	static int last_created_idx_ptr_;
+	static int last_created_idx_[8];
+#endif
+
+	static inline void xtrace_db_dump()
 	{
-		#undef YOSYS_XTRACE_GET_PUT
-		#undef YOSYS_SORT_ID_FREE_LIST
-		#undef YOSYS_USE_STICKY_IDS
-		#undef YOSYS_NO_IDS_REFCNT
-
-		// the global id string cache
-
-		static bool destruct_guard_ok; // POD, will be initialized to zero
-		static struct destruct_guard_t {
-			destruct_guard_t() { destruct_guard_ok = true; }
-			~destruct_guard_t() { destruct_guard_ok = false; }
-		} destruct_guard;
-
-		static std::vector<char*> global_id_storage_;
-		static dict<char*, int> global_id_index_;
-	#ifndef YOSYS_NO_IDS_REFCNT
-		static std::vector<int> global_refcount_storage_;
-		static std::vector<int> global_free_idx_list_;
+	#ifdef YOSYS_XTRACE_GET_PUT
+		for (int idx = 0; idx < GetSize(global_id_storage_); idx++)
+		{
+			if (global_id_storage_.at(idx) == nullptr)
+				log("#X# DB-DUMP index %d: FREE\n", idx);
+			else
+				log("#X# DB-DUMP index %d: '%s' (ref %d)\n", idx, global_id_storage_.at(idx), global_refcount_storage_.at(idx));
+		}
 	#endif
+	}
 
+	static inline void checkpoint()
+	{
 	#ifdef YOSYS_USE_STICKY_IDS
-		static int last_created_idx_ptr_;
-		static int last_created_idx_[8];
+		last_created_idx_ptr_ = 0;
+		for (int i = 0; i < 8; i++) {
+			if (last_created_idx_[i])
+				put_reference(last_created_idx_[i]);
+			last_created_idx_[i] = 0;
+		}
 	#endif
+	#ifdef YOSYS_SORT_ID_FREE_LIST
+		std::sort(global_free_idx_list_.begin(), global_free_idx_list_.end(), std::greater<int>());
+	#endif
+	}
 
-		static inline void xtrace_db_dump()
-		{
-		#ifdef YOSYS_XTRACE_GET_PUT
-			for (int idx = 0; idx < GetSize(global_id_storage_); idx++)
-			{
-				if (global_id_storage_.at(idx) == nullptr)
-					log("#X# DB-DUMP index %d: FREE\n", idx);
-				else
-					log("#X# DB-DUMP index %d: '%s' (ref %d)\n", idx, global_id_storage_.at(idx), global_refcount_storage_.at(idx));
-			}
-		#endif
+	static inline int get_reference(int idx)
+	{
+		if (idx) {
+	#ifndef YOSYS_NO_IDS_REFCNT
+			global_refcount_storage_[idx]++;
+	#endif
+	#ifdef YOSYS_XTRACE_GET_PUT
+			if (yosys_xtrace)
+				log("#X# GET-BY-INDEX '%s' (index %d, refcount %d)\n", global_id_storage_.at(idx), idx, global_refcount_storage_.at(idx));
+	#endif
+		}
+		return idx;
+	}
+
+	static int get_reference(const char *p)
+	{
+		log_assert(destruct_guard_ok);
+
+		if (!p[0])
+			return 0;
+
+		auto it = global_id_index_.find((char*)p);
+		if (it != global_id_index_.end()) {
+	#ifndef YOSYS_NO_IDS_REFCNT
+			global_refcount_storage_.at(it->second)++;
+	#endif
+	#ifdef YOSYS_XTRACE_GET_PUT
+			if (yosys_xtrace)
+				log("#X# GET-BY-NAME '%s' (index %d, refcount %d)\n", global_id_storage_.at(it->second), it->second, global_refcount_storage_.at(it->second));
+	#endif
+			return it->second;
 		}
 
-		static inline void checkpoint()
-		{
-		#ifdef YOSYS_USE_STICKY_IDS
-			last_created_idx_ptr_ = 0;
-			for (int i = 0; i < 8; i++) {
-				if (last_created_idx_[i])
-					put_reference(last_created_idx_[i]);
-				last_created_idx_[i] = 0;
-			}
-		#endif
-		#ifdef YOSYS_SORT_ID_FREE_LIST
-			std::sort(global_free_idx_list_.begin(), global_free_idx_list_.end(), std::greater<int>());
-		#endif
-		}
+		log_assert(p[0] == '$' || p[0] == '\\');
+		log_assert(p[1] != 0);
+		for (const char *c = p; *c; c++)
+			if ((unsigned)*c <= (unsigned)' ')
+				log_error("Found control character or space (0x%02x) in string '%s' which is not allowed in RTLIL identifiers\n", *c, p);
 
-		static inline int get_reference(int idx)
-		{
-			if (idx) {
-		#ifndef YOSYS_NO_IDS_REFCNT
-				global_refcount_storage_[idx]++;
-		#endif
-		#ifdef YOSYS_XTRACE_GET_PUT
-				if (yosys_xtrace)
-					log("#X# GET-BY-INDEX '%s' (index %d, refcount %d)\n", global_id_storage_.at(idx), idx, global_refcount_storage_.at(idx));
-		#endif
-			}
-			return idx;
-		}
-
-		static int get_reference(const char *p)
-		{
-			log_assert(destruct_guard_ok);
-
-			if (!p[0])
-				return 0;
-
-			auto it = global_id_index_.find((char*)p);
-			if (it != global_id_index_.end()) {
-		#ifndef YOSYS_NO_IDS_REFCNT
-				global_refcount_storage_.at(it->second)++;
-		#endif
-		#ifdef YOSYS_XTRACE_GET_PUT
-				if (yosys_xtrace)
-					log("#X# GET-BY-NAME '%s' (index %d, refcount %d)\n", global_id_storage_.at(it->second), it->second, global_refcount_storage_.at(it->second));
-		#endif
-				return it->second;
-			}
-
-			log_assert(p[0] == '$' || p[0] == '\\');
-			log_assert(p[1] != 0);
-			for (const char *c = p; *c; c++)
-				if ((unsigned)*c <= (unsigned)' ')
-					log_error("Found control character or space (0x%02x) in string '%s' which is not allowed in RTLIL identifiers\n", *c, p);
-
-		#ifndef YOSYS_NO_IDS_REFCNT
-			if (global_free_idx_list_.empty()) {
-				if (global_id_storage_.empty()) {
-					global_refcount_storage_.push_back(0);
-					global_id_storage_.push_back((char*)"");
-					global_id_index_[global_id_storage_.back()] = 0;
-				}
-				log_assert(global_id_storage_.size() < 0x40000000);
-				global_free_idx_list_.push_back(global_id_storage_.size());
-				global_id_storage_.push_back(nullptr);
-				global_refcount_storage_.push_back(0);
-			}
-
-			int idx = global_free_idx_list_.back();
-			global_free_idx_list_.pop_back();
-			global_id_storage_.at(idx) = strdup(p);
-			global_id_index_[global_id_storage_.at(idx)] = idx;
-			global_refcount_storage_.at(idx)++;
-		#else
+	#ifndef YOSYS_NO_IDS_REFCNT
+		if (global_free_idx_list_.empty()) {
 			if (global_id_storage_.empty()) {
+				global_refcount_storage_.push_back(0);
 				global_id_storage_.push_back((char*)"");
 				global_id_index_[global_id_storage_.back()] = 0;
 			}
-			int idx = global_id_storage_.size();
-			global_id_storage_.push_back(strdup(p));
-			global_id_index_[global_id_storage_.back()] = idx;
-		#endif
-
-			if (yosys_xtrace) {
-				log("#X# New IdString '%s' with index %d.\n", p, idx);
-				log_backtrace("-X- ", yosys_xtrace-1);
-			}
-
-		#ifdef YOSYS_XTRACE_GET_PUT
-			if (yosys_xtrace)
-				log("#X# GET-BY-NAME '%s' (index %d, refcount %d)\n", global_id_storage_.at(idx), idx, global_refcount_storage_.at(idx));
-		#endif
-
-		#ifdef YOSYS_USE_STICKY_IDS
-			// Avoid Create->Delete->Create pattern
-			if (last_created_idx_[last_created_idx_ptr_])
-				put_reference(last_created_idx_[last_created_idx_ptr_]);
-			last_created_idx_[last_created_idx_ptr_] = idx;
-			get_reference(last_created_idx_[last_created_idx_ptr_]);
-			last_created_idx_ptr_ = (last_created_idx_ptr_ + 1) & 7;
-		#endif
-
-			return idx;
+			log_assert(global_id_storage_.size() < 0x40000000);
+			global_free_idx_list_.push_back(global_id_storage_.size());
+			global_id_storage_.push_back(nullptr);
+			global_refcount_storage_.push_back(0);
 		}
 
-	#ifndef YOSYS_NO_IDS_REFCNT
-		static inline void put_reference(int idx)
-		{
-			// put_reference() may be called from destructors after the destructor of
-			// global_refcount_storage_ has been run. in this case we simply do nothing.
-			if (!destruct_guard_ok || !idx)
-				return;
-
-		#ifdef YOSYS_XTRACE_GET_PUT
-			if (yosys_xtrace) {
-				log("#X# PUT '%s' (index %d, refcount %d)\n", global_id_storage_.at(idx), idx, global_refcount_storage_.at(idx));
-			}
-		#endif
-
-			int &refcount = global_refcount_storage_[idx];
-
-			if (--refcount > 0)
-				return;
-
-			log_assert(refcount == 0);
-			free_reference(idx);
-		}
-		static inline void free_reference(int idx)
-		{
-			if (yosys_xtrace) {
-				log("#X# Removed IdString '%s' with index %d.\n", global_id_storage_.at(idx), idx);
-				log_backtrace("-X- ", yosys_xtrace-1);
-			}
-
-			global_id_index_.erase(global_id_storage_.at(idx));
-			free(global_id_storage_.at(idx));
-			global_id_storage_.at(idx) = nullptr;
-			global_free_idx_list_.push_back(idx);
-		}
+		int idx = global_free_idx_list_.back();
+		global_free_idx_list_.pop_back();
+		global_id_storage_.at(idx) = strdup(p);
+		global_id_index_[global_id_storage_.at(idx)] = idx;
+		global_refcount_storage_.at(idx)++;
 	#else
-		static inline void put_reference(int) { }
+		if (global_id_storage_.empty()) {
+			global_id_storage_.push_back((char*)"");
+			global_id_index_[global_id_storage_.back()] = 0;
+		}
+		int idx = global_id_storage_.size();
+		global_id_storage_.push_back(strdup(p));
+		global_id_index_[global_id_storage_.back()] = idx;
 	#endif
 
-		// the actual IdString object is just is a single int
-
-		int index_;
-
-		inline IdString() : index_(0) { }
-		inline IdString(const char *str) : index_(get_reference(str)) { }
-		inline IdString(const IdString &str) : index_(get_reference(str.index_)) { }
-		inline IdString(IdString &&str) : index_(str.index_) { str.index_ = 0; }
-		inline IdString(const std::string &str) : index_(get_reference(str.c_str())) { }
-		inline ~IdString() { put_reference(index_); }
-
-		inline void operator=(const IdString &rhs) {
-			put_reference(index_);
-			index_ = get_reference(rhs.index_);
+		if (yosys_xtrace) {
+			log("#X# New IdString '%s' with index %d.\n", p, idx);
+			log_backtrace("-X- ", yosys_xtrace-1);
 		}
 
-		inline void operator=(const char *rhs) {
-			IdString id(rhs);
-			*this = id;
+	#ifdef YOSYS_XTRACE_GET_PUT
+		if (yosys_xtrace)
+			log("#X# GET-BY-NAME '%s' (index %d, refcount %d)\n", global_id_storage_.at(idx), idx, global_refcount_storage_.at(idx));
+	#endif
+
+	#ifdef YOSYS_USE_STICKY_IDS
+		// Avoid Create->Delete->Create pattern
+		if (last_created_idx_[last_created_idx_ptr_])
+			put_reference(last_created_idx_[last_created_idx_ptr_]);
+		last_created_idx_[last_created_idx_ptr_] = idx;
+		get_reference(last_created_idx_[last_created_idx_ptr_]);
+		last_created_idx_ptr_ = (last_created_idx_ptr_ + 1) & 7;
+	#endif
+
+		return idx;
+	}
+
+#ifndef YOSYS_NO_IDS_REFCNT
+	static inline void put_reference(int idx)
+	{
+		// put_reference() may be called from destructors after the destructor of
+		// global_refcount_storage_ has been run. in this case we simply do nothing.
+		if (!destruct_guard_ok || !idx)
+			return;
+
+	#ifdef YOSYS_XTRACE_GET_PUT
+		if (yosys_xtrace) {
+			log("#X# PUT '%s' (index %d, refcount %d)\n", global_id_storage_.at(idx), idx, global_refcount_storage_.at(idx));
+		}
+	#endif
+
+		int &refcount = global_refcount_storage_[idx];
+
+		if (--refcount > 0)
+			return;
+
+		log_assert(refcount == 0);
+		free_reference(idx);
+	}
+	static inline void free_reference(int idx)
+	{
+		if (yosys_xtrace) {
+			log("#X# Removed IdString '%s' with index %d.\n", global_id_storage_.at(idx), idx);
+			log_backtrace("-X- ", yosys_xtrace-1);
 		}
 
-		inline void operator=(const std::string &rhs) {
-			IdString id(rhs);
-			*this = id;
-		}
-
-		inline const char *c_str() const {
-			return global_id_storage_.at(index_);
-		}
-
-		inline std::string str() const {
-			return std::string(global_id_storage_.at(index_));
-		}
-
-		inline bool operator<(const IdString &rhs) const {
-			return index_ < rhs.index_;
-		}
-
-		inline bool operator==(const IdString &rhs) const { return index_ == rhs.index_; }
-		inline bool operator!=(const IdString &rhs) const { return index_ != rhs.index_; }
-
-		// The methods below are just convenience functions for better compatibility with std::string.
-
-		bool operator==(const std::string &rhs) const { return c_str() == rhs; }
-		bool operator!=(const std::string &rhs) const { return c_str() != rhs; }
-
-		bool operator==(const char *rhs) const { return strcmp(c_str(), rhs) == 0; }
-		bool operator!=(const char *rhs) const { return strcmp(c_str(), rhs) != 0; }
-
-		char operator[](size_t i) const {
-                        const char *p = c_str();
-#ifndef NDEBUG
-			for (; i != 0; i--, p++)
-				log_assert(*p != 0);
-			return *p;
+		global_id_index_.erase(global_id_storage_.at(idx));
+		free(global_id_storage_.at(idx));
+		global_id_storage_.at(idx) = nullptr;
+		global_free_idx_list_.push_back(idx);
+	}
 #else
-			return *(p + i);
+	static inline void put_reference(int) { }
 #endif
+
+	// the actual IdString object is just is a single int
+
+	int index_;
+
+	inline IdString() : index_(0) { }
+	inline IdString(const char *str) : index_(get_reference(str)) { }
+	inline IdString(const IdString &str) : index_(get_reference(str.index_)) { }
+	inline IdString(IdString &&str) : index_(str.index_) { str.index_ = 0; }
+	inline IdString(const std::string &str) : index_(get_reference(str.c_str())) { }
+	inline ~IdString() { put_reference(index_); }
+
+	inline void operator=(const IdString &rhs) {
+		put_reference(index_);
+		index_ = get_reference(rhs.index_);
+	}
+
+	inline void operator=(const char *rhs) {
+		IdString id(rhs);
+		*this = id;
+	}
+
+	inline void operator=(const std::string &rhs) {
+		IdString id(rhs);
+		*this = id;
+	}
+
+	inline const char *c_str() const {
+		return global_id_storage_.at(index_);
+	}
+
+	inline std::string str() const {
+		return std::string(global_id_storage_.at(index_));
+	}
+
+	inline bool operator<(const IdString &rhs) const {
+		return index_ < rhs.index_;
+	}
+
+	inline bool operator==(const IdString &rhs) const { return index_ == rhs.index_; }
+	inline bool operator!=(const IdString &rhs) const { return index_ != rhs.index_; }
+
+	// The methods below are just convenience functions for better compatibility with std::string.
+
+	bool operator==(const std::string &rhs) const { return c_str() == rhs; }
+	bool operator!=(const std::string &rhs) const { return c_str() != rhs; }
+
+	bool operator==(const char *rhs) const { return strcmp(c_str(), rhs) == 0; }
+	bool operator!=(const char *rhs) const { return strcmp(c_str(), rhs) != 0; }
+
+	char operator[](size_t i) const {
+					const char *p = c_str();
+#ifndef NDEBUG
+		for (; i != 0; i--, p++)
+			log_assert(*p != 0);
+		return *p;
+#else
+		return *(p + i);
+#endif
+	}
+
+	std::string substr(size_t pos = 0, size_t len = std::string::npos) const {
+		if (len == std::string::npos || len >= strlen(c_str() + pos))
+			return std::string(c_str() + pos);
+		else
+			return std::string(c_str() + pos, len);
+	}
+
+	int compare(size_t pos, size_t len, const char* s) const {
+		return strncmp(c_str()+pos, s, len);
+	}
+
+	bool begins_with(const char* prefix) const {
+		size_t len = strlen(prefix);
+		if (size() < len) return false;
+		return compare(0, len, prefix) == 0;
+	}
+
+	bool ends_with(const char* suffix) const {
+		size_t len = strlen(suffix);
+		if (size() < len) return false;
+		return compare(size()-len, len, suffix) == 0;
+	}
+
+	bool contains(const char* str) const {
+		return strstr(c_str(), str);
+	}
+
+	size_t size() const {
+		return strlen(c_str());
+	}
+
+	bool empty() const {
+		return c_str()[0] == 0;
+	}
+
+	void clear() {
+		*this = IdString();
+	}
+
+	Hasher hash_acc(Hasher h) const { return hash_ops<int>::hash_acc(index_, h); }
+
+	Hasher hash_top() const {
+		Hasher h;
+		h.force((Hasher::hash_t) index_);
+		return h;
+	}
+
+	// The following is a helper key_compare class. Instead of for example std::set<Cell*>
+	// use std::set<Cell*, IdString::compare_ptr_by_name<Cell>> if the order of cells in the
+	// set has an influence on the algorithm.
+
+	template<typename T> struct compare_ptr_by_name {
+		bool operator()(const T *a, const T *b) const {
+			return (a == nullptr || b == nullptr) ? (a < b) : (a->name < b->name);
 		}
-
-		std::string substr(size_t pos = 0, size_t len = std::string::npos) const {
-			if (len == std::string::npos || len >= strlen(c_str() + pos))
-				return std::string(c_str() + pos);
-			else
-				return std::string(c_str() + pos, len);
-		}
-
-		int compare(size_t pos, size_t len, const char* s) const {
-			return strncmp(c_str()+pos, s, len);
-		}
-
-		bool begins_with(const char* prefix) const {
-			size_t len = strlen(prefix);
-			if (size() < len) return false;
-			return compare(0, len, prefix) == 0;
-		}
-
-		bool ends_with(const char* suffix) const {
-			size_t len = strlen(suffix);
-			if (size() < len) return false;
-			return compare(size()-len, len, suffix) == 0;
-		}
-
-		bool contains(const char* str) const {
-			return strstr(c_str(), str);
-		}
-
-		size_t size() const {
-			return strlen(c_str());
-		}
-
-		bool empty() const {
-			return c_str()[0] == 0;
-		}
-
-		void clear() {
-			*this = IdString();
-		}
-
-		Hasher hash_acc(Hasher h) const {
-			// If we're starting a hashing sequence, simply start with unhashed ID
-			if (h.is_new()) {
-				h.force((Hasher::hash_t) index_);
-				return h;
-			}
-
-			return hash_ops<int>::hash_acc(index_, h);
-		}
-
-		// The following is a helper key_compare class. Instead of for example std::set<Cell*>
-		// use std::set<Cell*, IdString::compare_ptr_by_name<Cell>> if the order of cells in the
-		// set has an influence on the algorithm.
-
-		template<typename T> struct compare_ptr_by_name {
-			bool operator()(const T *a, const T *b) const {
-				return (a == nullptr || b == nullptr) ? (a < b) : (a->name < b->name);
-			}
-		};
-
-		// often one needs to check if a given IdString is part of a list (for example a list
-		// of cell types). the following functions helps with that.
-
-		template<typename... Args>
-		bool in(Args... args) const {
-			// Credit: https://articles.emptycrate.com/2016/05/14/folds_in_cpp11_ish.html
-			bool result = false;
-			(void) std::initializer_list<int>{ (result = result || in(args), 0)... };
-			return result;
-		}
-
-		bool in(const IdString &rhs) const { return *this == rhs; }
-		bool in(const char *rhs) const { return *this == rhs; }
-		bool in(const std::string &rhs) const { return *this == rhs; }
-		bool in(const pool<IdString> &rhs) const { return rhs.count(*this) != 0; }
-
-		bool isPublic() const { return begins_with("\\"); }
 	};
 
+	// often one needs to check if a given IdString is part of a list (for example a list
+	// of cell types). the following functions helps with that.
+	template<typename... Args>
+	bool in(Args... args) const {
+		return (... || in(args));
+	}
+
+	bool in(const IdString &rhs) const { return *this == rhs; }
+	bool in(const char *rhs) const { return *this == rhs; }
+	bool in(const std::string &rhs) const { return *this == rhs; }
+	inline bool in(const pool<IdString> &rhs) const;
+	inline bool in(const pool<IdString> &&rhs) const;
+
+	bool isPublic() const { return begins_with("\\"); }
+};
+
+namespace hashlib {
+	template <>
+	struct hash_top_ops<RTLIL::IdString> {
+		static inline bool cmp(const RTLIL::IdString &a, const RTLIL::IdString &b) {
+			return a == b;
+		}
+		static inline Hasher hash(const RTLIL::IdString id) {
+			return id.hash_top();
+		}
+	};
+};
+
+// TODO deprecate this
+inline bool RTLIL::IdString::in(const pool<IdString> &rhs) const { return rhs.count(*this) != 0; }
+inline bool RTLIL::IdString::in(const pool<IdString> &&rhs) const { return rhs.count(*this) != 0; }
+
+namespace RTLIL {
 	namespace ID {
 #define X(_id) extern IdString _id;
 #include "kernel/constids.inc"
 #undef X
 	};
-
 	extern dict<std::string, std::string> constpad;
 
 	const pool<IdString> &builtin_ff_cell_types();

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1862,7 +1862,7 @@ inline Hasher RTLIL::SigBit::hash_eat(Hasher h) const {
 inline Hasher RTLIL::SigBit::hash_top() const {
 	Hasher h;
 	if (wire) {
-		h.force(hashlib::legacy::mkhash_add(wire->name.index_, offset));
+		h.force(hashlib::legacy::djb2_add(wire->name.index_, offset));
 		return h;
 	}
 	h.force(data);

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -362,7 +362,7 @@ struct RTLIL::IdString
 		*this = IdString();
 	}
 
-	Hasher hash_eat(Hasher h) const { return hash_ops<int>::hash_eat(index_, h); }
+	Hasher hash_into(Hasher h) const { return hash_ops<int>::hash_into(index_, h); }
 
 	Hasher hash_top() const {
 		Hasher h;
@@ -815,7 +815,7 @@ public:
 		bv.resize(width, bv.empty() ? RTLIL::State::Sx : bv.back());
 	}
 
-	inline Hasher hash_eat(Hasher h) const {
+	inline Hasher hash_into(Hasher h) const {
 		// TODO hash size
 		for (auto b : *this)
 			h.eat(b);
@@ -908,7 +908,7 @@ struct RTLIL::SigBit
 	bool operator <(const RTLIL::SigBit &other) const;
 	bool operator ==(const RTLIL::SigBit &other) const;
 	bool operator !=(const RTLIL::SigBit &other) const;
-	Hasher hash_eat(Hasher h) const;
+	Hasher hash_into(Hasher h) const;
 	Hasher hash_top() const;
 };
 
@@ -1115,7 +1115,7 @@ public:
 	operator std::vector<RTLIL::SigBit>() const { return bits(); }
 	const RTLIL::SigBit &at(int offset, const RTLIL::SigBit &defval) { return offset < width_ ? (*this)[offset] : defval; }
 
-	Hasher hash_eat(Hasher h) const { if (!hash_) updhash(); h.eat(hash_); return h; }
+	Hasher hash_into(Hasher h) const { if (!hash_) updhash(); h.eat(hash_); return h; }
 
 #ifndef NDEBUG
 	void check(Module *mod = nullptr) const;
@@ -1157,7 +1157,7 @@ struct RTLIL::Selection
 struct RTLIL::Monitor
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_eat(Hasher h) const { h.eat(hashidx_); return h; }
+	Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
 
 	Monitor() {
 		static unsigned int hashidx_count = 123456789;
@@ -1180,7 +1180,7 @@ struct define_map_t;
 struct RTLIL::Design
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_eat(Hasher h) const { h.eat(hashidx_); return h; }
+	Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
 
 	pool<RTLIL::Monitor*> monitors;
 	dict<std::string, std::string> scratchpad;
@@ -1285,7 +1285,7 @@ struct RTLIL::Design
 struct RTLIL::Module : public RTLIL::AttrObject
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_eat(Hasher h) const { h.eat(hashidx_); return h; }
+	Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
 
 protected:
 	void add(RTLIL::Wire *wire);
@@ -1640,7 +1640,7 @@ void dump_wire(std::ostream &f, std::string indent, const RTLIL::Wire *wire);
 struct RTLIL::Wire : public RTLIL::AttrObject
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_eat(Hasher h) const { h.eat(hashidx_); return h; }
+	Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
 
 protected:
 	// use module->addWire() and module->remove() to create or destroy wires
@@ -1679,7 +1679,7 @@ inline int GetSize(RTLIL::Wire *wire) {
 struct RTLIL::Memory : public RTLIL::AttrObject
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_eat(Hasher h) const { h.eat(hashidx_); return h; }
+	Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
 
 	Memory();
 
@@ -1694,7 +1694,7 @@ struct RTLIL::Memory : public RTLIL::AttrObject
 struct RTLIL::Cell : public RTLIL::AttrObject
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_eat(Hasher h) const { h.eat(hashidx_); return h; }
+	Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
 
 protected:
 	// use module->addCell() and module->remove() to create or destroy cells
@@ -1804,7 +1804,7 @@ struct RTLIL::SyncRule
 struct RTLIL::Process : public RTLIL::AttrObject
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_eat(Hasher h) const { h.eat(hashidx_); return h; }
+	Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
 
 protected:
 	// use module->addProcess() and module->remove() to create or destroy processes
@@ -1848,7 +1848,7 @@ inline bool RTLIL::SigBit::operator!=(const RTLIL::SigBit &other) const {
 	return (wire != other.wire) || (wire ? (offset != other.offset) : (data != other.data));
 }
 
-inline Hasher RTLIL::SigBit::hash_eat(Hasher h) const {
+inline Hasher RTLIL::SigBit::hash_into(Hasher h) const {
 	if (wire) {
 		h.eat(offset);
 		h.eat(wire->name);

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -408,8 +408,14 @@ namespace hashlib {
 	};
 };
 
-// TODO deprecate this
+/**
+ * How to not use these methods:
+ * 1. if(celltype.in({...})) -> if(celltype.in(...))
+ * 2. pool<IdString> p; ... a.in(p) -> (bool)p.count(a)
+ */
+[[deprecated]]
 inline bool RTLIL::IdString::in(const pool<IdString> &rhs) const { return rhs.count(*this) != 0; }
+[[deprecated]]
 inline bool RTLIL::IdString::in(const pool<IdString> &&rhs) const { return rhs.count(*this) != 0; }
 
 namespace RTLIL {
@@ -816,7 +822,7 @@ public:
 	}
 
 	inline Hasher hash_into(Hasher h) const {
-		// TODO hash size
+		h.eat(size());
 		for (auto b : *this)
 			h.eat(b);
 		return h;
@@ -1002,12 +1008,6 @@ public:
 	SigSpec(const pool<RTLIL::SigBit> &bits);
 	SigSpec(const std::set<RTLIL::SigBit> &bits);
 	explicit SigSpec(bool bit);
-
-	[[deprecated]]
-	size_t get_hash() const {
-		log_assert(false && "deprecated");
-		return 0;
-	}
 
 	inline const std::vector<RTLIL::SigChunk> &chunks() const { pack(); return chunks_; }
 	inline const std::vector<RTLIL::SigBit> &bits() const { inline_unpack(); return bits_; }

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -95,7 +95,7 @@ namespace RTLIL
 		} destruct_guard;
 
 		static std::vector<char*> global_id_storage_;
-		static dict<char*, int, hash_cstr_ops> global_id_index_;
+		static dict<char*, int> global_id_index_;
 	#ifndef YOSYS_NO_IDS_REFCNT
 		static std::vector<int> global_refcount_storage_;
 		static std::vector<int> global_free_idx_list_;
@@ -360,8 +360,8 @@ namespace RTLIL
 			*this = IdString();
 		}
 
-		unsigned int hash() const {
-			return index_;
+		Hasher hash_acc(Hasher h) const {
+			return hash_ops<int>::hash_acc(index_, h);
 		}
 
 		// The following is a helper key_compare class. Instead of for example std::set<Cell*>
@@ -796,11 +796,10 @@ public:
 		bv.resize(width, bv.empty() ? RTLIL::State::Sx : bv.back());
 	}
 
-	inline unsigned int hash() const {
-		unsigned int h = mkhash_init;
-
-		for (State b : *this)
-			h = mkhash(h, b);
+	inline Hasher hash_acc(Hasher h) const {
+		// TODO hash size
+		for (auto b : *this)
+			h.acc(b);
 		return h;
 	}
 };
@@ -890,7 +889,7 @@ struct RTLIL::SigBit
 	bool operator <(const RTLIL::SigBit &other) const;
 	bool operator ==(const RTLIL::SigBit &other) const;
 	bool operator !=(const RTLIL::SigBit &other) const;
-	unsigned int hash() const;
+	Hasher hash_acc(Hasher h) const;
 };
 
 struct RTLIL::SigSpecIterator
@@ -931,7 +930,7 @@ struct RTLIL::SigSpec
 {
 private:
 	int width_;
-	unsigned long hash_;
+	Hasher::hash_t hash_;
 	std::vector<RTLIL::SigChunk> chunks_; // LSB at index 0
 	std::vector<RTLIL::SigBit> bits_; // LSB at index 0
 
@@ -972,9 +971,10 @@ public:
 	SigSpec(const std::set<RTLIL::SigBit> &bits);
 	explicit SigSpec(bool bit);
 
+	[[deprecated]]
 	size_t get_hash() const {
-		if (!hash_) hash();
-		return hash_;
+		log_assert(false && "deprecated");
+		return 0;
 	}
 
 	inline const std::vector<RTLIL::SigChunk> &chunks() const { pack(); return chunks_; }
@@ -1083,7 +1083,7 @@ public:
 	operator std::vector<RTLIL::SigBit>() const { return bits(); }
 	const RTLIL::SigBit &at(int offset, const RTLIL::SigBit &defval) { return offset < width_ ? (*this)[offset] : defval; }
 
-	unsigned int hash() const { if (!hash_) updhash(); return hash_; };
+	Hasher hash_acc(Hasher h) const { if (!hash_) updhash(); h.acc(hash_); return h; }
 
 #ifndef NDEBUG
 	void check(Module *mod = nullptr) const;
@@ -1124,8 +1124,8 @@ struct RTLIL::Selection
 
 struct RTLIL::Monitor
 {
-	unsigned int hashidx_;
-	unsigned int hash() const { return hashidx_; }
+	Hasher::hash_t hashidx_;
+	Hasher hash_acc(Hasher h) const { h.acc(hashidx_); return h; }
 
 	Monitor() {
 		static unsigned int hashidx_count = 123456789;
@@ -1147,8 +1147,8 @@ struct define_map_t;
 
 struct RTLIL::Design
 {
-	unsigned int hashidx_;
-	unsigned int hash() const { return hashidx_; }
+	Hasher::hash_t hashidx_;
+	Hasher hash_acc(Hasher h) const { h.acc(hashidx_); return h; }
 
 	pool<RTLIL::Monitor*> monitors;
 	dict<std::string, std::string> scratchpad;
@@ -1252,8 +1252,8 @@ struct RTLIL::Design
 
 struct RTLIL::Module : public RTLIL::AttrObject
 {
-	unsigned int hashidx_;
-	unsigned int hash() const { return hashidx_; }
+	Hasher::hash_t hashidx_;
+	Hasher hash_acc(Hasher h) const { h.acc(hashidx_); return h; }
 
 protected:
 	void add(RTLIL::Wire *wire);
@@ -1607,8 +1607,8 @@ void dump_wire(std::ostream &f, std::string indent, const RTLIL::Wire *wire);
 
 struct RTLIL::Wire : public RTLIL::AttrObject
 {
-	unsigned int hashidx_;
-	unsigned int hash() const { return hashidx_; }
+	Hasher::hash_t hashidx_;
+	Hasher hash_acc(Hasher h) const { h.acc(hashidx_); return h; }
 
 protected:
 	// use module->addWire() and module->remove() to create or destroy wires
@@ -1646,8 +1646,8 @@ inline int GetSize(RTLIL::Wire *wire) {
 
 struct RTLIL::Memory : public RTLIL::AttrObject
 {
-	unsigned int hashidx_;
-	unsigned int hash() const { return hashidx_; }
+	Hasher::hash_t hashidx_;
+	Hasher hash_acc(Hasher h) const { h.acc(hashidx_); return h; }
 
 	Memory();
 
@@ -1661,8 +1661,8 @@ struct RTLIL::Memory : public RTLIL::AttrObject
 
 struct RTLIL::Cell : public RTLIL::AttrObject
 {
-	unsigned int hashidx_;
-	unsigned int hash() const { return hashidx_; }
+	Hasher::hash_t hashidx_;
+	Hasher hash_acc(Hasher h) const { h.acc(hashidx_); return h; }
 
 protected:
 	// use module->addCell() and module->remove() to create or destroy cells
@@ -1771,8 +1771,8 @@ struct RTLIL::SyncRule
 
 struct RTLIL::Process : public RTLIL::AttrObject
 {
-	unsigned int hashidx_;
-	unsigned int hash() const { return hashidx_; }
+	Hasher::hash_t hashidx_;
+	Hasher hash_acc(Hasher h) const { h.acc(hashidx_); return h; }
 
 protected:
 	// use module->addProcess() and module->remove() to create or destroy processes
@@ -1816,10 +1816,14 @@ inline bool RTLIL::SigBit::operator!=(const RTLIL::SigBit &other) const {
 	return (wire != other.wire) || (wire ? (offset != other.offset) : (data != other.data));
 }
 
-inline unsigned int RTLIL::SigBit::hash() const {
-	if (wire)
-		return mkhash_add(wire->name.hash(), offset);
-	return data;
+inline Hasher RTLIL::SigBit::hash_acc(Hasher h) const {
+	if (wire) {
+		h = wire->name.hash_acc(h);
+		h.acc(offset);
+		return h;
+	}
+	h.acc(data);
+	return h;
 }
 
 inline RTLIL::SigBit &RTLIL::SigSpecIterator::operator*() const {

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -362,7 +362,7 @@ struct RTLIL::IdString
 		*this = IdString();
 	}
 
-	Hasher hash_acc(Hasher h) const { return hash_ops<int>::hash_acc(index_, h); }
+	Hasher hash_eat(Hasher h) const { return hash_ops<int>::hash_eat(index_, h); }
 
 	Hasher hash_top() const {
 		Hasher h;
@@ -815,10 +815,10 @@ public:
 		bv.resize(width, bv.empty() ? RTLIL::State::Sx : bv.back());
 	}
 
-	inline Hasher hash_acc(Hasher h) const {
+	inline Hasher hash_eat(Hasher h) const {
 		// TODO hash size
 		for (auto b : *this)
-			h.acc(b);
+			h.eat(b);
 		return h;
 	}
 };
@@ -908,7 +908,7 @@ struct RTLIL::SigBit
 	bool operator <(const RTLIL::SigBit &other) const;
 	bool operator ==(const RTLIL::SigBit &other) const;
 	bool operator !=(const RTLIL::SigBit &other) const;
-	Hasher hash_acc(Hasher h) const;
+	Hasher hash_eat(Hasher h) const;
 	Hasher hash_top() const;
 };
 
@@ -1115,7 +1115,7 @@ public:
 	operator std::vector<RTLIL::SigBit>() const { return bits(); }
 	const RTLIL::SigBit &at(int offset, const RTLIL::SigBit &defval) { return offset < width_ ? (*this)[offset] : defval; }
 
-	Hasher hash_acc(Hasher h) const { if (!hash_) updhash(); h.acc(hash_); return h; }
+	Hasher hash_eat(Hasher h) const { if (!hash_) updhash(); h.eat(hash_); return h; }
 
 #ifndef NDEBUG
 	void check(Module *mod = nullptr) const;
@@ -1157,7 +1157,7 @@ struct RTLIL::Selection
 struct RTLIL::Monitor
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_acc(Hasher h) const { h.acc(hashidx_); return h; }
+	Hasher hash_eat(Hasher h) const { h.eat(hashidx_); return h; }
 
 	Monitor() {
 		static unsigned int hashidx_count = 123456789;
@@ -1180,7 +1180,7 @@ struct define_map_t;
 struct RTLIL::Design
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_acc(Hasher h) const { h.acc(hashidx_); return h; }
+	Hasher hash_eat(Hasher h) const { h.eat(hashidx_); return h; }
 
 	pool<RTLIL::Monitor*> monitors;
 	dict<std::string, std::string> scratchpad;
@@ -1285,7 +1285,7 @@ struct RTLIL::Design
 struct RTLIL::Module : public RTLIL::AttrObject
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_acc(Hasher h) const { h.acc(hashidx_); return h; }
+	Hasher hash_eat(Hasher h) const { h.eat(hashidx_); return h; }
 
 protected:
 	void add(RTLIL::Wire *wire);
@@ -1640,7 +1640,7 @@ void dump_wire(std::ostream &f, std::string indent, const RTLIL::Wire *wire);
 struct RTLIL::Wire : public RTLIL::AttrObject
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_acc(Hasher h) const { h.acc(hashidx_); return h; }
+	Hasher hash_eat(Hasher h) const { h.eat(hashidx_); return h; }
 
 protected:
 	// use module->addWire() and module->remove() to create or destroy wires
@@ -1679,7 +1679,7 @@ inline int GetSize(RTLIL::Wire *wire) {
 struct RTLIL::Memory : public RTLIL::AttrObject
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_acc(Hasher h) const { h.acc(hashidx_); return h; }
+	Hasher hash_eat(Hasher h) const { h.eat(hashidx_); return h; }
 
 	Memory();
 
@@ -1694,7 +1694,7 @@ struct RTLIL::Memory : public RTLIL::AttrObject
 struct RTLIL::Cell : public RTLIL::AttrObject
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_acc(Hasher h) const { h.acc(hashidx_); return h; }
+	Hasher hash_eat(Hasher h) const { h.eat(hashidx_); return h; }
 
 protected:
 	// use module->addCell() and module->remove() to create or destroy cells
@@ -1804,7 +1804,7 @@ struct RTLIL::SyncRule
 struct RTLIL::Process : public RTLIL::AttrObject
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_acc(Hasher h) const { h.acc(hashidx_); return h; }
+	Hasher hash_eat(Hasher h) const { h.eat(hashidx_); return h; }
 
 protected:
 	// use module->addProcess() and module->remove() to create or destroy processes
@@ -1848,13 +1848,13 @@ inline bool RTLIL::SigBit::operator!=(const RTLIL::SigBit &other) const {
 	return (wire != other.wire) || (wire ? (offset != other.offset) : (data != other.data));
 }
 
-inline Hasher RTLIL::SigBit::hash_acc(Hasher h) const {
+inline Hasher RTLIL::SigBit::hash_eat(Hasher h) const {
 	if (wire) {
-		h.acc(offset);
-		h.acc(wire->name);
+		h.eat(offset);
+		h.eat(wire->name);
 		return h;
 	}
-	h.acc(data);
+	h.eat(data);
 	return h;
 }
 

--- a/kernel/scopeinfo.h
+++ b/kernel/scopeinfo.h
@@ -322,7 +322,7 @@ struct ModuleItem {
 	Cell *cell() const { return type == Type::Cell ? static_cast<Cell *>(ptr) : nullptr; }
 
 	bool operator==(const ModuleItem &other) const { return ptr == other.ptr && type == other.type; }
-	unsigned int hash() const { return (uintptr_t)ptr; }
+	Hasher hash_acc(Hasher h) const { h.acc(ptr); return h; }
 };
 
 static inline void log_dump_val_worker(typename IdTree<ModuleItem>::Cursor cursor ) { log("%p %s", cursor.target, log_id(cursor.scope_name)); }

--- a/kernel/scopeinfo.h
+++ b/kernel/scopeinfo.h
@@ -169,8 +169,11 @@ public:
 			return !(*this == other);
 		}
 
-		int hash() const {
-			return mkhash(scope_name.hash(), hash_ptr_ops::hash(target));
+		Hasher hash_acc(Hasher h) const
+		{
+			h.acc(scope_name);
+			h.acc(target);
+			return h;
 		}
 
 		bool valid() const {

--- a/kernel/scopeinfo.h
+++ b/kernel/scopeinfo.h
@@ -169,7 +169,7 @@ public:
 			return !(*this == other);
 		}
 
-		Hasher hash_acc(Hasher h) const
+		Hasher hash_into(Hasher h) const
 		{
 			h.eat(scope_name);
 			h.eat(target);
@@ -325,7 +325,7 @@ struct ModuleItem {
 	Cell *cell() const { return type == Type::Cell ? static_cast<Cell *>(ptr) : nullptr; }
 
 	bool operator==(const ModuleItem &other) const { return ptr == other.ptr && type == other.type; }
-	Hasher hash_eat(Hasher h) const { h.eat(ptr); return h; }
+	Hasher hash_into(Hasher h) const { h.eat(ptr); return h; }
 };
 
 static inline void log_dump_val_worker(typename IdTree<ModuleItem>::Cursor cursor ) { log("%p %s", cursor.target, log_id(cursor.scope_name)); }

--- a/kernel/scopeinfo.h
+++ b/kernel/scopeinfo.h
@@ -171,8 +171,8 @@ public:
 
 		Hasher hash_acc(Hasher h) const
 		{
-			h.acc(scope_name);
-			h.acc(target);
+			h.eat(scope_name);
+			h.eat(target);
 			return h;
 		}
 
@@ -325,7 +325,7 @@ struct ModuleItem {
 	Cell *cell() const { return type == Type::Cell ? static_cast<Cell *>(ptr) : nullptr; }
 
 	bool operator==(const ModuleItem &other) const { return ptr == other.ptr && type == other.type; }
-	Hasher hash_acc(Hasher h) const { h.acc(ptr); return h; }
+	Hasher hash_eat(Hasher h) const { h.eat(ptr); return h; }
 };
 
 static inline void log_dump_val_worker(typename IdTree<ModuleItem>::Cursor cursor ) { log("%p %s", cursor.target, log_id(cursor.scope_name)); }

--- a/kernel/sigtools.h
+++ b/kernel/sigtools.h
@@ -29,7 +29,7 @@ struct SigPool
 	struct bitDef_t : public std::pair<RTLIL::Wire*, int> {
 		bitDef_t() : std::pair<RTLIL::Wire*, int>(NULL, 0) { }
 		bitDef_t(const RTLIL::SigBit &bit) : std::pair<RTLIL::Wire*, int>(bit.wire, bit.offset) { }
-		Hasher hash_eat(Hasher h) const {
+		Hasher hash_into(Hasher h) const {
 			h.eat(first->name);
 			h.eat(second);
 			return h;
@@ -147,7 +147,7 @@ struct SigSet
 	struct bitDef_t : public std::pair<RTLIL::Wire*, int> {
 		bitDef_t() : std::pair<RTLIL::Wire*, int>(NULL, 0) { }
 		bitDef_t(const RTLIL::SigBit &bit) : std::pair<RTLIL::Wire*, int>(bit.wire, bit.offset) { }
-		Hasher hash_eat(Hasher h) const {
+		Hasher hash_into(Hasher h) const {
 			h.eat(first->name);
 			h.eat(second);
 			return h;

--- a/kernel/sigtools.h
+++ b/kernel/sigtools.h
@@ -29,9 +29,9 @@ struct SigPool
 	struct bitDef_t : public std::pair<RTLIL::Wire*, int> {
 		bitDef_t() : std::pair<RTLIL::Wire*, int>(NULL, 0) { }
 		bitDef_t(const RTLIL::SigBit &bit) : std::pair<RTLIL::Wire*, int>(bit.wire, bit.offset) { }
-		Hasher hash_acc(Hasher h) const {
-			h.acc(first->name);
-			h.acc(second);
+		Hasher hash_eat(Hasher h) const {
+			h.eat(first->name);
+			h.eat(second);
 			return h;
 		}
 	};
@@ -147,9 +147,9 @@ struct SigSet
 	struct bitDef_t : public std::pair<RTLIL::Wire*, int> {
 		bitDef_t() : std::pair<RTLIL::Wire*, int>(NULL, 0) { }
 		bitDef_t(const RTLIL::SigBit &bit) : std::pair<RTLIL::Wire*, int>(bit.wire, bit.offset) { }
-		Hasher hash_acc(Hasher h) const {
-			h.acc(first->name);
-			h.acc(second);
+		Hasher hash_eat(Hasher h) const {
+			h.eat(first->name);
+			h.eat(second);
 			return h;
 		}
 	};

--- a/kernel/sigtools.h
+++ b/kernel/sigtools.h
@@ -29,7 +29,11 @@ struct SigPool
 	struct bitDef_t : public std::pair<RTLIL::Wire*, int> {
 		bitDef_t() : std::pair<RTLIL::Wire*, int>(NULL, 0) { }
 		bitDef_t(const RTLIL::SigBit &bit) : std::pair<RTLIL::Wire*, int>(bit.wire, bit.offset) { }
-		unsigned int hash() const { return first->name.hash() + second; }
+		Hasher hash_acc(Hasher h) const {
+			h.acc(first->name);
+			h.acc(second);
+			return h;
+		}
 	};
 
 	pool<bitDef_t> bits;
@@ -143,7 +147,11 @@ struct SigSet
 	struct bitDef_t : public std::pair<RTLIL::Wire*, int> {
 		bitDef_t() : std::pair<RTLIL::Wire*, int>(NULL, 0) { }
 		bitDef_t(const RTLIL::SigBit &bit) : std::pair<RTLIL::Wire*, int>(bit.wire, bit.offset) { }
-		unsigned int hash() const { return first->name.hash() + second; }
+		Hasher hash_acc(Hasher h) const {
+			h.acc(first->name);
+			h.acc(second);
+			return h;
+		}
 	};
 
 	dict<bitDef_t, std::set<T, Compare>> bits;

--- a/kernel/timinginfo.h
+++ b/kernel/timinginfo.h
@@ -44,7 +44,7 @@ struct TimingInfo
 				return {};
 			return port[offset];
 		}
-		Hasher hash_eat(Hasher h) const {
+		Hasher hash_into(Hasher h) const {
 			h.eat(name);
 			h.eat(offset);
 			return h;
@@ -56,7 +56,7 @@ struct TimingInfo
 		BitBit(const NameBit &first, const NameBit &second) : first(first), second(second) {}
 		BitBit(const SigBit &first, const SigBit &second) : first(first), second(second) {}
 		bool operator==(const BitBit& bb) const { return bb.first == first && bb.second == second; }
-		Hasher hash_eat(Hasher h) const {
+		Hasher hash_into(Hasher h) const {
 			h.eat(first);
 			h.eat(second);
 			return h;

--- a/kernel/timinginfo.h
+++ b/kernel/timinginfo.h
@@ -44,9 +44,9 @@ struct TimingInfo
 				return {};
 			return port[offset];
 		}
-		Hasher hash_acc(Hasher h) const {
-			h.acc(name);
-			h.acc(offset);
+		Hasher hash_eat(Hasher h) const {
+			h.eat(name);
+			h.eat(offset);
 			return h;
 		}
 	};
@@ -56,9 +56,9 @@ struct TimingInfo
 		BitBit(const NameBit &first, const NameBit &second) : first(first), second(second) {}
 		BitBit(const SigBit &first, const SigBit &second) : first(first), second(second) {}
 		bool operator==(const BitBit& bb) const { return bb.first == first && bb.second == second; }
-		Hasher hash_acc(Hasher h) const {
-			h.acc(first);
-			h.acc(second);
+		Hasher hash_eat(Hasher h) const {
+			h.eat(first);
+			h.eat(second);
 			return h;
 		}
 	};

--- a/kernel/timinginfo.h
+++ b/kernel/timinginfo.h
@@ -36,7 +36,6 @@ struct TimingInfo
 		explicit NameBit(const RTLIL::SigBit &b) : name(b.wire->name), offset(b.offset) {}
 		bool operator==(const NameBit& nb) const { return nb.name == name && nb.offset == offset; }
 		bool operator!=(const NameBit& nb) const { return !operator==(nb); }
-		unsigned int hash() const { return mkhash_add(name.hash(), offset); }
 		std::optional<SigBit> get_connection(RTLIL::Cell *cell) {
 			if (!cell->hasPort(name))
 				return {};
@@ -45,6 +44,11 @@ struct TimingInfo
 				return {};
 			return port[offset];
 		}
+		Hasher hash_acc(Hasher h) const {
+			h.acc(name);
+			h.acc(offset);
+			return h;
+		}
 	};
 	struct BitBit
 	{
@@ -52,7 +56,11 @@ struct TimingInfo
 		BitBit(const NameBit &first, const NameBit &second) : first(first), second(second) {}
 		BitBit(const SigBit &first, const SigBit &second) : first(first), second(second) {}
 		bool operator==(const BitBit& bb) const { return bb.first == first && bb.second == second; }
-		unsigned int hash() const { return mkhash_add(first.hash(), second.hash()); }
+		Hasher hash_acc(Hasher h) const {
+			h.acc(first);
+			h.acc(second);
+			return h;
+		}
 	};
 
 	struct ModuleTiming

--- a/kernel/utils.h
+++ b/kernel/utils.h
@@ -31,17 +31,17 @@ YOSYS_NAMESPACE_BEGIN
 // A map-like container, but you can save and restore the state
 // ------------------------------------------------
 
-template<typename Key, typename T, typename OPS = hash_ops<Key>>
+template<typename Key, typename T>
 struct stackmap
 {
 private:
-	std::vector<dict<Key, T*, OPS>> backup_state;
-	dict<Key, T, OPS> current_state;
+	std::vector<dict<Key, T*>> backup_state;
+	dict<Key, T> current_state;
 	static T empty_tuple;
 
 public:
 	stackmap() { }
-	stackmap(const dict<Key, T, OPS> &other) : current_state(other) { }
+	stackmap(const dict<Key, T> &other) : current_state(other) { }
 
 	template<typename Other>
 	void operator=(const Other &other)
@@ -94,7 +94,7 @@ public:
 		current_state.erase(k);
 	}
 
-	const dict<Key, T, OPS> &stdmap()
+	const dict<Key, T> &stdmap()
 	{
 		return current_state;
 	}
@@ -128,7 +128,7 @@ public:
 // A simple class for topological sorting
 // ------------------------------------------------
 
-template <typename T, typename C = std::less<T>, typename OPS = hash_ops<T>> class TopoSort
+template <typename T, typename C = std::less<T>> class TopoSort
 {
       public:
 	// We use this ordering of the edges in the adjacency matrix for

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -93,6 +93,7 @@ std::set<std::string> yosys_input_files, yosys_output_files;
 bool memhasher_active = false;
 uint32_t memhasher_rng = 123456;
 std::vector<void*> memhasher_store;
+uint32_t Hasher::fudge = 0;
 
 std::string yosys_share_dirname;
 std::string yosys_abc_executable;

--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -153,6 +153,15 @@ using std::get;
 using std::min;
 using std::max;
 
+using hashlib::Hasher;
+using hashlib::run_hash;
+using hashlib::hash_ops;
+using hashlib::mkhash_xorshift;
+using hashlib::dict;
+using hashlib::idict;
+using hashlib::pool;
+using hashlib::mfp;
+
 // A primitive shared string implementation that does not
 // move its .c_str() when the object is copied or moved.
 struct shared_str {
@@ -163,21 +172,11 @@ struct shared_str {
 	const char *c_str() const { return content->c_str(); }
 	const string &str() const { return *content; }
 	bool operator==(const shared_str &other) const { return *content == *other.content; }
-	unsigned int hash() const { return hashlib::hash_ops<std::string>::hash(*content); }
+	Hasher hash_acc(Hasher h) const {
+		h.acc(*content);
+		return h;
+	}
 };
-
-using hashlib::mkhash;
-using hashlib::mkhash_init;
-using hashlib::mkhash_add;
-using hashlib::mkhash_xorshift;
-using hashlib::hash_ops;
-using hashlib::hash_cstr_ops;
-using hashlib::hash_ptr_ops;
-using hashlib::hash_obj_ops;
-using hashlib::dict;
-using hashlib::idict;
-using hashlib::pool;
-using hashlib::mfp;
 
 namespace RTLIL {
 	struct IdString;
@@ -216,26 +215,6 @@ using RTLIL::Design;
 using RTLIL::State;
 using RTLIL::SigChunk;
 using RTLIL::SigSig;
-
-namespace hashlib {
-	template<> struct hash_ops<RTLIL::Wire*> : hash_obj_ops {};
-	template<> struct hash_ops<RTLIL::Cell*> : hash_obj_ops {};
-	template<> struct hash_ops<RTLIL::Memory*> : hash_obj_ops {};
-	template<> struct hash_ops<RTLIL::Process*> : hash_obj_ops {};
-	template<> struct hash_ops<RTLIL::Module*> : hash_obj_ops {};
-	template<> struct hash_ops<RTLIL::Design*> : hash_obj_ops {};
-	template<> struct hash_ops<RTLIL::Monitor*> : hash_obj_ops {};
-	template<> struct hash_ops<AST::AstNode*> : hash_obj_ops {};
-
-	template<> struct hash_ops<const RTLIL::Wire*> : hash_obj_ops {};
-	template<> struct hash_ops<const RTLIL::Cell*> : hash_obj_ops {};
-	template<> struct hash_ops<const RTLIL::Memory*> : hash_obj_ops {};
-	template<> struct hash_ops<const RTLIL::Process*> : hash_obj_ops {};
-	template<> struct hash_ops<const RTLIL::Module*> : hash_obj_ops {};
-	template<> struct hash_ops<const RTLIL::Design*> : hash_obj_ops {};
-	template<> struct hash_ops<const RTLIL::Monitor*> : hash_obj_ops {};
-	template<> struct hash_ops<const AST::AstNode*> : hash_obj_ops {};
-}
 
 void memhasher_on();
 void memhasher_off();
@@ -346,10 +325,6 @@ RTLIL::IdString new_id_suffix(std::string file, int line, std::string func, std:
 #define ID(_id) ([]() { const char *p = "\\" #_id, *q = p[1] == '$' ? p+1 : p; \
         static const YOSYS_NAMESPACE_PREFIX RTLIL::IdString id(q); return id; })()
 namespace ID = RTLIL::ID;
-
-namespace hashlib {
-	template<> struct hash_ops<RTLIL::State> : hash_ops<int> {};
-}
 
 
 YOSYS_NAMESPACE_END

--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -171,7 +171,7 @@ struct shared_str {
 	const char *c_str() const { return content->c_str(); }
 	const string &str() const { return *content; }
 	bool operator==(const shared_str &other) const { return *content == *other.content; }
-	Hasher hash_eat(Hasher h) const {
+	Hasher hash_into(Hasher h) const {
 		h.eat(*content);
 		return h;
 	}

--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -134,8 +134,7 @@ YOSYS_NAMESPACE_BEGIN
 // Note: All headers included in hashlib.h must be included
 // outside of YOSYS_NAMESPACE before this or bad things will happen.
 #ifdef HASHLIB_H
-#  undef HASHLIB_H
-#  include "kernel/hashlib.h"
+#  error You've probably included hashlib.h under two namespace paths. Bad idea.
 #else
 #  include "kernel/hashlib.h"
 #  undef HASHLIB_H

--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -215,6 +215,26 @@ using RTLIL::State;
 using RTLIL::SigChunk;
 using RTLIL::SigSig;
 
+namespace hashlib {
+	template<> struct hash_ops<RTLIL::Wire*> : hash_obj_ops {};
+	template<> struct hash_ops<RTLIL::Cell*> : hash_obj_ops {};
+	template<> struct hash_ops<RTLIL::Memory*> : hash_obj_ops {};
+	template<> struct hash_ops<RTLIL::Process*> : hash_obj_ops {};
+	template<> struct hash_ops<RTLIL::Module*> : hash_obj_ops {};
+	template<> struct hash_ops<RTLIL::Design*> : hash_obj_ops {};
+	template<> struct hash_ops<RTLIL::Monitor*> : hash_obj_ops {};
+	template<> struct hash_ops<AST::AstNode*> : hash_obj_ops {};
+
+	template<> struct hash_ops<const RTLIL::Wire*> : hash_obj_ops {};
+	template<> struct hash_ops<const RTLIL::Cell*> : hash_obj_ops {};
+	template<> struct hash_ops<const RTLIL::Memory*> : hash_obj_ops {};
+	template<> struct hash_ops<const RTLIL::Process*> : hash_obj_ops {};
+	template<> struct hash_ops<const RTLIL::Module*> : hash_obj_ops {};
+	template<> struct hash_ops<const RTLIL::Design*> : hash_obj_ops {};
+	template<> struct hash_ops<const RTLIL::Monitor*> : hash_obj_ops {};
+	template<> struct hash_ops<const AST::AstNode*> : hash_obj_ops {};
+}
+
 void memhasher_on();
 void memhasher_off();
 void memhasher_do();

--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -171,8 +171,8 @@ struct shared_str {
 	const char *c_str() const { return content->c_str(); }
 	const string &str() const { return *content; }
 	bool operator==(const shared_str &other) const { return *content == *other.content; }
-	Hasher hash_acc(Hasher h) const {
-		h.acc(*content);
+	Hasher hash_eat(Hasher h) const {
+		h.eat(*content);
 		return h;
 	}
 };

--- a/kernel/yw.h
+++ b/kernel/yw.h
@@ -35,7 +35,7 @@ struct IdPath : public std::vector<RTLIL::IdString>
 	bool has_address() const { int tmp; return get_address(tmp); };
 	bool get_address(int &addr) const;
 
-	Hasher hash_eat(Hasher h) const { h.eat(*this); return h; }
+	Hasher hash_into(Hasher h) const { h.eat(*this); return h; }
 };
 
 struct WitnessHierarchyItem {

--- a/kernel/yw.h
+++ b/kernel/yw.h
@@ -35,7 +35,7 @@ struct IdPath : public std::vector<RTLIL::IdString>
 	bool has_address() const { int tmp; return get_address(tmp); };
 	bool get_address(int &addr) const;
 
-	int hash() const { return hashlib::hash_ops<std::vector<RTLIL::IdString>>::hash(*this); }
+	Hasher hash_acc(Hasher h) const { h.acc(*this); return h; }
 };
 
 struct WitnessHierarchyItem {

--- a/kernel/yw.h
+++ b/kernel/yw.h
@@ -35,7 +35,7 @@ struct IdPath : public std::vector<RTLIL::IdString>
 	bool has_address() const { int tmp; return get_address(tmp); };
 	bool get_address(int &addr) const;
 
-	Hasher hash_acc(Hasher h) const { h.acc(*this); return h; }
+	Hasher hash_eat(Hasher h) const { h.eat(*this); return h; }
 };
 
 struct WitnessHierarchyItem {

--- a/misc/py_wrap_generator.py
+++ b/misc/py_wrap_generator.py
@@ -855,7 +855,11 @@ class WClass:
 		if self.hash_id != None:
 			text += "\n\t\tunsigned int get_hash_py()"
 			text += "\n\t\t{"
-			text += "\n\t\t\treturn get_cpp_obj()->" + self.hash_id + ";"
+			suffix = f"->{self.hash_id}" if self.hash_id else f"->{self.hash_id}"
+			if self.hash_id == "":
+				text += f"\n\t\t\treturn run_hash(*(get_cpp_obj()));"
+			else:
+				text += f"\n\t\t\treturn run_hash(get_cpp_obj()->{self.hash_id});"
 			text += "\n\t\t}"
 
 		text += "\n\t};\n"
@@ -956,7 +960,7 @@ class WClass:
 
 sources = [
 	Source("kernel/celltypes",[
-		WClass("CellType", link_types.pointer, None, None, "type.hash()", True),
+		WClass("CellType", link_types.pointer, None, None, "type", True),
 		WClass("CellTypes", link_types.pointer, None, None, None, True)
 		]
 		),
@@ -970,23 +974,23 @@ sources = [
 		]
 		),
 	Source("kernel/rtlil",[
-		WClass("IdString", link_types.ref_copy, None, "str()", "hash()"),
-		WClass("Const", link_types.ref_copy, None, "as_string()", "hash()"),
+		WClass("IdString", link_types.ref_copy, None, "str()", ""),
+		WClass("Const", link_types.ref_copy, None, "as_string()", ""),
 		WClass("AttrObject", link_types.ref_copy, None, None, None),
 		WClass("Selection", link_types.ref_copy, None, None, None),
 		WClass("Monitor", link_types.derive, None, None, None),
 		WClass("CaseRule",link_types.ref_copy, None, None, None, True),
 		WClass("SwitchRule",link_types.ref_copy, None, None, None, True),
 		WClass("SyncRule", link_types.ref_copy, None, None, None, True),
-		WClass("Process",  link_types.ref_copy, None, "name.c_str()", "name.hash()"),
+		WClass("Process",  link_types.ref_copy, None, "name.c_str()", "name"),
 		WClass("SigChunk", link_types.ref_copy, None, None, None),
-		WClass("SigBit", link_types.ref_copy, None, None, "hash()"),
-		WClass("SigSpec", link_types.ref_copy, None, None, "hash()"),
-		WClass("Cell", link_types.global_list, Attribute(WType("unsigned int"), "hashidx_"), "name.c_str()", "hash()"),
-		WClass("Wire", link_types.global_list, Attribute(WType("unsigned int"), "hashidx_"), "name.c_str()", "hash()"),
-		WClass("Memory", link_types.global_list, Attribute(WType("unsigned int"), "hashidx_"), "name.c_str()", "hash()"),
-		WClass("Module", link_types.global_list, Attribute(WType("unsigned int"), "hashidx_"), "name.c_str()", "hash()"),
-		WClass("Design", link_types.global_list, Attribute(WType("unsigned int"), "hashidx_"), "hashidx_", "hash()")
+		WClass("SigBit", link_types.ref_copy, None, None, ""),
+		WClass("SigSpec", link_types.ref_copy, None, None, ""),
+		WClass("Cell", link_types.global_list, Attribute(WType("unsigned int"), "hashidx_"), "name.c_str()", ""),
+		WClass("Wire", link_types.global_list, Attribute(WType("unsigned int"), "hashidx_"), "name.c_str()", ""),
+		WClass("Memory", link_types.global_list, Attribute(WType("unsigned int"), "hashidx_"), "name.c_str()", ""),
+		WClass("Module", link_types.global_list, Attribute(WType("unsigned int"), "hashidx_"), "name.c_str()", ""),
+		WClass("Design", link_types.global_list, Attribute(WType("unsigned int"), "hashidx_"), "hashidx_", "")
 		]
 		),
 	#Source("kernel/satgen",[

--- a/passes/cmds/dft_tag.cc
+++ b/passes/cmds/dft_tag.cc
@@ -47,7 +47,7 @@ struct DftTagWorker {
 		bool operator<(const tag_set &other) const { return index < other.index; }
 		bool operator==(const tag_set &other) const { return index == other.index; }
 
-		unsigned int hash() const { return hash_ops<int>::hash(index); }
+		Hasher hash_acc(Hasher h) const { h.acc(index); return h; }
 
 		bool empty() const { return index == 0; }
 	};

--- a/passes/cmds/dft_tag.cc
+++ b/passes/cmds/dft_tag.cc
@@ -47,7 +47,7 @@ struct DftTagWorker {
 		bool operator<(const tag_set &other) const { return index < other.index; }
 		bool operator==(const tag_set &other) const { return index == other.index; }
 
-		Hasher hash_eat(Hasher h) const { h.eat(index); return h; }
+		Hasher hash_into(Hasher h) const { h.eat(index); return h; }
 
 		bool empty() const { return index == 0; }
 	};

--- a/passes/cmds/dft_tag.cc
+++ b/passes/cmds/dft_tag.cc
@@ -47,7 +47,7 @@ struct DftTagWorker {
 		bool operator<(const tag_set &other) const { return index < other.index; }
 		bool operator==(const tag_set &other) const { return index == other.index; }
 
-		Hasher hash_acc(Hasher h) const { h.acc(index); return h; }
+		Hasher hash_eat(Hasher h) const { h.eat(index); return h; }
 
 		bool empty() const { return index == 0; }
 	};

--- a/passes/cmds/example_dt.cc
+++ b/passes/cmds/example_dt.cc
@@ -52,7 +52,7 @@ struct ExampleDtPass : public Pass
 					return name == other.name && parameters == other.parameters;
 				}
 
-				Hasher hash_eat(Hasher h) const {
+				Hasher hash_into(Hasher h) const {
 					h.eat(name);
 					h.eat(parameters);
 					return h;

--- a/passes/cmds/example_dt.cc
+++ b/passes/cmds/example_dt.cc
@@ -52,9 +52,9 @@ struct ExampleDtPass : public Pass
 					return name == other.name && parameters == other.parameters;
 				}
 
-				Hasher hash_acc(Hasher h) const {
-					h.acc(name);
-					h.acc(parameters);
+				Hasher hash_eat(Hasher h) const {
+					h.eat(name);
+					h.eat(parameters);
 					return h;
 				}
 			};

--- a/passes/cmds/example_dt.cc
+++ b/passes/cmds/example_dt.cc
@@ -52,8 +52,10 @@ struct ExampleDtPass : public Pass
 					return name == other.name && parameters == other.parameters;
 				}
 
-				unsigned int hash() const {
-					return mkhash(name.hash(), parameters.hash());
+				Hasher hash_acc(Hasher h) const {
+					h.acc(name);
+					h.acc(parameters);
+					return h;
 				}
 			};
 

--- a/passes/cmds/rename.cc
+++ b/passes/cmds/rename.cc
@@ -20,7 +20,6 @@
 #include "kernel/register.h"
 #include "kernel/rtlil.h"
 #include "kernel/log.h"
-#include "kernel/hashlib.h"
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN

--- a/passes/cmds/viz.cc
+++ b/passes/cmds/viz.cc
@@ -70,13 +70,13 @@ struct GraphNode {
 
 	pool<IdString> names_;
 	dict<int, uint8_t> tags_;
-	pool<GraphNode*, hash_ptr_ops> upstream_;
-	pool<GraphNode*, hash_ptr_ops> downstream_;
+	pool<GraphNode*> upstream_;
+	pool<GraphNode*> downstream_;
 
 	pool<IdString> &names() { return get()->names_; }
 	dict<int, uint8_t> &tags() { return get()->tags_; }
-	pool<GraphNode*, hash_ptr_ops> &upstream() { return get()->upstream_; }
-	pool<GraphNode*, hash_ptr_ops> &downstream() { return get()->downstream_; }
+	pool<GraphNode*> &upstream() { return get()->upstream_; }
+	pool<GraphNode*> &downstream() { return get()->downstream_; }
 
 	uint8_t tag(int index) {
 		return tags().at(index, 0);
@@ -154,8 +154,8 @@ struct Graph {
 			nodes.push_back(n);
 			n->index = GetSize(nodes);
 
-			pool<GraphNode*, hash_ptr_ops> new_upstream;
-			pool<GraphNode*, hash_ptr_ops> new_downstream;
+			pool<GraphNode*> new_upstream;
+			pool<GraphNode*> new_downstream;
 
 			for (auto g : n->upstream()) {
 				if (n != (g = g->get()))
@@ -302,7 +302,7 @@ struct Graph {
 			}
 		}
 
-		pool<GraphNode*, hash_ptr_ops> excluded;
+		pool<GraphNode*> excluded;
 
 		for (auto grp : config.groups)
 		{
@@ -348,7 +348,7 @@ struct Graph {
 			excluded.insert(g->get());
 
 		dict<Cell*, GraphNode*> cell_nodes;
-		dict<SigBit, pool<GraphNode*, hash_ptr_ops>> sig_users;
+		dict<SigBit, pool<GraphNode*>> sig_users;
 
 		for (auto cell : module->selected_cells()) {
 			auto g = new GraphNode;
@@ -483,8 +483,8 @@ struct Graph {
 
 			{
 				header("Any nodes with identical connections");
-				typedef pair<pool<GraphNode*, hash_ptr_ops>, pool<GraphNode*, hash_ptr_ops>> node_conn_t;
-				dict<node_conn_t, pool<GraphNode*, hash_ptr_ops>> nodes_by_conn;
+				typedef pair<pool<GraphNode*>, pool<GraphNode*>> node_conn_t;
+				dict<node_conn_t, pool<GraphNode*>> nodes_by_conn;
 				for (auto g : term ? term_nodes : nonterm_nodes) {
 					auto &entry = nodes_by_conn[node_conn_t(g->upstream(), g->downstream())];
 					for (auto n : entry)
@@ -506,8 +506,8 @@ struct Graph {
 
 				header("Sibblings with identical tags");
 				for (auto g : nonterm_nodes) {
-					auto process_conns = [&](const pool<GraphNode*, hash_ptr_ops> &stream) {
-						dict<std::vector<int>, pool<GraphNode*, hash_ptr_ops>> nodes_by_tags;
+					auto process_conns = [&](const pool<GraphNode*> &stream) {
+						dict<std::vector<int>, pool<GraphNode*>> nodes_by_tags;
 						for (auto n : stream) {
 							if (n->terminal) continue;
 							std::vector<int> key;
@@ -556,7 +556,7 @@ struct Graph {
 			if (!term) {
 				header("Sibblings with similar tags (strict)");
 				for (auto g : nonterm_nodes) {
-					auto process_conns = [&](const pool<GraphNode*, hash_ptr_ops> &stream) {
+					auto process_conns = [&](const pool<GraphNode*> &stream) {
 						std::vector<GraphNode*> nodes;
 						for (auto n : stream)
 							if (!n->terminal) nodes.push_back(n);
@@ -585,7 +585,7 @@ struct Graph {
 			if (!term) {
 				header("Sibblings with similar tags (non-strict)");
 				for (auto g : nonterm_nodes) {
-					auto process_conns = [&](const pool<GraphNode*, hash_ptr_ops> &stream) {
+					auto process_conns = [&](const pool<GraphNode*> &stream) {
 						std::vector<GraphNode*> nodes;
 						for (auto n : stream)
 							if (!n->terminal) nodes.push_back(n);
@@ -603,7 +603,7 @@ struct Graph {
 
 			{
 				header("Any nodes with identical fan-in or fan-out");
-				dict<pool<GraphNode*, hash_ptr_ops>, pool<GraphNode*, hash_ptr_ops>> nodes_by_conn[2];
+				dict<pool<GraphNode*>, pool<GraphNode*>> nodes_by_conn[2];
 				for (auto g : term ? term_nodes : nonterm_nodes) {
 					auto &up_entry = nodes_by_conn[0][g->upstream()];
 					auto &down_entry = nodes_by_conn[1][g->downstream()];
@@ -629,7 +629,7 @@ struct Graph {
 			if (!term) {
 				header("Sibblings with similar tags (lax)");
 				for (auto g : nonterm_nodes) {
-					auto process_conns = [&](const pool<GraphNode*, hash_ptr_ops> &stream) {
+					auto process_conns = [&](const pool<GraphNode*> &stream) {
 						std::vector<GraphNode*> nodes;
 						for (auto n : stream)
 							if (!n->terminal) nodes.push_back(n);
@@ -720,9 +720,9 @@ struct VizWorker
 		fprintf(f, "digraph \"%s\" {\n", log_id(module));
 		fprintf(f, "  rankdir = LR;\n");
 
-		dict<GraphNode*, std::vector<std::vector<std::string>>, hash_ptr_ops> extra_lines;
-		dict<GraphNode*, GraphNode*, hash_ptr_ops> bypass_nodes;
-		pool<GraphNode*, hash_ptr_ops> bypass_candidates;
+		dict<GraphNode*, std::vector<std::vector<std::string>>> extra_lines;
+		dict<GraphNode*, GraphNode*> bypass_nodes;
+		pool<GraphNode*> bypass_candidates;
 
 		auto bypass = [&](GraphNode *g, GraphNode *n) {
 			log_assert(g->terminal);

--- a/passes/equiv/equiv_struct.cc
+++ b/passes/equiv/equiv_struct.cc
@@ -46,11 +46,11 @@ struct EquivStructWorker
 					parameters == other.parameters && port_sizes == other.port_sizes;
 		}
 
-		unsigned int hash() const {
-			unsigned int h = mkhash_init;
-			h = mkhash(h, mkhash(type));
-			h = mkhash(h, mkhash(parameters));
-			h = mkhash(h, mkhash(connections));
+		Hasher hash_acc(Hasher h) const {
+			h.acc(type);
+			h.acc(parameters);
+			h.acc(port_sizes);
+			h.acc(connections);
 			return h;
 		}
 	};

--- a/passes/equiv/equiv_struct.cc
+++ b/passes/equiv/equiv_struct.cc
@@ -46,7 +46,7 @@ struct EquivStructWorker
 					parameters == other.parameters && port_sizes == other.port_sizes;
 		}
 
-		Hasher hash_eat(Hasher h) const {
+		Hasher hash_into(Hasher h) const {
 			h.eat(type);
 			h.eat(parameters);
 			h.eat(port_sizes);

--- a/passes/equiv/equiv_struct.cc
+++ b/passes/equiv/equiv_struct.cc
@@ -46,11 +46,11 @@ struct EquivStructWorker
 					parameters == other.parameters && port_sizes == other.port_sizes;
 		}
 
-		Hasher hash_acc(Hasher h) const {
-			h.acc(type);
-			h.acc(parameters);
-			h.acc(port_sizes);
-			h.acc(connections);
+		Hasher hash_eat(Hasher h) const {
+			h.eat(type);
+			h.eat(parameters);
+			h.eat(port_sizes);
+			h.eat(connections);
 			return h;
 		}
 	};

--- a/passes/proc/proc_dlatch.cc
+++ b/passes/proc/proc_dlatch.cc
@@ -127,10 +127,10 @@ struct proc_dlatch_db_t
 			return signal == other.signal && match == other.match && children == other.children;
 		}
 
-		Hasher hash_acc(Hasher h) const {
-			h.acc(signal);
-			h.acc(match);
-			h.acc(children);
+		Hasher hash_eat(Hasher h) const {
+			h.eat(signal);
+			h.eat(match);
+			h.eat(children);
 			return h;
 		}
 	};

--- a/passes/proc/proc_dlatch.cc
+++ b/passes/proc/proc_dlatch.cc
@@ -127,7 +127,7 @@ struct proc_dlatch_db_t
 			return signal == other.signal && match == other.match && children == other.children;
 		}
 
-		Hasher hash_eat(Hasher h) const {
+		Hasher hash_into(Hasher h) const {
 			h.eat(signal);
 			h.eat(match);
 			h.eat(children);

--- a/passes/proc/proc_dlatch.cc
+++ b/passes/proc/proc_dlatch.cc
@@ -127,11 +127,10 @@ struct proc_dlatch_db_t
 			return signal == other.signal && match == other.match && children == other.children;
 		}
 
-		unsigned int hash() const {
-			unsigned int h = mkhash_init;
-			mkhash(h, signal.hash());
-			mkhash(h, match.hash());
-			for (auto i : children) mkhash(h, i);
+		Hasher hash_acc(Hasher h) const {
+			h.acc(signal);
+			h.acc(match);
+			h.acc(children);
 			return h;
 		}
 	};

--- a/passes/proc/proc_mux.cc
+++ b/passes/proc/proc_mux.cc
@@ -108,8 +108,8 @@ struct SigSnippets
 
 struct SnippetSwCache
 {
-	dict<RTLIL::SwitchRule*, pool<RTLIL::SigBit>, hash_ptr_ops> full_case_bits_cache;
-	dict<RTLIL::SwitchRule*, pool<int>, hash_ptr_ops> cache;
+	dict<RTLIL::SwitchRule*, pool<RTLIL::SigBit>> full_case_bits_cache;
+	dict<RTLIL::SwitchRule*, pool<int>> cache;
 	const SigSnippets *snippets;
 	int current_snippet;
 
@@ -318,7 +318,7 @@ const pool<SigBit> &get_full_case_bits(SnippetSwCache &swcache, RTLIL::SwitchRul
 	return swcache.full_case_bits_cache.at(sw);
 }
 
-RTLIL::SigSpec signal_to_mux_tree(RTLIL::Module *mod, SnippetSwCache &swcache, dict<RTLIL::SwitchRule*, bool, hash_ptr_ops> &swpara,
+RTLIL::SigSpec signal_to_mux_tree(RTLIL::Module *mod, SnippetSwCache &swcache, dict<RTLIL::SwitchRule*, bool> &swpara,
 		RTLIL::CaseRule *cs, const RTLIL::SigSpec &sig, const RTLIL::SigSpec &defval, bool ifxmode)
 {
 	RTLIL::SigSpec result = defval;
@@ -421,7 +421,7 @@ void proc_mux(RTLIL::Module *mod, RTLIL::Process *proc, bool ifxmode)
 	swcache.snippets = &sigsnip;
 	swcache.insert(&proc->root_case);
 
-	dict<RTLIL::SwitchRule*, bool, hash_ptr_ops> swpara;
+	dict<RTLIL::SwitchRule*, bool> swpara;
 
 	int cnt = 0;
 	for (int idx : sigsnip.snippets)

--- a/passes/sat/mutate.cc
+++ b/passes/sat/mutate.cc
@@ -176,7 +176,7 @@ struct coverdb_t
 
 struct mutate_queue_t
 {
-	pool<mutate_t*, hash_ptr_ops> db;
+	pool<mutate_t*> db;
 
 	mutate_t *pick(xs128_t &rng, coverdb_t &coverdb, const mutate_opts_t &opts) {
 		mutate_t *m = nullptr;

--- a/passes/sat/recover_names.cc
+++ b/passes/sat/recover_names.cc
@@ -46,7 +46,7 @@ struct IdBit {
 
     bool operator==(const IdBit &other) const { return name == other.name && bit == other.bit; };
     bool operator!=(const IdBit &other) const { return name != other.name || bit != other.bit; };
-    Hasher hash_eat(Hasher h) const
+    Hasher hash_into(Hasher h) const
     {
         h.eat(name);
         h.eat(bit);
@@ -64,7 +64,7 @@ struct InvBit {
 
     bool operator==(const InvBit &other) const { return bit == other.bit && inverted == other.inverted; };
     bool operator!=(const InvBit &other) const { return bit != other.bit || inverted != other.inverted; };
-    Hasher hash_eat(Hasher h) const
+    Hasher hash_into(Hasher h) const
     {
         h.eat(bit);
         h.eat(inverted);

--- a/passes/sat/recover_names.cc
+++ b/passes/sat/recover_names.cc
@@ -46,9 +46,11 @@ struct IdBit {
 
     bool operator==(const IdBit &other) const { return name == other.name && bit == other.bit; };
     bool operator!=(const IdBit &other) const { return name != other.name || bit != other.bit; };
-    unsigned hash() const
+    Hasher hash_acc(Hasher h) const
     {
-        return mkhash_add(name.hash(), bit);
+        h.acc(name);
+        h.acc(bit);
+        return h;
     }
 
     IdString name;
@@ -62,9 +64,11 @@ struct InvBit {
 
     bool operator==(const InvBit &other) const { return bit == other.bit && inverted == other.inverted; };
     bool operator!=(const InvBit &other) const { return bit != other.bit || inverted != other.inverted; };
-    unsigned hash() const
+    Hasher hash_acc(Hasher h) const
     {
-        return mkhash(bit.hash(), inverted);
+        h.acc(bit);
+        h.acc(inverted);
+        return h;
     }
 
     IdBit bit;

--- a/passes/sat/recover_names.cc
+++ b/passes/sat/recover_names.cc
@@ -46,10 +46,10 @@ struct IdBit {
 
     bool operator==(const IdBit &other) const { return name == other.name && bit == other.bit; };
     bool operator!=(const IdBit &other) const { return name != other.name || bit != other.bit; };
-    Hasher hash_acc(Hasher h) const
+    Hasher hash_eat(Hasher h) const
     {
-        h.acc(name);
-        h.acc(bit);
+        h.eat(name);
+        h.eat(bit);
         return h;
     }
 
@@ -64,10 +64,10 @@ struct InvBit {
 
     bool operator==(const InvBit &other) const { return bit == other.bit && inverted == other.inverted; };
     bool operator!=(const InvBit &other) const { return bit != other.bit || inverted != other.inverted; };
-    Hasher hash_acc(Hasher h) const
+    Hasher hash_eat(Hasher h) const
     {
-        h.acc(bit);
-        h.acc(inverted);
+        h.eat(bit);
+        h.eat(inverted);
         return h;
     }
 

--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -161,7 +161,7 @@ struct SimInstance
 	pool<SigBit> dirty_bits;
 	pool<Cell*> dirty_cells;
 	pool<IdString> dirty_memories;
-	pool<SimInstance*, hash_ptr_ops> dirty_children;
+	pool<SimInstance*> dirty_children;
 
 	struct ff_state_t
 	{

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1411,6 +1411,7 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 			module->connect(conn);
 		}
 
+		cell_stats.sort();
 		for (auto &it : cell_stats)
 			log("ABC RESULTS:   %15s cells: %8d\n", it.first.c_str(), it.second);
 		int in_wires = 0, out_wires = 0;

--- a/passes/techmap/alumacc.cc
+++ b/passes/techmap/alumacc.cc
@@ -111,7 +111,7 @@ struct AlumaccWorker
 
 	dict<RTLIL::SigBit, int> bit_users;
 	dict<RTLIL::SigSpec, maccnode_t*> sig_macc;
-	dict<RTLIL::SigSig, pool<alunode_t*, hash_ptr_ops>> sig_alu;
+	dict<RTLIL::SigSig, pool<alunode_t*>> sig_alu;
 	int macc_counter, alu_counter;
 
 	AlumaccWorker(RTLIL::Module *module) : module(module), sigmap(module)
@@ -226,7 +226,7 @@ struct AlumaccWorker
 	{
 		while (1)
 		{
-			pool<maccnode_t*, hash_ptr_ops> delete_nodes;
+			pool<maccnode_t*> delete_nodes;
 
 			for (auto &it : sig_macc)
 			{
@@ -278,7 +278,7 @@ struct AlumaccWorker
 
 	void macc_to_alu()
 	{
-		pool<maccnode_t*, hash_ptr_ops> delete_nodes;
+		pool<maccnode_t*> delete_nodes;
 
 		for (auto &it : sig_macc)
 		{

--- a/passes/techmap/clockgate.cc
+++ b/passes/techmap/clockgate.cc
@@ -233,9 +233,9 @@ struct ClockgatePass : public Pass {
 		SigBit ce_bit;
 		bool pol_clk;
 		bool pol_ce;
-		Hasher hash_acc(Hasher h) const {
+		Hasher hash_eat(Hasher h) const {
 			auto t = std::make_tuple(clk_bit, ce_bit, pol_clk, pol_ce);
-			h.acc(t);
+			h.eat(t);
 			return h;
 		}
 		bool operator==(const ClkNetInfo& other) const {

--- a/passes/techmap/clockgate.cc
+++ b/passes/techmap/clockgate.cc
@@ -233,10 +233,9 @@ struct ClockgatePass : public Pass {
 		SigBit ce_bit;
 		bool pol_clk;
 		bool pol_ce;
-		unsigned int hash() const {
+		Hasher hash_acc(Hasher h) const {
 			auto t = std::make_tuple(clk_bit, ce_bit, pol_clk, pol_ce);
-			unsigned int h = mkhash_init;
-			h = mkhash(h, hash_ops<decltype(t)>::hash(t));
+			h.acc(t);
 			return h;
 		}
 		bool operator==(const ClkNetInfo& other) const {

--- a/passes/techmap/clockgate.cc
+++ b/passes/techmap/clockgate.cc
@@ -233,7 +233,7 @@ struct ClockgatePass : public Pass {
 		SigBit ce_bit;
 		bool pol_clk;
 		bool pol_ce;
-		Hasher hash_eat(Hasher h) const {
+		Hasher hash_into(Hasher h) const {
 			auto t = std::make_tuple(clk_bit, ce_bit, pol_clk, pol_ce);
 			h.eat(t);
 			return h;

--- a/passes/techmap/flowmap.cc
+++ b/passes/techmap/flowmap.cc
@@ -250,9 +250,11 @@ struct FlowGraph
 		{
 			return !(*this == other);
 		}
-		unsigned int hash() const
+		Hasher hash_acc(Hasher h) const
 		{
-			return hash_ops<pair<RTLIL::SigBit, int>>::hash({node, is_bottom});
+			std::pair<RTLIL::SigBit, int> p = {node, is_bottom};
+			h.acc(p);
+			return h;
 		}
 
 		static NodePrime top(RTLIL::SigBit node)

--- a/passes/techmap/flowmap.cc
+++ b/passes/techmap/flowmap.cc
@@ -250,10 +250,10 @@ struct FlowGraph
 		{
 			return !(*this == other);
 		}
-		Hasher hash_acc(Hasher h) const
+		Hasher hash_eat(Hasher h) const
 		{
 			std::pair<RTLIL::SigBit, int> p = {node, is_bottom};
-			h.acc(p);
+			h.eat(p);
 			return h;
 		}
 

--- a/passes/techmap/flowmap.cc
+++ b/passes/techmap/flowmap.cc
@@ -250,7 +250,7 @@ struct FlowGraph
 		{
 			return !(*this == other);
 		}
-		Hasher hash_eat(Hasher h) const
+		Hasher hash_into(Hasher h) const
 		{
 			std::pair<RTLIL::SigBit, int> p = {node, is_bottom};
 			h.eat(p);

--- a/techlibs/quicklogic/ql_dsp_simd.cc
+++ b/techlibs/quicklogic/ql_dsp_simd.cc
@@ -53,7 +53,7 @@ struct QlDspSimdPass : public Pass {
 		DspConfig(const DspConfig &ref) = default;
 		DspConfig(DspConfig &&ref) = default;
 
-		Hasher hash_eat(Hasher h) const { h.eat(connections); return h; }
+		Hasher hash_into(Hasher h) const { h.eat(connections); return h; }
 
 		bool operator==(const DspConfig &ref) const { return connections == ref.connections; }
 	};

--- a/techlibs/quicklogic/ql_dsp_simd.cc
+++ b/techlibs/quicklogic/ql_dsp_simd.cc
@@ -53,7 +53,7 @@ struct QlDspSimdPass : public Pass {
 		DspConfig(const DspConfig &ref) = default;
 		DspConfig(DspConfig &&ref) = default;
 
-		Hasher hash_acc(Hasher h) const { h.acc(connections); return h; }
+		Hasher hash_eat(Hasher h) const { h.eat(connections); return h; }
 
 		bool operator==(const DspConfig &ref) const { return connections == ref.connections; }
 	};

--- a/techlibs/quicklogic/ql_dsp_simd.cc
+++ b/techlibs/quicklogic/ql_dsp_simd.cc
@@ -53,7 +53,7 @@ struct QlDspSimdPass : public Pass {
 		DspConfig(const DspConfig &ref) = default;
 		DspConfig(DspConfig &&ref) = default;
 
-		unsigned int hash() const { return connections.hash(); }
+		Hasher hash_acc(Hasher h) const { h.acc(connections); return h; }
 
 		bool operator==(const DspConfig &ref) const { return connections == ref.connections; }
 	};


### PR DESCRIPTION
Please read `docs/source/yosys_internals/hashing.rst` for what the interface is now.

We want to be able to plug-and-play hash functions to improve hashlib structure collision rates and hashing speed. Currently, in some ways, hashes are incorrectly handled: for deep structure hashing, each substructure constructs a hash from scratch, and these hashes are then combined with addition, XOR, sometimes xorshifted to make this less iffy, but overall, this is risky, as it may degrade various hash functions to varying degrees. It seems to me that the correct combination of hashes is to have a hash state that is mutated with each datum hashed in sequence. That's what this PR does.

- [x] check performance impact since this PR isn't NFC as it changes how structures are hashed
- [x] clean up things left over from experiments with inheriting from `Hashable`
- [x] fix pyosys
- [x] finish the plugin compatibility part of the doc