### PR TITLE
bufnorm: preserve constant bits driving wires

### DIFF
--- a/passes/techmap/bufnorm.cc
+++ b/passes/techmap/bufnorm.cc
@@ -438,8 +438,13 @@ struct BufnormPass : public Pass {
 				bool chain_this_wire = chain_this_wire_f(wire);
 
 				SigSpec keysig = sigmap(wire), insig = wire, outsig = wire;
-				for (int i = 0; i < GetSize(insig); i++)
-					insig[i] = mapped_bits.at(keysig[i], State::Sx);
+				for (int i = 0; i < GetSize(insig); i++) {
+					if (keysig[i].is_wire())
+						insig[i] = mapped_bits.at(keysig[i], State::Sx);
+					else
+						insig[i] = keysig[i];
+				}
+
 				if (chain_this_wire) {
 					for (int i = 0; i < GetSize(outsig); i++)
 						mapped_bits[keysig[i]] = outsig[i];

--- a/tests/techmap/bufnorm.ys
+++ b/tests/techmap/bufnorm.ys
@@ -1,0 +1,11 @@
+# Check wires driven by constants are kept
+read_verilog <<EOT
+module top(output wire [7:0] y);
+assign y = 27;
+endmodule
+EOT
+
+equiv_opt -assert bufnorm
+design -load postopt
+select -assert-count 1 t:$buf
+select -assert-count 1 w:y %ci t:$buf %i


### PR DESCRIPTION
Fixes an issue where constant driving bits in connections would be replaced with `Sx` by bufnorm