### PR TITLE
AstNode garbage collector for debugging

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -290,8 +290,8 @@ void AstNode::delete_children()
 	for (auto &it : children)
 		if (Tagger::get().nodes.count(it))
 			delete it;
-		else
-			log("skip child %p\n", it);
+		// else
+		// 	log("skip child %p\n", it);
 #else
 	for (auto &it : children)
 		delete it;
@@ -302,8 +302,8 @@ void AstNode::delete_children()
 	for (auto &it : attributes)
 		if (Tagger::get().nodes.count(it.second))
 			delete it.second;
-		else
-			log("skip attr %p\n", it.second);
+		// else
+		// 	log("skip attr %p\n", it.second);
 #else
 	for (auto &it : attributes)
 		delete it.second;

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -467,7 +467,7 @@ namespace AST_INTERNAL
 	                           AST::AstNode *original_ast = nullptr);
 }
 
-#define ASTNODE_GC
+#undef ASTNODE_GC
 #ifdef ASTNODE_GC
 struct Tagger {
 	std::set<AST::AstNode*> nodes;

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -467,7 +467,7 @@ namespace AST_INTERNAL
 	                           AST::AstNode *original_ast = nullptr);
 }
 
-#undef ASTNODE_GC
+#define ASTNODE_GC
 #ifdef ASTNODE_GC
 struct Tagger {
 	std::set<AST::AstNode*> nodes;
@@ -524,7 +524,6 @@ struct Tagger {
 		while (!copy.empty()) {
 			AST::AstNode* p = *(copy.begin());
 			copy.erase(p);
-			fflush(stdout);
 			if (!tagged.count(p)) {
 				shadow_kill(p);
 			}

--- a/frontends/verilog/verilog_frontend.cc
+++ b/frontends/verilog/verilog_frontend.cc
@@ -39,6 +39,7 @@
 YOSYS_NAMESPACE_BEGIN
 using namespace VERILOG_FRONTEND;
 
+
 // use the Verilog bison/flex parser to generate an AST and use AST::process() to convert it to RTLIL
 
 static std::vector<std::string> verilog_defaults;
@@ -528,7 +529,15 @@ struct VerilogFrontend : public Frontend {
 
 		AST::process(design, current_ast, flag_nodisplay, flag_dump_ast1, flag_dump_ast2, flag_no_dump_ptr, flag_dump_vlog1, flag_dump_vlog2, flag_dump_rtlil, flag_nolatches,
 				flag_nomeminit, flag_nomem2reg, flag_mem2reg, flag_noblackbox, lib_mode, flag_nowb, flag_noopt, flag_icells, flag_pwires, flag_nooverwrite, flag_overwrite, flag_defer, default_nettype_wire);
+#ifdef ASTNODE_GC
+		Tagger::get().clear();
+		Tagger::get().tag(current_ast);
+		for (RTLIL::Module* m : design->modules())
+			if (AST::AstModule* am = dynamic_cast<AST::AstModule*>(m))
+				Tagger::get().tag(am->ast);
 
+		Tagger::get().dump_untagged();
+#endif
 
 		if (!flag_nopp)
 			delete lexin;
@@ -539,6 +548,9 @@ struct VerilogFrontend : public Frontend {
 
 		delete current_ast;
 		current_ast = NULL;
+#ifdef ASTNODE_GC
+		Tagger::get().kill_untagged();
+#endif
 
 		log("Successfully finished Verilog frontend.\n");
 	}

--- a/frontends/verilog/verilog_frontend.cc
+++ b/frontends/verilog/verilog_frontend.cc
@@ -536,7 +536,7 @@ struct VerilogFrontend : public Frontend {
 			if (AST::AstModule* am = dynamic_cast<AST::AstModule*>(m))
 				Tagger::get().tag(am->ast);
 
-		Tagger::get().dump_untagged();
+		// Tagger::get().dump_untagged();
 #endif
 
 		if (!flag_nopp)

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -32,19 +32,6 @@
 
 YOSYS_NAMESPACE_BEGIN
 
-bool RTLIL::IdString::destruct_guard_ok = false;
-RTLIL::IdString::destruct_guard_t RTLIL::IdString::destruct_guard;
-std::vector<char*> RTLIL::IdString::global_id_storage_;
-dict<char*, int> RTLIL::IdString::global_id_index_;
-#ifndef YOSYS_NO_IDS_REFCNT
-std::vector<int> RTLIL::IdString::global_refcount_storage_;
-std::vector<int> RTLIL::IdString::global_free_idx_list_;
-#endif
-#ifdef YOSYS_USE_STICKY_IDS
-int RTLIL::IdString::last_created_idx_[8];
-int RTLIL::IdString::last_created_idx_ptr_;
-#endif
-
 #define X(_id) IdString RTLIL::ID::_id;
 #include "kernel/constids.inc"
 #undef X

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -106,7 +106,7 @@ namespace RTLIL
 	typedef std::pair<SigSpec, SigSpec> SigSig;
 };
 
-#define YOSYS_XTRACE_GET_PUT
+#undef YOSYS_XTRACE_GET_PUT
 #undef YOSYS_SORT_ID_FREE_LIST
 #undef YOSYS_USE_STICKY_IDS
 #undef YOSYS_NO_IDS_REFCNT

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -185,7 +185,7 @@ void yosys_setup()
 	if(already_setup)
 		return;
 	already_setup = true;
-	(void)Interner::instance();
+	(void)Interner::get();
 
 #ifdef WITH_PYTHON
 	// With Python 3.12, calling PyImport_AppendInittab on an already

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -185,6 +185,7 @@ void yosys_setup()
 	if(already_setup)
 		return;
 	already_setup = true;
+	(void)Interner::instance();
 
 #ifdef WITH_PYTHON
 	// With Python 3.12, calling PyImport_AppendInittab on an already


### PR DESCRIPTION
Sanitizers can detect the presence of a memory safety violation, but not with much detail. I'm adding a debugging garbage collector for tracking lifetimes and provenance of AstNodes. AstNodes that aren't part of some AstModule AST are collected, optionally debugged, and destroyed, as they'd otherwise leak

Tracking is done by collecting an `std::set<AstNode*> nodes`. `AstNode` constructors register `this` into `nodes` and destructors deregister `this`. At a moment when all AstNodes should be "owned" by something point to them, they are tagged, and therefore, the set of untagged nodes should be empty. These nodes get killed to trip the sanitizer if they were being "owned" by anything that wasn't tagged. They can also be dumped. The code is off by macro, just like legacy debug features such as YOSYS_USE_STICKY_IDS. It's expected that the use case is only for debugging as it slows down the program to a large extent and on its own doesn't really dump anything. The PR is temporarily based on top of #5060 which makes the diff messy, sorry

In case you want to test the change, you could comment out some `delete` statement from ast.cc or simplify.cc, build yosys with `SANITIZER=address`, see the sanitizer detect a leak on yosys exit from an invocation where read_verilog is run, change the undef in ast.h to an ifdef, rebuild, and no longer see that leak