### PR TITLE
liberty: fix clear and preset latches

### DIFF
--- a/frontends/liberty/liberty.cc
+++ b/frontends/liberty/liberty.cc
@@ -348,7 +348,7 @@ static bool create_latch(RTLIL::Module *module, const LibertyAst *node, bool fla
 		RTLIL::Cell *enable_gate = module->addCell(NEW_ID, enable_polarity ? ID($_OR_) : ID($_AND_));
 		enable_gate->setPort(ID::A, enable_sig);
 		enable_gate->setPort(ID::B, clear_enable);
-		enable_gate->setPort(ID::Y, data_sig = module->addWire(NEW_ID));
+		enable_gate->setPort(ID::Y, enable_sig = module->addWire(NEW_ID));
 	}
 
 	if (preset_sig.size() == 1)
@@ -376,7 +376,7 @@ static bool create_latch(RTLIL::Module *module, const LibertyAst *node, bool fla
 		RTLIL::Cell *enable_gate = module->addCell(NEW_ID, enable_polarity ? ID($_OR_) : ID($_AND_));
 		enable_gate->setPort(ID::A, enable_sig);
 		enable_gate->setPort(ID::B, preset_enable);
-		enable_gate->setPort(ID::Y, data_sig = module->addWire(NEW_ID));
+		enable_gate->setPort(ID::Y, enable_sig = module->addWire(NEW_ID));
 	}
 
 	cell = module->addCell(NEW_ID, stringf("$_DLATCH_%c_", enable_polarity ? 'P' : 'N'));


### PR DESCRIPTION
Fixes #4885. Currently, all Liberty-described clear and preset latches were modeled with a disconnected data input, since the enable logic is clobbering the data signal. This PR fixes this.

Reproducer, from IHP 130:
```
library (sg13g2_stdcell_fast_1p32V_m40C_latch_repro) {
  comment : "IHP Microelectronics GmbH, 2024, modified";
  date : "$Date: Thu Mar 14 15:30:46 2024 $";
  revision : "$Revision: 0.1.0 $";
  cell (sg13g2_dllrq_1) {
    area : 29.0304;
    pin (Q) {
      direction : "output";
      function : "IQ";
    }
    pin (D) {
      direction : "input";
    }
    pin (GATE_N) {
      clock : true;
      direction : "input";
    }
    pin (RESET_B) {
      direction : "input";
    }
    latch (IQ,IQN) {
      clear : "RESET_B'";
      data_in : "D";
      enable : "GATE_N'";
    }
  }
}
```
`yosys -p "read_liberty latch.lib; opt; show` reproduces the image
`yosys -p "read_liberty latch.lib; show` shows that some attempt to use `D` is made