### PR TITLE
Add "Get vcd2fst" step to test-yosys job

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -100,6 +100,16 @@ jobs:
           cd iverilog
           echo "IVERILOG_GIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
+      - name: Get vcd2fst
+        shell: bash
+        run: |
+          git clone https://github.com/mmicko/libwave.git
+          mkdir -p ${{ github.workspace }}/.local/
+          cd libwave
+          cmake . -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/.local
+          make -j$procs
+          make install
+
       - name: Cache iverilog
         id: cache-iverilog
         uses: actions/cache@v4


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
To be able to load VCD files with `sim`, the executable `vcd2fst` has to be available in PATH.

While FST files can also be used for simulation, VCD files are human readable, which can be useful for issues like https://github.com/YosysHQ/yosys/pull/4620.

_Explain how this is achieved._
Instead of installing `gtkwave` from `apt`, which would bring too many dependencies into scope, we just compile all the helpers from `gtkwave` in a repo maintained by @mmicko.
_If applicable, please suggest to reviewers how they can test the change._

### Note
Credit goes to @mmicko.