### PR TITLE
add IOFF inference for qlf_k6n10f

### DIFF
--- a/techlibs/quicklogic/Makefile.inc
+++ b/techlibs/quicklogic/Makefile.inc
@@ -6,6 +6,7 @@ OBJS += techlibs/quicklogic/ql_bram_merge.o
 OBJS += techlibs/quicklogic/ql_bram_types.o
 OBJS += techlibs/quicklogic/ql_dsp_simd.o
 OBJS += techlibs/quicklogic/ql_dsp_io_regs.o
+OBJS += techlibs/quicklogic/ql_ioff.o
 
 # --------------------------------------
 

--- a/techlibs/quicklogic/ql_ioff.cc
+++ b/techlibs/quicklogic/ql_ioff.cc
@@ -39,13 +39,14 @@ struct QlIoffPass : public Pass {
 				if (!(e_const && r_const && s_const))
 					continue;
 
-				auto d_sig = modwalker.sigmap(cell->getPort(ID::D));
-				if (d_sig.is_wire() && d_sig.as_wire()->port_input) {
+				SigSpec d = cell->getPort(ID::D);
+				if (GetSize(d) != 1) continue;
+				SigBit d_sig = modwalker.sigmap(d[0]);
+				if (d_sig.is_wire() && d_sig.wire->port_input) {
 					log_debug("Cell %s is potentially eligible for promotion to input IOFF.\n", cell->name.c_str());
 					// check that d_sig has no other consumers
-					if (GetSize(d_sig) != 1) continue;
 					pool<ModWalker::PortBit> portbits;
-					modwalker.get_consumers(portbits, d_sig[0]);
+					modwalker.get_consumers(portbits, d_sig);
 					if (GetSize(portbits) > 1) {
 						log_debug("not promoting: d_sig has other consumers\n");
 						continue;
@@ -53,13 +54,14 @@ struct QlIoffPass : public Pass {
 					cells_to_replace.insert(cell);
 					continue; // no need to check Q if we already put it on the list
 				}
-				auto q_sig = modwalker.sigmap(cell->getPort(ID::Q));
-				if (q_sig.is_wire() && q_sig.as_wire()->port_output) {
+				SigSpec q = cell->getPort(ID::Q);
+				if (GetSize(q) != 1) continue;
+				SigBit q_sig = modwalker.sigmap(q[0]);
+				if (q_sig.is_wire() && q_sig.wire->port_output) {
 					log_debug("Cell %s is potentially eligible for promotion to output IOFF.\n", cell->name.c_str());
 					// check that q_sig has no other consumers
-					if (GetSize(q_sig) != 1) continue;
 					pool<ModWalker::PortBit> portbits;
-					modwalker.get_consumers(portbits, q_sig[0]);
+					modwalker.get_consumers(portbits, q_sig);
 					if (GetSize(portbits) > 0) {
 						log_debug("not promoting: q_sig has other consumers\n");
 						continue;

--- a/techlibs/quicklogic/ql_ioff.cc
+++ b/techlibs/quicklogic/ql_ioff.cc
@@ -1,0 +1,82 @@
+#include "kernel/log.h"
+#include "kernel/modtools.h"
+#include "kernel/register.h"
+#include "kernel/rtlil.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+struct QlIoffPass : public Pass {
+	QlIoffPass() : Pass("ql_ioff", "Infer I/O FFs for qlf_k6n10f architecture") {}
+
+	void help() override
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    ql_ioff [selection]\n");
+		log("\n");
+		log("This pass promotes qlf_k6n10f registers directly connected to a top-level I/O\n");
+		log("port to I/O FFs.\n");
+		log("\n");
+	}
+
+	void execute(std::vector<std::string>, RTLIL::Design *design) override
+	{
+		log_header(design, "Executing QL_IOFF pass.\n");
+
+		ModWalker modwalker(design);
+		Module *module = design->top_module();
+		if (!module)
+			return;
+		modwalker.setup(module);
+		pool<RTLIL::Cell *> cells_to_replace;
+		for (auto cell : module->selected_cells()) {
+			if (cell->type.in(ID(dffsre), ID(sdffsre))) {
+				bool e_const = cell->getPort(ID::E).is_fully_ones();
+				bool r_const = cell->getPort(ID::R).is_fully_ones();
+				bool s_const = cell->getPort(ID::S).is_fully_ones();
+
+				if (!(e_const && r_const && s_const))
+					continue;
+
+				auto d_sig = modwalker.sigmap(cell->getPort(ID::D));
+				if (d_sig.is_wire() && d_sig.as_wire()->port_input) {
+					log_debug("Cell %s is potentially eligible for promotion to input IOFF.\n", cell->name.c_str());
+					// check that d_sig has no other consumers
+					if (GetSize(d_sig) != 1) continue;
+					pool<ModWalker::PortBit> portbits;
+					modwalker.get_consumers(portbits, d_sig[0]);
+					if (GetSize(portbits) > 1) {
+						log_debug("not promoting: d_sig has other consumers\n");
+						continue;
+					}
+					cells_to_replace.insert(cell);
+					continue; // no need to check Q if we already put it on the list
+				}
+				auto q_sig = modwalker.sigmap(cell->getPort(ID::Q));
+				if (q_sig.is_wire() && q_sig.as_wire()->port_output) {
+					log_debug("Cell %s is potentially eligible for promotion to output IOFF.\n", cell->name.c_str());
+					// check that q_sig has no other consumers
+					if (GetSize(q_sig) != 1) continue;
+					pool<ModWalker::PortBit> portbits;
+					modwalker.get_consumers(portbits, q_sig[0]);
+					if (GetSize(portbits) > 0) {
+						log_debug("not promoting: q_sig has other consumers\n");
+						continue;
+					}
+					cells_to_replace.insert(cell);
+				}
+			}
+		}
+
+		for (auto cell : cells_to_replace) {
+			log("Promoting register %s to IOFF.\n", log_signal(cell->getPort(ID::Q)));
+			cell->type = ID(dff);
+			cell->unsetPort(ID::E);
+			cell->unsetPort(ID::R);
+			cell->unsetPort(ID::S);
+		}
+	}
+} QlIoffPass;
+
+PRIVATE_NAMESPACE_END

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -334,9 +334,10 @@ struct SynthQuickLogicPass : public ScriptPass {
 			run("opt_lut");
 		}
 		
-		if (check_label("iomap", "(for qlf_k6n10f)") && (family == "qlf_k6n10f" || help_mode)) {
+		if (check_label("iomap", "(for qlf_k6n10f, skip if -noioff)") && (family == "qlf_k6n10f" || help_mode)) {
 			if (ioff || help_mode) {
-				run("ql_ioff", "(unless -noioff)");
+				run("ql_ioff");
+				run("opt_clean");
 			}
 		}
 

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -78,7 +78,7 @@ struct SynthQuickLogicPass : public ScriptPass {
 	}
 
 	string top_opt, blif_file, edif_file, family, currmodule, verilog_file, lib_path;
-	bool abc9, inferAdder, nobram, bramTypes, dsp;
+	bool abc9, inferAdder, nobram, bramTypes, dsp, ioff;
 
 	void clear_flags() override
 	{
@@ -94,6 +94,7 @@ struct SynthQuickLogicPass : public ScriptPass {
 		bramTypes = false;
 		lib_path = "+/quicklogic/";
 		dsp = true;
+		ioff = true;
 	}
 
 	void set_scratchpad_defaults(RTLIL::Design *design) {
@@ -156,6 +157,10 @@ struct SynthQuickLogicPass : public ScriptPass {
 			}
 			if (args[argidx] == "-nodsp" || args[argidx] == "-no_dsp") {
 				dsp = false;
+				continue;
+			}
+			if (args[argidx] == "-noioff") {
+				ioff = false;
 				continue;
 			}
 			break;
@@ -327,6 +332,12 @@ struct SynthQuickLogicPass : public ScriptPass {
 			run("techmap -map " + lib_path + family + "/lut_map.v");
 			run("clean");
 			run("opt_lut");
+		}
+		
+		if (check_label("iomap", "(for qlf_k6n10f)") && (family == "qlf_k6n10f" || help_mode)) {
+			if (ioff || help_mode) {
+				run("ql_ioff", "(unless -noioff)");
+			}
 		}
 
 		if (check_label("check")) {

--- a/tests/arch/quicklogic/qlf_k6n10f/counter.ys
+++ b/tests/arch/quicklogic/qlf_k6n10f/counter.ys
@@ -2,7 +2,7 @@ read_verilog ../../common/counter.v
 hierarchy -top top
 proc
 flatten
-equiv_opt -assert -multiclock -map +/quicklogic/qlf_k6n10f/cells_sim.v -map +/quicklogic/common/cells_sim.v synth_quicklogic -family qlf_k6n10f # equivalency check
+equiv_opt -assert -multiclock -map +/quicklogic/qlf_k6n10f/cells_sim.v -map +/quicklogic/common/cells_sim.v synth_quicklogic -family qlf_k6n10f -noioff # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
 select -assert-count 4 t:$lut

--- a/tests/arch/quicklogic/qlf_k6n10f/dffs.ys
+++ b/tests/arch/quicklogic/qlf_k6n10f/dffs.ys
@@ -5,7 +5,7 @@ design -save read
 
 hierarchy -top my_dff
 proc
-equiv_opt -async2sync -assert -map +/quicklogic/qlf_k6n10f/cells_sim.v -map +/quicklogic/common/cells_sim.v synth_quicklogic -family qlf_k6n10f # equivalency check
+equiv_opt -async2sync -assert -map +/quicklogic/qlf_k6n10f/cells_sim.v -map +/quicklogic/common/cells_sim.v synth_quicklogic -family qlf_k6n10f -noioff # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd my_dff # Constrain all select calls below inside the top module
 select -assert-count 1 t:sdffsre
@@ -14,7 +14,7 @@ select -assert-none t:sdffsre %% t:* %D
 design -load read
 hierarchy -top my_dffe
 proc
-equiv_opt -async2sync -assert -map +/quicklogic/qlf_k6n10f/cells_sim.v -map +/quicklogic/common/cells_sim.v synth_quicklogic -family qlf_k6n10f # equivalency check
+equiv_opt -async2sync -assert -map +/quicklogic/qlf_k6n10f/cells_sim.v -map +/quicklogic/common/cells_sim.v synth_quicklogic -family qlf_k6n10f -noioff # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd my_dffe # Constrain all select calls below inside the top module
 select -assert-count 1 t:sdffsre

--- a/tests/arch/quicklogic/qlf_k6n10f/ioff.ys
+++ b/tests/arch/quicklogic/qlf_k6n10f/ioff.ys
@@ -22,6 +22,21 @@ synth_quicklogic -family qlf_k6n10f -top top
 select -assert-count 4 t:dff
 
 design -reset
+# test: acceptable for output IOFF promotion; duplicate output FF
+read_verilog <<EOF
+module top (input clk, input [3:0] a, output [3:0] o, output [3:0] p);
+    reg [3:0] r;
+    always @(posedge clk) begin
+        r <= ~a;
+    end
+    assign o = r;
+    assign p = r;
+endmodule
+EOF
+synth_quicklogic -family qlf_k6n10f -top top
+select -assert-count 8 t:dff
+
+design -reset
 # test: acceptable for input IOFF promotion
 read_verilog <<EOF
 module top (input clk, input a, output o);
@@ -170,3 +185,25 @@ endmodule
 EOF
 synth_quicklogic -family qlf_k6n10f -top top
 select -assert-count 0 t:dff
+
+design -reset
+# test: duplicate registers driving multiple output ports
+read_verilog <<EOF
+module top (
+    input clk,
+    input en,
+    input [3:0] a,
+    output reg [3:0] o_1,
+	output wire [3:0] o_2
+);
+always @(posedge clk) begin
+    o_1[1:0] <= ~a[1:0];
+    if (en)
+        o_1[2] <= a[2];
+end
+always @(*) o_1[3] = a[3];
+assign o_2 = o_1;
+endmodule
+EOF
+synth_quicklogic -family qlf_k6n10f -top top
+select -assert-count 4 t:dff

--- a/tests/arch/quicklogic/qlf_k6n10f/ioff.ys
+++ b/tests/arch/quicklogic/qlf_k6n10f/ioff.ys
@@ -1,0 +1,91 @@
+# test: acceptable for output IOFF promotion
+read_verilog <<EOF
+module top (input clk, input a, output reg o);
+    always @(posedge clk) begin
+        o <= ~a;
+    end
+endmodule
+EOF
+synth_quicklogic -family qlf_k6n10f -top top
+select -assert-count 1 t:dff
+
+design -reset
+# test: acceptable for input IOFF promotion
+read_verilog <<EOF
+module top (input clk, input a, output o);
+    reg r;
+    always @(posedge clk) begin
+        r <= a;
+    end
+    assign o = ~r;
+endmodule
+EOF
+synth_quicklogic -family qlf_k6n10f -top top
+select -assert-count 1 t:dff
+
+design -reset
+# test: acceptable for either IOFF promotion
+read_verilog <<EOF
+module top (input clk, input a, output reg o);
+    always @(posedge clk) begin
+        o <= a;
+    end
+endmodule
+EOF
+synth_quicklogic -family qlf_k6n10f -top top
+select -assert-count 1 t:dff
+
+design -reset
+# test: not acceptable for output IOFF promotion: output signal is used
+read_verilog <<EOF
+module top (input clk, input a, output reg o);
+    always @(posedge clk) begin
+        o <= ~a | o;
+    end
+endmodule
+EOF
+synth_quicklogic -family qlf_k6n10f -top top
+select -assert-count 0 t:dff
+
+design -reset
+# test: not acceptable for input IOFF promotion: input signal is used
+read_verilog <<EOF
+module top (input clk, input a, output o, p);
+    reg r;
+    always @(posedge clk) begin
+        r <= a;
+    end
+    assign o = ~r;
+    assign p = ~a;
+endmodule
+EOF
+synth_quicklogic -family qlf_k6n10f -top top
+select -assert-count 0 t:dff
+
+design -reset
+# test: not acceptable for IOFF promotion: FF has reset
+read_verilog <<EOF
+module top (input clk, input rst, input a, output reg o);
+    always @(posedge clk) begin
+        if (rst)
+            o <= 1'b0;
+        else
+            o <= a;
+    end
+endmodule
+EOF
+synth_quicklogic -family qlf_k6n10f -top top
+select -assert-count 0 t:dff
+
+design -reset
+# test: not acceptable for IOFF promotion: FF has enable
+read_verilog <<EOF
+module top (input clk, input en, input a, output reg o);
+    always @(posedge clk) begin
+        if (en)
+            o <= a;
+    end
+endmodule
+EOF
+synth_quicklogic -family qlf_k6n10f -top top
+select -assert-count 0 t:dff

--- a/tests/arch/quicklogic/qlf_k6n10f/ioff.ys
+++ b/tests/arch/quicklogic/qlf_k6n10f/ioff.ys
@@ -10,6 +10,18 @@ synth_quicklogic -family qlf_k6n10f -top top
 select -assert-count 1 t:dff
 
 design -reset
+# test: acceptable for output IOFF promotion
+read_verilog <<EOF
+module top (input clk, input [3:0] a, output reg [3:0] o);
+    always @(posedge clk) begin
+        o <= ~a;
+    end
+endmodule
+EOF
+synth_quicklogic -family qlf_k6n10f -top top
+select -assert-count 4 t:dff
+
+design -reset
 # test: acceptable for input IOFF promotion
 read_verilog <<EOF
 module top (input clk, input a, output o);
@@ -22,6 +34,20 @@ endmodule
 EOF
 synth_quicklogic -family qlf_k6n10f -top top
 select -assert-count 1 t:dff
+
+design -reset
+# test: acceptable for input IOFF promotion
+read_verilog <<EOF
+module top (input clk, input [3:0] a, output [3:0] o);
+    reg [3:0] r;
+    always @(posedge clk) begin
+        r <= a;
+    end
+    assign o = ~r;
+endmodule
+EOF
+synth_quicklogic -family qlf_k6n10f -top top
+select -assert-count 4 t:dff
 
 design -reset
 # test: acceptable for either IOFF promotion
@@ -48,10 +74,37 @@ synth_quicklogic -family qlf_k6n10f -top top
 select -assert-count 0 t:dff
 
 design -reset
+# test: not acceptable for output IOFF promotion: output signal is used
+read_verilog <<EOF
+module top (input clk, input [3:0] a, output reg [3:0] o);
+    always @(posedge clk) begin
+        o <= ~a | o;
+    end
+endmodule
+EOF
+synth_quicklogic -family qlf_k6n10f -top top
+select -assert-count 0 t:dff
+
+design -reset
 # test: not acceptable for input IOFF promotion: input signal is used
 read_verilog <<EOF
 module top (input clk, input a, output o, p);
     reg r;
+    always @(posedge clk) begin
+        r <= a;
+    end
+    assign o = ~r;
+    assign p = ~a;
+endmodule
+EOF
+synth_quicklogic -family qlf_k6n10f -top top
+select -assert-count 0 t:dff
+
+design -reset
+# test: not acceptable for input IOFF promotion: input signal is used
+read_verilog <<EOF
+module top (input clk, input [3:0] a, output [3:0] o, output [3:0] p);
+    reg [3:0] r;
     always @(posedge clk) begin
         r <= a;
     end
@@ -78,9 +131,37 @@ synth_quicklogic -family qlf_k6n10f -top top
 select -assert-count 0 t:dff
 
 design -reset
+# test: not acceptable for IOFF promotion: FF has reset
+read_verilog <<EOF
+module top (input clk, input rst, input [3:0] a, output reg [3:0] o);
+    always @(posedge clk) begin
+        if (rst)
+            o <= 4'b0;
+        else
+            o <= a;
+    end
+endmodule
+EOF
+synth_quicklogic -family qlf_k6n10f -top top
+select -assert-count 0 t:dff
+
+design -reset
 # test: not acceptable for IOFF promotion: FF has enable
 read_verilog <<EOF
 module top (input clk, input en, input a, output reg o);
+    always @(posedge clk) begin
+        if (en)
+            o <= a;
+    end
+endmodule
+EOF
+synth_quicklogic -family qlf_k6n10f -top top
+select -assert-count 0 t:dff
+
+design -reset
+# test: not acceptable for IOFF promotion: FF has enable
+read_verilog <<EOF
+module top (input clk, input en, input [3:0] a, output reg [3:0] o);
     always @(posedge clk) begin
         if (en)
             o <= a;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

There are registered I/Os available in the qlf_k6n10f architecture, using them saves fabric FFs. 

_Explain how this is achieved._

If a `dffsre` or `sdffsre` cell in the top module fulfils the following criteria:
- the set, reset, and enable ports are unused
- the D port is connected to an input signal or the Q port is connected to an output signal
- the signal in question has no other users

then its type is changed to `dff`.

_If applicable, please suggest to reviewers how they can test the change._

Testcase included.