### PR TITLE
tests: fix blockrom.v driver conflict

### DIFF
--- a/tests/arch/common/blockrom.v
+++ b/tests/arch/common/blockrom.v
@@ -10,8 +10,11 @@ module sync_rom #(parameter DATA_WIDTH=8, ADDRESS_WIDTH=10)
 	reg [WORD:0] data_out_r;
 	reg [WORD:0] memory [0:DEPTH];
 
-	integer i,j = 64'hF4B1CA8127865242;
-	initial
+	integer i,j;
+	// Initialize in initial block as a workaround for
+	// https://github.com/YosysHQ/yosys/issues/4792
+	initial begin
+		j = 64'hF4B1CA8127865242;
 		for (i = 0; i <= DEPTH; i++) begin
 			// In case this ROM will be implemented in fabric: fill the memory with some data
 			// uncorrelated with the address, or Yosys might see through the ruse and e.g. not
@@ -21,6 +24,7 @@ module sync_rom #(parameter DATA_WIDTH=8, ADDRESS_WIDTH=10)
 			j = j ^ (j << 25);
 			j = j ^ (j >> 27);
 		end
+	end
 
 	always @(posedge clk) begin
 		data_out_r <= memory[address_in];


### PR DESCRIPTION
Prior to this PR, `integer j` had two drivers: a constant, and the result of the xorshift chain. This can be verified by replacing the contents of `tests/arch/ice40/memories.ys` with the following pass sequence. The driver conflict created a loop which later somehow would get resolved, but it killed `opt_expr` topological ordering and inflated `make test` runtime. This PR reduces the duration of `make test -j24` on my machine by a factor of >2.5.

```
design -reset; read_verilog -defer ../common/blockrom.v
chparam -set ADDRESS_WIDTH 2 -set DATA_WIDTH 2 sync_rom
hierarchy -top sync_rom
proc -noopt
check
```