### PR TITLE
techlibs: add _TECHMAP_DO_ to Han-Carlson adder

### DIFF
--- a/techlibs/common/choices/han-carlson.v
+++ b/techlibs/common/choices/han-carlson.v
@@ -13,6 +13,8 @@ module _80_lcu_han_carlson (P, G, CI, CO);
 	(* force_downto *)
 	reg [WIDTH-1:0] p, g;
 
+	wire [1023:0] _TECHMAP_DO_ = "proc; opt -fast";
+
 	always @* begin
 		i = 0;
 		p = P;


### PR DESCRIPTION
This was left out by copy pasting mistake. Removes the necessity for `-autoproc` and makes it consistent with Kogge-Stone