### PR TITLE
A few fixes, mostly local docs builds

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,15 +16,17 @@ html_theme_options: dict[str] = {
     "source_branch": "main",
     "source_directory": "docs/source/",
 }
+html_context: dict[str] = {}
 
 # try to fix the readthedocs detection
-html_context: dict[str] = {
-    "READTHEDOCS": True,
-    "display_github": True,
-    "github_user": "YosysHQ",
-    "github_repo": "yosys",
-    "slug": "yosys",
-}
+if os.getenv("READTHEDOCS"):
+    html_context.update({
+        "READTHEDOCS": True,
+        "display_github": True,
+        "github_user": "YosysHQ",
+        "github_repo": "yosys",
+        "slug": "yosys",
+    })
 
 # override source_branch if not main
 git_slug = os.getenv("READTHEDOCS_VERSION_NAME")

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -34,30 +34,17 @@ Targeted architectures
 
 The `OSS CAD Suite`_ releases `nightly builds`_ for the following architectures:
 
-.. only:: html
+- **linux-x64** - Most personal Linux based computers
+- **darwin-x64** - macOS 12 or later with Intel CPU
+- **darwin-arm64** - macOS 12 or later with M1/M2 CPU
+- **windows-x64** - Targeted for Windows 10 and 11
+- **linux-arm64** - Devices such as Raspberry Pi with 64bit OS
 
-   - linux-x64 |linux-x64|
-      - Most personal Linux based computers
-
-   - darwin-x64 |darwin-x64|
-      - macOS 12 or later with Intel CPU
-
-   - darwin-arm64 |darwin-arm64|
-      - macOS 12 or later with M1/M2 CPU
-
-   - windows-x64 |windows-x64|
-      - Targeted for Windows 10 and 11
-
-   - linux-arm64 |linux-arm64|
+For more information about the targeted architectures, and the current build
+status, check the `OSS CAD Suite`_ git repository.
 
 .. _OSS CAD Suite: https://github.com/YosysHQ/oss-cad-suite-build
 .. _nightly builds: https://github.com/YosysHQ/oss-cad-suite-build/releases/latest
-
-.. |linux-x64| image:: https://github.com/YosysHQ/oss-cad-suite-build/actions/workflows/linux-x64.yml/badge.svg
-.. |darwin-x64| image:: https://github.com/YosysHQ/oss-cad-suite-build/actions/workflows/darwin-x64.yml/badge.svg
-.. |darwin-arm64| image:: https://github.com/YosysHQ/oss-cad-suite-build/actions/workflows/darwin-arm64.yml/badge.svg
-.. |windows-x64| image:: https://github.com/YosysHQ/oss-cad-suite-build/actions/workflows/windows-x64.yml/badge.svg
-.. |linux-arm64| image:: https://github.com/YosysHQ/oss-cad-suite-build/actions/workflows/linux-arm64.yml/badge.svg
 
 Building from source
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/yosys_internals/extending_yosys/test_suites.rst
+++ b/docs/source/yosys_internals/extending_yosys/test_suites.rst
@@ -6,22 +6,12 @@ Testing Yosys
 Automatic testing
 -----------------
 
-.. only:: html
-
-   The `Yosys Git repo`_ has automatic testing of builds and running of the
-   included test suite on the following platforms:
-
-   - Ubuntu |test-linux|
-   - macOS |test-macos|
+The `Yosys Git repo`_ has automatic testing of builds and running of the
+included test suite on both Ubuntu and macOS, as well as across range of
+compiler versions.  For up to date information, including OS versions, refer to
+`the git actions page`_.
 
 .. _Yosys Git repo: https://github.com/YosysHQ/yosys
-
-.. |test-linux| image:: https://github.com/YosysHQ/yosys/actions/workflows/test-linux.yml/badge.svg?branch=main
-.. |test-macos| image:: https://github.com/YosysHQ/yosys/actions/workflows/test-macos.yml/badge.svg?branch=main
-
-For up to date information, including OS versions, refer to `the git actions
-page`_.
-
 .. _the git actions page: https://github.com/YosysHQ/yosys/actions
 
 .. todo:: are unit tests currently working

--- a/libs/fst/00_PATCH_i386_endian.patch
+++ b/libs/fst/00_PATCH_i386_endian.patch
@@ -1,0 +1,14 @@
+--- fstapi.cc
++++ fstapi.cc
+@@ -4723,7 +4723,10 @@ if(gzread_pass_status)
+                                 hdr_incomplete = (xc->start_time == 0) && (xc->end_time == 0);
+ 
+                                 fstFread(&dcheck, 8, 1, xc->f);
+-                                xc->double_endian_match = (dcheck == FST_DOUBLE_ENDTEST);
++				/*
++				 * Yosys patch: Fix double endian check for i386 targets built in modern gcc
++				 */
++                                xc->double_endian_match = (dcheck == (double)FST_DOUBLE_ENDTEST);
+                                 if(!xc->double_endian_match)
+                                         {
+                                         union   {

--- a/libs/fst/00_UPDATE.sh
+++ b/libs/fst/00_UPDATE.sh
@@ -19,3 +19,4 @@ patch -p0 < 00_PATCH_win_zlib.patch
 patch -p0 < 00_PATCH_win_io.patch
 patch -p1 < 00_PATCH_strict_alignment.patch
 patch -p0 < 00_PATCH_wx_len_overread.patch
+patch -p0 < 00_PATCH_i386_endian.patch

--- a/libs/fst/fstapi.cc
+++ b/libs/fst/fstapi.cc
@@ -4723,7 +4723,10 @@ if(gzread_pass_status)
                                 hdr_incomplete = (xc->start_time == 0) && (xc->end_time == 0);
 
                                 fstFread(&dcheck, 8, 1, xc->f);
-                                xc->double_endian_match = (dcheck == FST_DOUBLE_ENDTEST);
+				/*
+				 * Yosys patch: Fix double endian check for i386 targets built in modern gcc
+				 */
+                                xc->double_endian_match = (dcheck == (double)FST_DOUBLE_ENDTEST);
                                 if(!xc->double_endian_match)
                                         {
                                         union   {


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
- Close #3898 (again).
- Local html builds included `READTHEDOCS` et al, making a weird and unformatted version selector element in the sidebar.
- Close #4777.

_Explain how this is achieved._
- Reapply #3904, now with patch file.
- Gate `READTHEDOCS` on environment variable.
- Drop svg badges.

_If applicable, please suggest to reviewers how they can test the change._
