### PR TITLE
read_liberty: Optionally import unit delay arcs

### DIFF
--- a/tests/liberty/.gitignore
+++ b/tests/liberty/.gitignore
@@ -1,4 +1,3 @@
 *.log
-test.ys
 *.filtered
 *.verilogsim

--- a/tests/liberty/run-test.sh
+++ b/tests/liberty/run-test.sh
@@ -8,3 +8,8 @@ for x in *.lib; do
 	../../yosys-filterlib -verilogsim $x > $x.verilogsim
 	diff $x.filtered $x.filtered.ok && diff $x.verilogsim $x.verilogsim.ok
 done
+
+for x in *.ys; do
+  echo "Running $x.."
+  ../../yosys -q -s $x -l ${x%.ys}.log
+done

--- a/tests/liberty/run-test.sh
+++ b/tests/liberty/run-test.sh
@@ -3,10 +3,7 @@ set -e
 
 for x in *.lib; do
 	echo "Testing on $x.."
-	echo "read_verilog small.v" > test.ys
-	echo "synth -top small" >> test.ys
-	echo "dfflibmap -info -liberty ${x}" >> test.ys
-	../../yosys -ql ${x%.lib}.log -s test.ys
+	../../yosys -p "read_verilog small.v; synth -top small; dfflibmap -info -liberty ${x}" -ql ${x%.lib}.log
 	../../yosys-filterlib - $x 2>/dev/null > $x.filtered
 	../../yosys-filterlib -verilogsim $x > $x.verilogsim
 	diff $x.filtered $x.filtered.ok && diff $x.verilogsim $x.verilogsim.ok

--- a/tests/liberty/unit_delay.ys
+++ b/tests/liberty/unit_delay.ys
@@ -1,0 +1,3 @@
+# Nothing gets imported: the file lacks timing data
+read_liberty -wb -unit_delay normal.lib
+select -assert-none =*/t:$specify*


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Avoiding timing path segmentation on explicitly instantiated or pre-mapped standard cells. When the SC mapper is configured for the unit delay model, with this new option we can supply complementary arcs for those cells which are viewed as boxes

_Explain how this is achieved._

Under each cell and pin, we look at `timing()` sections with `timing_type` set to `combinational`, and for each arc found, we emit a `$specify2` cell with fixed delay of 1000 which matches the unit delay inside ABC.
