### PR TITLE
write_verilog: emit $check cell names as labels

### DIFF
--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -1044,16 +1044,21 @@ void dump_cell_expr_print(std::ostream &f, std::string indent, const RTLIL::Cell
 void dump_cell_expr_check(std::ostream &f, std::string indent, const RTLIL::Cell *cell)
 {
 	std::string flavor = cell->getParam(ID(FLAVOR)).decode_string();
+	std::string label = "";
+	if (cell->name.isPublic()) {
+		label = stringf("%s: ", id(cell->name).c_str());
+	}
+
 	if (flavor == "assert")
-		f << stringf("%s" "assert (", indent.c_str());
+		f << stringf("%s" "%s" "assert (", indent.c_str(), label.c_str());
 	else if (flavor == "assume")
-		f << stringf("%s" "assume (", indent.c_str());
+		f << stringf("%s" "%s" "assume (", indent.c_str(), label.c_str());
 	else if (flavor == "live")
-		f << stringf("%s" "assert (eventually ", indent.c_str());
+		f << stringf("%s" "%s" "assert (eventually ", indent.c_str(), label.c_str());
 	else if (flavor == "fair")
-		f << stringf("%s" "assume (eventually ", indent.c_str());
+		f << stringf("%s" "%s" "assume (eventually ", indent.c_str(), label.c_str());
 	else if (flavor == "cover")
-		f << stringf("%s" "cover (", indent.c_str());
+		f << stringf("%s" "%s" "cover (", indent.c_str(), label.c_str());
 	dump_sigspec(f, cell->getPort(ID::A));
 	f << stringf(");\n");
 }

--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -1059,6 +1059,8 @@ void dump_cell_expr_check(std::ostream &f, std::string indent, const RTLIL::Cell
 		f << stringf("%s" "%s" "assume (eventually ", indent.c_str(), label.c_str());
 	else if (flavor == "cover")
 		f << stringf("%s" "%s" "cover (", indent.c_str(), label.c_str());
+	else
+		log_abort();
 	dump_sigspec(f, cell->getPort(ID::A));
 	f << stringf(");\n");
 }


### PR DESCRIPTION
Right now `assert`/`assume`/`cover` cell labels get parsed as the cell name of the `$check` cell, but the verilog backend does not use that information again. 

This now emits public names again as labels in the verilog backend.

Running the following script:
```
read -sv -formal <<EOF
module test();
    always test : assert(1);
endmodule
EOF
prep -top test
write_verilog
```
used to result in 
```sv
(* keep =  1  *)
(* hdlname = "test" *)
(* top =  1  *)
(* src = "<<EOF:1.1-3.10" *)
module test();
  (* src = "<<EOF:2.9-2.25" *)
  wire test_EN;
  always @*
    if (1'h1) begin
      assert (1'h1);
    end
  assign test_EN = 1'h1;
endmodule
```
and with this change results in 
```sv
(* keep =  1  *)
(* hdlname = "test" *)
(* top =  1  *)
(* src = "<<EOF:1.1-3.10" *)
module test();
  (* src = "<<EOF:2.9-2.25" *)
  wire test_EN;
  always @*
    if (1'h1) begin
      test: assert (1'h1);
    end
  assign test_EN = 1'h1;
endmodule
```