### PR TITLE
Makefile: add YOSYS_VER and friends to CXXFLAGS for plugin compat che…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,13 @@ CXXFLAGS += -D_DEFAULT_SOURCE
 endif
 
 YOSYS_VER := 0.50+56
+YOSYS_MAJOR := $(shell echo $(YOSYS_VER) | cut -d'.' -f1)
+YOSYS_MINOR := $(shell echo $(YOSYS_VER) | cut -d'.' -f2 | cut -d'+' -f1)
+YOSYS_COMMIT := $(shell echo $(YOSYS_VER) | cut -d'+' -f2)
+CXXFLAGS += -DYOSYS_VER=\\"$(YOSYS_VER)\\" \
+			-DYOSYS_MAJOR=$(YOSYS_MAJOR) \
+			-DYOSYS_MINOR=$(YOSYS_MINOR) \
+			-DYOSYS_COMMIT=$(YOSYS_COMMIT)
 
 # Note: We arrange for .gitcommit to contain the (short) commit hash in
 # tarballs generated with git-archive(1) using .gitattributes. The git repo


### PR DESCRIPTION
As Yosys interfaces change, plugin developers may decide to stay compatible with a broad spectrum of versions. We will provide per-interface feature defines of some sort, but as a fallback in case we don't, I'm adding Makefile variable `YOSYS_VER` to `CXXFLAGS` so that `yosys-config` reports reports it to the plugin sources when building them. It also splits `YOSYS_VER` to `YOSYS_MAJOR`, `YOSYS_MINOR`, `YOSYS_COMMIT` which don't need quoting and can be used as integers. For example:

```
$ cat a.cpp
#include <stdio.h>
#include <string.h>

int main() {
	if (!strcmp(YOSYS_VER, "0.47+86"))
		printf("Yay %d\n", YOSYS_MINOR);
	else
		printf("Nay\n");

	printf(YOSYS_VER "\n");
	return 0;
}
$ yosys-config --exec --cxx --cxxflags --ldflags a.cpp
$ ./a.out
Yay 47
0.47+86
```

This could also be the base for requiring plugins to report the version they were built against.