### PR TITLE
mk: Avoid broken rebuild if program --help fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1038,7 +1038,7 @@ docs/source/generated:
 
 # some commands return an error and print the usage text to stderr
 define DOC_USAGE_STDERR
-docs/source/generated/$(1): $(TARGETS) docs/source/generated
+docs/source/generated/$(1): $(TARGETS) docs/source/generated FORCE
 	-$(Q) ./$(PROGRAM_PREFIX)$(1) --help 2> $$@
 endef
 DOCS_USAGE_STDERR := yosys-config yosys-filterlib
@@ -1053,7 +1053,7 @@ $(foreach usage,$(DOCS_USAGE_STDERR),$(eval $(call DOC_USAGE_STDERR,$(usage))))
 # others print to stdout
 define DOC_USAGE_STDOUT
 docs/source/generated/$(1): $(TARGETS) docs/source/generated
-	$(Q) ./$(PROGRAM_PREFIX)$(1) --help > $$@
+	$(Q) ./$(PROGRAM_PREFIX)$(1) --help > $$@ || rm $$@
 endef
 DOCS_USAGE_STDOUT := yosys yosys-smtbmc yosys-witness
 $(foreach usage,$(DOCS_USAGE_STDOUT),$(eval $(call DOC_USAGE_STDOUT,$(usage))))
@@ -1189,6 +1189,8 @@ echo-cxx:
 -include backends/*/*.d
 -include kernel/*.d
 -include techlibs/*/*.d
+
+FORCE:
 
 .PHONY: all top-all abc test install install-abc docs clean mrproper qtcreator coverage vcxsrc
 .PHONY: config-clean config-clang config-gcc config-gcc-static config-gprof config-sudo


### PR DESCRIPTION
Make will happily consider a target available if it's zero sized.

It's necessary to apply the `|| rm $@` pattern when writing output files with shell redirections to avoid problems with rebuilds here.

--Daniel
