### PR TITLE
Run functional tests on private runner only

### DIFF
--- a/.github/workflows/test-verific.yml
+++ b/.github/workflows/test-verific.yml
@@ -41,6 +41,7 @@ jobs:
           echo "ENABLE_VERIFIC_LIBERTY := 1" >> Makefile.conf
           echo "ENABLE_VERIFIC_YOSYSHQ_EXTENSIONS := 1" >> Makefile.conf
           echo "ENABLE_CCACHE := 1" >> Makefile.conf
+          echo "ENABLE_FUNCTIONAL_TESTS := 1" >> Makefile.conf
           make -j${{ env.procs }} ENABLE_LTO=1
 
       - name: Install Yosys

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ ENABLE_LTO := 0
 ENABLE_CCACHE := 0
 # sccache is not always a drop-in replacement for ccache in practice
 ENABLE_SCCACHE := 0
+ENABLE_FUNCTIONAL_TESTS := 0
 LINK_CURSES := 0
 LINK_TERMCAP := 0
 LINK_ABC := 0
@@ -891,7 +892,9 @@ endif
 	+cd tests/xprop && bash run-test.sh $(SEEDOPT)
 	+cd tests/fmt && bash run-test.sh
 	+cd tests/cxxrtl && bash run-test.sh
+ifeq ($(ENABLE_FUNCTIONAL_TESTS),1)
 	+cd tests/functional && bash run-test.sh
+endif
 	@echo ""
 	@echo "  Passed \"make test\"."
 	@echo ""


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
Save time running these tests on public CI

_Explain how this is achieved._
Added ENABLE_FUNCTIONAL_TESTS option disabled by default
