### PR TITLE
docs: Add latex magic to make PDFs reproducible again

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,6 +93,9 @@ bibtex_bibfiles = ['literature.bib']
 latex_elements = {
         'releasename': 'Version',
         'preamble': r'''
+\pdfinfoomitdate 1
+\pdfsuppressptexinfo 1
+\pdftrailerid{}
 \usepackage{lmodern}
 \usepackage{comment}
 


### PR DESCRIPTION
Scott found we need this latex magic to get reproducible PDFs out of sphinx in our Debian packaging.

I haven't checked personally and this hasn't gone through repro testing in our infrastructure yet, but it seems correct enough given prior battles I did with latex. :-)  

--Daniel
