### PR TITLE
Fix setting bits of parameters in setundef pass

### DIFF
--- a/passes/cmds/setundef.cc
+++ b/passes/cmds/setundef.cc
@@ -243,7 +243,7 @@ struct SetundefPass : public Pass {
 			{
 				for (auto *cell : module->selected_cells()) {
 					for (auto &parameter : cell->parameters) {
-						for (auto bit : parameter.second) {
+						for (auto &bit : parameter.second.bits()) {
 							if (bit > RTLIL::State::S1)
 								bit = worker.next_bit();
 						}

--- a/tests/various/setundef.sv
+++ b/tests/various/setundef.sv
@@ -1,0 +1,10 @@
+module foo #(parameter [1:0] a) (output [1:0] o);
+	assign o = a;
+endmodule
+
+module top(output [1:0] o);
+	foo #(2'b0x) foo(o);
+	always_comb begin
+		assert(o == 2'b00);
+	end
+endmodule

--- a/tests/various/setundef.ys
+++ b/tests/various/setundef.ys
@@ -1,0 +1,8 @@
+read_verilog -sv setundef.sv
+setundef -zero -params
+hierarchy -top top
+flatten
+proc
+async2sync
+write_json
+sat -seq 5 -prove-asserts


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

This PR fixes setting bits of parameters in `setundef` pass.

_Explain how this is achieved._

Currently we are looping through module parameters using `for (auto bit : parameter.second)`.
It is equivalent to:
```
for( auto _bit = parameter.second.begin(); _bit != parameter.second.end(); _bit++) {
    auto bit = *_bit;
    ...
}
```
where `auto` is resolved to [`RTLIL::Const`](https://github.com/YosysHQ/yosys/blob/915df16c84f4595b6ad5f198de0f7aaf43896723/kernel/rtlil.h#L1677C2-L1677C49). 

Iterator that we are using is defined in [`Const` class](https://github.com/YosysHQ/yosys/blob/915df16c84f4595b6ad5f198de0f7aaf43896723/kernel/rtlil.h#L713) which iterates through [`State` enum](https://github.com/YosysHQ/yosys/blob/6d4f056a353faeaa69dc23bb30c1ea05f38aae80/kernel/rtlil.h#L30). 

`operator *` of iterator returns [copy of the state](https://github.com/YosysHQ/yosys/blob/915df16c84f4595b6ad5f198de0f7aaf43896723/kernel/rtlil.cc#L543).

This PR changes to use reference instead.

_If applicable, please suggest to reviewers how they can test the change._

I attached example test case that showcase the problem.

Fixes: https://github.com/YosysHQ/yosys/issues/4732