### PR TITLE
ice40_dsp: fix const handling

### DIFF
--- a/techlibs/ice40/ice40_dsp.pmg
+++ b/techlibs/ice40/ice40_dsp.pmg
@@ -23,7 +23,7 @@ match mul
 endmatch
 
 code sigA sigB sigH
-	auto unextend = [](const SigSpec &sig) {
+	auto unextend_signed = [](const SigSpec &sig) {
 		int i;
 		for (i = GetSize(sig)-1; i > 0; i--)
 			if (sig[i] != sig[i-1])
@@ -32,8 +32,16 @@ code sigA sigB sigH
 		++i;
 		return sig.extract(0, i);
 	};
-	sigA = param(mul, \A_SIGNED).as_bool() ? unextend(port(mul, \A)) : port(mul, \A);
-	sigB = param(mul, \B_SIGNED).as_bool() ? unextend(port(mul, \B)) : port(mul, \B);
+	auto unextend_unsigned = [](const SigSpec &sig) {
+		int i; 
+		for (i = GetSize(sig)-1; i > 0; i--)
+			if (sig[i] != SigBit(State::S0))
+				break;
+		++i;
+		return sig.extract(0, i);
+	};
+	sigA = param(mul, \A_SIGNED).as_bool() ? unextend_signed(port(mul, \A)) : unextend_unsigned(port(mul, \A));
+	sigB = param(mul, \B_SIGNED).as_bool() ? unextend_signed(port(mul, \B)) : unextend_unsigned(port(mul, \B));
 
 	SigSpec O;
 	if (mul->type == $mul)

--- a/techlibs/ice40/ice40_dsp.pmg
+++ b/techlibs/ice40/ice40_dsp.pmg
@@ -32,8 +32,8 @@ code sigA sigB sigH
 		++i;
 		return sig.extract(0, i);
 	};
-	sigA = port(mul, \A).is_fully_const() ? port(mul, \A) : unextend(port(mul, \A));
-	sigB = port(mul, \B).is_fully_const() ? port(mul, \B) : unextend(port(mul, \B));
+	sigA = param(mul, \A_SIGNED).as_bool() ? unextend(port(mul, \A)) : port(mul, \A);
+	sigB = param(mul, \B_SIGNED).as_bool() ? unextend(port(mul, \B)) : port(mul, \B);
 
 	SigSpec O;
 	if (mul->type == $mul)

--- a/techlibs/ice40/ice40_dsp.pmg
+++ b/techlibs/ice40/ice40_dsp.pmg
@@ -32,8 +32,8 @@ code sigA sigB sigH
 		++i;
 		return sig.extract(0, i);
 	};
-	sigA = unextend(port(mul, \A));
-	sigB = unextend(port(mul, \B));
+	sigA = port(mul, \A).is_fully_const() ? port(mul, \A) : unextend(port(mul, \A));
+	sigB = port(mul, \B).is_fully_const() ? port(mul, \B) : unextend(port(mul, \B));
 
 	SigSpec O;
 	if (mul->type == $mul)

--- a/tests/arch/ice40/ice40_dsp_const.ys
+++ b/tests/arch/ice40/ice40_dsp_const.ys
@@ -1,0 +1,80 @@
+read_verilog << EOT
+module top(input wire [14:0] a, output wire [18:0] b);
+assign b = a*$unsigned(5'b01111);
+endmodule
+EOT
+
+prep
+ice40_dsp
+
+read_verilog << EOT
+module ref(a, b);
+  wire _0_;
+  wire _1_;
+  wire _2_;
+  wire [12:0] _3_;
+  (* src = "<<EOT:1.30-1.31" *)
+  input [14:0] a;
+  wire [14:0] a;
+  (* src = "<<EOT:1.52-1.53" *)
+  output [18:0] b;
+  wire [18:0] b;
+  SB_MAC16 #(
+    .A_REG(1'h0),
+    .A_SIGNED(32'd0),
+    .BOTADDSUB_CARRYSELECT(2'h0),
+    .BOTADDSUB_LOWERINPUT(2'h2),
+    .BOTADDSUB_UPPERINPUT(1'h1),
+    .BOTOUTPUT_SELECT(2'h3),
+    .BOT_8x8_MULT_REG(1'h0),
+    .B_REG(1'h0),
+    .B_SIGNED(32'd0),
+    .C_REG(1'h0),
+    .D_REG(1'h0),
+    .MODE_8x8(1'h0),
+    .NEG_TRIGGER(1'h0),
+    .PIPELINE_16x16_MULT_REG1(1'h0),
+    .PIPELINE_16x16_MULT_REG2(1'h0),
+    .TOPADDSUB_CARRYSELECT(2'h3),
+    .TOPADDSUB_LOWERINPUT(2'h2),
+    .TOPADDSUB_UPPERINPUT(1'h1),
+    .TOPOUTPUT_SELECT(2'h3),
+    .TOP_8x8_MULT_REG(1'h0)
+  ) _4_ (
+    .A({ 1'h0, a }),
+    .ACCUMCI(1'hx),
+    .ACCUMCO(_1_),
+    .ADDSUBBOT(1'h0),
+    .ADDSUBTOP(1'h0),
+    .AHOLD(1'h0),
+    .B(16'b1111),
+    .BHOLD(1'h0),
+    .C(16'h0000),
+    .CE(1'h0),
+    .CHOLD(1'h0),
+    .CI(1'hx),
+    .CLK(1'h0),
+    .CO(_2_),
+    .D(16'h0000),
+    .DHOLD(1'h0),
+    .IRSTBOT(1'h0),
+    .IRSTTOP(1'h0),
+    .O({ _3_, b }),
+    .OHOLDBOT(1'h0),
+    .OHOLDTOP(1'h0),
+    .OLOADBOT(1'h0),
+    .OLOADTOP(1'h0),
+    .ORSTBOT(1'h0),
+    .ORSTTOP(1'h0),
+    .SIGNEXTIN(1'hx),
+    .SIGNEXTOUT(_0_)
+  );
+endmodule
+EOT
+
+techmap -wb -D EQUIV -autoproc -map +/ice40/cells_sim.v
+
+equiv_make top ref equiv 
+select -assert-any -module equiv t:$equiv 
+equiv_induct 
+equiv_status -assert


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
ice40_dsp seems to incorrectly handle unsigned consts. The issue seems to be with unextend function. By searching previous issues I could find this one #2648.
_Explain how this is achieved._
Now unextend is called only on non constant inputs.
_If applicable, please suggest to reviewers how they can test the change._
```
read_verilog << EOT
module top(input wire [14:0] a, output wire [31:0] b);
assign b = a*$unsigned(5'b01111);
endmodule
EOT

prep
ice40_dsp
write_rtlil
```

```
read_verilog << EOT
module top(input wire signed [14:0] a, output wire signed [31:0] b);
assign b = a*$signed(5'b01111);
endmodule
EOT

prep
ice40_dsp
write_rtlil
```

Gives two different connect \B values in \SB_MAC16 cell on pre-PR code, and the same value on post-PR code.