### PR TITLE
Updating test_cell

### DIFF
--- a/kernel/celltypes.h
+++ b/kernel/celltypes.h
@@ -507,6 +507,8 @@ struct CellTypes
 	{
 		if (cell->type.in(ID($mux), ID($_MUX_)))
 			return const_mux(arg1, arg2, arg3);
+		if (cell->type == ID($_NMUX_))
+			return eval_not(const_mux(arg1, arg2, arg3));
 		if (cell->type == ID($bwmux))
 			return const_bwmux(arg1, arg2, arg3);
 		if (cell->type == ID($pmux))

--- a/kernel/consteval.h
+++ b/kernel/consteval.h
@@ -349,7 +349,11 @@ struct ConstEval
 				return false;
 
 			bool eval_err = false;
-			RTLIL::Const eval_ret = CellTypes::eval(cell, sig_a.as_const(), sig_b.as_const(), sig_c.as_const(), sig_d.as_const(), &eval_err);
+			RTLIL::Const eval_ret;
+			if (sig_s.size() > 0 && eval(sig_s, undef, cell)) {
+				eval_ret = CellTypes::eval(cell, sig_a.as_const(), sig_b.as_const(), sig_s.as_const(), &eval_err);
+			} else
+				eval_ret = CellTypes::eval(cell, sig_a.as_const(), sig_b.as_const(), sig_c.as_const(), sig_d.as_const(), &eval_err);
 
 			if (eval_err)
 				return false;

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -4242,9 +4242,9 @@ void RTLIL::Cell::fixup_parameters(bool set_a_signed, bool set_b_signed)
 			type.begins_with("$verific$") || type.begins_with("$array:") || type.begins_with("$extern:"))
 		return;
 
