### PR TITLE
Add `NamedObject` to `py_wrap_generator.py`

### DIFF
--- a/misc/py_wrap_generator.py
+++ b/misc/py_wrap_generator.py
@@ -977,6 +977,7 @@ sources = [
 		WClass("IdString", link_types.ref_copy, None, "str()", ""),
 		WClass("Const", link_types.ref_copy, None, "as_string()", ""),
 		WClass("AttrObject", link_types.ref_copy, None, None, None),
+		WClass("NamedObject", link_types.ref_copy, None, None, None),
 		WClass("Selection", link_types.ref_copy, None, None, None),
 		WClass("Monitor", link_types.derive, None, None, None),
 		WClass("CaseRule",link_types.ref_copy, None, None, None, True),


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

It seems that `pyosys` breaks with latest changes adding `NamedObject` class. Attempting to get the name of a module in `pyosys` no longer works.

_Explain how this is achieved._

Register `NamedObject` in `py_wrap_generator.py`

_If applicable, please suggest to reviewers how they can test the change._

Load a simple design in `pyosys` and try to get the name of the top module before and after the change.
