### PR TITLE
Add `muldiv_c` and `muxadd` peepopts

### DIFF
--- a/passes/pmgen/Makefile.inc
+++ b/passes/pmgen/Makefile.inc
@@ -57,6 +57,8 @@ PEEPOPT_PATTERN  = passes/pmgen/peepopt_shiftmul_right.pmg
 PEEPOPT_PATTERN += passes/pmgen/peepopt_shiftmul_left.pmg
 PEEPOPT_PATTERN += passes/pmgen/peepopt_shiftadd.pmg
 PEEPOPT_PATTERN += passes/pmgen/peepopt_muldiv.pmg
+PEEPOPT_PATTERN += passes/pmgen/peepopt_muldiv_c.pmg
+PEEPOPT_PATTERN += passes/pmgen/peepopt_muxadd.pmg
 PEEPOPT_PATTERN += passes/pmgen/peepopt_formal_clockgateff.pmg
 
 passes/pmgen/peepopt_pm.h: passes/pmgen/pmgen.py $(PEEPOPT_PATTERN)

--- a/passes/pmgen/peepopt.cc
+++ b/passes/pmgen/peepopt.cc
@@ -42,7 +42,11 @@ struct PeepoptPass : public Pass {
 		log("\n");
 		log("This pass employs the following rules by default:\n");
 		log("\n");
+		log("   * muxadd - Replace S?(A+B):A with A+(S?B:0)\n");
+		log("\n");
 		log("   * muldiv - Replace (A*B)/B with A\n");
+		log("\n");
+		log("   * muldiv_c - Replace (A*B)/C with A*(B/C) when C is a const divisible by B.\n");
 		log("\n");
 		log("   * shiftmul - Replace A>>(B*C) with A'>>(B<<K) where C and K are constants\n");
 		log("                and A' is derived from A by appropriately inserting padding\n");
@@ -105,6 +109,8 @@ struct PeepoptPass : public Pass {
 					pm.run_shiftmul_right();
 					pm.run_shiftmul_left();
 					pm.run_muldiv();
+					pm.run_muldiv_c();
+					pm.run_muxadd();
 				}
 			}
 		}

--- a/passes/pmgen/peepopt_muldiv_c.pmg
+++ b/passes/pmgen/peepopt_muldiv_c.pmg
@@ -1,0 +1,76 @@
+pattern muldiv_c
+//
+// Authored by Akash Levy of Silimate, Inc. under ISC license.
+// Transforms mul->div into const->mul when b and c are divisible constants:
+// y = (a * b_const) / c_const   ===>   a * eval(b_const / c_const)
+//
+
+state <SigSpec> a b_const mul_y
+
+match mul
+	// Select multiplier
+	select mul->type == $mul
+endmatch
+
+code a b_const mul_y
+	// Get multiplier signals
+	a = port(mul, \A);
+	b_const = port(mul, \B);
+	mul_y = port(mul, \Y);
+
+	// Fanout of each multiplier Y bit should be 1 (no bit-split)
+	for (auto bit : mul_y)
+		if (nusers(bit) != 2)
+			reject;
+
+	// A and B can be interchanged
+	branch;
+	std::swap(a, b_const);
+endcode
+
+match div
+	// Select div of form (a * b_const) / c_const
+	select div->type == $div
+
+	// Check that b_const and c_const is constant
+	filter b_const.is_fully_const()
+	filter port(div, \B).is_fully_const()
+endmatch
+
+code
+	// Get div signals
+	SigSpec div_a = port(div, \A);
+	SigSpec c_const = port(div, \B);
+	SigSpec div_y = port(div, \Y);
+
+	// Get offset of multiplier result chunk in divider
+	int offset = GetSize(div_a) - GetSize(mul_y);
+
+	// Get properties and values of b_const and c_const
+	int b_const_width = mul->getParam(ID::B_WIDTH).as_int();
+	bool b_const_signed = mul->getParam(ID::B_SIGNED).as_bool();
+	bool c_const_signed = div->getParam(ID::B_SIGNED).as_bool();
+	int b_const_int = b_const.as_int(b_const_signed);
+	int c_const_int = c_const.as_int(c_const_signed);
+	int b_const_int_shifted = b_const_int << offset;
+
+	// Check that there are only zeros before offset
+	if (offset < 0 || !div_a.extract(0, offset).is_fully_zero())
+		reject;
+
+	// Check that b is divisible by c
+	if (b_const_int_shifted % c_const_int != 0)
+		reject;
+
+	// Rewire to only keep multiplier
+	mul->setPort(\B, Const(b_const_int_shifted / c_const_int, b_const_width));
+	mul->setPort(\Y, div_y);
+
+	// Remove divider
+	autoremove(div);
+
+	// Log, fixup, accept
+	log("muldiv_const pattern in %s: mul=%s, div=%s\n", log_id(module), log_id(mul), log_id(div));
+	mul->fixup_parameters();
+	accept;
+endcode

