### PR TITLE
pyosys generator: ignore attributes

### DIFF
--- a/misc/py_wrap_generator.py
+++ b/misc/py_wrap_generator.py
@@ -1268,6 +1268,11 @@ class WFunction:
 		func.duplicate = False
 		func.namespace = namespace
 		str_def = str_def.replace("operator ","operator")
+
+		# remove attributes from the start
+		if str.startswith(str_def, "[[") and "]]" in str_def:
+			str_def = str_def[str_def.find("]]")+2:]
+
 		if str.startswith(str_def, "static "):
 			func.is_static = True
 			str_def = str_def[7:]


### PR DESCRIPTION
This allows `log_error`, `log_file_error` and `log_cmd_error` which are all marked `[[noreturn]]` to be wrapped.

The corresponding diff to the generated c++ is
```diff
12653a12654,12671
> 	// WRAPPED from "[[noreturn]] void log_error(const char_p format, ...) YS_ATTRIBUTE(format(printf, 1, 2));" in kernel/log
> 	void log_error(const char * format)
> 	{
> 		::YOSYS_NAMESPACE::log_error("%s", format);
> 	}
> 
> 	// WRAPPED from "[[noreturn]] void log_file_error(const string &filename, int lineno, const char_p format, ...) YS_ATTRIBUTE(format(printf, 3, 4));" in kernel/log
> 	void log_file_error(const string filename, int lineno, const char * format)
> 	{
> 		::YOSYS_NAMESPACE::log_file_error(filename, lineno, "%s", format);
> 	}
> 
> 	// WRAPPED from "[[noreturn]] void log_cmd_error(const char_p format, ...) YS_ATTRIBUTE(format(printf, 1, 2));" in kernel/log
> 	void log_cmd_error(const char * format)
> 	{
> 		::YOSYS_NAMESPACE::log_cmd_error("%s", format);
> 	}
> 
15278a15297,15299
> 		def<void (*)(const char *)>("log_error", YOSYS_PYTHON::log_error);
> 		def<void (*)(const string, int, const char *)>("log_file_error", YOSYS_PYTHON::log_file_error);
> 		def<void (*)(const char *)>("log_cmd_error", YOSYS_PYTHON::log_cmd_error);
```

Note that although all 3 of these commands are added, `log_cmd_error` shouldn't be used from python for now as in interactive mode it throws `log_cmd_error_exception`, expecting the main shell loop to catch it but this exception can't be passed through python so it causes python to throw its own exception. I'm not 100% sure how best to translate this exception so haven't bothered for now