### PR TITLE
gatemate: WRITE_THROUGH mode change

### DIFF
--- a/techlibs/gatemate/brams.txt
+++ b/techlibs/gatemate/brams.txt
@@ -34,7 +34,6 @@ ram block $__CC_BRAM_TDP_ {
 		}
 		portoption "WR_MODE" "WRITE_THROUGH" {
 			rdwr new;
-			wrtrans all new;
 		}
 		wrbe_separate;
 		optional_rw;


### PR DESCRIPTION
Removing "wrtrans" setting makes designs to work on actual hardware. Without this change LiteX cores are not working correctly and return bad chars over serial port.

Pinging @pu-cc