### PR TITLE
opt_clean, simplemap: Add `$buf` handling

### DIFF
--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -601,7 +601,7 @@ void rmunused_module(RTLIL::Module *module, bool purge_mode, bool verbose, bool 
 
 	std::vector<RTLIL::Cell*> delcells;
 	for (auto cell : module->cells())
-		if (cell->type.in(ID($pos), ID($_BUF_)) && !cell->has_keep_attr()) {
+		if (cell->type.in(ID($pos), ID($_BUF_), ID($buf)) && !cell->has_keep_attr()) {
 			bool is_signed = cell->type == ID($pos) && cell->getParam(ID::A_SIGNED).as_bool();
 			RTLIL::SigSpec a = cell->getPort(ID::A);
 			RTLIL::SigSpec y = cell->getPort(ID::Y);

--- a/passes/techmap/simplemap.cc
+++ b/passes/techmap/simplemap.cc
@@ -42,6 +42,14 @@ void simplemap_not(RTLIL::Module *module, RTLIL::Cell *cell)
 	}
 }
 
+void simplemap_buf(RTLIL::Module *module, RTLIL::Cell *cell)
+{
+	RTLIL::SigSpec sig_a = cell->getPort(ID::A);
+	RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
+
+	module->connect(RTLIL::SigSig(sig_y, sig_a));
+}
+
 void simplemap_pos(RTLIL::Module *module, RTLIL::Cell *cell)
 {
 	RTLIL::SigSpec sig_a = cell->getPort(ID::A);
@@ -411,6 +419,7 @@ void simplemap_get_mappers(dict<IdString, void(*)(RTLIL::Module*, RTLIL::Cell*)>
 {
 	mappers[ID($not)]         = simplemap_not;
 	mappers[ID($pos)]         = simplemap_pos;
+	mappers[ID($buf)]         = simplemap_buf;
 	mappers[ID($and)]         = simplemap_bitop;
 	mappers[ID($or)]          = simplemap_bitop;
 	mappers[ID($xor)]         = simplemap_bitop;

--- a/techlibs/common/techmap.v
+++ b/techlibs/common/techmap.v
@@ -59,7 +59,7 @@ module _90_simplemap_compare_ops;
 endmodule
 
 (* techmap_simplemap *)
-(* techmap_celltype = "$pos $slice $concat $mux $tribuf $bmux $bwmux $bweqx" *)
+(* techmap_celltype = "$buf $pos $slice $concat $mux $tribuf $bmux $bwmux $bweqx" *)
 module _90_simplemap_various;
 endmodule
 

--- a/tests/techmap/buf.ys
+++ b/tests/techmap/buf.ys
@@ -1,0 +1,13 @@
+read_verilog -icells <<EOF
+module top(input wire [2:0] a, output wire [2:0] y);
+	\$buf #(.WIDTH(3)) b(.A(a), .Y(y));
+endmodule
+EOF
+design -save save
+
+opt_clean
+select -assert-none t:$buf
+
+design -load save
+techmap
+select -assert-none t:$buf


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

The `write_xaiger2` command transiently enters the buffered-normalized mode. This can introduce `$buf` cells into the design. These cells are missing handling by the `opt_clean` and `techmap` passes, and as such they just fall through to the end of a flow.

So far the bufnormed mode usage has been isolated to the insides of a single pass, once we will want to extend this to let designs in bufnormed mode cross from one pass to another, we will need to revisit the `opt_clean`/`techmap` behavior. At that point we will need to revisit all other cases where these passes introduce connections anyway.

_If applicable, please suggest to reviewers how they can test the change._

There's a minimal `buf.ys` test of the new behavior
