### PR TITLE
`aldff`s do not get split by `splitcells` pass

### DIFF
--- a/passes/cmds/splitcells.cc
+++ b/passes/cmds/splitcells.cc
@@ -134,7 +134,7 @@ struct SplitcellsWorker
 			return GetSize(slices)-1;
 		}
 
-		if (cell->type.in("$ff", "$dff", "$dffe", "$dffsr", "$dffsre", "$adff", "$adffe", "$aldffe",
+		if (cell->type.in("$ff", "$dff", "$dffe", "$dffsr", "$dffsre", "$adff", "$adffe", "$aldff", "$aldffe",
 				"$sdff", "$sdffce", "$sdffe", "$dlatch", "$dlatchsr", "$adlatch"))
 		{
 			auto splitports = {ID::D, ID::Q, ID::AD, ID::SET, ID::CLR};


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Currently, `aldff`s do not get split by splitcells; this PR fixes this.

_Explain how this is achieved._

Add `aldff` to the list of reg/latch cell types to be split.

_If applicable, please suggest to reviewers how they can test the change._
