### PR TITLE
yosys_common: fix gcc warning in #error directive

### DIFF
--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -134,7 +134,7 @@ YOSYS_NAMESPACE_BEGIN
 // Note: All headers included in hashlib.h must be included
 // outside of YOSYS_NAMESPACE before this or bad things will happen.
 #ifdef HASHLIB_H
-#  error You've probably included hashlib.h under two namespace paths. Bad idea.
+#  error "You've probably included hashlib.h under two namespace paths. Bad idea."
 #else
 #  include "kernel/hashlib.h"
 #  undef HASHLIB_H


### PR DESCRIPTION
See [here](https://stackoverflow.com/a/37195204/8048373)