### PR TITLE
proc_dff: process sync rules in reverse input order

### DIFF
--- a/passes/proc/proc_dff.cc
+++ b/passes/proc/proc_dff.cc
@@ -54,7 +54,7 @@ RTLIL::SigSpec find_any_lvalue(const RTLIL::Process *proc)
 }
 
 /**
- * Container storing key,std::set(value) pairs in insertion order
+ * Container storing key,std::set(value) pairs in reverse insertion order
  * and provides a linear search.
  */
 template<typename Key, typename Value>
@@ -71,8 +71,8 @@ public:
 			return backing.back().second;
 		}
 	}
-	typename std::vector<entry>::iterator begin() { return backing.begin(); }
-	typename std::vector<entry>::iterator end() { return backing.end(); }
+	typename std::vector<entry>::reverse_iterator begin() { return backing.rbegin(); }
+	typename std::vector<entry>::reverse_iterator end() { return backing.rend(); }
 	typename std::vector<entry>::size_type size() { return backing.size(); }
 	void clear() { return backing.clear(); }
 };


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

It's assumed that sync rules are in some kind of priority ordering. See [here](https://github.com/YosysHQ/yosys/issues/4560#issuecomment-2312512074)

_Explain how this is achieved._

Since there is no "insertion ordered map" in STL, I provide a minimal one of my own

_If applicable, please suggest to reviewers how they can test the change._

The tests now pass including dfflibmap.ys even when our hash function is modified as in #4559 and #4524. More investigation is needed about proc_dff and into this particular test and its correctness