### PR TITLE
add hash method to scopeindex cursor

### DIFF
--- a/kernel/scopeinfo.h
+++ b/kernel/scopeinfo.h
@@ -169,6 +169,10 @@ public:
 			return !(*this == other);
 		}
 
+		int hash() const {
+			return mkhash(scope_name.hash(), hash_ptr_ops::hash(target));
+		}
+
 		bool valid() const {
 			return target != nullptr;
 		}


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Allow `Cursor` to be stored in a `dict`.