### PR TITLE
`write_verilog`: Fix `O(N^2)` port dumping to `O(N)`

### DIFF
--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -2332,7 +2332,6 @@ void dump_module(std::ostream &f, std::string indent, RTLIL::Module *module)
 
 	dump_attributes(f, indent, module->attributes, "\n", /*modattr=*/true);
 	f << stringf("%s" "module %s(", indent.c_str(), id(module->name, false).c_str());
-	bool keep_running = true;
 	int cnt = 0;
 	int max_port_id = 0;
 	for (auto wire : module->wires()) {
@@ -2348,7 +2347,6 @@ void dump_module(std::ostream &f, std::string indent, RTLIL::Module *module)
 			if (port_id != 1)
 				f << stringf(", ");
 			f << stringf("%s", id(wire->name).c_str());
-			keep_running = true;
 			if (cnt==20) { f << stringf("\n"); cnt = 0; } else cnt++;
 			continue;
 		}

--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -2334,17 +2334,23 @@ void dump_module(std::ostream &f, std::string indent, RTLIL::Module *module)
 	f << stringf("%s" "module %s(", indent.c_str(), id(module->name, false).c_str());
 	bool keep_running = true;
 	int cnt = 0;
-	for (int port_id = 1; keep_running; port_id++) {
-		keep_running = false;
-		for (auto wire : module->wires()) {
-			if (wire->port_id == port_id) {
-				if (port_id != 1)
-					f << stringf(", ");
-				f << stringf("%s", id(wire->name).c_str());
-				keep_running = true;
-				if (cnt==20) { f << stringf("\n"); cnt = 0; } else cnt++;
-				continue;
-			}
+	int max_port_id = 0;
+	for (auto wire : module->wires()) {
+		max_port_id = std::max(wire->port_id, max_port_id);
+	}
+	std::vector<Wire *> wires(max_port_id + 1, nullptr);
+	for (auto wire : module->wires()) {
+		wires[wire->port_id] = wire;
+	}
+	for (int port_id = 1; port_id <= max_port_id; port_id++) {
+		Wire *wire = wires[port_id];
+		if (wire) {
+			if (port_id != 1)
+				f << stringf(", ");
+			f << stringf("%s", id(wire->name).c_str());
+			keep_running = true;
+			if (cnt==20) { f << stringf("\n"); cnt = 0; } else cnt++;
+			continue;
 		}
 	}
 	f << stringf(");\n");

--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -2333,18 +2333,10 @@ void dump_module(std::ostream &f, std::string indent, RTLIL::Module *module)
 	dump_attributes(f, indent, module->attributes, "\n", /*modattr=*/true);
 	f << stringf("%s" "module %s(", indent.c_str(), id(module->name, false).c_str());
 	int cnt = 0;
-	int max_port_id = 0;
-	for (auto wire : module->wires()) {
-		max_port_id = std::max(wire->port_id, max_port_id);
-	}
-	std::vector<Wire *> wires(max_port_id + 1, nullptr);
-	for (auto wire : module->wires()) {
-		wires[wire->port_id] = wire;
-	}
-	for (int port_id = 1; port_id <= max_port_id; port_id++) {
-		Wire *wire = wires[port_id];
+	for (auto port : module->ports) {
+		Wire *wire = module->wire(port);
 		if (wire) {
-			if (port_id != 1)
+			if (port != module->ports[0])
 				f << stringf(", ");
 			f << stringf("%s", id(wire->name).c_str());
 			if (cnt==20) { f << stringf("\n"); cnt = 0; } else cnt++;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

`write_verilog` is incredibly slow for modules with lots of ports. We have some modules with thousands of ports and `write_verilog` can take hours to run. Related to issue #3845 perhaps.

This is because port dumping is `O(N^2)` runtime, where `N` is the number of ports in the design. This poor runtime behavior arises due to the nested `for` loop (see lines 2337-2349); each loop can iterate up to the number of ports in the design.

_Explain how this is achieved._

We reduce the runtime to `O(N)` by pre-building a `port_id` to `wire` vector, then using a single `for` loop.

_If applicable, please suggest to reviewers how they can test the change._

Passes all tests.