### PR TITLE
Tribuf propagate

### DIFF
--- a/kernel/calc.cc
+++ b/kernel/calc.cc
@@ -721,5 +721,16 @@ RTLIL::Const RTLIL::const_bwmux(const RTLIL::Const &arg1, const RTLIL::Const &ar
 	return result;
 }
 
+RTLIL::Const RTLIL::const_equiv(const RTLIL::Const &arg1, const RTLIL::Const &arg2)
+{
+	log_assert(arg2.size() == arg1.size());
+	RTLIL::Const result(RTLIL::State::S1, 1);
+	for (int i = 0; i < arg1.size(); i++)
+		if (arg1[i] != arg2[i])
+			result[i] = RTLIL::State::S0;
+
+	return result;
+}
+
 YOSYS_NAMESPACE_END
 

--- a/kernel/celltypes.h
+++ b/kernel/celltypes.h
@@ -495,6 +495,9 @@ struct CellTypes
 			return default_ret;
 		}
 
+		if (cell->type == ID($equiv))
+			return const_equiv(arg1, arg2);
+
 		bool signed_a = cell->parameters.count(ID::A_SIGNED) > 0 && cell->parameters[ID::A_SIGNED].as_bool();
 		bool signed_b = cell->parameters.count(ID::B_SIGNED) > 0 && cell->parameters[ID::B_SIGNED].as_bool();
 		int result_len = cell->parameters.count(ID::Y_WIDTH) > 0 ? cell->parameters[ID::Y_WIDTH].as_int() : -1;

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -514,6 +514,7 @@ namespace RTLIL
 	RTLIL::Const const_bweqx       (const RTLIL::Const &arg1, const RTLIL::Const &arg2);
 	RTLIL::Const const_bwmux       (const RTLIL::Const &arg1, const RTLIL::Const &arg2, const RTLIL::Const &arg3);
 
+	RTLIL::Const const_equiv       (const RTLIL::Const &arg1, const RTLIL::Const &arg2);
 
 	// This iterator-range-pair is used for Design::modules(), Module::wires() and Module::cells().
 	// It maintains a reference counter that is used to make sure that the container is not modified while being iterated over.

--- a/passes/techmap/tribuf.cc
+++ b/passes/techmap/tribuf.cc
@@ -17,8 +17,8 @@
  *
  */
 
-#include "kernel/yosys.h"
 #include "kernel/sigtools.h"
