### PR TITLE
synth_gatemate: Ensure proper mapping of multiplexers

### DIFF
--- a/techlibs/gatemate/synth_gatemate.cc
+++ b/techlibs/gatemate/synth_gatemate.cc
@@ -301,6 +301,7 @@ struct SynthGateMatePass : public ScriptPass
 			}
 			run("muxcover " + muxcover_args);
 			run("opt -full");
+			run("simplemap");
 			run("techmap -map +/gatemate/mux_map.v");
 		}
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

This PR addresses an issue where multiplexers may remain unmapped, leading to their representation as simple assignments in the final netlist instead of as technology primitives.

_Explain how this is achieved._

By running `simplemap` after `muxcover`, we ensure proper mapping of multiplexers into technology primitives.