### PR TITLE
log: Never silence `log_cmd_error`

### DIFF
--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -459,8 +459,21 @@ void log_cmd_error(const char *format, ...)
 
 	if (log_cmd_error_throw) {
 		log_last_error = vstringf(format, ap);
+
+		// Make sure the error message gets through any selective silencing
+		// of log output
+		bool pop_errfile = false;
+		if (log_errfile != NULL) {
+			log_files.push_back(log_errfile);
+			pop_errfile = true;
+		}
+
 		log("ERROR: %s", log_last_error.c_str());
 		log_flush();
+
+		if (pop_errfile)
+			log_files.pop_back();
+
 		throw log_cmd_error_exception();
 	}
 

--- a/tests/various/logger_cmd_error.sh
+++ b/tests/various/logger_cmd_error.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+trap 'echo "ERROR in logger_cmd_error.sh" >&2; exit 1' ERR
+
+(../../yosys -v 3 -C <<EOF
+yosys -import
+hierarchy -top nonexistent
+EOF
+) 2>&1 | grep -F "ERROR: Module \`nonexistent' not found!" > /dev/null


### PR DESCRIPTION

_What are the reasons/motivation for this change?_

Some errors can get hidden by `-v N`, see The-OpenROAD-Project/OpenROAD-flow-scripts#2375

This makes the user almost always worse off. The only exception I can think of is someone scripting around Yosys commands, checking for their exit status, and handling failures gracefully (for the few failure modes where that can be done). I've never seen such a Yosys script.

_Explain how this is achieved._

Add extra handling to arrange for `log_cmd_error` never being silenced by the command line `-v N` option. Similar path for `log_error` exists already.

_If applicable, please suggest to reviewers how they can test the change._

With test.tcl:

```
yosys -import
hierarchy -top nonexistent
```

Before

```
$ ./yosys -v 3 test.tcl
1. Executing HIERARCHY pass (managing design hierarchy).
ERROR: TCL interpreter returned an error: Yosys command produced an error
```

After

```
$ ./yosys -v 3 test.tcl
1. Executing HIERARCHY pass (managing design hierarchy).
ERROR: Module `nonexistent' not found!
ERROR: TCL interpreter returned an error: Yosys command produced an error
```
