### PR TITLE
CI: force brew formula update

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -14,6 +14,7 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew update
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install bison flex gawk libffi pkg-config bash autoconf llvm lld
 
     - name: Linux runtime environment


### PR DESCRIPTION
brew formulas are better updated otherwise it depend of runner if new packages (like in case  of lld) or new versions would be detected.
