### PR TITLE
opt_expr: Fix #4590

### DIFF
--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -1573,6 +1573,20 @@ skip_identity:
 			}
 		}
 
+		if (mux_undef && cell->type.in(ID($_MUX4_), ID($_MUX8_), ID($_MUX16_))) {
+			int num_inputs = 4;
+			if (cell->type == ID($_MUX8_)) num_inputs = 8;
+			if (cell->type == ID($_MUX16_)) num_inputs = 16;
+			int undef_inputs = 0;
+			for (auto &conn : cell->connections())
+				if (!conn.first.in(ID::S, ID::T, ID::U, ID::V, ID::Y))
+					undef_inputs += conn.second.is_fully_undef();
+			if (undef_inputs == num_inputs) {
+				replace_cell(assign_map, module, cell, "mux_undef", ID::Y, cell->getPort(ID::A));
+				goto next_cell;
+			}
+		}
+
 #define FOLD_1ARG_CELL(_t) \
 		if (cell->type == ID($##_t)) { \
 			RTLIL::SigSpec a = cell->getPort(ID::A); \

--- a/tests/opt/opt_expr_mux_undef.ys
+++ b/tests/opt/opt_expr_mux_undef.ys
@@ -1,0 +1,290 @@
+
+read_rtlil <<EOT
+module \uut
+  wire output 1 \out
+  wire input 2 width 16 \in
+  wire input 3 width 4 \sel
+  cell $_MUX16_ \mux
+    connect \A \in [0]
+    connect \B \in [1]
+    connect \C \in [2]
+    connect \D \in [3]
+    connect \E \in [4]
+    connect \F \in [5]
+    connect \G \in [6]
+    connect \H \in [7]
+    connect \I \in [8]
+    connect \J \in [9]
+    connect \K \in [10]
+    connect \L \in [11]
+    connect \M \in [12]
+    connect \N \in [13]
+    connect \O \in [14]
+    connect \P \in [15]
+    connect \S \sel [0]
+    connect \T \sel [1]
+    connect \U \sel [2]
+    connect \V \sel [3]
+    connect \Y \out
+  end
+end
+EOT
+
+##########
+# all undef
+# no mux
+# output undef
+
+design -reset
+read_rtlil <<EOT
+module \uut
+  wire output 1 \out
+  cell $mux \mux
+    parameter \WIDTH 1
+    connect \A 1'x
+    connect \B 1'x
+    connect \S 1'x
+    connect \Y \out
+  end
+end
+EOT
+
+opt_expr -mux_undef
+select -assert-none t:$mux
+select -assert-count 1 o:out %ci*
+
+##
+
+design -reset
+read_rtlil <<EOT
+module \uut
+  wire output 1 \out
+  cell $_MUX_ \mux
+    connect \A 1'x
+    connect \B 1'x
+    connect \S 1'x
+    connect \Y \out
+  end
+end
+EOT
+
+opt_expr -mux_undef
+select -assert-none t:$_MUX_
+select -assert-count 1 o:out %ci*
+
+##
+
+design -reset
+read_rtlil <<EOT
+module \uut
+  wire output 1 \out
+  cell $_MUX4_ \mux
+    connect \A 1'x
+    connect \B 1'x
+    connect \C 1'x
+    connect \D 1'x
+    connect \S 1'x
+    connect \T 1'x
+    connect \Y \out
+  end
+end
+EOT
+
+opt_expr -mux_undef
+select -assert-none t:$_MUX4_
+
+##
+
+design -reset
+read_rtlil <<EOT
+module \uut
+  wire output 1 \out
+  cell $_MUX8_ \mux
+    connect \A 1'x
+    connect \B 1'x
+    connect \C 1'x
+    connect \D 1'x
+    connect \E 1'x
+    connect \F 1'x
+    connect \G 1'x
+    connect \H 1'x
+    connect \S 1'x
+    connect \T 1'x
+    connect \U 1'x
+    connect \Y \out
+  end
+end
+EOT
+
+opt_expr -mux_undef
+select -assert-none t:$_MUX8_
+
+##
+
+design -reset
+read_rtlil <<EOT
+module \uut
+  wire output 1 \out
+  cell $_MUX16_ \mux
+    connect \A 1'x
+    connect \B 1'x
+    connect \C 1'x
+    connect \D 1'x
+    connect \E 1'x
+    connect \F 1'x
+    connect \G 1'x
+    connect \H 1'x
+    connect \I 1'x
+    connect \J 1'x
+    connect \K 1'x
+    connect \L 1'x
+    connect \M 1'x
+    connect \N 1'x
+    connect \O 1'x
+    connect \P 1'x
+    connect \S 1'x
+    connect \T 1'x
+    connect \U 1'x
+    connect \V 1'x
+    connect \Y \out
+  end
+end
+EOT
+
+opt_expr -mux_undef
+select -assert-none t:$_MUX16_
+
+##########
+# a and b undef
+# no mux
+# output undef
+
+design -reset
+read_rtlil <<EOT
+module \uut
+  wire output 1 \out
+  wire input 3 \sel
+  cell $mux \mux
+    parameter \WIDTH 1
+    connect \A 1'x
+    connect \B 1'x
+    connect \S \sel
+    connect \Y \out
+  end
+end
+EOT
+
+opt_expr -mux_undef
+select -assert-none t:$mux
+select -assert-count 1 o:out %ci*
+
+##
+
+design -reset
+read_rtlil <<EOT
+module \uut
+  wire output 1 \out
+  wire input 3 \sel
+  cell $_MUX_ \mux
+    connect \A 1'x
+    connect \B 1'x
+    connect \S \sel
+    connect \Y \out
+  end
+end
+EOT
+
+opt_expr -mux_undef
+select -assert-none t:$_MUX_
+select -assert-count 1 o:out %ci*
+
+##
+
+design -reset
+read_rtlil <<EOT
+module \uut
+  wire output 1 \out
+  wire input 3 width 2 \sel
+  cell $_MUX4_ \mux
+    connect \A 1'x
+    connect \B 1'x
+    connect \C 1'x
+    connect \D 1'x
+    connect \S \sel [0]
+    connect \T \sel [1]
+    connect \Y \out
+  end
+end
+EOT
+
+opt_expr -mux_undef
+select -assert-none t:$_MUX4_
+select -assert-count 1 o:out %ci*
+
+##
+
+design -reset
+read_rtlil <<EOT
+module \uut
+  wire output 1 \out
+  wire input 3 width 3 \sel
+  cell $_MUX8_ \mux
+    connect \A 1'x
+    connect \B 1'x
+    connect \C 1'x
+    connect \D 1'x
+    connect \E 1'x
+    connect \F 1'x
+    connect \G 1'x
+    connect \H 1'x
+    connect \S \sel [0]
+    connect \T \sel [1]
+    connect \U \sel [2]
+    connect \Y \out
+  end
+end
+EOT
+
+opt_expr -mux_undef
+select -assert-none t:$_MUX8_
+select -assert-count 1 o:out %ci*
+
+##
+
+design -reset
+read_rtlil <<EOT
+module \uut
+  wire output 1 \out
+  wire input 3 width 4 \sel
+  cell $_MUX16_ \mux
+    connect \A 1'x
+    connect \B 1'x
+    connect \C 1'x
+    connect \D 1'x
+    connect \E 1'x
+    connect \F 1'x
+    connect \G 1'x
+    connect \H 1'x
+    connect \I 1'x
+    connect \J 1'x
+    connect \K 1'x
+    connect \L 1'x
+    connect \M 1'x
+    connect \N 1'x
+    connect \O 1'x
+    connect \P 1'x
+    connect \S \sel [0]
+    connect \T \sel [1]
+    connect \U \sel [2]
+    connect \V \sel [3]
+    connect \Y \out
+  end
+end
+EOT
+
+opt_expr -mux_undef
+select -assert-none t:$_MUX16_
+select -assert-count 1 o:out %ci*
+
+##########
+


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

#4590

_Explain how this is achieved._

If all the (non-select) inputs of a `$_MUX{4,8,16}_` are undefined, replace it, just like we do for `$mux` and `$_MUX_`. Add `tests/opt/opt_expr_mux_undef.ys` to verify this.

This doesn't do any const folding on the wide muxes, or shrinking to less wide muxes.  It only handles the case where all inputs are 'x and the mux can be completely removed.

_If applicable, please suggest to reviewers how they can test the change._

The following script (from https://github.com/YosysHQ/yosys/issues/4590#issuecomment-2766390391) fails without this patch, and passes with it.

```
read_verilog << EOT
module top (
	input  clk,
	output [7:0] rddata
);

  reg [31:0] index;

  always @(posedge clk)
    index <= index + 1;
  initial
    index = 32'b0;

  reg [7:0] rom[33:0];
  initial begin
    rom[33] = 8'b00000000;
    rom[32] = 8'b00000001;
    rom[31] = 8'b00000010;
    rom[30] = 8'b00000011;
    rom[29] = 8'b00000100;
    rom[28] = 8'b00000101;
    rom[27] = 8'b00000110;
    rom[26] = 8'b00000111;
    rom[25] = 8'b00001000;
    rom[24] = 8'b00001001;
    rom[23] = 8'b00001010;
    rom[22] = 8'b00001011;
    rom[21] = 8'b00001100;
    rom[20] = 8'b00001101;
    rom[19] = 8'b00001110;
    rom[18] = 8'b00001111;
    rom[17] = 8'b00010000;
    rom[16] = 8'b00010001;
    rom[15] = 8'b00010010;
    rom[14] = 8'b00010011;
    rom[13] = 8'b00010100;
    rom[12] = 8'b00010101;
    rom[11] = 8'b00010110;
    rom[10] = 8'b00010111;
    rom[ 9] = 8'b00011000;
    rom[ 8] = 8'b00011001;
    rom[ 7] = 8'b00011010;
    rom[ 6] = 8'b00011011;
    rom[ 5] = 8'b00011100;
    rom[ 4] = 8'b00011101;
    rom[ 3] = 8'b00011110;
    rom[ 2] = 8'b00011111;
    rom[ 1] = 8'b00100000;
    rom[ 0] = 8'b00100001;
    end

  assign rddata = rom[index];

endmodule
EOT
synth_xilinx -arch xc7 -top top -widemux 5
```