### PR TITLE
test-compile: Use newer clang and gcc versions

### DIFF
--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -33,8 +33,8 @@ jobs:
           - 'clang-14'
           - 'gcc-10'
           # newest
-          - 'clang'
-          - 'gcc'
+          - 'clang-18'
+          - 'gcc-14'
         include:
           # macOS
           - os: macos-13
@@ -72,7 +72,7 @@ jobs:
 
       # maximum standard, only on newest compilers
       - name: Build C++20
-        if: ${{ matrix.compiler == 'clang' || matrix.compiler == 'gcc'}}
+        if: ${{ matrix.compiler == 'clang-18' || matrix.compiler == 'gcc-14' }}
         shell: bash
         run: |
           make config-$CC_SHORT

--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -32,9 +32,9 @@ jobs:
           # oldest supported
           - 'clang-14'
           - 'gcc-10'
-          # newest
+          # newest, make sure to update maximum standard step to match
           - 'clang-18'
-          - 'gcc-14'
+          - 'gcc-13'
         include:
           # macOS
           - os: macos-13
@@ -72,7 +72,7 @@ jobs:
 
       # maximum standard, only on newest compilers
       - name: Build C++20
-        if: ${{ matrix.compiler == 'clang-18' || matrix.compiler == 'gcc-14' }}
+        if: ${{ matrix.compiler == 'clang-18' || matrix.compiler == 'gcc-13' }}
         shell: bash
         run: |
           make config-$CC_SHORT


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
The 'newest' compilers are actually not all that new, they're just the default for the image.

_Explain how this is achieved._
Explicitly use clang-18 and gcc-13 as the 'newest' versions.

_If applicable, please suggest to reviewers how they can test the change._
