### PR TITLE
smt2: fix bitwuzla invocation

### DIFF
--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -226,12 +226,21 @@ class SmtIo:
                 print('timeout option is not supported for mathsat.')
                 sys.exit(1)
 
-        if self.solver in ["boolector", "bitwuzla"]:
+        if self.solver == "boolector":
             if self.noincr:
                 self.popen_vargs = [self.solver, '--smt2'] + self.solver_opts
             else:
                 self.popen_vargs = [self.solver, '--smt2', '-i'] + self.solver_opts
             self.unroll = True
+            if self.timeout != 0:
+                print('timeout option is not supported for %s.' % self.solver)
+                sys.exit(1)
+
+        if self.solver == "bitwuzla":
+            self.popen_vargs = [self.solver, '--lang', 'smt2'] + self.solver_opts
+            self.unroll = True
+            # Bitwuzla always uses incremental solving
+            self.noincr = False
             if self.timeout != 0:
                 print('timeout option is not supported for %s.' % self.solver)
                 sys.exit(1)


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Bitwuzla no longer shares options in common with Boolector. It now requires "--lang smt2" instead of "--smt2", and always runs incrementally by default (see: [Bitwuzla news](https://github.com/bitwuzla/bitwuzla/blob/69e4be28d86ef9e0cebee2e846378e56b6da978a/NEWS.md?plain=1#L163))

I found this because I'm using Bitwuzla 0.5.0-dev-main@69e4be28-dirty (through the AUR `bitwuzla-git` package), and it currently does not run correctly through eqy. 

_Explain how this is achieved._

`smtio.py` is modified to invoke Bitwuzla correctly, taking into account the fact it uses incremental solving by default 

_If applicable, please suggest to reviewers how they can test the change._

This should be testable by using any sby tools with Bitwuzla. I was using eqy and confirmed it worked with a very small testbench of mine (it's a bit hard to share because it's a Yosys plugin that generates the design on the fly).
