### PR TITLE
Document `cellmatch -derive_luts` option

### DIFF
--- a/passes/techmap/cellmatch.cc
+++ b/passes/techmap/cellmatch.cc
@@ -214,7 +214,7 @@ struct CellmatchPass : Pass {
 			r.first->second = new Design;
 		Design *map_design = r.first->second;
 
-		for (auto m : d->selected_whole_modules_warn()) {
+		for (auto m : d->selected_whole_modules_warn(/* visit whiteboxes */derive_luts)) {
 			std::vector<uint64_t> luts;
 			if (!derive_module_luts(m, luts))
 				continue;

--- a/passes/techmap/cellmatch.cc
+++ b/passes/techmap/cellmatch.cc
@@ -155,18 +155,22 @@ struct CellmatchPass : Pass {
 		log("equivalent as long as their truth tables are identical upto a permutation of\n");
 		log("inputs and outputs. The supported number of inputs is limited to 6.\n");
 		log("\n");
+		log("    cellmatch -derive_luts [module selection]\n");
+		log("\n");
+		log("For every port in each selected module, characterize its combinational\n");
+		log("function with a 'lut' attribute if possible.\n");
+		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *d) override
 	{
 		log_header(d, "Executing CELLMATCH pass. (match cells)\n");
 
 		size_t argidx;
-		bool lut_attrs = false;
+		bool derive_luts = false;
 		Design *lib = NULL;
 		for (argidx = 1; argidx < args.size(); argidx++) {
-			if (args[argidx] == "-lut_attrs") {
-				// an undocumented debugging option
-				lut_attrs = true;
+			if (args[argidx] == "-derive_luts") {
+				derive_luts = true;
 			} else if (args[argidx] == "-lib" && argidx + 1 < args.size()) {
 				if (!saved_designs.count(args[++argidx]))
 					log_cmd_error("No design '%s' found!\n", args[argidx].c_str());
@@ -177,8 +181,8 @@ struct CellmatchPass : Pass {
 		}
 		extra_args(args, argidx, d);
 
-		if (!lib && !lut_attrs)
-			log_cmd_error("Missing required -lib option.\n");
+		if (!lib && !derive_luts)
+			log_cmd_error("Missing required -lib or -derive_luts option.\n");
 
 		struct Target {
 			Module *module;
@@ -218,7 +222,7 @@ struct CellmatchPass : Pass {
 			SigSpec inputs = module_inputs(m);
 			SigSpec outputs = module_outputs(m);
 
-			if (lut_attrs) {
+			if (derive_luts) {
 				int no = 0;
 				for (auto bit : outputs) {
 					log_assert(bit.is_wire());

--- a/tests/select/mod-attribute.ys
+++ b/tests/select/mod-attribute.ys
@@ -41,7 +41,7 @@ module \top
 end
 EOT
 
-cellmatch -lut_attrs *
+cellmatch -derive_luts *
 
 select -set buffers a:lut=2'b10 %m
 select -set inverters a:lut=2'b01 %m

--- a/tests/techmap/cellmatch.ys
+++ b/tests/techmap/cellmatch.ys
@@ -77,3 +77,11 @@ opt_clean
 equiv_induct equiv
 equiv_status -assert
 
+design -reset
+design -load gatelib
+cellmatch -derive_luts
+select -assert-any bufgate/w:Y a:lut=2'b10 %i
+select -assert-any reducegate/w:X a:lut=8'b10000000 %i
+select -assert-any reducegate/w:Y a:lut=8'b11111110 %i
+select -assert-any fagate/w:X a:lut=8'b10010110 %i
+select -assert-any fagate/w:Y a:lut=8'b11101000 %i


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

I found this (previously undocumented) command mode useful for identifying the nand2 gate in a library to do some rough instance count to/from area conversions.
