### PR TITLE
opt_dff: fix infinite loop

### DIFF
--- a/tests/opt/bug4979.ys
+++ b/tests/opt/bug4979.ys
@@ -1,0 +1,36 @@
+read_verilog << EOT
+module a (
+    input b,
+    input h,
+    input i,
+    output reg o
+);
+    wire c, j, k, e, g;
+
+    reg l, n, d, f;
+
+    always @(posedge b or negedge c) begin
+        if (c) begin
+            o = j > l;
+            l = (l | j) ? k ? h : i ? 0 : n : 0;      
+        end
+    end
+
+    always @(h) begin
+        d = k;
+    end
+
+    always @(e or g or f) begin
+        if (e) begin
+            l = 0;
+        end else begin
+            d = g;
+            l = f;
+        end
+    end
+
+endmodule
+EOT
+
+synth -run coarse
+opt -undriven


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
#4979 
_Explain how this is achieved._
The original opt_dff code had a problem handling simplified cells, there was no check for the presence of an already optimized enables / sync resets signals. I considered two options for solving it, memoization of optimized cells or DFS from ce or srts port, and I think memoization suits better.
_If applicable, please suggest to reviewers how they can test the change._
`/tests/opt/bug4979.ys`