### PR TITLE
Allow whitespace in `tee` command paths

### DIFF
--- a/passes/cmds/tee.cc
+++ b/passes/cmds/tee.cc
@@ -72,7 +72,9 @@ struct TeePass : public Pass {
 			}
 			if ((args[argidx] == "-o" || args[argidx] == "-a") && argidx+1 < args.size()) {
 				const char *open_mode = args[argidx] == "-o" ? "w" : "a+";
-				FILE *f = fopen(args[++argidx].c_str(), open_mode);
+				auto path = args[++argidx];
+				rewrite_filename(path);
+				FILE *f = fopen(path.c_str(), open_mode);
 				yosys_input_files.insert(args[argidx]);
 				if (f == NULL) {
 					for (auto cf : files_to_close)


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Currently, `tee -o "test file"` creates a file literally named `"test file"`. This essentially makes it impossible to indicate files/paths that include whitespace without adding the literal quotes.

_Explain how this is achieved._

Uses `void rewrite_filename(std::string &filename)` to rewrite the path. As a nice side effect, ~/tilde paths are now expanded as well.

_If applicable, please suggest to reviewers how they can test the change._

Just try `tee -o "test file"` before and after.
