### PR TITLE
wheels: fix builds, add linux aarch64 to ci

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,16 +14,12 @@ jobs:
               runner: "ubuntu-22.04",
               archs: "x86_64",
             },
-            ## Aarch64 is disabled for now: GitHub is committing to EOY
-            ## for free aarch64 runners for open-source projects and
-            ## emulation times out:
-            ## https://github.com/orgs/community/discussions/19197#discussioncomment-10550689
-            # {
-            #   name: "Ubuntu 22.04",
-            #   family: "linux",
-            #   runner: "ubuntu-22.04",
-            #   archs: "aarch64",
-            # },
+            {
+              name: "Ubuntu 22.04",
+              family: "linux",
+              runner: "ubuntu-22.04-arm",
+              archs: "aarch64",
+            },
             {
               name: "macOS 13",
               family: "macos",

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ class libyosys_so_ext(Extension):
         )
         self.args = [
             "ENABLE_PYOSYS=1",
-            # Wheel meant to be imported from interpreter
-            "ENABLE_PYTHON_CONFIG_EMBED=0",
+            # Prevent recursive wheel build
+            "ENABLE_WHEEL=0",
             # Would need to be installed separately by the user
             "ENABLE_TCL=0",
             "ENABLE_READLINE=0",


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Essentially, something is attempting to build the Yosys EXE when you build libyosys.so now. With `ENABLE_PYTHON_CONFIG_EMBED=0`, the Yosys EXE will always fail to build.

Furthermore, because `ENABLE_PYOSYS` now attempts to build a wheel, building a wheel has become recursive.

_Explain how this is achieved._

This commit uses a supplementary set of libs for the EXE (EXE_LIBS) so it and libyosys.so can be built simultaneously, as well as a new Makefile flag, `ENABLE_WHEEL`, to prevent the aforementioned recursion.

I also enabled aarch64 Linux in the CI because it's publicly available now.

_If applicable, please suggest to reviewers how they can test the change._

Create a venv and `pip3 install .`.
