### PR TITLE
fix missing sign extension before shift operation for signed values

### DIFF
--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -1769,10 +1769,6 @@ value<BitsY> shr_uu(const value<BitsA> &a, const value<BitsB> &b) {
 template<size_t BitsY, size_t BitsA, size_t BitsB>
 CXXRTL_ALWAYS_INLINE
 value<BitsY> shr_su(const value<BitsA> &a, const value<BitsB> &b) {
-	if (BitsY > BitsA) {
-		value<BitsY> extended_a = a.template scast<BitsY>();
-		return extended_a.shr(b);
-	}
 	return a.template scast<BitsY>().shr(b);
 }
 

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -1769,6 +1769,10 @@ value<BitsY> shr_uu(const value<BitsA> &a, const value<BitsB> &b) {
 template<size_t BitsY, size_t BitsA, size_t BitsB>
 CXXRTL_ALWAYS_INLINE
 value<BitsY> shr_su(const value<BitsA> &a, const value<BitsB> &b) {
+	if (BitsY > BitsA) {
+		value<BitsY> extended_a = a.template scast<BitsY>();
+		return extended_a.shr(b);
+	}
 	return a.shr(b).template scast<BitsY>();
 }
 

--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -1773,7 +1773,7 @@ value<BitsY> shr_su(const value<BitsA> &a, const value<BitsB> &b) {
 		value<BitsY> extended_a = a.template scast<BitsY>();
 		return extended_a.shr(b);
 	}
-	return a.shr(b).template scast<BitsY>();
+	return a.template scast<BitsY>().shr(b);
 }
 
 template<size_t BitsY, size_t BitsA, size_t BitsB>


### PR DESCRIPTION
This PR fixes the issue described in https://github.com/YosysHQ/yosys/issues/5074. Now, for expressions like `assign t = a op b`, when the width of the expression is larger than the width of `a` and `a` is signed, `a` will first be sign-extended before performing the shift operation. 

The fix is implemented by applying the above logic in the `shr_su` function：
```cpp
template<size_t BitsY, size_t BitsA, size_t BitsB>
CXXRTL_ALWAYS_INLINE
value<BitsY> shr_su(const value<BitsA> &a, const value<BitsB> &b) {
	if (BitsY > BitsA) {
		value<BitsY> extended_a = a.template scast<BitsY>();
		return extended_a.shr(b);
	}
	return a.shr(b).template scast<BitsY>();
}
```

After the fix, the CXXRTL produces results consistent with other simulators for the test case related to https://github.com/YosysHQ/yosys/issues/5074.