### PR TITLE
booth: Map simple `$macc` instances too

### DIFF
--- a/kernel/macc.h
+++ b/kernel/macc.h
@@ -228,6 +228,14 @@ struct Macc
 		return true;
 	}
 
+	bool is_simple_product()
+	{
+		return bit_ports.empty() &&
+				ports.size() == 1 &&
+				!ports[0].in_b.empty() &&
+				!ports[0].do_subtract;
+	}
+
 	Macc(RTLIL::Cell *cell = nullptr)
 	{
 		if (cell != nullptr)

--- a/passes/techmap/booth.cc
+++ b/passes/techmap/booth.cc
@@ -57,6 +57,7 @@ synth -top my_design -booth
 
 #include "kernel/sigtools.h"
 #include "kernel/yosys.h"
+#include "kernel/macc.h"
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
@@ -207,12 +208,33 @@ struct BoothPassWorker {
 	void run()
 	{
 		for (auto cell : module->selected_cells()) {
-			if (cell->type != ID($mul))
-				continue;
+			SigSpec A, B, Y;
+			bool is_signed;
 
-			SigSpec A = cell->getPort(ID::A);
-			SigSpec B = cell->getPort(ID::B);
-			SigSpec Y = cell->getPort(ID::Y);
+			if (cell->type == ID($mul)) {
+				A = cell->getPort(ID::A);
+				B = cell->getPort(ID::B);
+				Y = cell->getPort(ID::Y);
+
+				log_assert(cell->getParam(ID::A_SIGNED).as_bool() == cell->getParam(ID::B_SIGNED).as_bool());
+				is_signed = cell->getParam(ID::A_SIGNED).as_bool();
+			} else if (cell->type == ID($macc)) {
+				Macc macc;
+				macc.from_cell(cell);
+
+				if (!macc.is_simple_product()) {
+					log_debug("Not mapping cell %s: not a simple macc cell\n", log_id(cell));
+					continue;
+				}
+
+				A = macc.ports[0].in_a;
+				B = macc.ports[0].in_b;
+				is_signed = macc.ports[0].is_signed;
+				Y = cell->getPort(ID::Y);
+			} else {
+				continue;
+			}
+
 			int x_sz = GetSize(A), y_sz = GetSize(B), z_sz = GetSize(Y);
 
 			if (x_sz < 4 || y_sz < 4 || z_sz < 8) {
@@ -220,9 +242,6 @@ struct BoothPassWorker {
 					  log_id(cell), x_sz, y_sz, z_sz);
 				continue;
 			}
-
-			log_assert(cell->getParam(ID::A_SIGNED).as_bool() == cell->getParam(ID::B_SIGNED).as_bool());
-			bool is_signed = cell->getParam(ID::A_SIGNED).as_bool();
 
 			log("Mapping cell %s to %s Booth multiplier\n", log_id(cell), is_signed ? "signed" : "unsigned");
 

--- a/tests/techmap/booth.ys
+++ b/tests/techmap/booth.ys
@@ -10,6 +10,19 @@ endmodule
 EOF
 booth
 sat -verify -set a 0 -set b 0 -prove y 0
-design -reset
 
+design -reset
 test_cell -s 1694091355 -n 100 -script booth_map_script.ys_ $mul
+
+design -reset
+read_verilog <<EOF
+module top(a,b,y);
+input wire [4:0] a;
+input wire [5:0] b;
+output wire [6:0] y;
+assign y = a * b;
+endmodule
+EOF
+synth -run :fine
+# test compatibility with alumacc
+equiv_opt -assert booth


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

As it stands `booth` ignores `$macc` cells, which means one cannot sequence `booth` after `alumacc`. Make the change to `booth` to handle at least the basic `$macc` cells which represent a simple product. The more advanced case in which `$macc` is a combined multiply-accumulate operation is left for later to be dealt with
