### PR TITLE
pyosys: dereference cpp objects when constructing a tuple

### DIFF
--- a/misc/py_wrap_generator.py
+++ b/misc/py_wrap_generator.py
@@ -515,11 +515,11 @@ class TupleTranslator(PythonDictTranslator):
 		if types[0].name.split(" ")[-1] in primitive_types:
 			text += varname + "___tmp_0, "
 		else:
-			text += varname + "___tmp_0.get_cpp_obj(), "
+			text += "*" + varname + "___tmp_0.get_cpp_obj(), "
 		if types[1].name.split(" ")[-1] in primitive_types:
 			text += varname + "___tmp_1);"
 		else:
-			text += varname + "___tmp_1.get_cpp_obj());"
+			text += "*" + varname + "___tmp_1.get_cpp_obj());"
 		return text
 
 	#Generate c++ code to translate to a boost::python::tuple


### PR DESCRIPTION
This fixes a bug where when converting a tuple from python to c++, `get_cpp_obj()` was called (returning a pointer) without dereferencing the pointer to get the underlying object.
