### PR TITLE
Fix runtime error on shift by INT_MAX

### DIFF
--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -1315,6 +1315,10 @@ skip_fine_alu:
 			RTLIL::SigSpec sig_a = assign_map(cell->getPort(ID::A));
 			RTLIL::SigSpec sig_y(cell->type == ID($shiftx) ? RTLIL::State::Sx : RTLIL::State::S0, cell->getParam(ID::Y_WIDTH).as_int());
 
+			// Limit indexing to the size of a, which is behaviourally identical (result is all 0)
+			// and avoids integer overflow of i + shift_bits when e.g. ID::B == INT_MAX
+			shift_bits = min(shift_bits, GetSize(sig_a));
+
 			if (cell->type != ID($shiftx) && GetSize(sig_a) < GetSize(sig_y))
 				sig_a.extend_u0(GetSize(sig_y), cell->getParam(ID::A_SIGNED).as_bool());
 

--- a/tests/opt/opt_expr_shr_int_max.ys
+++ b/tests/opt/opt_expr_shr_int_max.ys
@@ -1,0 +1,9 @@
+read_verilog << EOF
+module uut_00034(b, y);
+  input signed [30:0] b;
+  output [11:0] y = b >> ~31'b0; // shift by INT_MAX
+endmodule
+EOF
+
+# This should succeed, even with UBSAN halt_on_error
+opt_expr


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Main is failing CI on a seeded fsm test: https://github.com/YosysHQ/yosys/actions/runs/13282021101/job/37083651932#step:11:1099

This specific case can be minimised to calling `opt_expr` on the following verilog:
```verilog
module uut_00034(b, y);
  input signed [30:0] b;
  output [11:0] y = b >> ~31'b0; // shift by INT_MAX
endmodule
```

The line in `opt_expr` encountering the error is `int idx = i + shift_bits;`, where `shift_bits` is equal to the value of the RHS, which in this case is INT_MAX.  Therefore any non-zero value of `i` results in an integer overflow. 

_Explain how this is achieved._

The value of `shift_bits` is meaningless for values greater than the width of the A port, since anything greater than or equal to that causes the Y output to be all 0.  As such, we can safely cap the value of `shift_bits` to this value.

This doesn't prevent overflow entirely; if A is more than 2^30 bits wide it could still overflow, but given that we already have the below in `celledges.cc::shift_op()` I'm pretty sure other problems will already be cropping up by then.

```c++
// the cap below makes sure we don't overflow in the arithmetic further down, though
// it makes the edge data invalid once a_width approaches the order of 2**30
// (that ever happening is considered improbable)
int b_width_capped = min(b_width, 30);
```

_If applicable, please suggest to reviewers how they can test the change._

Build Yosys with make option `SANITIZER=undefined` and run `opt_expr_shr_int_max.ys` with environment variable `UBSAN_OPTIONS=halt_on_errror=1`.  Without this change it should fail, with this change it should pass (and other tests should be unaffected).