### PR TITLE
cellmatch: Size the `lut` attribute

### DIFF
--- a/passes/techmap/cellmatch.cc
+++ b/passes/techmap/cellmatch.cc
@@ -223,7 +223,7 @@ struct CellmatchPass : Pass {
 				for (auto bit : outputs) {
 					log_assert(bit.is_wire());
 					bit.wire->attributes[ID(p_class)] = p_class(inputs.size(), luts[no]);
-					bit.wire->attributes[ID(lut)] = luts[no++];
+					bit.wire->attributes[ID(lut)] = Const(luts[no++], 1 << inputs.size());
 				}
 			}
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Under an undocumented `-lut_attrs` option the `cellmatch` command can annotate output ports with a `lut` attribute describing the port's function. Previously these attributes were 32-bit, which meant the value for 6-input cells was cropped, and one needed knowledge of the number of inputs to interpret the value. Make the change to size the `lut` attribute to two to the power of number of inputs.