### PR TITLE
cxxrtl: use octal encoding of non-printables.

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -616,7 +616,7 @@ std::string escape_c_string(const std::string &input)
 				output.push_back('\\');
 			output.push_back(c);
 		} else {
-			char l = c & 0x3, m = (c >> 3) & 0x3, h = (c >> 6) & 0x3;
+			char l = c & 0x7, m = (c >> 3) & 0x7, h = (c >> 6) & 0x3;
 			output.append("\\");
 			output.push_back('0' + h);
 			output.push_back('0' + m);

--- a/kernel/fmt.cc
+++ b/kernel/fmt.cc
@@ -634,10 +634,11 @@ std::string escape_cxx_string(const std::string &input)
 				output.push_back('\\');
 			output.push_back(c);
 		} else {
-			char l = c & 0xf, h = (c >> 4) & 0xf;
-			output.append("\\x");
-			output.push_back((h < 10 ? '0' + h : 'a' + h - 10));
-			output.push_back((l < 10 ? '0' + l : 'a' + l - 10));
+			char l = c & 0x7, m = (c >> 3) & 0x7, h = (c >> 6) & 0x3;
+			output.push_back('\\');
+			output.push_back('0' + h);
+			output.push_back('0' + m);
+			output.push_back('0' + l);
 		}
 	}
 	output.push_back('"');


### PR DESCRIPTION
`"\x0a"` is a perfectly valid escape sequence, but unfortunately `"\x0ac"` is equivalent to `"\xac"`, and not `"\x0a" "c"` as we might expect --- *any* number of hexadecimal characters after the `\x` is accepted. This can be hit pretty easily if a newline is present in a format string.

`"\x{...}"` syntax is only available as of C++23, so use octal format instead; a maximum of 3 digits following the backslash is accepted.

The alternative would be to render every escape like `" "\x0a" "`, but it seems more effort that way.

cc @whitequark.