### PR TITLE
Stop and prevent discarding hash_into values

### DIFF
--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -177,7 +177,7 @@ namespace AST
 	{
 		// for dict<> and pool<>
 		unsigned int hashidx_;
-		Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
+		[[nodiscard]] Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
 
 		// this nodes type
 		AstNodeType type;

--- a/kernel/bitpattern.h
+++ b/kernel/bitpattern.h
@@ -43,7 +43,7 @@ struct BitPatternPool
 				return false;
 			return bitdata == other.bitdata;
 		}
-		Hasher hash_into(Hasher h) const {
+		[[nodiscard]] Hasher hash_into(Hasher h) const {
 			if (!cached_hash)
 				cached_hash = run_hash(bitdata);
 			h.eat(cached_hash);

--- a/kernel/cellaigs.h
+++ b/kernel/cellaigs.h
@@ -34,7 +34,7 @@ struct AigNode
 
 	AigNode();
 	bool operator==(const AigNode &other) const;
-	Hasher hash_into(Hasher h) const;
+	[[nodiscard]] Hasher hash_into(Hasher h) const;
 };
 
 struct Aig
@@ -44,7 +44,7 @@ struct Aig
 	Aig(Cell *cell);
 
 	bool operator==(const Aig &other) const;
-	Hasher hash_into(Hasher h) const;
+	[[nodiscard]] Hasher hash_into(Hasher h) const;
 };
 
 YOSYS_NAMESPACE_END

--- a/kernel/drivertools.h
+++ b/kernel/drivertools.h
@@ -74,7 +74,7 @@ struct DriveBitWire
 		return offset < other.offset;
 	}
 
-	Hasher hash_into(Hasher h) const;
+	[[nodiscard]] Hasher hash_into(Hasher h) const;
 
 
 	operator SigBit() const
@@ -105,7 +105,7 @@ struct DriveBitPort
 		return offset < other.offset;
 	}
 
-	Hasher hash_into(Hasher h) const;
+	[[nodiscard]] Hasher hash_into(Hasher h) const;
 
 };
 
@@ -129,7 +129,7 @@ struct DriveBitMarker
 		return offset < other.offset;
 	}
 
-	Hasher hash_into(Hasher h) const;
+	[[nodiscard]] Hasher hash_into(Hasher h) const;
 
 };
 
@@ -164,7 +164,7 @@ public:
 		return multiple_ == other.multiple_;
 	}
 
-	Hasher hash_into(Hasher h) const;
+	[[nodiscard]] Hasher hash_into(Hasher h) const;
 };
 
 struct DriveBit
@@ -352,7 +352,7 @@ public:
 		return *this;
 	}
 
-	Hasher hash_into(Hasher h) const;
+	[[nodiscard]] Hasher hash_into(Hasher h) const;
 
 	bool operator==(const DriveBit &other) const
 	{
@@ -473,7 +473,7 @@ struct DriveChunkWire
 		return offset < other.offset;
 	}
 
-	Hasher hash_into(Hasher h) const;
+	[[nodiscard]] Hasher hash_into(Hasher h) const;
 
 	explicit operator SigChunk() const
 	{
@@ -531,7 +531,7 @@ struct DriveChunkPort
 		return offset < other.offset;
 	}
 
-	Hasher hash_into(Hasher h) const;
+	[[nodiscard]] Hasher hash_into(Hasher h) const;
 };
 
 
@@ -572,7 +572,7 @@ struct DriveChunkMarker
 		return offset < other.offset;
 	}
 
-	Hasher hash_into(Hasher h) const;
+	[[nodiscard]] Hasher hash_into(Hasher h) const;
 };
 
 struct DriveChunkMultiple
@@ -612,7 +612,7 @@ public:
 		return false; // TODO implement, canonicalize order
 	}
 
-	Hasher hash_into(Hasher h) const;
+	[[nodiscard]] Hasher hash_into(Hasher h) const;
 };
 
 struct DriveChunk
@@ -863,7 +863,7 @@ public:
 	bool try_append(DriveBit const &bit);
 	bool try_append(DriveChunk const &chunk);
 
-	Hasher hash_into(Hasher h) const;
+	[[nodiscard]] Hasher hash_into(Hasher h) const;
 
 	bool operator==(const DriveChunk &other) const
 	{
@@ -1074,7 +1074,7 @@ public:
 		hash_ |= (hash_ == 0);
 	}
 
