### PR TITLE
Update workflow(s) for ubuntu-latest == ubuntu-24.04

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -8,7 +8,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install gperf build-essential bison flex libreadline-dev gawk tcl-dev libffi-dev git graphviz xdot pkg-config python3 libboost-system-dev libboost-python-dev libboost-filesystem-dev zlib1g-dev
+        sudo apt-get install gperf build-essential bison flex libreadline-dev gawk tcl-dev libffi-dev git graphviz xdot pkg-config python3 libboost-system-dev libboost-python-dev libboost-filesystem-dev zlib1g-dev libbz2-dev
 
     - name: Install macOS Dependencies
       if: runner.os == 'macOS'

--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -30,7 +30,7 @@ jobs:
           - ubuntu-latest
         compiler:
           # oldest supported
-          - 'clang-14'
+          - 'clang-16'
           - 'gcc-10'
           # newest, make sure to update maximum standard step to match
           - 'clang-18'

--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -33,7 +33,7 @@ jobs:
           - 'clang-16'
           - 'gcc-10'
           # newest, make sure to update maximum standard step to match
-          - 'clang-18'
+          - 'clang-19'
           - 'gcc-13'
         include:
           # macOS
@@ -72,7 +72,7 @@ jobs:
 
       # maximum standard, only on newest compilers
       - name: Build C++20
-        if: ${{ matrix.compiler == 'clang-18' || matrix.compiler == 'gcc-13' }}
+        if: ${{ matrix.compiler == 'clang-19' || matrix.compiler == 'gcc-13' }}
         shell: bash
         run: |
           make config-$CC_SHORT

--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -30,7 +30,7 @@ jobs:
           - ubuntu-latest
         compiler:
           # oldest supported
-          - 'clang-16'
+          - 'clang-10'
           - 'gcc-10'
           # newest, make sure to update maximum standard step to match
           - 'clang-19'
@@ -39,9 +39,6 @@ jobs:
           # macOS
           - os: macos-13
             compiler: 'clang'
-          # oldest clang not available on ubuntu-latest
-          - os: ubuntu-20.04
-            compiler: 'clang-10'
       fail-fast: false
     steps:
       - name: Checkout Yosys


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
ubuntu-latest is now 24.04 instead of 22.04 and broke some things:
- test-compile for {os: ubuntu-latest, compiler: clang-14} failing cpp setup
- test-build for {os: ubuntu-latest} missing bzlib.h

_Explain how this is achieved._
Change clang-14 to clang-10 as oldest supported under ubuntu-latest (somehow clang-10 is now working under latest but clang-11 through clang-16 are not).
Also update newest clang to -19.
apt-get libbz2-dev.

_If applicable, please suggest to reviewers how they can test the change._