### PR TITLE
liberty: fix tests

### DIFF
--- a/tests/liberty/run-test.sh
+++ b/tests/liberty/run-test.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
-set -e
+set -eo pipefail
 
 for x in *.lib; do
 	echo "Testing on $x.."
 	../../yosys -p "read_verilog small.v; synth -top small; dfflibmap -info -liberty ${x}" -ql ${x%.lib}.log
 	../../yosys-filterlib - $x 2>/dev/null > $x.filtered
 	../../yosys-filterlib -verilogsim $x > $x.verilogsim
-	diff $x.filtered $x.filtered.ok && diff $x.verilogsim $x.verilogsim.ok
-done || exit 1
+	diff $x.filtered $x.filtered.ok
+	diff $x.verilogsim $x.verilogsim.ok
+done
 
 for x in *.ys; do
   echo "Running $x.."
   ../../yosys -q -s $x -l ${x%.ys}.log
-done || exit 1
+done
 


### PR DESCRIPTION
`set -e` is the correct solution but `&&` prevents it from working. Doing `|| exit 1` on a for loop only checks the last iteration of the for loop, or something of that sort. `pipefail` added out of superstition