### PR TITLE
cxxrtl: strip `$paramod` from module name in scope info

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -2402,7 +2402,12 @@ struct CxxrtlWorker {
 						auto cell_attrs = scopeinfo_attributes(cell, ScopeinfoAttrs::Cell);
 						cell_attrs.erase(ID::module_not_derived);
 						f << indent << "scopes->add(path, " << escape_cxx_string(get_hdl_name(cell)) << ", ";
-						f << escape_cxx_string(cell->get_string_attribute(ID(module))) << ", ";
+						if (module_attrs.count(ID(hdlname))) {
+							f << escape_cxx_string(module_attrs.at(ID(hdlname)).decode_string());
+						} else {
+							f << escape_cxx_string(cell->get_string_attribute(ID(module)));
+						}
+						f << ", ";
 						dump_serialized_metadata(module_attrs);
 						f << ", ";
 						dump_serialized_metadata(cell_attrs);


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

The `$paramod\...\...` name for a module doesn't match the source code and isn't useful to the end user given that it's usually containing just a hash.

_Explain how this is achieved._

Module's `hdlname` attribute is used if present.
