### PR TITLE
share: add -pattern-limit to limit analysis effort

### DIFF
--- a/passes/opt/share.cc
+++ b/passes/opt/share.cc
@@ -1454,6 +1454,7 @@ struct SharePass : public Pass {
 		log("\n");
 		log("  -limit N\n");
 		log("    Only perform the first N merges, then stop. This is useful for debugging.\n");
+		log("\n");
 		log("  -pattern-limit N\n");
 		log("    Only analyze up to N activation patterns per cell, otherwise assume active.\n");
 		log("    N is 1000 by default. Higher values may merge more resources at the cost of\n");

--- a/passes/opt/share.cc
+++ b/passes/opt/share.cc
@@ -1477,7 +1477,7 @@ struct SharePass : public Pass {
 		ShareWorkerConfig config;
 
 		config.limit = -1;
-		config.pattern_limit = 1000;
+		config.pattern_limit = design->scratchpad_get_int("share.pattern_limit", 1000);
 		config.opt_force = false;
 		config.opt_aggressive = false;
 		config.opt_fast = false;

--- a/passes/opt/share.cc
+++ b/passes/opt/share.cc
@@ -23,6 +23,7 @@
 #include "kernel/modtools.h"
 #include "kernel/utils.h"
 #include "kernel/macc.h"
+#include <iterator>
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
@@ -33,6 +34,7 @@ typedef std::pair<RTLIL::SigSpec, RTLIL::Const> ssc_pair_t;
 struct ShareWorkerConfig
 {
 	int limit;
+	size_t pattern_limit;
 	bool opt_force;
 	bool opt_aggressive;
 	bool opt_fast;
@@ -853,6 +855,21 @@ struct ShareWorker
 		optimize_activation_patterns(patterns);
 	}
 
+	template<typename Iterator>
+	void insert_capped(pool<ssc_pair_t>& cache, Iterator begin_pattern, Iterator end_pattern)
+	{
+		if (cache.size() + std::distance(begin_pattern, end_pattern) > config.pattern_limit) {
+			cache.clear();
+			cache.insert(ssc_pair_t());
+		} else {
+			cache.insert(begin_pattern, end_pattern);
+		}
+	}
+	void insert_capped(pool<ssc_pair_t>& cache, ssc_pair_t pattern)
+	{
+		insert_capped(cache, &pattern, &pattern + 1);
+	}
+
 	const pool<ssc_pair_t> &find_cell_activation_patterns(RTLIL::Cell *cell, const char *indent)
 	{
 		if (recursion_state.count(cell)) {
@@ -909,20 +926,20 @@ struct ShareWorker
 					for (int i = 0; i < GetSize(sig_s); i++)
 						p.first.append(sig_s[i]), p.second.bits().push_back(RTLIL::State::S0);
 					if (sort_check_activation_pattern(p))
-						activation_patterns_cache[cell].insert(p);
+						insert_capped(activation_patterns_cache[cell], p);
 				}
 
 			for (int idx : used_in_b_parts)
 				for (auto p : c_patterns) {
 					p.first.append(sig_s[idx]), p.second.bits().push_back(RTLIL::State::S1);
 					if (sort_check_activation_pattern(p))
-						activation_patterns_cache[cell].insert(p);
+						insert_capped(activation_patterns_cache[cell], p);
 				}
 		}
 
 		for (auto c : driven_cells) {
 			const pool<ssc_pair_t> &c_patterns = find_cell_activation_patterns(c, indent);
-			activation_patterns_cache[cell].insert(c_patterns.begin(), c_patterns.end());
+			insert_capped(activation_patterns_cache[cell], c_patterns.begin(), c_patterns.end());
 		}
 
 		log_assert(recursion_state.count(cell) != 0);
@@ -1437,6 +1454,10 @@ struct SharePass : public Pass {
 		log("\n");
 		log("  -limit N\n");
 		log("    Only perform the first N merges, then stop. This is useful for debugging.\n");
+		log("  -pattern-limit N\n");
+		log("    Only analyze up to N activation patterns per cell, otherwise assume active.\n");
+		log("    N is 1000 by default. Higher values may merge more resources at the cost of\n");
+		log("    more runtime and memory consumption.\n");
 		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
@@ -1444,6 +1465,7 @@ struct SharePass : public Pass {
 		ShareWorkerConfig config;
 
 		config.limit = -1;
+		config.pattern_limit = 1000;
 		config.opt_force = false;
 		config.opt_aggressive = false;
 		config.opt_fast = false;
@@ -1506,6 +1528,10 @@ struct SharePass : public Pass {
 			}
 			if (args[argidx] == "-limit" && argidx+1 < args.size()) {
 				config.limit = atoi(args[++argidx].c_str());
+				continue;
+			}
+			if (args[argidx] == "-pattern-limit" && argidx+1 < args.size()) {
+				config.pattern_limit = atoi(args[++argidx].c_str());
 				continue;
 			}
 			break;


### PR DESCRIPTION
The `share` pass uses SAT to find cells with same observability with regards to inputs of cells other than `$mux`. First, it expresses the observability conditions as basically a logical function over the S inputs of `$mux` cells in `find_cell_activation_patterns` by traversing contiguous `$mux` regions. This function is stored per cell as a sum of products in `activation_patterns_cache[cell]`. In some unfortunately shaped designs, the count of these products increases exponentially with the length of a chain of divering-converging muxes. This PR adds a user-configurable limit to how many "patterns" can be stored per cell. When this limit is exceeded, the cell is assumed to be always "active" in the sense that some of its input bits are always observable by outputs or cells other than multiplexers. This is always safe to do so as it can only inhibit merging cells. This limit is set to 1000 by default.

To test, you can observe the linear rise of memory usage beyond any reasonable bounds when running  `yosys -p "verific -sv slow-share.sv; prep; share"` on the following:

```sv
module test_case (
  input  wire         clk,
  input  wire         rst_clk,
  output wire [32:0]  rd [8:0],
  input  wire  [5:0]  wa [8:0],
  input  wire  [8:0]  wen
);

  logic [63:0][32:0] big;
  logic [63:0][32:0] wd;
  logic [5:0]        ra [8:0];

  always @(posedge clk) begin
      if (rst_clk) begin
        big <= '0;
      end
      else begin
        for (int i = 0; i < 9; i++) begin
          if (wen[i]) big[wa[i]] <= wd[wa[i]];
        end
      end
  end

  generate
    for (genvar i = 0; i < 9; i++) begin
      assign rd[i] = big[ra[i]];
    end
  endgenerate

endmodule
```

While this reproducer uses kind of a lot of wire bits, it is a completely reasonable design pattern. Pre-share statistics:

```
   Number of wires:                699
   Number of wire bits:          43561
   Number of public wires:          95
   Number of public wire bits:    2560
   Number of ports:                 21
   Number of port bits:            362
   Number of memories:               0
   Number of memory bits:            0
   Number of processes:              0
   Number of cells:                606
     $bmux                           9
     $dff                            1
     $mem_v2                         1
     $mux                          586
     $shl                            9
```

- [ ] add scratchpad support so that the limit can be adjusted even when `share` is used from `synth` commands