### PR TITLE
Replace test-compile (ubuntu-22.04, clang-11)

### DIFF
--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -40,8 +40,8 @@ jobs:
           - os: macos-13
             compiler: 'clang'
           # oldest clang not available on ubuntu-latest
-          - os: ubuntu-22.04
-            compiler: 'clang-11'
+          - os: ubuntu-20.04
+            compiler: 'clang-10'
       fail-fast: false
     steps:
       - name: Checkout Yosys


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
[test-compile (ubuntu-22.04, clang-11)](https://github.com/YosysHQ/yosys/actions/runs/10374983466/job/28755517074?pr=4537#logs) is broken as of 14/08/2024 since clang-11 and clang-12 were dropped from ubuntu-22.04.

_Explain how this is achieved._
Replace with ubuntu-20.04, which also has earlier versions of clang so we can test clang-10 instead.

_If applicable, please suggest to reviewers how they can test the change._
