### PR TITLE
Change the implementation of log_debug in kernel/log.h

### DIFF
--- a/kernel/log.h
+++ b/kernel/log.h
@@ -148,7 +148,7 @@ static inline bool ys_debug(int n = 0) { if (log_force_debug) return true; log_d
 #else
 static inline bool ys_debug(int = 0) { return false; }
 #endif
-#  define log_debug(...) do { if (ys_debug(1)) log(__VA_ARGS__); } while (0)
+static inline void log_debug(const char *format, ...) { if (ys_debug(1)) { va_list args; va_start(args, format); logv(format, args); va_end(args); } }
 
 static inline void log_suppressed() {
 	if (log_debug_suppressed && !log_make_debug) {


### PR DESCRIPTION
Change the implementation of log_debug in kernel/log.h from a macro function to a normal function.

_What are the reasons/motivation for this change?_

Because when integrating Yosys in other applications, if you do not use the code like `using namespace Yosys;`, `log` will not be found correctly, which leads to the mandatory use of `using namespace` and potential namespace pollution problems.

_Explain how this is achieved._

It is just variable length parameter forwarding.

_If applicable, please suggest to reviewers how they can test the change._

Just run the regression tests.