-	if (type == ID($buf) || type == ID($mux) || type == ID($pmux) || type == ID($bmux)) {
+	if (type == ID($buf) || type == ID($mux) || type == ID($pmux) || type == ID($bmux) || type == ID($bwmux) || type == ID($bweqx)) {
 		parameters[ID::WIDTH] = GetSize(connections_[ID::Y]);
-		if (type != ID($buf) && type != ID($mux))
+		if (type.in(ID($pmux), ID($bmux)))
 			parameters[ID::S_WIDTH] = GetSize(connections_[ID::S]);
 		check();
 		return;
@@ -4299,7 +4299,7 @@ void RTLIL::Cell::fixup_parameters(bool set_a_signed, bool set_b_signed)
 		parameters[ID::B_WIDTH] = GetSize(connections_[ID::B]);
 	}
 
-	if (connections_.count(ID::Y))
+	if (connections_.count(ID::Y) && type != ID($concat))
 		parameters[ID::Y_WIDTH] = GetSize(connections_[ID::Y]);
 
 	if (connections_.count(ID::Q))

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -433,13 +433,13 @@ static RTLIL::Cell* create_gold_module(RTLIL::Design *design, RTLIL::IdString ce
 		int a_size = GetSize(cell->getPort(ID::A));
 		wire = module->addWire(ID::B);
 		wire->width = a_size;
-		wire->port_output = true;
+		wire->port_input = true;
 		cell->setPort(ID::B, wire);
 		if (cell_type == ID($bwmux))
 		{
 			wire = module->addWire(ID::S);
 			wire->width = a_size;
-			wire->port_output = true;
+			wire->port_input = true;
 			cell->setPort(ID::S, wire);
 		}
 		wire = module->addWire(ID::Y);
@@ -1017,10 +1017,8 @@ struct TestCellPass : public Pass {
 		{
 			cell_types[ID($eqx)] = "ABSY";
 			cell_types[ID($nex)] = "ABSY";
-		}
-		// $bweqx is additionally unsupported by ConstEval
-		if (nosat && techmap_cmd.compare("techmap -assert") != 0 && noeval)
 			cell_types[ID($bweqx)] = "A";
+		}
 		cell_types[ID($ge)]  = "ABSY";
 		cell_types[ID($gt)]  = "ABSY";
 

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -937,7 +937,7 @@ struct TestCellPass : public Pass {
 		cell_types[ID($sop)] = "*";
 		cell_types[ID($alu)] = "ABSY";
 		cell_types[ID($lcu)] = "*";
-		cell_types[ID($macc)] = "*";
+		// cell_types[ID($macc)] = "*";
 		cell_types[ID($fa)] = "*";
 
 		for (; argidx < GetSize(args); argidx++)

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -1044,9 +1044,7 @@ struct TestCellPass : public Pass {
 		// $pmux doesn't work in sat, and is not supported with 'techmap -assert'
 		if (nosat && techmap_cmd.compare("aigmap") == 0)
 			cell_types[ID($pmux)] = "*";
-		// $bwmux is not supported by ConstEval
-		if (noeval)
-			cell_types[ID($bwmux)] = "A";
+		cell_types[ID($bwmux)] = "A";
 
 		cell_types[ID($slice)] = "A";
 		cell_types[ID($concat)] = "AB";

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -71,6 +71,29 @@ static RTLIL::Cell* create_gold_module(RTLIL::Design *design, RTLIL::IdString ce
 		cell->setPort(ID::Y, wire);
 	}
 
+	if (cell_type.in(ID($_MUX_), ID($_NMUX_)))
+	{
+		wire = module->addWire(ID::A);
+		wire->width = 1;
+		wire->port_input = true;
+		cell->setPort(ID::A, wire);
+
+		wire = module->addWire(ID::B);
+		wire->width = 1;
+		wire->port_input = true;
+		cell->setPort(ID::B, wire);
+
+		wire = module->addWire(ID::S);
+		wire->width = 1;
+		wire->port_input = true;
+		cell->setPort(ID::S, wire);
+
+		wire = module->addWire(ID::Y);
+		wire->width = 1;
+		wire->port_output = true;
+		cell->setPort(ID::Y, wire);
+	}
+
 	if (cell_type == ID($bmux))
 	{
 		int width = 1 + xorshift32(8 * bloat_factor);
@@ -273,19 +296,44 @@ static RTLIL::Cell* create_gold_module(RTLIL::Design *design, RTLIL::IdString ce
 
 	if (cell_type_flags.find('A') != std::string::npos) {
 		wire = module->addWire(ID::A);
-		wire->width = 1 + xorshift32(8 * bloat_factor);
+		if (cell_type_flags.find('b') != std::string::npos)
+			wire->width = 1;
+		else
+			wire->width = 1 + xorshift32(8 * bloat_factor);
 		wire->port_input = true;
 		cell->setPort(ID::A, wire);
 	}
 
 	if (cell_type_flags.find('B') != std::string::npos) {
 		wire = module->addWire(ID::B);
-		if (cell_type_flags.find('h') != std::string::npos)
+		if (cell_type_flags.find('b') != std::string::npos)
+			wire->width = 1;
+		else if (cell_type_flags.find('h') != std::string::npos)
 			wire->width = 1 + xorshift32(6 * bloat_factor);
 		else
 			wire->width = 1 + xorshift32(8 * bloat_factor);
 		wire->port_input = true;
 		cell->setPort(ID::B, wire);
+	}
+
+	if (cell_type_flags.find('C') != std::string::npos) {
+		wire = module->addWire(ID::C);
+		if (cell_type_flags.find('b') != std::string::npos)
+			wire->width = 1;
+		else
+			wire->width = 1 + xorshift32(8 * bloat_factor);
+		wire->port_input = true;
+		cell->setPort(ID::C, wire);
+	}
+
+	if (cell_type_flags.find('D') != std::string::npos) {
+		wire = module->addWire(ID::D);
+		if (cell_type_flags.find('b') != std::string::npos)
+			wire->width = 1;
+		else
+			wire->width = 1 + xorshift32(8 * bloat_factor);
+		wire->port_input = true;
+		cell->setPort(ID::D, wire);
 	}
 
 	if (cell_type_flags.find('S') != std::string::npos && xorshift32(2)) {
@@ -304,7 +352,10 @@ static RTLIL::Cell* create_gold_module(RTLIL::Design *design, RTLIL::IdString ce
 
 	if (cell_type_flags.find('Y') != std::string::npos) {
 		wire = module->addWire(ID::Y);
-		wire->width = 1 + xorshift32(8 * bloat_factor);
+		if (cell_type_flags.find('b') != std::string::npos)
+			wire->width = 1;
+		else
+			wire->width = 1 + xorshift32(8 * bloat_factor);
 		wire->port_output = true;
 		cell->setPort(ID::Y, wire);
 	}
@@ -343,6 +394,58 @@ static RTLIL::Cell* create_gold_module(RTLIL::Design *design, RTLIL::IdString ce
 		wire->width = GetSize(cell->getPort(ID::Y));
 		wire->port_output = true;
 		cell->setPort(ID::CO, wire);
+	}
+
+	if (cell_type == ID($slice))
+	{
+		int a_size = GetSize(cell->getPort(ID::A));
+		int y_size = 1;
+		if (a_size > 1)
+			y_size += (xorshift32(8 * bloat_factor) % (a_size - 1));
+		wire = module->addWire(ID::Y);
+		wire->width = y_size;
+		wire->port_output = true;
+		cell->setPort(ID::Y, wire);
+		if (a_size > y_size)
+			cell->setParam(ID::OFFSET, (xorshift32(8 * bloat_factor) % (a_size - y_size)));
+		else
+			cell->setParam(ID::OFFSET, 0);
+	}
+
+	if (cell_type == ID($concat))
+	{
+		wire = module->addWire(ID::Y);
+		wire->width = GetSize(cell->getPort(ID::A)) + GetSize(cell->getPort(ID::B));
+		wire->port_output = true;
+		cell->setPort(ID::Y, wire);
+	}
+
+	if (cell_type == ID($buf))
+	{
+		wire = module->addWire(ID::Y);
+		wire->width = GetSize(cell->getPort(ID::A));
+		wire->port_output = true;
+		cell->setPort(ID::Y, wire);
+	}
+
+	if (cell_type.in(ID($bwmux), ID($bweqx)))
+	{
+		int a_size = GetSize(cell->getPort(ID::A));
+		wire = module->addWire(ID::B);
+		wire->width = a_size;
+		wire->port_output = true;
+		cell->setPort(ID::B, wire);
+		if (cell_type == ID($bwmux))
+		{
+			wire = module->addWire(ID::S);
+			wire->width = a_size;
+			wire->port_output = true;
+			cell->setPort(ID::S, wire);
+		}
+		wire = module->addWire(ID::Y);
+		wire->width = a_size;
+		wire->port_output = true;
+		cell->setPort(ID::Y, wire);
 	}
 
 	if (constmode)
@@ -882,6 +985,9 @@ struct TestCellPass : public Pass {
 		cell_types[ID($not)] = "ASY";
 		cell_types[ID($pos)] = "ASY";
 		cell_types[ID($neg)] = "ASY";
+		// $buf is unsupported with techmap -assert
+		if (techmap_cmd.compare("techmap -assert") != 0)
+			cell_types[ID($buf)] = "A";
 
 		cell_types[ID($and)]  = "ABSY";
 		cell_types[ID($or)]   = "ABSY";
@@ -905,8 +1011,16 @@ struct TestCellPass : public Pass {
 		cell_types[ID($le)]  = "ABSY";
 		cell_types[ID($eq)]  = "ABSY";
 		cell_types[ID($ne)]  = "ABSY";
-		// cell_types[ID($eqx)] = "ABSY";
-		// cell_types[ID($nex)] = "ABSY";
+		// $eqx, $nex, and $bweqx don't work in sat, and are unsupported with
+		// 'techmap -assert'
+		if (nosat && techmap_cmd.compare("techmap -assert") != 0)
+		{
+			cell_types[ID($eqx)] = "ABSY";
+			cell_types[ID($nex)] = "ABSY";
+		}
+		// $bweqx is additionally unsupported by ConstEval
+		if (nosat && techmap_cmd.compare("techmap -assert") != 0 && noeval)
+			cell_types[ID($bweqx)] = "A";
 		cell_types[ID($ge)]  = "ABSY";
 		cell_types[ID($gt)]  = "ABSY";
 
@@ -917,7 +1031,10 @@ struct TestCellPass : public Pass {
 		cell_types[ID($mod)] = "ABSY";
 		cell_types[ID($divfloor)] = "ABSY";
 		cell_types[ID($modfloor)] = "ABSY";
-		// cell_types[ID($pow)] = "ABsY";
+		// $pow doesnt work in sat, not supported with 'techmap -assert', and only
+		// only partially supported with '-simlib'
+		if (nosat && techmap_cmd.compare("aigmap") == 0)
+			cell_types[ID($pow)] = "ABsY";
 
 		cell_types[ID($logic_not)] = "ASY";
 		cell_types[ID($logic_and)] = "ABSY";
@@ -926,19 +1043,44 @@ struct TestCellPass : public Pass {
 		cell_types[ID($mux)] = "*";
 		cell_types[ID($bmux)] = "*";
 		cell_types[ID($demux)] = "*";
-		if (edges) {
+		// $pmux doesn't work in sat, and is not supported with 'techmap -assert'
+		if (nosat && techmap_cmd.compare("aigmap") == 0)
 			cell_types[ID($pmux)] = "*";
-		}
+		// $bwmux is not supported by ConstEval
+		if (noeval)
+			cell_types[ID($bwmux)] = "A";
 
-		// cell_types[ID($slice)] = "A";
-		// cell_types[ID($concat)] = "A";
+		cell_types[ID($slice)] = "A";
+		cell_types[ID($concat)] = "AB";
 
 		cell_types[ID($lut)] = "*";
 		cell_types[ID($sop)] = "*";
 		cell_types[ID($alu)] = "ABSY";
 		cell_types[ID($lcu)] = "*";
+		// create_gold_module() needs updating for $macc_v2
 		// cell_types[ID($macc)] = "*";
 		cell_types[ID($fa)] = "*";
+
+		cell_types[ID($_BUF_)] = "AYb";
+		cell_types[ID($_NOT_)] = "AYb";
+		cell_types[ID($_AND_)] = "ABYb";
+		cell_types[ID($_NAND_)] = "ABYb";
+		cell_types[ID($_OR_)] = "ABYb";
+		cell_types[ID($_NOR_)] = "ABYb";
+		cell_types[ID($_XOR_)] = "ABYb";
+		cell_types[ID($_XNOR_)] = "ABYb";
+		cell_types[ID($_ANDNOT_)] = "ABYb";
+		cell_types[ID($_ORNOT_)] = "ABYb";
+		cell_types[ID($_MUX_)] = "*";
+		cell_types[ID($_NMUX_)] = "*";
+		// wide $_MUX_ cells are not yet implemented
+		// cell_types[ID($_MUX4_)] = "*";
+		// cell_types[ID($_MUX8_)] = "*";
+		// cell_types[ID($_MUX16_)] = "*";
+		cell_types[ID($_AOI3_)] = "ABCYb";
+		cell_types[ID($_OAI3_)] = "ABCYb";
+		cell_types[ID($_AOI4_)] = "ABCDYb";
+		cell_types[ID($_OAI4_)] = "ABCDYb";
 
 		for (; argidx < GetSize(args); argidx++)
 		{


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

The `test_cell` pass hasn't been kept fully up to date, and there are a number of cells marked as `evaluable` but not supported by it (or in some cases, by `ConstEval::eval()` which it uses).  This is spun out of #4910.

_Explain how this is achieved._

Update `test_cell` with support for (most) of the `evaluable` cells, gated by `nosat` or `techmap_cmd.compare` as needed.
Fix `ConstEval::eval()` base case to work with `$bwmux`.

_If applicable, please suggest to reviewers how they can test the change._
