### PR TITLE
dump: add --sorted flag

### DIFF
--- a/backends/rtlil/rtlil_backend.cc
+++ b/backends/rtlil/rtlil_backend.cc
@@ -302,10 +302,19 @@ void RTLIL_BACKEND::dump_conn(std::ostream &f, std::string indent, const RTLIL::
 	f << stringf("\n");
 }
 
-void RTLIL_BACKEND::dump_module(std::ostream &f, std::string indent, RTLIL::Module *module, RTLIL::Design *design, bool only_selected, bool flag_m, bool flag_n)
+void RTLIL_BACKEND::dump_module(std::ostream &f, std::string indent, RTLIL::Module *module, RTLIL::Design *design, bool only_selected, bool flag_m, bool flag_n, bool flag_sorted)
 {
 	bool print_header = flag_m || design->selected_whole_module(module->name);
 	bool print_body = !flag_n || !design->selected_whole_module(module->name);
+
+	std::unique_ptr<Design> d(new Design);
+	if (flag_sorted) {
+		Module* new_module = d->addModule(module->name);
+		module->cloneInto(new_module);
+		module = new_module;
+		module->sort();
+		std::sort(module->connections_.begin(), module->connections_.end());
+	}
 
 	if (print_header)
 	{
@@ -386,9 +395,10 @@ void RTLIL_BACKEND::dump_module(std::ostream &f, std::string indent, RTLIL::Modu
 
 	if (print_header)
 		f << stringf("%s" "end\n", indent.c_str());
+
 }
 
-void RTLIL_BACKEND::dump_design(std::ostream &f, RTLIL::Design *design, bool only_selected, bool flag_m, bool flag_n)
+void RTLIL_BACKEND::dump_design(std::ostream &f, RTLIL::Design *design, bool only_selected, bool flag_m, bool flag_n, bool flag_sorted)
 {
 	int init_autoidx = autoidx;
 
@@ -414,7 +424,7 @@ void RTLIL_BACKEND::dump_design(std::ostream &f, RTLIL::Design *design, bool onl
 		if (!only_selected || design->selected(module)) {
 			if (only_selected)
 				f << stringf("\n");
-			dump_module(f, "", module, design, only_selected, flag_m, flag_n);
+			dump_module(f, "", module, design, only_selected, flag_m, flag_n, flag_sorted);
 		}
 	}
 
@@ -488,11 +498,14 @@ struct DumpPass : public Pass {
 		log("    -a <filename>\n");
 		log("        like -outfile but append instead of overwrite\n");
 		log("\n");
+		log("    --sorted\n");
+		log("        dump sorted representation for nicer diffs. Doesn't modify design\n");
+		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		std::string filename;
-		bool flag_m = false, flag_n = false, append = false;
+		bool flag_m = false, flag_n = false, append = false, flag_sorted = false;
 
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
@@ -516,6 +529,10 @@ struct DumpPass : public Pass {
 				flag_n = true;
 				continue;
 			}
+			if (arg == "--sorted") {
+				flag_sorted = true;
+				continue;
+			}
 			break;
 		}
 		extra_args(args, argidx, design);
@@ -537,7 +554,7 @@ struct DumpPass : public Pass {
 			f = &buf;
 		}
 
-		RTLIL_BACKEND::dump_design(*f, design, true, flag_m, flag_n);
+		RTLIL_BACKEND::dump_design(*f, design, true, flag_m, flag_n, flag_sorted);
 
 		if (!empty) {
 			delete f;

--- a/backends/rtlil/rtlil_backend.h
+++ b/backends/rtlil/rtlil_backend.h
@@ -42,8 +42,8 @@ namespace RTLIL_BACKEND {
 	void dump_proc_sync(std::ostream &f, std::string indent, const RTLIL::SyncRule *sy);
 	void dump_proc(std::ostream &f, std::string indent, const RTLIL::Process *proc);
 	void dump_conn(std::ostream &f, std::string indent, const RTLIL::SigSpec &left, const RTLIL::SigSpec &right);
-	void dump_module(std::ostream &f, std::string indent, RTLIL::Module *module, RTLIL::Design *design, bool only_selected, bool flag_m = true, bool flag_n = false);
-	void dump_design(std::ostream &f, RTLIL::Design *design, bool only_selected, bool flag_m = true, bool flag_n = false);
+	void dump_module(std::ostream &f, std::string indent, RTLIL::Module *module, RTLIL::Design *design, bool only_selected, bool flag_m = true, bool flag_n = false, bool flag_sorted = false);
+	void dump_design(std::ostream &f, RTLIL::Design *design, bool only_selected, bool flag_m = true, bool flag_n = false, bool flag_sorted = false);
 }
 
 YOSYS_NAMESPACE_END


### PR DESCRIPTION
This is helpful for diffs when roundtripping. The sort is somewhat imperfect as sorting the connections uses SigSpec `operator<` which doesn't result in a nice ordering. However, this comes into play only if the connections aren't equivalent, like here: 
![image](https://github.com/user-attachments/assets/eef648fa-0735-4601-adf4-9d42ae5cce73)
Therefore for getting a nice diff to check total complete equivalence excluding ordering even though `opt_clean` reordered your design (#3426) this is is still useful