### PR TITLE
Verilog file list suport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ __pycache__
 /qtcreator.config
 /qtcreator.creator
 /qtcreator.creator.user
+/compile_commands.json
 /coverage.info
 /coverage_html
 /Makefile.conf
@@ -53,4 +54,3 @@ __pycache__
 /venv
 /boost
 /ffi
-/compile_commands.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.gcno
 *~
 __pycache__
+/.cache
 /.cproject
 /.project
 /.settings
@@ -52,3 +53,4 @@ __pycache__
 /venv
 /boost
 /ffi
+/compile_commands.json

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -4298,7 +4298,7 @@ struct ReadPass : public Pass {
 		log("\n");
 		log("    read {-f|-F} <command-file>\n");
 		log("\n");
-		log("Load and execute the specified command file. (Requires Verific.)\n");
+		log("Load and execute the specified command file.\n");
 		log("Check verific command for more information about supported commands in file.\n");
 		log("\n");
 		log("\n");
@@ -4412,10 +4412,10 @@ struct ReadPass : public Pass {
 		if (args[1] == "-f" || args[1] == "-F") {
 			if (use_verific) {
 				args[0] = "verific";
-				Pass::call(design, args);
 			} else {
-				cmd_error(args, 1, "This version of Yosys is built without Verific support.\n");
+				args[0] = "read_verilog_file_list";
 			}
+			Pass::call(design, args);
 			return;
 		}
 

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -4413,7 +4413,11 @@ struct ReadPass : public Pass {
 			if (use_verific) {
 				args[0] = "verific";
 			} else {
+#if !defined(__wasm)
 				args[0] = "read_verilog_file_list";
+#else
+				cmd_error(args, 1, "Command files are not supported on this platform.\n");
+#endif
 			}
 			Pass::call(design, args);
 			return;

--- a/frontends/verilog/verilog_frontend.cc
+++ b/frontends/verilog/verilog_frontend.cc
@@ -686,11 +686,11 @@ struct VerilogFileList : public Pass {
 		log("\n");
 		log("    -F file_list_path\n");
 		log("        File list file contains list of Verilog files to be parsed, any\n");
-		log("        ' path is treated relative to the file list file'\n");
+		log("          path is treated relative to the file list file\n");
 		log("\n");
 		log("    -f file_list_path\n");
 		log("        File list file contains list of Verilog files to be parsed, any\n");
-		log("        ' path is treated relative to current working directroy'\n");
+		log("          path is treated relative to current working directroy\n");
 		log("\n");
 	}
 
@@ -710,21 +710,21 @@ struct VerilogFileList : public Pass {
 				continue;
 			}
 
-			std::string verilog_file_path;
+			std::filesystem::path verilog_file_path;
 			if (relative_to_file_list_path) {
-				verilog_file_path = file_list_parent_dir.string() + '/' + v_file_name;
+				verilog_file_path = file_list_parent_dir / v_file_name;
 			} else {
-				verilog_file_path = std::filesystem::current_path().string() + '/' + v_file_name;
+				verilog_file_path = std::filesystem::current_path() / v_file_name;
 			}
 
-			bool is_sv = (std::filesystem::path(verilog_file_path).extension() == ".sv");
+			bool is_sv = (verilog_file_path.extension() == ".sv");
 
-			std::string command = "read_verilog";
+			std::vector<std::string> read_verilog_cmd = {"read_verilog", "-defer"};
 			if (is_sv) {
-				command += " -sv";
+				read_verilog_cmd.push_back("-sv");
 			}
-			command = command + ' ' + verilog_file_path;
-			Pass::call(design, command);
+			read_verilog_cmd.push_back(verilog_file_path.string());
+			Pass::call(design, read_verilog_cmd);
 		}
 
 		flist.close();
@@ -748,9 +748,7 @@ struct VerilogFileList : public Pass {
 			break;
 		}
 
-		if (args.size() != argidx) {
-			cmd_error(args, argidx, "Extra argument.");
-		}
+		extra_args(args, argidx, design);
 	}
 } VerilogFilelist;
 

--- a/frontends/verilog/verilog_frontend.cc
+++ b/frontends/verilog/verilog_frontend.cc
@@ -722,13 +722,16 @@ struct VerilogFileList : public Pass {
 		log("\n");
 		log("    read_verilog_file_list [options]\n");
 		log("\n");
-		log("Parse a Verilog file list, and pass the list of Verilog files to read_verilog command.\n");
+		log("Parse a Verilog file list, and pass the list of Verilog files to read_verilog\n");
+		log("command\n");
 		log("\n");
 		log("    -F file_list_path\n");
-		log("        File list file contains list of Verilog files to be parsed, any path is treated relative to the file list file\n");
+		log("        File list file contains list of Verilog files to be parsed, any path is\n");
+		log("        treated relative to the file list file\n");
 		log("\n");
 		log("    -f file_list_path\n");
-		log("        File list file contains list of Verilog files to be parsed, any path is treated relative to current working directroy\n");
+		log("        File list file contains list of Verilog files to be parsed, any path is\n");
+		log("        treated relative to current working directroy\n");
 		log("\n");
 	}
 

--- a/frontends/verilog/verilog_frontend.cc
+++ b/frontends/verilog/verilog_frontend.cc
@@ -26,7 +26,9 @@
  *
  */
 
+#if !defined(__wasm)
 #include <filesystem>
+#endif
 
 #include "verilog_frontend.h"
 #include "preproc.h"
@@ -674,6 +676,8 @@ struct VerilogDefines : public Pass {
 	}
 } VerilogDefines;
 
+#if !defined(__wasm)
+
 static void parse_file_list(const std::string &file_list_path, RTLIL::Design *design, bool relative_to_file_list_path)
 {
 	std::ifstream flist(file_list_path);
@@ -721,12 +725,10 @@ struct VerilogFileList : public Pass {
 		log("Parse a Verilog file list, and pass the list of Verilog files to read_verilog command.\n");
 		log("\n");
 		log("    -F file_list_path\n");
-		log("        File list file contains list of Verilog files to be parsed, any\n");
-		log("          path is treated relative to the file list file\n");
+		log("        File list file contains list of Verilog files to be parsed, any path is treated relative to the file list file\n");
 		log("\n");
 		log("    -f file_list_path\n");
-		log("        File list file contains list of Verilog files to be parsed, any\n");
-		log("          path is treated relative to current working directroy\n");
+		log("        File list file contains list of Verilog files to be parsed, any path is treated relative to current working directroy\n");
 		log("\n");
 	}
 
@@ -751,6 +753,8 @@ struct VerilogFileList : public Pass {
 		extra_args(args, argidx, design);
 	}
 } VerilogFilelist;
+
+#endif
 
 YOSYS_NAMESPACE_END
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Most large Verilog/SystemVerilog IP use a file list/command '.f' file to hold list of Verilog file need to be compiled, this change make yosys able to directly parse file list.

_Explain how this is achieved._

Implement a `read_verilog_file_list` command, that read in file list, and calls `read_verilog` on each Verilog file in the file list. Currently the command only handles file path in file list file, in a future PR I will implement support for `+define+` and `+incdir+` in file list file.

_If applicable, please suggest to reviewers how they can test the change._
