### PR TITLE
satgen: Fix $macc_v2 x-prop

### DIFF
--- a/kernel/satgen.cc
+++ b/kernel/satgen.cc
@@ -788,12 +788,18 @@ bool SatGen::importCell(RTLIL::Cell *cell, int timestep)
 		{
 			std::vector<int> undef_a = importUndefSigSpec(cell->getPort(ID::A), timestep);
 			std::vector<int> undef_b = importUndefSigSpec(cell->getPort(ID::B), timestep);
+			std::vector<int> undef_c;
+
+			if (cell->type == ID($macc_v2))
+				undef_c = importUndefSigSpec(cell->getPort(ID::C), timestep);
 
 			int undef_any_a = ez->expression(ezSAT::OpOr, undef_a);
 			int undef_any_b = ez->expression(ezSAT::OpOr, undef_b);
+			int undef_any_c = ez->expression(ezSAT::OpOr, undef_c);
+			int undef_any = ez->OR(undef_any_a, ez->OR(undef_any_b, undef_any_c));
 
 			std::vector<int> undef_y = importUndefSigSpec(cell->getPort(ID::Y), timestep);
-			ez->assume(ez->vec_eq(undef_y, std::vector<int>(GetSize(y), ez->OR(undef_any_a, undef_any_b))));
+			ez->assume(ez->vec_eq(undef_y, std::vector<int>(GetSize(y), undef_any)));
 
 			undefGating(y, tmp, undef_y);
 		}


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
_Explain how this is achieved._

Fix the x-prop behavior of `$macc_v2` in satgen. The satgen extension from #4818 missed to account for `$macc_v2` having an extra `C` port.

_If applicable, please suggest to reviewers how they can test the change._

Testing coupled to #5024