### PR TITLE
Fixing undefined behaviours

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -2936,7 +2936,10 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 					lsb_expr->children[stride_ix]->detectSignWidth(stride_width, stride_sign);
 					max_width = std::max(i_width, stride_width);
 					// Stride width calculated from actual stride value.
-					stride_width = std::ceil(std::log2(std::abs(stride)));
+					if (stride == 0)
+						stride_width = 0;
+					else
+						stride_width = std::ceil(std::log2(std::abs(stride)));
 
 					if (i_width + stride_width > max_width) {
 						// For (truncated) i*stride to be within the range of dst, the following must hold:

--- a/kernel/celledges.cc
+++ b/kernel/celledges.cc
@@ -253,13 +253,13 @@ void shift_op(AbstractCellEdgesDatabase *db, RTLIL::Cell *cell)
 				if (a_width == 1 && is_signed) {
 					int skip = 1 << (k + 1);
 					int base = skip -1;
-					if (i % skip != base && i - a_width + 2 < 1 << b_width)
+					if (i % skip != base && i - a_width + 2 < 1 << b_width_capped)
 						db->add_edge(cell, ID::B, k, ID::Y, i, -1);	
 				} else if (is_signed) {
-					if (i - a_width + 2 < 1 << b_width)
+					if (i - a_width + 2 < 1 << b_width_capped)
 						db->add_edge(cell, ID::B, k, ID::Y, i, -1);
 				} else {
-					if (i - a_width + 1 < 1 << b_width)
+					if (i - a_width + 1 < 1 << b_width_capped)
 						db->add_edge(cell, ID::B, k, ID::Y, i, -1);
 				}
 			// right shifts


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

#4845 (and https://github.com/YosysHQ/yosys/issues/4844#issuecomment-2589140999) reveal undefined behaviors in the Yosys code.  This PR aims to resolve them.

_Explain how this is achieved._

- [x] kernel/celledges.cc
`b_width_capped` already exists for preventing arithmetic overflow, limiting the value of `b_width` to 30.  This just changes the left shifts to also use it. The caveat of incorrect results for extremely large values of `a_width` still applies, as does the improbability of that actually happening. This fixes #4844 (or at least, the floating point exception; the circuit still isn't valid but I think that's fine).
- [x] frontends/ast/simplify.cc
In the `nowrshmsk` handling, `log2(0)` returns -inf, which gives undefined behaviour when casting to an int.  So catch the case when the stride is 0 and just set the stride_width to 0.

_If applicable, please suggest to reviewers how they can test the change._

Follow instructions for testing #4845 on this branch