### PR TITLE
Cover all cases of submodule status in check-git-abc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -780,6 +780,10 @@ check-git-abc:
 		echo "Run 'git submodule update' to check out the correct version."; \
 		echo "Note: If testing a different version of abc, call `git commit abc` in the Yosys source directory to update the expected commit."; \
 		exit 1; \
+	elif git -C "$(YOSYS_SRC)" submodule status abc 2>/dev/null | grep -q '^U'; then \
+		echo "'abc' submodule has merge conflicts."; \
+		echo "Please resolve merge conflicts before continuing."; \
+		exit 1; \
 	elif [ -f "$(YOSYS_SRC)/abc/.gitcommit" ] && grep -q '\$$Format:%[hH]\$$' "$(YOSYS_SRC)/abc/.gitcommit"; then \
 		echo "Error: 'abc' is not configured as a git submodule."; \
 		echo "To resolve this:"; \

--- a/Makefile
+++ b/Makefile
@@ -778,7 +778,7 @@ check-git-abc:
 	elif git -C "$(YOSYS_SRC)" submodule status abc 2>/dev/null | grep -q '^+'; then \
 		echo "'abc' submodule does not match expected commit."; \
 		echo "Run 'git submodule update' to check out the correct version."; \
-		echo "Note: If testing a different version of abc, call `git commit abc` in the Yosys source directory to update the expected commit."; \
+		echo "Note: If testing a different version of abc, call 'git commit abc' in the Yosys source directory to update the expected commit."; \
 		exit 1; \
 	elif git -C "$(YOSYS_SRC)" submodule status abc 2>/dev/null | grep -q '^U'; then \
 		echo "'abc' submodule has merge conflicts."; \

--- a/Makefile
+++ b/Makefile
@@ -775,6 +775,11 @@ check-git-abc:
 	elif [ -f "$(YOSYS_SRC)/abc/.gitcommit" ] && ! grep -q '\$$Format:%[hH]\$$' "$(YOSYS_SRC)/abc/.gitcommit"; then \
 		echo "'abc' comes from a tarball. Continuing."; \
 		exit 0; \
+	elif git -C "$(YOSYS_SRC)" submodule status abc 2>/dev/null | grep -q '^+'; then \
+		echo "'abc' submodule does not match expected commit."; \
+		echo "Run 'git submodule update' to check out the correct version."; \
+		echo "Note: If testing a different version of abc, call `git commit abc` in the Yosys source directory to update the expected commit."; \
+		exit 1; \
 	elif [ -f "$(YOSYS_SRC)/abc/.gitcommit" ] && grep -q '\$$Format:%[hH]\$$' "$(YOSYS_SRC)/abc/.gitcommit"; then \
 		echo "Error: 'abc' is not configured as a git submodule."; \
 		echo "To resolve this:"; \


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

`git submodule status` can be prefixed with `[ -+U]`, of which we expect the space, and assume anything else is a `-`.  But seeing an error message that tells you abc is not initialized when it *is* initialized but pointing at a different commit is confusing.
Also closes #4888.

_Explain how this is achieved._

Handle the `[+U]` cases and give an actually related error message instead of the generic one.

_If applicable, please suggest to reviewers how they can test the change._
