### PR TITLE
share: fix misleading 0 cells log message

### DIFF
--- a/passes/opt/share.cc
+++ b/passes/opt/share.cc
@@ -1255,7 +1255,6 @@ struct ShareWorker
 					qcsat.max_cell_count = 100;
 				}
 
-				pool<RTLIL::Cell*> sat_cells;
 				std::set<RTLIL::SigBit> bits_queue;
 
 				std::vector<int> cell_active, other_cell_active;
@@ -1298,8 +1297,8 @@ struct ShareWorker
 
 				qcsat.ez->assume(qcsat.ez->AND(sub1, sub2));
 
-				log("      Size of SAT problem: %d cells, %d variables, %d clauses\n",
-						GetSize(sat_cells), qcsat.ez->numCnfVariables(), qcsat.ez->numCnfClauses());
+				log("      Size of SAT problem: %d variables, %d clauses\n",
+						qcsat.ez->numCnfVariables(), qcsat.ez->numCnfClauses());
 
 				if (qcsat.ez->solve(sat_model, sat_model_values)) {
 					log("      According to the SAT solver this pair of cells can not be shared.\n");


### PR DESCRIPTION
Prior to this PR, yosys would always print "0 cells" in the affected log message since `sat_cells` is an otherwise unused object. This may mislead users about the SAT being stuck thinking about nothing. This PR removes this alleged cell count instead. There is no replacement cell count implemented, open to suggestions or followups.

`../../yosys share.ys | grep "Size of SAT"` demonstrates this well:

```
      Size of SAT problem: 0 cells, 8 variables, 19 clauses
      Size of SAT problem: 0 cells, 8 variables, 19 clauses
      Size of SAT problem: 0 cells, 240 variables, 617 clauses
      Size of SAT problem: 0 cells, 236 variables, 605 clauses
      Size of SAT problem: 0 cells, 245 variables, 632 clauses
```

Credit for digging up the report to @JulianKemmerer
