### PR TITLE
Fix nix devShell warning

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
         packages.default = yosys;
         defaultPackage = yosys;
         devShell = pkgs.mkShell {
+          LOCALE_ARCHIVE = "${pkgs.glibcLocales}/lib/locale/locale-archive";
           buildInputs = with pkgs; [ clang llvmPackages.bintools bison flex libffi tcl readline python3 llvmPackages.libcxxClang zlib git gtest abc-verifier ];
         };
       }


### PR DESCRIPTION
Fix "bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UT…F-8)" warning on nix devShell

_What are the reasons/motivation for this change?_
Quality of life.
_Explain how this is achieved._
We set the locale correctly in the nix devShell.
_If applicable, please suggest to reviewers how they can test the change._
