### PR TITLE
Fixed #321, support for reduce ops in share command

### DIFF
--- a/passes/opt/share.cc
+++ b/passes/opt/share.cc
@@ -1486,6 +1486,12 @@ struct SharePass : public Pass {
 		config.generic_cbin_ops.insert(ID($logic_and));
 		config.generic_cbin_ops.insert(ID($logic_or));
 
+		config.generic_uni_ops.insert(ID($reduce_and));
+		config.generic_uni_ops.insert(ID($reduce_or));
+		config.generic_uni_ops.insert(ID($reduce_xor));
+		config.generic_uni_ops.insert(ID($reduce_xnor));
+		config.generic_uni_ops.insert(ID($reduce_bool));
+
 		config.generic_other_ops.insert(ID($alu));
 		config.generic_other_ops.insert(ID($macc));
 

--- a/tests/share/.gitignore
+++ b/tests/share/.gitignore
@@ -1,1 +1,2 @@
 temp
+*.log

--- a/tests/share/bug321.ys
+++ b/tests/share/bug321.ys
@@ -1,0 +1,11 @@
+read_verilog <<EOF
+module top(a, b, s, y);
+	input wire [7:0] a;
+	input wire [7:0] b;
+	input wire s;
+	output wire y;
+	assign y = s ? |a : |b;
+endmodule
+EOF
+
+share -force

--- a/tests/share/run-test.sh
+++ b/tests/share/run-test.sh
@@ -36,4 +36,9 @@ if [ -n "$failed_share" ]; then
 	false
 fi
 
+for x in *.ys; do
+  echo "Running $x.."
+  ../../yosys -ql ${x%.ys}.log $x
+done
+
 exit 0


### PR DESCRIPTION
The share command aborts if the cell type is a reduce operation. This fix prevents the abort by supporting `$reduce_and/or/xor/xnor/bool`.

Added the following test that would fail before the fix:

```
read_verilog <<EOF
module top(a, b, s, y);
	input wire [7:0] a;
	input wire [7:0] b;
	input wire s;
	output wire y;
	assign y = s ? |a : |b;
endmodule
EOF

share -force
```
