### PR TITLE
read_liberty: Revisit for abc9 whiteboxes

### DIFF
--- a/frontends/liberty/liberty.cc
+++ b/frontends/liberty/liberty.cc
@@ -727,7 +727,7 @@ struct LibertyFrontend : public Frontend {
 			}
 
 			if (simple_comb_cell && has_outputs) {
-				module->set_bool_attribute(ID(simple_comb_cell));
+				module->set_bool_attribute(ID::abc9_box);
 
 				if (flag_unit_delay) {
 					for (auto wi : module->wires())


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Make two changes which make it easier to use boxes loaded in by `read_liberty` for abc9 boxes: Attach the `simple_comb_cell` attribute on box definitions which are purely combinational and have simple input/output pins. Also redo the `-unit_delay` mode to: avoid reading the `timing_type` attribute (which is optional) and avoid needing to deal with arcs from an output pin to an output pin.