### PR TITLE
extract_fa: Fix `xor3`/`xnor3` inversion bug

### DIFF
--- a/passes/techmap/extract_fa.cc
+++ b/passes/techmap/extract_fa.cc
@@ -412,14 +412,15 @@ struct ExtractFaWorker
 					facache[fakey] = make_tuple(X, Y, cell);
 				}
 
+				bool invert_y = f3i.inv_a ^ f3i.inv_b ^ f3i.inv_c;
 				if (func3.at(key).count(xor3_func)) {
-					SigBit YY = invert_xy ? module->NotGate(NEW_ID, Y) : Y;
+					SigBit YY = invert_xy ^ invert_y ? module->NotGate(NEW_ID, Y) : Y;
 					for (auto bit : func3.at(key).at(xor3_func))
 						assign_new_driver(bit, YY);
 				}
 
 				if (func3.at(key).count(xnor3_func)) {
-					SigBit YY = invert_xy ? Y : module->NotGate(NEW_ID, Y);
+					SigBit YY = invert_xy ^ invert_y ? Y : module->NotGate(NEW_ID, Y);
 					for (auto bit : func3.at(key).at(xnor3_func))
 						assign_new_driver(bit, YY);
 				}

--- a/tests/various/bug3879.ys
+++ b/tests/various/bug3879.ys
@@ -1,0 +1,29 @@
+read_verilog <<EOF
+module gcd(I, D);
+
+  output [2:0] I;
+  input [3:0] D;
+
+  assign I = D[0]+D[1]+D[2]+D[3];
+endmodule
+EOF
+design -save input
+
+prep
+
+design -stash gold
+
+design -load input
+
+synth  -top gcd -flatten
+
+extract_fa -v
+
+design -stash gate
+
+design -copy-from gold -as gold gcd
+design -copy-from gate -as gate gcd
+
+miter -equiv -make_assert -flatten gold gate miter
+
+sat -verify -prove-asserts -show-all miter


### PR DESCRIPTION
#### _What are the reasons/motivation for this change?_

The `extract_fa` pass seems to have issues when an odd number of inputs are inverted, this is previously reported in https://github.com/YosysHQ/yosys/issues/3879 and https://github.com/YosysHQ/yosys/issues/4573.

_I think_ @eddiehung solved this in the `xor2`/`xnor2` case in https://github.com/YosysHQ/yosys/pull/1297, but the `xor3`/`xnor3` case lacks the equivalent logic. 

#### _Explain how this is achieved._

Similarly to how it is handled in the `xor2`/`xnor2` case, we invert the `xor3`/`xnor3` output if the `majority3` has an odd number of inverted inputs.

#### _If applicable, please suggest to reviewers how they can test the change._

I have tried to make this break using @jix's test case from https://github.com/YosysHQ/yosys/pull/3882.

~I don't have much confidence in my understanding of this code, and I hope that some discussion here will help clarify some things for me.~

~94215584e9bbc648c7c6184a4239d3be7df65db3 should perhaps be in a separate pull request (or probably just deleted). I left it in so I could ask if somebody could help clarify to me what the deleted code segment achieves.~

~84d0c8fbfc66bcd2a5ff54bd00a9cfba500ed248 I thought initially this was a bug fix, but I'm not sure `invert_xy` and `f2i.inv_a ^ f2i.inv_b` can be true at the same time?~

Thanks for the amazing tool!