### PR TITLE
Make 32-bit tests pass

### DIFF
--- a/techlibs/common/simlib.v
+++ b/techlibs/common/simlib.v
@@ -2224,10 +2224,10 @@ module \$print (EN, TRG, ARGS);
 parameter PRIORITY = 0;
 
 parameter FORMAT = "";
-parameter ARGS_WIDTH = 0;
+parameter signed ARGS_WIDTH = 0;
 
 parameter TRG_ENABLE = 1;
-parameter TRG_WIDTH = 0;
+parameter signed TRG_WIDTH = 0;
 parameter TRG_POLARITY = 0;
 
 input EN;

--- a/tests/cxxrtl/test_value_fuzz.cc
+++ b/tests/cxxrtl/test_value_fuzz.cc
@@ -241,7 +241,10 @@ struct CtlzTest
 	{
 		if (a == 0)
 			return bits;
-		return __builtin_clzl(a) - (64 - bits);
+		if (sizeof(long) == 4)
+			return __builtin_clzll(a) - (64 - bits);
+		else
+			return __builtin_clzl(a) - (64 - bits);
 	}
 
 	template<size_t Bits>


### PR DESCRIPTION
While working to get the Debian package up to date I noticed that some tests failed on 32-bit archs.

The first one was fixed by #3904 this should mop up the other two.

The simple/string_format test was causing iverilog to try to allocate huge amounts of memory.
This can be fixed by making sure that the arguments to $print were signed when needed.
A similar fix was done to $mem back in 2015, 95944eb

The cxxrtl tests were also failing but this time the problem was in the test code's reference implementation.
A 64-bit int is being passed to __builtin_clzl which is fine when longs are 64-bit but fails when they are 32-bit.
I chose to check the size of long and use __builtin_clzll is required rather than any of the newer standardised alternatives (stdc_leading_zeros) so as not to change the compiler requirements.