### PR TITLE
clockgate: add -liberty

### DIFF
--- a/passes/techmap/clockgate.cc
+++ b/passes/techmap/clockgate.cc
@@ -107,22 +107,25 @@ static std::pair<std::optional<ClockGateCell>, std::optional<ClockGateCell>>
 				continue;
 
 			if (auto clk = pin->find("clock_gate_clock_pin")) {
-				if (!icg_interface.clk_in_pin.empty())
-					log_error("Malformed liberty file - multiple clock_gate_clock_pin in cell %s\n",
+				if (!icg_interface.clk_in_pin.empty()) {
+					log_warning("Malformed liberty file - multiple clock_gate_clock_pin in cell %s\n",
 						cell_name.c_str());
-				else
+					continue;
+				} else
 					icg_interface.clk_in_pin = RTLIL::escape_id(pin->args[0]);
 			} else if (auto gclk = pin->find("clock_gate_out_pin")) {
-				if (!icg_interface.clk_out_pin.empty())
-					log_error("Malformed liberty file - multiple clock_gate_out_pin in cell %s\n",
+				if (!icg_interface.clk_out_pin.empty()) {
+					log_warning("Malformed liberty file - multiple clock_gate_out_pin in cell %s\n",
 						cell_name.c_str());
-				else
+					continue;
+				} else
 					icg_interface.clk_out_pin = RTLIL::escape_id(pin->args[0]);
 			} else if (auto en = pin->find("clock_gate_enable_pin")) {
-				if (!icg_interface.ce_pin.empty())
-					log_error("Malformed liberty file - multiple clock_gate_enable_pin in cell %s\n",
+				if (!icg_interface.ce_pin.empty()) {
+					log_warning("Malformed liberty file - multiple clock_gate_enable_pin in cell %s\n",
 						cell_name.c_str());
-				else
+					continue;
+				} else
 					icg_interface.ce_pin = RTLIL::escape_id(pin->args[0]);
 			} else if (auto se = pin->find("clock_gate_test_pin")) {
 				icg_interface.tie_lo_pins.push_back(RTLIL::escape_id(pin->args[0]));
@@ -131,20 +134,27 @@ static std::pair<std::optional<ClockGateCell>, std::optional<ClockGateCell>>
 				if (dir->value == "internal")
 					continue;
 
-				log_error("Malformed liberty file - extra pin %s in cell %s\n",
+				log_warning("Malformed liberty file - extra pin %s in cell %s\n",
 					pin->args[0].c_str(), cell_name.c_str());
+				continue;
 			}
 		}
 
-		if (icg_interface.clk_in_pin.empty())
-			log_error("Malformed liberty file - missing clock_gate_clock_pin in cell %s",
+		if (icg_interface.clk_in_pin.empty()) {
+			log_warning("Malformed liberty file - missing clock_gate_clock_pin in cell %s",
 				cell_name.c_str());
-		if (icg_interface.clk_out_pin.empty())
-			log_error("Malformed liberty file - missing clock_gate_out_pin in cell %s",
+			continue;
+		}
+		if (icg_interface.clk_out_pin.empty()) {
+			log_warning("Malformed liberty file - missing clock_gate_out_pin in cell %s",
 				cell_name.c_str());
-		if (icg_interface.ce_pin.empty())
-			log_error("Malformed liberty file - missing clock_gate_enable_pin in cell %s",
+			continue;
+		}
+		if (icg_interface.ce_pin.empty()) {
+			log_warning("Malformed liberty file - missing clock_gate_enable_pin in cell %s",
 				cell_name.c_str());
+			continue;
+		}
 
 		double area = 0;
 		const LibertyAst *ar = cell->find("area");
@@ -179,11 +189,11 @@ static std::pair<std::optional<ClockGateCell>, std::optional<ClockGateCell>>
 	std::optional<ClockGateCell> pos;
 	std::optional<ClockGateCell> neg;
 	if (best_pos) {
-		log("Selected rising edge ICG %s\n", best_pos->name.c_str());
+		log("Selected rising edge ICG %s from Liberty file\n", best_pos->name.c_str());
 		pos.emplace(*best_pos);
 	}
 	if (best_neg) {
-		log("Selected falling edge ICG %s\n", best_neg->name.c_str());
+		log("Selected falling edge ICG %s from Liberty file\n", best_neg->name.c_str());
 		neg.emplace(*best_neg);
 	}
 	return std::make_pair(pos, neg);

--- a/passes/techmap/clockgate.cc
+++ b/passes/techmap/clockgate.cc
@@ -212,13 +212,20 @@ struct ClockgatePass : public Pass {
 		log("        user-specified <celltype> ICG (integrated clock gating)\n");
 		log("        cell with ports named <ce>, <clk>, <gclk>.\n");
 		log("        The ICG's clock enable pin must be active high.\n");
-		// TODO -liberty
+		log("    -liberty <filename>\n");
+		log("        If specified, ICGs will be selected from the liberty file\n");
+		log("        if available. Priority is given to cells with fewer tie_lo\n");
+		log("        inputs and smaller size. This removes the need to manually\n");
+		log("        specify -pos or -neg and -tie_lo.\n");
+		log("    -dont_use <celltype>\n");
+		log("        Cells <celltype> won't be considered when searching for ICGs\n");
+		log("        in the liberty file specified by -liberty.\n");
 		log("    -tie_lo <port_name>\n");
 		log("        Port <port_name> of the ICG will be tied to zero.\n");
 		log("        Intended for DFT scan-enable pins.\n");
 		log("    -min_net_size <n>\n");
 		log("        Only transform sets of at least <n> eligible FFs.\n");
-		// log("        \n");
+		log("        \n");
 	}
 
 	// One ICG will be generated per ClkNetInfo

--- a/tests/techmap/clockgate.lib
+++ b/tests/techmap/clockgate.lib
@@ -1,0 +1,107 @@
+library(test) {
+    /* Integrated clock gating cells */
+    cell (pos_big) {
+        area : 10;
+        clock_gating_integrated_cell : latch_posedge;
+        pin (GCLK) {
+            clock_gate_out_pin : true;
+            direction : output;
+        }
+        pin (CLK) {
+            clock_gate_clock_pin : true;
+            direction : input;
+        }
+        pin (CE) {
+            clock_gate_enable_pin : true;
+            direction : input;
+        }
+    }
+    cell (pos_small_tielo) {
+        area : 1;
+        clock_gating_integrated_cell : latch_posedge_precontrol;
+        pin (GCLK) {
+            clock_gate_out_pin : true;
+            direction : output;
+        }
+        pin (CLK) {
+            clock_gate_clock_pin : true;
+            direction : input;
+        }
+        pin (CE) {
+            clock_gate_enable_pin : true;
+            direction : input;
+        }
+        pin (SE) {
+            clock_gate_test_pin : true;
+            direction : input;
+        }
+    }
+    cell (pos_small) {
+        area : 1;
+        clock_gating_integrated_cell : latch_posedge;
+        pin (GCLK) {
+            clock_gate_out_pin : true;
+            direction : output;
+        }
+        pin (CLK) {
+            clock_gate_clock_pin : true;
+            direction : input;
+        }
+        pin (CE) {
+            clock_gate_enable_pin : true;
+            direction : input;
+        }
+    }
+    cell (neg_big) {
+        area : 10;
+        clock_gating_integrated_cell : latch_negedge;
+        pin (GCLK) {
+            clock_gate_out_pin : true;
+            direction : output;
+        }
+        pin (CLK) {
+            clock_gate_clock_pin : true;
+            direction : input;
+        }
+        pin (CE) {
+            clock_gate_enable_pin : true;
+            direction : input;
+        }
+    }
+    cell (neg_small_tielo) {
+        area : 1;
+        clock_gating_integrated_cell : latch_negedge_precontrol;
+        pin (GCLK) {
+            clock_gate_out_pin : true;
+            direction : output;
+        }
+        pin (CLK) {
+            clock_gate_clock_pin : true;
+            direction : input;
+        }
+        pin (CE) {
+            clock_gate_enable_pin : true;
+            direction : input;
+        }
+        pin (SE) {
+            clock_gate_test_pin : true;
+            direction : input;
+        }
+    }
+    cell (neg_small) {
+        area : 1;
+        clock_gating_integrated_cell : latch_negedge;
+        pin (GCLK) {
+            clock_gate_out_pin : true;
+            direction : output;
+        }
+        pin (CLK) {
+            clock_gate_clock_pin : true;
+            direction : input;
+        }
+        pin (CE) {
+            clock_gate_enable_pin : true;
+            direction : input;
+        }
+    }
+}

--- a/tests/techmap/clockgate.lib
+++ b/tests/techmap/clockgate.lib
@@ -1,21 +1,5 @@
 library(test) {
     /* Integrated clock gating cells */
-    cell (pos_big) {
-        area : 10;
-        clock_gating_integrated_cell : latch_posedge;
-        pin (GCLK) {
-            clock_gate_out_pin : true;
-            direction : output;
-        }
-        pin (CLK) {
-            clock_gate_clock_pin : true;
-            direction : input;
-        }
-        pin (CE) {
-            clock_gate_enable_pin : true;
-            direction : input;
-        }
-    }
     cell (pos_small_tielo) {
         area : 1;
         clock_gating_integrated_cell : latch_posedge_precontrol;
@@ -33,6 +17,22 @@ library(test) {
         }
         pin (SE) {
             clock_gate_test_pin : true;
+            direction : input;
+        }
+    }
+    cell (pos_big) {
+        area : 10;
+        clock_gating_integrated_cell : latch_posedge;
+        pin (GCLK) {
+            clock_gate_out_pin : true;
+            direction : output;
+        }
+        pin (CLK) {
+            clock_gate_clock_pin : true;
+            direction : input;
+        }
+        pin (CE) {
+            clock_gate_enable_pin : true;
             direction : input;
         }
     }

--- a/tests/techmap/clockgate.ys
+++ b/tests/techmap/clockgate.ys
@@ -193,4 +193,42 @@ select -assert-count 1 t:\\pdk_icg
 
 #------------------------------------------------------------------------------
 
-# TODO test -tie_lo
+design -load before
+clockgate -liberty clockgate.lib
+
+# rising edge ICGs
+select -module dffe_00 -assert-count 0 t:\\pos_small
+select -module dffe_01 -assert-count 0 t:\\pos_small
+
+select -module dffe_10 -assert-count 1 t:\\pos_small
+select -module dffe_11 -assert-count 1 t:\\pos_small
+
+# falling edge ICGs
+select -module dffe_00 -assert-count 1 t:\\neg_small
+select -module dffe_01 -assert-count 1 t:\\neg_small
+
+select -module dffe_10 -assert-count 0 t:\\neg_small
+select -module dffe_11 -assert-count 0 t:\\neg_small
+
+# and nothing else
+select -module dffe_00 -assert-count 0 t:\\pos_big
+select -module dffe_01 -assert-count 0 t:\\pos_big
+select -module dffe_10 -assert-count 0 t:\\pos_big
+select -module dffe_11 -assert-count 0 t:\\pos_big
+select -module dffe_00 -assert-count 0 t:\\pos_small_tielo
+select -module dffe_01 -assert-count 0 t:\\pos_small_tielo
+select -module dffe_10 -assert-count 0 t:\\pos_small_tielo
+select -module dffe_11 -assert-count 0 t:\\pos_small_tielo
+select -module dffe_00 -assert-count 0 t:\\neg_big
+select -module dffe_01 -assert-count 0 t:\\neg_big
+select -module dffe_10 -assert-count 0 t:\\neg_big
+select -module dffe_11 -assert-count 0 t:\\neg_big
+select -module dffe_00 -assert-count 0 t:\\neg_small_tielo
+select -module dffe_01 -assert-count 0 t:\\neg_small_tielo
+select -module dffe_10 -assert-count 0 t:\\neg_small_tielo
+select -module dffe_11 -assert-count 0 t:\\neg_small_tielo
+
+# if necessary, EN is inverted, since the given ICG
+# is assumed to have an active-high EN
+select -module dffe_10 -assert-count 1 t:\$_NOT_
+select -module dffe_11 -assert-count 0 t:\$_NOT_

--- a/tests/techmap/clockgate.ys
+++ b/tests/techmap/clockgate.ys
@@ -61,7 +61,7 @@ clockgate -pos pdk_icg ce:clkin:clkout -tie_lo scanen
 # falling edge clock flops don't get matched on -pos
 select -module dffe_00 -assert-count 0 t:\\pdk_icg
 select -module dffe_01 -assert-count 0 t:\\pdk_icg
-# falling edge clock flops do get matched on -pos
+# rising edge clock flops do get matched on -pos
 select -module dffe_10 -assert-count 1 t:\\pdk_icg
 select -module dffe_11 -assert-count 1 t:\\pdk_icg
 # if necessary, EN is inverted, since the given ICG
@@ -79,10 +79,10 @@ select -module dffe_wide_11 -assert-count 1 t:\\pdk_icg
 design -load before
 clockgate -min_net_size 1 -neg pdk_icg ce:clkin:clkout -tie_lo scanen
 
-# rising edge clock flops don't get matched on -neg
+# falling edge clock flops do get matched on -neg
 select -module dffe_00 -assert-count 1 t:\\pdk_icg
 select -module dffe_01 -assert-count 1 t:\\pdk_icg
-# rising edge clock flops do get matched on -neg
+# rising edge clock flops don't get matched on -neg
 select -module dffe_10 -assert-count 0 t:\\pdk_icg
 select -module dffe_11 -assert-count 0 t:\\pdk_icg
 # if necessary, EN is inverted, since the given ICG

--- a/tests/techmap/clockgate.ys
+++ b/tests/techmap/clockgate.ys
@@ -232,3 +232,16 @@ select -module dffe_11 -assert-count 0 t:\\neg_small_tielo
 # is assumed to have an active-high EN
 select -module dffe_10 -assert-count 1 t:\$_NOT_
 select -module dffe_11 -assert-count 0 t:\$_NOT_
+
+#------------------------------------------------------------------------------
+
+design -load before
+clockgate -liberty clockgate.lib -dont_use pos_small -dont_use neg_small
+
+# rising edge ICGs
+select -module dffe_10 -assert-count 1 t:\\pos_big
+select -module dffe_11 -assert-count 1 t:\\pos_big
+
+# falling edge ICGs
+select -module dffe_00 -assert-count 1 t:\\neg_big
+select -module dffe_01 -assert-count 1 t:\\neg_big


### PR DESCRIPTION
Integrated clock gating cells (ICGs) are ASIC cells designed as part of PDKs and they are described in Liberty files. To avoid requiring per-PDK hacks to PDK-agnostic scripts, instead of requiring in the invocation a specification of a concrete ICG cell name and its interface, this PR allows the user to use `-liberty <filename>` argument for the `clockgate` command and automatically selects the most suitable ICGs described in `<filename>`. A suitable cell is one with matching clock polarity, a reasonable interface based on the [Liberty Reference Manual](https://people.eecs.berkeley.edu/~alanmi/publications/other/liberty07_03.pdf) (refer to pin attributes `clock_gate_...` and cell attribute `clock_gating_integrated_cell`). Most suitable cells are those with the fewest scan/test inputs to tie low and smallest area. Using existing current libparse, I use logic similar to that in `dfflibmap.cc` to find these cells and interfaces.

This PR also assumes all test inputs are to be tied low and all enables are active high. I've tested it manually with asap7 and sky130hd to behave as expected

- [x] test
- [x] help string