### PR TITLE
driver: add --autoidx

### DIFF
--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -276,6 +276,8 @@ int main(int argc, char **argv)
 	options.add_options("developer")
 		("X,trace", "enable tracing of core data structure changes. for debugging")
 		("M,randomize-pointers", "will slightly randomize allocated pointer addresses. for debugging")
+		("autoidx", "start counting autoidx up from <seed>, similar effect to --hash-seed",
+			cxxopts::value<uint64_t>(), "<idx>")
 		("A,abort", "will call abort() at the end of the script. for debugging")
 		("x,experimental", "do not print warnings for the experimental <feature>",
 			cxxopts::value<std::vector<std::string>>(), "<feature>")
@@ -426,6 +428,10 @@ int main(int argc, char **argv)
 		if (result.count("perffile")) perffile = result["perffile"].as<std::string>();
 		if (result.count("infile")) {
 			frontend_files = result["infile"].as<std::vector<std::string>>();
+		}
+		if (result.count("autoidx")) {
+			int idx = result["autoidx"].as<uint64_t>();
+			autoidx = idx;
 		}
 
 		if (log_errfile == NULL) {


### PR DESCRIPTION
[autoidx](https://yosyshq.readthedocs.io/projects/yosys/en/latest/appendix/rtlil_text.html#autoindex-statements) is an arbitrarily incrementing integer used to create unique names. We're suspicious it's another source of unimportant changes that introduce false regressions and should be randomized in testing quality of synthesis results. I'm adding an `--autoidx=<n>` option in the developer section of the help string to set its initial value to `<n>` on yosys startup. 