### PR TITLE
rtlil: Adjust internal check for `$mem_v2` cells

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1856,9 +1856,9 @@ namespace {
 				param_bits(ID::RD_COLLISION_X_MASK, max(1, param(ID::RD_PORTS) * param(ID::WR_PORTS)));
 				param_bits(ID::RD_WIDE_CONTINUATION, max(1, param(ID::RD_PORTS)));
 				param_bits(ID::RD_CE_OVER_SRST, max(1, param(ID::RD_PORTS)));
-				param_bits(ID::RD_ARST_VALUE, param(ID::RD_PORTS) * param(ID::WIDTH));
-				param_bits(ID::RD_SRST_VALUE, param(ID::RD_PORTS) * param(ID::WIDTH));
-				param_bits(ID::RD_INIT_VALUE, param(ID::RD_PORTS) * param(ID::WIDTH));
+				param_bits(ID::RD_ARST_VALUE, max(1, param(ID::RD_PORTS) * param(ID::WIDTH)));
+				param_bits(ID::RD_SRST_VALUE, max(1, param(ID::RD_PORTS) * param(ID::WIDTH)));
+				param_bits(ID::RD_INIT_VALUE, max(1, param(ID::RD_PORTS) * param(ID::WIDTH)));
 				param_bits(ID::WR_CLK_ENABLE, max(1, param(ID::WR_PORTS)));
 				param_bits(ID::WR_CLK_POLARITY, max(1, param(ID::WR_PORTS)));
 				param_bits(ID::WR_WIDE_CONTINUATION, max(1, param(ID::WR_PORTS)));

--- a/tests/memories/nordports.ys
+++ b/tests/memories/nordports.ys
@@ -1,0 +1,9 @@
+# check memory_collect doesn't produce invalid RTLIL on a memory w/o read ports
+read_rtlil <<EOF
+autoidx 1
+attribute \top 1
+module \top
+  memory width 4 size 3 \foo
+end
+EOF
+memory_collect


### PR DESCRIPTION
There's a mismatch between what `kernel/mem.cc` emits for memories with no read ports and what the internal RTLIL check expects.

The point of dispute it whether some of the parameters relating to read ports have a zero-width value in this case. The `mem.cc` code says no, the internal checker says yes.

Surveying the other `$mem_v2` parameters, and internal cell parameters in general, I am inclined to side with the `mem.cc` code.

This breaks RTLIL compatibility but for an obscure edge case.
