### PR TITLE
read_rtlil: Warn on assigns after switches in case rules

### DIFF
--- a/docs/source/appendix/rtlil_text.rst
+++ b/docs/source/appendix/rtlil_text.rst
@@ -242,7 +242,7 @@ Processes
 
 Declares a process, with zero or more attributes, with the given identifier in
 the enclosing module. The body of a process consists of zero or more
-assignments, exactly one switch, and zero or more syncs.
+assignments followed by zero or more switches and zero or more syncs.
 
 See :ref:`sec:rtlil_process` for an overview of processes.
 
@@ -250,7 +250,7 @@ See :ref:`sec:rtlil_process` for an overview of processes.
 
     <process>       ::= <attr-stmt>* <proc-stmt> <process-body> <proc-end-stmt>
     <proc-stmt>     ::= process <id> <eol>
-    <process-body>  ::= <assign-stmt>* <switch>? <assign-stmt>* <sync>*
+    <process-body>  ::= <assign-stmt>* <switch>* <sync>*
     <assign-stmt>   ::= assign <dest-sigspec> <src-sigspec> <eol>
     <dest-sigspec>  ::= <sigspec>
     <src-sigspec>   ::= <sigspec>
@@ -262,8 +262,8 @@ Switches
 Switches test a signal for equality against a list of cases. Each case specifies
 a comma-separated list of signals to check against. If there are no signals in
 the list, then the case is the default case. The body of a case consists of zero
-or more switches and assignments. Both switches and cases may have zero or more
-attributes.
+or more assignments followed by zero or more switches. Both switches and cases
+may have zero or more attributes.
 
 .. code:: BNF
 
@@ -272,7 +272,7 @@ attributes.
     <case>              ::= <attr-stmt>* <case-stmt> <case-body>
     <case-stmt>         ::= case <compare>? <eol>
     <compare>           ::= <sigspec> (, <sigspec>)*
-    <case-body>         ::= (<switch> | <assign-stmt>)*
+    <case-body>         ::= <assign-stmt>* <switch>*
     <switch-end-stmt>   ::= end <eol>
 
 Syncs

--- a/frontends/rtlil/rtlil_frontend.cc
+++ b/frontends/rtlil/rtlil_frontend.cc
@@ -31,6 +31,11 @@ void rtlil_frontend_yyerror(char const *s)
 	YOSYS_NAMESPACE_PREFIX log_error("Parser error in line %d: %s\n", rtlil_frontend_yyget_lineno(), s);
 }
 
+void rtlil_frontend_yywarning(char const *s)
+{
+	YOSYS_NAMESPACE_PREFIX log_warning("In line %d: %s\n", rtlil_frontend_yyget_lineno(), s);
+}
+
 YOSYS_NAMESPACE_BEGIN
 
 struct RTLILFrontend : public Frontend {

--- a/frontends/rtlil/rtlil_frontend.h
+++ b/frontends/rtlil/rtlil_frontend.h
@@ -42,6 +42,7 @@ YOSYS_NAMESPACE_END
 extern int rtlil_frontend_yydebug;
 int rtlil_frontend_yylex(void);
 void rtlil_frontend_yyerror(char const *s);
+void rtlil_frontend_yywarning(char const *s);
 void rtlil_frontend_yyrestart(FILE *f);
 int rtlil_frontend_yyparse(void);
 int rtlil_frontend_yylex_destroy(void);

--- a/frontends/rtlil/rtlil_parser.y
+++ b/frontends/rtlil/rtlil_parser.y
@@ -344,6 +344,16 @@ assign_stmt:
 	TOK_ASSIGN sigspec sigspec EOL {
 		if (attrbuf.size() != 0)
 			rtlil_frontend_yyerror("dangling attribute");
+
+		// See https://github.com/YosysHQ/yosys/pull/4765 for discussion on this
+		// warning
+		if (!switch_stack.back()->empty()) {
+			rtlil_frontend_yywarning(
+				"case rule assign statements after switch statements may cause unexpected behaviour. "
+				"The assign statement is reordered to come before all switch statements."
+			);
+		}
+
 		case_stack.back()->actions.push_back(RTLIL::SigSig(*$2, *$3));
 		delete $2;
 		delete $3;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Previously `read_rtlil` would allow `assign` and `switch` rules to be freely mixed in RTLIL case rules, but internally yosys stores the two in two separate vectors and treats assigns as if they came before switches. This change modifies the parser to ~~reject~~ (edit: changed to emit a warning instead) RTLIL that doesn't obey this and updates the docs. `write_rtlil` will only write RTLIL obeying this property.

_Explain how this is achieved._

~~The `case_body` rule is split into two parts, firstly assignments and then switches.~~ edit: A warning is run in the assign rule if the current level already has switches assigned.

_If applicable, please suggest to reviewers how they can test the change._

The `read_rtlil` commands in the test suite should give some confidence to this.