### PR TITLE
Trigger abc segfault for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -832,64 +832,65 @@ endif
 
 # Tests that generate .mk with tests/gen-tests-makefile.sh
 MK_TEST_DIRS =
-MK_TEST_DIRS += tests/arch/anlogic
-MK_TEST_DIRS += tests/arch/ecp5
-MK_TEST_DIRS += tests/arch/efinix
-MK_TEST_DIRS += tests/arch/gatemate
-MK_TEST_DIRS += tests/arch/gowin
-MK_TEST_DIRS += tests/arch/ice40
-MK_TEST_DIRS += tests/arch/intel_alm
-MK_TEST_DIRS += tests/arch/machxo2
-MK_TEST_DIRS += tests/arch/microchip
-MK_TEST_DIRS += tests/arch/nanoxplore
-MK_TEST_DIRS += tests/arch/nexus
-MK_TEST_DIRS += tests/arch/quicklogic/pp3
-MK_TEST_DIRS += tests/arch/quicklogic/qlf_k6n10f
-MK_TEST_DIRS += tests/arch/xilinx
-MK_TEST_DIRS += tests/opt
-MK_TEST_DIRS += tests/sat
-MK_TEST_DIRS += tests/sim
-MK_TEST_DIRS += tests/svtypes
-MK_TEST_DIRS += tests/techmap
-MK_TEST_DIRS += tests/various
-ifeq ($(ENABLE_VERIFIC),1)
-ifneq ($(YOSYS_NOVERIFIC),1)
-MK_TEST_DIRS += tests/verific
-endif
-endif
-MK_TEST_DIRS += tests/verilog
+# MK_TEST_DIRS += tests/arch/anlogic
+# MK_TEST_DIRS += tests/arch/ecp5
+# MK_TEST_DIRS += tests/arch/efinix
+# MK_TEST_DIRS += tests/arch/gatemate
+# MK_TEST_DIRS += tests/arch/gowin
+# MK_TEST_DIRS += tests/arch/ice40
+# MK_TEST_DIRS += tests/arch/intel_alm
+# MK_TEST_DIRS += tests/arch/machxo2
+# MK_TEST_DIRS += tests/arch/microchip
+# MK_TEST_DIRS += tests/arch/nanoxplore
+# MK_TEST_DIRS += tests/arch/nexus
+# MK_TEST_DIRS += tests/arch/quicklogic/pp3
+# MK_TEST_DIRS += tests/arch/quicklogic/qlf_k6n10f
+# MK_TEST_DIRS += tests/arch/xilinx
+# MK_TEST_DIRS += tests/opt
+# MK_TEST_DIRS += tests/sat
+# MK_TEST_DIRS += tests/sim
+# MK_TEST_DIRS += tests/svtypes
+# MK_TEST_DIRS += tests/techmap
+# MK_TEST_DIRS += tests/various
+# ifeq ($(ENABLE_VERIFIC),1)
+# ifneq ($(YOSYS_NOVERIFIC),1)
+# MK_TEST_DIRS += tests/verific
+# endif
+# endif
+# MK_TEST_DIRS += tests/verilog
 
 # Tests that don't generate .mk
 SH_TEST_DIRS =
-SH_TEST_DIRS += tests/simple
-SH_TEST_DIRS += tests/simple_abc9
-SH_TEST_DIRS += tests/hana
-SH_TEST_DIRS += tests/asicworld
-# SH_TEST_DIRS += tests/realmath
-SH_TEST_DIRS += tests/share
-SH_TEST_DIRS += tests/opt_share
-SH_TEST_DIRS += tests/fsm
-SH_TEST_DIRS += tests/memlib
-SH_TEST_DIRS += tests/bram
-SH_TEST_DIRS += tests/svinterfaces
-SH_TEST_DIRS += tests/xprop
-SH_TEST_DIRS += tests/select
-SH_TEST_DIRS += tests/proc
-SH_TEST_DIRS += tests/blif
-SH_TEST_DIRS += tests/arch
-SH_TEST_DIRS += tests/rpc
-SH_TEST_DIRS += tests/memfile
-SH_TEST_DIRS += tests/fmt
-SH_TEST_DIRS += tests/cxxrtl
-ifeq ($(ENABLE_FUNCTIONAL_TESTS),1)
-SH_TEST_DIRS += tests/functional
-endif
+SH_TEST_DIRS += tests/abc_segfault
+# SH_TEST_DIRS += tests/simple
+# SH_TEST_DIRS += tests/simple_abc9
+# SH_TEST_DIRS += tests/hana
+# SH_TEST_DIRS += tests/asicworld
+# # SH_TEST_DIRS += tests/realmath
+# SH_TEST_DIRS += tests/share
+# SH_TEST_DIRS += tests/opt_share
+# SH_TEST_DIRS += tests/fsm
+# SH_TEST_DIRS += tests/memlib
+# SH_TEST_DIRS += tests/bram
+# SH_TEST_DIRS += tests/svinterfaces
+# SH_TEST_DIRS += tests/xprop
+# SH_TEST_DIRS += tests/select
+# SH_TEST_DIRS += tests/proc
+# SH_TEST_DIRS += tests/blif
+# SH_TEST_DIRS += tests/arch
+# SH_TEST_DIRS += tests/rpc
+# SH_TEST_DIRS += tests/memfile
+# SH_TEST_DIRS += tests/fmt
+# SH_TEST_DIRS += tests/cxxrtl
+# ifeq ($(ENABLE_FUNCTIONAL_TESTS),1)
+# SH_TEST_DIRS += tests/functional
+# endif
 
 # Tests that don't generate .mk and need special args
 SH_ABC_TEST_DIRS =
-SH_ABC_TEST_DIRS += tests/memories
-SH_ABC_TEST_DIRS += tests/aiger
-SH_ABC_TEST_DIRS += tests/alumacc
+# SH_ABC_TEST_DIRS += tests/memories
+# SH_ABC_TEST_DIRS += tests/aiger
+# SH_ABC_TEST_DIRS += tests/alumacc
 
 # seed-tests/ is a dummy string, not a directory
 .PHONY: seed-tests

--- a/tests/abc_segfault/run-test.sh
+++ b/tests/abc_segfault/run-test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+../../yosys-abc -c "&segfault"


### PR DESCRIPTION
`abc` likes to crash irreproducibly. We'd like to gather core dumps or have more context for the crashes in other ways. This PR is triggers abc segfaults in CI