### PR TITLE
write_json: add option to include $scopeinfo cells

### DIFF
--- a/backends/json/json.cc
+++ b/backends/json/json.cc
@@ -193,8 +193,6 @@ struct JsonWriter
 		for (auto c : module->cells()) {
 			if (use_selection && !module->selected(c))
 				continue;
-			// Eventually we will want to emit $scopeinfo, but currently this
-			// will break JSON netlist consumers like nextpnr
 			if (!scopeinfo_mode && c->type == ID($scopeinfo))
 				continue;
 			f << stringf("%s\n", first ? "" : ",");
@@ -357,8 +355,8 @@ struct JsonBackend : public Backend {
 		log("    -selected\n");
 		log("        output only select module\n");
 		log("\n");
-		log("    -scopeinfo\n");
-		log("        include $scopeinfo cells in the output\n");
+		log("    -noscopeinfo\n");
+		log("        don't include $scopeinfo cells in the output\n");
 		log("\n");
 		log("\n");
 		log("The general syntax of the JSON output created by this command is as follows:\n");
@@ -605,7 +603,7 @@ struct JsonBackend : public Backend {
 		bool aig_mode = false;
 		bool compat_int_mode = false;
 		bool use_selection = false;
-		bool scopeinfo_mode = false;
+		bool scopeinfo_mode = true;
 
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
@@ -622,8 +620,8 @@ struct JsonBackend : public Backend {
 				use_selection = true;
 				continue;
 			}
-			if (args[argidx] == "-scopeinfo") {
-				scopeinfo_mode = true;
+			if (args[argidx] == "-noscopeinfo") {
+				scopeinfo_mode = false;
 				continue;
 			}
 			break;
@@ -657,8 +655,8 @@ struct JsonPass : public Pass {
 		log("        emit 32-bit or smaller fully-defined parameter values directly\n");
 		log("        as JSON numbers (for compatibility with old parsers)\n");
 		log("\n");
-		log("    -scopeinfo\n");
-		log("        include $scopeinfo cells in the output\n");
+		log("    -noscopeinfo\n");
+		log("        don't include $scopeinfo cells in the output\n");
 		log("\n");
 		log("See 'help write_json' for a description of the JSON format used.\n");
 		log("\n");
@@ -668,7 +666,7 @@ struct JsonPass : public Pass {
 		std::string filename;
 		bool aig_mode = false;
 		bool compat_int_mode = false;
-		bool scopeinfo_mode = false;
+		bool scopeinfo_mode = true;
 
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
@@ -685,8 +683,8 @@ struct JsonPass : public Pass {
 				compat_int_mode = true;
 				continue;
 			}
-			if (args[argidx] == "-scopeinfo") {
-				scopeinfo_mode = true;
+			if (args[argidx] == "-noscopeinfo") {
+				scopeinfo_mode = false;
 				continue;
 			}
 			break;

--- a/tests/various/json_scopeinfo.ys
+++ b/tests/various/json_scopeinfo.ys
@@ -1,0 +1,38 @@
+read_verilog <<EOT
+module top(input in, output out);
+	wire [1:0] w1, w2;
+	f1_test u1 (.in(in), .out(w1[0]));
+	f2_test u2 (.in(w1), .out(w2));
+	f3_test u3 (.in(w2[0]), .out(out));
+endmodule
+
+module f1_test(input in, output out);
+	assign out = in;
+endmodule
+
+module f2_test(input [1:0] in, output [1:0] out);
+	assign out[0] = in[0];
+	assign out[1] = in[1];
+endmodule
+
+module f3_test(input in, output [1:0] out);
+	assign out[0] = in;
+	assign out[1] = in;
+endmodule
+EOT
+
+hierarchy -top top
+flatten -scopename
+prep
+
+write_json json_scopeinfo.out
+!grep -qvF '$scopeinfo' json_scopeinfo.out
+
+write_json -scopeinfo json_scopeinfo.out
+!grep -qF '$scopeinfo' json_scopeinfo.out
+
+json -o json_scopeinfo.out
+!grep -qvF '$scopeinfo' json_scopeinfo.out
+
+json -scopeinfo -o json_scopeinfo.out
+!grep -qF '$scopeinfo' json_scopeinfo.out

--- a/tests/various/json_scopeinfo.ys
+++ b/tests/various/json_scopeinfo.ys
@@ -26,13 +26,13 @@ flatten -scopename
 prep
 
 write_json json_scopeinfo.out
-!grep -qvF '$scopeinfo' json_scopeinfo.out
-
-write_json -scopeinfo json_scopeinfo.out
 !grep -qF '$scopeinfo' json_scopeinfo.out
+
+write_json -noscopeinfo json_scopeinfo.out
+!grep -qvF '$scopeinfo' json_scopeinfo.out
 
 json -o json_scopeinfo.out
-!grep -qvF '$scopeinfo' json_scopeinfo.out
-
-json -scopeinfo -o json_scopeinfo.out
 !grep -qF '$scopeinfo' json_scopeinfo.out
+
+json -noscopeinfo -o json_scopeinfo.out
+!grep -qvF '$scopeinfo' json_scopeinfo.out


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Linty want to use the JSON output to build interactive netlist visualization, including of flattened designs. The information carried by `$scopeinfo` cells is valuable for that purpose.

_Explain how this is achieved._

Add an argument to override the logic that currently skips `$scopeinfo`.

_If applicable, please suggest to reviewers how they can test the change._

Testcase included