### PR TITLE
Derive abstract cells in top module during hierarchy

### DIFF
--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -1066,6 +1066,17 @@ struct HierarchyPass : public Pass {
 					mod->attributes[ID::initial_top] = RTLIL::Const(1);
 				else
 					mod->attributes.erase(ID::initial_top);
+
+			std::vector<IdString> abstract_ids;
+			for (auto cell : top_mod->cells()) {
+				IdString abstract_id = "$abstract" + cell->type.str();
+				if (design->module(cell->type) == nullptr && design->module(abstract_id))
+					abstract_ids.push_back(abstract_id);
+			}
+			for (auto abstract_id : abstract_ids)
+				design->module(abstract_id)->derive(design, {});
+			for (auto abstract_id : abstract_ids)
+				design->remove(design->module(abstract_id));
 		}
 
 		bool did_something = true;

--- a/tests/various/hierarchy_reassign_localparam.ys
+++ b/tests/various/hierarchy_reassign_localparam.ys
@@ -1,0 +1,18 @@
+read_verilog -defer <<EOT
+
+module bb (...);
+localparam A = "abc";
+input a;
+output b;
+endmodule
+
+module top (...);
+input a;
+output b;
+bb #(.A("def")) my_bb (a, b);
+endmodule
+
+EOT
+
+logger -expect error "does not have a parameter named 'A'" 1
+hierarchy -check -top top


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Previously if hierarchy had a top module then it would not derive any other abstract cells, this means that `-check` could miss certain kinds of errors that it would normally detect, such as in #4927.

_Explain how this is achieved._

After finding (and potentially deriving) `top_mod`, find all of the cells included and derive them as well; similarly to how if there is no top module then *all* abstract modules are derived.  I'm just now realising this only works for one level of abstract cells, which means we probably need some kind of recursive approach instead so I'm leaving this as draft for now.

_If applicable, please suggest to reviewers how they can test the change._

Includes `tests/various/hierarchy_reassign_localparam.ys` which fails under previous versions (instead giving the less helpful `ERROR: Module name in defparam contains non-constant expressions!`), but works when not using `read_verilog` without `-defer`, and/or when using `hierarchy -check` without `-top`.