### PR TITLE
py_wrap: implement nested class definitions

### DIFF
--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -53,14 +53,8 @@ namespace RTLIL
 		CONST_FLAG_NONE   = 0,
 		CONST_FLAG_STRING = 1,
 		CONST_FLAG_SIGNED = 2,  // only used for parameters
-		CONST_FLAG_REAL   = 4,  // only used for parameters
+		CONST_FLAG_REAL   = 4   // only used for parameters
 	};
-
-	// // Union discriminator. Values are exclusive
-	// enum ConstRepr : unsigned char {
-	// 	CONST_REPR_BITS   = 1,
-	// 	CONST_REPR_STRING = 2,
-	// };
 
 	struct Const;
 	struct AttrObject;

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -660,7 +660,7 @@ namespace RTLIL
 
 struct RTLIL::Const
 {
-	short flags;
+	short int flags;
 private:
 	friend class KernelRtlilTest;
 	FRIEND_TEST(KernelRtlilTest, ConstStr);

--- a/misc/py_wrap_generator.py
+++ b/misc/py_wrap_generator.py
@@ -2046,13 +2046,11 @@ def parse_header(source):
 		if len(classes):
 			c = (classes[-1][0], classes[-1][1] + nesting_delta(ugly_line))
 			classes[-1] = c
-			debug(f"switch to uhh depth {c[1]}", 2)
 			if c[1] == 0:
 				if c[0] == None:
 					debug("\tExiting unknown class", 3)
 				else:
 					debug("\tExiting class " + c[0].name, 3)
-				debug(f"nevermind!", 2)
 				classes.pop()
 				private_segment = False
 				i += 1

--- a/misc/py_wrap_generator.py
+++ b/misc/py_wrap_generator.py
@@ -2045,6 +2045,7 @@ def parse_header(source):
 
 		if len(classes):
 			c = (classes[-1][0], classes[-1][1] + nesting_delta(ugly_line))
+			classes[-1] = c
 			debug(f"switch to uhh depth {c[1]}", 2)
 			if c[1] == 0:
 				if c[0] == None:
@@ -2172,6 +2173,7 @@ def parse_header(source):
 						namespaces.pop()
 				if len(classes):
 					c = (classes[-1][0] , classes[-1][1] + nesting_delta(ugly_line))
+					classes[-1] = c
 					if c[1] == 0:
 						if c[0] == None:
 							debug("\tExiting unknown class", 3)

--- a/misc/py_wrap_generator.py
+++ b/misc/py_wrap_generator.py
@@ -1958,7 +1958,10 @@ def assure_length(text, length, left = False):
 	if left:
 		return text + " "*(length - len(text))
 	return " "*(length - len(text)) + text
-	
+
+def nesting_delta(s):
+	return s.count("{") - s.count("}")
+
 def parse_header(source):
 	debug("Parsing " + source.name + ".pyh",1)
 	source_file = open(source.name + ".pyh", "r")
@@ -1982,6 +1985,7 @@ def parse_header(source):
 	while i < len(source_text):
 		line = source_text[i].replace("YOSYS_NAMESPACE_BEGIN", "                    namespace YOSYS_NAMESPACE{").replace("YOSYS_NAMESPACE_END","                    }")
 		ugly_line = unpretty_string(line)
+		debug(f"READ:>> {line}", 2)
 
 		# for anonymous unions, ignore union enclosure by skipping start line and replacing end line with new line
 		if 'union {' in line:
@@ -2004,15 +2008,15 @@ def parse_header(source):
 			continue
 
 		if len(namespaces) != 0:
-			namespaces[-1] = (namespaces[-1][0], namespaces[-1][1] + ugly_line.count("{") - ugly_line.count("}"))
+			namespaces[-1] = (namespaces[-1][0], namespaces[-1][1] + nesting_delta(ugly_line))
 			if namespaces[-1][1] == 0:
 				debug("-----END NAMESPACE " + concat_namespace(namespaces) + "-----",3)
-				del namespaces[-1]
+				namespaces.pop()
 				i += 1
 				continue
 
 		if class_ == None and (str.startswith(ugly_line, "struct ") or str.startswith(ugly_line, "class")) and ugly_line.count(";") == 0:
-
+			# Opening a record declaration which isn't a forward declaration
 			struct_name = ugly_line.split(" ")[1].split("::")[-1]
 			impl_namespaces = ugly_line.split(" ")[1].split("::")[:-1]
 			complete_namespace = concat_namespace(namespaces)
@@ -2031,6 +2035,7 @@ def parse_header(source):
 			base_class = class_by_name(base_class_name)
 
 			class_ = (class_by_name(struct_name), ugly_line.count("{"))#calc_ident(line))
+			debug(f"switch to {struct_name} in namespace {namespaces}", 2)
 			if struct_name in classnames:
 				class_[0].namespace = complete_namespace
 				class_[0].base_class = base_class
@@ -2038,12 +2043,14 @@ def parse_header(source):
 			continue
 
 		if class_ != None:
-			class_ = (class_[0], class_[1] + ugly_line.count("{") - ugly_line.count("}"))
+			class_ = (class_[0], class_[1] + nesting_delta(ugly_line))
+			debug(f"switch to uhh depth {class_[1]}", 2)
 			if class_[1] == 0:
 				if class_[0] == None:
 					debug("\tExiting unknown class", 3)
 				else:
 					debug("\tExiting class " + class_[0].name, 3)
+				debug(f"nevermind!", 2)
 				class_ = None
 				private_segment = False
 				i += 1
@@ -2156,12 +2163,12 @@ def parse_header(source):
 				line = source_text[i].replace("YOSYS_NAMESPACE_BEGIN", "                    namespace YOSYS_NAMESPACE{").replace("YOSYS_NAMESPACE_END","                    }")
 				ugly_line = unpretty_string(line)
 				if len(namespaces) != 0:
-					namespaces[-1] = (namespaces[-1][0], namespaces[-1][1] + ugly_line.count("{") - ugly_line.count("}"))
+					namespaces[-1] = (namespaces[-1][0], namespaces[-1][1] + nesting_delta(ugly_line))
 					if namespaces[-1][1] == 0:
 						debug("-----END NAMESPACE " + concat_namespace(namespaces) + "-----",3)
-						del namespaces[-1]
+						namespaces.pop()
 				if class_ != None:
-					class_ = (class_[0] , class_[1] + ugly_line.count("{") - ugly_line.count("}"))
+					class_ = (class_[0] , class_[1] + nesting_delta(ugly_line))
 					if class_[1] == 0:
 						if class_[0] == None:
 							debug("\tExiting unknown class", 3)


### PR DESCRIPTION
Fixes #4670 by probably implementing nested class declaration. I don't really know what the wrapper generator does and I don't want to find out more than I already did. Also the DIY C++ parser doesn't like trailing commas in enum declarations so I removed it from `RTLIL::ConstFlags`.