### PR TITLE
Fix links for view/edit source

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,6 +11,29 @@ yosys_ver = "0.48"
 # select HTML theme
 html_theme = 'furo-ys'
 html_css_files = ['custom.css']
+html_theme_options: dict[str] = {
+    "source_repository": "https://github.com/YosysHQ/yosys/",
+    "source_branch": "main",
+    "source_directory": "docs/",
+}
+
+# try to fix the readthedocs detection
+html_context: dict[str] = {
+    "READTHEDOCS": True,
+    "display_github": True,
+    "github_user": "YosysHQ",
+    "github_repo": "yosys",
+    "slug": "yosys",
+}
+
+# override source_branch if not main
+git_slug = os.getenv("READTHEDOCS_VERSION_NAME")
+if git_slug not in [None, "latest", "stable"]:
+    html_theme_options["source_branch"] = git_slug
+
+# edit only works on branches, not tags
+if os.getenv("READTHEDOCS_VERSION_TYPE", "branch") != "branch":
+        html_theme_options["top_of_page_buttons"] = ["view"]
 
 # These folders are copied to the documentation's HTML output
 html_static_path = ['_static', "_images"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,7 @@ html_css_files = ['custom.css']
 html_theme_options: dict[str] = {
     "source_repository": "https://github.com/YosysHQ/yosys/",
     "source_branch": "main",
-    "source_directory": "docs/",
+    "source_directory": "docs/source/",
 }
 
 # try to fix the readthedocs detection


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
For some reason the automatic detection for read the docs github repository information is missing.

_Explain how this is achieved._
We can manually assign the values needed to get the links to work.

_If applicable, please suggest to reviewers how they can test the change._
The [preview build](https://yosyshq.readthedocs.io/projects/yosys/en/docs-preview-git_links/) for this pr should have working view source and edit source buttons at the top of each page, as well as footer icons linking to the readthedocs project and the git repository.
