### PR TITLE
simplify: fix struct wiretype attr memory leak

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1919,6 +1919,8 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 			if (!str.empty() && str[0] == '\\' && (template_node->type == AST_STRUCT || template_node->type == AST_UNION)) {
 				// replace instance with wire representing the packed structure
 				newNode = make_packed_struct(template_node, str, attributes);
+				if (newNode->attributes.count(ID::wiretype))
+					delete newNode->attributes[ID::wiretype];
 				newNode->set_attribute(ID::wiretype, mkconst_str(resolved_type_node->str));
 				// add original input/output attribute to resolved wire
 				newNode->is_input = this->is_input;


### PR DESCRIPTION
This fixes `tests/various/struct_access.ys` when run with `SANITIZER=address` as described in #5020. All AstNodes must be part of some AstModule and dangling ones are leaks that cause yosys to exit with an error if instrumented with some sanitizers. Unimportant problems like this make sanitizers unusable which is a sever quality issue. This PR deletes an attribute AstNode if it were to become no longer referred to by anything in the AST