### PR TITLE
improve mkdtemp error message

### DIFF
--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -413,8 +413,11 @@ std::string make_temp_dir(std::string template_str)
 #  endif
 
 	char *p = strdup(template_str.c_str());
+	log_assert(p);
 	char *res = mkdtemp(p);
-	log_assert(res != NULL);
+	if (!res)
+		log_error("mkdtemp failed for '%s': %s [Error %d]\n",
+			p, strerror(errno), errno);
 	template_str = p;
 	free(p);
 


### PR DESCRIPTION
`TMPDIR=/foo ./yosys -p "read_verilog tests/sat/alu.v; proc; abc"` 
before:
```
3. Executing ABC pass (technology mapping using ABC).
ERROR: Assert `res != NULL' failed in kernel/yosys.cc:417.
```
now:
```
3. Executing ABC pass (technology mapping using ABC).
ERROR: mkdtemp failed for '/foo/yosys-abc-e7oKww': No such file or directory [Error 2]
```