### PR TITLE
driver: print maximum memory usage on macOS

### DIFF
--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -721,13 +721,17 @@ int main(int argc, char **argv)
 			ru_buffer.ru_utime.tv_usec += ru_buffer_children.ru_utime.tv_usec;
 			ru_buffer.ru_stime.tv_sec += ru_buffer_children.ru_stime.tv_sec;
 			ru_buffer.ru_stime.tv_usec += ru_buffer_children.ru_stime.tv_usec;
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
 			ru_buffer.ru_maxrss = std::max(ru_buffer.ru_maxrss, ru_buffer_children.ru_maxrss);
 #endif
 		}
 #if defined(__linux__) || defined(__FreeBSD__)
 		meminfo = stringf(", MEM: %.2f MB peak",
 				ru_buffer.ru_maxrss / 1024.0);
+#elif defined(__APPLE__)
+// https://stackoverflow.com/questions/59913657/strange-values-of-get-rusage-maxrss-on-macos-and-linux
+		meminfo = stringf(", MEM: %.2f MB peak",
+				ru_buffer.ru_maxrss / (1024.0 * 1024.0));
 #endif
 		log("End of script. Logfile hash: %s%sCPU: user %.2fs system %.2fs%s\n", hash.c_str(),
 				stats_divider.c_str(), ru_buffer.ru_utime.tv_sec + 1e-6 * ru_buffer.ru_utime.tv_usec,


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Yosys on macOS doesn't print peak memory usage, even though the resource usage API should provide it anyway, except it's in bytes, not kilobytes.

_Explain how this is achieved._

Adjust ifdefs and divide max resident memory usage [by 1M](https://stackoverflow.com/questions/59913657/strange-values-of-get-rusage-maxrss-on-macos-and-linux)

_If applicable, please suggest to reviewers how they can test the change._

`$ yosys -p "read_verilog invert.v"`

where invert.v is

```verilog
module invert_n_times #(parameter N = 100000) (
    input wire in,
    output wire out
);
    wire [N:0] intermediate;

    assign intermediate[0] = in;

    genvar i;
    generate
        for (i = 0; i < N; i = i + 1) begin : invert_loop
            assign intermediate[i+1] = ~intermediate[i];
        end
    endgenerate

    assign out = intermediate[N];
endmodule
```

on my Linux machine prints `End of script. Logfile hash: a63152f4f6, CPU: user 3.40s system 0.18s, MEM: 637.87 MB peak`. If the memory usage reported is now similar on a macOS device, the PR does what it's supposed to