### PR TITLE
read_aiger: Interpret new extension with cell mapping

### DIFF
--- a/frontends/aiger/aigerparse.h
+++ b/frontends/aiger/aigerparse.h
@@ -54,6 +54,7 @@ struct AigerReader
     void parse_aiger_binary();
     void post_process();
 
+    RTLIL::IdString litName(unsigned literal);
     RTLIL::Wire* createWireIfNotExists(RTLIL::Module *module, unsigned literal);
 };
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

A stepping stone to be able to use abc9 for ASIC flows

_Explain how this is achieved._

We read a new 'M' extension with cell mapping that's part of the output AIGER file written by abc (complementary PR on the  abc side: berkeley-abc/abc#327)

_If applicable, please suggest to reviewers how they can test the change._
