### PR TITLE
Fix for WindowsApps permission denied with run_command().

### DIFF
--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -308,6 +308,7 @@ std::vector<std::string> split_tokens(const std::string &text, const char *sep =
 bool patmatch(const char *pattern, const char *string);
 #if !defined(YOSYS_DISABLE_SPAWN)
 int run_command(const std::string &command, std::function<void(const std::string&)> process_line = std::function<void(const std::string&)>());
+int run_direct_command(const std::string &command, std::function<void(const std::string&)> process_line = std::function<void(const std::string&)>());
 #endif
 std::string get_base_tmpdir();
 std::string make_temp_file(std::string template_str = get_base_tmpdir() + "/yosys_XXXXXX");

--- a/passes/sat/qbfsat.cc
+++ b/passes/sat/qbfsat.cc
@@ -240,7 +240,7 @@ QbfSolutionType call_qbf_solver(RTLIL::Module *mod, const QbfSolveOptions &opt, 
 	log_header(mod->design, "Solving QBF-SAT problem.\n");
 	if (!quiet) log("Launching \"%s\".\n", smtbmc_cmd.c_str());
 	int64_t begin = PerformanceTimer::query();
-	run_command(smtbmc_cmd, process_line);
+	run_direct_command(smtbmc_cmd, process_line);
 	int64_t end = PerformanceTimer::query();
 	ret.solver_time = (end - begin) / 1e9f;
 	if (!quiet) log("Solver finished in %.3f seconds.\n", ret.solver_time);

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1110,7 +1110,7 @@ void abc_module(RTLIL::Design *design, RTLIL::Module *current_module, std::strin
 
 #ifndef YOSYS_LINK_ABC
 		abc_output_filter filt(tempdir_name, show_tempdir);
-		int ret = run_command(buffer, std::bind(&abc_output_filter::next_line, filt, std::placeholders::_1));
+		int ret = run_direct_command(buffer, std::bind(&abc_output_filter::next_line, filt, std::placeholders::_1));
 #else
 		string temp_stdouterr_name = stringf("%s/stdouterr.txt", tempdir_name.c_str());
 		FILE *temp_stdouterr_w = fopen(temp_stdouterr_name.c_str(), "w");

--- a/passes/techmap/abc9_exe.cc
+++ b/passes/techmap/abc9_exe.cc
@@ -278,7 +278,7 @@ void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe
 
 #ifndef YOSYS_LINK_ABC
 	abc9_output_filter filt(tempdir_name, show_tempdir);
-	int ret = run_command(buffer, std::bind(&abc9_output_filter::next_line, filt, std::placeholders::_1));
+	int ret = run_direct_command(buffer, std::bind(&abc9_output_filter::next_line, filt, std::placeholders::_1));
 #else
 	string temp_stdouterr_name = stringf("%s/stdouterr.txt", tempdir_name.c_str());
 	FILE *temp_stdouterr_w = fopen(temp_stdouterr_name.c_str(), "w");


### PR DESCRIPTION
I've been integrating Yosys into an application ([Alchitry Labs](https://github.com/alchitry/Alchitry-Labs-V2)) and it fails to run on Windows when installed to WindowsApps. The original error was reported [here](https://forum.alchitry.com/t/yosys-error-cant-guess-frontend-for-input-file/1585/4?u=alchitry).

I found that my program could run `yosys` but when `yosys` would start `yosys-abc` it would simply return `Access is denied.`

After two days of pulling my hair out, I discovered that using [`CreateProcessA()`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa) instead of `popen()` or `system()` makes it work. I don't know exactly what the difference is but Windows must be passing something along that doesn't happen otherwise.

This is a Windows only problem and a Windows only solution so a lot was added in an `#ifdef` block. I couldn't find a way to make it work using the more standard functions.