### PR TITLE
proc_dff: fix early return bug

### DIFF
--- a/passes/proc/proc_dff.cc
+++ b/passes/proc/proc_dff.cc
@@ -262,7 +262,7 @@ void proc_dff(RTLIL::Module *mod, RTLIL::Process *proc, ConstEval &ce)
 		{
 			log_warning("Complex async reset for dff `%s'.\n", log_signal(sig));
 			gen_dffsr_complex(mod, insig, sig, sync_edge->signal, sync_edge->type == RTLIL::SyncType::STp, async_rules, proc);
-			return;
+			continue;
 		}
 
 		// If there is a reset condition in the async rules, use it
@@ -277,7 +277,7 @@ void proc_dff(RTLIL::Module *mod, RTLIL::Process *proc, ConstEval &ce)
 					sync_edge->type == RTLIL::SyncType::STp,
 					sync_level && sync_level->type == RTLIL::SyncType::ST1,
 					sync_edge->signal, sync_level->signal, proc);
-			return;
+			continue;
 		}
 
 		gen_dff(mod, insig, rstval.as_const(), sig_q,

--- a/tests/proc/bug4712.ys
+++ b/tests/proc/bug4712.ys
@@ -1,0 +1,31 @@
+read_rtlil <<EOT
+autoidx 1
+module \top
+  wire input 1 \clk
+  wire input 2 \rst
+
+  wire input 3 \a_r
+  wire input 4 \a_n
+  wire input 5 \b_n
+
+  wire \a
+  wire \b
+
+  process $proc
+    sync high \rst
+      update \a \a_r
+      update \b \b
+    sync posedge \clk
+      update \a \a_n
+      update \b \b_n
+  end
+end
+EOT
+
+proc_dff
+proc_clean
+
+# Processes should have been converted to one aldff and one dff
+select -assert-none p:*
+select -assert-count 1 t:$aldff
+select -assert-count 1 t:$dff


### PR DESCRIPTION
Fixes #4712 which is a bug introduced in #4569, where multiple rules in processes were not being considered if an asynchronous one was encountered as the code erroneously returned from the function instead of continuing the processing loop.