### PR TITLE
Add -blackbox option to cutpoint pass

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -2140,7 +2140,7 @@ namespace {
 				param(ID::TYPE);
 				check_expected();
 				std::string scope_type = cell->getParam(ID::TYPE).decode_string();
-				if (scope_type != "module" && scope_type != "struct")
+				if (scope_type != "module" && scope_type != "struct" && scope_type != "blackbox")
 					error(__LINE__);
 				return;
 			}

--- a/passes/sat/cutpoint.cc
+++ b/passes/sat/cutpoint.cc
@@ -90,6 +90,8 @@ struct CutpointPass : public Pass {
 				if (module->get_blackbox_attribute()) {
 					module->set_bool_attribute(ID::blackbox, false);
 					module->set_bool_attribute(ID::whitebox, false);
+					auto scopeinfo = module->addCell(NEW_ID, ID($scopeinfo));
+					scopeinfo->setParam(ID::TYPE, RTLIL::Const("blackbox"));
 				}
 				continue;
 			}

--- a/passes/sat/cutpoint.cc
+++ b/passes/sat/cutpoint.cc
@@ -79,19 +79,18 @@ struct CutpointPass : public Pass {
 		if (flag_blackbox) {
 			if (!design->full_selection())
 				log_cmd_error("This command only operates on fully selected designs!\n");
-			RTLIL::Selection boxes(false);
+			design->push_empty_selection();
 			for (auto module : design->modules())
 				if (flag_instances) {
 					for (auto cell : module->cells()) {
 						auto mod = design->module(cell->type);
 						if (mod != nullptr && mod->get_blackbox_attribute())
-							boxes.select(module, cell);
+							design->select(module, cell);
 					}
 				} else {
 					if (module->get_blackbox_attribute())
-						boxes.select(module);
+						design->select(module);
 			}
-			design->selection_stack.push_back(boxes);
 		}
 
 		for (auto module : design->all_selected_modules())

--- a/passes/sat/cutpoint.cc
+++ b/passes/sat/cutpoint.cc
@@ -37,19 +37,20 @@ struct CutpointPass : public Pass {
 		log("        set cutpoint nets to undef (x). the default behavior is to create\n");
 		log("        an $anyseq cell and drive the cutpoint net from that\n");
 		log("\n");
+		log("    -noscopeinfo\n");
+		log("        do not create '$scopeinfo' cells that preserve attributes of cells that\n");
+		log("        were removed by this pass\n");
+		log("\n");
 		log("    cutpoint -blackbox [options]\n");
 		log("\n");
-		log("Replace the contents of all blackboxes in the design with a formal cut point.\n");
-		log("\n");
-		log("    -instances\n");
-		log("        replace instances of blackboxes instead of the modules\n");
+		log("Replace all instances of blackboxes in the design with a formal cut point.\n");
 		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		bool flag_undef = false;
+		bool flag_scopeinfo = true;
 		bool flag_blackbox = false;
-		bool flag_instances = false;
 
 		log_header(design, "Executing CUTPOINT pass.\n");
 
@@ -60,61 +61,31 @@ struct CutpointPass : public Pass {
 				flag_undef = true;
 				continue;
 			}
-			if (args[argidx] == "-blackbox") {
-				flag_blackbox = true;
+			if (args[argidx] == "-noscopeinfo") {
+				flag_scopeinfo = false;
 				continue;
 			}
-			if (args[argidx] == "-instances") {
-				flag_instances = true;
+			if (args[argidx] == "-blackbox") {
+				flag_blackbox = true;
 				continue;
 			}
 			break;
 		}
 		extra_args(args, argidx, design);
 
-		if (flag_instances && !flag_blackbox) {
-			log_cmd_error("-instances flag only valid with -blackbox!\n");
-		}
-
 		if (flag_blackbox) {
 			if (!design->full_selection())
 				log_cmd_error("This command only operates on fully selected designs!\n");
 			design->push_empty_selection();
+			auto &selection = design->selection();
 			for (auto module : design->modules())
-				if (flag_instances) {
-					for (auto cell : module->cells()) {
-						auto mod = design->module(cell->type);
-						if (mod != nullptr && mod->get_blackbox_attribute())
-							design->select(module, cell);
-					}
-				} else {
-					if (module->get_blackbox_attribute())
-						design->select(module);
-			}
+				for (auto cell : module->cells())
+					if (selection.boxed_module(cell->type))
+						selection.select(module, cell);
 		}
 
 		for (auto module : design->all_selected_modules())
 		{
-			if (module->is_selected_whole() && !flag_instances) {
-				log("Making all outputs of module %s cut points, removing module contents.\n", log_id(module));
-				module->new_connections(std::vector<RTLIL::SigSig>());
-				for (auto cell : vector<Cell*>(module->cells()))
-					module->remove(cell);
-				vector<Wire*> output_wires;
-				for (auto wire : module->wires())
-					if (wire->port_output)
-						output_wires.push_back(wire);
-				for (auto wire : output_wires)
-					module->connect(wire, flag_undef ? Const(State::Sx, GetSize(wire)) : module->Anyseq(NEW_ID, GetSize(wire)));
-				if (module->get_blackbox_attribute()) {
-					module->set_bool_attribute(ID::blackbox, false);
-					module->set_bool_attribute(ID::whitebox, false);
-					auto scopeinfo = module->addCell(NEW_ID, ID($scopeinfo));
-					scopeinfo->setParam(ID::TYPE, RTLIL::Const("blackbox"));
-				}
-				continue;
-			}
-
 			SigMap sigmap(module);
 			pool<SigBit> cutpoint_bits;
 
@@ -129,7 +100,7 @@ struct CutpointPass : public Pass {
 
 				RTLIL::Cell *scopeinfo = nullptr;
 				auto cell_name = cell->name;
-				if (flag_instances && cell_name.isPublic()) {
+				if (flag_scopeinfo && cell_name.isPublic()) {
 					auto scopeinfo = module->addCell(NEW_ID, ID($scopeinfo));
 					scopeinfo->setParam(ID::TYPE, RTLIL::Const("blackbox"));
 

--- a/tests/various/.gitignore
+++ b/tests/various/.gitignore
@@ -1,5 +1,6 @@
 /*.log
 /*.out
+/*.sel
 /write_gzip.v
 /write_gzip.v.gz
 /run-test.mk

--- a/tests/various/cutpoint_blackbox.ys
+++ b/tests/various/cutpoint_blackbox.ys
@@ -1,13 +1,14 @@
 read_verilog -specify << EOT
 module top(input a, b, output o);
-    wire c, d;
-    bb bb1 (.a (a), .b (b), .o (c));
-    wb wb1 (.a (a), .b (b), .o (d));
-    some_mod some_inst (.a (c), .b (d), .o (o));
+    wire c, d, e;
+    bb #(.SOME_PARAM(1)) bb1 (.a (a), .b (b), .o (c));
+    bb #(.SOME_PARAM(2)) bb2 (.a (a), .b (b), .o (d));
+    wb wb1 (.a (a), .b (b), .o (e));
+    some_mod some_inst (.a (c), .b (d), .c (e), .o (o));
 endmodule
 
 (* blackbox *)
-module bb(input a, b, output o);
+module bb #( parameter SOME_PARAM=0 ) (input a, b, output o);
 assign o = a | b;
 specify
 	(a => o) = 1;
@@ -19,15 +20,20 @@ module wb(input a, b, output o);
 assign o = a ^ b;
 endmodule
 
-module some_mod(input a, b, output o);
-assign o = a & b;
+module some_mod(input a, b, c, output o);
+assign o = a & (b | c);
 endmodule
 EOT
 
-select top
+hierarchy -top top
 
 select -assert-count 0 t:$anyseq
-select -assert-count 2 =t:?b
-cutpoint -blackbox =*
-select -assert-count 2 t:$anyseq
-select -assert-count 2 t:?b
+select -assert-count 3 =t:?b
+cutpoint -blackbox
+
+select -assert-count 3 =t:?b
+select -assert-count 2 r:SOME_PARAM
+select -assert-count 1 r:SOME_PARAM=1
+
+flatten
+select -assert-count 3 t:$anyseq

--- a/tests/various/cutpoint_blackbox.ys
+++ b/tests/various/cutpoint_blackbox.ys
@@ -1,0 +1,33 @@
+read_verilog -specify << EOT
+module top(input a, b, output o);
+    wire c, d;
+    bb bb1 (.a (a), .b (b), .o (c));
+    wb wb1 (.a (a), .b (b), .o (d));
+    some_mod some_inst (.a (c), .b (d), .o (o));
+endmodule
+
+(* blackbox *)
+module bb(input a, b, output o);
+assign o = a | b;
+specify
+	(a => o) = 1;
+endspecify
+endmodule
+
+(* whitebox *)
+module wb(input a, b, output o);
+assign o = a ^ b;
+endmodule
+
+module some_mod(input a, b, output o);
+assign o = a & b;
+endmodule
+EOT
+
+select top
+
+select -assert-count 0 t:$anyseq
+select -assert-count 2 =t:?b
+cutpoint -blackbox =*
+select -assert-count 2 t:$anyseq
+select -assert-count 2 t:?b

--- a/tests/various/cutpoint_blackbox.ys
+++ b/tests/various/cutpoint_blackbox.ys
@@ -28,49 +28,27 @@ EOT
 hierarchy -top top
 design -save hier
 
-select -assert-count 0 t:$anyseq
+select -assert-none t:$anyseq
 select -assert-count 3 =t:?b
 cutpoint -blackbox
 
-select -assert-count 3 =t:?b
-select -assert-count 2 r:SOME_PARAM
-select -assert-count 1 r:SOME_PARAM=1
+select -assert-none =t:?b
+select -assert-none r:SOME_PARAM
 
-flatten
 select -assert-count 3 t:$anyseq
+select -assert-count 3 t:$scopeinfo
+select -assert-count 3 t:$scopeinfo r:TYPE=blackbox %i
 select -assert-count 3 t:$scopeinfo n:*cutpoint.cc* %i
 
-# cutpoint -blackbox === cutpoint =A:whitebox =A:blackbox %u
-#                        (simplified to =A:*box)
+# -noscopeinfo works with -blackbox
+design -load hier
+cutpoint -blackbox -noscopeinfo
+select -assert-none t:$scopeinfo
+
+# cutpoint -blackbox === cutpoint =A:whitebox =A:blackbox %u %C
+#                        (simplified to =A:*box %C)
 design -load hier
 cutpoint -blackbox
-rename -enumerate -pattern A_% t:$scopeinfo
-rename -enumerate -pattern B_% t:$anyseq
-rename -enumerate -pattern C_% w:*Anyseq*
-design -save gold
-select -write cutpoint.gold.sel =*
-
-design -load hier
-cutpoint =A:*box
-rename -enumerate -pattern A_% t:$scopeinfo
-rename -enumerate -pattern B_% t:$anyseq
-rename -enumerate -pattern C_% w:*Anyseq*
-design -save gate
-select -write cutpoint.gate.sel
-select -read cutpoint.gold.sel
-# nothing in gate but not gold
-select -assert-none % %n
-
-design -load gold
-select -read cutpoint.gate.sel
-# nothing in gold but not gate
-select -assert-none % %n
-
-# cutpoint -blackbox -instances !== cutpoint =A:whitebox =A:blackbox %u %C
-#                                   (simplified to =A:*box %C)
-# because cutpoint -blackbox -instances adds $scopeinfo cells
-design -load hier
-cutpoint -blackbox -instances
 rename -enumerate -pattern A_% t:$scopeinfo
 rename -enumerate -pattern B_% t:$anyseq
 rename -enumerate -pattern C_% w:*Anyseq*
@@ -90,6 +68,5 @@ select -assert-none % %n
 
 design -load gold
 select -read cutpoint.gate.sel
-# 3 $scopeinfo in gold but not gate
-select -assert-count 3 % %n
-select -assert-count 3 t:$scopeinfo
+# nothing in gold but not gate
+select -assert-none % %n

--- a/tests/various/cutpoint_blackbox.ys
+++ b/tests/various/cutpoint_blackbox.ys
@@ -26,6 +26,7 @@ endmodule
 EOT
 
 hierarchy -top top
+design -save hier
 
 select -assert-count 0 t:$anyseq
 select -assert-count 3 =t:?b
@@ -37,3 +38,58 @@ select -assert-count 1 r:SOME_PARAM=1
 
 flatten
 select -assert-count 3 t:$anyseq
+select -assert-count 3 t:$scopeinfo n:*cutpoint.cc* %i
+
+# cutpoint -blackbox === cutpoint =A:whitebox =A:blackbox %u
+#                        (simplified to =A:*box)
+design -load hier
+cutpoint -blackbox
+rename -enumerate -pattern A_% t:$scopeinfo
+rename -enumerate -pattern B_% t:$anyseq
+rename -enumerate -pattern C_% w:*Anyseq*
+design -save gold
+select -write cutpoint.gold.sel =*
+
+design -load hier
+cutpoint =A:*box
+rename -enumerate -pattern A_% t:$scopeinfo
+rename -enumerate -pattern B_% t:$anyseq
+rename -enumerate -pattern C_% w:*Anyseq*
+design -save gate
+select -write cutpoint.gate.sel
+select -read cutpoint.gold.sel
+# nothing in gate but not gold
+select -assert-none % %n
+
+design -load gold
+select -read cutpoint.gate.sel
+# nothing in gold but not gate
+select -assert-none % %n
+
+# cutpoint -blackbox -instances !== cutpoint =A:whitebox =A:blackbox %u %C
+#                                   (simplified to =A:*box %C)
+# because cutpoint -blackbox -instances adds $scopeinfo cells
+design -load hier
+cutpoint -blackbox -instances
+rename -enumerate -pattern A_% t:$scopeinfo
+rename -enumerate -pattern B_% t:$anyseq
+rename -enumerate -pattern C_% w:*Anyseq*
+design -save gold
+select -write cutpoint.gold.sel =*
+
+design -load hier
+cutpoint =A:*box %C
+rename -enumerate -pattern A_% t:$scopeinfo
+rename -enumerate -pattern B_% t:$anyseq
+rename -enumerate -pattern C_% w:*Anyseq*
+design -save gate
+select -write cutpoint.gate.sel
+select -read cutpoint.gold.sel
+# nothing in gate but not gold
+select -assert-none % %n
+
+design -load gold
+select -read cutpoint.gate.sel
+# 3 $scopeinfo in gold but not gate
+select -assert-count 3 % %n
+select -assert-count 3 t:$scopeinfo


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
Supersedes #4812.

_Explain how this is achieved._
Calling `cutpoint -blackbox [options]` will replace the contents of all (black)boxes in the design with a formal cut point (`$anyseq` cell by default).
This is preferable to #4812, which instead calls `cutpoint` on instances of (black)box modules.
Since the module now has contents, it is also no longer a (black)box so we can remove those attributes.

_If applicable, please suggest to reviewers how they can test the change._
