### PR TITLE
Selection fixes

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1193,8 +1193,8 @@ void RTLIL::Design::pop_selection()
 std::vector<RTLIL::Module*> RTLIL::Design::selected_modules(RTLIL::SelectPartials partials, RTLIL::SelectBoxes boxes) const
 {
 	bool include_partials = partials == RTLIL::SELECT_ALL;
-	bool exclude_boxes = (partials & RTLIL::SB_UNBOXED_ONLY) != 0;
-	bool ignore_wb = (partials & RTLIL::SB_INCL_WB) != 0;
+	bool exclude_boxes = (boxes & RTLIL::SB_UNBOXED_ONLY) != 0;
+	bool ignore_wb = (boxes & RTLIL::SB_INCL_WB) != 0;
 	std::vector<RTLIL::Module*> result;
 	result.reserve(modules_.size());
 	for (auto &it : modules_)

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1183,7 +1183,7 @@ struct RTLIL::Selection
 		// the design to select from
 		RTLIL::Design *design = nullptr
 	) : 
-		full_selection(full && !boxes), selects_boxes(boxes), complete_selection(full && boxes), current_design(design) { }
+		selects_boxes(boxes), complete_selection(full && boxes), full_selection(full && !boxes), current_design(design) { }
 
 	// checks if the given module exists in the current design and is a
 	// boxed module, warning the user if the current design is not set

--- a/tests/select/boxes_equals_clean.ys
+++ b/tests/select/boxes_equals_clean.ys
@@ -1,7 +1,0 @@
-read_verilog -specify boxes.v
-clean
-
-logger -expect-no-warnings
-select -assert-count 5 =wb
-clean =wb
-select -assert-count 4 =wb


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
Constructor ordering warnings on every `#include` of `rtlil.h`, and broken EQY.

_Explain how this is achieved._
Reorder the ctor order, and check the right enum in `selected_modules()`.

_If applicable, please suggest to reviewers how they can test the change._
