### PR TITLE
Set VHDL assert condition initial state if fed by FF

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -2142,13 +2142,12 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 			if (verific_verbose)
 				log("    assert condition %s.\n", log_signal(cond));
 
-			const char *assume_attr = nullptr; // inst->GetAttValue("assume");
-
-			Cell *cell = nullptr;
-			if (assume_attr != nullptr && !strcmp(assume_attr, "1"))
-				cell = module->addAssume(new_verific_id(inst), cond, State::S1);
-			else
-				cell = module->addAssert(new_verific_id(inst), cond, State::S1);
+			Cell *cell = module->addAssert(new_verific_id(inst), cond, State::S1);
+			// Initialize FF feeding condition  to 1, in case it is not
+			// used by rest of design logic, to prevent failing on
+			// initial uninitialized state
+			if (cond.is_wire() && !cond.wire->name.isPublic())
+				cond.wire->attributes[ID::init] = Const(1,1);
 
 			import_attributes(cell->attributes, inst);
 			continue;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
If we have assert that is inside VHLD process, it fails since condition signal is coming from uninitialized FF. 
Please note that this primitive is VHDL only so it will not affect SVA code path.
Also there is left-over from past and there was never an "assume" attribute to convert this to assume.
```
    assert (conv_integer(addr) >= sram'low and conv_integer(addr) <= sram'high) report "out of bounds for read" severity error;
    rdata <= sram(conv_integer(addr));
    process(clk)
    begin
        if clk'event and clk = '1' then
            if wen = '1' then
                assert (conv_integer(addr) >= sram'low and conv_integer(addr) <= sram'high) report "out of bounds for write" severity error;
                sram(conv_integer(addr)) <= wdata;
            end if;
        end if;
    end process;

```
_Explain how this is achieved._
Initial state in condition wire is set to 1, making assert not trigger on its undefined state.
Since condition signal may originate from any internal signal (including register) we are checking if it is public.
Note that it will use register condition directly only if outside process block.
