### PR TITLE
opt_merge: hashing performance and correctness

### DIFF
--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -154,7 +154,7 @@ struct OptMergeWorker
 
 	bool compare_cell_parameters_and_connections(const RTLIL::Cell *cell1, const RTLIL::Cell *cell2) const
 	{
-		log_assert(cell1 != cell2);
+		if (cell1 == cell2) return true;
 		if (cell1->type != cell2->type) return false;
 
 		if (cell1->parameters != cell2->parameters)
@@ -313,6 +313,8 @@ struct OptMergeWorker
 					if (cell->has_keep_attr()) {
 						if (other_cell->has_keep_attr())
 							continue;
+						known_cells.erase(other_cell);
+						known_cells.insert(cell);
 						std::swap(other_cell, cell);
 					}
 

--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -95,7 +95,6 @@ struct OptMergeWorker
 			};
 			std::sort(inputs.begin(), inputs.end());
 			h = hash_ops<std::array<RTLIL::SigSpec, 2>>::hash_into(inputs, h);
-			h = assign_map(cell->getPort(ID::Y)).hash_into(h);
 		} else if (cell->type.in(ID($reduce_xor), ID($reduce_xnor))) {
 			SigSpec a = assign_map(cell->getPort(ID::A));
 			a.sort();

--- a/tests/opt/opt_merge_basic.ys
+++ b/tests/opt/opt_merge_basic.ys
@@ -1,13 +1,74 @@
-read_verilog -icells <<EOT
+read_verilog <<EOT
 module top(A, B, X, Y);
-input [8:0] A, B;
-output [8:0] X, Y;
+input [7:0] A, B;
+output [7:0] X, Y;
 assign X = A + B;
 assign Y = A + B;
 endmodule
 EOT
-
+# Most basic case
+# Binary
 select -assert-count 2 t:$add
 equiv_opt -assert opt_merge
 design -load postopt
 select -assert-count 1 t:$add
+
+design -reset
+read_verilog <<EOT
+module top(A, B, C, X, Y);
+input [7:0] A, B, C;
+output [7:0] X, Y;
+assign X = A + B;
+assign Y = A + C;
+endmodule
+EOT
+# Reject on a different input
+select -assert-count 2 t:$add
+opt_merge
+select -assert-count 2 t:$add
+
+design -reset
+read_verilog <<EOT
+module top(A, X, Y);
+input [7:0] A;
+output X, Y;
+assign X = ^A;
+assign Y = ^A;
+endmodule
+EOT
+# Unary
+select -assert-count 2 t:$reduce_xor
+dump
+opt_merge
+select -assert-count 1 t:$reduce_xor
+
+design -reset
+read_verilog -icells <<EOT
+module top(A, B, X, Y);
+input [7:0] A;
+input [7:0] B;
+output X, Y;
+  \$reduce_or  #(
+    .A_SIGNED(32'd0),
+    .A_WIDTH(32'd16),
+    .Y_WIDTH(32'd1),
+  ) one  (
+    .A({A, B}), // <- look here
+    .Y(X)
+  );
+  \$reduce_or  #(
+    .A_SIGNED(32'd0),
+    .A_WIDTH(32'd16),
+    .Y_WIDTH(32'd1),
+  ) other  (
+    .A({B, A}), // <- look here
+    .Y(Y)
+  );
+endmodule
+EOT
+# Unary
+opt_expr
+select -assert-count 2 t:$reduce_or
+equiv_opt -assert opt_merge
+design -load postopt
+select -assert-count 1 t:$reduce_or

--- a/tests/opt/opt_merge_basic.ys
+++ b/tests/opt/opt_merge_basic.ys
@@ -1,0 +1,13 @@
+read_verilog -icells <<EOT
+module top(A, B, X, Y);
+input [8:0] A, B;
+output [8:0] X, Y;
+assign X = A + B;
+assign Y = A + B;
+endmodule
+EOT
+
+select -assert-count 2 t:$add
+equiv_opt -assert opt_merge
+design -load postopt
+select -assert-count 1 t:$add

--- a/tests/opt/opt_merge_basic.ys
+++ b/tests/opt/opt_merge_basic.ys
@@ -19,7 +19,7 @@ module top(A, B, C, X, Y);
 input [7:0] A, B, C;
 output [7:0] X, Y;
 assign X = A + B;
-assign Y = A + C;
+assign Y = A + C; // <- look here
 endmodule
 EOT
 # Reject on a different input
@@ -45,10 +45,9 @@ select -assert-count 1 t:$reduce_xor
 design -reset
 read_verilog -icells <<EOT
 module top(A, B, X, Y);
-input [7:0] A;
-input [7:0] B;
+input [7:0] A, B;
 output X, Y;
-  \$reduce_or  #(
+  \$reduce_xor  #(
     .A_SIGNED(32'd0),
     .A_WIDTH(32'd16),
     .Y_WIDTH(32'd1),
@@ -56,7 +55,7 @@ output X, Y;
     .A({A, B}), // <- look here
     .Y(X)
   );
-  \$reduce_or  #(
+  \$reduce_xor  #(
     .A_SIGNED(32'd0),
     .A_WIDTH(32'd16),
     .Y_WIDTH(32'd1),
@@ -66,9 +65,102 @@ output X, Y;
   );
 endmodule
 EOT
-# Unary
+# Unary is sorted
+opt_expr
+select -assert-count 2 t:$reduce_xor
+equiv_opt -assert opt_merge
+design -load postopt
+select -assert-count 1 t:$reduce_xor
+
+design -reset
+read_verilog -icells <<EOT
+module top(A, B, X, Y);
+input [7:0] A, B;
+output X, Y;
+  \$reduce_or  #(
+    .A_SIGNED(32'd0),
+    .A_WIDTH(32'd24),
+    .Y_WIDTH(32'd1),
+  ) one  (
+    .A({A, B, B}), // <- look here
+    .Y(X)
+  );
+  \$reduce_or  #(
+    .A_SIGNED(32'd0),
+    .A_WIDTH(32'd24),
+    .Y_WIDTH(32'd1),
+  ) other  (
+    .A({A, A, B}), // <- look here
+    .Y(Y)
+  );
+endmodule
+EOT
+# Unary is unified when valid
 opt_expr
 select -assert-count 2 t:$reduce_or
 equiv_opt -assert opt_merge
 design -load postopt
 select -assert-count 1 t:$reduce_or
+
+design -reset
+read_verilog -icells <<EOT
+module top(A, B, X, Y);
+input [7:0] A, B;
+output X, Y;
+  \$reduce_xor  #(
+    .A_SIGNED(32'd0),
+    .A_WIDTH(32'd24),
+    .Y_WIDTH(32'd1),
+  ) one  (
+    .A({A, B, B}), // <- look here
+    .Y(X)
+  );
+  \$reduce_xor  #(
+    .A_SIGNED(32'd0),
+    .A_WIDTH(32'd24),
+    .Y_WIDTH(32'd1),
+  ) other  (
+    .A({A, A, B}), // <- look here
+    .Y(Y)
+  );
+endmodule
+EOT
+# Unary isn't unified when that would be invalid
+opt_expr
+select -assert-count 2 t:$reduce_xor
+equiv_opt -assert opt_merge
+design -load postopt
+select -assert-count 2 t:$reduce_xor
+
+# TODO pmux
+
+design -reset
+read_verilog <<EOT
+module top(A, B, X, Y);
+input [7:0] A, B;
+output X, Y;
+assign X = A > B;
+assign Y = A > B;
+endmodule
+EOT
+# Exercise the general case in hash_cell_inputs - accept
+opt_expr
+select -assert-count 2 t:$gt
+equiv_opt -assert opt_merge
+design -load postopt
+select -assert-count 1 t:$gt
+
+design -reset
+read_verilog <<EOT
+module top(A, B, C, X, Y);
+input [7:0] A, B, C;
+output X, Y;
+assign X = A > B;
+assign Y = A > C; // <- look here
+endmodule
+EOT
+# Exercise the general case in hash_cell_inputs - reject
+opt_expr
+select -assert-count 2 t:$gt
+opt_merge
+select -assert-count 2 t:$gt


### PR DESCRIPTION
This is a direct remake of #4175 sans the 64-bit hash value. I'm making use of the interface in #4524 and requiring that PR (and containing its commits at the moment). Instead of xorshifts, values are sorted, though a final xorshift is included as a part of the fudge (`--hash-seed=N`) mechanism.

Additionally, I discovered opt_merge behaves incorrectly in the case of hash collisions. This suggests that this PR might in rare cases bring improvements in quality of results for flows that use opt_merge, since prior to it, hash collisions would inhibit merging. I modified the `sharemap` from a `dict<hash_t, Cell*>` to an equivalent `std::unordered_multimap` so that multiple cells can be associated with the same hash. This can't be a separate change since this bug actually broke the build just by changing how the hashes are constructed.

Sorry for the spam to code owners due to being based on the above mentioned wide-reaching PR #4524, I don't have a way of removing you from the reviewer list. The diff for this PR is not going to be very readable on github either until that's merged