### PR TITLE
hashlib: merge hash_ops with hash_top_ops for plugin compat

### DIFF
--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -142,7 +142,7 @@ using Hasher = HasherDJB32;
 #define HASH_TOP_LOOP_FST [[nodiscard]] static inline Hasher hash
 #define HASH_TOP_LOOP_SND { \
 	Hasher h; \
-	h.eat(a); \
+	h = hash_into(a, h); \
 	return h; \
 }
 
@@ -239,11 +239,7 @@ struct hash_cstr_ops {
 			h.hash32(*(a++));
 		return h;
 	}
-	[[nodiscard]] static inline Hasher hash(const char *a) {
-		Hasher h;
-		h = hash_cstr_ops::hash_into(a, h);
-		return h;
-	}
+	HASH_TOP_LOOP_FST (const char *a) HASH_TOP_LOOP_SND
 };
 
 template <> struct hash_ops<char*> : hash_cstr_ops {};
@@ -255,11 +251,7 @@ struct hash_ptr_ops {
 	[[nodiscard]] static inline Hasher hash_into(const void *a, Hasher h) {
 		return hash_ops<uintptr_t>::hash_into((uintptr_t)a, h);
 	}
-	[[nodiscard]] static inline Hasher hash(const void *a) {
-		Hasher h;
-		h = hash_ptr_ops::hash_into(a, h);
-		return h;
-	}
+	HASH_TOP_LOOP_FST (const void *a) HASH_TOP_LOOP_SND
 };
 
 struct hash_obj_ops {
@@ -275,11 +267,7 @@ struct hash_obj_ops {
 		return h;
 	}
 	template<typename T>
-	[[nodiscard]] static inline Hasher hash(const T *a) {
-		Hasher h;
-		h = hash_obj_ops::hash_into(a, h);
-		return h;
-	}
+	HASH_TOP_LOOP_FST (const T *a) HASH_TOP_LOOP_SND
 };
 /**
  * If you find yourself using this function, think hard

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -61,18 +61,8 @@ namespace legacy {
 	}
 };
 
-/**
- * Hash a type with an accumulator in a record or array context
- */
 template<typename T>
 struct hash_ops;
-
-/**
- * Hash a single instance in isolation.
- * Can have explicit specialization, but the default redirects to hash_ops
- */
-template<typename T>
-struct hash_top_ops;
 
 inline unsigned int mkhash_xorshift(unsigned int a) {
 	if (sizeof(a) == 4) {
@@ -147,15 +137,14 @@ private:
 
 using Hasher = HasherDJB32;
 
-template<typename T>
-struct hash_top_ops {
-	static inline bool cmp(const T &a, const T &b) {
-		return hash_ops<T>::cmp(a, b);
-	}
-	static inline Hasher hash(const T &a) {
-		return hash_ops<T>::hash_into(a, Hasher());
-	}
-};
+// Boilerplate compressor for trivially implementing
+// top-level hash method with hash_into
+#define HASH_TOP_LOOP_FST [[nodiscard]] static inline Hasher hash
+#define HASH_TOP_LOOP_SND { \
+	Hasher h; \
+	h.eat(a); \
+	return h; \
+}
 
 template<typename T>
 struct hash_ops {
@@ -183,6 +172,7 @@ struct hash_ops {
 			return a.hash_into(h);
 		}
 	}
+	HASH_TOP_LOOP_FST (const T &a) HASH_TOP_LOOP_SND
 };
 
 template<typename P, typename Q> struct hash_ops<std::pair<P, Q>> {
@@ -194,6 +184,7 @@ template<typename P, typename Q> struct hash_ops<std::pair<P, Q>> {
 		h = hash_ops<Q>::hash_into(a.second, h);
 		return h;
 	}
+	HASH_TOP_LOOP_FST (std::pair<P, Q> a) HASH_TOP_LOOP_SND
 };
 
 template<typename... T> struct hash_ops<std::tuple<T...>> {
@@ -211,6 +202,7 @@ template<typename... T> struct hash_ops<std::tuple<T...>> {
 		h = element_ops_t::hash_into(std::get<I>(a), h);
 		return h;
 	}
+	HASH_TOP_LOOP_FST (std::tuple<T...> a) HASH_TOP_LOOP_SND
 };
 
 template<typename T> struct hash_ops<std::vector<T>> {
@@ -223,6 +215,7 @@ template<typename T> struct hash_ops<std::vector<T>> {
 			h.eat(k);
 		return h;
 	}
+	HASH_TOP_LOOP_FST (std::vector<T> a) HASH_TOP_LOOP_SND
 };
 
 template<typename T, size_t N> struct hash_ops<std::array<T, N>> {
@@ -234,6 +227,7 @@ template<typename T, size_t N> struct hash_ops<std::array<T, N>> {
             h = hash_ops<T>::hash_into(k, h);
         return h;
     }
+	HASH_TOP_LOOP_FST (std::array<T, N> a) HASH_TOP_LOOP_SND
 };
 
 struct hash_cstr_ops {
@@ -243,6 +237,11 @@ struct hash_cstr_ops {
 	[[nodiscard]] static inline Hasher hash_into(const char *a, Hasher h) {
 		while (*a)
 			h.hash32(*(a++));
+		return h;
+	}
+	[[nodiscard]] static inline Hasher hash(const char *a) {
+		Hasher h;
+		h = hash_cstr_ops::hash_into(a, h);
 		return h;
 	}
 };
@@ -255,6 +254,11 @@ struct hash_ptr_ops {
 	}
 	[[nodiscard]] static inline Hasher hash_into(const void *a, Hasher h) {
 		return hash_ops<uintptr_t>::hash_into((uintptr_t)a, h);
+	}
+	[[nodiscard]] static inline Hasher hash(const void *a) {
+		Hasher h;
+		h = hash_ptr_ops::hash_into(a, h);
+		return h;
 	}
 };
 
