### PR TITLE
Gowin. BUGFIX. Restore MUXes.

### DIFF
--- a/techlibs/gowin/cells_xtra.py
+++ b/techlibs/gowin/cells_xtra.py
@@ -26,8 +26,7 @@ _skip = { # These are already described, no need to extract them from the vendor
           'RAM16SDP1', 'RAM16SDP2', 'RAM16SDP4', 'rPLL', 'SDP',
           'SDPX9', 'SP', 'SPX9', 'TBUF', 'TLVDS_OBUF', 'VCC', 'DCS', 'EMCU',
           # These are not planned for implementation
-          'MUX2_MUX8', 'MUX2_MUX16', 'MUX2_MUX32', 'MUX4', 'MUX8', 'MUX16',
-          'MUX32', 'DL', 'DLE', 'DLC', 'DLCE', 'DLP', 'DLPE', 'DLN', 'DLNE',
+          'DL', 'DLE', 'DLC', 'DLCE', 'DLP', 'DLPE', 'DLN', 'DLNE',
           'DLNC', 'DLNCE', 'DLNP', 'DLNPE', 'rSDP', 'rSDPX9', 'rROM', 'rROMX9',
           'TLVDS_OEN_BK', 'DLL', 'DCC', 'I3C', 'IODELAYA', 'IODELAYC', 'IODELAYB',
           'SPMI', 'PLLO', 'DCCG', 'MIPI_DPHY_RX', 'CLKDIVG', 'PWRGRD', 'FLASH96KA',

--- a/techlibs/gowin/cells_xtra_gw1n.v
+++ b/techlibs/gowin/cells_xtra_gw1n.v
@@ -1,6 +1,53 @@
 // Created by cells_xtra.py
 
 
+module MUX2_MUX8 (...);
+input I0,I1;
+input S0;
+output O;
+endmodule
+
+
+module MUX2_MUX16 (...);
+input I0,I1;
+input S0;
+output O;
+endmodule
+
+
+module MUX2_MUX32 (...);
+input I0,I1;
+input S0;
+output O;
+endmodule
+
+
+module MUX4 (...);
+input I0, I1, I2, I3;
+input S0, S1;
+output O;
+endmodule
+
+
+module MUX8 (...);
+input I0, I1, I2, I3, I4, I5, I6, I7;
+input S0, S1, S2;
+output O;
+endmodule
+
+
+module MUX16 (...);
+input I0, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15;
+input S0, S1, S2, S3;
+output O;
+endmodule
+
+module MUX32 (...);
+input I0, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, I17, I18, I19, I20, I21, I22, I23, I24, I25, I26, I27, I28, I29, I30, I31;
+input S0, S1, S2, S3, S4;
+output O;
+endmodule
+
 module LUT5 (...);
 parameter INIT = 32'h00000000;
 input I0, I1, I2, I3, I4;

--- a/techlibs/gowin/cells_xtra_gw2a.v
+++ b/techlibs/gowin/cells_xtra_gw2a.v
@@ -1,6 +1,53 @@
 // Created by cells_xtra.py
 
 
+module MUX2_MUX8 (...);
+input I0,I1;
+input S0;
+output O;
+endmodule
+
+
+module MUX2_MUX16 (...);
+input I0,I1;
+input S0;
+output O;
+endmodule
+
+
+module MUX2_MUX32 (...);
+input I0,I1;
+input S0;
+output O;
+endmodule
+
+
+module MUX4 (...);
+input I0, I1, I2, I3;
+input S0, S1;
+output O;
+endmodule
+
+
+module MUX8 (...);
+input I0, I1, I2, I3, I4, I5, I6, I7;
+input S0, S1, S2;
+output O;
+endmodule
+
+
+module MUX16 (...);
+input I0, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15;
+input S0, S1, S2, S3;
+output O;
+endmodule
+
+module MUX32 (...);
+input I0, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, I17, I18, I19, I20, I21, I22, I23, I24, I25, I26, I27, I28, I29, I30, I31;
+input S0, S1, S2, S3, S4;
+output O;
+endmodule
+
 module LUT5 (...);
 parameter INIT = 32'h00000000;
 input I0, I1, I2, I3, I4;

--- a/techlibs/gowin/cells_xtra_gw5a.v
+++ b/techlibs/gowin/cells_xtra_gw5a.v
@@ -1,6 +1,53 @@
 // Created by cells_xtra.py
 
 
+module MUX2_MUX8 (...);
+input I0,I1;
+input S0;
+output O;
+endmodule
+
+
+module MUX2_MUX16 (...);
+input I0,I1;
+input S0;
+output O;
+endmodule
+
+
+module MUX2_MUX32 (...);
+input I0,I1;
+input S0;
+output O;
+endmodule
+
+
+module MUX4 (...);
+input I0, I1, I2, I3;
+input S0, S1;
+output O;
+endmodule
+
+
+module MUX8 (...);
+input I0, I1, I2, I3, I4, I5, I6, I7;
+input S0, S1, S2;
+output O;
+endmodule
+
+
+module MUX16 (...);
+input I0, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15;
+input S0, S1, S2, S3;
+output O;
+endmodule
+
+module MUX32 (...);
+input I0, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, I17, I18, I19, I20, I21, I22, I23, I24, I25, I26, I27, I28, I29, I30, I31;
+input S0, S1, S2, S3, S4;
+output O;
+endmodule
+
 module LUT5 (...);
 parameter INIT = 32'h00000000;
 input I0, I1, I2, I3, I4;


### PR DESCRIPTION
I mistakenly listed MUXes as unplanned (https://github.com/YosysHQ/yosys/pull/4966). This did not lead to catastrophic consequences - all apicula and uLinux examples compile and work, but the quality of synthesis was significantly reduced, which affected the compilation time badly.

Restoring the MUXes will bring the compilation time back to normal.

![times](https://github.com/user-attachments/assets/36cb3c2e-581c-4f94-a864-1820ffb1c7fd)
