### PR TITLE
dfflibmap: Adds flop name preserving pass to match write_verilog

### DIFF
--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -483,28 +483,30 @@ static void find_cell_sr(const LibertyAst *ast, IdString cell_type, bool clkpol,
 	}
 }
 
-std::optional<std::string> generate_flop_name(RTLIL::Cell *cell,
-                                              RTLIL::Module *curren_module) {
-  if (!RTLIL::builtin_ff_cell_types().count(cell->type) ||
-      !cell->hasPort(ID::Q)) {
-    return std::nullopt;
-  }
+std::optional<std::string> generate_flop_name(RTLIL::Cell *cell, RTLIL::Module *current_module)
+{
+	if (!RTLIL::builtin_ff_cell_types().count(cell->type) || !cell->hasPort(ID::Q)) {
+		return std::nullopt;
+	}
 
-  RTLIL::SigSpec flop_q_port = cell->getPort(ID::Q);
-  RTLIL::Wire *src_wire = flop_q_port[0].wire;
-  std::string cell_name = src_wire->name.str();
+	RTLIL::SigSpec flop_q_port = cell->getPort(ID::Q);
+	RTLIL::Wire *src_wire = flop_q_port[0].wire;
+	std::string cell_name = src_wire->name.str();
 
-  size_t pos = cell_name.find('[');
-  if (pos != std::string::npos)
-    cell_name = cell_name.substr(0, pos) + "_reg" + cell_name.substr(pos);
-  else
-    cell_name = cell_name + "_reg";
+	size_t pos = cell_name.find('[');
+	if (pos != std::string::npos)
+		cell_name = cell_name.substr(0, pos) + "_reg" + cell_name.substr(pos);
+	else
+		cell_name = cell_name + "_reg";
 
-  if (src_wire->width != 1) {
-    cell_name +=
-        stringf("[%d]", src_wire->start_offset + flop_q_port[0].offset);
-  }
-	
+	if (src_wire->width != 1) {
+		cell_name += stringf("[%d]", src_wire->start_offset + flop_q_port[0].offset);
+	}
+
+	if (current_module && current_module->count_id(cell_name) > 0) {
+		return std::nullopt;
+	}
+
 	return cell_name;
 }
 


### PR DESCRIPTION


_What are the reasons/motivation for this change?_
When using the dfflibmap pass it prevents write_verilog from adding proper flop names based on the Q output port. This makes it harder to read timing reports in OpenROAD. This code only works on internal flop types and does not work for cells mapped to standard cell modules.

See code in write_verilog:
```c++
if (!norename && cell->name[0] == '$' && RTLIL::builtin_ff_cell_types().count(cell->type) && cell->hasPort(ID::Q) && !cell->type.in(ID($ff), ID($_FF_)))
	{
		RTLIL::SigSpec sig = cell->getPort(ID::Q);
		if (GetSize(sig) != 1 || sig.is_fully_const())
			goto no_special_reg_name;

		RTLIL::Wire *wire = sig[0].wire;

		if (wire->name[0] != '\\')
			goto no_special_reg_name;

		std::string cell_name = wire->name.str();

		size_t pos = cell_name.find('[');
		if (pos != std::string::npos)
			cell_name = cell_name.substr(0, pos) + "_reg" + cell_name.substr(pos);
		else
			cell_name = cell_name + "_reg";

		if (wire->width != 1)
			cell_name += stringf("[%d]", wire->start_offset + sig[0].offset);

		if (active_module && active_module->count_id(cell_name) > 0)
				goto no_special_reg_name;

		return id(cell_name);
	}
```

_Explain how this is achieved._

If the user passes -infer_flop_names to dfflibmap then it will attempt to rename flops based on the Q input port of the flop. This follows a similar renaming as in write_verilog, but that only works on $DFF and $dff based cell.

_If applicable, please suggest to reviewers how they can test the change._

Pass -infer_flop_names to dfflibmap