### PR TITLE
docs: Only trigger RTDs on main

### DIFF
--- a/.github/workflows/test-verific.yml
+++ b/.github/workflows/test-verific.yml
@@ -112,6 +112,7 @@ jobs:
             docs/source/code_examples
 
       - name: Trigger RTDs build
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: dfm/rtds-action@v1.1.0
         with:
           webhook_url: ${{ secrets.RTDS_WEBHOOK_URL }}


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
PRs from forks don't have access to secrets and will error when trying to trigger ReadtheDocs, e.g. https://github.com/YosysHQ/yosys/actions/runs/10456408410/job/28954216463?pr=4550

_Explain how this is achieved._
Add back the "if ref == main" check from previous docs building.

_If applicable, please suggest to reviewers how they can test the change._
The "Trigger RTDs build" step of this pr's action should be skipped.