### PR TITLE
add support for passing flatten -separator to flatten in synth

### DIFF
--- a/passes/techmap/flatten.cc
+++ b/passes/techmap/flatten.cc
@@ -357,6 +357,9 @@ struct FlattenPass : public Pass {
 
 		FlattenWorker worker;
 
+		if (design->scratchpad.count("flatten.separator"))
+			worker.separator = design->scratchpad_get_string("flatten.separator");
+
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++) {
 			if (args[argidx] == "-wb") {

--- a/techlibs/common/synth.cc
+++ b/techlibs/common/synth.cc
@@ -98,7 +98,7 @@ struct SynthPass : public ScriptPass {
 		log("\n");
 	}
 
-	string top_module, fsm_opts, memory_opts, abc, flatten_separator;
+	string top_module, fsm_opts, memory_opts, abc;
 	bool autotop, flatten, noalumacc, nofsm, noabc, noshare, flowmap, booth;
 	int lut;
 	std::vector<std::string> techmap_maps;
@@ -120,7 +120,6 @@ struct SynthPass : public ScriptPass {
 		booth = false;
 		abc = "abc";
 		techmap_maps.clear();
-		flatten_separator = "";
 	}
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
@@ -155,8 +154,6 @@ struct SynthPass : public ScriptPass {
 			}
 			if (args[argidx] == "-flatten") {
 				flatten = true;
-				if (design->scratchpad.count("flatten.separator"))
-					flatten_separator = design->scratchpad_get_string("flatten.separator");
 				continue;
 			}
 			if (args[argidx] == "-lut" && argidx + 1 < args.size()) {
@@ -242,12 +239,8 @@ struct SynthPass : public ScriptPass {
 
 		if (check_label("coarse")) {
 			run("proc");
-			if (flatten || help_mode) {
-				if (!flatten_separator.empty())
-					run(stringf("flatten -separator %s", flatten_separator.c_str()), "  (if -flatten)");
-				else
-					run("flatten", "  (if -flatten)");
-			}
+			if (flatten || help_mode)
+				run("flatten", "  (if -flatten)");
 			run("opt_expr");
 			run("opt_clean");
 			run("check");

--- a/techlibs/common/synth.cc
+++ b/techlibs/common/synth.cc
@@ -98,7 +98,7 @@ struct SynthPass : public ScriptPass {
 		log("\n");
 	}
 
-	string top_module, fsm_opts, memory_opts, abc;
+	string top_module, fsm_opts, memory_opts, abc, flatten_separator;
 	bool autotop, flatten, noalumacc, nofsm, noabc, noshare, flowmap, booth;
 	int lut;
 	std::vector<std::string> techmap_maps;
@@ -120,6 +120,7 @@ struct SynthPass : public ScriptPass {
 		booth = false;
 		abc = "abc";
 		techmap_maps.clear();
+		flatten_separator = "";
 	}
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
@@ -154,6 +155,8 @@ struct SynthPass : public ScriptPass {
 			}
 			if (args[argidx] == "-flatten") {
 				flatten = true;
+				if (design->scratchpad.count("flatten.separator"))
+					flatten_separator = design->scratchpad_get_string("flatten.separator");
 				continue;
 			}
 			if (args[argidx] == "-lut" && argidx + 1 < args.size()) {
@@ -239,8 +242,12 @@ struct SynthPass : public ScriptPass {
 
 		if (check_label("coarse")) {
 			run("proc");
-			if (flatten || help_mode)
-				run("flatten", "  (if -flatten)");
+			if (flatten || help_mode) {
+				if (!flatten_separator.empty())
+					run(stringf("flatten -separator %s", flatten_separator.c_str()), "  (if -flatten)");
+				else
+					run("flatten", "  (if -flatten)");
+			}
 			run("opt_expr");
 			run("opt_clean");
 			run("check");


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Closes https://github.com/YosysHQ/yosys/issues/4843

_Explain how this is achieved._

Since https://github.com/YosysHQ/yosys/pull/4839 added this flag to flatten, this change allows for the user to specify this for the synth command.

_If applicable, please suggest to reviewers how they can test the change._
```
scratchpad -set flatten.separator "/"
synth -flatten
write_verilog test.v
```