### PR TITLE
CI: Sanitize for undefined behavior

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -56,6 +56,7 @@ jobs:
           mkdir build
           cd build
           make -f ../Makefile config-$CC
+          echo 'SANITIZER = undefined' >> Makefile.conf
           make -f ../Makefile -j$procs ENABLE_LTO=1
 
       - name: Log yosys-config output
@@ -82,6 +83,7 @@ jobs:
     if: needs.pre_job.outputs.should_skip != 'true'
     env:
       CC: clang
+      UBSAN_OPTIONS: halt_on_error=1
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/libs/fst/00_PATCH_strict_alignment.patch
+++ b/libs/fst/00_PATCH_strict_alignment.patch
@@ -1,0 +1,42 @@
+diff --git a/fastlz.cc b/fastlz.cc
+index 3272ca7a8..41ea27a16 100644
+--- a/fastlz.cc
++++ b/fastlz.cc
+@@ -60,24 +60,9 @@
+ #endif
+ 
+ /*
+- * Prevent accessing more than 8-bit at once, except on x86 architectures.
++ * Yosys patch: do not do unaligned accesses on any platform
+  */
+-#if !defined(FASTLZ_STRICT_ALIGN)
+ #define FASTLZ_STRICT_ALIGN
+-#if defined(__i386__) || defined(__386)  /* GNU C, Sun Studio */
+-#undef FASTLZ_STRICT_ALIGN
+-#elif defined(__i486__) || defined(__i586__) || defined(__i686__) || defined(__amd64) /* GNU C */
+-#undef FASTLZ_STRICT_ALIGN
+-#elif defined(_M_IX86) /* Intel, MSVC */
+-#undef FASTLZ_STRICT_ALIGN
+-#elif defined(__386)
+-#undef FASTLZ_STRICT_ALIGN
+-#elif defined(_X86_) /* MinGW */
+-#undef FASTLZ_STRICT_ALIGN
+-#elif defined(__I86__) /* Digital Mars */
+-#undef FASTLZ_STRICT_ALIGN
+-#endif
+-#endif
+ 
+ /* prototypes */
+ int fastlz_compress(const void* input, int length, void* output);
+@@ -88,11 +73,7 @@ int fastlz_decompress(const void* input, int length, void* output, int maxout);
+ #define MAX_LEN       264  /* 256 + 8 */
+ #define MAX_DISTANCE 8192
+ 
+-#if !defined(FASTLZ_STRICT_ALIGN)
+-#define FASTLZ_READU16(p) *((const flzuint16*)(p))
+-#else
+ #define FASTLZ_READU16(p) ((p)[0] | (p)[1]<<8)
+-#endif
+ 
+ #define HASH_LOG  13
+ #define HASH_SIZE (1<< HASH_LOG)

--- a/libs/fst/00_UPDATE.sh
+++ b/libs/fst/00_UPDATE.sh
@@ -17,3 +17,4 @@ sed -i -e 's,"fastlz.c","fastlz.cc",' *.cc *.h
 
 patch -p0 < 00_PATCH_win_zlib.patch
 patch -p0 < 00_PATCH_win_io.patch
+patch -p1 < 00_PATCH_strict_alignment.patch

--- a/libs/fst/fastlz.cc
+++ b/libs/fst/fastlz.cc
@@ -60,24 +60,9 @@
 #endif
 
 /*
- * Prevent accessing more than 8-bit at once, except on x86 architectures.
+ * Yosys patch: do not do unaligned accesses on any platform
  */
-#if !defined(FASTLZ_STRICT_ALIGN)
 #define FASTLZ_STRICT_ALIGN
-#if defined(__i386__) || defined(__386)  /* GNU C, Sun Studio */
-#undef FASTLZ_STRICT_ALIGN
-#elif defined(__i486__) || defined(__i586__) || defined(__i686__) || defined(__amd64) /* GNU C */
-#undef FASTLZ_STRICT_ALIGN
-#elif defined(_M_IX86) /* Intel, MSVC */
-#undef FASTLZ_STRICT_ALIGN
-#elif defined(__386)
-#undef FASTLZ_STRICT_ALIGN
-#elif defined(_X86_) /* MinGW */
-#undef FASTLZ_STRICT_ALIGN
-#elif defined(__I86__) /* Digital Mars */
-#undef FASTLZ_STRICT_ALIGN
-#endif
-#endif
 
 /* prototypes */
 int fastlz_compress(const void* input, int length, void* output);
@@ -88,11 +73,7 @@ int fastlz_decompress(const void* input, int length, void* output, int maxout);
 #define MAX_LEN       264  /* 256 + 8 */
 #define MAX_DISTANCE 8192
 
-#if !defined(FASTLZ_STRICT_ALIGN)
-#define FASTLZ_READU16(p) *((const flzuint16*)(p))
-#else
 #define FASTLZ_READU16(p) ((p)[0] | (p)[1]<<8)
-#endif
 
 #define HASH_LOG  13
 #define HASH_SIZE (1<< HASH_LOG)


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Yosys includes some amount of buggy code that invokes undefined behavior, e.g. https://github.com/YosysHQ/yosys/issues/4844. This should be fixed and stay fixed.

_Explain how this is achieved._

By running the Undefined Behavior Sanitizer on each commit/PR. UBSan does not have false positives and has a slim impact on performance, so this is done unconditionally.

_If applicable, please suggest to reviewers how they can test the change._

Add `SANITIZER = undefined` to your `Makefile.conf`, then run `make clean && make && UBSAN_OPTIONS=halt_on_error=1 make test`.