### PR TITLE
Move get_blackbox_attribute method to Module instead of AttrObject

### DIFF
--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -814,6 +814,7 @@ struct RTLIL::AttrObject
 	void set_bool_attribute(const RTLIL::IdString &id, bool value=true);
 	bool get_bool_attribute(const RTLIL::IdString &id) const;
 
+	[[deprecated("Use Module::get_blackbox_attribute() instead.")]]
 	bool get_blackbox_attribute(bool ignore_wb=false) const {
 		return get_bool_attribute(ID::blackbox) || (!ignore_wb && get_bool_attribute(ID::whitebox));
 	}
@@ -1290,6 +1291,10 @@ public:
 	virtual void check();
 	virtual void optimize();
 	virtual void makeblackbox();
+
+	bool get_blackbox_attribute(bool ignore_wb=false) const {
+		return get_bool_attribute(ID::blackbox) || (!ignore_wb && get_bool_attribute(ID::whitebox));
+	}
 
 	void connect(const RTLIL::SigSig &conn);
 	void connect(const RTLIL::SigSpec &lhs, const RTLIL::SigSpec &rhs);


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
`ID::blackbox` and `ID::whitebox` attributes never appear to be set on anything except modules, and the `get_blackbox_attribute()` method appears to only be called on a `Module`.

_Explain how this is achieved._
Mark `AttrObject::get_blackbox_attribute()` deprecated and add `Module::get_blackbox_attribute()` to replace it.

_If applicable, please suggest to reviewers how they can test the change._
