### PR TITLE
Add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ __pycache__
 /venv
 /boost
 /ffi
+.vscode


### PR DESCRIPTION
This PR adds the .vscode directory to .gitignore to prevent it from being tracked in version control.