### PR TITLE
Add -blackbox option to setundef pass

### DIFF
--- a/tests/various/setundef_blackbox.ys
+++ b/tests/various/setundef_blackbox.ys
@@ -1,0 +1,32 @@
+read_verilog -specify << EOT
+module top(input a, b, output o);
+    wire c, d;
+    bb bb1 (.a (a), .b (b), .o (c));
+    wb wb1 (.a (a), .b (b), .o (d));
+    some_mod some_inst (.a (c), .b (d), .o (o));
+endmodule
+
+(* blackbox *)
+module bb(input a, b, output o);
+assign o = a | b;
+specify
+	(a => o) = 1;
+endspecify
+endmodule
+
+(* whitebox *)
+module wb(input a, b, output o);
+assign o = a ^ b;
+endmodule
+
+module some_mod(input a, b, output o);
+assign o = a & b;
+endmodule
+EOT
+
+select top
+
+select -assert-count 2 =t:?b
+setundef -blackbox -anyseq
+select -assert-count 2 t:$anyseq
+select -assert-count 0 =t:?b


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
From Dev JF:
> Add an option -blackbox to setundef which will operate on the non-blackbox modules and remove the instances (cells) of blackbox modules and connect their outputs to $anyseq cells instead. Make this the default in SBY. This way we avoid any problems with needing to derive de-blackboxed modules to handle I/O signals with parametrizable widths, which isn't possible when they came from verific.

_Explain how this is achieved._
- [x] Add `-blackbox` option to `setundef`.  If used, all instances of blackboxes in a module will be removed via `cutpoint -undef`.  The undef wires can then be handled as usual by `setundef`.  e.g. `setundef -blackbox -anyseq` will remove instances of blackboxes and replace their outputs with `$anyseq` cells.
- [x] Add test for `setundef -blackbox`.
- [ ] Add `$scopeinfo` cells for removed instances (should this be in `cutpoint` or in `setundef`?)

_If applicable, please suggest to reviewers how they can test the change._
