### PR TITLE
Resolve (some) compiler warnings

### DIFF
--- a/kernel/fmt.cc
+++ b/kernel/fmt.cc
@@ -832,7 +832,7 @@ std::string Fmt::render() const
 						}
 					} else log_abort();
 					if (part.justify == FmtPart::NUMERIC && part.group && part.padding == '0') {
-						int group_size = part.base == 10 ? 3 : 4;
+						size_t group_size = part.base == 10 ? 3 : 4;
 						while (prefix.size() + buf.size() < part.width) {
 							if (buf.size() % (group_size + 1) == group_size)
 								buf += '_';

--- a/kernel/satgen.cc
+++ b/kernel/satgen.cc
@@ -1228,7 +1228,7 @@ bool SatGen::importCell(RTLIL::Cell *cell, int timestep)
 			if (ff.has_srst && ff.has_ce && ff.ce_over_srst) {
 				int srst = importDefSigSpec(ff.sig_srst, timestep-1).at(0);
 				std::vector<int> rval = importDefSigSpec(ff.val_srst, timestep-1);
-				int undef_srst;
+				int undef_srst = -1;
 				std::vector<int> undef_rval;
 				if (model_undef) {
 					undef_srst = importUndefSigSpec(ff.sig_srst, timestep-1).at(0);
@@ -1242,7 +1242,7 @@ bool SatGen::importCell(RTLIL::Cell *cell, int timestep)
 			if (ff.has_ce) {
 				int ce = importDefSigSpec(ff.sig_ce, timestep-1).at(0);
 				std::vector<int> old_q = importDefSigSpec(ff.sig_q, timestep-1);
-				int undef_ce;
+				int undef_ce = -1;
 				std::vector<int> undef_old_q;
 				if (model_undef) {
 					undef_ce = importUndefSigSpec(ff.sig_ce, timestep-1).at(0);
@@ -1256,7 +1256,7 @@ bool SatGen::importCell(RTLIL::Cell *cell, int timestep)
 			if (ff.has_srst && !(ff.has_ce && ff.ce_over_srst)) {
 				int srst = importDefSigSpec(ff.sig_srst, timestep-1).at(0);
 				std::vector<int> rval = importDefSigSpec(ff.val_srst, timestep-1);
-				int undef_srst;
+				int undef_srst = -1;
 				std::vector<int> undef_rval;
 				if (model_undef) {
 					undef_srst = importUndefSigSpec(ff.sig_srst, timestep-1).at(0);

--- a/libs/fst/fstapi.cc
+++ b/libs/fst/fstapi.cc
@@ -1907,7 +1907,8 @@ void fstWriterClose(void *ctx)
             int zfd;
             int fourpack_duo = 0;
 #ifndef __MINGW32__
-            char *fnam = (char *)malloc(strlen(xc->filename) + 5 + 1);
+            auto fnam_size = strlen(xc->filename) + 5 + 1;
+            char *fnam = (char *)malloc(fnam_size);
 #endif
 
             fixup_offs = ftello(xc->handle);
@@ -1991,7 +1992,7 @@ void fstWriterClose(void *ctx)
             fflush(xc->handle);
 
 #ifndef __MINGW32__
-            snprintf(fnam, sizeof(fnam), "%s.hier", xc->filename);
+            snprintf(fnam, fnam_size, "%s.hier", xc->filename);
             unlink(fnam);
             free(fnam);
 #endif
@@ -3579,7 +3580,8 @@ static int fstReaderRecreateHierFile(struct fstReaderContext *xc)
 
     if (!xc->fh) {
         fst_off_t offs_cache = ftello(xc->f);
-        char *fnam = (char *)malloc(strlen(xc->filename) + 6 + 16 + 32 + 1);
+	auto fnam_size = strlen(xc->filename) + 6 + 16 + 32 + 1;
+        char *fnam = (char *)malloc(fnam_size);
         unsigned char *mem = (unsigned char *)malloc(FST_GZIO_LEN);
         fst_off_t hl, uclen;
         fst_off_t clen = 0;
@@ -3594,7 +3596,7 @@ static int fstReaderRecreateHierFile(struct fstReaderContext *xc)
             htyp = xc->contains_hier_section_lz4duo ? FST_BL_HIER_LZ4DUO : FST_BL_HIER_LZ4;
         }
 
-        snprintf(fnam, sizeof(fnam), "%s.hier_%d_%p", xc->filename, getpid(), (void *)xc);
+        snprintf(fnam, fnam_size, "%s.hier_%d_%p", xc->filename, getpid(), (void *)xc);
         fstReaderFseeko(xc, xc->f, xc->hier_pos, SEEK_SET);
         uclen = fstReaderUint64(xc->f);
 #ifndef __MINGW32__
@@ -4239,9 +4241,10 @@ int fstReaderInit(struct fstReaderContext *xc)
         if (!seclen)
             return (0); /* not finished compressing, this is a failed read */
 
-        hf = (char *)calloc(1, flen + 16 + 32 + 1);
+	size_t hf_size = flen + 16 + 32 + 1;
+        hf = (char *)calloc(1, hf_size);
 
-        snprintf(hf, sizeof(hf), "%s.upk_%d_%p", xc->filename, getpid(), (void *)xc);
+        snprintf(hf, hf_size, "%s.upk_%d_%p", xc->filename, getpid(), (void *)xc);
         fcomp = fopen(hf, "w+b");
         if (!fcomp) {
             fcomp = tmpfile_open(&xc->f_nam);
@@ -6045,7 +6048,7 @@ process_value:
                         }
                     }
 
-                    snprintf(buf, sizeof(buf), "r%.16g", d);
+                    snprintf(buf, 32, "r%.16g", d);
                     return (buf);
                 }
             } else {

--- a/libs/fst/fstapi.cc
+++ b/libs/fst/fstapi.cc
@@ -5536,7 +5536,9 @@ char *fstReaderGetValueFromHandleAtTime(void *ctx, uint64_t tim, fstHandle facid
     fst_off_t blkpos = 0, prev_blkpos;
     uint64_t beg_tim, end_tim, beg_tim2, end_tim2;
     int sectype;
+#ifdef FST_DEBUG
     unsigned int secnum = 0;
+#endif
     uint64_t seclen;
     uint64_t tsec_uclen = 0, tsec_clen = 0;
     uint64_t tsec_nitems;
@@ -5620,7 +5622,9 @@ char *fstReaderGetValueFromHandleAtTime(void *ctx, uint64_t tim, fstHandle facid
         }
 
         blkpos += seclen;
+#ifdef FST_DEBUG
         secnum++;
+#endif
     }
 
     xc->rvat_beg_tim = beg_tim;

--- a/libs/fst/fstapi.cc
+++ b/libs/fst/fstapi.cc
@@ -1991,7 +1991,7 @@ void fstWriterClose(void *ctx)
             fflush(xc->handle);
 
 #ifndef __MINGW32__
-            sprintf(fnam, "%s.hier", xc->filename);
+            snprintf(fnam, sizeof(fnam), "%s.hier", xc->filename);
             unlink(fnam);
             free(fnam);
 #endif
@@ -2616,7 +2616,7 @@ fstEnumHandle fstWriterCreateEnumTable(void *ctx, const char *name, uint32_t ele
         uint32_t i;
 
         name_len = strlen(name);
-        elem_count_len = sprintf(elem_count_buf, "%" PRIu32, elem_count);
+        elem_count_len = snprintf(elem_count_buf, sizeof(elem_count_buf), "%" PRIu32, elem_count);
 
         literal_lens = (unsigned int *)calloc(elem_count, sizeof(unsigned int));
         val_lens = (unsigned int *)calloc(elem_count, sizeof(unsigned int));
@@ -3594,7 +3594,7 @@ static int fstReaderRecreateHierFile(struct fstReaderContext *xc)
             htyp = xc->contains_hier_section_lz4duo ? FST_BL_HIER_LZ4DUO : FST_BL_HIER_LZ4;
         }
 
-        sprintf(fnam, "%s.hier_%d_%p", xc->filename, getpid(), (void *)xc);
+        snprintf(fnam, sizeof(fnam), "%s.hier_%d_%p", xc->filename, getpid(), (void *)xc);
         fstReaderFseeko(xc, xc->f, xc->hier_pos, SEEK_SET);
         uclen = fstReaderUint64(xc->f);
 #ifndef __MINGW32__
@@ -4241,7 +4241,7 @@ int fstReaderInit(struct fstReaderContext *xc)
 
         hf = (char *)calloc(1, flen + 16 + 32 + 1);
 
-        sprintf(hf, "%s.upk_%d_%p", xc->filename, getpid(), (void *)xc);
+        snprintf(hf, sizeof(hf), "%s.upk_%d_%p", xc->filename, getpid(), (void *)xc);
         fcomp = fopen(hf, "w+b");
         if (!fcomp) {
             fcomp = tmpfile_open(&xc->f_nam);
@@ -4799,21 +4799,21 @@ int fstReaderIterBlocks2(void *ctx,
 
                     if (beg_tim) {
                         if (dumpvars_state == 1) {
-                            wx_len = sprintf(wx_buf, "$end\n");
+                            wx_len = snprintf(wx_buf, 6, "$end\n");
                             fstWritex(xc, wx_buf, wx_len);
                             dumpvars_state = 2;
                         }
-                        wx_len = sprintf(wx_buf, "#%" PRIu64 "\n", beg_tim);
+                        wx_len = snprintf(wx_buf, 20, "#%" PRIu64 "\n", beg_tim);
                         fstWritex(xc, wx_buf, wx_len);
                         if (!dumpvars_state) {
-                            wx_len = sprintf(wx_buf, "$dumpvars\n");
+                            wx_len = snprintf(wx_buf, 11, "$dumpvars\n");
                             fstWritex(xc, wx_buf, wx_len);
                             dumpvars_state = 1;
                         }
                     }
                     if ((xc->num_blackouts) && (cur_blackout != xc->num_blackouts)) {
                         if (beg_tim == xc->blackout_times[cur_blackout]) {
-                            wx_len = sprintf(wx_buf, "$dump%s $end\n",
+                            wx_len = snprintf(wx_buf, 16, "$dump%s $end\n",
                                              (xc->blackout_activity[cur_blackout++]) ? "on" : "off");
                             fstWritex(xc, wx_buf, wx_len);
                         }
@@ -4914,7 +4914,7 @@ int fstReaderIterBlocks2(void *ctx,
                                                 clone_d[j] = srcdata[7 - j];
                                             }
                                         }
-                                        sprintf((char *)xc->temp_signal_value_buf, "%.16g", d);
+                                        snprintf((char *)xc->temp_signal_value_buf, 32, "%.16g", d);
                                         value_change_callback(user_callback_data_pointer, beg_tim, idx + 1,
                                                               xc->temp_signal_value_buf);
                                     }
@@ -4936,7 +4936,7 @@ int fstReaderIterBlocks2(void *ctx,
                                         }
 
                                         fstVcdID(vcdid_buf, idx + 1);
-                                        wx_len = sprintf(wx_buf, "r%.16g %s\n", d, vcdid_buf);
+                                        wx_len = snprintf(wx_buf, sizeof(wx_buf), "r%.16g %s\n", d, vcdid_buf);
                                         fstWritex(xc, wx_buf, wx_len);
                                     }
                                 }
@@ -5179,21 +5179,21 @@ int fstReaderIterBlocks2(void *ctx,
                     }
 
                     if (dumpvars_state == 1) {
-                        wx_len = sprintf(wx_buf, "$end\n");
+                        wx_len = snprintf(wx_buf, 6, "$end\n");
                         fstWritex(xc, wx_buf, wx_len);
                         dumpvars_state = 2;
                     }
-                    wx_len = sprintf(wx_buf, "#%" PRIu64 "\n", time_table[i]);
+                    wx_len = snprintf(wx_buf, 20, "#%" PRIu64 "\n", time_table[i]);
                     fstWritex(xc, wx_buf, wx_len);
                     if (!dumpvars_state) {
-                        wx_len = sprintf(wx_buf, "$dumpvars\n");
+                        wx_len = snprintf(wx_buf, 11, "$dumpvars\n");
                         fstWritex(xc, wx_buf, wx_len);
                         dumpvars_state = 1;
                     }
 
                     if ((xc->num_blackouts) && (cur_blackout != xc->num_blackouts)) {
                         if (time_table[i] == xc->blackout_times[cur_blackout]) {
-                            wx_len = sprintf(wx_buf, "$dump%s $end\n",
+                            wx_len = snprintf(wx_buf, 16, "$dump%s $end\n",
                                              (xc->blackout_activity[cur_blackout++]) ? "on" : "off");
                             fstWritex(xc, wx_buf, wx_len);
                         }
@@ -5407,7 +5407,7 @@ int fstReaderIterBlocks2(void *ctx,
                                         clone_d[j] = srcdata[7 - j];
                                     }
                                 }
-                                sprintf((char *)xc->temp_signal_value_buf, "%.16g", d);
+                                snprintf((char *)xc->temp_signal_value_buf, 32, "%.16g", d);
                                 value_change_callback(user_callback_data_pointer, time_table[i], idx + 1,
                                                       xc->temp_signal_value_buf);
                             }
@@ -5427,7 +5427,7 @@ int fstReaderIterBlocks2(void *ctx,
                                     }
                                 }
 
-                                wx_len = sprintf(wx_buf, "r%.16g", d);
+                                wx_len = snprintf(wx_buf, sizeof(wx_buf), "r%.16g", d);
                                 fstWritex(xc, wx_buf, wx_len);
                             }
                         }
@@ -5523,7 +5523,7 @@ static char *fstExtractRvatDataFromFrame(struct fstReaderContext *xc, fstHandle 
                 }
             }
 
-            sprintf((char *)buf, "%.16g", d);
+            snprintf((char *)buf, 32, "%.16g", d);
         }
     }
 
