### PR TITLE
Adjust `keep_hierarchy` behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,11 @@ Verilog Attributes and non-standard features
 - The ``keep_hierarchy`` attribute on cells and modules keeps the ``flatten``
   command from flattening the indicated cells and modules.
 
+- The `gate_cost_equivalent` attribute on a module can be used to specify
+  the estimated cost of the module as a number of basic gate instances. See
+  the help message of command `keep_hierarchy` which interprets this
+  attribute.
+
 - The ``init`` attribute on wires is set by the frontend when a register is
   initialized "FPGA-style" with ``reg foo = val``. It can be used during
   synthesis to add the necessary reset logic.
@@ -574,10 +579,6 @@ Non-standard or SystemVerilog features for formal verification
   explicit clock input (``$ff`` cells). The same can be achieved by using
   ``@(posedge <netname>)`` or ``@(negedge <netname>)`` when ``<netname>``
   is marked with the ``(* gclk *)`` Verilog attribute.
-
-- The `gate_cost_equivalent` attribute on a module can be used to specify
-  the estimated cost of a module as an equivalent number of basic gate
-  instances.
 
 Supported features from SystemVerilog
 =====================================

--- a/README.md
+++ b/README.md
@@ -575,6 +575,9 @@ Non-standard or SystemVerilog features for formal verification
   ``@(posedge <netname>)`` or ``@(negedge <netname>)`` when ``<netname>``
   is marked with the ``(* gclk *)`` Verilog attribute.
 
+- The `gate_cost_equivalent` attribute on a module can be used to specify
+  the estimated cost of a module as an equivalent number of basic gate
+  instances.
 
 Supported features from SystemVerilog
 =====================================

--- a/passes/hierarchy/keep_hierarchy.cc
+++ b/passes/hierarchy/keep_hierarchy.cc
@@ -37,6 +37,9 @@ struct ThresholdHiearchyKeeping {
 		if (module->has_attribute(ID(gate_cost_equivalent)))
 			return module->attributes[ID(gate_cost_equivalent)].as_int();
 
+		if (module->get_blackbox_attribute())
+			log_error("Missing cost information on instanced blackbox %s\n", log_id(module));
+
 		if (done.count(module))
 			return done.at(module);
 

--- a/passes/hierarchy/keep_hierarchy.cc
+++ b/passes/hierarchy/keep_hierarchy.cc
@@ -37,6 +37,9 @@ struct ThresholdHierarchyKeeping {
 		if (module->has_attribute(ID(gate_cost_equivalent)))
 			return module->attributes[ID(gate_cost_equivalent)].as_int();
 
+		if (module->has_attribute(ID(keep_hierarchy)))
+			return 0;
+
 		if (module->get_blackbox_attribute())
 			log_error("Missing cost information on instanced blackbox %s\n", log_id(module));
 

--- a/passes/hierarchy/keep_hierarchy.cc
+++ b/passes/hierarchy/keep_hierarchy.cc
@@ -23,14 +23,14 @@
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
-struct ThresholdHiearchyKeeping {
+struct ThresholdHierarchyKeeping {
 	Design *design;
 	CellCosts costs;
 	dict<Module *, int> done;
 	pool<Module *> in_progress;
 	uint64_t threshold;
 
-	ThresholdHiearchyKeeping(Design *design, uint64_t threshold)
+	ThresholdHierarchyKeeping(Design *design, uint64_t threshold)
 		: design(design), costs(design), threshold(threshold) {}
 
 	uint64_t visit(RTLIL::Module *module) {
@@ -116,7 +116,7 @@ struct KeepHierarchyPass : public Pass {
 			if (!top)
 				log_cmd_error("'-min_cost' mode requires a single top module in the design\n");
 
-			ThresholdHiearchyKeeping worker(design, min_cost);
+			ThresholdHierarchyKeeping worker(design, min_cost);
 			worker.visit(top);
 		} else {
 			for (auto module : design->selected_modules()) {

--- a/passes/hierarchy/keep_hierarchy.cc
+++ b/passes/hierarchy/keep_hierarchy.cc
@@ -63,7 +63,7 @@ struct ThresholdHiearchyKeeping {
 		}
 
 		if (size > threshold) {
-			log("Marking %s (module too big: %llu > %llu).\n", log_id(module), size, threshold);
+			log("Keeping %s (estimated size above threshold: %llu > %llu).\n", log_id(module), size, threshold);
 			module->set_bool_attribute(ID::keep_hierarchy);
 			size = 0;
 		}
@@ -75,7 +75,7 @@ struct ThresholdHiearchyKeeping {
 };
 
 struct KeepHierarchyPass : public Pass {
-	KeepHierarchyPass() : Pass("keep_hierarchy", "add the keep_hierarchy attribute") {}
+	KeepHierarchyPass() : Pass("keep_hierarchy", "selectively add the keep_hierarchy attribute") {}
 	void help() override
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
@@ -85,9 +85,15 @@ struct KeepHierarchyPass : public Pass {
 		log("Add the keep_hierarchy attribute.\n");
 		log("\n");
 		log("    -min_cost <min_cost>\n");
-		log("        only add the attribute to modules estimated to have more\n");
-		log("        than <min_cost> gates after simple techmapping. Intended\n");
-		log("        for tuning trade-offs between quality and yosys runtime.\n");
+		log("        only add the attribute to modules estimated to have more than <min_cost>\n");
+		log("        gates after simple techmapping. Intended for tuning trade-offs between\n");
+		log("        quality and yosys runtime.\n");
+		log("\n");
+		log("        When evaluating a module's cost, gates which are within a submodule\n");
+		log("        which is marked with the keep_hierarchy attribute are not counted\n");
+		log("        towards the upper module's cost. This applies to both when the attribute\n");
+		log("        was added by this command or was pre-existing.\n");
+		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{

--- a/tests/various/keep_hierarchy.ys
+++ b/tests/various/keep_hierarchy.ys
@@ -1,0 +1,53 @@
+read_verilog <<EOF
+(* blackbox *)
+(* gate_cost_equivalent=150 *)
+module macro;
+endmodule
+
+module branch1;
+	macro inst1();
+	macro inst2();
+	macro inst3();
+endmodule
+
+module branch2;
+	macro inst1();
+	macro inst2();
+	macro inst3();
+	macro inst4();
+endmodule
+
+// branch3_submod on its own doesn't meet the threshold
+module branch3_submod();
+	wire [2:0] y;
+	wire [2:0] a;
+	wire [2:0] b;
+	assign y = a * b;
+endmodule
+
+// on the other hand four branch3_submods do
+module branch3;
+	branch3_submod inst1();
+	branch3_submod inst2();
+	branch3_submod inst3();
+	branch3_submod inst4();
+endmodule
+
+// wrapper should have zero cost when branch3 is marked
+// keep_hierarchy
+module branch3_wrapper;
+	branch3 inst();
+endmodule
+
+module top;
+	branch1 inst1();
+	branch2 inst2();
+	branch3_wrapper wrapper();
+endmodule
+EOF
+
+hierarchy -top top
+keep_hierarchy -min_cost 500
+select -assert-mod-count 2 A:keep_hierarchy
+select -assert-any A:keep_hierarchy branch2 %i
+select -assert-any A:keep_hierarchy branch3 %i


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

This makes two changes to `keep_hierarchy -min_cost` to make it better suited to the task of partially preserving hierarchy for macro placement:

 * Don't count cost from submodules marked with `keep_hierarchy` towards the upper module's cost.
 * Accept a `gate_cost_equivalent` attribute as a way of specifying cost on blackboxes. 
