### PR TITLE
Makefile: add -rdynamic on macOS to fix plugins with LTO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ AWK ?= awk
 
 ifeq ($(OS), Darwin)
 PLUGIN_LINKFLAGS += -undefined dynamic_lookup
+LINKFLAGS += -rdynamic
 
 # homebrew search paths
 ifneq ($(shell :; command -v brew),)


### PR DESCRIPTION
Prior to this change, some symbols would be missing from the yosys executable if built on macOS with LTO. This would break plugins on dlopen. By adding `-rdynamic` to the linker flags, we can export all symbols even if they're unused due to LTO-enabled inlining or otherwise. You can check the exported symbols by building yosys with LTO on macOS and running `objdump --macho --exports-trie yosys`.