### PR TITLE
Makefile: Test yosys git status in check-git-abc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -785,7 +785,7 @@ $(PROGRAM_PREFIX)yosys-config: misc/yosys-config.in $(YOSYS_SRC)/Makefile
 .PHONY: check-git-abc
 
 check-git-abc:
-	@if [ ! -d "$(YOSYS_SRC)/abc" ] && git -C "$(YOSYS_SRC)" status 2>/dev/null; then \
+	@if [ ! -d "$(YOSYS_SRC)/abc" ] && git -C "$(YOSYS_SRC)" status >/dev/null 2>&1; then \
 		echo "Error: The 'abc' directory does not exist."; \
 		echo "Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule."; \
 		exit 1; \
@@ -811,7 +811,7 @@ check-git-abc:
 		echo "3. Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule."; \
 		echo "4. Reapply your changes: Move your saved changes back to the 'abc' directory, if necessary."; \
 		exit 1; \
-	elif ! git -C "$(YOSYS_SRC)" status 2>/dev/null; then \
+	elif ! git -C "$(YOSYS_SRC)" status >/dev/null 2>&1; then \
 		echo "$(realpath $(YOSYS_SRC)) is not configured as a git repository, and 'abc' folder is missing."; \
 		echo "If you already have ABC, set 'ABCEXTERNAL' make variable to point to ABC executable."; \
 		echo "Otherwise, download release archive 'yosys.tar.gz' from https://github.com/YosysHQ/yosys/releases."; \

--- a/Makefile
+++ b/Makefile
@@ -785,7 +785,7 @@ $(PROGRAM_PREFIX)yosys-config: misc/yosys-config.in $(YOSYS_SRC)/Makefile
 .PHONY: check-git-abc
 
 check-git-abc:
-	@if [ ! -d "$(YOSYS_SRC)/abc" ]; then \
+	@if [ ! -d "$(YOSYS_SRC)/abc" ] && git -C "$(YOSYS_SRC)" status 2>/dev/null; then \
 		echo "Error: The 'abc' directory does not exist."; \
 		echo "Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule."; \
 		exit 1; \
@@ -810,6 +810,12 @@ check-git-abc:
 		echo "2. Remove the existing 'abc' directory: Delete the 'abc' directory and all its contents."; \
 		echo "3. Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule."; \
 		echo "4. Reapply your changes: Move your saved changes back to the 'abc' directory, if necessary."; \
+		exit 1; \
+	elif ! git -C "$(YOSYS_SRC)" status 2>/dev/null; then \
+		echo "$(realpath $(YOSYS_SRC)) is not configured as a git repository, and 'abc' folder is missing."; \
+		echo "If you already have ABC, set 'ABCEXTERNAL' make variable to point to ABC executable."; \
+		echo "Otherwise, download release archive 'yosys.tar.gz' from https://github.com/YosysHQ/yosys/releases."; \
+		echo "    ('Source code' archive does not contain submodules.)"; \
 		exit 1; \
 	else \
 		echo "Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule."; \


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

As in #4968, `check-git-abc` is misleading if Yosys itself isn't a git repository. 

_Explain how this is achieved._

So check `git status` before suggesting `git` based solutions, providing alternative suggestions for using ABCEXTERNAL (which bypasses `check-git-abc`), or downloading release tar (noting that the 'Source code' archives won't work, which is probably how they ended up in this situtation).

_If applicable, please suggest to reviewers how they can test the change._

Applying patch to release yosys.tar.gz and running `make check-git-abc` should be be unaffected (i.e. should still succeed).
Applying patch to release source code archive and running `make check-git-abc` (or removing contents of abc folder from yosys.tar.gz) should give new error message.
Applying patch to either archive, and deleting abc folder should give new error message.
All other cases should be unaffected.