### PR TITLE
mk: Fall back to cp if rsync is not available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,12 @@ BISON ?= bison
 STRIP ?= strip
 AWK ?= awk
 
+ifneq ($(shell :; command -v rsync),)
+RSYNC_CP ?= rsync -rc
+else
+RSYNC_CP ?= cp -ru
+endif
+
 ifeq ($(OS), Darwin)
 PLUGIN_LINKFLAGS += -undefined dynamic_lookup
 LINKFLAGS += -rdynamic
@@ -1005,13 +1011,13 @@ docs/source/cmd/abc.rst: $(TARGETS) $(EXTRA_TARGETS)
 	$(Q) mkdir -p docs/source/cmd
 	$(Q) mkdir -p temp/docs/source/cmd
 	$(Q) cd temp && ./../$(PROGRAM_PREFIX)yosys -p 'help -write-rst-command-reference-manual'
-	$(Q) rsync -rc temp/docs/source/cmd docs/source
+	$(Q) $(RSYNC_CP) temp/docs/source/cmd docs/source
 	$(Q) rm -rf temp
 docs/source/cell/word_add.rst: $(TARGETS) $(EXTRA_TARGETS)
 	$(Q) mkdir -p docs/source/cell
 	$(Q) mkdir -p temp/docs/source/cell
 	$(Q) cd temp && ./../$(PROGRAM_PREFIX)yosys -p 'help -write-rst-cells-manual'
-	$(Q) rsync -rc temp/docs/source/cell docs/source
+	$(Q) $(RSYNC_CP) temp/docs/source/cell docs/source
 	$(Q) rm -rf temp
 
 docs/source/generated/cells.json: docs/source/generated $(TARGETS) $(EXTRA_TARGETS)

--- a/docs/source/_images/Makefile
+++ b/docs/source/_images/Makefile
@@ -3,6 +3,12 @@ all: examples all_tex
 # set a fake time in pdf generation to prevent unnecessary differences in output
 FAKETIME := TZ='Z' faketime -f '2022-01-01 00:00:00 x0,001'
 
+ifneq ($(shell :; command -v rsync),)
+RSYNC_CP ?= rsync -t
+else
+RSYNC_CP ?= cp -a
+endif
+
 # find all code example makefiles
 .PHONY: examples
 CODE_EXAMPLES := ../code_examples/*/Makefile
@@ -19,7 +25,7 @@ FORCE:
 ../%/Makefile: FORCE
 	@make -C $(@D) dots
 	@mkdir -p $*
-	@find $(@D) -name *.dot -exec rsync -t {} $* \;
+	@find $(@D) -name *.dot -exec $(RSYNC_CP) {} $* \;
 
 # find and build all tex files
 .PHONY: all_tex


### PR DESCRIPTION
Using rsync for such a simple job seems excessive. We're using this patch in Debian to avoid the build-dependency on `rsync`.

I'd actually just recommend switching to `cp -ru` (-u is "update") completely but I'm not sure what the rsync call is trying to accomplish exactly.

From `man cp`:
 
       -u, --update
              copy only when the SOURCE file is  newer  than  the  destination
              file or when the destination file is missing

--Daniel
