### PR TITLE
rtlil: less sketchy lifetimes

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -32,19 +32,6 @@
 
 YOSYS_NAMESPACE_BEGIN
 
-bool RTLIL::IdString::destruct_guard_ok = false;
-RTLIL::IdString::destruct_guard_t RTLIL::IdString::destruct_guard;
-std::vector<char*> RTLIL::IdString::global_id_storage_;
-dict<char*, int> RTLIL::IdString::global_id_index_;
-#ifndef YOSYS_NO_IDS_REFCNT
-std::vector<int> RTLIL::IdString::global_refcount_storage_;
-std::vector<int> RTLIL::IdString::global_free_idx_list_;
-#endif
-#ifdef YOSYS_USE_STICKY_IDS
-int RTLIL::IdString::last_created_idx_[8];
-int RTLIL::IdString::last_created_idx_ptr_;
-#endif
-
 #define X(_id) IdString RTLIL::ID::_id;
 #include "kernel/constids.inc"
 #undef X

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -106,7 +106,7 @@ namespace RTLIL
 	typedef std::pair<SigSpec, SigSpec> SigSig;
 };
 
-#define YOSYS_XTRACE_GET_PUT
+#undef YOSYS_XTRACE_GET_PUT
 #undef YOSYS_SORT_ID_FREE_LIST
 #undef YOSYS_USE_STICKY_IDS
 #undef YOSYS_NO_IDS_REFCNT

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -185,7 +185,7 @@ void yosys_setup()
 	if(already_setup)
 		return;
 	already_setup = true;
-	(void)Interner::instance();
+	(void)Interner::get();
 
 #ifdef WITH_PYTHON
 	// With Python 3.12, calling PyImport_AppendInittab on an already

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -185,6 +185,7 @@ void yosys_setup()
 	if(already_setup)
 		return;
 	already_setup = true;
+	(void)Interner::instance();
 
 #ifdef WITH_PYTHON
 	// With Python 3.12, calling PyImport_AppendInittab on an already


### PR DESCRIPTION
We have some asan findings noted in #5020 so I'm making a pass through the codebase and seeing what's ripe for a cleanup. So far I have replaced the destruct guard with a singleton pattern and demoted string interning data structures from globals into it, which doesn't resolve any known problems but seems like the right thing to do

- [ ] performance impact check