### PR TITLE
techmap: Add `-dont_map` for selective disabling of rules

### DIFF
--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -1029,8 +1029,7 @@ struct TechmapPass : public Pass {
 		log("        '-nooverwrite' option set.\n");
 		log("\n");
 		log("    -dont_map <celltype>\n");
-		log("        ignore any mapping rules for the given cell type, that is leave it\n");
-		log("        unmapped.\n");
+		log("        leave the given cell type unmapped by ignoring any mapping rules for it\n");
 		log("\n");
 		log("When a module in the map file has the 'techmap_celltype' attribute set, it will\n");
 		log("match cells with a type that match the text value of this attribute. Otherwise\n");

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -1028,6 +1028,10 @@ struct TechmapPass : public Pass {
 		log("        map file. Note that the Verilog frontend is also called with the\n");
 		log("        '-nooverwrite' option set.\n");
 		log("\n");
+		log("    -dont_map <celltype>\n");
+		log("        ignore any mapping rules for the given cell type, that is leave it\n");
+		log("        unmapped.\n");
+		log("\n");
 		log("When a module in the map file has the 'techmap_celltype' attribute set, it will\n");
 		log("match cells with a type that match the text value of this attribute. Otherwise\n");
 		log("the module name will be used to match the cell.  Multiple space-separated cell\n");
@@ -1159,6 +1163,7 @@ struct TechmapPass : public Pass {
 		simplemap_get_mappers(worker.simplemap_mappers);
 
 		std::vector<std::string> map_files;
+		std::vector<RTLIL::IdString> dont_map;
 		std::string verilog_frontend = "verilog -nooverwrite -noblackbox";
 		int max_iter = -1;
 
@@ -1198,6 +1203,10 @@ struct TechmapPass : public Pass {
 			}
 			if (args[argidx] == "-wb") {
 				worker.ignore_wb = true;
+				continue;
+			}
+			if (args[argidx] == "-dont_map" && argidx+1 < args.size()) {
+				dont_map.push_back(RTLIL::escape_id(args[++argidx]));
 				continue;
 			}
 			break;
@@ -1256,6 +1265,11 @@ struct TechmapPass : public Pass {
 				celltypeMap[module_name].insert(module->name);
 			}
 		}
+
+		// Erase any rules disabled with a -dont_map argument
+		for (auto type : dont_map)
+			celltypeMap.erase(type);
+
 		log_debug("Cell type mappings to use:\n");
 		for (auto &i : celltypeMap) {
 			i.second.sort(RTLIL::sort_by_id_str());


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Preserving operator boundaries requires leaving some cells unmapped at first. That can be accomplished by commenting out the relevant section of the mapping rule file, but an explicit argument to `techmap` is a more elegant solution.