### PR TITLE
tests: replace read_ilang with read_rtlil

### DIFF
--- a/tests/opt/bug4610.ys
+++ b/tests/opt/bug4610.ys
@@ -1,4 +1,4 @@
-read_ilang <<EOT
+read_rtlil <<EOT
 autoidx 1
 module \top
   wire output 1 \Y


### PR DESCRIPTION
#4612 was written before read_ilang was deprecated but merged after so caused test failures. This switches read_ilang to read_rtlil in its testcase.

