### PR TITLE
dft_tag: fix autoNot not notting

### DIFF
--- a/passes/cmds/dft_tag.cc
+++ b/passes/cmds/dft_tag.cc
@@ -883,7 +883,7 @@ struct DftTagWorker {
 	{
 		if (sig_a.is_fully_const()) {
 			auto const_val = sig_a.as_const();
-			for (auto bit : const_val)
+			for (State& bit : const_val.bits())
 				bit = bit == State::S0 ? State::S1 : bit == State::S1 ? State::S0 : bit;
 			return const_val;
 		}


### PR DESCRIPTION
Previously, `auto bit` would be `State bit`, a copy of a member of a `vector<State>`, and wouldn't modify it in place as the code is supposed to, leaving `sig_a` unmodified instead of negated. Now, it's `State& bit`, a reference to a member of the `vector<State>` implementing the value of `sig_a`.

This points out towards a lack of test coverage for this part of the codebase