### PR TITLE
share: fix infinite loop in find_terminal_bits on $mux loop

### DIFF
--- a/passes/opt/share.cc
+++ b/passes/opt/share.cc
@@ -87,7 +87,7 @@ struct ShareWorker
 			queue_bits.clear();
 
 			for (auto &pbit : portbits) {
-				if (pbit.cell->type == ID($mux) || pbit.cell->type == ID($pmux)) {
+				if ((pbit.cell->type == ID($mux) || pbit.cell->type == ID($pmux)) && visited_cells.count(pbit.cell) == 0) {
 					pool<RTLIL::SigBit> bits = modwalker.sigmap(pbit.cell->getPort(ID::S)).to_sigbit_pool();
 					terminal_bits.insert(bits.begin(), bits.end());
 					queue_bits.insert(bits.begin(), bits.end());


### PR DESCRIPTION
Previously, `share` assumed there is no combinational loop composed of `$mux` cells when collecting terminal bits. This PR uses the already implemented `visited_cells` to avoid running forever in the case of a `$mux` cell loop. Fixes #4260
