### PR TITLE
Fix `editline` Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,12 +396,12 @@ ifeq ($(CONFIG),mxe)
 LIBS += -ltermcap
 endif
 else
-ifeq ($(ENABLE_EDITLINE),1)
-CXXFLAGS += -DYOSYS_ENABLE_EDITLINE
-LIBS += -ledit -ltinfo -lbsd
-else
 ABCMKARGS += "ABC_USE_NO_READLINE=1"
 endif
+
+ifeq ($(ENABLE_EDITLINE),1)
+CXXFLAGS += -DYOSYS_ENABLE_EDITLINE
+LIBS += -ledit
 endif
 
 ifeq ($(DISABLE_ABC_THREADS),1)

--- a/Makefile
+++ b/Makefile
@@ -396,12 +396,11 @@ ifeq ($(CONFIG),mxe)
 LIBS += -ltermcap
 endif
 else
-ABCMKARGS += "ABC_USE_NO_READLINE=1"
-endif
-
 ifeq ($(ENABLE_EDITLINE),1)
 CXXFLAGS += -DYOSYS_ENABLE_EDITLINE
 LIBS += -ledit
+endif
+ABCMKARGS += "ABC_USE_NO_READLINE=1"
 endif
 
 ifeq ($(DISABLE_ABC_THREADS),1)


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

There are three issues with `editline` in the Makefile:

1. It includes `libbsd` and `ncurses` libraries, which are no longer needed
2. It needs `ENABLE_READLINE := 1` in the Makefile to do anything
3. It does not properly set `ABC_USE_NO_READLINE=1`, so `readline` still gets used for `abc`

_Explain how this is achieved._

Fully decouple `editline` from `readline` in the Makefile and reduce `LIBS` flags down to just `-ledit`

_If applicable, please suggest to reviewers how they can test the change._

Test on a machine/container/VM with `editline` installed but no `readline`. Run `make ENABLE_READLINE=0 ENABLE_EDITLINE=1` before and after the change
