### PR TITLE
verific: fix blackbox regression and add test case

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3428,6 +3428,7 @@ struct VerificPass : public Pass {
 			RuntimeFlags::SetVar("veri_preserve_assignments", 1);
 			RuntimeFlags::SetVar("veri_preserve_comments", 1);
 			RuntimeFlags::SetVar("veri_preserve_drivers", 1);
+			RuntimeFlags::SetVar("veri_create_empty_box", 1);
 
 			// Workaround for VIPER #13851
 			RuntimeFlags::SetVar("veri_create_name_for_unnamed_gen_block", 1);

--- a/tests/verific/blackbox.ys
+++ b/tests/verific/blackbox.ys
@@ -1,0 +1,24 @@
+verific -sv -lib <<EOF
+module TEST_CELL(input clk, input a, input b, output reg c);
+parameter PATH = "DEFAULT";
+always @(posedge clk) begin
+    if (PATH=="DEFAULT")
+		c <= a;
+	else 
+		c <= b;
+end
+
+endmodule
+EOF
+
+verific -sv <<EOF
+module top(input clk, input a, input b, output c, output d);
+	TEST_CELL  #(.PATH("TEST")) test1(.clk(clk),.a(a),.b(1'b1),.c(c));
+	TEST_CELL  #(.PATH("DEFAULT")) test2(.clk(clk),.a(a),.b(1'bx),.c(d));
+endmodule
+EOF
+
+verific -import top
+hierarchy -top top
+stat
+select -assert-count 2 t:TEST_CELL


### PR DESCRIPTION
Due to a change to Verific, "veri_create_empty_box" parameter needs to be set to get blackboxes import correctly after static and full elaboration.
Added test case to make sure blackboxes are imported.