### PR TITLE
verific: Add bottom and top bound properties to wire

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -450,6 +450,19 @@ void VerificImporter::import_attributes(dict<RTLIL::IdString, RTLIL::Const> &att
 		auto type_range = nl->GetTypeRange(obj->Name());
 		if (!type_range)
 			return;
+		if (type_range->IsTypeScalar()) {
+			const long long bottom_bound = type_range->GetScalarRangeLeftBound();
+			const long long top_bound = type_range->GetScalarRangeRightBound();
+			const unsigned bit_width = type_range->NumElements();
+			RTLIL::Const bottom_const(bottom_bound, bit_width);
+			RTLIL::Const top_const(top_bound, bit_width);
+			if (bottom_bound < 0 || top_bound < 0) {
+				bottom_const.flags |= RTLIL::CONST_FLAG_SIGNED;
+				top_const.flags |= RTLIL::CONST_FLAG_SIGNED;
+			}
+			attributes.emplace(ID(bottom_bound), bottom_const);
+			attributes.emplace(ID(top_bound), top_const);
+		}
 		if (!type_range->IsTypeEnum())
 			return;
 #ifdef VERIFIC_VHDL_SUPPORT

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -213,7 +213,7 @@ RTLIL::Const::Const(const std::string &str)
 	}
 }
 
-RTLIL::Const::Const(int val, int width)
+RTLIL::Const::Const(long long val, int width)
 {
 	flags = RTLIL::CONST_FLAG_NONE;
 	bits.reserve(width);

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -662,7 +662,7 @@ struct RTLIL::Const
 
 	Const() : flags(RTLIL::CONST_FLAG_NONE) {}
 	Const(const std::string &str);
-	Const(int val, int width = 32);
+	Const(long long val, int width = 32);
 	Const(RTLIL::State bit, int width = 1);
 	Const(const std::vector<RTLIL::State> &bits) : bits(bits) { flags = CONST_FLAG_NONE; }
 	Const(const std::vector<bool> &bits);

--- a/passes/cmds/printattrs.cc
+++ b/passes/cmds/printattrs.cc
@@ -42,7 +42,7 @@ struct PrintAttrsPass : public Pass {
 	static void log_const(const RTLIL::IdString &s, const RTLIL::Const &x, const unsigned int indent) {
 		if (x.flags == RTLIL::CONST_FLAG_STRING)
 			log("%s(* %s=\"%s\" *)\n", get_indent_str(indent).c_str(), log_id(s), x.decode_string().c_str());
-		else if (x.flags == RTLIL::CONST_FLAG_NONE)
+		else if (x.flags == RTLIL::CONST_FLAG_NONE || x.flags == RTLIL::CONST_FLAG_SIGNED)
 			log("%s(* %s=%s *)\n", get_indent_str(indent).c_str(), log_id(s), x.as_string().c_str());
 		else
 			log_assert(x.flags == RTLIL::CONST_FLAG_STRING || x.flags == RTLIL::CONST_FLAG_NONE); //intended to fail

--- a/tests/verific/bounds.vhd
+++ b/tests/verific/bounds.vhd
@@ -1,0 +1,18 @@
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+use IEEE.NUMERIC_STD.ALL;
+
+entity work is
+    Port (
+        a : in INTEGER range -5 to 10;
+        b : out INTEGER range -6 to 11
+    );
+end entity work;
+
+architecture Behavioral of work is
+begin
+    process(a)
+    begin
+        b <= a;
+    end process;
+end architecture Behavioral;

--- a/tests/verific/bounds.ys
+++ b/tests/verific/bounds.ys
@@ -1,0 +1,6 @@
+read -vhdl bounds.vhd
+verific -import work
+select -assert-count 1 a:bottom_bound=5'bs11011
+select -assert-count 1 a:top_bound=5'bs01010
+select -assert-count 1 a:bottom_bound=5'bs11010
+select -assert-count 1 a:top_bound=5'bs01011


### PR DESCRIPTION
### What are the reasons/motivation for this change?
Having bound properties for wires would help detect underflow and overflow in cases where the user is more restrictive than the RTLIL representation.
For example, the following VHDL

`signal a : INTEGER range 0 to 6;
`
is represented in RTLIL as:
`wire width 3 input 1 \a
`because to represent decimal 6 you need at least 3 bits.
However, decimal 7 can also be represented, which would be an overflow as per the user specified range, and that user constraint would get lost without this attribute.
This patch helps ensure that those user constraints are maintained and accessible in the RTLIL representation.
### Explain how this is achieved.
With the Verific API, we get the bounds information and create attributes (named `bottom_bound` and `top_bound`).
Those attributes are of the same bit width as the wire they belong to.
If at least one the bound is negative, both constants are flagged as signed.
#### Supporting changes
printattrs.cc: Updated the logic to print attributes for signed constants.
RTLIL::Const: The constructor was modified to use `long long` instead of `int`. This is necessary because to support VHDL 2019 integers with bit widths up to 64, the Verific API’s `TypeRange::GetScalarRangeLeftBound()` method returns a `long long`.
### Discarded options
We decided that bound attributes for enumeration types will not be added in this PR.
