### PR TITLE
yw: fix unintensional recursion in hash_into

### DIFF
--- a/kernel/yw.h
+++ b/kernel/yw.h
@@ -35,7 +35,10 @@ struct IdPath : public std::vector<RTLIL::IdString>
 	bool has_address() const { int tmp; return get_address(tmp); };
 	bool get_address(int &addr) const;
 
-	Hasher hash_into(Hasher h) const { h.eat(*this); return h; }
+	Hasher hash_into(Hasher h) const {
+		h.eat(static_cast<const std::vector<RTLIL::IdString>&&>(*this));
+		return h;
+	}
 };
 
 struct WitnessHierarchyItem {


### PR DESCRIPTION
`IdPath` is an `std::vector<IdString>` with extra methods and should be hashed as `std::vector<IdString>`. That was the intention behind this implementation but it ended up creating unintential recursion