### PR TITLE
fix udivmod crashes when operand value exceeds logical width

### DIFF
--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -2010,7 +2010,7 @@ std::pair<value<BitsY>, value<BitsY>> divmod_uu(const value<BitsA> &a, const val
 	value<Bits> quotient;
 	value<Bits> remainder;
 	value<Bits> dividend = a.template zext<Bits>();
-	value<Bits> divisor = b.template zext<Bits>();
+	value<Bits> divisor  = b.template trunc<BitsB>().template zext<Bits>();
 	std::tie(quotient, remainder) = dividend.udivmod(divisor);
 	return {quotient.template trunc<BitsY>(), remainder.template trunc<BitsY>()};
 }


### PR DESCRIPTION
This PR fixes https://github.com/YosysHQ/yosys/issues/5048, which causes an assertion failure during division when the actual value of the divisor exceeds its bit-width range.

The issue is resolved by modifying the `divmod_uu()` function to truncate the divisor to its declared bit-width before zero-extending it to the unified width, ensuring that the value passed to `udivmod()` remains within valid bounds:

```cpp
value<Bits> divisor = b.template trunc<BitsB>().template zext<Bits>();
```