### PR TITLE
Include cstdlib for free()

### DIFF
--- a/libs/subcircuit/subcircuit.cc
+++ b/libs/subcircuit/subcircuit.cc
@@ -21,6 +21,7 @@
 #include "subcircuit.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <assert.h>
 #include <stdarg.h>
 #include <stdio.h>


### PR DESCRIPTION
Little cleanup as we're currently [using `free()`](https://github.com/YosysHQ/yosys/blob/2de9f0036833f782318a475d20dd982193bf2501/libs/subcircuit/subcircuit.cc#L51)  without declaration.