### PR TITLE
CI: make CI continue even if brew objects

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -15,7 +15,7 @@ runs:
       shell: bash
       run: |
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew update
-        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install bison flex gawk libffi pkg-config bash autoconf llvm lld
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install bison flex gawk libffi pkg-config bash autoconf llvm lld || true
 
     - name: Linux runtime environment
       if: runner.os == 'Linux'


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
macOS brew upgrade reports that it can not update links to python (3.12->3.13) but that it also returns error code even if it is not a critical issue. It is something that commonly occurred in the past on github runners, and got fixed when they updated the base image to be based on the same python major version.

_Explain how this is achieved._
It affects only macos-13 but we just ignore error code now that is coming from brew.
