### PR TITLE
techmap: map $alu to $fa instead of relying on extract_fa

### DIFF
--- a/techlibs/common/techmap.v
+++ b/techlibs/common/techmap.v
@@ -283,9 +283,16 @@ module _90_alu (A, B, CI, BI, X, Y, CO);
 	\$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(Y_WIDTH)) A_conv (.A(A), .Y(A_buf));
 	\$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(Y_WIDTH)) B_conv (.A(B), .Y(B_buf));
 
-	\$lcu #(.WIDTH(Y_WIDTH)) lcu (.P(X), .G(AA & BB), .CI(CI), .CO(CO));
+	(* force_downto *)
+	wire [Y_WIDTH-1:0] P;
+	wire [Y_WIDTH-1:0] G;
+	wire [Y_WIDTH-1:0] Cnull;
+	assign Cnull = 1'b0;
 
-	assign X = AA ^ BB;
+	\$fa #(.WIDTH(Y_WIDTH)) fa (.A(AA), .B(BB), .C(Cnull), .X(G), .Y(P));
+	\$lcu #(.WIDTH(Y_WIDTH)) lcu (.P(P), .G(G), .CI(CI), .CO(CO));
+
+	assign X = P;
 	assign Y = X ^ {CO, CI};
 endmodule
 


### PR DESCRIPTION
`extract_fa` is used in ASIC flows to find full and half adder cells by extracting any matching logic. It has been suggested that a better approach is to use full/half adders only when emitted from actual arithmetic. In most synthesis flows, cells that use an adder-like structure (addition, subtraction, comparison) get converted to `$alu`. For ASIC flows, they are then techmapped to a multi-bit `$lcu` in `techlibs/common/techmap.v`. `$lcu` cells need propagate (P) and generate (G) inputs which have to be generated by half adders.

Prior to this PR, `techmap.v` was generating these with explicit logic and relying on `extract_fa` to discover that it's half adders. As of this PR, half adders are instantiated directly as `$fa` cells with C inputs at constant 0. This is how `extract_fa` implements half adders already, and for example ORFS uses this constant C=0 to [map directly to half adders](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/blob/master/flow/platforms/sky130hd/cells_adders_hd.v) in the PDK. 

This PR is best evaluated in the context of an ASIC flow as-is or with `extract_fa` removed

- [ ] add an equivalence test