### PR TITLE
techlibs/lattice: add missing clock muxes to ECP5 block ram blackboxes

### DIFF
--- a/techlibs/lattice/cells_bb_ecp5.v
+++ b/techlibs/lattice/cells_bb_ecp5.v
@@ -19,6 +19,8 @@ endmodule
 
 (* blackbox *)
 module DP16KD (...);
+    parameter CLKAMUX = "CLKA";
+    parameter CLKBMUX = "CLKB";
     parameter DATA_WIDTH_A = 18;
     parameter DATA_WIDTH_B = 18;
     parameter REGMODE_A = "NOREG";
@@ -215,6 +217,8 @@ endmodule
 
 (* blackbox *)
 module PDPW16KD (...);
+    parameter CLKRMUX = "CLKR";
+    parameter CLKWMUX = "CLKW";
     parameter DATA_WIDTH_W = 36;
     parameter DATA_WIDTH_R = 36;
     parameter GSR = "ENABLED";


### PR DESCRIPTION
## _What are the reasons/motivation for this change?_

Fixes #3952 , missing parameters on ECP5 EBR blackboxes.

## _Explain how this is achieved._

prjtrellis documentation shows that EBR clock inputs have optional inverters. The bram techmap outputs those parameters, and nextpnr consumes them. But for whatever reason, Diamond doesn't include those parameters in its blackbox models. This makes synth_lattice fail when targeting ECP5 with a design that maps block RAMs.

This change fixes up the ECP5 bram blackbox models at generation time, by adding in the missing parameters.

## _If applicable, please suggest to reviewers how they can test the change._

1. Grab this `synth.v` https://gist.github.com/danderson/3e80ce79da41673de1ee0dff22e0e596 . The Verilog is a bit verbose, but it's just a basic 1kiB block RAM with registered output.

2. With yosys@main: `yosys -p 'read_verilog -sv -defer synth.v; hierarchy -top mkTop; synth_lattice -family ecp5'`

Observe synthesis failure with error:

```
4.47.1. Analyzing design hierarchy..
Top module:  \mkTop
ERROR: Module `DP16KD' referenced in module `mkTop' in cell `ram_.RAM.0.0' does not have a parameter named 'CLKAMUX'.
```

3. Apply this patch to yosys install tree, run same thing again: `yosys -p 'read_verilog -sv -defer synth.v; hierarchy -top mkTop; synth_lattice -family ecp5'`

Observe synthesis now succeeds.

4. Also compare passing `-abc9` to `synth_lattice` before and after. Before: 

```
4.43.2. Executing ABC9_OPS pass (helper functions for ABC9).
/usr/bin/../share/yosys/lattice/common_sim.vh:0: ERROR: Can't find object for defparam `CLKAMUX`!
```

After: synthesis succeeds.