### PR TITLE
docs: avoid concurrency issues when generating images in parallel

### DIFF
--- a/.github/workflows/prepare-docs.yml
+++ b/.github/workflows/prepare-docs.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Prepare docs
         shell: bash
         run:
-          make docs/prep TARGETS= EXTRA_TARGETS=
+          make docs/prep -j${{ env.procs }} TARGETS= EXTRA_TARGETS=
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -979,16 +979,17 @@ docs/source/cmd/abc.rst: $(TARGETS) $(EXTRA_TARGETS)
 	./$(PROGRAM_PREFIX)yosys -p 'help -write-rst-command-reference-manual'
 
 PHONY: docs/gen_examples docs/gen_images docs/guidelines docs/usage docs/reqs
-docs/gen_examples:
+docs/gen_examples: $(TARGETS)
 	$(Q) $(MAKE) -C docs examples
 
-docs/gen_images:
+docs/gen_images: $(TARGETS)
 	$(Q) $(MAKE) -C docs images
 
 DOCS_GUIDELINE_FILES := GettingStarted CodingStyle
-docs/guidelines docs/source/generated:
+DOCS_GUIDELINE_SOURCE := $(addprefix guidelines/,$(DOCS_GUIDELINE_FILES))
+docs/guidelines docs/source/generated: $(DOCS_GUIDELINE_SOURCE)
 	$(Q) mkdir -p docs/source/generated
-	$(Q) cp -f $(addprefix guidelines/,$(DOCS_GUIDELINE_FILES)) docs/source/generated
+	$(Q) cp -f $(DOCS_GUIDELINE_SOURCE) docs/source/generated
 
 # some commands return an error and print the usage text to stderr
 define DOC_USAGE_STDERR

--- a/docs/source/_images/Makefile
+++ b/docs/source/_images/Makefile
@@ -1,4 +1,4 @@
-all: examples all_tex tidy
+all: examples all_tex
 
 # set a fake time in pdf generation to prevent unnecessary differences in output
 FAKETIME := TZ='Z' faketime -f '2022-01-01 00:00:00 x0,001'


### PR DESCRIPTION
This should resolve issue #4631 when building the doc images in parallel.

I have removed the `tidy` target and I just delete log and aux file after building each pdf.
