### PR TITLE
verilog_parser: silence yynerrs warning

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -464,6 +464,7 @@ static const AstNode *addAsgnBinopStmt(dict<IdString, AstNode*> *attr, AstNode *
 %%
 
 input: {
+	(void)frontend_verilog_yynerrs;
 	ast_stack.clear();
 	ast_stack.push_back(current_ast);
 } design {


### PR DESCRIPTION
`yynerrs` is an automatically emitted variable we have no use for. Ignoring warnings isn't in good taste and leads to overlooking more meaningful ones.

```
frontends/verilog/verilog_parser.tab.cc:3743:9: warning: variable 'frontend_verilog_yynerrs' set but not used [-Wunused-but-set-variable]
    int yynerrs = 0;
        ^
frontends/verilog/verilog_parser.tab.cc:74:25: note: expanded from macro 'yynerrs'
#define yynerrs         frontend_verilog_yynerrs
                        ^
```

In this PR I cast the variable to void at a reasonably top level rule in the parser. You can check the effect by observing there's no yynerrs warning when building this PR, but there is when building its parent commit