### PR TITLE
liberty expression lexer check if characters are found and use size if not for `pin()`

### DIFF
--- a/passes/techmap/libparse.h
+++ b/passes/techmap/libparse.h
@@ -59,6 +59,10 @@ namespace Yosys
 
 			std::string pin() {
 				auto length = s.find_first_of("\t()'!^*& +|");
+				if (length == std::string::npos) {
+					// nothing found so use size of s
+					length = s.size();
+				}
 				auto pin = s.substr(0, length);
 				s = s.substr(length, s.size());
 				return pin;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

When the clocked_on expression contains an expression like: `D&!SE+SE&SI` the lexer segfaults when processing the SI pin because `find_first_of` returns `std::string::npos` causing the calls to `strsub` to throw an exception.

_Explain how this is achieved._

Check the return value and use the size of the string if those characters are not found.

_If applicable, please suggest to reviewers how they can test the change._

I have a liberty file which was modified from one of the yosys testcases I can add, but I might need to guidance on how to integrate that as a test.
See attached (added the sdff cell for testing): [normal_scan_ff.zip](https://github.com/user-attachments/files/18594737/normal_scan_ff.zip)
