### PR TITLE
cxxrtl: test stream operator

### DIFF
--- a/tests/cxxrtl/test_value.cc
+++ b/tests/cxxrtl/test_value.cc
@@ -49,4 +49,12 @@ int main()
         cxxrtl::value<1> sel(0u);
         assert(val.template bmux<4>(sel).get<uint64_t>() == 0xfu);
     }
+
+    {
+        // stream operator smoke test
+        cxxrtl::value<8> val(0x1fu);
+        std::ostringstream oss;
+        oss << val;
+        assert(oss.str() == "8'1f");
+    }
 }


### PR DESCRIPTION
Through fast and loose regex action in #4516 I broke the stream operator for `cxxrtl::value` but the tests didn't discover this. This PR addresses that