### PR TITLE
Print a note about finding attribute (* top *) in hierarchy

### DIFF
--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -1003,8 +1003,10 @@ struct HierarchyPass : public Pass {
 
 		if (top_mod == nullptr)
 			for (auto mod : design->modules())
-				if (mod->get_bool_attribute(ID::top))
+				if (mod->get_bool_attribute(ID::top)) {
+					log("Attribute `top' found on module `%s'. Setting top module to %s.\n", log_id(mod), log_id(mod));
 					top_mod = mod;
+				}
 
 		if (top_mod == nullptr)
 		{


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

As suggested in https://github.com/YosysHQ/yosys/issues/3717#issuecomment-2460672212, make it more obvious to the user if the top module was selected due to an attribute overriding the heuristic.

_Explain how this is achieved._

Print a log message. If multiple modules are marked `(* top *)`, the message gets repeated multiple times, matching how the code works (the last attribute encountered while iterating over `design->modules()` overrides any previously seen attributes).

