### PR TITLE
Break tests with a small hash function perturbation

### DIFF
--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -24,11 +24,6 @@ namespace hashlib {
 const int hashtable_size_trigger = 2;
 const int hashtable_size_factor = 3;
 
-// The XOR version of DJB2
-inline unsigned int mkhash(unsigned int a, unsigned int b) {
-	return ((a << 5) + a) ^ b;
-}
-
 // traditionally 5381 is used as starting value for the djb2 hash
 const unsigned int mkhash_init = 5381;
 
@@ -50,6 +45,15 @@ inline unsigned int mkhash_xorshift(unsigned int a) {
 	} else
 		throw std::runtime_error("mkhash_xorshift() only implemented for 32 bit and 64 bit ints");
 	return a;
+}
+
+static int fudge = 123456;
+
+// The XOR version of DJB2
+inline unsigned int mkhash(unsigned int a, unsigned int b) {
+	unsigned int hash = ((a << 5) + a) ^ b;
+	hash = fudge ^ mkhash_xorshift(hash);
+	return hash;
 }
 
 template<typename T> struct hash_ops {


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Test failures due to hashing refactoring have uncovered `dfflibmap.ys` to fail to prove the first step base case in the first `equiv_opt` call. This PR demonstrates that it is sufficient to slightly change the hashing function to break that test. Famously, go lang standard library and abseil randomize hash functions to prevent users on depending on the ordering of items in unordered maps like dicts and sets. In Yosys, the DJB2 hash function hasn't been touched in 10 years. This draft PR will be closed when this problem is resolved and the hash function has a mechanism when it's randomized. Until then, it's a reproducer.

There is no way to write an "incorrect" hash function that isn't meant to be cryptographic, since hash functions are only meant to be used for fast path handling of data. A `return 1;` hash function is just as valid as an actual hash function, though it make tests run for too long. Therefore this PR should never make correctness tests fail.

_Explain how this is achieved._

Every time you hash, xorshift the result, and xor with a fudge constant. For example, you can reproduce this with a fudge constant of 123456 or 42069, but not 3.