### PR TITLE
opt_reduce: keep at least one input to $reduce_or/and cells

### DIFF
--- a/passes/opt/opt_reduce.cc
+++ b/passes/opt/opt_reduce.cc
@@ -89,6 +89,9 @@ struct OptReduceWorker
 		RTLIL::SigSpec new_sig_a(new_sig_a_bits);
 		new_sig_a.sort_and_unify();
 
+		if (GetSize(new_sig_a) == 0)
+			new_sig_a = (cell->type == ID($reduce_or)) ? State::S0 : State::S1;
+
 		if (new_sig_a != sig_a || sig_a.size() != cell->getPort(ID::A).size()) {
 			log("    New input vector for %s cell %s: %s\n", cell->type.c_str(), cell->name.c_str(), log_signal(new_sig_a));
 			did_something = true;

--- a/tests/opt/opt_reduce_andor.ys
+++ b/tests/opt/opt_reduce_andor.ys
@@ -1,0 +1,14 @@
+# Check that opt_reduce doesn't produce zero width $reduce_or/$reduce_and,
+
+read_verilog <<EOT
+module reduce_const(output wire o, output wire a);
+    wire [3:0] zero = 4'b0000;
+    wire [3:0] ones = 4'b1111;
+    assign o = |zero;
+    assign a = &ones;
+endmodule
+EOT
+
+equiv_opt -assert opt_reduce
+design -load postopt
+select -assert-none r:A_WIDTH=0


### PR DESCRIPTION
When all inputs to a `$reduce_or` (resp. `$reduce_and`) are `0` (resp `1`), `opt_reduce` would remove them all leaving a zero width input to the cell. This can sometimes be poorly handled by other passes as in #4610, so this PR checks for that case and drives the cell by a constant.

I haven't chosen to fully replace the cell as the logic in that function would turn e.g. `|{a, 1'b1, 1'b0}` into `|{1'b1}` rather than `1'b1`, so this is in keeping for the `1'b0` case. `opt_expr` easily eliminates this cell due to the constant input.