### PR TITLE
check: promote some problems to errors by default, add -permissive

### DIFF
--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -400,6 +400,16 @@ void log_file_error(const string &filename, int lineno,
 	logv_file_error(filename, lineno, format, ap);
 }
 
+std::string fmt(const char *format, ...)
+{
+	std::string s;
+	va_list ap;
+	va_start(ap, format);
+	s = vstringf(format, ap);
+	va_end(ap);
+	return s;
+}
+
 void log(const char *format, ...)
 {
 	va_list ap;

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -126,6 +126,7 @@ void logv_warning_noprefix(const char *format, va_list ap);
 [[noreturn]] void logv_error(const char *format, va_list ap);
 [[noreturn]] void logv_file_error(const string &filename, int lineno, const char *format, va_list ap);
 
+std::string fmt(const char *format, ...)  YS_ATTRIBUTE(format(printf, 1, 2));
 void log(const char *format, ...)  YS_ATTRIBUTE(format(printf, 1, 2));
 void log_header(RTLIL::Design *design, const char *format, ...) YS_ATTRIBUTE(format(printf, 2, 3));
 void log_warning(const char *format, ...) YS_ATTRIBUTE(format(printf, 1, 2));


### PR DESCRIPTION
Some problems `check` discovers are too severe to keep as warnings by default.

Yosys is expected to continue to cover dodgy scenarios, such as combinational loops in flip flop models[[1]](#1). multiple drivers for a signal[[2]](#2), and undriven signals. When you mix a couple of these you can end up with nasty results[[3]](#3). For greater user experience, we should treat multiple drivers and possibly combinational loops as an error at any point we may encounter it, unless the user specifies otherwise. This is different from `check -assert` which makes every `check` warning an error, effectively.

The user should be able to ask for the old behavior by either
- directly using a flag like `check -permissive`
- indirectly using a flag like `synth -check-permissive` for any script pass running `check` (that's `proc` and `synth*`)
- maybe as a driver option like `yosys --check-permissive`

Alternatively, to avoid strongly customized scripts, we can keep old `check` behavior and add a flag like `check -smart` and use that in script passes. This way we still get the friendlier UX of `synth*` with less breakage.

A change to `check` like this could also be a step towards design-level invariant flags ("design has no loops", "design only includes fine-grained cells" etc) that have been brought up a couple of times by now

<a id="1">[1]</a> `tests/asicworld/code_hdl_models_d_ff_gates.v`, this should make the CI red on this draft
<a id="2">[2]</a> [opt_clean.cc](https://github.com/YosysHQ/yosys/blob/bf20bc0848e2089a4ca814c60471e82c7b666986/passes/opt/opt_clean.cc#L147C1-L147C5)
<a id="3">[3]</a> https://github.com/YosysHQ/yosys/issues/4979#issuecomment-2824113291