### PR TITLE
wreduce: fix warning for deprecated IdString::in(pool<IdString>)

### DIFF
--- a/passes/opt/wreduce.cc
+++ b/passes/opt/wreduce.cc
@@ -280,7 +280,7 @@ struct WreduceWorker
 	{
 		bool did_something = false;
 
-		if (!cell->type.in(config->supported_cell_types))
+		if (!config->supported_cell_types.count(cell->type))
 			return;
 
 		if (cell->type.in(ID($mux), ID($pmux)))


### PR DESCRIPTION
In #4524 I found the `IdString::in(pool<IdString>)` to be redundant and being annoying about the ordering of definitions or something and deprecated it. This PR replaces the pattern creating a warning, which was generated due to parallel work on the aforementioned PR and #4819 with the usage `pool<IdString>::count(IdString)` as suggested in the comment above the deprecated method definitions