### PR TITLE
actions: vendor sources with submodules for releases

### DIFF
--- a/.github/workflows/source-vendor.yml
+++ b/.github/workflows/source-vendor.yml
@@ -1,0 +1,33 @@
+name: Create source archive with vendored dependencies
+
+on: [push, workflow_dispatch]
+
+jobs:
+  vendor-sources:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository with submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Create clean tarball
+        run: |
+          git archive --format=tar HEAD -o yosys-src-vendored.tar
+          git submodule foreach '
+            git archive --format=tar --prefix="${sm_path}/" HEAD --output=${toplevel}/vendor-${name}.tar
+          '
+
+          # 2008 bug https://lists.gnu.org/archive/html/bug-tar/2008-08/msg00002.html
+          for file in vendor-*.tar; do
+              tar --concatenate --file=yosys-src-vendored.tar "$file"
+          done
+
+          gzip yosys-src-vendored.tar
+
+      - name: Store tarball artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vendored-sources
+          path: yosys-src-vendored.tar.gz
+          retention-days: 1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "abc"]
 	path = abc
 	url = https://github.com/YosysHQ/abc
-[submodule "libs/cxxopts"]
+# Don't use paths as names to avoid git archive problems
+[submodule "cxxopts"]
 	path = libs/cxxopts
 	url = https://github.com/jarro2783/cxxopts

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Yosys is free software licensed under the ISC license (a GPL
 compatible license that is similar in terms to the MIT license
 or the 2-clause BSD license).
 
+Third-party software distributed alongside this software
+is licensed under compatible licenses.
+Please refer to `abc` and `libs` subdirectories for their license terms.
 
 Web Site and Other Resources
 ============================


### PR DESCRIPTION
We like submodules for SBOM reasons and prefer them over in-repo vendored libraries. However this creates a burden on users with needs for gitless workflows who have to take our (yosys) source tarball, drop in our other (yosys-abc) source tarball, manually check submodules versions at the git tag, download those, and only then build yosys. An alternate solution is to add Makefile targets like curl-abc #4472 but that needs per-submodule work. This PR adds a workflow which on main commits creates a source tarball artifact including submodule sources

- [x] instruct users of vendored dependencies that licenses in `abc/` and `libs/*` apply to those components
- [x] eliminate zeroes that prevent `libs/cxxopts` from being visible