### PR TITLE
wheels: fix missing yosys-abc/share directory

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -110,7 +110,7 @@ jobs:
             MACOSX_DEPLOYMENT_TARGET=11
             makeFlags='BOOST_PYTHON_LIB=./boost/pfx/lib/libboost_python*.a CONFIG=clang'
           CIBW_BEFORE_BUILD: bash ./.github/workflows/wheels/cibw_before_build.sh
-          CIBW_TEST_COMMAND: python3 -c "from pyosys import libyosys as ys;d=ys.Design();ys.run_pass('help', d)"
+          CIBW_TEST_COMMAND: python3 {project}/tests/arch/ecp5/add_sub.py
       - uses: actions/upload-artifact@v4
         with:
           name: python-wheels-${{ matrix.os.runner }}

--- a/Makefile
+++ b/Makefile
@@ -737,6 +737,12 @@ compile-only: $(OBJS) $(GENFILES) $(EXTRA_TARGETS)
 	@echo "  Compile successful."
 	@echo ""
 
+.PHONY: share
+share: $(EXTRA_TARGETS)
+	@echo ""
+	@echo "  Share directory created."
+	@echo ""
+
 $(PROGRAM_PREFIX)yosys$(EXE): $(OBJS)
 	$(P) $(CXX) -o $(PROGRAM_PREFIX)yosys$(EXE) $(EXE_LINKFLAGS) $(LINKFLAGS) $(OBJS) $(LIBS) $(LIBS_VERIFIC)
 

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -554,17 +554,17 @@ void yosys_setup()
 #include "kernel/constids.inc"
 #undef X
 
-	#ifdef WITH_PYTHON
-		// With Python 3.12, calling PyImport_AppendInittab on an already
-		// initialized platform fails (such as when libyosys is imported
-		// from a Python interpreter)
-		if (!Py_IsInitialized()) {
-			PyImport_AppendInittab((char*)"libyosys", INIT_MODULE);
-			Py_Initialize();
-			PyRun_SimpleString("import sys");
-			signal(SIGINT, SIG_DFL);
-		}
-	#endif
+#ifdef WITH_PYTHON
+	// With Python 3.12, calling PyImport_AppendInittab on an already
+	// initialized platform fails (such as when libyosys is imported
+	// from a Python interpreter)
+	if (!Py_IsInitialized()) {
+		PyImport_AppendInittab((char*)"libyosys", INIT_MODULE);
+		Py_Initialize();
+		PyRun_SimpleString("import sys");
+		signal(SIGINT, SIG_DFL);
+	}
+#endif
 
 	Pass::init_register();
 	yosys_design = new RTLIL::Design;
@@ -1013,6 +1013,16 @@ void init_share_dirname()
 #else
 void init_share_dirname()
 {
+#  ifdef WITH_PYTHON
+	PyObject *sys_obj = PyImport_ImportModule("sys");
+
+	if (PyObject_HasAttrString(sys_obj, "_pyosys_share_dirname")) {
+		PyObject *share_path_obj = PyObject_GetAttrString(sys_obj, "_pyosys_share_dirname");
+		const char *share_path = PyUnicode_AsUTF8(share_path_obj);
+		yosys_share_dirname = std::string(share_path);
+		return;
+	}
+#  endif
 	std::string proc_self_path = proc_self_dirname();
 #  if defined(_WIN32) && !defined(YOSYS_WIN32_UNIX_DIR)
 	std::string proc_share_path = proc_self_path + "share\\";
@@ -1058,12 +1068,20 @@ void init_abc_executable_name()
 	}
 #else
 	yosys_abc_executable = proc_self_dirname() + proc_program_prefix()+ "yosys-abc";
-#endif
-#ifdef _WIN32
-#ifndef ABCEXTERNAL
+#  ifdef _WIN32
 	if (!check_file_exists(yosys_abc_executable + ".exe") && check_file_exists(proc_self_dirname() + "..\\" + proc_program_prefix() + "yosys-abc.exe"))
 		yosys_abc_executable = proc_self_dirname() + "..\\" + proc_program_prefix() + "yosys-abc";
-#endif
+#  endif
+
+#  ifdef WITH_PYTHON
+	PyObject *sys_obj = PyImport_ImportModule("sys");
+
+	if (PyObject_HasAttrString(sys_obj, "_pyosys_abc")) {
+		PyObject *abc_path_obj = PyObject_GetAttrString(sys_obj, "_pyosys_abc");
+		const char *abc_path = PyUnicode_AsUTF8(abc_path_obj);
+		yosys_abc_executable = std::string(abc_path);
+	}
+#  endif
 #endif
 }
 
