### PR TITLE
write_verilog: Use assign for `$buf`

### DIFF
--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -1071,7 +1071,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 		return true;
 	}
 
-	if (cell->type == ID($_BUF_)) {
+	if (cell->type.in(ID($_BUF_), ID($buf))) {
 		f << stringf("%s" "assign ", indent.c_str());
 		dump_sigspec(f, cell->getPort(ID::Y));
 		f << stringf(" = ");


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

In the expr mode use `assign Y = A;` to export a `$buf` cell instead of falling back to an explicit instantiation of an internal cell type (which is a bug in the expr mode)