### PR TITLE
Reduce number of warnings

### DIFF
--- a/backends/aiger2/aiger.cc
+++ b/backends/aiger2/aiger.cc
@@ -262,7 +262,8 @@ struct Index {
 				if (cell->type.in(ID($gt), ID($ge)))
 					std::swap(aport, bport);
 				int carry = cell->type.in(ID($le), ID($ge)) ? CFALSE : CTRUE; 
-				Lit a, b;
+				Lit a = Writer::EMPTY_LIT;
+				Lit b = Writer::EMPTY_LIT;
 				// TODO: this might not be the most economic structure; revisit at a later date
 				for (int i = 0; i < width; i++) {
 					a = visit(cursor, aport[i]);
@@ -664,8 +665,6 @@ struct Index {
 struct AigerWriter : Index<AigerWriter, unsigned int, 0, 1> {
 	typedef unsigned int Lit;
 
-	const static Lit CONST_FALSE = 0;
-	const static Lit CONST_TRUE = 1;
 	const static constexpr Lit EMPTY_LIT = std::numeric_limits<Lit>::max();
 
 	static Lit negate(Lit lit) {
@@ -802,8 +801,6 @@ struct AigerWriter : Index<AigerWriter, unsigned int, 0, 1> {
 };
 
 struct XAigerAnalysis : Index<XAigerAnalysis, int, 0, 0> {
-	const static int CONST_FALSE = 0;
-	const static int CONST_TRUE = 0;
 	const static constexpr int EMPTY_LIT = -1;
 
 	XAigerAnalysis()

--- a/backends/edif/edif.cc
+++ b/backends/edif/edif.cc
@@ -338,7 +338,7 @@ struct EdifBackend : public Backend {
 				*f << stringf("\n            (property %s (integer %u))", EDIF_DEF(name), val.as_int());
 			else {
 				std::string hex_string = "";
-				for (size_t i = 0; i < val.size(); i += 4) {
+				for (auto i = 0; i < val.size(); i += 4) {
 					int digit_value = 0;
 					if (i+0 < val.size() && val.at(i+0) == RTLIL::State::S1) digit_value |= 1;
 					if (i+1 < val.size() && val.at(i+1) == RTLIL::State::S1) digit_value |= 2;

--- a/frontends/aiger2/xaiger.cc
+++ b/frontends/aiger2/xaiger.cc
@@ -198,11 +198,10 @@ struct Xaiger2Frontend : public Frontend {
 
 				int ci_counter = 0;
 				for (uint32_t i = 0; i < no_boxes; i++) {
-					uint32_t box_inputs, box_outputs, box_id, box_seq;
-					box_inputs = read_be32(*f);
-					box_outputs = read_be32(*f);
-					box_id = read_be32(*f);
-					box_seq = read_be32(*f);
+					/* unused box_inputs = */ read_be32(*f);
+					YS_MAYBE_UNUSED auto box_outputs = read_be32(*f);
+					/* unused box_id = */ read_be32(*f);
+					auto box_seq = read_be32(*f);
 
 					log("box_seq=%d boxes.size=%d\n", box_seq, (int) boxes.size());
 					log_assert(box_seq < boxes.size());
@@ -337,11 +336,10 @@ struct Xaiger2Frontend : public Frontend {
 						  len, ci_num, co_num, pi_num, po_num, no_boxes);
 
 				for (uint32_t i = 0; i < no_boxes; i++) {
-					uint32_t box_inputs, box_outputs, box_id, box_seq;
-					box_inputs = read_be32(*f);
-					box_outputs = read_be32(*f);
-					box_id = read_be32(*f);
-					box_seq = read_be32(*f);
+					YS_MAYBE_UNUSED auto box_inputs = read_be32(*f);
+					/* unused box_outputs = */ read_be32(*f);
+					/* unused box_id = */ read_be32(*f);
+					auto box_seq = read_be32(*f);
 
 					log("box_seq=%d boxes.size=%d\n", box_seq, (int) boxes.size());
 					log_assert(box_seq < boxes.size());

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -931,7 +931,7 @@ bool AstNode::bits_only_01() const
 RTLIL::Const AstNode::bitsAsUnsizedConst(int width)
 {
 	RTLIL::State extbit = bits.back();
-	while (width > int(bits.size()))
+	while (width > GetSize(bits))
 		bits.push_back(extbit);
 	return RTLIL::Const(bits);
 }
@@ -939,13 +939,13 @@ RTLIL::Const AstNode::bitsAsUnsizedConst(int width)
 RTLIL::Const AstNode::bitsAsConst(int width, bool is_signed)
 {
 	std::vector<RTLIL::State> bits = this->bits;
-	if (width >= 0 && width < int(bits.size()))
+	if (width >= 0 && width < GetSize(bits))
 		bits.resize(width);
-	if (width >= 0 && width > int(bits.size())) {
+	if (width >= 0 && width > GetSize(bits)) {
 		RTLIL::State extbit = RTLIL::State::S0;
 		if ((is_signed || is_unsized) && !bits.empty())
 			extbit = bits.back();
-		while (width > int(bits.size()))
+		while (width > GetSize(bits))
 			bits.push_back(extbit);
 	}
 	return RTLIL::Const(bits);
@@ -1029,7 +1029,7 @@ double AstNode::asReal(bool is_signed)
 			val = const_neg(val, val, false, false, val.size());
 
 		double v = 0;
-		for (size_t i = 0; i < val.size(); i++)
+		for (auto i = 0; i < val.size(); i++)
 			// IEEE Std 1800-2012 Par 6.12.2: Individual bits that are x or z in
 			// the net or the variable shall be treated as zero upon conversion.
 			if (val.at(i) == RTLIL::State::S1)

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -984,7 +984,7 @@ void AstNode::detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *foun
 		// unallocated enum, ignore
 		break;
 	case AST_CONSTANT:
-		width_hint = max(width_hint, int(bits.size()));
+		width_hint = max(width_hint, GetSize(bits));
 		if (!is_signed)
 			sign_hint = false;
 		break;

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -3493,7 +3493,7 @@ skip_dynamic_range_lvalue_expansion:;
 				delete buf;
 
 				uint32_t result = 0;
-				for (size_t i = 0; i < arg_value.size(); i++)
+				for (auto i = 0; i < arg_value.size(); i++)
 					if (arg_value.at(i) == RTLIL::State::S1)
 						result = i + 1;
 
@@ -4339,7 +4339,7 @@ replace_fcall_later:;
 					RTLIL::Const a = children[1]->bitsAsConst(width_hint, sign_hint);
 					RTLIL::Const b = children[2]->bitsAsConst(width_hint, sign_hint);
 					log_assert(a.size() == b.size());
-					for (size_t i = 0; i < a.size(); i++)
+					for (auto i = 0; i < a.size(); i++)
 						if (a[i] != b[i])
 							a.bits()[i] = RTLIL::State::Sx;
 					newNode = mkconst_bits(a.to_bits(), sign_hint);

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -380,7 +380,7 @@ int RTLIL::Const::as_int(bool is_signed) const
 	return ret;
 }
 
-size_t RTLIL::Const::get_min_size(bool is_signed) const
+int RTLIL::Const::get_min_size(bool is_signed) const
 {
 	if (empty()) return 0;
 
@@ -391,7 +391,7 @@ size_t RTLIL::Const::get_min_size(bool is_signed) const
 	else
 		leading_bit = RTLIL::State::S0;
 
-	size_t idx = size();
+	auto idx = size();
 	while (idx > 0 && (*this)[idx -1] == leading_bit) {
 		idx--;
 	}
@@ -406,22 +406,22 @@ size_t RTLIL::Const::get_min_size(bool is_signed) const
 
 void RTLIL::Const::compress(bool is_signed)
 {
-	size_t idx = get_min_size(is_signed);
+	auto idx = get_min_size(is_signed);
 	bits().erase(bits().begin() + idx, bits().end());
 }
 
 std::optional<int> RTLIL::Const::as_int_compress(bool is_signed) const
 {
-	size_t size = get_min_size(is_signed);
+	auto size = get_min_size(is_signed);
 	if(size == 0 || size > 32)
 		return std::nullopt;
 
 	int32_t ret = 0;
-	for (size_t i = 0; i < size && i < 32; i++)
+	for (auto i = 0; i < size && i < 32; i++)
 		if ((*this)[i] == State::S1)
 			ret |= 1 << i;
 	if (is_signed && (*this)[size-1] == State::S1)
-		for (size_t i = size; i < 32; i++)
+		for (auto i = size; i < 32; i++)
 			ret |= 1 << i;
 	return ret;
 }

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -780,7 +780,7 @@ public:
 	RTLIL::Const extract(int offset, int len = 1, RTLIL::State padding = RTLIL::State::S0) const;
 
 	// find the MSB without redundant leading bits
-	size_t get_min_size(bool is_signed) const;
+	int get_min_size(bool is_signed) const;
 
 	// compress representation to the minimum required bits
 	void compress(bool is_signed = false);

--- a/passes/fsm/fsm_map.cc
+++ b/passes/fsm/fsm_map.cc
@@ -54,7 +54,7 @@ static void implement_pattern_cache(RTLIL::Module *module, std::map<RTLIL::Const
 		RTLIL::Const pattern = it.first;
 		RTLIL::SigSpec eq_sig_a, eq_sig_b, or_sig;
 
-		for (size_t j = 0; j < pattern.size(); j++)
+		for (auto j = 0; j < pattern.size(); j++)
 			if (pattern[j] == RTLIL::State::S0 || pattern[j] == RTLIL::State::S1) {
 				eq_sig_a.append(ctrl_in.extract(j, 1));
 				eq_sig_b.append(RTLIL::SigSpec(pattern[j]));
@@ -198,7 +198,7 @@ static void map_fsm(RTLIL::Cell *fsm_cell, RTLIL::Module *module)
 		RTLIL::Const state = fsm_data.state_table[i];
 		RTLIL::SigSpec sig_a, sig_b;
 
-		for (size_t j = 0; j < state.size(); j++)
+		for (auto j = 0; j < state.size(); j++)
 			if (state[j] == RTLIL::State::S0 || state[j] == RTLIL::State::S1) {
 				sig_a.append(RTLIL::SigSpec(state_wire, j));
 				sig_b.append(RTLIL::SigSpec(state[j]));
@@ -261,7 +261,7 @@ static void map_fsm(RTLIL::Cell *fsm_cell, RTLIL::Module *module)
 			for (size_t i = 0; i < fsm_data.state_table.size(); i++) {
 				RTLIL::Const state = fsm_data.state_table[i];
 				int bit_idx = -1;
-				for (size_t j = 0; j < state.size(); j++)
+				for (auto j = 0; j < state.size(); j++)
 					if (state[j] == RTLIL::State::S1)
 						bit_idx = j;
 				if (bit_idx >= 0)

--- a/techlibs/quicklogic/ql_dsp_simd.cc
+++ b/techlibs/quicklogic/ql_dsp_simd.cc
@@ -60,7 +60,7 @@ struct QlDspSimdPass : public Pass {
 
 	// ..........................................
 
-	const size_t m_ModeBitsSize = 80;
+	const int m_ModeBitsSize = 80;
 
 	// DSP parameters
 	const std::vector<std::string> m_DspParams = {"COEFF_3", "COEFF_2", "COEFF_1", "COEFF_0"};


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
There are a number of easy to fix warnings:
1.  `comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'int' [-Wsign-compare]` 

_Explain how this is achieved._
1. `Const::size()` returns int, so change iterators that use it to `auto` instead of `size_t`. For cases where size is being explicitly cast to `int`, use the wrapper that we already have instead: `Yosys::GetSize()`.

_If applicable, please suggest to reviewers how they can test the change._
Check what/if any warnings still show up at the bottom of the "Files changed" tab and in the "Compiler testing" section of the checks