### PR TITLE
Fix undefined type error

### DIFF
--- a/libs/json11/json11.cpp
+++ b/libs/json11/json11.cpp
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstdio>
+#include <cstdint>
 #include <limits>
 
 namespace json11 {


### PR DESCRIPTION
Explicitly include <cstdint> in libs/json11/json11.cpp, to avoid:

    "error: ‘uint8_t’ does not name a type"

compile errors when building against TCL 9.0
(https://bugzilla.redhat.com/show_bug.cgi?id=2337817)