### PR TITLE
More *.err files in test failures

### DIFF
--- a/tests/gen-tests-makefile.sh
+++ b/tests/gen-tests-makefile.sh
@@ -17,20 +17,20 @@ generate_target() {
 generate_ys_test() {
 	ys_file=$1
 	yosys_args_=${2:-}
-	generate_target "$ys_file" "\"$YOSYS_BASEDIR/yosys\" -ql ${ys_file%.*}.err $yosys_args_ $ys_file && mv ${ys_file%.*}.err ${ys_file%.*}.log"
+	generate_target "$ys_file" "\"$YOSYS_BASEDIR/yosys\" -ql ${ys_file}.err $yosys_args_ $ys_file && mv ${ys_file}.err ${ys_file}.log"
 }
 
 # $ generate_tcl_test tcl_file [yosys_args]
 generate_tcl_test() {
 	tcl_file=$1
 	yosys_args_=${2:-}
-	generate_target "$tcl_file" "\"$YOSYS_BASEDIR/yosys\" -ql ${tcl_file%.*}.err $yosys_args_ $tcl_file && mv ${tcl_file%.*}.err ${tcl_file%.*}.log"
+	generate_target "$tcl_file" "\"$YOSYS_BASEDIR/yosys\" -ql ${tcl_file}.err $yosys_args_ $tcl_file && mv ${tcl_file}.err ${tcl_file}.log"
 }
 
 # $ generate_bash_test bash_file
 generate_bash_test() {
 	bash_file=$1
-	generate_target "$bash_file" "bash -v $bash_file >${bash_file%.*}.err 2>&1 && mv ${bash_file%.*}.err ${bash_file%.*}.log"
+	generate_target "$bash_file" "bash -v $bash_file >${bash_file}.err 2>&1 && mv ${bash_file}.err ${bash_file}.log"
 }
 
 # $ generate_tests [-y|--yosys-scripts] [-s|--prove-sv] [-b|--bash] [-a|--yosys-args yosys_args]

--- a/tests/gen-tests-makefile.sh
+++ b/tests/gen-tests-makefile.sh
@@ -17,20 +17,20 @@ generate_target() {
 generate_ys_test() {
 	ys_file=$1
 	yosys_args_=${2:-}
-	generate_target "$ys_file" "\"$YOSYS_BASEDIR/yosys\" -ql ${ys_file%.*}.log $yosys_args_ $ys_file"
+	generate_target "$ys_file" "\"$YOSYS_BASEDIR/yosys\" -ql ${ys_file%.*}.err $yosys_args_ $ys_file && mv ${ys_file%.*}.err ${ys_file%.*}.log"
 }
 
 # $ generate_tcl_test tcl_file [yosys_args]
 generate_tcl_test() {
 	tcl_file=$1
 	yosys_args_=${2:-}
-	generate_target "$tcl_file" "\"$YOSYS_BASEDIR/yosys\" -ql ${tcl_file%.*}.log $yosys_args_ $tcl_file"
+	generate_target "$tcl_file" "\"$YOSYS_BASEDIR/yosys\" -ql ${tcl_file%.*}.err $yosys_args_ $tcl_file && mv ${tcl_file%.*}.err ${tcl_file%.*}.log"
 }
 
 # $ generate_bash_test bash_file
 generate_bash_test() {
 	bash_file=$1
-	generate_target "$bash_file" "bash -v $bash_file >${bash_file%.*}.log 2>&1"
+	generate_target "$bash_file" "bash -v $bash_file >${bash_file%.*}.err 2>&1 && mv ${bash_file%.*}.err ${bash_file%.*}.log"
 }
 
 # $ generate_tests [-y|--yosys-scripts] [-s|--prove-sv] [-b|--bash] [-a|--yosys-args yosys_args]


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

CI checks for `*.err` files for reporting failures, but only tests that use `autotest.sh` get a `*.err` file, and not tests that use `gen-tests-makefile.sh`.

_Explain how this is achieved._

Modify `gen-tests-makefile.sh` so that instead of logging to `*.log`, we log to `*.err`, and then `mv` the `*.err` to `*.log`.  Because it is `&& mv` it only gets renamed on a success, leaving behind the `*.err` file on a failure so that it can be reported as expected.

_If applicable, please suggest to reviewers how they can test the change._

If CI for this PR passes then the change doesn't break anything.  To check for correct behaviour, checkout locally and change a test that uses `gen-tests-makefile.sh`, such as `tests/arch/gatemate/memory.ys` to fail, then run the corresponding `run-test.sh` and then the generated `run-test.mk`.