### PR TITLE
stat: fix sequential area not being included in addition/multiplication

### DIFF
--- a/passes/cmds/stat.cc
+++ b/passes/cmds/stat.cc
@@ -40,7 +40,7 @@ struct statdata_t
 			X(num_ports) X(num_port_bits) X(num_memories) X(num_memory_bits) X(num_cells) \
 			X(num_processes)
 
-	#define STAT_NUMERIC_MEMBERS STAT_INT_MEMBERS X(area)
+	#define STAT_NUMERIC_MEMBERS STAT_INT_MEMBERS X(area) X(sequential_area)
 
 	#define X(_name) unsigned int _name;
 	STAT_INT_MEMBERS

--- a/tests/various/stat.ys
+++ b/tests/various/stat.ys
@@ -1,4 +1,4 @@
-read_rtlil << EOF
+read_rtlil << EOT
 module \top
   wire input 1 \A
   wire output 2 \Y
@@ -8,7 +8,52 @@ module \top
     connect \Y \Y
   end
 end
-EOF
+EOT
 logger -expect log "Chip area for module '\\top': 9.072000" 1
+logger -expect-no-warnings
+stat -liberty ../../tests/liberty/foundry_data/sg13g2_stdcell_typ_1p20V_25C.lib.filtered.gz
+
+
+design -reset
+read_rtlil <<EOT
+module \top
+  wire input 1 \A
+  wire output 2 \Y
+  wire output 3 \NY
+  cell \child \sequential
+    connect \A \A
+    connect \B 1'0
+    connect \R 1'0
+    connect \Y \Y
+    connect \NY \NY
+  end
+
+  cell \sg13g2_and2_1 \sub
+    connect \A \A
+    connect \B 1'0
+    connect \Y \Y
+  end
+end
+
+module \child
+  wire input 1 \A
+  wire input 2 \B
+  wire input 3 \R
+
+  wire output 4 \Y
+  wire output 5 \NY
+  cell \sg13g2_dfrbp_1 
+    connect \CLK \A
+    connect \D \B
+    connect \Q \Y
+    connect \Q_N \NY
+    connect \RESET_B \R
+  end
+
+  
+end
+EOT
+logger -expect log "Chip area for module '\\top': 63.504000" 1
+logger -expect log "of which used for sequential elements: 54.432000 (85.71%) " 1
 logger -expect-no-warnings
 stat -liberty ../../tests/liberty/foundry_data/sg13g2_stdcell_typ_1p20V_25C.lib.filtered.gz

--- a/tests/various/stat.ys
+++ b/tests/various/stat.ys
@@ -15,20 +15,35 @@ stat -liberty ../../tests/liberty/foundry_data/sg13g2_stdcell_typ_1p20V_25C.lib.
 
 
 design -reset
-read_rtlil <<EOT
+read_rtlil << EOT
 module \top
   wire input 1 \A
   wire output 2 \Y
-  wire output 3 \NY
+  wire output 3 \N
+
+  cell \sg13g2_and2_1 \sub1
+    connect \A \A
+    connect \B 1'0
+    connect \Y \Y
+  end
+
   cell \child \sequential
     connect \A \A
     connect \B 1'0
     connect \R 1'0
     connect \Y \Y
-    connect \NY \NY
+    connect \N \N
   end
 
-  cell \sg13g2_and2_1 \sub
+  cell \child \sequential1
+    connect \A \A
+    connect \B 1'0
+    connect \R 1'0
+    connect \Y \Y
+    connect \N \N
+  end
+
+  cell \sg13g2_and2_1 \sub2
     connect \A \A
     connect \B 1'0
     connect \Y \Y
@@ -41,19 +56,19 @@ module \child
   wire input 3 \R
 
   wire output 4 \Y
-  wire output 5 \NY
-  cell \sg13g2_dfrbp_1 
+  wire output 5 \N
+
+  cell \sg13g2_dfrbp_1 \sequential_ff
     connect \CLK \A
     connect \D \B
     connect \Q \Y
-    connect \Q_N \NY
+    connect \Q_N \N
     connect \RESET_B \R
   end
 
-  
 end
 EOT
-logger -expect log "Chip area for module '\\top': 63.504000" 1
-logger -expect log "of which used for sequential elements: 54.432000 (85.71%) " 1
+logger -expect log "Chip area for top module '\\top': 112.492800" 1
+logger -expect log "of which used for sequential elements: 94.348800" 1
 logger -expect-no-warnings
-stat -liberty ../../tests/liberty/foundry_data/sg13g2_stdcell_typ_1p20V_25C.lib.filtered.gz
+stat -liberty ../../tests/liberty/foundry_data/sg13g2_stdcell_typ_1p20V_25C.lib.filtered.gz -top \top


### PR DESCRIPTION
In Stat there is a separate calculation for the sequential area of a circuit. 
This output of stat has been incorrect if the design isn't flattened. 

_What are the reasons/motivation for this change?_
We would like to be able to calculate accurate sequential area for non flattened designs. 

_Explain how this is achieved._
add the sequential area to the macro that implements the add and multiply operations. 

_If applicable, please suggest to reviewers how they can test the change._
Check a report of a flattened and unflattened design. 
Before it had different sequential areas. Now the sequential area will be the same. 

