### PR TITLE
quicklogic: Avoid carry chains in division mapping

### DIFF
--- a/techlibs/common/techmap.v
+++ b/techlibs/common/techmap.v
@@ -304,6 +304,7 @@ endmodule
 // Divide and Modulo
 // --------------------------------------------------------
 
+`ifndef NODIV
 module \$__div_mod_u (A, B, Y, R);
 	parameter WIDTH = 1;
 
@@ -531,7 +532,7 @@ module _90_modfloor (A, B, Y);
 		.R(Y)
 	);
 endmodule
-
+`endif
 
 // --------------------------------------------------------
 // Power

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -266,7 +266,8 @@ struct SynthQuickLogicPass : public ScriptPass {
 
 		if (check_label("map_gates")) {
 			if (inferAdder && family == "qlf_k6n10f") {
-				run("techmap -map +/techmap.v -map " + lib_path + family + "/arith_map.v", "(unless -no_adder)");
+				run("techmap -map +/techmap.v -map " + lib_path + family + "/arith_map.v -D NODIV", "(unless -no_adder)");
+				run("techmap", "(unless -no_adder)");
 			} else {
 				run("techmap");
 			}

--- a/tests/arch/quicklogic/qlf_k6n10f/div.ys
+++ b/tests/arch/quicklogic/qlf_k6n10f/div.ys
@@ -10,5 +10,5 @@ EOF
 equiv_opt -assert -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
-select -assert-count 26 t:$lut
+select -assert-max 100 t:$lut
 select -assert-none t:$lut %% t:* %D

--- a/tests/arch/quicklogic/qlf_k6n10f/div.ys
+++ b/tests/arch/quicklogic/qlf_k6n10f/div.ys
@@ -1,0 +1,14 @@
+# division by constants should not infer carry chains.
+read_verilog <<EOF
+
+module top (input [15:0] a, output [15:0] y);
+assign y = a / 3;
+endmodule
+
+EOF
+
+equiv_opt -assert -map +/quicklogic/qlf_k6n10f/cells_sim.v synth_quicklogic -family qlf_k6n10f
+design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
+cd top # Constrain all select calls below inside the top module
+select -assert-count 26 t:$lut
+select -assert-none t:$lut %% t:* %D


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

The default mapping rules for division-like operations (div/divfloor/ mod/modfloor) invoke subtractions which can get mapped to carry chains in FPGA flows. Optimizations across carry chains are weak, so in practice this ends up too costly compared to implementing the division purely in soft logic.

_Explain how this is achieved._

For this reason arrange for `techmap.v` ignoring division operations under `-D NODIV`, and use this mode in `synth_quicklogic` to avoid carry chains for divisions.
