### PR TITLE
Ensure signed constants are correctly parsed and exported in RTLIL. Add a test to check parsing and exporting

### DIFF
--- a/.github/workflows/test-verific.yml
+++ b/.github/workflows/test-verific.yml
@@ -112,6 +112,7 @@ jobs:
             docs/source/code_examples
 
       - name: Trigger RTDs build
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: dfm/rtds-action@v1.1.0
         with:
           webhook_url: ${{ secrets.RTDS_WEBHOOK_URL }}

--- a/backends/rtlil/rtlil_backend.cc
+++ b/backends/rtlil/rtlil_backend.cc
@@ -51,6 +51,9 @@ void RTLIL_BACKEND::dump_const(std::ostream &f, const RTLIL::Const &data, int wi
 			}
 		}
 		f << stringf("%d'", width);
+		if (data.flags & RTLIL::CONST_FLAG_SIGNED) {
+			f << stringf("s");
+		}
 		if (data.is_fully_undef_x_only()) {
 			f << "x";
 		} else {

--- a/frontends/rtlil/rtlil_lexer.l
+++ b/frontends/rtlil/rtlil_lexer.l
@@ -88,7 +88,7 @@ USING_YOSYS_NAMESPACE
 "\\"[^ \t\r\n]+		{ rtlil_frontend_yylval.string = strdup(yytext); return TOK_ID; }
 "$"[^ \t\r\n]+		{ rtlil_frontend_yylval.string = strdup(yytext); return TOK_ID; }
 
-[0-9]+'[01xzm-]*	{ rtlil_frontend_yylval.string = strdup(yytext); return TOK_VALUE; }
+[0-9]+'s?[01xzm-]*	{ rtlil_frontend_yylval.string = strdup(yytext); return TOK_VALUE; }
 -?[0-9]+		{
 	char *end = nullptr;
 	errno = 0;

--- a/frontends/rtlil/rtlil_parser.y
+++ b/frontends/rtlil/rtlil_parser.y
@@ -450,7 +450,6 @@ constant:
 			$$->bits.push_back(*it);
 		if (is_signed) {
 			$$->flags |= RTLIL::CONST_FLAG_SIGNED;
-			log("Setting SIGNED flag for constant with width %d\n", width);
 		}
 		free($1);
 	} |

--- a/frontends/rtlil/rtlil_parser.y
+++ b/frontends/rtlil/rtlil_parser.y
@@ -412,8 +412,16 @@ constant:
 	TOK_VALUE {
 		char *ep;
 		int width = strtol($1, &ep, 10);
+		bool is_signed = false;
+		if (*ep == '\'') {
+			ep++;
+		}
+		if (*ep == 's') {
+			is_signed = true;
+			ep++;
+		}
 		std::list<RTLIL::State> bits;
-		while (*(++ep) != 0) {
+		while (*ep != 0) {
 			RTLIL::State bit = RTLIL::Sx;
 			switch (*ep) {
 			case '0': bit = RTLIL::S0; break;
@@ -424,7 +432,9 @@ constant:
 			case 'm': bit = RTLIL::Sm; break;
 			}
 			bits.push_front(bit);
+			ep++;
 		}
+
 		if (bits.size() == 0)
 			bits.push_back(RTLIL::Sx);
 		while ((int)bits.size() < width) {
@@ -438,6 +448,10 @@ constant:
 		$$ = new RTLIL::Const;
 		for (auto it = bits.begin(); it != bits.end(); it++)
 			$$->bits.push_back(*it);
+		if (is_signed) {
+			$$->flags |= RTLIL::CONST_FLAG_SIGNED;
+			log("Setting SIGNED flag for constant with width %d\n", width);
+		}
 		free($1);
 	} |
 	TOK_INT {

--- a/tests/various/rtlil_signed_attribute.ys
+++ b/tests/various/rtlil_signed_attribute.ys
@@ -1,0 +1,10 @@
+! mkdir -p temp
+read_rtlil <<EOT
+module \test
+  attribute \bottom_bound 3's101
+  wire width 3 output 1 \a
+  connect \a 3'001
+end
+EOT
+write_rtlil temp/rtlil_signed_attribute.il
+! grep -F -q "attribute \bottom_bound 3's101" temp/rtlil_signed_attribute.il


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Fix https://github.com/YosysHQ/yosys/issues/4539

_Explain how this is achieved._

Updated rtlil_lexer.l to recognize constants with an optional s for signedness.
Modified rtlil_parser.y to set RTLIL::CONST_FLAG_SIGNED when appropriate.
Adjusted rtlil_backend.cc to correctly export signed constants.
Added a test (rtlil_signed_attribute.ys) for round-trip verification of signed constants.

_If applicable, please suggest to reviewers how they can test the change._

I have included a test doing round trip test. I assume the rest of tests could catch relevant bugs.