### PR TITLE
Adjust `abc9_ops -prep_box` to allow repeated invocation

### DIFF
--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -969,13 +969,10 @@ void prep_box(RTLIL::Design *design)
 		if (it == module->attributes.end())
 			continue;
 		bool box = it->second.as_bool();
-		module->attributes.erase(it);
 		if (!box)
 			continue;
 
 		auto r = module->attributes.insert(ID::abc9_box_id);
-		if (!r.second)
-			continue;
 		r.first->second = abc9_box_id++;
 
 		if (module->get_bool_attribute(ID::abc9_flop)) {

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -1093,8 +1093,9 @@ void prep_box(RTLIL::Design *design)
 			ss << std::endl;
 
 			auto &t = timing.setup_module(module);
-			if (t.comb.empty())
+			if (t.comb.empty() && !outputs.empty() && !inputs.empty()) {
 				log_error("Module '%s' with (* abc9_box *) has no timing (and thus no connectivity) information.\n", log_id(module));
+			}
 
 			for (const auto &o : outputs) {
 				first = true;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

`abc9_ops -prep_box` manipulates the relevant attributes (`abc9_box` and `abc9_box_id`) in a way which prohibits repeated invocation of the command unless the design is reloaded. Adjust it.

Repeated invocation is required for the feature #4737. The `abc9` script which only calls the command once should be unaffected.