### PR TITLE
write_verilog: Lower `$bwmux` in expr mode

### DIFF
--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -2587,6 +2587,7 @@ struct VerilogBackend : public Backend {
 		if (!noexpr) {
 			Pass::call(design, "bmuxmap");
 			Pass::call(design, "demuxmap");
+			Pass::call(design, "bwmuxmap");
 		}
 		Pass::call(design, "clean_zerowidth");
 		log_pop();


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

`write_verilog` doesn't know how to directly write an expression for `$bwmux` cells, so those are printed as an internall cell even if outside the `-noexpr` mode. To address, call `bwmuxmap` like we do to the same effect in btor/firrtl/smv backends.

Fixes #4751 