### PR TITLE
Add -blackbox flag to cutpoint pass

### DIFF
--- a/passes/sat/cutpoint.cc
+++ b/passes/sat/cutpoint.cc
@@ -72,7 +72,6 @@ struct CutpointPass : public Pass {
 				}
 			}
 			std::ostringstream pattern;
-
 			for (size_t i = 0; i < blackbox_module_names.size(); ++i) {
 				pattern << blackbox_module_names[i].str();
 				if (i != blackbox_module_names.size() - 1) {
@@ -81,6 +80,7 @@ struct CutpointPass : public Pass {
 			}
 			if (!pattern.str().empty()) {
 				args.push_back(pattern.str());
+				args.push_back("t:" + pattern.str());
 			}
 		}
 

--- a/tests/select/cutpoint.ys
+++ b/tests/select/cutpoint.ys
@@ -1,0 +1,30 @@
+read_verilog <<EOT
+module passthrough(
+    input wire in,  // Input signal
+    output wire out // Output signal
+);
+
+    // Assign the output to be the same as the input
+    assign out = in;
+
+endmodule
+EOT
+cutpoint -blackbox =*
+select -assert-count 1 =t:$anyseq
+
+design -reset
+
+read_verilog <<EOT
+(* blackbox *)
+module passthrough(
+    input wire in,  // Input signal
+    output wire out // Output signal
+);
+
+    // Assign the output to be the same as the input
+    assign out = in;
+
+endmodule
+EOT
+cutpoint -blackbox =*
+select -assert-count 1 =t:$anyseq


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
Black/white boxes cannot be processed by `sby`, so they must be substituted by `$anyseq` cells.
_Explain how this is achieved._
Adding a `-blackbox` flag to `cutpoint`.
If that flag is set, we find all modules that are black/white boxes, add their module names to the `select` pattern, and remove their black/whitebox attribute.
_If applicable, please suggest to reviewers how they can test the change._
