### PR TITLE
Select list mod

### DIFF
--- a/passes/cmds/logger.cc
+++ b/passes/cmds/logger.cc
@@ -162,7 +162,8 @@ struct LoggerPass : public Pass {
 					log_cmd_error("Number of expected messages must be higher then 0 !\n");
 				if (type=="error" && count!=1)
 					log_cmd_error("Expected error message occurrences must be 1 !\n");
-				log("Added regex '%s' for warnings to expected %s list.\n", pattern.c_str(), type.c_str());
+				log("Added regex '%s' to expected %s messages list.\n",
+					pattern.c_str(), type.c_str());
 				try {
 					if (type == "error")
 						log_expect_error[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);

--- a/passes/cmds/select.cc
+++ b/passes/cmds/select.cc
@@ -1041,7 +1041,7 @@ struct SelectPass : public Pass {
 		log("    select [ -add | -del | -set <name> ] {-read <filename> | <selection>}\n");
 		log("    select [ -unset <name> ]\n");
 		log("    select [ <assert_option> ] {-read <filename> | <selection>}\n");
-		log("    select [ -list | -write <filename> | -count | -clear ]\n");
+		log("    select [ -list | -list-mod | -write <filename> | -count | -clear ]\n");
 		log("    select -module <modname>\n");
 		log("\n");
 		log("Most commands use the list of currently selected objects to determine which part\n");
@@ -1277,6 +1277,7 @@ struct SelectPass : public Pass {
 		bool clear_mode = false;
 		bool none_mode = false;
 		bool list_mode = false;
+		bool list_mod_mode = false;
 		bool count_mode = false;
 		bool got_module = false;
 		bool assert_none = false;
@@ -1336,6 +1337,11 @@ struct SelectPass : public Pass {
 			}
 			if (arg == "-list") {
 				list_mode = true;
+				continue;
+			}
+			if (arg == "-list-mod") {
+				list_mode = true;
+				list_mod_mode = true;
 				continue;
 			}
 			if (arg == "-write" && argidx+1 < args.size()) {
@@ -1416,7 +1422,7 @@ struct SelectPass : public Pass {
 			log_cmd_error("Options %s can not be combined.\n", common_flagset);                
 
 		if ((list_mode || !write_file.empty() || count_mode) && common_flagset_tally)
-			log_cmd_error("Options -list, -write and -count can not be combined with %s.\n", common_flagset);
+			log_cmd_error("Options -list, -list-mod, -write and -count can not be combined with %s.\n", common_flagset);
 
 		if (!set_name.empty() && (list_mode || !write_file.empty() || count_mode || !unset_name.empty() || common_flagset_tally))
 			log_cmd_error("Option -set can not be combined with -list, -write, -count, -unset, %s.\n", common_flagset);
@@ -1467,7 +1473,7 @@ struct SelectPass : public Pass {
 			{
 				if (sel->selected_whole_module(mod->name) && list_mode)
 					log("%s\n", id2cstr(mod->name));
-				if (sel->selected_module(mod->name)) {
+				if (sel->selected_module(mod->name) && !list_mod_mode) {
 					for (auto wire : mod->wires())
 						if (sel->selected_member(mod->name, wire->name))
 							LOG_OBJECT("%s/%s\n", id2cstr(mod->name), id2cstr(wire->name))

--- a/tests/select/list_mod.ys
+++ b/tests/select/list_mod.ys
@@ -1,0 +1,13 @@
+read_verilog <<EOF
+module top1;
+(* foo *)
+wire w;
+endmodule
+
+module top2;
+(* bar *)
+wire w;
+endmodule
+EOF
+logger -expect log top1 1
+select -list-mod a:foo %m


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

The existing

    select -list

command will list all members of a fully selected module. This new command lets you list the modules only.
