### PR TITLE
pyosys: support ObjRange

### DIFF
--- a/misc/py_wrap_generator.py
+++ b/misc/py_wrap_generator.py
@@ -375,6 +375,10 @@ class PoolTranslator(PythonListTranslator):
 	insert_name = ".insert"
 	orig_name = "pool"
 
+#Sub-type for ObjRange
+class ObjRangeTranslator(PythonListTranslator):
+	orig_name = "RTLIL::ObjRange"
+
 #Translates dict-types (dict, std::map), that only differ in their name and
 #the name of the insertion function
 class PythonDictTranslator(Translator):
@@ -536,13 +540,14 @@ class TupleTranslator(PythonDictTranslator):
 
 #Associate the Translators with their c++ type
 known_containers = {
-	"std::set"		:	SetTranslator,
-	"std::vector"	:	VectorTranslator,
-	"pool"			:	PoolTranslator,
-	"idict"			:	IDictTranslator,
-	"dict"			:	DictTranslator,
-	"std::pair"		:	TupleTranslator,
-	"std::map"		:	MapTranslator
+	"std::set"        : SetTranslator,
+	"std::vector"     : VectorTranslator,
+	"pool"            : PoolTranslator,
+	"idict"           : IDictTranslator,
+	"dict"            : DictTranslator,
+	"std::pair"       : TupleTranslator,
+	"std::map"        : MapTranslator,
+	"RTLIL::ObjRange" : ObjRangeTranslator
 }
 
 class Attribute:


### PR DESCRIPTION
This adds support for `cells()`, `modules()` and `wires()` that all return ObjRanges, converting them into lists for python.

The C++ diff is slightly messy as this causes a load of generated variable indices to be shifted, but ignoring those changes you get the following
```diff
2572a2573,2578
> 		// WRAPPED from "RTLIL::ObjRange<RTLIL::Wire*> wires() { return RTLIL::ObjRange<RTLIL::Wire*>(&wires_, &refcount_wires_); }" in kernel/rtlil
> 		boost::python::list wires();
>
> 		// WRAPPED from "RTLIL::ObjRange<RTLIL::Cell*> cells() { return RTLIL::ObjRange<RTLIL::Cell*>(&cells_, &refcount_cells_); }" in kernel/rtlil
> 		boost::python::list cells();
>
4082a4089,4091
> 		// WRAPPED from "RTLIL::ObjRange<RTLIL::Module*> modules();" in kernel/rtlil
> 		boost::python::list modules();
>
8760a8770,8793
> 	// WRAPPED from "RTLIL::ObjRange<RTLIL::Wire*> wires() { return RTLIL::ObjRange<RTLIL::Wire*>(&wires_, &refcount_wires_); }" in kernel/rtlil
> 	boost::python::list Module::wires()
> 	{
> 		RTLIL::ObjRange<YOSYS_NAMESPACE::RTLIL::Wire*> ret_ = this->get_cpp_obj()->wires();
> 		boost::python::list ret____tmp;
> 		for(auto tmp_205 : ret_)
> 		{
> 			ret____tmp.append(Wire::get_py_obj(tmp_205));
> 		}
> 		return ret____tmp;
> 	}
>
> 	// WRAPPED from "RTLIL::ObjRange<RTLIL::Cell*> cells() { return RTLIL::ObjRange<RTLIL::Cell*>(&cells_, &refcount_cells_); }" in kernel/rtlil
> 	boost::python::list Module::cells()
> 	{
> 		RTLIL::ObjRange<YOSYS_NAMESPACE::RTLIL::Cell*> ret_ = this->get_cpp_obj()->cells();
> 		boost::python::list ret____tmp;
> 		for(auto tmp_206 : ret_)
> 		{
> 			ret____tmp.append(Cell::get_py_obj(tmp_206));
> 		}
> 		return ret____tmp;
> 	}
>
12284a12318,12329
> 	// WRAPPED from "RTLIL::ObjRange<RTLIL::Module*> modules();" in kernel/rtlil
> 	boost::python::list Design::modules()
> 	{
> 		RTLIL::ObjRange<YOSYS_NAMESPACE::RTLIL::Module*> ret_ = this->get_cpp_obj()->modules();
> 		boost::python::list ret____tmp;
> 		for(auto tmp_230 : ret_)
> 		{
> 			ret____tmp.append(Module::get_py_obj(tmp_230));
> 		}
> 		return ret____tmp;
> 	}
>
14722a14768,14769
> 			.def<boost::python::list (Module::*)(void)>("wires", &Module::wires)
> 			.def<boost::python::list (Module::*)(void)>("cells", &Module::cells)
15216a15264
> 			.def<boost::python::list (Design::*)(void)>("modules", &Design::modules)
```

*apologies for the number of pyosys PRs in one afternoon - I'm trying to get it working and fixing up little issues I have along the way*