### PR TITLE
verific: set VHDL entity source location from another attribute if available

### DIFF
--- a/frontends/verific/verific.h
+++ b/frontends/verific/verific.h
@@ -81,7 +81,7 @@ struct VerificImporter
 	RTLIL::SigBit net_map_at(Verific::Net *net);
 
 	RTLIL::IdString new_verific_id(Verific::DesignObj *obj);
-	void import_attributes(dict<RTLIL::IdString, RTLIL::Const> &attributes, Verific::DesignObj *obj, Verific::Netlist  *nl = nullptr, int wire_width_hint = -1);
+	void import_attributes(dict<RTLIL::IdString, RTLIL::Const> &attributes, Verific::DesignObj *obj, Verific::Netlist  *nl = nullptr, int wire_width_hint = -1, bool is_module = false);
 
 	RTLIL::SigBit netToSigBit(Verific::Net *net);
 	RTLIL::SigSpec operatorInput(Verific::Instance *inst);


### PR DESCRIPTION
Source location coming from Verific is now pointing to architecture and not entity. Additional patch now adds new hidden attribute (starting with empty place) that adds source location of entity. With this change default behavior is not affected and it is possible to use Verific without our patch, but in case information exists it will be included in yosys netlist. In this case also architecture source location will be stored in "src_architecture" attribute.