+#include "kernel/yosys.h"
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
@@ -28,7 +28,8 @@ struct TribufConfig {
 	bool logic_mode;
 	bool formal_mode;
 
-	TribufConfig() {
+	TribufConfig()
+	{
 		merge_mode = false;
 		logic_mode = false;
 		formal_mode = false;
@@ -40,9 +41,7 @@ struct TribufWorker {
 	SigMap sigmap;
 	const TribufConfig &config;
 
-	TribufWorker(Module *module, const TribufConfig &config) : module(module), sigmap(module), config(config)
-	{
-	}
+	TribufWorker(Module *module, const TribufConfig &config) : module(module), sigmap(module), config(config) {}
 
 	static bool is_all_z(SigSpec sig)
 	{
@@ -54,7 +53,7 @@ struct TribufWorker {
 
 	void run()
 	{
-		dict<SigSpec, vector<Cell*>> tribuf_cells;
+		dict<SigSpec, vector<Cell *>> tribuf_cells;
 		pool<SigBit> output_bits;
 
 		if (config.logic_mode || config.formal_mode)
@@ -63,16 +62,14 @@ struct TribufWorker {
 					for (auto bit : sigmap(wire))
 						output_bits.insert(bit);
 
-		for (auto cell : module->selected_cells())
-		{
+		for (auto cell : module->selected_cells()) {
 			if (cell->type == ID($tribuf))
 				tribuf_cells[sigmap(cell->getPort(ID::Y))].push_back(cell);
 
 			if (cell->type == ID($_TBUF_))
 				tribuf_cells[sigmap(cell->getPort(ID::Y))].push_back(cell);
 
-			if (cell->type.in(ID($mux), ID($_MUX_)))
-			{
+			if (cell->type.in(ID($mux), ID($_MUX_))) {
 				IdString en_port = cell->type == ID($mux) ? ID::EN : ID::E;
 				IdString tri_type = cell->type == ID($mux) ? ID($tribuf) : ID($_TBUF_);
 
@@ -104,10 +101,8 @@ struct TribufWorker {
 			}
 		}
 
-		if (config.merge_mode || config.logic_mode || config.formal_mode)
-		{
-			for (auto &it : tribuf_cells)
-			{
+		if (config.merge_mode || config.logic_mode || config.formal_mode) {
+			for (auto &it : tribuf_cells) {
 				bool no_tribuf = false;
 
 				if (config.logic_mode && !config.formal_mode) {
@@ -162,7 +157,8 @@ struct TribufWorker {
 					module->remove(cell);
 				}
 
-				SigSpec muxout = GetSize(pmux_s) > 1 ? module->Pmux(NEW_ID, SigSpec(State::Sx, GetSize(it.first)), pmux_b, pmux_s) : pmux_b;
+				SigSpec muxout =
+				  GetSize(pmux_s) > 1 ? module->Pmux(NEW_ID, SigSpec(State::Sx, GetSize(it.first)), pmux_b, pmux_s) : pmux_b;
 
 				if (no_tribuf)
 					module->connect(it.first, muxout);
@@ -176,7 +172,7 @@ struct TribufWorker {
 };
 
 struct TribufPass : public Pass {
-	TribufPass() : Pass("tribuf", "infer tri-state buffers") { }
+	TribufPass() : Pass("tribuf", "infer tri-state buffers") {}
 	void help() override
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|

--- a/passes/techmap/tribuf.cc
+++ b/passes/techmap/tribuf.cc
@@ -17,8 +17,10 @@
  *
  */
 
+#include "backends/rtlil/rtlil_backend.h"
+#include "kernel/log.h"
+#include "kernel/rtlil.h"
 #include "kernel/sigtools.h"
-#include "kernel/yosys.h"
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
@@ -27,12 +29,16 @@ struct TribufConfig {
 	bool merge_mode;
 	bool logic_mode;
 	bool formal_mode;
+	bool propagate;
+	bool force;
 
 	TribufConfig()
 	{
 		merge_mode = false;
 		logic_mode = false;
 		formal_mode = false;
+		propagate = false;
+		force = false;
 	}
 };
 
@@ -40,6 +46,7 @@ struct TribufWorker {
 	Module *module;
 	SigMap sigmap;
 	const TribufConfig &config;
+	pool<SigBit> output_bits;
 
 	TribufWorker(Module *module, const TribufConfig &config) : module(module), sigmap(module), config(config) {}
 
@@ -51,11 +58,83 @@ struct TribufWorker {
 		return true;
 	}
 
+	// Sigbits that are input to mux cells or tri-state buffer cells
+	dict<SigBit, pool<Cell *>> get_know_muxes()
+	{
+		dict<SigBit, pool<Cell *>> know_muxes;
+		for (auto cell : module->selected_cells()) {
+			if (cell->type.in(ID($mux), ID($_MUX_))) {
+				for (auto bit : sigmap(cell->getPort(ID::A)))
+					if (bit.wire != nullptr)
+						know_muxes[bit].insert(cell);
+				for (auto bit : sigmap(cell->getPort(ID::B)))
+					if (bit.wire != nullptr)
+						know_muxes[bit].insert(cell);
+			}
+
+			if (cell->type.in(ID($tribuf), ID($_TBUF_))) {
+				for (auto bit : sigmap(cell->getPort(ID::A)))
+					if (bit.wire != nullptr)
+						know_muxes[bit].insert(cell);
+			}
+		}
+
+		return know_muxes;
+	}
+
+	// all cells that drive a sigbit
+	dict<SigBit, pool<Cell *>> get_driving_cells()
+	{
+		dict<SigBit, pool<Cell *>> driving_cells;
+		for (auto cell : module->cells()) {
+			for (auto &conn : cell->connections()) {
+				if (cell->output(conn.first)) {
+					for (auto bit : sigmap(conn.second)) {
+						if (bit.wire != nullptr)
+							driving_cells[bit].insert(cell);
+					}
+				}
+			}
+		}
+		return driving_cells;
+	}
+
+	// check if tribuf_signals is still consistent.
+	void check_tribuf_signals_consistency(pool<SigBit> const &tribuf_signals)
+	{
+#ifndef NDEBUG
+		auto const driving_cells = get_driving_cells();
+		for (auto bit : tribuf_signals) {
+			log_assert(sigmap(bit) == bit);
+
+			if (driving_cells.count(bit) == 0) {
+				log_error("Signal %s is in tribuf_signals, but is not in driving_cells\n", log_signal(bit));
+			}
+			for (auto cell : driving_cells.at(bit)) {
+				if (cell->type.in(ID($tribuf), ID($_TBUF_))) {
+					goto has_tribuf_driver;
+				}
+			}
+
+			log("There is no tri-state buffer driving %s\n", log_signal(bit));
+			for (auto cell : driving_cells.at(bit)) {
+				log("  %s (%s)\n", log_id(cell->name), log_id(cell->type));
+			}
+			log_flush();
+			log_error("There is no tri-state buffer driving %s\n", log_signal(bit));
+
+		has_tribuf_driver:;
+			// ok
+		}
+#endif
+	}
+
 	void run()
 	{
-		dict<SigSpec, vector<Cell *>> tribuf_cells;
-		pool<SigBit> output_bits;
+		// SigSpecs that are outputs of tri-state buffers
+		pool<SigBit> tribuf_signals;
 
+		// find all SigBits that are output ports
 		if (config.logic_mode || config.formal_mode)
 			for (auto wire : module->wires())
 				if (wire->port_output)
@@ -63,111 +142,511 @@ struct TribufWorker {
 						output_bits.insert(bit);
 
 		for (auto cell : module->selected_cells()) {
-			if (cell->type == ID($tribuf))
-				tribuf_cells[sigmap(cell->getPort(ID::Y))].push_back(cell);
-
-			if (cell->type == ID($_TBUF_))
-				tribuf_cells[sigmap(cell->getPort(ID::Y))].push_back(cell);
+			if (cell->type.in(ID($tribuf), ID($_TBUF_))) {
+				for (auto bit : sigmap(cell->getPort(ID::Y)))
+					tribuf_signals.insert(bit);
+			}
 
 			if (cell->type.in(ID($mux), ID($_MUX_))) {
 				IdString en_port = cell->type == ID($mux) ? ID::EN : ID::E;
 				IdString tri_type = cell->type == ID($mux) ? ID($tribuf) : ID($_TBUF_);
 
-				if (is_all_z(cell->getPort(ID::A)) && is_all_z(cell->getPort(ID::B))) {
+				bool is_a_all_z = is_all_z(cell->getPort(ID::A));
+				bool is_b_all_z = is_all_z(cell->getPort(ID::B));
+
+				if (is_a_all_z && is_b_all_z) {
 					module->remove(cell);
 					continue;
 				}
 
-				if (is_all_z(cell->getPort(ID::A))) {
+				if (is_a_all_z) {
+					log_cell(cell);
 					cell->setPort(ID::A, cell->getPort(ID::B));
 					cell->setPort(en_port, cell->getPort(ID::S));
 					cell->unsetPort(ID::B);
 					cell->unsetPort(ID::S);
 					cell->type = tri_type;
-					tribuf_cells[sigmap(cell->getPort(ID::Y))].push_back(cell);
+					for (auto bit : sigmap(cell->getPort(ID::Y)))
+						tribuf_signals.insert(bit);
+					log_cell(cell);
 					module->design->scratchpad_set_bool("tribuf.added_something", true);
 					continue;
 				}
 
-				if (is_all_z(cell->getPort(ID::B))) {
+				if (is_b_all_z) {
+					log_cell(cell);
 					cell->setPort(en_port, module->Not(NEW_ID, cell->getPort(ID::S)));
 					cell->unsetPort(ID::B);
 					cell->unsetPort(ID::S);
 					cell->type = tri_type;
-					tribuf_cells[sigmap(cell->getPort(ID::Y))].push_back(cell);
+					for (auto bit : sigmap(cell->getPort(ID::Y)))
+						tribuf_signals.insert(bit);
+					log_cell(cell);
 					module->design->scratchpad_set_bool("tribuf.added_something", true);
 					continue;
 				}
 			}
 		}
 
-		if (config.merge_mode || config.logic_mode || config.formal_mode) {
-			for (auto &it : tribuf_cells) {
-				bool no_tribuf = false;
+		check_tribuf_signals_consistency(tribuf_signals);
 
-				if (config.logic_mode && !config.formal_mode) {
-					no_tribuf = true;
-					for (auto bit : it.first)
-						if (output_bits.count(bit))
-							no_tribuf = false;
-				}
+		if (config.propagate) {
+			// SigSpecs that are driven by tri-state buffers and still need to
+			// be checked for propagation
+			pool<SigBit> added_tribufs;
 
-				if (config.formal_mode)
-					no_tribuf = true;
+			for (auto &it : tribuf_signals) {
+				added_tribufs.insert(it);
+			}
+			pool<SigBit> current_tribufs;
 
-				if (GetSize(it.second) <= 1 && !no_tribuf)
-					continue;
+			while (!added_tribufs.empty()) {
+				log("Propagating tri-state buffers through muxes: %d signals left.\n", int(added_tribufs.size()));
+				std::swap(added_tribufs, current_tribufs);
+				added_tribufs.clear();
 
-				if (config.formal_mode && GetSize(it.second) >= 2) {
-					for (auto cell : it.second) {
-						SigSpec others_s;
+				for (auto it : current_tribufs) {
+					// PERF: this two calls are traversing the whole design, per tribuf modification. A more efficient way would
+					// be to update these values as the module is modified, but doing that in a naive way is too repetitive and
+					// error prone.
+					auto know_muxes = get_know_muxes();
+					auto driving_cells = get_driving_cells();
 
-						for (auto other_cell : it.second) {
-							if (other_cell == cell)
-								continue;
-							else if (other_cell->type == ID($tribuf))
-								others_s.append(other_cell->getPort(ID::EN));
-							else
-								others_s.append(other_cell->getPort(ID::E));
+					check_tribuf_signals_consistency(tribuf_signals);
+
+					if (know_muxes.count(it) == 0)
+						continue;
+
+					// check that all driving cells are tri-state buffers
+					bool is_all_tribufs = true;
+					for (const auto &cell : driving_cells.at(it)) {
+						if (cell->type != ID($tribuf) && cell->type != ID($_TBUF_)) {
+							log_debug("There is a non-tri-state buffer driving %s\n", log_signal(it));
+							is_all_tribufs = false;
+							break;
 						}
+					}
+					if (!is_all_tribufs)
+						continue;
 
-						auto cell_s = cell->type == ID($tribuf) ? cell->getPort(ID::EN) : cell->getPort(ID::E);
+					if (driving_cells.at(it).size() > 1) {
+						if (config.merge_mode) {
+							merge(it, driving_cells, tribuf_signals);
+							driving_cells = get_driving_cells();
+							log_assert(driving_cells.at(it).size() == 1);
+						} else {
+							log_debug("There is more than one tri-state buffer driving %s\n", log_signal(it));
+							continue;
+						}
+					}
 
-						auto other_s = module->ReduceOr(NEW_ID, others_s);
+					if (tribuf_signals.count(it) != 1) {
+						log_warning("No tribuf for %s\n", log_signal(it));
+						continue;
+					}
 
-						auto conflict = module->And(NEW_ID, cell_s, other_s);
+					log_assert(driving_cells.at(it).size() == 1);
+					RTLIL::Cell *tribuf = *driving_cells.at(it).begin();
+					tribuf_signals.erase(it);
 
-						std::string name = stringf("$tribuf_conflict$%s", log_id(cell->name));
-						auto assert_cell = module->addAssert(name, module->Not(NEW_ID, conflict), SigSpec(true));
+					IdString en1_port = tribuf->type == ID($tribuf) ? ID::EN : ID::E;
 
-						assert_cell->set_src_attribute(cell->get_src_attribute());
-						assert_cell->set_bool_attribute(ID::keep);
+					// propagates the tribuf that drives this signal through all
+					// muxes/tribufs that this signal drives
+					for (auto cell : know_muxes.at(it)) {
+						// only propagate trough selected cells
+						if (!module->design->selected(module, cell))
+							continue;
 
-						module->design->scratchpad_set_bool("tribuf.added_something", true);
+						if (cell->type == ID($mux) || cell->type == ID($_MUX_)) {
+							IdString en2_port = cell->type == ID($mux) ? ID::EN : ID::E;
+							IdString tri_type = cell->type == ID($mux) ? ID($tribuf) : ID($_TBUF_);
+
+							bool is_a;
+							if (sigmap(cell->getPort(ID::A)).extract(it).size() > 0) {
+								// convert: $tribuf(X, E, Y) -> $mux(Y, B, S, Y2)
+								//      to:                     $mux(X, B, S, Y3) -> $tribuf(Y3, E || S, Y2)
+								is_a = true;
+							} else if (sigmap(cell->getPort(ID::B)).extract(it).size() > 0) {
+								// convert: $tribuf(X, E, Y) -> $mux(A, Y, S, Y2)
+								//      to:                     $mux(A, X, S, Y3) -> $tribuf(Y3, E || ~S, Y2)
+								is_a = false;
+							} else {
+								log_error("Mux %s is not driven by %s, but %s or %s\n", log_id(cell), log_signal(it),
+									  log_signal(cell->getPort(ID::A)), log_signal(cell->getPort(ID::B)));
+								continue;
+							}
+
+							auto output_y = sigmap(tribuf->getPort(ID::Y));
+							auto input_y = sigmap(cell->getPort(is_a ? ID::A : ID::B));
+							auto x = sigmap(tribuf->getPort(ID::A));
+
+							// get the intersection between input and output
+							auto extracted_y = output_y.extract(input_y);
+							auto extracted_x = output_y.extract(input_y, &x);
+
+							auto y2 = cell->getPort(ID::Y);
+							RTLIL::SigSpec extracted_y2 = input_y.extract(extracted_y, &y2);
+
+							RTLIL::Wire *y3 = module->addWire(NEW_ID, GetSize(extracted_y));
+
+							if (extracted_y.size() == input_y.size()) {
+								// just modify the mux
+								cell->setPort(is_a ? ID::A : ID::B, extracted_x);
+								cell->setPort(ID::Y, y3);
+
+							} else {
+								log_debug("splitting %s into (%s, %s) and (%s, %s)\n", log_id(cell->name),
+									  log_signal(extracted_x), log_signal(extracted_y), log_signal(input_y),
+									  log_signal(extracted_y2));
+								// split the mux
+								auto a = cell->getPort(ID::A);
+								auto b = cell->getPort(ID::B);
+
+								auto extracted_a = input_y.extract(extracted_y, &a);
+								auto extracted_b = input_y.extract(extracted_y, &b);
+
+								a.remove(extracted_a);
+								b.remove(extracted_b);
+								y2.remove(extracted_y2);
+
+								cell->setPort(ID::A, a);
+								cell->setPort(ID::B, b);
+								cell->setPort(ID::Y, y2);
+								cell->setParam(ID::WIDTH, GetSize(extracted_y));
+
+								module->addMux(NEW_ID, is_a ? extracted_x : extracted_a,
+									       is_a ? extracted_b : extracted_x, cell->getPort(ID::S), y3);
+							}
+							RTLIL::SigSpec or_y;
+							if (!is_a) {
+								or_y = module->Or(NEW_ID, tribuf->getPort(en1_port),
+										  module->Not(NEW_ID, cell->getPort(ID::S)));
+							} else {
+								or_y = module->Or(NEW_ID, tribuf->getPort(en1_port), cell->getPort(ID::S));
+							}
+							module->addTribuf(NEW_ID, y3, or_y, extracted_y2);
+
+							for (auto bit : sigmap(extracted_y2)) {
+								tribuf_signals.insert(bit);
+								added_tribufs.insert(bit);
+							}
+						}
+						if (cell->type == ID($tribuf) || cell->type == ID($_TBUF_)) {
+							// convert: $tribuf(A, E1, Y) -> $tribuf(Y, E2, Y2)
+							//      to:                      $tribuf(A, E1 && E2, Y2)
+							IdString en2_port = cell->type == ID($tribuf) ? ID::EN : ID::E;
+
+							auto output = sigmap(tribuf->getPort(ID::Y));
+							auto input = sigmap(cell->getPort(ID::A));
+
+							// get only the input signals that are driven by the tribuf
+							auto extracted_y = input.extract(output);
+
+							log_debug("extracted %s from %s and %s\n", log_signal(extracted_y), log_signal(output),
+								  log_signal(input));
+							log_assert(extracted_y.size() > 0);
+
+							auto extracted_a = output.extract(input, &tribuf->getPort(ID::A));
+							if (extracted_y == input) {
+								log_assert(extracted_a.size() == extracted_y.size());
+
+								// just replace the second tribuf
+								cell->setPort(ID::A, extracted_a);
+								cell->setPort(
+								  en2_port, module->And(NEW_ID, tribuf->getPort(en1_port), cell->getPort(en2_port)));
+							} else {
+								// split the second tribuf. A new tribuf cell will be created, with the signals
+								// extracted from `cell`.
+								auto a2 = cell->getPort(ID::A);
+								auto y2 = cell->getPort(ID::Y);
+
+								auto extracted_a2 = input.extract(extracted_y, &a2);
+								auto extracted_y2 = input.extract(extracted_y, &y2);
+
+								a2.remove(extracted_a2);
+								y2.remove(extracted_y2);
+
+								log_debug("splitting %s into (%s, %s) and (%s, %s)\n", log_id(cell->name),
+									  log_signal(a2), log_signal(y2), log_signal(extracted_a2),
+									  log_signal(extracted_y2));
+
+								cell->setPort(ID::A, a2);
+								cell->setPort(ID::Y, y2);
+								cell->setParam(ID::WIDTH, GetSize(a2));
+
+								module->addTribuf(
+								  NEW_ID, extracted_y,
+								  module->And(NEW_ID, tribuf->getPort(en1_port), cell->getPort(en2_port)),
+								  extracted_y2);
+
+								for (auto bit : sigmap(extracted_y2)) {
+									tribuf_signals.insert(bit);
+									added_tribufs.insert(bit);
+								}
+							}
+						}
 					}
 				}
+			}
+		}
 
-				SigSpec pmux_b, pmux_s;
-				for (auto cell : it.second) {
-					if (cell->type == ID($tribuf))
-						pmux_s.append(cell->getPort(ID::EN));
-					else
-						pmux_s.append(cell->getPort(ID::E));
-					pmux_b.append(cell->getPort(ID::A));
-					module->remove(cell);
+		check_tribuf_signals_consistency(tribuf_signals);
+
+		if (config.merge_mode || config.logic_mode || config.formal_mode) {
+			while (!tribuf_signals.empty()) {
+				auto it = *tribuf_signals.begin();
+				auto const driving_cells = get_driving_cells();
+
+				auto drivers = driving_cells.at(it);
+
+				// if there is only one driver, we don't need to merge it
+				if (GetSize(drivers) <= 1) {
+					tribuf_signals.erase(it);
+					continue;
 				}
 
-				SigSpec muxout =
-				  GetSize(pmux_s) > 1 ? module->Pmux(NEW_ID, SigSpec(State::Sx, GetSize(it.first)), pmux_b, pmux_s) : pmux_b;
+				// check that all driving cells are tri-state buffers
+				for (const auto &cell : drivers) {
+					if (cell->type != ID($tribuf) && cell->type != ID($_TBUF_)) {
+						log_warning("There is a non-tri-state buffer driving %s\n", log_signal(it));
+						tribuf_signals.erase(it);
+						goto skip_signal;
+					}
+				}
+				merge(it, driving_cells, tribuf_signals);
+				check_tribuf_signals_consistency(tribuf_signals);
+			skip_signal:;
+			}
+		}
+	}
 
-				if (no_tribuf)
-					module->connect(it.first, muxout);
-				else {
-					module->addTribuf(NEW_ID, muxout, module->ReduceOr(NEW_ID, pmux_s), it.first);
-					module->design->scratchpad_set_bool("tribuf.added_something", true);
+	void merge(RTLIL::SigBit sig, dict<SigBit, pool<Cell *>> const &driving_cells, pool<SigBit> &tribuf_signals)
+	{
+		// sigmap.set(module);
+		bool no_tribuf = false;
+
+		if (config.logic_mode && !config.formal_mode) {
+			no_tribuf = true;
+			if (!config.force && output_bits.count(sig))
+				no_tribuf = false;
+		}
+
+		if (config.formal_mode)
+			no_tribuf = true;
+
+		pool<Cell *> cells = driving_cells.at(sig);
+
+		if (GetSize(cells) <= 1 && !no_tribuf)
+			return;
+
+		// check if all driving cells are tri-state buffers
+		for (const auto &cell : cells) {
+			if (cell->type != ID($tribuf) && cell->type != ID($_TBUF_)) {
+				log("There is a non-tri-state buffer driving %s\n", log_signal(sig));
+				return;
+			}
+		}
+
+		// find all signals that the driving cells of this signal are also driving
+		pool<SigBit> siblings;
+		for (const auto &cell : cells) {
+			SigSpec y = sigmap(cell->getPort(ID::Y));
+			for (auto bit : y) {
+				siblings.insert(bit);
+			}
+		}
+
+		// find all cells driving one of the siblings signals
+		pool<Cell *> drivers;
+		for (const auto bit : siblings) {
+			pool<Cell *> this_cells = driving_cells.at(bit);
+			for (auto cell : this_cells)
+				if (cell->type != ID($tribuf) && cell->type != ID($_TBUF_)) {
+					log("There is a non-tri-state buffer driving %s\n", log_signal(bit));
+					return;
+				}
+			drivers.insert(this_cells.begin(), this_cells.end());
+		}
+
+		// partition the cells by the enabled signal. If they share the enabled signal, they can be merged.
+		dict<SigBit, pool<Cell *>> partitions;
+		for (const auto cell : drivers) {
+			IdString en_port = cell->type == ID($tribuf) ? ID::EN : ID::E;
+			SigSpec e = sigmap(cell->getPort(en_port));
+			partitions[e.as_bit()].insert(cell);
+		}
+
+		// get the partitions that driven this sigbit
+		pool<SigBit> en_driving_this;
+		for (auto &pair : partitions) {
+			for (auto cell : cells) {
+				if (pair.second.count(cell) > 0) {
+					en_driving_this.insert(pair.first);
+					break;
 				}
 			}
 		}
+
+		// considering the set of sigbits drived by each partition, find the set-intersection of them.
+		dict<SigBit, pool<SigBit>> partitions_sigbits;
+		for (auto sigbit : en_driving_this) {
+			pool<Cell *> this_cells = partitions.at(sigbit);
+			pool<SigBit> bits;
+			for (auto cell : this_cells) {
+				SigSpec e = sigmap(cell->getPort(ID::Y));
+				bits.insert(e.begin(), e.end());
+			}
+			partitions_sigbits[sigbit] = bits;
+		}
+
+		pool<SigBit> intersection;
+		for (SigBit bit : siblings) {
+			bool has_in_all = true;
+			for (auto &pair : partitions_sigbits) {
+				if (pair.second.count(bit) == 0) {
+					has_in_all = false;
+					break;
+				}
+			}
+			if (has_in_all)
+				intersection.insert(bit);
+		}
+		SigSpec intersection_sig(intersection);
+
+		check_tribuf_signals_consistency(tribuf_signals);
+
+		// now, for each tribuf, split them, or merge them, depending on the intersection
+		cells.clear();
+		for (auto en : en_driving_this) {
+			pool<Cell *> to_be_merged;
+			for (auto cell : partitions.at(en)) {
+				std::vector<int> matching_sigbits;
+				SigSpec output = sigmap(cell->getPort(ID::Y));
+				for (int i = 0; i < GetSize(output); i++) {
+					if (intersection.count(output[i]) > 0) {
+						matching_sigbits.push_back(i);
+					}
+				}
+				if ((int)matching_sigbits.size() == output.size() && matching_sigbits.size() == intersection.size()) {
+					// all bits of the tribuf matched, so we don't need to split or merge it.
+					to_be_merged.insert(cell);
+				} else if ((int)matching_sigbits.size() == output.size()) {
+					// all bits of the tribuf matched, so we don't need to split it.
+					to_be_merged.insert(cell);
+				} else if (matching_sigbits.size() == 0) {
+					log_error("No matching bits?!\n");
+				} else {
+					// some of the bits matched, so we need to split the tribuf in two, one with matching bits and another with
+					// the non-matching ones. The matching tribuf will be merged with other cells in this partition.
+					SigSpec extracted_a;
+					SigSpec extracted_y;
+					SigSpec port_a = cell->getPort(ID::A);
+					SigSpec port_y = cell->getPort(ID::Y);
+					for (int i = GetSize(port_a) - 1; i >= 0; i--) {
+						if (matching_sigbits[matching_sigbits.size() - 1] == i) {
+							extracted_a.append(port_a.extract(i));
+							extracted_y.append(port_y.extract(i));
+							port_a.remove(i);
+							port_y.remove(i);
+							matching_sigbits.pop_back();
+							if (matching_sigbits.size() == 0)
+								break;
+						}
+					}
+
+					log_assert(!port_a.empty() && !port_y.empty() && !extracted_y.empty() && !extracted_a.empty());
+					log_assert(cell->type.in(ID($tribuf), ID($_TBUF_)));
+
+					cell->setPort(ID::A, port_a);
+					cell->setPort(ID::Y, port_y);
+					cell->setParam(ID::WIDTH, GetSize(port_a));
+
+					RTLIL::Cell *new_tribuf = module->addTribuf(NEW_ID, extracted_a, en, extracted_y);
+					to_be_merged.insert(new_tribuf);
+				}
+			}
+			SigSpec merged_a;
+			SigSpec merged_y;
+			for (auto cell : to_be_merged) {
+				merged_a.append(cell->getPort(ID::A));
+				merged_y.append(cell->getPort(ID::Y));
+				if (cell->type.in(ID($tribuf), ID($_TBUF_)))
+					for (auto bit : sigmap(cell->getPort(ID::Y)))
+						tribuf_signals.erase(bit);
+				module->remove(cell);
+			}
+
+			RTLIL::Cell *new_tribuf = module->addTribuf(NEW_ID, merged_a, en, merged_y);
+			cells.insert(new_tribuf);
+			for (auto bit : sigmap(merged_y))
+				tribuf_signals.insert(bit);
+		}
+
+		check_tribuf_signals_consistency(tribuf_signals);
+
+		if (config.formal_mode && GetSize(cells) >= 2) {
+			for (auto cell : cells) {
+				SigSpec others_s;
+
+				for (auto other_cell : cells) {
+					if (other_cell == cell)
+						continue;
+					else if (other_cell->type == ID($tribuf))
+						others_s.append(other_cell->getPort(ID::EN));
+					else
+						others_s.append(other_cell->getPort(ID::E));
+				}
+
+				auto cell_s = cell->type == ID($tribuf) ? cell->getPort(ID::EN) : cell->getPort(ID::E);
+
+				auto other_s = module->ReduceOr(NEW_ID, others_s);
+
+				auto conflict = module->And(NEW_ID, cell_s, other_s);
+
+				std::string name = stringf("$tribuf_conflict$%s", log_id(cell->name));
+				auto assert_cell = module->addAssert(name, module->Not(NEW_ID, conflict), SigSpec(true));
+
+				assert_cell->set_src_attribute(cell->get_src_attribute());
+				assert_cell->set_bool_attribute(ID::keep);
+
+				module->design->scratchpad_set_bool("tribuf.added_something", true);
+			}
+		}
+
+		SigSpec pmux_b, pmux_s;
+		for (auto cell : cells) {
+			if (cell->type == ID($tribuf))
+				pmux_s.append(cell->getPort(ID::EN));
+			else
+				pmux_s.append(cell->getPort(ID::E));
+			pmux_b.append(cell->getPort(ID::A));
+
+			if (cell->type.in(ID($tribuf), ID($_TBUF_)))
+				for (auto bit : sigmap(cell->getPort(ID::Y)))
+					tribuf_signals.erase(bit);
+			module->remove(cell);
+		}
+		cells.clear();
+
+		check_tribuf_signals_consistency(tribuf_signals);
+
+		SigSpec muxout;
+		if (GetSize(pmux_s) > 1) {
+			muxout = module->Pmux(NEW_ID, SigSpec(State::Sx, GetSize(intersection_sig)), pmux_b, pmux_s);
+		} else {
+			muxout = pmux_b;
+		};
+
+		if (no_tribuf) {
+			module->connect(intersection_sig, muxout);
+		} else {
+			RTLIL::Cell *new_tribuf = module->addTribuf(NEW_ID, muxout, module->ReduceOr(NEW_ID, pmux_s), intersection_sig);
+			for (auto bit : sigmap(intersection_sig))
+				tribuf_signals.insert(bit);
+			module->design->scratchpad_set_bool("tribuf.added_something", true);
+		}
+		check_tribuf_signals_consistency(tribuf_signals);
 	}
 };
 
@@ -194,6 +673,15 @@ struct TribufPass : public Pass {
 		log("        add a formal assertion that no two buffers are driving the\n");
 		log("        same net simultaneously. this option implies -merge.\n");
 		log("\n");
+		log("    -propagate\n");
+		log("        propagate the tribuffer through mux cells. Basically converts\n");
+		log("        `x ? (y ? a : 1'bz) : b` into `y || ~x ? (x ? a : b) : 1'bz`,\n");
+		log("        etc. this option implies -merge\n");
+		log("\n");
+		log("    -force\n");
+		log("        convert tri-state buffers to non-tristate logic, even if\n");
+		log("        they are output ports. this option depends on -logic or -formal.\n");
+		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
@@ -213,6 +701,15 @@ struct TribufPass : public Pass {
 			}
 			if (args[argidx] == "-formal") {
 				config.formal_mode = true;
+				continue;
+			}
+			if (args[argidx] == "-propagate") {
+				config.propagate = true;
+				config.merge_mode = true;
+				continue;
+			}
+			if (args[argidx] == "-force") {
+				config.force = true;
 				continue;
 			}
 			break;

--- a/tests/sat/eval.ys
+++ b/tests/sat/eval.ys
@@ -1,0 +1,12 @@
+read_verilog <<EOT
+module test(input a, b, output q, p);
+	assign p = a ^ b;
+	assign q = 1'b0;
+endmodule
+EOT
+
+eval -set a 0 -set b 0 -assert p 0
+eval -set a 1 -set b 0 -assert p 1
+eval -set a 1 -set b 1 -assert p 0
+eval -set a 0 -set b 1 -assert p 1
+eval -table a -table b -assert q 0

--- a/tests/techmap/tribuf.ys
+++ b/tests/techmap/tribuf.ys
@@ -1,0 +1,466 @@
+log simple
+read_verilog <<EOT
+module top(...);
+	input a;
+	input x;
+	output b;
+
+	assign b = x ? a : 1'bz;
+endmodule
+EOT
+
+copy top gold
+
+cd top
+select -assert-count 1 t:$mux
+select -assert-count 0 t:$tribuf
+tribuf
+select -assert-count 0 t:$mux
+select -assert-count 1 t:$tribuf
+cd
+
+equiv_make gold top equiv
+eval -table a -table x -assert b 11 equiv
+
+design -reset
+
+
+log two drivers
+read_verilog <<EOT
+module top(...);
+	input [1:0] a;
+	input x;
+	output [1:0] b;
+
+	assign b = x ? a : 2'bz;
+	assign b = x ? 2'bz : a;
+endmodule
+EOT
+
+copy top gold
+
+cd top
+tribuf -merge
+select -assert-count 0 t:$mux
+cd
+
+equiv_make gold top equiv
+eval -table a -table x -assert b 11 equiv
+
+design -reset
+
+
+log mix drivers
+read_verilog <<EOT
+module top(...);
+	input [1:0] a;
+	input x;
+	output [2:0] b;
+
+	assign b[1:0] = x ? a : 2'bz;
+	assign b[1:0] = x ? 2'bz : a;
+	assign b[2] = 1'b1;
+endmodule
+EOT
+
+copy top gold
+
+cd top
+tribuf -merge
+cd
+
+equiv_make gold top equiv
+eval -table a -table x -assert b 111 equiv
+
+design -reset
+
+
+log nested
+read_verilog <<EOT
+module top(...);
+	input a;
+	input x;
+	input y;
+	output b;
+
+	assign b = x ? (y ? a : 1'bz) : 1'bz;
+endmodule
+EOT
+
+copy top gold
+
+cd top
+tribuf -propagate
+cd
+
+equiv_make gold top equiv
+eval -table a -table x -table y -assert b 11 equiv
+
+design -reset
+
+
+log nested 2
+read_verilog <<EOT
+module top(...);
+	input a;
+	input b;
+	input x;
+	input y;
+	output q;
+
+	assign q = x ? a : (y ? b : 1'bz);
+endmodule
+EOT
+
+copy top gold
+
+cd top
+tribuf -propagate
+cd
+
+equiv_make gold top equiv
+eval -table a -table b -table x -table y -assert q 1 equiv
+
+design -reset
+
+
+log mismatch width
+read_verilog <<EOT
+module top(...);
+	input [1:0] a;
+	input x;
+	output [1:0] b;
+
+	assign b = x ? a : 2'bz;
+	assign b[0] = x ? 1'bz : a[0];
+	assign b[1] = x ? 1'bz : a[1];
+endmodule
+EOT
+
+copy top gold
+
+cd top
+tribuf -merge
+cd
+
+equiv_make gold top equiv
+eval -table a -table x -assert b 11 equiv
+
+design -reset
+
+
+log mismatch width 2
+read_verilog <<EOT
+module top(...);
+	input [1:0] a;
+	input x;
+	output [1:0] b;
+
+	assign b = x ? a : 2'bz;
+	assign b[0] = x ? 1'bz : a[0];
+	assign b[1] = x ? 1'bz : a[1];
+endmodule
+EOT
+
+copy top gold
+
+cd top
+
+# We first convert to tribuf, which will generate not(x) cells, we merge these
+# cells and them try to merge. Otherwise the tribuf merge pass will not detect
+# the different not(x) cells as the same enabled signal, and so it will create a
+# tribuf for each sigbit. By merging the not(x) cells into one, it will now
+# merge the 3 tribufs into one.
+tribuf
+opt_merge
+
+tribuf -merge
+cd
+
+equiv_make gold top equiv
+eval -table a -table x -assert b 11 equiv
+
+design -reset
+
+
+log splitted mux
+read_verilog <<EOT
+module top(...);
+	input [1:0] a;
+	input x;
+	input y;
+	output [1:0] q;
+	wire [1:0] b;
+
+	assign b = x ? a : 2'bzz;
+
+	assign q[0] = y ? b[0] : a[0];
+	assign q[1] = y ? b[1] : a[1];
+endmodule
+EOT
+
+copy top gold
+
+cd top
+tribuf -propagate
+cd
+
+equiv_make gold top equiv
+eval -table a -table b -table x -table y -assert q 2'b11 equiv
+
+design -reset
+
+
+log splitted mux 2
+read_verilog <<EOT
+module top(...);
+	input [1:0] a;
+	input x;
+	input y;
+	output [1:0] q;
+	wire [1:0] b;
+
+	assign b[0] = y ? a[0] : 1'bz;
+	assign b[1] = y ? a[1] : 1'bz;
+
+	assign q = x ? b : a;
+endmodule
+EOT
+
+copy top gold
+
+cd top
+tribuf -propagate
+cd
+
+equiv_make gold top equiv
+eval -table a -table b -table x -table y -assert q 2'b11 equiv
+
+design -reset
+
+
+log splitted mux 3
+read_verilog <<EOT
+module top(...);
+	input [1:0] a;
+	input x;
+	input y;
+	output [1:0] q;
+	wire [1:0] b;
+
+	assign b[0] = y ? a[0] : 1'bz;
+	assign b[1] = y ? a[1] : 1'bz;
+
+	assign q = x ? a : b;
+endmodule
+EOT
+
+copy top gold
+
+cd top
+tribuf -propagate
+cd
+
+equiv_make gold top equiv
+eval -table a -table b -table x -table y -assert q 2'b11 equiv
+
+design -reset
+
+
+log splitted tribuf
+read_verilog <<EOT
+module top(...);
+	input [1:0] a;
+	input x;
+	input y;
+	output [1:0] q;
+	wire [1:0] b;
+
+	assign b = x ? a : 2'bzz;
+
+	assign q[0] = y ? b[0] : 1'bz;
+	assign q[1] = y ? b[1] : 1'bz;
+endmodule
+EOT
+
+copy top gold
+
+cd top
+tribuf -propagate
+cd
+
+equiv_make gold top equiv
+eval -table a -table b -table x -table y -show q_gold -show q_gate -assert q 2'b11 equiv
+
+design -reset
+
+
+log splitted tribuf 2
+read_verilog <<EOT
+module top(...);
+	input [1:0] a;
+	input x;
+	input y;
+	output [1:0] q;
+	wire [1:0] b;
+
+	assign b[0] = y ? a[0] : 1'bz;
+	assign b[1] = y ? a[1] : 1'bz;
+
+	assign q = x ? b : 2'bzz;
+endmodule
+EOT
+
+copy top gold
+
+cd top
+tribuf -propagate
+cd
+
+equiv_make gold top equiv
+eval -table a -table b -table x -table y -assert q 2'b11 equiv
+
+design -reset
+
+
+log splitted tribuf 3.1
+read_verilog <<EOT
+module top(...);
+	input [2:0] a;
+	input x;
+	input y;
+	output [2:0] q;
+	wire [2:0] b;
+
+	assign b = x ? a : 3'bzzz;
+
+	assign q[1:0] = y ? b[1:0] : 2'bzz;
+	assign q[2] = y ? b[2] : 1'bz;
+endmodule
+EOT
+
+copy top gold
+
+cd top
+tribuf -propagate
+cd
+
+equiv_make gold top equiv
+eval -table a -table b -table x -table y -show q_gold -show q_gate -assert q 3'b111 equiv
+
+design -reset
+
+
+log splitted tribuf 3.2
+read_verilog <<EOT
+module top(...);
+	input [2:0] a;
+	input x;
+	input y;
+	output [2:0] q;
+	wire [2:0] b;
+
+	assign b = x ? a : 3'bzzz;
+
+	assign q[0] = y ? b[0] : 1'bz;
+	assign q[2:1] = y ? b[2:1] : 2'bzz;
+endmodule
+EOT
+
+copy top gold
+
+cd top
+tribuf -propagate
+cd
+
+equiv_make gold top equiv
+eval -table a -table b -table x -table y -show q_gold -show q_gate -assert q 3'b111 equiv
+
+design -reset
+
+
+log splitted tribuf 4.1
+read_verilog <<EOT
+module top(...);
+	input [2:0] a;
+	input x;
+	input y;
+	output [2:0] q;
+	wire [2:0] b;
+
+	assign b[1:0] = y ? a[1:0] : 2'bzz;
+	assign b[2] = y ? a[2] : 1'bz;
+
+	assign q = x ? b : 3'bzzz;
+endmodule
+EOT
+
+copy top gold
+
+cd top
+tribuf -propagate
+cd
+
+equiv_make gold top equiv
+eval -table a -table b -table x -table y -assert q 3'b111 equiv
+
+design -reset
+
+
+log splitted tribuf 4.2
+read_verilog <<EOT
+module top(...);
+	input [2:0] a;
+	input x;
+	input y;
+	output [2:0] q;
+	wire [2:0] b;
+
+	assign b[0] = y ? a[0] : 1'bz;
+	assign b[2:1] = y ? a[2:1] : 2'bzz;
+
+	assign q = x ? b : 3'bzzz;
+endmodule
+EOT
+
+copy top gold
+
+cd top
+tribuf -propagate
+cd
+
+equiv_make gold top equiv
+eval -table a -table b -table x -table y -assert q 3'b111 equiv
+
+design -reset
+
+
+log tribuf intersection
+read_verilog <<EOT
+module top(...);
+	input [1:0] a;
+	input x;
+	input y;
+	output q;
+
+	wire [1:0] b;
+	wire [1:0] c;
+
+	assign b = x ? a : 2'bzz;
+	assign c = y ? a : 2'bzz;
+
+	assign q = b[1];
+	assign q = c[0];
+endmodule
+EOT
+
+copy top gold
+
+cd top
+tribuf -propagate
+cd
+
+equiv_make gold top equiv
+eval -table a -table b -table x -table y -assert q 1'b1 equiv
+
+design -reset


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

I am working on a non-synthesizable project, that make extensive use of tri-state signals, which. This change allows to eliminating all tristate usage in the design, by flattening the module hierarchy, detecting and propagating all tribuf cells, and  https://github.com/emu-russia/dmgcpu/pull/292

_Explain how this is achieved._

_If applicable, please suggest to reviewers how they can test the change._
