### PR TITLE
docs: gvpack on macos requires the file name to appear after the flags

### DIFF
--- a/docs/source/code_examples/opt/Makefile
+++ b/docs/source/code_examples/opt/Makefile
@@ -13,7 +13,7 @@ dots: $(DOTS)
 	$(YOSYS) $<
 
 %.dot: %_full.dot
-	gvpack -u $*_full.dot -o $@
+	gvpack -u -o $@ $*_full.dot
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
gvpack on macos will try to read from stdin if you use flags after the file name, so we need to swap the `-o` argument and the input file name.