### PR TITLE
Remove obsolete Makefile docs/images clean call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1054,7 +1054,6 @@ clean:
 	rm -f tests/svinterfaces/*.log_stdout tests/svinterfaces/*.log_stderr tests/svinterfaces/dut_result.txt tests/svinterfaces/reference_result.txt tests/svinterfaces/a.out tests/svinterfaces/*_syn.v tests/svinterfaces/*.diff
 	rm -f  tests/tools/cmp_tbdata
 	-$(MAKE) -C docs clean
-	-$(MAKE) -C docs/images clean
 	rm -rf docs/source/cmd docs/util/__pycache__
 
 clean-abc:


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Every time when I run `make config-gcc` or `make clean` it would give an error of `docs/images` directory could not be found.

_Explain how this is achieved._

Remove Makefile call to `docs/images clean` from top level makefile, the new `docs/sources/_images` clean target would be called by `docs` Makefile clean target

_If applicable, please suggest to reviewers how they can test the change._
