### PR TITLE
cost: Add `$mem_v2`, `$macc_v2` estimates

### DIFF
--- a/kernel/consteval.h
+++ b/kernel/consteval.h
@@ -315,7 +315,7 @@ struct ConstEval
 			Macc macc;
 			macc.from_cell(cell);
 
-			for (auto &port : macc.ports) {
+			for (auto &port : macc.terms) {
 				if (!eval(port.in_a, undef, cell))
 					return false;
 				if (!eval(port.in_b, undef, cell))

--- a/kernel/cost.cc
+++ b/kernel/cost.cc
@@ -1,4 +1,5 @@
 #include "kernel/cost.h"
+#include "kernel/macc.h"
 
 USING_YOSYS_NAMESPACE
 
@@ -148,6 +149,9 @@ unsigned int CellCosts::get(RTLIL::Cell *cell)
 		log_assert(cell->hasPort(ID::Q) && "Weird flip flop");
 		log_debug("%s is ff\n", cell->name.c_str());
 		return cell->getParam(ID::WIDTH).as_int();
+	} else if (cell->type.in(ID($mem), ID($mem_v2))) {
+		log_debug("%s is mem\n", cell->name.c_str());
+		return cell->getParam(ID::WIDTH).as_int() * cell->getParam(ID::SIZE).as_int();
 	} else if (y_coef(cell->type)) {
 		// linear with Y_WIDTH or WIDTH
 		log_assert((cell->hasParam(ID::Y_WIDTH) || cell->hasParam(ID::WIDTH)) && "Unknown width");
@@ -173,6 +177,22 @@ unsigned int CellCosts::get(RTLIL::Cell *cell)
 		unsigned int coef = cell->type == ID($mul) ? 3 : 5;
 		log_debug("%s coef*(sum**2) %d * %d\n", cell->name.c_str(), coef, sum * sum);
 		return coef * sum * sum;
+	} else if (cell->type.in(ID($macc), ID($macc_v2))) {
+		// quadratic per term
+		unsigned int cost_sum = 0;
+		Macc macc;
+		macc.from_cell(cell);
+		unsigned int y_width = cell->getParam(ID::Y_WIDTH).as_int();
+		for (auto &term: macc.terms) {
+			if (term.in_b.empty()) {
+				// neglect addends
+				continue;
+			}
+			unsigned a_width = term.in_a.size(), b_width = term.in_b.size();
+			unsigned int sum = a_width + b_width + std::min(y_width, a_width + b_width);
+			cost_sum += 3 * sum * sum;
+		}
+		return cost_sum;
 	} else if (cell->type == ID($lut)) {
 		int width = cell->getParam(ID::WIDTH).as_int();
 		unsigned int cost = 1U << (unsigned int)width;
@@ -187,8 +207,8 @@ unsigned int CellCosts::get(RTLIL::Cell *cell)
 		log_debug("%s is free\n", cell->name.c_str());
 		return 0;
 	}
-	// TODO: $fsm $mem.* $macc
-	// ignored: $pow
+	// TODO: $fsm
+	// ignored: $pow $memrd $memwr $meminit (and v2 counterparts)
 
 	log_warning("Can't determine cost of %s cell (%d parameters).\n", log_id(cell->type), GetSize(cell->parameters));
 	return 1;

--- a/kernel/satgen.cc
+++ b/kernel/satgen.cc
@@ -750,7 +750,7 @@ bool SatGen::importCell(RTLIL::Cell *cell, int timestep)
 
 		std::vector<int> tmp(GetSize(y), ez->CONST_FALSE);
 
-		for (auto &port : macc.ports)
+		for (auto &port : macc.terms)
 		{
 			std::vector<int> in_a = importDefSigSpec(port.in_a, timestep);
 			std::vector<int> in_b = importDefSigSpec(port.in_b, timestep);

--- a/passes/techmap/booth.cc
+++ b/passes/techmap/booth.cc
@@ -227,9 +227,9 @@ struct BoothPassWorker {
 					continue;
 				}
 
-				A = macc.ports[0].in_a;
-				B = macc.ports[0].in_b;
-				is_signed = macc.ports[0].is_signed;
+				A = macc.terms[0].in_a;
+				B = macc.terms[0].in_b;
+				is_signed = macc.terms[0].is_signed;
 				Y = cell->getPort(ID::Y);
 			} else {
 				continue;

--- a/passes/techmap/maccmap.cc
+++ b/passes/techmap/maccmap.cc
@@ -278,42 +278,42 @@ void maccmap(RTLIL::Module *module, RTLIL::Cell *cell, bool unmap)
 		return;
 	}
 
-	for (auto &port : macc.ports)
-		if (GetSize(port.in_b) == 0)
-			log("  %s %s (%d bits, %s)\n", port.do_subtract ? "sub" : "add", log_signal(port.in_a),
-					GetSize(port.in_a), port.is_signed ? "signed" : "unsigned");
+	for (auto &term : macc.terms)
+		if (GetSize(term.in_b) == 0)
+			log("  %s %s (%d bits, %s)\n", term.do_subtract ? "sub" : "add", log_signal(term.in_a),
+					GetSize(term.in_a), term.is_signed ? "signed" : "unsigned");
 		else
-			log("  %s %s * %s (%dx%d bits, %s)\n", port.do_subtract ? "sub" : "add", log_signal(port.in_a), log_signal(port.in_b),
-					GetSize(port.in_a), GetSize(port.in_b), port.is_signed ? "signed" : "unsigned");
+			log("  %s %s * %s (%dx%d bits, %s)\n", term.do_subtract ? "sub" : "add", log_signal(term.in_a), log_signal(term.in_b),
+					GetSize(term.in_a), GetSize(term.in_b), term.is_signed ? "signed" : "unsigned");
 
 	if (unmap)
 	{
 		typedef std::pair<RTLIL::SigSpec, bool> summand_t;
 		std::vector<summand_t> summands;
 
-		RTLIL::SigSpec bit_ports;
+		RTLIL::SigSpec bit_terms;
 
-		for (auto &port : macc.ports) {
+		for (auto &term : macc.terms) {
 			summand_t this_summand;
-			if (GetSize(port.in_b)) {
+			if (GetSize(term.in_b)) {
 				this_summand.first = module->addWire(NEW_ID, width);
-				module->addMul(NEW_ID, port.in_a, port.in_b, this_summand.first, port.is_signed);
-			} else if (GetSize(port.in_a) == 1 && GetSize(port.in_b) == 0 && !port.is_signed && !port.do_subtract) {
-				// Mimic old 'bit_ports' treatment in case it's relevant for performance,
+				module->addMul(NEW_ID, term.in_a, term.in_b, this_summand.first, term.is_signed);
+			} else if (GetSize(term.in_a) == 1 && GetSize(term.in_b) == 0 && !term.is_signed && !term.do_subtract) {
+				// Mimic old 'bit_terms' treatment in case it's relevant for performance,
 				// i.e. defer single-bit summands to be the last ones
-				bit_ports.append(port.in_a);
+				bit_terms.append(term.in_a);
 				continue;
-			} else if (GetSize(port.in_a) != width) {
+			} else if (GetSize(term.in_a) != width) {
 				this_summand.first = module->addWire(NEW_ID, width);
-				module->addPos(NEW_ID, port.in_a, this_summand.first, port.is_signed);
+				module->addPos(NEW_ID, term.in_a, this_summand.first, term.is_signed);
 			} else {
-				this_summand.first = port.in_a;
+				this_summand.first = term.in_a;
 			}
-			this_summand.second = port.do_subtract;
+			this_summand.second = term.do_subtract;
 			summands.push_back(this_summand);
 		}
 
-		for (auto &bit : bit_ports)
+		for (auto &bit : bit_terms)
 			summands.push_back(summand_t(bit, false));
 
 		if (GetSize(summands) == 0)
@@ -350,20 +350,20 @@ void maccmap(RTLIL::Module *module, RTLIL::Cell *cell, bool unmap)
 	else
 	{
 		MaccmapWorker worker(module, width);
-		RTLIL::SigSpec bit_ports;
+		RTLIL::SigSpec bit_terms;
 
-		for (auto &port : macc.ports) {
-			// Mimic old 'bit_ports' treatment in case it's relevant for performance,
+		for (auto &term : macc.terms) {
+			// Mimic old 'bit_terms' treatment in case it's relevant for performance,
 			// i.e. defer single-bit summands to be the last ones
-			if (GetSize(port.in_a) == 1 && GetSize(port.in_b) == 0 && !port.is_signed && !port.do_subtract)
-				bit_ports.append(port.in_a);
-			else if (GetSize(port.in_b) == 0)
-				worker.add(port.in_a, port.is_signed, port.do_subtract);
+			if (GetSize(term.in_a) == 1 && GetSize(term.in_b) == 0 && !term.is_signed && !term.do_subtract)
+				bit_terms.append(term.in_a);
+			else if (GetSize(term.in_b) == 0)
+				worker.add(term.in_a, term.is_signed, term.do_subtract);
 			else
-				worker.add(port.in_a, port.in_b, port.is_signed, port.do_subtract);
+				worker.add(term.in_a, term.in_b, term.is_signed, term.do_subtract);
 		}
 
-		for (auto bit : bit_ports)
+		for (auto bit : bit_terms)
 			worker.add(bit, 0);
 
 		module->connect(cell->getPort(ID::Y), worker.synth());

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -189,17 +189,17 @@ static RTLIL::Cell* create_gold_module(RTLIL::Design *design, RTLIL::IdString ce
 			} else
 				size_b = 0;
 
-			Macc::port_t this_port;
+			Macc::term_t this_term;
 
 			wire_a->width += size_a;
-			this_port.in_a = RTLIL::SigSpec(wire_a, wire_a->width - size_a, size_a);
+			this_term.in_a = RTLIL::SigSpec(wire_a, wire_a->width - size_a, size_a);
 
 			wire_a->width += size_b;
-			this_port.in_b = RTLIL::SigSpec(wire_a, wire_a->width - size_b, size_b);
+			this_term.in_b = RTLIL::SigSpec(wire_a, wire_a->width - size_b, size_b);
 
-			this_port.is_signed = xorshift32(2) == 1;
-			this_port.do_subtract = xorshift32(2) == 1;
-			macc.ports.push_back(this_port);
+			this_term.is_signed = xorshift32(2) == 1;
+			this_term.do_subtract = xorshift32(2) == 1;
+			macc.terms.push_back(this_term);
 		}
 		// Macc::to_cell sets the input ports
 		macc.to_cell(cell);


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Fill in blind spots of the keep_hierarchy command.

_Explain how this is achieved._

Add `$mem`, `$macc` estimation consistent with existing `$mul`, `$dff` formulas.

_If applicable, please suggest to reviewers how they can test the change._

This script can exercise the new support:

```
design -reset
read_verilog <<EOF
module top(input clk, input [10:0] a, input [2:0] w, output [2:0] y);
	reg [3:0] m[60:0];

	always @(posedge clk) begin
		y <= m[a];
		m[a] <= w;
	end
endmodule
EOF
prep
keep_hierarchy -min_cost 20

design -reset
read_verilog <<EOF
module top(input [2:0] a, input [2:0] b, output [2:0] y);
	assign y = a * b;
endmodule
EOF
design -save r
keep_hierarchy -min_cost 20

design -load r
alumacc
opt_clean
keep_hierarchy -min_cost 20
```