@@ -6045,7 +6045,7 @@ process_value:
                         }
                     }
 
-                    sprintf(buf, "r%.16g", d);
+                    snprintf(buf, sizeof(buf), "r%.16g", d);
                     return (buf);
                 }
             } else {

--- a/libs/minisat/00_PATCH_warnings.patch
+++ b/libs/minisat/00_PATCH_warnings.patch
@@ -1,0 +1,37 @@
+--- System.cc
++++ System.cc
+@@ -43,7 +43,7 @@ static inline int memReadStat(int field)
+     pid_t pid = getpid();
+     int   value;
+ 
+-    sprintf(name, "/proc/%d/statm", pid);
++    snprintf(name, 256, "/proc/%d/statm", pid);
+     FILE* in = fopen(name, "rb");
+     if (in == NULL) return 0;
+ 
+@@ -60,7 +60,7 @@ static inline int memReadPeak(void)
+     char  name[256];
+     pid_t pid = getpid();
+ 
+-    sprintf(name, "/proc/%d/status", pid);
++    snprintf(name, 256, "/proc/%d/status", pid);
+     FILE* in = fopen(name, "rb");
+     if (in == NULL) return 0;
+ 
+--- Vec.h
++++ Vec.h
+@@ -100,7 +100,13 @@ void vec<T,_Size>::capacity(Size min_cap) {
+     Size add = max((min_cap - cap + 1) & ~1, ((cap >> 1) + 2) & ~1);   // NOTE: grow by approximately 3/2
+     const Size size_max = std::numeric_limits<Size>::max();
+     if ( ((size_max <= std::numeric_limits<int>::max()) && (add > size_max - cap))
+-    ||   (((data = (T*)::realloc(data, (cap += add) * sizeof(T))) == NULL) && errno == ENOMEM) )
++    ||   (
++#ifdef _DEFAULT_SOURCE
++            ((data = (T*)::reallocarray(data, (cap += add), sizeof(T))) == NULL)
++#else
++            ((data = (T*)::realloc(data, (cap += add) * sizeof(T))) == NULL) 
++#endif
++	&& errno == ENOMEM) )
+         throw OutOfMemoryException();
+  }
+ 

