### PR TITLE
add setenv pass

### DIFF
--- a/passes/cmds/Makefile.inc
+++ b/passes/cmds/Makefile.inc
@@ -52,3 +52,4 @@ OBJS += passes/cmds/box_derive.o
 OBJS += passes/cmds/example_dt.o
 OBJS += passes/cmds/portarcs.o
 OBJS += passes/cmds/wrapcell.o
+OBJS += passes/cmds/setenv.o

--- a/passes/cmds/setenv.cc
+++ b/passes/cmds/setenv.cc
@@ -1,0 +1,49 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2024 N. Engelhardt <nak@yosyshq.com>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/register.h"
+#include "kernel/rtlil.h"
+#include "kernel/log.h"
+#include <stdlib.h>
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+struct SetenvPass : public Pass {
+	SetenvPass() : Pass("setenv", "set an environment variable") { }
+	void help() override
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    setenv name value\n");
+		log("\n");
+		log("Set the given environment variable on the current process. String values must be\n");
+		log("passed in double quotes (\").\n");
+		log("\n");
+	}
+	void execute(std::vector<std::string> args, [[maybe_unused]] RTLIL::Design *design) override
+	{
+		if(args.size() != 3)
+			log_cmd_error("Wrong number of arguments given.\n");
+		
+		setenv(args[1].c_str(), args[2].c_str(), 1);
+		
+	}
+} SetenvPass;
+
+PRIVATE_NAMESPACE_END

--- a/passes/cmds/setenv.cc
+++ b/passes/cmds/setenv.cc
@@ -41,8 +41,12 @@ struct SetenvPass : public Pass {
 		if(args.size() != 3)
 			log_cmd_error("Wrong number of arguments given.\n");
 		
+#if defined(_WIN32)
+		_putenv_s(args[1].c_str(), args[2].c_str());
+#else
 		setenv(args[1].c_str(), args[2].c_str(), 1);
-		
+#endif
+
 	}
 } SetenvPass;
 

--- a/passes/cmds/setenv.cc
+++ b/passes/cmds/setenv.cc
@@ -32,21 +32,26 @@ struct SetenvPass : public Pass {
 		log("\n");
 		log("    setenv name value\n");
 		log("\n");
-		log("Set the given environment variable on the current process. String values must be\n");
-		log("passed in double quotes (\").\n");
+		log("Set the given environment variable on the current process. Values containing\n");
+		log("whitespace must be passed in double quotes (\").\n");
 		log("\n");
 	}
 	void execute(std::vector<std::string> args, [[maybe_unused]] RTLIL::Design *design) override
 	{
 		if(args.size() != 3)
 			log_cmd_error("Wrong number of arguments given.\n");
+
+		std::string name = args[1];
+		std::string value = args[2];
+		if (value.front() == '\"' && value.back() == '\"') value = value.substr(1, value.size() - 2);
 		
 #if defined(_WIN32)
-		_putenv_s(args[1].c_str(), args[2].c_str());
+		_putenv_s(name.c_str(), value.c_str());
 #else
-		setenv(args[1].c_str(), args[2].c_str(), 1);
+		if (setenv(name.c_str(), value.c_str(), 1))
+			log_cmd_error("Invalid name \"%s\".\n", name.c_str());
 #endif
-
+		
 	}
 } SetenvPass;
 

--- a/tests/verific/setenv.flist
+++ b/tests/verific/setenv.flist
@@ -1,0 +1,1 @@
+${filename}

--- a/tests/verific/setenv.ys
+++ b/tests/verific/setenv.ys
@@ -1,0 +1,4 @@
+setenv filename case.sv
+verific -f -sv setenv.flist
+verific -import top
+select -assert-mod-count 1 top


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

File lists (a verific feature) will often make use of environment variables in file paths, e.g. [this example from the CV32E40P core](https://github.com/openhwgroup/cv32e40p/blob/master/cv32e40p_manifest.flist). This provides a way to set these variables from within a yosys script.

_Explain how this is achieved._

Add a `setenv` command that simply passes its arguments to the `setenv()` POSIX function.

_If applicable, please suggest to reviewers how they can test the change._

There's a testcase included that can be used with verific.

In the absence of verific, it's possible to use this to set any other environment variable that yosys checks (although there aren't too many - you can change HOME or PATH and see what mayhem you can cause...) It would also be possible to use TCL to check that the value was updated correctly.

Unlike the TCL implementation, this is not thread-safe, but neither is most of the rest of yosys.

TODO: 

- [x] add the right guards for windows. @mmicko, could you have a look at that?
- [x] handle quoted strings