### PR TITLE
yosys-config: Propagate exit code for help command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1049,7 +1049,7 @@ define DOC_USAGE_STDERR
 docs/source/generated/$(1): $(TARGETS) docs/source/generated FORCE
 	-$(Q) ./$(PROGRAM_PREFIX)$(1) --help 2> $$@
 endef
-DOCS_USAGE_STDERR := yosys-config yosys-filterlib
+DOCS_USAGE_STDERR := yosys-filterlib
 
 # The in-tree ABC (yosys-abc) is only built when ABCEXTERNAL is not set.
 ifeq ($(ABCEXTERNAL),)
@@ -1063,7 +1063,7 @@ define DOC_USAGE_STDOUT
 docs/source/generated/$(1): $(TARGETS) docs/source/generated
 	$(Q) ./$(PROGRAM_PREFIX)$(1) --help > $$@ || rm $$@
 endef
-DOCS_USAGE_STDOUT := yosys yosys-smtbmc yosys-witness
+DOCS_USAGE_STDOUT := yosys yosys-smtbmc yosys-witness yosys-config
 $(foreach usage,$(DOCS_USAGE_STDOUT),$(eval $(call DOC_USAGE_STDOUT,$(usage))))
 
 docs/usage: $(addprefix docs/source/generated/,$(DOCS_USAGE_STDOUT) $(DOCS_USAGE_STDERR))

--- a/misc/yosys-config.in
+++ b/misc/yosys-config.in
@@ -37,11 +37,11 @@ help() {
 		echo "  $0 --datdir/simlib.v"
 		echo ""
 	} >&2
-	exit 1
+	exit $1
 }
 
 if [ $# -eq 0 ]; then
-	help
+	help 1
 fi
 
 if [ "$1" = "--build" ]; then
@@ -83,7 +83,7 @@ for opt; do
 			tokens=( "${tokens[@]}" '@DATDIR@'"${opt#${prefix}datdir}" ) ;;
 		--help|-\?|-h)
 			if [ ${#tokens[@]} -eq 0 ]; then
-				help
+				help 0
 			else
 				tokens=( "${tokens[@]}" "$opt" )
 			fi ;;

--- a/misc/yosys-config.in
+++ b/misc/yosys-config.in
@@ -36,7 +36,7 @@ help() {
 		echo ""
 		echo "  $0 --datdir/simlib.v"
 		echo ""
-	} >&2
+	} >&$(( $1 + 1))
 	exit $1
 }
 


### PR DESCRIPTION
To be consistent we should return exit code 1 only if no parameters are provided to yosys-config, asking for actual help will return exit code 0