### PR TITLE
Fix #5046

### DIFF
--- a/passes/cmds/clean_zerowidth.cc
+++ b/passes/cmds/clean_zerowidth.cc
@@ -128,7 +128,7 @@ struct CleanZeroWidthPass : public Pass {
 					// A and B to 1-bit if their width is 0.
 					if (cell->getParam(ID::Y_WIDTH).as_int() == 0) {
 						module->remove(cell);
-					} else if (cell->type == ID($macc)) {
+					} else if (cell->type.in(ID($macc), ID($macc_v2))) {
 						// TODO: fixing zero-width A and B not supported.
 					} else {
 						if (cell->getParam(ID::A_WIDTH).as_int() == 0) {


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
Reported in #5046, `clean_zerowidth` had skipped $macc, but not $macc_v2.

_Explain how this is achieved._
Change skip to include $macc_v2.

_If applicable, please suggest to reviewers how they can test the change._
Refer to #5046.
