### PR TITLE
Support `abc9_box` on ordinary modules in abc_new

### DIFF
--- a/backends/aiger2/aiger.cc
+++ b/backends/aiger2/aiger.cc
@@ -832,12 +832,8 @@ struct XAigerAnalysis : Index<XAigerAnalysis, int, 0, 0> {
 			return false;
 
 		Cell *driver = bit.wire->driverCell();
-		if (!driver->type.isPublic())
-			return false;
-
 		Module *mod = design->module(driver->type);
-		log_assert(mod);
-		if (!mod->has_attribute(ID::abc9_box_id))
+		if (!mod || !mod->has_attribute(ID::abc9_box_id))
 			return false;
 
 		int max = 1;
@@ -870,7 +866,7 @@ struct XAigerAnalysis : Index<XAigerAnalysis, int, 0, 0> {
 		HierCursor cursor;
 		for (auto box : top_minfo->found_blackboxes) {
 			Module *def = design->module(box->type);
-			if (!box->type.isPublic() || (def && !def->has_attribute(ID::abc9_box_id)))
+			if (!(def && def->has_attribute(ID::abc9_box_id)))
 			for (auto &conn : box->connections_)
 			if (box->output(conn.first))
 			for (auto bit : conn.second)
@@ -885,7 +881,7 @@ struct XAigerAnalysis : Index<XAigerAnalysis, int, 0, 0> {
 
 		for (auto box : top_minfo->found_blackboxes) {
 			Module *def = design->module(box->type);
-			if (!box->type.isPublic() || (def && !def->has_attribute(ID::abc9_box_id)))
+			if (!(def && def->has_attribute(ID::abc9_box_id)))
 			for (auto &conn : box->connections_)
 			if (box->input(conn.first))
 			for (auto bit : conn.second)

--- a/backends/aiger2/aiger.cc
+++ b/backends/aiger2/aiger.cc
@@ -1102,7 +1102,7 @@ struct XAigerWriter : AigerWriter {
 							holes_module->ports.push_back(w->name);
 							holes_pis.push_back(w);
 						}
-						in_conn.append(holes_pis[i]);
+						in_conn.append(holes_pis[holes_pi_idx]);
 						holes_pi_idx++;
 					}
 					holes_wb->setPort(port_id, in_conn);

--- a/frontends/aiger2/xaiger.cc
+++ b/frontends/aiger2/xaiger.cc
@@ -203,7 +203,6 @@ struct Xaiger2Frontend : public Frontend {
 					/* unused box_id = */ read_be32(*f);
 					auto box_seq = read_be32(*f);
 
-					log("box_seq=%d boxes.size=%d\n", box_seq, (int) boxes.size());
 					log_assert(box_seq < boxes.size());
 
 					auto [cell, def] = boxes[box_seq];

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -1078,7 +1078,8 @@ void prep_box(RTLIL::Design *design)
 			}
 
 			ss << log_id(module) << " " << module->attributes.at(ID::abc9_box_id).as_int();
-			ss << " " << (module->get_bool_attribute(ID::whitebox) ? "1" : "0");
+			bool has_model = module->get_bool_attribute(ID::whitebox) || !module->get_bool_attribute(ID::blackbox);
+			ss << " " << (has_model ? "1" : "0");
 			ss << " " << GetSize(inputs) << " " << GetSize(outputs) << std::endl;
 
 			bool first = true;

--- a/passes/techmap/abc_new.cc
+++ b/passes/techmap/abc_new.cc
@@ -131,11 +131,25 @@ struct AbcNewPass : public ScriptPass {
 					active_design->selection().select(mod);
 				}
 
+				std::string script_save;
+				if (mod->has_attribute(ID(abc9_script))) {
+					script_save = active_design->scratchpad_get_string("abc9.script");
+					active_design->scratchpad_set_string("abc9.script",
+						mod->get_string_attribute(ID(abc9_script)));
+				}
+
 				run(stringf("  abc9_ops -write_box %s/input.box", tmpdir.c_str()));
 				run(stringf("  write_xaiger2 -mapping_prep -map2 %s/input.map2 %s/input.xaig", tmpdir.c_str(), tmpdir.c_str()));
 				run(stringf("  abc9_exe %s -cwd %s -box %s/input.box", exe_options.c_str(), tmpdir.c_str(), tmpdir.c_str()));
 				run(stringf("  read_xaiger2 -sc_mapping -module_name %s -map2 %s/input.map2 %s/output.aig",
 							modname.c_str(), tmpdir.c_str(), tmpdir.c_str()));
+
+				if (mod->has_attribute(ID(abc9_script))) {
+					if (script_save.empty())
+						active_design->scratchpad_unset("abc9.script");
+					else
+						active_design->scratchpad_set_string("abc9.script", script_save);
+				}
 
 				if (!help_mode) {
 					active_design->selection().selected_modules.clear();

--- a/passes/techmap/abc_new.cc
+++ b/passes/techmap/abc_new.cc
@@ -161,7 +161,7 @@ struct AbcNewPass : public ScriptPass {
 				}
 
 				std::string script_save;
-				if (mod->has_attribute(ID(abc9_script))) {
+				if (!help_mode && mod->has_attribute(ID(abc9_script))) {
 					script_save = active_design->scratchpad_get_string("abc9.script");
 					active_design->scratchpad_set_string("abc9.script",
 						mod->get_string_attribute(ID(abc9_script)));
@@ -173,7 +173,7 @@ struct AbcNewPass : public ScriptPass {
 				run(stringf("  read_xaiger2 -sc_mapping -module_name %s -map2 %s/input.map2 %s/output.aig",
 							modname.c_str(), tmpdir.c_str(), tmpdir.c_str()));
 
-				if (mod->has_attribute(ID(abc9_script))) {
+				if (!help_mode && mod->has_attribute(ID(abc9_script))) {
 					if (script_save.empty())
 						active_design->scratchpad_unset("abc9.script");
 					else


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

To preserve boundaries of arithmetic operators, we want to isolate them into a new module which will become part of the design hierarchy. Ordinarily this would mean segmenting the timing paths for the technology mapper within ABC, but with new changes to `abc_new` we support having those be abc9 boxes with their propagation arcs described to the mapper.

Internally this calls the new `portarcs` command (PR #4736) once the module to be boxed has been technology-mapped.

In addition this PR allows applying different ABC scripts per module.
