### PR TITLE
Add parameter to not filter out blackboxes in selected_modules and selected_whole_modules

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -884,22 +884,22 @@ bool RTLIL::Design::selected_whole_module(RTLIL::Module *mod) const
 	return selected_whole_module(mod->name);
 }
 
-std::vector<RTLIL::Module*> RTLIL::Design::selected_modules() const
+std::vector<RTLIL::Module*> RTLIL::Design::selected_modules(bool include_bw_box) const
 {
 	std::vector<RTLIL::Module*> result;
 	result.reserve(modules_.size());
 	for (auto &it : modules_)
-		if (selected_module(it.first) && !it.second->get_blackbox_attribute())
+		if (selected_module(it.first) && (include_bw_box ? true : !it.second->get_blackbox_attribute()))
 			result.push_back(it.second);
 	return result;
 }
 
-std::vector<RTLIL::Module*> RTLIL::Design::selected_whole_modules() const
+std::vector<RTLIL::Module*> RTLIL::Design::selected_whole_modules(bool include_bw_box) const
 {
 	std::vector<RTLIL::Module*> result;
 	result.reserve(modules_.size());
 	for (auto &it : modules_)
-		if (selected_whole_module(it.first) && !it.second->get_blackbox_attribute())
+		if (selected_whole_module(it.first) && (include_bw_box ? true : !it.second->get_blackbox_attribute()))
 			result.push_back(it.second);
 	return result;
 }

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1150,8 +1150,8 @@ struct RTLIL::Design
 	}
 
 
-	std::vector<RTLIL::Module*> selected_modules() const;
-	std::vector<RTLIL::Module*> selected_whole_modules() const;
+	std::vector<RTLIL::Module*> selected_modules(bool include_bw_box = false) const;
+	std::vector<RTLIL::Module*> selected_whole_modules(bool include_bw_box = false) const;
 	std::vector<RTLIL::Module*> selected_whole_modules_warn(bool include_wb = false) const;
 #ifdef WITH_PYTHON
 	static std::map<unsigned int, RTLIL::Design*> *get_all_designs(void);

--- a/passes/sat/cutpoint.cc
+++ b/passes/sat/cutpoint.cc
@@ -55,7 +55,7 @@ struct CutpointPass : public Pass {
 		}
 		extra_args(args, argidx, design);
 
-		for (auto module : design->selected_modules())
+		for (auto module : design->selected_modules(true))
 		{
 			if (design->selected_whole_module(module->name)) {
 				log("Making all outputs of module %s cut points, removing module contents.\n", log_id(module));

--- a/passes/techmap/attrmap.cc
+++ b/passes/techmap/attrmap.cc
@@ -263,12 +263,12 @@ struct AttrmapPass : public Pass {
 
 		if (modattr_mode)
 		{
-			for (auto module : design->selected_whole_modules())
+			for (auto module : design->selected_whole_modules(true))
 				attrmap_apply(stringf("%s", log_id(module)), actions, module->attributes);
 		}
 		else
 		{
-			for (auto module : design->selected_modules())
+			for (auto module : design->selected_modules(true))
 			{
 				for (auto wire : module->selected_wires())
 					attrmap_apply(stringf("%s.%s", log_id(module), log_id(wire)), actions, wire->attributes);

--- a/tests/select/cutpoint_blackbox.v
+++ b/tests/select/cutpoint_blackbox.v
@@ -1,0 +1,7 @@
+(* blackbox *)
+module add #(parameter N=3) (input [N-1:0] a, b, output [N-1:0] q);
+endmodule
+
+module top(input [7:0] a, b, output [7:0] q);
+   add #(.N(8)) add_i(.a(a), .b(b), .q(q));
+endmodule

--- a/tests/select/cutpoint_blackbox.ys
+++ b/tests/select/cutpoint_blackbox.ys
@@ -1,0 +1,9 @@
+read_verilog cutpoint_blackbox.v
+check
+select -assert-mod-count 1 =A:blackbox
+select -assert-count 0 =t:$anyseq
+cutpoint =A:blackbox
+attrmap -modattr -remove blackbox
+check
+select -assert-mod-count 0 =A:blackbox
+select -assert-count 1 =t:$anyseq


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
The select command in Yosys includes an option that allows patterns to match black/white-box modules or their contents by prefixing the pattern with =. This is documented [here](https://yosyshq.readthedocs.io/projects/yosys/en/latest/cmd/select.html):
> By default, patterns will not match black/white-box modules or their
> contents. To include such objects, prefix the pattern with '='.

However, the method `RTLIL::Design::selected_modules()` filters out blackboxes, so adding a `=` to a pattern does nothing.

_Explain how this is achieved._
We add a `include_bw_box` parameter that defaults to false to `RTLIL::Design::selected_modules()` and `RTLIL::Design::selected_whole_modules()`.

_If applicable, please suggest to reviewers how they can test the change._
### Discarded options
#### Unconditionally selecting blackboxes
That would break some passes, like `opt`.
#### Adding a `-blackbox` flag to `cutpoint`
https://github.com/YosysHQ/yosys/pull/4566