### PR TITLE
Local readthedocs

### DIFF
--- a/.github/workflows/test-verific.yml
+++ b/.github/workflows/test-verific.yml
@@ -47,30 +47,6 @@ jobs:
         run: |
           make install DESTDIR=${GITHUB_WORKSPACE}/.local PREFIX=
 
-      - name: Checkout Documentation
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: actions/checkout@v4
-        with:
-          path: 'yosys-cmd-ref'
-          repository: 'YosysHQ-Docs/yosys-cmd-ref'
-          fetch-depth: 0
-          token: ${{ secrets.CI_DOCS_UPDATE_PAT }}
-          persist-credentials: true
-
-      - name: Update documentation
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: |
-          make docs
-          rm -rf docs/build
-          cd yosys-cmd-ref
-          rm -rf *
-          git checkout README.md
-          cp -R ../docs/* .
-          rm -rf util/__pycache__
-          git add -A .
-          git diff-index --quiet HEAD || git commit -m "Update"
-          git push
-
       - name: Checkout SBY
         uses: actions/checkout@v4
         with:
@@ -94,3 +70,50 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           make -C sby run_ci
+
+  prepare-docs:
+    name: Generate docs artifact
+    needs: pre_job, test-verific
+    if: needs.pre_job.outputs.should_skip != 'true'
+    runs-on: [self-hosted, linux, x64]
+    steps:
+      - name: Checkout Yosys
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          submodules: true
+      - name: Runtime environment
+        run: |
+          echo "procs=$(nproc)" >> $GITHUB_ENV
+
+      - name: Build Yosys
+        run: |
+          make config-clang
+          echo "ENABLE_VERIFIC := 1" >> Makefile.conf
+          echo "ENABLE_VERIFIC_EDIF := 1" >> Makefile.conf
+          echo "ENABLE_VERIFIC_LIBERTY := 1" >> Makefile.conf
+          echo "ENABLE_VERIFIC_YOSYSHQ_EXTENSIONS := 1" >> Makefile.conf
+          echo "ENABLE_CCACHE := 1" >> Makefile.conf
+          make -j${{ env.procs }} ENABLE_LTO=1
+
+      - name: Prepare docs
+        shell: bash
+        run:
+          make docs/source/cmd/abc.rst docs/gen_examples docs/gen_images docs/guidelines docs/usage docs/reqs TARGETS= EXTRA_TARGETS=
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cmd-ref-${{ github.sha }}
+          path: |
+            docs/source/cmd
+            docs/source/generated
+            docs/source/_images
+            docs/source/code_examples
+
+      - name: Trigger RTDs build
+        uses: dfm/rtds-action@v1.1.0
+        with:
+          webhook_url: ${{ secrets.RTDS_WEBHOOK_URL }}
+          webhook_token: ${{ secrets.RTDS_WEBHOOK_TOKEN }}
+          commit_ref: ${{ github.ref }}

--- a/.github/workflows/test-verific.yml
+++ b/.github/workflows/test-verific.yml
@@ -3,7 +3,7 @@ name: Build and run tests with Verific (Linux)
 on: [push, pull_request]
 
 jobs:
-  pre_job:
+  pre-job:
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -20,8 +20,8 @@ jobs:
           skip_after_successful_duplicate: 'false'
 
   test-verific:
-    needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
+    needs: pre-job
+    if: needs.pre-job.outputs.should_skip != 'true'
     runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout Yosys
@@ -73,8 +73,8 @@ jobs:
 
   prepare-docs:
     name: Generate docs artifact
-    needs: pre_job, test-verific
-    if: needs.pre_job.outputs.should_skip != 'true'
+    needs: [pre-job, test-verific]
+    if: needs.pre-job.outputs.should_skip != 'true'
     runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout Yosys

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# .readthedocs.yaml
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+    os: ubuntu-22.04
+    tools:
+        python: '3.12'
+
+formats:
+  - pdf
+
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+  install:
+    - requirements: docs/source/requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -984,8 +984,8 @@ docs/guidelines docs/source/generated:
 
 # some commands return an error and print the usage text to stderr
 define DOC_USAGE_STDERR
-docs/source/generated/$(1): $(PROGRAM_PREFIX)$(1) docs/source/generated
-	-$(Q) ./$$< --help 2> $$@
+docs/source/generated/$(1): $(TARGETS) docs/source/generated
+	-$(Q) ./$(PROGRAM_PREFIX)$(1) --help 2> $$@
 endef
 DOCS_USAGE_STDERR := yosys-config yosys-filterlib
 
@@ -998,8 +998,8 @@ $(foreach usage,$(DOCS_USAGE_STDERR),$(eval $(call DOC_USAGE_STDERR,$(usage))))
 
 # others print to stdout
 define DOC_USAGE_STDOUT
-docs/source/generated/$(1): $(PROGRAM_PREFIX)$(1) docs/source/generated
-	$(Q) ./$$< --help > $$@
+docs/source/generated/$(1): $(TARGETS) docs/source/generated
+	$(Q) ./$(PROGRAM_PREFIX)$(1) --help > $$@
 endef
 DOCS_USAGE_STDOUT := yosys yosys-smtbmc yosys-witness
 $(foreach usage,$(DOCS_USAGE_STDOUT),$(eval $(call DOC_USAGE_STDOUT,$(usage))))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,7 +41,13 @@ html_static_path = ['_static', "_images"]
 pygments_style = 'colorful'
 highlight_language = 'none'
 
-extensions = ['sphinx.ext.autosectionlabel', 'sphinxcontrib.bibtex']
+extensions = ['sphinx.ext.autosectionlabel', 'sphinxcontrib.bibtex', 'rtds_action']
+
+# rtds_action
+rtds_action_github_repo = "YosysHQ/yosys"
+rtds_action_path = "."
+rtds_action_artifact_prefix = "cmd-ref-"
+rtds_action_github_token = os.environ["GITHUB_TOKEN"]
 
 # Ensure that autosectionlabel will produce unique names
 autosectionlabel_prefix_document = True

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,2 +1,3 @@
 furo
 sphinxcontrib-bibtex
+rtds-action


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
[Yosys ReadtheDocs](https://yosyshq.readthedocs.io/projects/yosys/en/latest/) is currently built from a separate repo, [yosys-cmd-ref](https://github.com/YosysHQ-Docs/yosys-cmd-ref).  This would occasionally lead to problems with people looking at the wrong repository for the documentation source, since yosys-cmd-ref is automatically updated from this repo with the verific runner.  This was being done since a portion of the documentation requires yosys to be compiled in order to generate, which would take too long for the ReadtheDocs builder and would generate without verific compatibility which also changes the generated documentation.

Because the verific runner would only update documentation from the main branch, the current setup also makes it more difficult to preview documentation changes for, e.g., yosys PRs.  The yosys-cmd-ref repo also ends up with a lot of code-generated images and such which get committed/updated from time to time.

_Explain how this is achieved._
This PR provides the necessary framework to allow ReadtheDocs to be built from the Yosys repository directly, making use of the [rtds-action](https://github.com/dfm/rtds-action) to create build artifacts and trigger ReadtheDocs to build using those artifacts; negating the need for a second repository.

_If applicable, please suggest to reviewers how they can test the change._
[These docs](https://tyrtd.readthedocs.io/en/latest/) were built from [my fork](https://github.com/KrystalDelusion/yosys/tree/rtd) of this repo with all of the expected artifacts (compiled on the standard git runner without verific).  And [another example](https://tyrtd--2.org.readthedocs.build/en/2/) demonstrating how [pr previews](https://github.com/KrystalDelusion/yosys/pull/2) could work with this.

If this PR is passing all checks, it should be safe to merge into main.  The current status of the ReadtheDocs integration is that the verific runner builds and uploads the artifact needed, and can trigger the ReadtheDocs webhook to build, but ReadtheDocs rejects building because krys/rtd is not a branch that it recognises as needing to publish.  Once this gets merged into main, I suspect that the verific runner will run the merged commit, triggering the webhook from the main branch, which will then update the 'latest' version of the ReadtheDocs.  If for some reason that breaks, manually rebuilding on ReadtheDocs will continue to use the yosys-cmd-ref repo.