### PR TITLE
Initialize area stats in stat pass

### DIFF
--- a/passes/cmds/stat.cc
+++ b/passes/cmds/stat.cc
@@ -44,8 +44,8 @@ struct statdata_t
 	#define X(_name) unsigned int _name;
 	STAT_INT_MEMBERS
 	#undef X
-	double area;
-	double sequential_area;
+	double area = 0;
+	double sequential_area = 0;
 	string tech;
 
 	std::map<RTLIL::IdString, int> techinfo;


### PR DESCRIPTION
Currently, the area variables in the stat struct are not initialized. This caused the area stats occasionally being an erroneous value.

I got the following output when synthesizing a two-bit flip-flop using SKY130 PDK,

```
Chip area for module '\main': 40.038400
     of which used for sequential elements: -nan (-nan%)
```