### PR TITLE
Detect FF functions that use parentheses.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ ifeq ($(OS), Haiku)
 CXXFLAGS += -D_DEFAULT_SOURCE
 endif
 
-YOSYS_VER := 0.52+75
+YOSYS_VER := 0.52+89
 YOSYS_MAJOR := $(shell echo $(YOSYS_VER) | cut -d'.' -f1)
 YOSYS_MINOR := $(shell echo $(YOSYS_VER) | cut -d'.' -f2 | cut -d'+' -f1)
 YOSYS_COMMIT := $(shell echo $(YOSYS_VER) | cut -d'+' -f2)

--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -102,6 +102,9 @@ static bool parse_next_state(const LibertyAst *cell, const LibertyAst *attr, std
 	} else if (expr[0] == '!') {
 		data_name = expr.substr(1, expr.size()-1);
 		data_not_inverted = false;
+	} else if (expr[0] == '(' && expr[expr.size() - 1] == ')') {
+		data_name = expr.substr(1, expr.size() - 2);
+		data_not_inverted = true;
 	} else {
 		data_name = expr;
 		data_not_inverted = true;

--- a/tests/liberty/dff.lib
+++ b/tests/liberty/dff.lib
@@ -1,0 +1,22 @@
+// Test library for different DFF function expressions
+
+library(dff) {
+  cell (dff) {
+    area : 1;
+    ff("IQ", "IQN") {
+      next_state : "(D)";
+      clocked_on : "CLK";
+    } 
+    pin(D) {
+      direction : input;
+    }
+    pin(CLK) {
+      direction : input;
+    }
+    pin(Q) {
+      direction: output;
+      function : "IQ";   
+    }
+  }
+
+} /* end */

--- a/tests/liberty/dff.lib.filtered.ok
+++ b/tests/liberty/dff.lib.filtered.ok
@@ -1,0 +1,19 @@
+library(dff) {
+  cell(dff) {
+    area : 1 ;
+    ff("IQ", "IQN") {
+      next_state : "(D)" ;
+      clocked_on : "CLK" ;
+    }
+    pin(D) {
+      direction : input ;
+    }
+    pin(CLK) {
+      direction : input ;
+    }
+    pin(Q) {
+      direction : output ;
+      function : "IQ" ;
+    }
+  }
+}

--- a/tests/liberty/dff.lib.verilogsim.ok
+++ b/tests/liberty/dff.lib.verilogsim.ok
@@ -1,0 +1,12 @@
+module dff (D, CLK, Q);
+  reg "IQ", "IQN";
+  input D;
+  input CLK;
+  output Q;
+  assign Q = IQ; // "IQ"
+  always @(posedge CLK) begin
+      // "(D)"
+      "IQ" <= (D);
+      "IQN" <= ~((D));
+  end
+endmodule

--- a/tests/liberty/dff.log.ok
+++ b/tests/liberty/dff.log.ok
@@ -1,0 +1,29 @@
+
+-- Running command `dfflibmap -info -liberty dff.lib' --
+
+1. Executing DFFLIBMAP pass (mapping DFF cells to sequential cells from liberty file).
+  cell dff (noninv, pins=3, area=1.00) is a direct match for cell type $_DFF_P_.
+  final dff cell mappings:
+    unmapped dff cell: $_DFF_N_
+    \dff _DFF_P_ (.CLK( C), .D( D), .Q( Q));
+    unmapped dff cell: $_DFF_NN0_
+    unmapped dff cell: $_DFF_NN1_
+    unmapped dff cell: $_DFF_NP0_
+    unmapped dff cell: $_DFF_NP1_
+    unmapped dff cell: $_DFF_PN0_
+    unmapped dff cell: $_DFF_PN1_
+    unmapped dff cell: $_DFF_PP0_
+    unmapped dff cell: $_DFF_PP1_
+    unmapped dff cell: $_DFFE_NN_
+    unmapped dff cell: $_DFFE_NP_
+    unmapped dff cell: $_DFFE_PN_
+    unmapped dff cell: $_DFFE_PP_
+    unmapped dff cell: $_DFFSR_NNN_
+    unmapped dff cell: $_DFFSR_NNP_
+    unmapped dff cell: $_DFFSR_NPN_
+    unmapped dff cell: $_DFFSR_NPP_
+    unmapped dff cell: $_DFFSR_PNN_
+    unmapped dff cell: $_DFFSR_PNP_
+    unmapped dff cell: $_DFFSR_PPN_
+    unmapped dff cell: $_DFFSR_PPP_
+dfflegalize command line: dfflegalize -cell $_DFF_P_ 01 t:$_DFF* t:$_SDFF*

--- a/tests/liberty/run-test.sh
+++ b/tests/liberty/run-test.sh
@@ -7,6 +7,10 @@ for x in *.lib; do
 	../../yosys-filterlib - $x 2>/dev/null > $x.filtered
 	../../yosys-filterlib -verilogsim $x > $x.verilogsim
 	diff $x.filtered $x.filtered.ok && diff $x.verilogsim $x.verilogsim.ok
+	if [[ -e ${x%.lib}.log.ok ]]; then
+		../../yosys -p "dfflibmap -info -liberty ${x}" -TqqQl ${x%.lib}.log
+		diff ${x%.lib}.log ${x%.lib}.log.ok
+	fi
 done || exit 1
 
 for x in *.ys; do

--- a/tests/liberty/run-test.sh
+++ b/tests/liberty/run-test.sh
@@ -1,20 +1,21 @@
 #!/usr/bin/env bash
-set -e
+set -eo pipefail
 
 for x in *.lib; do
 	echo "Testing on $x.."
 	../../yosys -p "read_verilog small.v; synth -top small; dfflibmap -info -liberty ${x}" -ql ${x%.lib}.log
 	../../yosys-filterlib - $x 2>/dev/null > $x.filtered
 	../../yosys-filterlib -verilogsim $x > $x.verilogsim
-	diff $x.filtered $x.filtered.ok && diff $x.verilogsim $x.verilogsim.ok
+	diff $x.filtered $x.filtered.ok
+	diff $x.verilogsim $x.verilogsim.ok
 	if [[ -e ${x%.lib}.log.ok ]]; then
 		../../yosys -p "dfflibmap -info -liberty ${x}" -TqqQl ${x%.lib}.log
 		diff ${x%.lib}.log ${x%.lib}.log.ok
 	fi
-done || exit 1
+done
 
 for x in *.ys; do
   echo "Running $x.."
   ../../yosys -q -s $x -l ${x%.ys}.log
-done || exit 1
+done
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

This supports PDKs that may enclose the `ff` `next_state` function in parentheses.

example:

```
ff (IQ,IQN) {
    clocked_on : "!clk";
    next_state : "(d)";
}
```
