### PR TITLE
libs/fst: Fix stringop_overread warning under GCC

### DIFF
--- a/libs/fst/00_PATCH_wx_len_overread.patch
+++ b/libs/fst/00_PATCH_wx_len_overread.patch
@@ -1,0 +1,10 @@
+--- fstapi.cc
++++ fstapi.cc
+@@ -6072,6 +6072,7 @@ for(;;)
+                                                                 }
+ 
+                                                         wx_len = snprintf(wx_buf, 32, "r%.16g", d);
++                                                        if (wx_len > 32 || wx_len < 0) wx_len = 32;
+                                                         fstWritex(xc, wx_buf, wx_len);
+                                                         }
+                                                 }

--- a/libs/fst/00_UPDATE.sh
+++ b/libs/fst/00_UPDATE.sh
@@ -18,3 +18,4 @@ sed -i -e 's,"fastlz.c","fastlz.cc",' *.cc *.h
 patch -p0 < 00_PATCH_win_zlib.patch
 patch -p0 < 00_PATCH_win_io.patch
 patch -p1 < 00_PATCH_strict_alignment.patch
+patch -p0 < 00_PATCH_wx_len_overread.patch

--- a/libs/fst/fstapi.cc
+++ b/libs/fst/fstapi.cc
@@ -3907,16 +3907,18 @@ while (value)
 static int fstVcdIDForFwrite(char *buf, unsigned int value)
 {
 char *pnt = buf;
+ int len = 0;
 
 /* zero is illegal for a value...it is assumed they start at one */
-while (value)
+while (value && len < 14)
         {
         value--;
+	++len;
         *(pnt++) = (char)('!' + value % 94);
         value = value / 94;
         }
 
-return(pnt - buf);
+return len;
 }
 
 

--- a/libs/fst/fstapi.cc
+++ b/libs/fst/fstapi.cc
@@ -6072,6 +6072,7 @@ for(;;)
                                                                 }
 
                                                         wx_len = snprintf(wx_buf, 32, "r%.16g", d);
+                                                        if (wx_len > 32 || wx_len < 0) wx_len = 32;
                                                         fstWritex(xc, wx_buf, wx_len);
                                                         }
                                                 }


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Fix the compiler warnings

    ‘ssize_t write(int, const void*, size_t)’ reading between 65536 and 4294967295 bytes from a region of size 16 [-Wstringop-overread]

_Explain how this is achieved._

Two of the three warnings were already fixed upstream, so we pull the fix and then patch the third.