### PR TITLE
cxxrtl: fix vcd writer scope handling

### DIFF
--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl_vcd.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl_vcd.h
@@ -50,9 +50,13 @@ class vcd_writer {
 
 	void emit_scope(const std::vector<std::string> &scope) {
 		assert(!streaming);
-		while (current_scope.size() > scope.size() ||
-		       (current_scope.size() > 0 &&
-			current_scope[current_scope.size() - 1] != scope[current_scope.size() - 1])) {
+		size_t same_scope_count = 0;
+		while ((same_scope_count < current_scope.size()) &&
+			   (same_scope_count < scope.size()) &&
+			   (current_scope[same_scope_count] == scope[same_scope_count])) {
+			same_scope_count++;
+		}
+		while (current_scope.size() > same_scope_count) {
 			buffer += "$upscope $end\n";
 			current_scope.pop_back();
 		}


### PR DESCRIPTION
The vcd writer incorrectly treated two scope vectors as the same, whenever they have the same length of entries and the last item matches. This is however not always true, for example consider a current_scope of ["top", "something0", "other_i"] and a scope of ["top", "something1", "other_i"] as one might obtain from the following verilog file:
```verilog
module other2();
    wire w_inner;
endmodule

module other();
    other2 other_i();
endmodule


module top();
    other something0();
    other something1();
endmodule
```
The old code emitted a vcd of 
```
$scope module top $end
$scope module something0 $end
$scope module other_i $end
$var wire 1 ! w_inner $end
$var wire 1 " w_inner $end
$upscope $end
$upscope $end
$upscope $end
$enddefinitions $end
#0
0!
0"
```
not changing the scope correctly for the two `w_inner` wires. This now correctly generates 
```
$scope module top $end
$scope module something0 $end
$scope module other_i $end
$var wire 1 ! w_inner $end
$upscope $end
$upscope $end
$scope module something1 $end
$scope module other_i $end
$var wire 1 " w_inner $end
$upscope $end
$upscope $end
$upscope $end
$enddefinitions $end
#0
0!
0"
```