@@ -270,6 +274,12 @@ struct hash_obj_ops {
 			h.eat(0);
 		return h;
 	}
+	template<typename T>
+	[[nodiscard]] static inline Hasher hash(const T *a) {
+		Hasher h;
+		h = hash_obj_ops::hash_into(a, h);
+		return h;
+	}
 };
 /**
  * If you find yourself using this function, think hard
@@ -280,7 +290,7 @@ struct hash_obj_ops {
 template<typename T>
 [[nodiscard]]
 Hasher::hash_t run_hash(const T& obj) {
-	return hash_top_ops<T>::hash(obj).yield();
+	return hash_ops<T>::hash(obj).yield();
 }
 
 /** Refer to docs/source/yosys_internals/hashing.rst */
@@ -352,10 +362,10 @@ inline unsigned int hashtable_size(unsigned int min_size)
 	throw std::length_error("hash table exceeded maximum size.");
 }
 
-template<typename K, typename T, typename OPS = hash_top_ops<K>> class dict;
-template<typename K, int offset = 0, typename OPS = hash_top_ops<K>> class idict;
-template<typename K, typename OPS = hash_top_ops<K>> class pool;
-template<typename K, typename OPS = hash_top_ops<K>> class mfp;
+template<typename K, typename T, typename OPS = hash_ops<K>> class dict;
+template<typename K, int offset = 0, typename OPS = hash_ops<K>> class idict;
+template<typename K, typename OPS = hash_ops<K>> class pool;
+template<typename K, typename OPS = hash_ops<K>> class mfp;
 
 template<typename K, typename T, typename OPS>
 class dict {

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -398,12 +398,15 @@ struct RTLIL::IdString
 
 namespace hashlib {
 	template <>
-	struct hash_top_ops<RTLIL::IdString> {
+	struct hash_ops<RTLIL::IdString> {
 		static inline bool cmp(const RTLIL::IdString &a, const RTLIL::IdString &b) {
 			return a == b;
 		}
-		static inline Hasher hash(const RTLIL::IdString id) {
+		[[nodiscard]] static inline Hasher hash(const RTLIL::IdString id) {
 			return id.hash_top();
+		}
+		[[nodiscard]] static inline Hasher hash_into(const RTLIL::IdString id, Hasher h) {
+			return id.hash_into(h);
 		}
 	};
 };
@@ -920,12 +923,15 @@ struct RTLIL::SigBit
 
 namespace hashlib {
 	template <>
-	struct hash_top_ops<RTLIL::SigBit> {
+	struct hash_ops<RTLIL::SigBit> {
 		static inline bool cmp(const RTLIL::SigBit &a, const RTLIL::SigBit &b) {
 			return a == b;
 		}
-		static inline Hasher hash(const RTLIL::SigBit sb) {
+		[[nodiscard]] static inline Hasher hash(const RTLIL::SigBit sb) {
 			return sb.hash_top();
+		}
+		[[nodiscard]] static inline Hasher hash_into(const RTLIL::SigBit sb, Hasher h) {
+			return sb.hash_into(h);
 		}
 	};
 };


### PR DESCRIPTION
When writing #4524 I made it so that a type can have an implementation for how to hash a single instance (`hash_top_ops`) distinct from one for how to hash an instance in the context of an on-going context (`hash_ops`). This PR implements @povik's idea to merge them together so that plugin code can still explicitly pass `hash_ptr_ops` into associative data structures like `dict`.

- [ ] adjust `docs/source/yosys_internals/hashing.rst` to match