--- a/libs/minisat/00_UPDATE.sh
+++ b/libs/minisat/00_UPDATE.sh
@@ -17,3 +17,4 @@ patch -p0 < 00_PATCH_remove_zlib.patch
 patch -p0 < 00_PATCH_no_fpu_control.patch
 patch -p0 < 00_PATCH_typofixes.patch
 patch -p0 < 00_PATCH_wasm.patch
+patch -p0 < 00_PATCH_warnings.patch

--- a/libs/minisat/System.cc
+++ b/libs/minisat/System.cc
@@ -43,7 +43,7 @@ static inline int memReadStat(int field)
     pid_t pid = getpid();
     int   value;
 
-    sprintf(name, "/proc/%d/statm", pid);
+    snprintf(name, 256, "/proc/%d/statm", pid);
     FILE* in = fopen(name, "rb");
     if (in == NULL) return 0;
 
@@ -60,7 +60,7 @@ static inline int memReadPeak(void)
     char  name[256];
     pid_t pid = getpid();
 
-    sprintf(name, "/proc/%d/status", pid);
+    snprintf(name, 256, "/proc/%d/status", pid);
     FILE* in = fopen(name, "rb");
     if (in == NULL) return 0;
 

--- a/libs/minisat/Vec.h
+++ b/libs/minisat/Vec.h
@@ -100,7 +100,13 @@ void vec<T,_Size>::capacity(Size min_cap) {
     Size add = max((min_cap - cap + 1) & ~1, ((cap >> 1) + 2) & ~1);   // NOTE: grow by approximately 3/2
     const Size size_max = std::numeric_limits<Size>::max();
     if ( ((size_max <= std::numeric_limits<int>::max()) && (add > size_max - cap))
-    ||   (((data = (T*)::reallocarray(data, (cap += add), sizeof(T))) == NULL) && errno == ENOMEM) )
+    ||   (
+#ifdef _DEFAULT_SOURCE
+            ((data = (T*)::reallocarray(data, (cap += add), sizeof(T))) == NULL)
+#else
+            ((data = (T*)::realloc(data, (cap += add) * sizeof(T))) == NULL) 
+#endif
+	&& errno == ENOMEM) )
         throw OutOfMemoryException();
  }
 

