### PR TITLE
Fix macOS boost-python issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,8 @@ ifeq ($(ENABLE_PYTHON_CONFIG_EMBED),1)
 PYTHON_CONFIG := $(PYTHON_EXECUTABLE)-config --embed
 else
 PYTHON_CONFIG := $(PYTHON_EXECUTABLE)-config
+
+LINKFLAGS += $(shell $(PYTHON_CONFIG) --ldflags)
 endif
 
 PYTHON_DESTDIR := $(shell $(PYTHON_EXECUTABLE) -c "import site; print(site.getsitepackages()[-1]);")
@@ -331,7 +333,7 @@ endif
 
 ifeq ($(ENABLE_PYOSYS),1)
 # Detect name of boost_python library. Some distros use boost_python-py<version>, other boost_python<version>, some only use the major version number, some a concatenation of major and minor version numbers
-CHECK_BOOST_PYTHON = (echo "int main(int argc, char ** argv) {return 0;}" | $(CXX) -xc -o /dev/null $(shell $(PYTHON_CONFIG) --ldflags) $(LINKFLAGS) -l$(1) - > /dev/null 2>&1 && echo "-l$(1)")
+CHECK_BOOST_PYTHON = (echo "int main(int argc, char ** argv) {return 0;}" | $(CXX) -xc -o /dev/null $(LINKFLAGS) -l$(1) - > /dev/null 2>&1 && echo "-l$(1)")
 BOOST_PYTHON_LIB ?= $(shell \
 	$(call CHECK_BOOST_PYTHON,boost_python-py$(subst .,,$(PYTHON_VERSION))) || \
 	$(call CHECK_BOOST_PYTHON,boost_python-py$(PYTHON_MAJOR_VERSION)) || \

--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,8 @@ ifneq ($(shell :; command -v brew),)
 BREW_PREFIX := $(shell brew --prefix)/opt
 $(info $$BREW_PREFIX is [${BREW_PREFIX}])
 ifeq ($(ENABLE_PYOSYS),1)
-CXXFLAGS += -I$(BREW_PREFIX)/boost/include/boost
-LINKFLAGS += -L$(BREW_PREFIX)/boost/lib
+CXXFLAGS += -I$(BREW_PREFIX)/boost/include
+LINKFLAGS += -L$(BREW_PREFIX)/boost/lib -L$(BREW_PREFIX)/boost-python3/lib
 endif
 CXXFLAGS += -I$(BREW_PREFIX)/readline/include
 LINKFLAGS += -L$(BREW_PREFIX)/readline/lib
@@ -331,7 +331,7 @@ endif
 
 ifeq ($(ENABLE_PYOSYS),1)
 # Detect name of boost_python library. Some distros use boost_python-py<version>, other boost_python<version>, some only use the major version number, some a concatenation of major and minor version numbers
-CHECK_BOOST_PYTHON = (echo "int main(int argc, char ** argv) {return 0;}" | $(CXX) -xc -o /dev/null $(shell $(PYTHON_CONFIG) --ldflags) -l$(1) - > /dev/null 2>&1 && echo "-l$(1)")
+CHECK_BOOST_PYTHON = (echo "int main(int argc, char ** argv) {return 0;}" | $(CXX) -xc -o /dev/null $(shell $(PYTHON_CONFIG) --ldflags) $(LINKFLAGS) -l$(1) - > /dev/null 2>&1 && echo "-l$(1)")
 BOOST_PYTHON_LIB ?= $(shell \
 	$(call CHECK_BOOST_PYTHON,boost_python-py$(subst .,,$(PYTHON_VERSION))) || \
 	$(call CHECK_BOOST_PYTHON,boost_python-py$(PYTHON_MAJOR_VERSION)) || \


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

This PR resolves the issue below seen on my macOS Apple Silicon with a vanilla Yosys clone:
```
akashlevy@Akashs-MacBook-Pro yosys % make -j8 ENABLE_PYOSYS=1
$BREW_PREFIX is [/opt/homebrew/opt]
Makefile:343: *** BOOST_PYTHON_LIB could not be detected. Please define manually.  Stop.
```

There are two issues:
1. The `boost` include path is incorrect (`$(BREW_PREFIX)/boost/include/boost` instead of `$(BREW_PREFIX)/boost/include`). This means that the canonical form of Boost includes such as `#include <boost/...>` will not work
2. `boost-python3` library needs to be linked to detect `boost-python3` properly

You can work around these issues by manually setting the `BOOST_PYTHON_LIB`, but this PR makes it so that is not needed.

_Explain how this is achieved._

1. Use `$(BREW_PREFIX)/boost/include` as the Boost include path
2. Add `-L$(BREW_PREFIX)/boost-python3/lib` to the `LINKFLAGS` and include `LINKFLAGS` in `CHECK_BOOST_PYTHON`

_If applicable, please suggest to reviewers how they can test the change._

This was tested on an Apple Silicon macOS (M2) with Pyosys enabled and was able to properly compile. I do not have access to an Intel macOS, it would be great if this can be tested against some builds as well.