--- a/passes/pmgen/peepopt_muxadd.pmg
+++ b/passes/pmgen/peepopt_muxadd.pmg
@@ -1,0 +1,57 @@
+pattern muxadd
+//
+// Authored by Akash Levy of Silimate, Inc. under ISC license.
+// Transforms add->mux into mux->add:
+// y = s ? (a + b) : a   ===>   y = a + (s ? b : 0)
+//
+
+state <SigSpec> add_a add_b add_y
+
+match add
+	// Select adder
+	select add->type == $add
+endmatch
+
+code add_y add_a add_b
+	// Get adder signals
+	add_a = port(add, \A);
+	add_b = port(add, \B);
+	add_y = port(add, \Y);
+
+	// Fanout of each adder Y bit should be 1 (no bit-split)
+	for (auto bit : add_y)
+		if (nusers(bit) != 2)
+			reject;
+
+	// A and B can be interchanged
+	branch;
+	std::swap(add_a, add_b);
+endcode
+
+match mux
+	// Select mux of form s ? (a + b) : a, allow leading 0s when A_WIDTH != Y_WIDTH
+	select mux->type == $mux
+	index <SigSpec> port(mux, \A) === SigSpec({Const(State::S0, GetSize(add_y)-GetSize(add_a)), add_a})
+	index <SigSpec> port(mux, \B) === add_y
+endmatch
+
+code
+	// Get mux signal
+	SigSpec mux_y = port(mux, \Y);
+
+	// Create new mid wire
+	SigSpec mid = module->addWire(NEW_ID, GetSize(add_b));
+
+	// Rewire
+	mux->setPort(\A, Const(State::S0, GetSize(add_b)));
+	mux->setPort(\B, add_b);
+	mux->setPort(\Y, mid);
+	add->setPort(\B, mid);
+	add->setPort(\Y, mux_y);
+
+	// Log, fixup, accept
+	log("muxadd pattern in %s: mux=%s, add=%s\n", log_id(module), log_id(mux), log_id(add));
+	add->fixup_parameters();
+	mux->fixup_parameters();
+	accept;
+endcode


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

This PR adds two peep-hole optimizations that improve netlist quality:

1. `muldiv_c`: `y = (a * b_const) / c_const   ===>   a * eval(b_const / c_const)` if `b_const % c_const == 0`. This implements basic constant propagation for multipliers and dividers with divisible constants. 
2. `muxadd`: `y = s ? (a + b) : a   ===>   y = a + (s ? b : 0)`. This provides useful restructuring for improving logic optimization. `s ? b : 0` can be optimized to a bitwise AND in subsequent optimizations.

_Explain how this is achieved._

- [x] `passes/pmgen/peepopt_muldiv_c.pmg`: `muldiv_c` peepopt
- [x] `passes/pmgen/peepopt_muxadd.pmg`: `muxadd` peepopt
- [x] `passes/pmgen/peepopt.cc`: Add to docs and run peepopts during `peepopt` pass
- [x] `passes/pmgen/Makefile.inc`: Add the new sources

_If applicable, please suggest to reviewers how they can test the change._

- [ ] YosysHQ to review source code and provide feedback/edits as necessary
- [ ] YosysHQ to construct test plan of 15-20 small-medium test cases per peepopt
- [ ] Silimate to review test plan and sign off
- [ ] YosysHQ to write test cases according to test plan and add to regression
- [ ] YosysHQ to provide formal equivalence checking scripts with `equiv_opt` or FOSS `eqy`
- [ ] Silimate to sign off on implementation
