### PR TITLE
gzip: refactor file open failure errors

### DIFF
--- a/kernel/gzip.cc
+++ b/kernel/gzip.cc
@@ -100,11 +100,12 @@ gzip_istream::ibuf::~ibuf() {
 
 // Takes a successfully opened ifstream. If it's gzipped, returns an istream. Otherwise,
 // returns the original ifstream, rewound to the start.
+// Never returns nullptr or failed state istream*
 std::istream* uncompressed(const std::string filename, std::ios_base::openmode mode) {
 	std::ifstream* f = new std::ifstream();
 	f->open(filename, mode);
 	if (f->fail())
-		return f;
+		log_cmd_error("Can't open input file `%s' for reading: %s\n", filename.c_str(), strerror(errno));
 	// Check for gzip magic
 	unsigned char magic[3];
 	int n = 0;
@@ -124,7 +125,7 @@ std::istream* uncompressed(const std::string filename, std::ios_base::openmode m
 				filename.c_str(), unsigned(magic[2]));
 		gzip_istream* s = new gzip_istream();
 		delete f;
-		s->open(filename.c_str());
+		log_assert(s->open(filename.c_str()));
 		return s;
 #else
 		log_cmd_error("File `%s' is a gzip file, but Yosys is compiled without zlib.\n", filename.c_str());

--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -472,8 +472,6 @@ void Frontend::extra_args(std::istream *&f, std::string &filename, std::vector<s
 			yosys_input_files.insert(filename);
 			f = uncompressed(filename, bin_input ? std::ifstream::binary : std::ifstream::in);
 		}
-		if (f == NULL)
-			log_cmd_error("Can't open input file `%s' for reading: %s\n", filename.c_str(), strerror(errno));
 
 		for (size_t i = argidx+1; i < args.size(); i++)
 			if (args[i].compare(0, 1, "-") == 0)

--- a/passes/cmds/stat.cc
+++ b/passes/cmds/stat.cc
@@ -350,8 +350,6 @@ void read_liberty_cellarea(dict<IdString, cell_area_t> &cell_area, string libert
 {
 	std::istream* f = uncompressed(liberty_file.c_str());
 	yosys_input_files.insert(liberty_file);
-	if (f->fail())
-		log_cmd_error("Can't open liberty file `%s': %s\n", liberty_file.c_str(), strerror(errno));
 	LibertyParser libparser(*f, liberty_file);
 	delete f;
 

--- a/passes/techmap/clockgate.cc
+++ b/passes/techmap/clockgate.cc
@@ -310,8 +310,6 @@ struct ClockgatePass : public Pass {
 			LibertyMergedCells merged;
 			for (auto path : liberty_files) {
 				std::istream* f = uncompressed(path);
-				if (f->fail())
-					log_cmd_error("Can't open liberty file `%s': %s\n", path.c_str(), strerror(errno));
 				LibertyParser p(*f, path);
 				merged.merge(p);
 				delete f;

--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -635,8 +635,6 @@ struct DfflibmapPass : public Pass {
 		LibertyMergedCells merged;
 		for (auto path : liberty_files) {
 			std::istream* f = uncompressed(path);
-			if (f->fail())
-				log_cmd_error("Can't open liberty file `%s': %s\n", path.c_str(), strerror(errno));
 			LibertyParser p(*f, path);
 			merged.merge(p);
 			delete f;


### PR DESCRIPTION
Fixes #5013

By refactoring any error handling away from the passes, we now report `ERROR: Can't open input file '$FILENAME' for reading: No such file or directory` every time we fail to open a file with `uncompress`. This includes cases when the file isn't actually compressed. This changes some error outputs (`Can't open liberty file` -> `Can't open input file`) but I doubt anybody minds since you see the filename right after anyway