### PR TITLE
kernel/drivertools.h: avoid maybe-uninitialized compile warnings

### DIFF
--- a/kernel/drivertools.h
+++ b/kernel/drivertools.h
@@ -364,7 +364,7 @@ public:
 
 	unsigned int hash() const
 	{
-		unsigned int inner;
+		unsigned int inner = 0;
 		switch (type_)
 		{
 			case DriveType::NONE:
@@ -384,6 +384,9 @@ public:
 				break;
 			case DriveType::MULTIPLE:
 				inner = multiple_.hash();
+				break;
+			default:
+				log_assert(0);
 				break;
 		}
 		return mkhash((unsigned int)type_, inner);
@@ -912,7 +915,7 @@ public:
 
 	unsigned int hash() const
 	{
-		unsigned int inner;
+		unsigned int inner = 0;
 		switch (type_)
 		{
 			case DriveType::NONE:
@@ -932,6 +935,9 @@ public:
 				break;
 			case DriveType::MULTIPLE:
 				inner = multiple_.hash();
+				break;
+			default:
+				log_assert(0);
 				break;
 		}
 		return mkhash((unsigned int)type_, inner);

--- a/kernel/drivertools.h
+++ b/kernel/drivertools.h
@@ -386,7 +386,7 @@ public:
 				inner = multiple_.hash();
 				break;
 			default:
-				log_assert(0);
+				log_abort();
 				break;
 		}
 		return mkhash((unsigned int)type_, inner);
@@ -937,7 +937,7 @@ public:
 				inner = multiple_.hash();
 				break;
 			default:
-				log_assert(0);
+				log_abort();
 				break;
 		}
 		return mkhash((unsigned int)type_, inner);


### PR DESCRIPTION
Initialize "unsigned int inner" in hash() functions
Includes a log_assert() that might help catch corrupted data structures or future incomplete modification of DriveType definition

See Issue #4713, Reduce compiler warnings when building yosys