### PR TITLE
Docs: Remove restructure note

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,17 +7,6 @@ see :doc:`/introduction`.  For a quick guide on how to get started using Yosys,
 check out :doc:`/getting_started/index`.  For the complete list of commands
 available, go to :ref:`commandindex`.
 
-.. note::
-
-   This documentation recently went through a major restructure.  If you're
-   looking for something from the previous version and can't find it here,
-   please `let us know`_.  Documentation from before the restructure can still
-   be found by switching to `version 0.36`_ or earlier.  Note that the previous
-   theme does not include a version switcher.
-
-.. _let us know: https://github.com/YosysHQ/yosys/issues/new/choose
-.. _version 0.36: https://yosyshq.readthedocs.io/projects/yosys/en/0.36/
-
 .. todo:: look into command ref improvements
 
    - Search bar with live drop down suggestions for matching on title /


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
It's been almost a year since the restructure, so it's not recent anymore and doesn't need to link back to the old version.

_Explain how this is achieved._
Remove the note (and associated links).

_If applicable, please suggest to reviewers how they can test the change._
[Preview build](https://yosyshq.readthedocs.io/projects/yosys/en/docs-preview-norestructure/) (note the TODOs don't appear in release builds).