### PR TITLE
macc: Stop using the B port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -869,6 +869,7 @@ endif
 SH_ABC_TEST_DIRS =
 SH_ABC_TEST_DIRS += tests/memories
 SH_ABC_TEST_DIRS += tests/aiger
+SH_ABC_TEST_DIRS += tests/alumacc
 
 # seed-tests/ is a dummy string, not a directory
 .PHONY: seed-tests

--- a/kernel/consteval.h
+++ b/kernel/consteval.h
@@ -315,9 +315,6 @@ struct ConstEval
 			Macc macc;
 			macc.from_cell(cell);
 
-			if (!eval(macc.bit_ports, undef, cell))
-				return false;
-
 			for (auto &port : macc.ports) {
 				if (!eval(port.in_a, undef, cell))
 					return false;

--- a/kernel/satgen.cc
+++ b/kernel/satgen.cc
@@ -743,7 +743,6 @@ bool SatGen::importCell(RTLIL::Cell *cell, int timestep)
 	if (cell->type == ID($macc))
 	{
 		std::vector<int> a = importDefSigSpec(cell->getPort(ID::A), timestep);
-		std::vector<int> b = importDefSigSpec(cell->getPort(ID::B), timestep);
 		std::vector<int> y = importDefSigSpec(cell->getPort(ID::Y), timestep);
 
 		Macc macc;
@@ -783,12 +782,6 @@ bool SatGen::importCell(RTLIL::Cell *cell, int timestep)
 				else
 					tmp = ez->vec_add(tmp, in_a);
 			}
-		}
-
-		for (int i = 0; i < GetSize(b); i++) {
-			std::vector<int> val(GetSize(y), ez->CONST_FALSE);
-			val.at(0) = b.at(i);
-			tmp = ez->vec_add(tmp, val);
 		}
 
 		if (model_undef)

--- a/passes/opt/share.cc
+++ b/passes/opt/share.cc
@@ -117,7 +117,7 @@ struct ShareWorker
 
 	static int bits_macc(const Macc &m, int width)
 	{
-		int bits = GetSize(m.bit_ports);
+		int bits = 0;
 		for (auto &p : m.ports)
 			bits += bits_macc_port(p, width);
 		return bits;

--- a/passes/techmap/alumacc.cc
+++ b/passes/techmap/alumacc.cc
@@ -283,7 +283,7 @@ struct AlumaccWorker
 		for (auto &it : sig_macc)
 		{
 			auto n = it.second;
-			RTLIL::SigSpec A, B, C = n->macc.bit_ports;
+			RTLIL::SigSpec A, B, C;
 			bool a_signed = false, b_signed = false;
 			bool subtract_b = false;
 			alunode_t *alunode;

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -201,18 +201,19 @@ static RTLIL::Cell* create_gold_module(RTLIL::Design *design, RTLIL::IdString ce
 			this_port.do_subtract = xorshift32(2) == 1;
 			macc.ports.push_back(this_port);
 		}
-
-		wire = module->addWire(ID::B);
-		wire->width = xorshift32(mulbits_a ? xorshift32(4)+1 : xorshift32(16)+1);
-		wire->port_input = true;
-		macc.bit_ports = wire;
+		// Macc::to_cell sets the input ports
+		macc.to_cell(cell);
 
 		wire = module->addWire(ID::Y);
 		wire->width = width;
 		wire->port_output = true;
 		cell->setPort(ID::Y, wire);
 
-		macc.to_cell(cell);
+		// override the B input (macc helpers always sets an empty vector)
+		wire = module->addWire(ID::B);
+		wire->width = xorshift32(mulbits_a ? xorshift32(4)+1 : xorshift32(16)+1);
+		wire->port_input = true;
+		cell->setPort(ID::B, wire);
 	}
 
 	if (cell_type == ID($lut))

--- a/tests/alumacc/macc_b_port_compat.ys
+++ b/tests/alumacc/macc_b_port_compat.ys
@@ -1,0 +1,50 @@
+# We don't set the B port on $macc cells anymore,
+# test compatibility with older RTLIL files which can
+# have the B port populated
+
+read_verilog <<EOF
+module gold(input signed [2:0] a1, input signed [2:0] b1,
+			input [1:0] a2, input [3:0] b2, input c, input d, output signed [3:0] y);
+  wire signed [3:0] ab1;
+  assign ab1 = a1 * b1;
+  assign y = ab1 + a2*b2 + c + d + 1;
+endmodule
+EOF
+prep
+
+# test the model for $macc including the retired B parameter
+# matches the gold module
+read_rtlil <<EOF
+attribute \src "<<EOF:1.1-4.10"
+module \gate
+  wire width 3 input 1 signed \a1
+  wire width 2 input 3 \a2
+  wire width 3 input 2 signed \b1
+  wire width 4 input 4 \b2
+  wire input 5 \c
+  wire input 6 \d
+  wire width 4 output 7 signed \y
+
+  cell $macc $1
+    parameter \A_WIDTH 12
+    parameter \B_WIDTH 3
+    parameter \CONFIG 20'01010000011011010011
+    parameter \CONFIG_WIDTH 20
+    parameter \Y_WIDTH 4
+    connect \A { \a2 \b2 \b1 \a1 }
+    connect \B { \d \c 1'1 }
+    connect \Y \y
+  end
+end
+EOF
+
+design -save gold_gate
+equiv_make gold gate equiv
+equiv_induct equiv
+equiv_status -assert equiv
+
+design -load gold_gate
+maccmap gate
+equiv_make gold gate equiv
+equiv_induct equiv
+equiv_status -assert equiv

--- a/tests/alumacc/run-test.sh
+++ b/tests/alumacc/run-test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+for x in *.ys; do
+  echo "Running $x.."
+  ../../yosys -ql ${x%.ys}.log $x
+done


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
_Explain how this is achieved._

The B port is for single-bit summands. These can just as well be represented as an additional summand on the A port (which supports summands of arbitrary width). An upcoming `$macc_v2` cell won't be special-casing single-bit summands in any way.

In preparation, make the following changes:

 * remove the `bit_ports` field from the `Macc` helper (instead add any single-bit summands to `ports` next to other summands)

 * leave `B` empty on cells emitted from `Macc::to_cell`

_If applicable, please suggest to reviewers how they can test the change._

An included test makes sure we interpret the B port on existing RTLIL exports.