@@ -1132,7 +1150,7 @@ bool run_frontend(std::string filename, std::string command, RTLIL::Design *desi
 
 	if (command == "auto") {
 	  std::string filename_trim = filename;
-	  
+
 	  auto has_extension = [](const std::string& filename, const std::string& extension) {
 	    if (filename.size() >= extension.size()) {
 	      return filename.compare(filename.size() - extension.size(), extension.size(), extension) == 0;
@@ -1143,7 +1161,7 @@ bool run_frontend(std::string filename, std::string command, RTLIL::Design *desi
 	  if (has_extension(filename_trim, ".gz")) {
 	    filename_trim.erase(filename_trim.size() - 3);
 	  }
-	  
+
 	  if (has_extension(filename_trim, ".v")) {
 	    command = " -vlog2k";
 	  } else if (has_extension(filename_trim, ".sv")) {

--- a/misc/__init__.py
+++ b/misc/__init__.py
@@ -1,5 +1,19 @@
 import os
 import sys
+
 sys.setdlopenflags(os.RTLD_NOW | os.RTLD_GLOBAL)
+
+__dir__ = os.path.abspath(os.path.dirname(__file__))
+sys._pyosys_dir = os.path.abspath(__dir__)
+
+bin_ext = ".exe" if os.name == "nt" else ""
+
+_share_candidate = os.path.join(__dir__, "share")
+if os.path.isdir(_share_candidate):
+    sys._pyosys_share_dirname = _share_candidate + os.path.sep
+
+_abc_candidate = os.path.join(__dir__, f"yosys-abc{bin_ext}")
+if os.path.isfile(_abc_candidate):
+    sys._pyosys_abc = _abc_candidate
 
 __all__ = ["libyosys"]

--- a/tests/arch/ecp5/add_sub.py
+++ b/tests/arch/ecp5/add_sub.py
@@ -1,0 +1,20 @@
+import os
+from pyosys import libyosys as ys
+
+__dir__ = os.path.dirname(os.path.abspath(__file__))
+add_sub = os.path.join(__dir__, "..", "common", "add_sub.v")
+
+base = ys.Design()
+ys.run_pass(f"read_verilog {add_sub}", base)
+ys.run_pass("hierarchy -top top", base)
+ys.run_pass("proc", base)
+ys.run_pass("equiv_opt -assert -map +/ecp5/cells_sim.v synth_ecp5", base)
+
+postopt = ys.Design()
+ys.run_pass("design -load postopt", postopt)
+ys.run_pass("cd top", postopt)
+ys.run_pass("select -assert-min 25 t:LUT4", postopt)
+ys.run_pass("select -assert-max 26 t:LUT4", postopt)
+ys.run_pass("select -assert-count 10 t:PFUMX", postopt)
+ys.run_pass("select -assert-count 6 t:L6MUX21", postopt)
+ys.run_pass("select -assert-none t:LUT4 t:PFUMX t:L6MUX21 %% t:* %D", postopt)


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Due to an oversight on my part, #4534 does not copy either `yosys-abc` or the `share` directory. While Yosys technically still runs, it is unusable for anything non-trivial.

_Explain how this is achieved._

* `misc/__init__.py`:
  * checks if there's a `yosys-abc` in the same directory - if yes, sets the variable `sys._pyosys_abc`
  * checks if there's a `share` in the same directory - if yes, sets the variable `sys._pyosys_share_dirname`
* `yosys.cc::init_share_dirname`: check for `sys._pyosys_share_dirname` at the highest priority if Python is enabled
* `yosys.cc::init_abc_executable_name`: check for `sys._pyosys_abc`, use it at at the highest priority if Python is enabled
* `Makefile`: add new target, `share`, to only create the extra targets
* `setup.py`: compile libyosys.so, yosys-abc and share, and copy them all as part of the pyosys build
* `test/arch/ecp5/add_sub.py`: ported `add_sub.ys` to Python to act as a test for the share directory and abc with Python wheels, used in CI

_If applicable, please suggest to reviewers how they can test the change._

```
pip install -i https://test.pypi.org/simple/ pyosys==0.46.0
```