### PR TITLE
Update ALU MULT mode in gowin to match nextpnr

### DIFF
--- a/techlibs/gowin/cells_sim.v
+++ b/techlibs/gowin/cells_sim.v
@@ -1005,7 +1005,7 @@ always @* begin
 			C = I0;
 		end
 		MULT: begin
-			S = I0 & I1;
+			S = (I0 & I1) ^ I3;
 			C = I0 & I1;
 		end
 	endcase


### PR DESCRIPTION
`nextpnr` currently wires an ALU in `MULT` mode in a different fashion than expected. Instead of `I2` to `GND`, it is connected to `VCC`. This has been mentioned in https://github.com/YosysHQ/nextpnr/pull/1407. While fixing this in `nextpnr` would work, leaving it as-is is arguably a better option, since it can perform the same operations plus being able to take a second operand. This would have a profound impact if choosing to synthesize multiplication using this mode.

So, instead of fixing the wiring in `nextpnr`, this PR seeks to update the expected behavior of the cell to reflect the current wiring.

`yosys` doesn't use this mode yet, and therefore no tests or workflows should be impacted.