### PR TITLE
handle some cases of hdlname attribute on private objects

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -1464,7 +1464,8 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 		log("Importing module %s.\n", RTLIL::id2cstr(module->name));
 	}
 	import_attributes(module->attributes, nl, nl);
-	module->set_string_attribute(ID::hdlname, nl->CellBaseName());
+	if (module->name.isPublic())
+		module->set_string_attribute(ID::hdlname, nl->CellBaseName());
 	module->set_string_attribute(ID(library), nl->Owner()->Owner()->Name());
 #ifdef VERIFIC_VHDL_SUPPORT
 	if (nl->IsFromVhdl()) {

--- a/kernel/scopeinfo.h
+++ b/kernel/scopeinfo.h
@@ -337,12 +337,12 @@ template<typename O>
 std::vector<IdString> parse_hdlname(const O* object)
 {
 	std::vector<IdString> path;
-	if (!object->name.isPublic())
-		return path;
 	for (auto const &item : object->get_hdlname_attribute())
 		path.push_back("\\" + item);
-	if (path.empty())
+	if (path.empty() && object->name.isPublic())
 		path.push_back(object->name);
+	if (!path.empty() && !(object->name.isPublic() || object->name.begins_with("$paramod") || object->name.begins_with("$abstract")))
+		path.pop_back();
 	return path;
 }
 
@@ -351,17 +351,22 @@ std::pair<std::vector<IdString>, IdString> parse_scopename(const O* object)
 {
 	std::vector<IdString> path;
 	IdString trailing = object->name;
-	if (object->name.isPublic()) {
+	if (object->name.isPublic() || object->name.begins_with("$paramod") || object->name.begins_with("$abstract")) {
 		for (auto const &item : object->get_hdlname_attribute())
 			path.push_back("\\" + item);
 		if (!path.empty()) {
 			trailing = path.back();
 			path.pop_back();
 		}
+	} else if (object->has_attribute(ID::hdlname)) {
+		for (auto const &item : object->get_hdlname_attribute())
+			path.push_back("\\" + item);
+		if (!path.empty()) {
+			path.pop_back();
+		}
 	} else {
 		for (auto const &item : split_tokens(object->get_string_attribute(ID(scopename)), " "))
 			path.push_back("\\" + item);
-
 	}
 	return {path, trailing};
 }

--- a/kernel/scopeinfo.h
+++ b/kernel/scopeinfo.h
@@ -341,8 +341,10 @@ std::vector<IdString> parse_hdlname(const O* object)
 		path.push_back("\\" + item);
 	if (path.empty() && object->name.isPublic())
 		path.push_back(object->name);
-	if (!path.empty() && !(object->name.isPublic() || object->name.begins_with("$paramod") || object->name.begins_with("$abstract")))
+	if (!path.empty() && !(object->name.isPublic() || object->name.begins_with("$paramod") || object->name.begins_with("$abstract"))) {
 		path.pop_back();
+		path.push_back(object->name);
+	}
 	return path;
 }
 

--- a/passes/fsm/fsm_extract.cc
+++ b/passes/fsm/fsm_extract.cc
@@ -377,6 +377,10 @@ static void extract_fsm(RTLIL::Wire *wire)
 	fsm_cell->setPort(ID::CTRL_OUT, ctrl_out);
 	fsm_cell->parameters[ID::NAME] = RTLIL::Const(wire->name.str());
 	fsm_cell->attributes = wire->attributes;
+	if(fsm_cell->attributes.count(ID::hdlname)) {
+		fsm_cell->attributes[ID(scopename)] = fsm_cell->attributes[ID::hdlname];
+		fsm_cell->attributes.erase(ID::hdlname);
+	}
 	fsm_data.copy_to_cell(fsm_cell);
 
 	// rename original state wire
@@ -385,6 +389,10 @@ static void extract_fsm(RTLIL::Wire *wire)
 	wire->attributes.erase(ID::fsm_encoding);
 	wire->name = stringf("$fsm$oldstate%s", wire->name.c_str());
 	module->wires_[wire->name] = wire;
+	if(wire->attributes.count(ID::hdlname)) {
+		wire->attributes[ID(scopename)] = wire->attributes[ID::hdlname];
+		wire->attributes.erase(ID::hdlname);
+	}
 
 	// unconnect control outputs from old drivers
 

--- a/passes/fsm/fsm_extract.cc
+++ b/passes/fsm/fsm_extract.cc
@@ -378,7 +378,10 @@ static void extract_fsm(RTLIL::Wire *wire)
 	fsm_cell->parameters[ID::NAME] = RTLIL::Const(wire->name.str());
 	fsm_cell->attributes = wire->attributes;
 	if(fsm_cell->attributes.count(ID::hdlname)) {
-		fsm_cell->attributes[ID(scopename)] = fsm_cell->attributes[ID::hdlname];
+		auto hdlname = fsm_cell->get_hdlname_attribute();
+		hdlname.pop_back();
+		fsm_cell->set_hdlname_attribute(hdlname);
+		fsm_cell->set_string_attribute(ID(scopename), fsm_cell->get_string_attribute(ID::hdlname));
 		fsm_cell->attributes.erase(ID::hdlname);
 	}
 	fsm_data.copy_to_cell(fsm_cell);
@@ -390,7 +393,10 @@ static void extract_fsm(RTLIL::Wire *wire)
 	wire->name = stringf("$fsm$oldstate%s", wire->name.c_str());
 	module->wires_[wire->name] = wire;
 	if(wire->attributes.count(ID::hdlname)) {
-		wire->attributes[ID(scopename)] = wire->attributes[ID::hdlname];
+		auto hdlname = wire->get_hdlname_attribute();
+		hdlname.pop_back();
+		wire->set_hdlname_attribute(hdlname);
+		wire->set_string_attribute(ID(scopename), wire->get_string_attribute(ID::hdlname));
 		wire->attributes.erase(ID::hdlname);
 	}
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Supersedes #4842: There are currently too many cases that don't respect this invariant, so defer the enforcement for now.

_Explain how this is achieved._

For the next release, just fix the cases already identified. In the case of an object with a private name and an `hdlname` attribute, allow `parse_hdlname()`/`parse_scopename()` to act as if it was a corresponding scopename attribute (ignoring the final entry). The behaviour should be unchanged for other cases.

_If applicable, please suggest to reviewers how they can test the change._
