### PR TITLE
Include stdlib.h for `abort()`

### DIFF
--- a/libs/ezsat/demo_cmp.cc
+++ b/libs/ezsat/demo_cmp.cc
@@ -19,6 +19,7 @@
 
 #include "ezminisat.h"
 #include <assert.h>
+#include <stdlib.h>
 
 #define INIT_X 123456789
 #define INIT_Y 362436069
@@ -143,4 +144,3 @@ int main()
 	}
 	return 0;
 }
-

--- a/libs/ezsat/demo_vec.cc
+++ b/libs/ezsat/demo_vec.cc
@@ -19,6 +19,7 @@
 
 #include "ezminisat.h"
 #include <assert.h>
+#include <stdlib.h>
 
 #define INIT_X 123456789
 #define INIT_Y 362436069
@@ -109,4 +110,3 @@ int main()
 
 	return 0;
 }
-


### PR DESCRIPTION
Simple cleanup notices by newer toolchains.