### PR TITLE
synth_quicklogic: add -noflatten option

### DIFF
--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -78,7 +78,7 @@ struct SynthQuickLogicPass : public ScriptPass {
 	}
 
 	string top_opt, blif_file, edif_file, family, currmodule, verilog_file, lib_path;
-	bool abc9, inferAdder, nobram, bramTypes, dsp, ioff;
+	bool abc9, inferAdder, nobram, bramTypes, dsp, ioff, flatten;
 
 	void clear_flags() override
 	{
@@ -95,6 +95,7 @@ struct SynthQuickLogicPass : public ScriptPass {
 		lib_path = "+/quicklogic/";
 		dsp = true;
 		ioff = true;
+		flatten = true;
 	}
 
 	void set_scratchpad_defaults(RTLIL::Design *design) {
@@ -163,6 +164,10 @@ struct SynthQuickLogicPass : public ScriptPass {
 				ioff = false;
 				continue;
 			}
+			if (args[argidx] == "-noflatten") {
+				flatten = false;
+				continue;
+			}
 			break;
 		}
 		extra_args(args, argidx, design);
@@ -207,7 +212,8 @@ struct SynthQuickLogicPass : public ScriptPass {
 
 		if (check_label("prepare")) {
 			run("proc");
-			run("flatten");
+			if (flatten)
+				run("flatten", "(unless -noflatten)");
 			if (help_mode || family == "pp3") {
 				run("tribuf -logic", "                   (for pp3)");
 			}


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Not flattening gives faster execution time and lower memory usage in exchange for worse QoR. Probably more useful for debugging/exploring synthesis results than for actual use with an FPGA (not sure if the VPR P&R flow even accepts hierarchical netlists at all).

_Explain how this is achieved._

Same way as for the other `synth_*` passes (except `synth_xilinx` which doesn't flatten by default).

_If applicable, please suggest to reviewers how they can test the change._
