### PR TITLE
Makefile: Add run-test.mk to clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1053,6 +1053,7 @@ clean:
 	rm -rf vloghtb/Makefile vloghtb/refdat vloghtb/rtl vloghtb/scripts vloghtb/spec vloghtb/check_yosys vloghtb/vloghammer_tb.tar.bz2 vloghtb/temp vloghtb/log_test_*
 	rm -f tests/svinterfaces/*.log_stdout tests/svinterfaces/*.log_stderr tests/svinterfaces/dut_result.txt tests/svinterfaces/reference_result.txt tests/svinterfaces/a.out tests/svinterfaces/*_syn.v tests/svinterfaces/*.diff
 	rm -f  tests/tools/cmp_tbdata
+	rm -f $(addsuffix /run-test.mk,$(MK_TEST_DIRS))
 	-$(MAKE) -C docs clean
 	-$(MAKE) -C docs/images clean
 	rm -rf docs/source/cmd docs/util/__pycache__


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

If a test directory already contains a `run-test.mk` file it won't regenerate if anything in the directory changes, meaning any files will be skipped and any removed tests will raise an error because of the missing file.

_Explain how this is achieved._

`MK_TEST_DIRS` provides a list of directories that generate `run-test.mk` files, so we can use that list in the `clean` target to delete them; thus allowing future runs of `make test` to correctly regenerate the needed file.

_If applicable, please suggest to reviewers how they can test the change._

```bash
make tests/techmap/run-test.mk
rm tests/techmap/abc9.ys
clean
make makefile-tests/tests/techmap
```
Without this change, the second call to make will raise an error due to the missing `abc9.ys`.