### PR TITLE
cxxrtl: Add internal cell "bwmux"

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -200,7 +200,7 @@ bool is_extending_cell(RTLIL::IdString type)
 bool is_inlinable_cell(RTLIL::IdString type)
 {
 	return is_unary_cell(type) || is_binary_cell(type) || type.in(
-		ID($mux), ID($concat), ID($slice), ID($pmux), ID($bmux), ID($demux));
+		ID($mux), ID($concat), ID($slice), ID($pmux), ID($bmux), ID($demux), ID($bwmux));
 }
 
 bool is_ff_cell(RTLIL::IdString type)
@@ -1196,6 +1196,14 @@ struct CxxrtlWorker {
 			f << ".bmux<";
 			f << cell->getParam(ID::WIDTH).as_int();
 			f << ">(";
+			dump_sigspec_rhs(cell->getPort(ID::S), for_debug);
+			f << ").val()";
+		// Bitwise muxes
+		} else if (cell->type == ID($bwmux)) {
+			dump_sigspec_rhs(cell->getPort(ID::A), for_debug);
+			f << ".bwmux(";
+			dump_sigspec_rhs(cell->getPort(ID::B), for_debug);
+			f << ",";
 			dump_sigspec_rhs(cell->getPort(ID::S), for_debug);
 			f << ").val()";
 		// Demuxes

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -498,6 +498,11 @@ struct value : public expr_base<value<Bits>> {
 		return result;
 	}
 
+	CXXRTL_ALWAYS_INLINE
+	value<Bits> bwmux(const value<Bits> &b, const value<Bits> &s) const {
+		return (bit_and(s.bit_not())).bit_or(b.bit_and(s));
+	}
+
 	template<size_t ResultBits, size_t SelBits>
 	value<ResultBits> demux(const value<SelBits> &sel) const {
 		static_assert(Bits << SelBits == ResultBits, "invalid sizes used in demux()");


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Fixes #5029 

_Explain how this is achieved._

By adding the cell to the cxxrtl backend.

_If applicable, please suggest to reviewers how they can test the change._

Follow the steps in #5029 to create the error.

For a trivial example, create:
```
module bwmux_test(
input [8-1:0] A, B,
input [8-1:0] S,
output [8-1:0] Y
);
	\$bwmux #(.WIDTH(8)) mux (.A(A), .B(B), .S(S), .Y(Y));
endmodule
```
and build the .cpp with 
```
yosys -p "read_verilog -icells test_bwmux.v; select =*; proc; clean; write_cxxrtl cxxrtl-test-bwmux.cc"
```
compiling it with the header afterwards.

Implementation is originally by @povik from https://github.com/YosysHQ/yosys/issues/5029#issuecomment-2809093496.


Supersedes #5030 