### PR TITLE
memory_libmap: Move MapWorker into loop

### DIFF
--- a/passes/memory/memory_libmap.cc
+++ b/passes/memory/memory_libmap.cc
@@ -2232,10 +2232,10 @@ struct MemoryLibMapPass : public Pass {
 			if (module->has_processes_warn())
 				continue;
 
-			MapWorker worker(module);
 			auto mems = Mem::get_selected_memories(module);
 			for (auto &mem : mems)
 			{
+				MapWorker worker(module);
 				MemMapping map(worker, mem, lib, opts);
 				int idx = -1;
 				int best = map.logic_cost;
@@ -2258,8 +2258,6 @@ struct MemoryLibMapPass : public Pass {
 					log("using FF mapping for memory %s.%s\n", log_id(module->name), log_id(mem.memid));
 				} else {
 					map.emit(map.cfgs[idx]);
-					// Rebuild indices after modifying module
-					worker = MapWorker(module);
 				}
 			}
 		}


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

#4964 revealed that a potential segfault was introduced with #4892 because of scope issues with the MapWorker.  The segfault was only occurring on ppcle64 when compiled gcc15, but was able to be verified with Clang's address sanitizer (ASAN).  I'm guessing some particular combination of optimisations meant that the memory was being freed prior to the reassignment at the end of the loop, leading to the segfault.  And also for whatever reason this wasn't picked up by valgrind, only ASAN.

_Explain how this is achieved._

By moving the declaration of `worker` into the for loop it no longer needs to be reassigned at the end of the loop so the scoping is safe again.

There might be some performance reduction here, since the method from #4892 only re-indexed when the memory was emitted.  But given that the only time time it isn't emitted is when the memory uses the logic fallback, this is probably not a huge hit.  The other option would be to add some way to update the `MapWorker`, probably during the `MemMapping::emit()` step so that it doesn't need reassigning while still being able to have up to date indexing.

_If applicable, please suggest to reviewers how they can test the change._

Build Yosys with `SANITIZER = address` and run `t_mem1.ys` from the `tests/arch/quicklogic/qlf_k6n10f` directory (test file can be generated by calling `python3 mem_gen.py`).  Without this change, the address sanitizer will report a `stack-out-of-scope` error.  With this change it does not.