--- a/libs/minisat/Vec.h
+++ b/libs/minisat/Vec.h
@@ -100,7 +100,7 @@ void vec<T,_Size>::capacity(Size min_cap) {
     Size add = max((min_cap - cap + 1) & ~1, ((cap >> 1) + 2) & ~1);   // NOTE: grow by approximately 3/2
     const Size size_max = std::numeric_limits<Size>::max();
     if ( ((size_max <= std::numeric_limits<int>::max()) && (add > size_max - cap))
-    ||   (((data = (T*)::realloc(data, (cap += add) * sizeof(T))) == NULL) && errno == ENOMEM) )
+    ||   (((data = (T*)::reallocarray(data, (cap += add), sizeof(T))) == NULL) && errno == ENOMEM) )
         throw OutOfMemoryException();
  }
 

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1718,7 +1718,7 @@ struct AbcPass : public Pass {
 			show_tempdir = true;
 		}
 
-		size_t argidx, g_argidx;
+		size_t argidx, g_argidx = -1;
 		bool g_arg_from_cmd = false;
 #if defined(__wasm)
 		const char *pwd = ".";


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
The test-compile.yml action ends up with a lot of warnings, e.g. [latest main run](https://github.com/YosysHQ/yosys/actions/runs/10406437503) has 47 warnings.  Many of these warnings are simple things like uninitialized/unused variables and deprecated system functions.

_Explain how this is achieved._
Assign default values to variables, add `ifdef` guards to debug variables, replace sprintf with snprintf, and replace `realloc` in the minisat library with `reallocarray` when using GCC.

_If applicable, please suggest to reviewers how they can test the change._
This should be passing all tests (and with fewer warnings), but there might be some weird edge case compilations that I'm not aware of