### PR TITLE
keep_hierarchy.cc: use strictly correct syntax for printf of uint64_t values

### DIFF
--- a/passes/hierarchy/keep_hierarchy.cc
+++ b/passes/hierarchy/keep_hierarchy.cc
@@ -17,6 +17,7 @@
  *
  */
 
+#include <inttypes.h>
 #include "kernel/yosys.h"
 #include "kernel/cost.h"
 
@@ -66,7 +67,7 @@ struct ThresholdHierarchyKeeping {
 		}
 
 		if (size > threshold) {
-			log("Keeping %s (estimated size above threshold: %llu > %llu).\n", log_id(module), size, threshold);
+			log("Keeping %s (estimated size above threshold: %" PRIu64 " > %" PRIu64 ").\n", log_id(module), size, threshold);
 			module->set_bool_attribute(ID::keep_hierarchy);
 			size = 0;
 		}


### PR DESCRIPTION
Removes two warnings from the compile, at least on amd64 arch
