### PR TITLE
Add verific verilog test cases for blackboxes

### DIFF
--- a/tests/verific/blackbox_empty.ys
+++ b/tests/verific/blackbox_empty.ys
@@ -1,0 +1,17 @@
+verific -sv  <<EOF
+module TEST_CELL(input clk, input a, input b, output reg c);
+parameter PATH = "DEFAULT";
+endmodule
+EOF
+
+verific -sv <<EOF
+module top(input clk, input a, input b, output c, output d);
+	TEST_CELL  #(.PATH("TEST")) test1(.clk(clk),.a(a),.b(1'b1),.c(c));
+	TEST_CELL  #(.PATH("DEFAULT")) test2(.clk(clk),.a(a),.b(1'bx),.c(d));
+endmodule
+EOF
+
+verific -import top
+hierarchy -top top
+stat
+select -assert-count 2 t:TEST_CELL

--- a/tests/verific/blackbox_ql.ys
+++ b/tests/verific/blackbox_ql.ys
@@ -1,0 +1,41 @@
+verific -sv -lib +/quicklogic/qlf_k6n10f/dsp_sim.v 
+
+verific -sv <<EOF
+module top (
+    input  wire [19:0] a,
+    input  wire [17:0] b,
+    output wire [37:0] z,
+    input  wire       clk,
+    input  wire       reset,
+    input  wire       unsigned_a,
+    input  wire       unsigned_b,
+    input  wire       f_mode,
+    input  wire [2:0] output_select,
+    input  wire       register_inputs
+);
+	
+// module instantiation
+QL_DSP2_MULT_REGIN_REGOUT #(
+    .MODE_BITS(80'h1232324)
+) u1 (
+    .a (a),
+    .b (b),
+    .z (z),
+    .clk (clk),
+    .reset (reset),
+
+    .unsigned_a (unsigned_a),
+    .unsigned_b (unsigned_b),
+
+    .f_mode (f_mode),
+    .output_select (output_select),
+    .register_inputs (register_inputs)
+);
+endmodule
+
+EOF
+
+verific -import top
+hierarchy -top top
+synth_quicklogic -family qlf_k6n10f
+select -assert-count 1 t:QL_DSP2_MULT_REGIN_REGOUT a:MODE_BITS=80'h1232324


### PR DESCRIPTION
Static elaboration will fail in cases there is an instance of blackbox module similar as for analysis, we are lowering msg level to INFO to prevent that. In case there is no blackbox module during elaboration then process will fail anyway.
Factored out  save_blackbox_msg_state() and restore_blackbox_msg_state for convinience sake.
Added couple of Verilog test cases.