### PR TITLE
rtlil: add Const::compress helper function

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -286,20 +286,22 @@ void RTLIL::Const::compress(bool is_signed)
 
 	// back to front (MSB to LSB)
 	RTLIL::State leading_bit;
-	if(is_signed)
+	if (is_signed)
 		leading_bit = (bits.back() == RTLIL::State::Sx) ? RTLIL::State::S0 : bits.back();
 	else
 		leading_bit = RTLIL::State::S0;
 
-    size_t idx = bits.size();
-    while (idx > 0 && bits[idx -1] == leading_bit) {
-        --idx;
-    }
+	size_t idx = bits.size();
+	while (idx > 0 && bits[idx -1] == leading_bit) {
+		idx--;
+	}
 
 	// signed needs one leading bit
 	if (is_signed && idx < bits.size()) {
-        ++idx;
-    }
+		idx++;
+	}
+	// must be at least one bit
+	idx = (idx == 0) ? 1 : idx;
 
 	bits.erase(bits.begin() + idx, bits.end());
 }

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -280,6 +280,30 @@ int RTLIL::Const::as_int(bool is_signed) const
 	return ret;
 }
 
+void RTLIL::Const::compress(bool is_signed)
+{
+	if (bits.empty()) return;
+
+	// back to front (MSB to LSB)
+	RTLIL::State leading_bit;
+	if(is_signed)
+		leading_bit = (bits.back() == RTLIL::State::Sx) ? RTLIL::State::S0 : bits.back();
+	else
+		leading_bit = RTLIL::State::S0;
+
+    size_t idx = bits.size();
+    while (idx > 0 && bits[idx -1] == leading_bit) {
+        --idx;
+    }
+
+	// signed needs one leading bit
+	if (is_signed && idx < bits.size()) {
+        ++idx;
+    }
+
+	bits.erase(bits.begin() + idx, bits.end());
+}
+
 std::string RTLIL::Const::as_string() const
 {
 	std::string ret;

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -703,8 +703,13 @@ struct RTLIL::Const
 		return ret;
 	}
 
+	// find the MSB without redundant leading bits
+	size_t get_min_size(bool is_signed) const;
+
 	// compress representation to the minimum required bits
 	void compress(bool is_signed = false);
+
+	std::optional<int> as_int_compress(bool is_signed) const;
 
 	void extu(int width) {
 		bits.resize(width, RTLIL::State::S0);

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -703,6 +703,9 @@ struct RTLIL::Const
 		return ret;
 	}
 
+	// compress representation to the minimum required bits
+	void compress(bool is_signed = false);
+
 	void extu(int width) {
 		bits.resize(width, RTLIL::State::S0);
 	}


### PR DESCRIPTION
If one has a Sigspec that is fully constant it is currently non-trivial to get its value.  
The main blocking point here is that the SigSpec may be wider than 32bit (an integer).  
However, this doesn't mean the value stored in it is necessarily this large/small.

Eg something like `33'd4` or `33'd-2` cannot be easily converted to an int.


This adds a `compress(is_signed)` function.  
It tries to minimize the number of bits used for the representation of the number. 
It does so by removing the leading bits while taking signedness into consideration.

With this function, the above can be successfully converted to an integer by first calling compress.


Edit:
Here is a possible application.
https://github.com/povik/yosys-slang/blob/28cea56840a6bc8a4b6398d36609500d5960ad79/src/builder.cc#L134  
With `compress` it is easy to check if the actual value has a larger representation than 24-bits instead of checking the SigSpec, which again may not use the minimum width.  
I am fairly convinced there are places in the Yosys codebase itself this would be helpful, finding them is a bit difficult.