### PR TITLE
Fix Cygwin compatibility

### DIFF
--- a/kernel/mem.cc
+++ b/kernel/mem.cc
@@ -1680,8 +1680,6 @@ SigSpec MemWr::decompress_en(const std::vector<int> &swizzle, SigSpec sig) {
 	return res;
 }
 
-using addr_t = MemContents::addr_t;
-
 MemContents::MemContents(Mem *mem) :
 	MemContents(ceil_log2(mem->size), mem->width)
 {
@@ -1758,7 +1756,7 @@ bool MemContents::_range_overlaps(std::map<addr_t, RTLIL::Const>::iterator it, a
 	return !(top1 < begin_addr || top2 < _range_begin(it));
 }
 
-std::map<addr_t, RTLIL::Const>::iterator MemContents::_range_at(addr_t addr) const {
+std::map<MemContents::addr_t, RTLIL::Const>::iterator MemContents::_range_at(addr_t addr) const {
 	// allow addr == 1<<_addr_width (which will just return end())
 	log_assert(addr <= (addr_t)(1<<_addr_width));
 	// get the first range with base > addr
@@ -1786,7 +1784,7 @@ RTLIL::Const MemContents::operator[](addr_t addr) const {
 		return _default_value;
 }
 
-addr_t MemContents::count_range(addr_t begin_addr, addr_t end_addr) const {
+MemContents::addr_t MemContents::count_range(addr_t begin_addr, addr_t end_addr) const {
 	addr_t count = 0;
 	for(auto it = _range_at(begin_addr); _range_overlaps(it, begin_addr, end_addr); it++) {
 		auto first = std::max(_range_begin(it), begin_addr);
@@ -1829,7 +1827,7 @@ void MemContents::clear_range(addr_t begin_addr, addr_t end_addr) {
 	_values.erase(begin_it, end_it);
 }
 
-std::map<addr_t, RTLIL::Const>::iterator MemContents::_reserve_range(addr_t begin_addr, addr_t end_addr) {
+std::map<MemContents::addr_t, RTLIL::Const>::iterator MemContents::_reserve_range(addr_t begin_addr, addr_t end_addr) {
 	if(begin_addr >= end_addr)
 		return _values.end(); // need a dummy value to return, end() is cheap
 	// find the first range containing any addr >= begin_addr - 1

--- a/libs/fst/00_PATCH_win_io.patch
+++ b/libs/fst/00_PATCH_win_io.patch
@@ -43,7 +43,7 @@
   * mmap compatibility
   */
 -#if defined __MINGW32__
-+#if defined __CYGWIN__ || defined __MINGW32__ || defined _MSC_VER
++#if defined __MINGW32__ || defined _MSC_VER
  #include <limits.h>
  #define fstMmap(__addr,__len,__prot,__flags,__fd,__off) fstMmap2((__len), (__fd), (__off))
  #define fstMunmap(__addr,__len)                         UnmapViewOfFile((LPCVOID)__addr)

--- a/libs/fst/fstapi.cc
+++ b/libs/fst/fstapi.cc
@@ -341,7 +341,7 @@ return(NULL);
 /*
  * mmap compatibility
  */
-#if defined __CYGWIN__ || defined __MINGW32__ || defined _MSC_VER
+#if defined __MINGW32__ || defined _MSC_VER
 #include <limits.h>
 #define fstMmap(__addr,__len,__prot,__flags,__fd,__off) fstMmap2((__len), (__fd), (__off))
 #define fstMunmap(__addr,__len)                         UnmapViewOfFile((LPCVOID)__addr)


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
Cygwin builds currently fail with two errors, one due to an overzealous compatibility check in libs/fst; the other in kernel/mem.cc due to redefining `addr_t` which is a system type.

_Explain how this is achieved._
Drop `__CYGWIN__` from the mmap compatibility check in libs/fst.
Remove the `addr_t` redefinition, instead using `MemContents::addr_t` where needed.

_If applicable, please suggest to reviewers how they can test the change._
