### PR TITLE
Fix bug when setting Verific runtime string  flags.

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -4184,7 +4184,7 @@ struct VerificPass : public Pass {
 				}
 				if (v[0] == '"') {
 					std::string s = v.substr(1, GetSize(v)-2);
-					RuntimeFlags::SetStringVar(k.c_str(), v.c_str());
+					RuntimeFlags::SetStringVar(k.c_str(), s.c_str());
 					goto check_error;
 				}
 				char *endptr;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
The setting of Verific runtime string flags does not work within Yosys as it encapsulates the value in quotes.

_Explain how this is achieved._
Temp string s that is preexisting is correctly passed into Verific RuntimeFlags call. 

_If applicable, please suggest to reviewers how they can test the change._
Attempting to change the value of a Verific string RuntimeFlag will fail before this change.