### PR TITLE
simplify: Skip AST_PRIMITIVE in AST_CELLARRAY

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1758,7 +1758,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 			break;
 		if (type == AST_GENBLOCK)
 			break;
-		if (type == AST_CELLARRAY && children[i]->type == AST_CELL)
+		if (type == AST_CELLARRAY && (children[i]->type == AST_CELL || children[i]->type == AST_PRIMITIVE))
 			continue;
 		if (type == AST_BLOCK && !str.empty())
 			break;
@@ -2741,6 +2741,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 			if (new_cell->type == AST_PRIMITIVE) {
 				input_error("Cell arrays of primitives are currently not supported.\n");
 			} else {
+				this->dumpAst(NULL, "    ");
 				log_assert(new_cell->children.at(0)->type == AST_CELLTYPE);
 				new_cell->children.at(0)->str = stringf("$array:%d:%d:%s", i, num, new_cell->children.at(0)->str.c_str());
 			}

--- a/tests/verilog/bug4785.ys
+++ b/tests/verilog/bug4785.ys
@@ -1,0 +1,9 @@
+logger -expect error "Cell arrays of primitives are currently not supported" 1
+read_verilog <<EOT
+module test(in1, in2, out1);
+  input in1, in2;
+  output out1;
+
+  nand  #2 t_nand[0:7](out1, in1, in2);
+endmodule
+EOT


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Close #4785.

We have an input error about cell arrays of primitives not being supported, but the `AST_PRIMITIVE` is simplified before it can be checked, leading to an assertion error instead.

_Explain how this is achieved._

Don't simplify `AST_PRIMITIVE` in `AST_CELLARRAY`, similar to #3467.

_If applicable, please suggest to reviewers how they can test the change._

Run `yosys tests/verilog/bug4785.ys` with/without this patch.