### PR TITLE
kernel: Remove global `tcl.h` include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ endif
 else ifeq ($(CONFIG),mxe)
 PKG_CONFIG = /usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-pkg-config
 CXX = /usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-g++
-CXXFLAGS += -std=$(CXXSTD) $(OPT_LEVEL) -D_POSIX_SOURCE -DYOSYS_MXE_HACKS -Wno-attributes
+CXXFLAGS += -std=$(CXXSTD) $(OPT_LEVEL) -D_POSIX_SOURCE -Wno-attributes
 CXXFLAGS := $(filter-out -fPIC,$(CXXFLAGS))
 LINKFLAGS := $(filter-out -rdynamic,$(LINKFLAGS)) -s
 LIBS := $(filter-out -lrt,$(LIBS))

--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -31,6 +31,10 @@
 #  include <editline/readline.h>
 #endif
 
+#ifdef YOSYS_ENABLE_TCL
+#  include <tcl.h>
+#endif
+
 #include <stdio.h>
 #include <string.h>
 #include <limits.h>

--- a/kernel/tclapi.cc
+++ b/kernel/tclapi.cc
@@ -22,8 +22,9 @@
 #include "libs/json11/json11.hpp"
 
 #ifdef YOSYS_ENABLE_TCL
-#include "tclTomMath.h"
-#include "tclTomMathDecls.h"
+#include <tcl.h>
+#include <tclTomMath.h>
+#include <tclTomMathDecls.h>
 #endif
 
 YOSYS_NAMESPACE_BEGIN

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -29,6 +29,10 @@
 #  include <editline/readline.h>
 #endif
 
+#ifdef YOSYS_ENABLE_TCL
+#  include <tcl.h>
+#endif
+
 #ifdef YOSYS_ENABLE_PLUGINS
 #  include <dlfcn.h>
 #endif

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -43,6 +43,10 @@
 #include "kernel/rtlil.h"
 #include "kernel/register.h"
 
+#ifdef YOSYS_ENABLE_TCL
+struct Tcl_Interp;
+#endif
+
 YOSYS_NAMESPACE_BEGIN
 
 void yosys_setup();

--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -65,29 +65,6 @@
 #define FRIEND_TEST(test_case_name, test_name) \
   friend class test_case_name##_##test_name##_Test
 
-#ifdef YOSYS_ENABLE_TCL
-#  include <tcl.h>
-#  ifdef YOSYS_MXE_HACKS
-extern Tcl_Command Tcl_CreateCommand(Tcl_Interp *interp, const char *cmdName, Tcl_CmdProc *proc, ClientData clientData, Tcl_CmdDeleteProc *deleteProc);
-extern Tcl_Interp *Tcl_CreateInterp(void);
-extern void Tcl_Preserve(ClientData data);
-extern void Tcl_Release(ClientData clientData);
-extern int Tcl_InterpDeleted(Tcl_Interp *interp);
-extern void Tcl_DeleteInterp(Tcl_Interp *interp);
-extern int Tcl_Eval(Tcl_Interp *interp, const char *script);
-extern int Tcl_EvalFile(Tcl_Interp *interp, const char *fileName);
-extern void Tcl_Finalize(void);
-extern int Tcl_GetCommandInfo(Tcl_Interp *interp, const char *cmdName, Tcl_CmdInfo *infoPtr);
-extern const char *Tcl_GetStringResult(Tcl_Interp *interp);
-extern Tcl_Obj *Tcl_NewStringObj(const char *bytes, int length);
-extern Tcl_Obj *Tcl_NewIntObj(int intValue);
-extern Tcl_Obj *Tcl_NewListObj(int objc, Tcl_Obj *const objv[]);
-extern Tcl_Obj *Tcl_ObjSetVar2(Tcl_Interp *interp, Tcl_Obj *part1Ptr, Tcl_Obj *part2Ptr, Tcl_Obj *newValuePtr, int flags);
-#  endif
-#  undef CONST
-#  undef INLINE
-#endif
-
 #ifdef _WIN32
 #  undef NOMINMAX
 #  define NOMINMAX 1


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

In commit ac988cf we made sure to undefine the CONST/VOID macros left defined by `tcl.h`, but this in turn makes it an issue to include additional Tcl headers later on (see issue #4808).

One way out is to avoid a global `tcl.h` include. In the process we drop support for Tcl-enabled MXE builds, which were likely broken anyway due to the additional Tcl APIs used from `tclapi.cc`.

Fixes #4808 cc @akashlevy 