### PR TITLE
cxxrtl: fix handling of 0-bit variables in `vcd_writer.sample()`.

### DIFF
--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl_vcd.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl_vcd.h
@@ -127,6 +127,8 @@ class vcd_writer {
 			bool bit_curr = var.curr[bit / (8 * sizeof(chunk_t))] & (1 << (bit % (8 * sizeof(chunk_t))));
 			buffer += (bit_curr ? '1' : '0');
 		}
+		if (var.width == 0)
+			buffer += '0';
 		buffer += ' ';
 		emit_ident(var.ident);
 		buffer += '\n';


### PR DESCRIPTION
Before this commit, `vcd_writer.sample()` emits vector values for 0-bit variables.

For example, the following RTLIL:

```
module \top
  wire width 0 \foo
end
```

would result in the following VCD:

```
$timescale 1 us $end
$var wire 0 ! foo $end
$enddefinitions $end
#0
b !
```

However, according to IEEE 1364-2001, the syntax for vector values is:

![20241011_22h37m15s_grim](https://github.com/user-attachments/assets/bbf3265b-27e7-4433-87c6-2996975fae57)

After this commit, `foo` is no longer sampled in the VCD:

```
$timescale 1 us $end
$var wire 0 ! foo $end
$enddefinitions $end
#0
```