-	Hasher hash_into(Hasher h) const;
+	[[nodiscard]] Hasher hash_into(Hasher h) const;
 
 	bool operator==(DriveSpec const &other) const {
 		updhash();
@@ -1112,7 +1112,7 @@ private:
 		bool operator==(const DriveBitId &other) const { return id == other.id; }
 		bool operator!=(const DriveBitId &other) const { return id != other.id; }
 		bool operator<(const DriveBitId &other) const { return id < other.id; }
-		Hasher hash_into(Hasher h) const;
+		[[nodiscard]] Hasher hash_into(Hasher h) const;
 	};
 	// Essentially a dict<DriveBitId, pool<DriveBitId>> but using less memory
 	// and fewer allocations

--- a/kernel/functional.h
+++ b/kernel/functional.h
@@ -151,7 +151,7 @@ namespace Functional {
 		// returns the data width of a bitvector sort, errors out for other sorts
 		int data_width() const { return std::get<1>(_v).second; }
 		bool operator==(Sort const& other) const { return _v == other._v; }
-		Hasher hash_into(Hasher h) const { h.eat(_v); return h; }
+		[[nodiscard]] Hasher hash_into(Hasher h) const { h.eat(_v); return h; }
 	};
 	class IR;
 	class Factory;
@@ -225,7 +225,7 @@ namespace Functional {
 			const RTLIL::Const &as_const() const { return std::get<RTLIL::Const>(_extra); }
 			std::pair<IdString, IdString> as_idstring_pair() const { return std::get<std::pair<IdString, IdString>>(_extra); }
 			int as_int() const { return std::get<int>(_extra); }
-			Hasher hash_into(Hasher h) const {
+			[[nodiscard]] Hasher hash_into(Hasher h) const {
 				h.eat((unsigned int) _fn);
 				h.eat(_extra);
 				return h;

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -162,7 +162,7 @@ struct hash_ops {
 	static inline bool cmp(const T &a, const T &b) {
 		return a == b;
 	}
-	static inline Hasher hash_into(const T &a, Hasher h) {
+	[[nodiscard]] static inline Hasher hash_into(const T &a, Hasher h) {
 		if constexpr (std::is_integral_v<T>) {
 			static_assert(sizeof(T) <= sizeof(uint64_t));
 			if (sizeof(T) == sizeof(uint64_t))
@@ -189,7 +189,7 @@ template<typename P, typename Q> struct hash_ops<std::pair<P, Q>> {
 	static inline bool cmp(std::pair<P, Q> a, std::pair<P, Q> b) {
 		return a == b;
 	}
-	static inline Hasher hash_into(std::pair<P, Q> a, Hasher h) {
+	[[nodiscard]] static inline Hasher hash_into(std::pair<P, Q> a, Hasher h) {
 		h = hash_ops<P>::hash_into(a.first, h);
 		h = hash_ops<Q>::hash_into(a.second, h);
 		return h;
@@ -217,7 +217,7 @@ template<typename T> struct hash_ops<std::vector<T>> {
 	static inline bool cmp(std::vector<T> a, std::vector<T> b) {
 		return a == b;
 	}
-	static inline Hasher hash_into(std::vector<T> a, Hasher h) {
+	[[nodiscard]] static inline Hasher hash_into(std::vector<T> a, Hasher h) {
 		h.eat((uint32_t)a.size());
 		for (auto k : a)
 			h.eat(k);
@@ -229,7 +229,7 @@ template<typename T, size_t N> struct hash_ops<std::array<T, N>> {
     static inline bool cmp(std::array<T, N> a, std::array<T, N> b) {
         return a == b;
     }
-    static inline Hasher hash_into(std::array<T, N> a, Hasher h) {
+    [[nodiscard]] static inline Hasher hash_into(std::array<T, N> a, Hasher h) {
         for (const auto& k : a)
             h = hash_ops<T>::hash_into(k, h);
         return h;
@@ -240,7 +240,7 @@ struct hash_cstr_ops {
 	static inline bool cmp(const char *a, const char *b) {
 		return strcmp(a, b) == 0;
 	}
-	static inline Hasher hash_into(const char *a, Hasher h) {
+	[[nodiscard]] static inline Hasher hash_into(const char *a, Hasher h) {
 		while (*a)
 			h.hash32(*(a++));
 		return h;
@@ -253,7 +253,7 @@ struct hash_ptr_ops {
 	static inline bool cmp(const void *a, const void *b) {
 		return a == b;
 	}
-	static inline Hasher hash_into(const void *a, Hasher h) {
+	[[nodiscard]] static inline Hasher hash_into(const void *a, Hasher h) {
 		return hash_ops<uintptr_t>::hash_into((uintptr_t)a, h);
 	}
 };
@@ -263,7 +263,7 @@ struct hash_obj_ops {
 		return a == b;
 	}
 	template<typename T>
-	static inline Hasher hash_into(const T *a, Hasher h) {
+	[[nodiscard]] static inline Hasher hash_into(const T *a, Hasher h) {
 		if (a)
 			h = a->hash_into(h);
 		else
@@ -295,7 +295,7 @@ template<> struct hash_ops<std::monostate> {
 	static inline bool cmp(std::monostate a, std::monostate b) {
 		return a == b;
 	}
-	static inline Hasher hash_into(std::monostate, Hasher h) {
+	[[nodiscard]] static inline Hasher hash_into(std::monostate, Hasher h) {
 		return h;
 	}
 };
@@ -304,7 +304,7 @@ template<typename... T> struct hash_ops<std::variant<T...>> {
 	static inline bool cmp(std::variant<T...> a, std::variant<T...> b) {
 		return a == b;
 	}
-	static inline Hasher hash_into(std::variant<T...> a, Hasher h) {
+	[[nodiscard]] static inline Hasher hash_into(std::variant<T...> a, Hasher h) {
 		std::visit([& h](const auto &v) { h.eat(v); }, a);
 		h.eat(a.index());
 		return h;
@@ -315,7 +315,7 @@ template<typename T> struct hash_ops<std::optional<T>> {
 	static inline bool cmp(std::optional<T> a, std::optional<T> b) {
 		return a == b;
 	}
-	static inline Hasher hash_into(std::optional<T> a, Hasher h) {
+	[[nodiscard]] static inline Hasher hash_into(std::optional<T> a, Hasher h) {
 		if(a.has_value())
 			h.eat(*a);
 		else
@@ -788,7 +788,7 @@ public:
 		return !operator==(other);
 	}
 
-	Hasher hash_into(Hasher h) const {
+	[[nodiscard]] Hasher hash_into(Hasher h) const {
 		for (auto &it : entries) {
 			Hasher entry_hash;
 			entry_hash.eat(it.udata.first);
@@ -1158,7 +1158,7 @@ public:
 		return !operator==(other);
 	}
 
-	Hasher hash_into(Hasher h) const {
+	[[nodiscard]] Hasher hash_into(Hasher h) const {
 		for (auto &it : entries) {
 			h.commutative_eat(ops.hash(it.udata).yield());
 		}

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -265,7 +265,7 @@ struct hash_obj_ops {
 	template<typename T>
 	static inline Hasher hash_into(const T *a, Hasher h) {
 		if (a)
-			a->hash_into(h);
+			h = a->hash_into(h);
 		else
 			h.eat(0);
 		return h;

--- a/kernel/modtools.h
+++ b/kernel/modtools.h
@@ -48,7 +48,7 @@ struct ModIndex : public RTLIL::Monitor
 			return cell == other.cell && port == other.port && offset == other.offset;
 		}
 
-		Hasher hash_into(Hasher h) const {
+		[[nodiscard]] Hasher hash_into(Hasher h) const {
 			h.eat(cell->name);
 			h.eat(port);
 			h.eat(offset);
@@ -321,7 +321,7 @@ struct ModWalker
 			return cell == other.cell && port == other.port && offset == other.offset;
 		}
 
-		Hasher hash_into(Hasher h) const {
+		[[nodiscard]] Hasher hash_into(Hasher h) const {
 			h.eat(cell->name);
 			h.eat(port);
 			h.eat(offset);

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -362,7 +362,7 @@ struct RTLIL::IdString
 		*this = IdString();
 	}
 
-	Hasher hash_into(Hasher h) const { return hash_ops<int>::hash_into(index_, h); }
+	[[nodiscard]] Hasher hash_into(Hasher h) const { return hash_ops<int>::hash_into(index_, h); }
 
 	Hasher hash_top() const {
 		Hasher h;
@@ -821,7 +821,7 @@ public:
 		bv.resize(width, bv.empty() ? RTLIL::State::Sx : bv.back());
 	}
 
-	inline Hasher hash_into(Hasher h) const {
+	[[nodiscard]] Hasher hash_into(Hasher h) const {
 		h.eat(size());
 		for (auto b : *this)
 			h.eat(b);
@@ -914,7 +914,7 @@ struct RTLIL::SigBit
 	bool operator <(const RTLIL::SigBit &other) const;
 	bool operator ==(const RTLIL::SigBit &other) const;
 	bool operator !=(const RTLIL::SigBit &other) const;
-	Hasher hash_into(Hasher h) const;
+	[[nodiscard]] Hasher hash_into(Hasher h) const;
 	Hasher hash_top() const;
 };
 
@@ -1115,7 +1115,7 @@ public:
 	operator std::vector<RTLIL::SigBit>() const { return bits(); }
 	const RTLIL::SigBit &at(int offset, const RTLIL::SigBit &defval) { return offset < width_ ? (*this)[offset] : defval; }
 
-	Hasher hash_into(Hasher h) const { if (!hash_) updhash(); h.eat(hash_); return h; }
+	[[nodiscard]] Hasher hash_into(Hasher h) const { if (!hash_) updhash(); h.eat(hash_); return h; }
 
 #ifndef NDEBUG
 	void check(Module *mod = nullptr) const;
@@ -1157,7 +1157,7 @@ struct RTLIL::Selection
 struct RTLIL::Monitor
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
+	[[nodiscard]] Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
 
 	Monitor() {
 		static unsigned int hashidx_count = 123456789;
@@ -1180,7 +1180,7 @@ struct define_map_t;
 struct RTLIL::Design
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
+	[[nodiscard]] Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
 
 	pool<RTLIL::Monitor*> monitors;
 	dict<std::string, std::string> scratchpad;
@@ -1285,7 +1285,7 @@ struct RTLIL::Design
 struct RTLIL::Module : public RTLIL::AttrObject
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
+	[[nodiscard]] Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
 
 protected:
 	void add(RTLIL::Wire *wire);
@@ -1640,7 +1640,7 @@ void dump_wire(std::ostream &f, std::string indent, const RTLIL::Wire *wire);
 struct RTLIL::Wire : public RTLIL::AttrObject
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
+	[[nodiscard]] Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
 
 protected:
 	// use module->addWire() and module->remove() to create or destroy wires
@@ -1679,7 +1679,7 @@ inline int GetSize(RTLIL::Wire *wire) {
 struct RTLIL::Memory : public RTLIL::AttrObject
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
+	[[nodiscard]] Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
 
 	Memory();
 
@@ -1694,7 +1694,7 @@ struct RTLIL::Memory : public RTLIL::AttrObject
 struct RTLIL::Cell : public RTLIL::AttrObject
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
+	[[nodiscard]] Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
 
 protected:
 	// use module->addCell() and module->remove() to create or destroy cells
@@ -1804,7 +1804,7 @@ struct RTLIL::SyncRule
 struct RTLIL::Process : public RTLIL::AttrObject
 {
 	Hasher::hash_t hashidx_;
-	Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
+	[[nodiscard]] Hasher hash_into(Hasher h) const { h.eat(hashidx_); return h; }
 
 protected:
 	// use module->addProcess() and module->remove() to create or destroy processes

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -364,7 +364,7 @@ struct RTLIL::IdString
 
 	[[nodiscard]] Hasher hash_into(Hasher h) const { return hash_ops<int>::hash_into(index_, h); }
 
-	Hasher hash_top() const {
+	[[nodiscard]] Hasher hash_top() const {
 		Hasher h;
 		h.force((Hasher::hash_t) index_);
 		return h;
@@ -915,7 +915,7 @@ struct RTLIL::SigBit
 	bool operator ==(const RTLIL::SigBit &other) const;
 	bool operator !=(const RTLIL::SigBit &other) const;
 	[[nodiscard]] Hasher hash_into(Hasher h) const;
-	Hasher hash_top() const;
+	[[nodiscard]] Hasher hash_top() const;
 };
 
 namespace hashlib {

--- a/kernel/scopeinfo.h
+++ b/kernel/scopeinfo.h
@@ -169,7 +169,7 @@ public:
 			return !(*this == other);
 		}
 
-		Hasher hash_into(Hasher h) const
+		[[nodiscard]] Hasher hash_into(Hasher h) const
 		{
 			h.eat(scope_name);
 			h.eat(target);
@@ -325,7 +325,7 @@ struct ModuleItem {
 	Cell *cell() const { return type == Type::Cell ? static_cast<Cell *>(ptr) : nullptr; }
 
 	bool operator==(const ModuleItem &other) const { return ptr == other.ptr && type == other.type; }
-	Hasher hash_into(Hasher h) const { h.eat(ptr); return h; }
+	[[nodiscard]] Hasher hash_into(Hasher h) const { h.eat(ptr); return h; }
 };
 
 static inline void log_dump_val_worker(typename IdTree<ModuleItem>::Cursor cursor ) { log("%p %s", cursor.target, log_id(cursor.scope_name)); }

--- a/kernel/sigtools.h
+++ b/kernel/sigtools.h
@@ -29,7 +29,7 @@ struct SigPool
 	struct bitDef_t : public std::pair<RTLIL::Wire*, int> {
 		bitDef_t() : std::pair<RTLIL::Wire*, int>(NULL, 0) { }
 		bitDef_t(const RTLIL::SigBit &bit) : std::pair<RTLIL::Wire*, int>(bit.wire, bit.offset) { }
-		Hasher hash_into(Hasher h) const {
+		[[nodiscard]] Hasher hash_into(Hasher h) const {
 			h.eat(first->name);
 			h.eat(second);
 			return h;
@@ -147,7 +147,7 @@ struct SigSet
 	struct bitDef_t : public std::pair<RTLIL::Wire*, int> {
 		bitDef_t() : std::pair<RTLIL::Wire*, int>(NULL, 0) { }
 		bitDef_t(const RTLIL::SigBit &bit) : std::pair<RTLIL::Wire*, int>(bit.wire, bit.offset) { }
-		Hasher hash_into(Hasher h) const {
+		[[nodiscard]] Hasher hash_into(Hasher h) const {
 			h.eat(first->name);
 			h.eat(second);
 			return h;

--- a/kernel/timinginfo.h
+++ b/kernel/timinginfo.h
@@ -44,7 +44,7 @@ struct TimingInfo
 				return {};
 			return port[offset];
 		}
-		Hasher hash_into(Hasher h) const {
+		[[nodiscard]] Hasher hash_into(Hasher h) const {
 			h.eat(name);
 			h.eat(offset);
 			return h;
@@ -56,7 +56,7 @@ struct TimingInfo
 		BitBit(const NameBit &first, const NameBit &second) : first(first), second(second) {}
 		BitBit(const SigBit &first, const SigBit &second) : first(first), second(second) {}
 		bool operator==(const BitBit& bb) const { return bb.first == first && bb.second == second; }
-		Hasher hash_into(Hasher h) const {
+		[[nodiscard]] Hasher hash_into(Hasher h) const {
 			h.eat(first);
 			h.eat(second);
 			return h;

--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -171,7 +171,7 @@ struct shared_str {
 	const char *c_str() const { return content->c_str(); }
 	const string &str() const { return *content; }
 	bool operator==(const shared_str &other) const { return *content == *other.content; }
-	Hasher hash_into(Hasher h) const {
+	[[nodiscard]] Hasher hash_into(Hasher h) const {
 		h.eat(*content);
 		return h;
 	}

--- a/kernel/yw.h
+++ b/kernel/yw.h
@@ -35,7 +35,7 @@ struct IdPath : public std::vector<RTLIL::IdString>
 	bool has_address() const { int tmp; return get_address(tmp); };
 	bool get_address(int &addr) const;
 
-	Hasher hash_into(Hasher h) const {
+	[[nodiscard]] Hasher hash_into(Hasher h) const {
 		h.eat(static_cast<const std::vector<RTLIL::IdString>&&>(*this));
 		return h;
 	}

--- a/passes/cmds/dft_tag.cc
+++ b/passes/cmds/dft_tag.cc
@@ -47,7 +47,7 @@ struct DftTagWorker {
 		bool operator<(const tag_set &other) const { return index < other.index; }
 		bool operator==(const tag_set &other) const { return index == other.index; }
 
-		Hasher hash_into(Hasher h) const { h.eat(index); return h; }
+		[[nodiscard]] Hasher hash_into(Hasher h) const { h.eat(index); return h; }
 
 		bool empty() const { return index == 0; }
 	};

--- a/passes/cmds/example_dt.cc
+++ b/passes/cmds/example_dt.cc
@@ -52,7 +52,7 @@ struct ExampleDtPass : public Pass
 					return name == other.name && parameters == other.parameters;
 				}
 
-				Hasher hash_into(Hasher h) const {
+				[[nodiscard]] Hasher hash_into(Hasher h) const {
 					h.eat(name);
 					h.eat(parameters);
 					return h;

--- a/passes/equiv/equiv_struct.cc
+++ b/passes/equiv/equiv_struct.cc
@@ -46,7 +46,7 @@ struct EquivStructWorker
 					parameters == other.parameters && port_sizes == other.port_sizes;
 		}
 
-		Hasher hash_into(Hasher h) const {
+		[[nodiscard]] Hasher hash_into(Hasher h) const {
 			h.eat(type);
 			h.eat(parameters);
 			h.eat(port_sizes);

--- a/passes/proc/proc_dlatch.cc
+++ b/passes/proc/proc_dlatch.cc
@@ -127,7 +127,7 @@ struct proc_dlatch_db_t
 			return signal == other.signal && match == other.match && children == other.children;
 		}
 
-		Hasher hash_into(Hasher h) const {
+		[[nodiscard]] Hasher hash_into(Hasher h) const {
 			h.eat(signal);
 			h.eat(match);
 			h.eat(children);

--- a/passes/sat/recover_names.cc
+++ b/passes/sat/recover_names.cc
@@ -46,7 +46,7 @@ struct IdBit {
 
     bool operator==(const IdBit &other) const { return name == other.name && bit == other.bit; };
     bool operator!=(const IdBit &other) const { return name != other.name || bit != other.bit; };
-    Hasher hash_into(Hasher h) const
+    [[nodiscard]] Hasher hash_into(Hasher h) const
     {
         h.eat(name);
         h.eat(bit);
@@ -64,7 +64,7 @@ struct InvBit {
 
     bool operator==(const InvBit &other) const { return bit == other.bit && inverted == other.inverted; };
     bool operator!=(const InvBit &other) const { return bit != other.bit || inverted != other.inverted; };
-    Hasher hash_into(Hasher h) const
+    [[nodiscard]] Hasher hash_into(Hasher h) const
     {
         h.eat(bit);
         h.eat(inverted);

--- a/passes/techmap/clockgate.cc
+++ b/passes/techmap/clockgate.cc
@@ -233,7 +233,7 @@ struct ClockgatePass : public Pass {
 		SigBit ce_bit;
 		bool pol_clk;
 		bool pol_ce;
-		Hasher hash_into(Hasher h) const {
+		[[nodiscard]] Hasher hash_into(Hasher h) const {
 			auto t = std::make_tuple(clk_bit, ce_bit, pol_clk, pol_ce);
 			h.eat(t);
 			return h;

--- a/passes/techmap/flowmap.cc
+++ b/passes/techmap/flowmap.cc
@@ -250,7 +250,7 @@ struct FlowGraph
 		{
 			return !(*this == other);
 		}
-		Hasher hash_into(Hasher h) const
+		[[nodiscard]] Hasher hash_into(Hasher h) const
 		{
 			std::pair<RTLIL::SigBit, int> p = {node, is_bottom};
 			h.eat(p);

--- a/techlibs/quicklogic/ql_dsp_simd.cc
+++ b/techlibs/quicklogic/ql_dsp_simd.cc
@@ -53,7 +53,7 @@ struct QlDspSimdPass : public Pass {
 		DspConfig(const DspConfig &ref) = default;
 		DspConfig(DspConfig &&ref) = default;
 
-		Hasher hash_into(Hasher h) const { h.eat(connections); return h; }
+		[[nodiscard]] Hasher hash_into(Hasher h) const { h.eat(connections); return h; }
 
 		bool operator==(const DspConfig &ref) const { return connections == ref.connections; }
 	};


### PR DESCRIPTION
Previously at some point when finishing #4524 I accidentally discarded the hashing result in the `hash_obj_ops` implementation. I'm fixing that here and marking all `hash_into` and `hash_top` methods `[[nodiscard]]`. Prior to this PR, any non-trivial design would run `opt_clean` for excessive amounts of time since all `Cell*` and `Wire*` hashes would collide. To test the impact, you can compare the perf of the PR head against the root commit of this PR branch (6225abec) and the main commit prior to the hashlib PR merge (7a362f1f).

Once again, reviewers are automatically set to code owners and I can't remove those, sorry for the spam.