### PR TITLE
Improve lexer performance for read_liberty

### DIFF
--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -128,6 +128,12 @@
 #  error "C++17 or later compatible compiler is required"
 #endif
 
+#if defined(__has_cpp_attribute) && __has_cpp_attribute(gnu::cold)
+#  define YS_COLD [[gnu::cold]]
+#else
+#  define YS_COLD
+#endif
+
 #include "kernel/io.h"
 
 YOSYS_NAMESPACE_BEGIN

--- a/passes/techmap/libparse.h
+++ b/passes/techmap/libparse.h
@@ -101,6 +101,7 @@ namespace Yosys
 		bool extend_buffer_at_least(size_t size = 1);
 
 		YS_COLD int get_cold();
+		YS_COLD int peek_cold(size_t offset);
 
 	public:
 		LibertyInputStream(std::istream &f) : f(f) {}
@@ -114,6 +115,16 @@ namespace Yosys
 			int c = buffer[buf_pos];
 			buf_pos += 1;
 			return c;
+		}
+
+		int peek(size_t offset = 0) {
+			if (buf_pos + offset >= buf_end)
+				return peek_cold(offset);
+			return buffer[buf_pos + offset];
+		}
+
+		void consume(size_t n = 1) {
+			buf_pos += n;
 		}
 
 		void unget() {

--- a/passes/techmap/libparse.h
+++ b/passes/techmap/libparse.h
@@ -90,12 +90,43 @@ namespace Yosys
 		bool eval(dict<std::string, bool>& values);
 	};
 
+	class LibertyInputStream {
+		std::istream &f;
+		std::vector<char> buffer;
+		size_t buf_pos = 0;
+		size_t buf_end = 0;
+		bool eof = false;
+
+		bool extend_buffer_once();
+		bool extend_buffer_at_least(size_t size = 1);
+
+		YS_COLD int get_cold();
+
+	public:
+		LibertyInputStream(std::istream &f) : f(f) {}
+
+		size_t buffered_size() { return buf_end - buf_pos; }
+		const char *buffered_data() { return buffer.data() + buf_pos; }
+
+		int get() {
+			if (buf_pos == buf_end)
+				return get_cold();
+			int c = buffer[buf_pos];
+			buf_pos += 1;
+			return c;
+		}
+
+		void unget() {
+			buf_pos -= 1;
+		}
+	};
+
 	class LibertyMergedCells;
 	class LibertyParser
 	{
 		friend class LibertyMergedCells;
 	private:
-		std::istream &f;
+		LibertyInputStream f;
 		int line;
 
 		/* lexer return values:


### PR DESCRIPTION
This PR makes liberty parsing roughly twice as fast by

1. using a custom ifstream wrapper that implements buffering and the used methods in a way that is much more amenable to compiler optimizations than ifstream, and
2. extending the ifstream wrapper with arbitrary lookahead to avoid growing std::string instances byte by byte.

Here 1. is the biggest improvement, reducing runtime by around 40% and 2. adds saves another 10%.