### PR TITLE
enforce that hdlname/scopename is used consistently with public/private names

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -1464,7 +1464,8 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 		log("Importing module %s.\n", RTLIL::id2cstr(module->name));
 	}
 	import_attributes(module->attributes, nl, nl);
-	module->set_string_attribute(ID::hdlname, nl->CellBaseName());
+	if (module->name.isPublic())
+		module->set_string_attribute(ID::hdlname, nl->CellBaseName());
 	module->set_string_attribute(ID(library), nl->Owner()->Owner()->Name());
 #ifdef VERIFIC_VHDL_SUPPORT
 	if (nl->IsFromVhdl()) {

--- a/kernel/scopeinfo.h
+++ b/kernel/scopeinfo.h
@@ -337,7 +337,7 @@ template<typename O>
 std::vector<IdString> parse_hdlname(const O* object)
 {
 	std::vector<IdString> path;
-	if (!object->name.isPublic())
+	if (!object->name.isPublic() && !object->name.begins_with("$paramod") && !object->name.begins_with("$abstract"))
 		return path;
 	for (auto const &item : object->get_hdlname_attribute())
 		path.push_back("\\" + item);
@@ -351,7 +351,7 @@ std::pair<std::vector<IdString>, IdString> parse_scopename(const O* object)
 {
 	std::vector<IdString> path;
 	IdString trailing = object->name;
-	if (object->name.isPublic()) {
+	if (object->name.isPublic() || object->name.begins_with("$paramod") || object->name.begins_with("$abstract")) {
 		for (auto const &item : object->get_hdlname_attribute())
 			path.push_back("\\" + item);
 		if (!path.empty()) {

--- a/passes/fsm/fsm_extract.cc
+++ b/passes/fsm/fsm_extract.cc
@@ -377,6 +377,10 @@ static void extract_fsm(RTLIL::Wire *wire)
 	fsm_cell->setPort(ID::CTRL_OUT, ctrl_out);
 	fsm_cell->parameters[ID::NAME] = RTLIL::Const(wire->name.str());
 	fsm_cell->attributes = wire->attributes;
+	if(fsm_cell->attributes.count(ID::hdlname)) {
+		fsm_cell->attributes[ID(scopename)] = fsm_cell->attributes[ID::hdlname];
+		fsm_cell->attributes.erase(ID::hdlname);
+	}
 	fsm_data.copy_to_cell(fsm_cell);
 
 	// rename original state wire
@@ -384,6 +388,10 @@ static void extract_fsm(RTLIL::Wire *wire)
 	module->wires_.erase(wire->name);
 	wire->attributes.erase(ID::fsm_encoding);
 	wire->name = stringf("$fsm$oldstate%s", wire->name.c_str());
+	if(wire->attributes.count(ID::hdlname)) {
+		wire->attributes[ID(scopename)] = wire->attributes[ID::hdlname];
+		wire->attributes.erase(ID::hdlname);
+	}
 	module->wires_[wire->name] = wire;
 
 	// unconnect control outputs from old drivers


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

A number of passes and utilities use code of the shape `if(foo->name.isPublic()) { foo->get_hdlname_attribute(); }` which doesn't work as expected if the implicit invariant to use `hdlname` on public objects and `scopename` on private objects isn't upheld. Since this invariant is easy to break accidentally, enforce it.

_Explain how this is achieved._

Add checks in `Module::check()` to make sure the invariant holds for Module, Wire, Cell, and Memory names. (Should processes also be checked?)

_If applicable, please suggest to reviewers how they can test the change._

Run larger flows and examples, and rarely used passes, especially in combination with `flatten -scopename`.