### PR TITLE
memory_libmap: update indices on design modification

### DIFF
--- a/passes/memory/memory_libmap.cc
+++ b/passes/memory/memory_libmap.cc
@@ -2258,6 +2258,8 @@ struct MemoryLibMapPass : public Pass {
 					log("using FF mapping for memory %s.%s\n", log_id(module->name), log_id(mem.memid));
 				} else {
 					map.emit(map.cfgs[idx]);
+					// Rebuild indices after modifying module
+					worker = MapWorker(module);
 				}
 			}
 		}


### PR DESCRIPTION
As reported in #4883, indices to the pass are reused after the module is modified, leading to dangling cell pointers in ModWalker etc. This has been the case since the inception of the pass but has only recently been discovered when 901935fbcec42cbf79594efd9cc2877810395715 exposed the issue as a segfault when a `PortBit` is hashed. This issue is easily detected with valgrind but since there's limited use of valgrind in testing (`vgtest` Makefile target only runs simple tests due to the runtime, for example) we've missed it. Whether this has lead to incorrect mapping results is uncertain.

This PR fixes the issue by rebuilding MapWorker but only when a memory actually gets emitted modifying the design. This rebuilds all the indices used in the and resolves anything detectable by valgrind at least on a clang debug build.

For testing with the segfault repro, see #4883 and run yosys with valgrind like `valgrind yosys -p "read_verilog ...`