### PR TITLE
misc/yosys-config.in: don't use the non-portable '==' operator with test(1)

### DIFF
--- a/misc/yosys-config.in
+++ b/misc/yosys-config.in
@@ -44,7 +44,7 @@ if [ $# -eq 0 ]; then
 	help
 fi
 
-if [ "$1" == "--build" ]; then
+if [ "$1" = "--build" ]; then
 	modname="$2"; shift 2
 	set -- --exec --cxx --cxxflags --ldflags -o "$modname" -shared "$@" --libs
 fi


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
The '==' operator is non-standard and does not work with all versions of test(1) or sh(1).

_Explain how this is achieved._
The fix is simple: use the standard '=' operator instead.

_If applicable, please suggest to reviewers how they can test the change._
Ensure yosys builds.

Resolves issue #4665.