### PR TITLE
Assume x values for missing signal data in FST

### DIFF
--- a/kernel/fstdata.cc
+++ b/kernel/fstdata.cc
@@ -258,7 +258,8 @@ void FstData::reconstructAllAtTimes(std::vector<fstHandle> &signal, uint64_t sta
 
 std::string FstData::valueOf(fstHandle signal)
 {
-	if (past_data.find(signal) == past_data.end())
-		log_error("Signal id %d not found\n", (int)signal);
+	if (past_data.find(signal) == past_data.end()) {
+		return std::string(handle_to_var[signal].width, 'x');
+	}
 	return past_data[signal];
 }

--- a/tests/sim/assume_x_first_step.ys
+++ b/tests/sim/assume_x_first_step.ys
@@ -1,0 +1,2 @@
+read_verilog simple_assign.v
+sim -r simple_assign.vcd -scope simple_assign

--- a/tests/sim/simple_assign.v
+++ b/tests/sim/simple_assign.v
@@ -1,0 +1,8 @@
+module simple_assign (
+    input wire in,
+    output wire out
+);
+
+    assign out = in;
+
+endmodule

--- a/tests/sim/simple_assign.vcd
+++ b/tests/sim/simple_assign.vcd
@@ -1,0 +1,13 @@
+$version Yosys $end
+$scope module simple_assign $end
+$var wire 1 n2 in $end
+$var wire 1 n1 out $end
+$upscope $end
+$enddefinitions $end
+#0
+#5
+b1 n1
+b1 n2
+#10
+b0 n1
+b0 n2


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
Handle cases where signal data is missing in FST files during simulation. Previously, when a signal ID was not found in past_data, it would cause an error. This patch ensures that missing signal data is assumed to be undefined ('x'), which aligns with the behaviour of `gtkwave`. Below is a screenshot of how `gtkwave` interprets `tests/sim/simple_assign.vcd`.
<img width="626" alt="gtkwave_simple_assign" src="https://github.com/user-attachments/assets/e2f52157-7990-4827-815d-9ec430d2a52a">

_Explain how this is achieved._
Instead of logging an error when the signal ID is not found, the `valueOf` now returns a string filled with 'x' characters, where the length of the string corresponds to the signal’s width.
_If applicable, please suggest to reviewers how they can test the change._
### Note
I considered adding a warning like:
`log_warning("Signal id %d not found, assuming x\n", (int)signal);`
but decided against it to avoid extra verbosity. Open to adding it if needed.