### PR TITLE
autoname: Check for potential overflow

### DIFF
--- a/passes/cmds/autoname.cc
+++ b/passes/cmds/autoname.cc
@@ -122,6 +122,15 @@ struct AutonamePass : public Pass {
 				if (bit.wire != nullptr)
 					wire_score[bit.wire]++;
 
+			for (auto &it : wire_score) {
+				// (10000*score + new_name.size())*2 must be less than INT32_MAX
+				// using 24000 allows for a name 2000 characters long
+				if (it.second > INT32_MAX/24000)
+					// We can't guarantee an earlier module hasn't already been processed, so use log_error
+					log_error("Fanout of %s too high (%d bits), unable to continue.\n", it.first->name.c_str(), it.second);
+				
+			}
+
 			int count = 0, iter = 0;
 			while (1) {
 				iter++;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
Fix #4983
While unlikely, a wire with a score greater than about `INT32_MAX/20000` will lead to an interger overflow when trying to rename users of that wire.

_Explain how this is achieved._
Call `log_error` if any of the wires have a score over `INT32_MAX/24000`.  Because the score is calculated with `(10000*score + new_name.size())*2`, if the new name is longer than 2000 characters long then there could still be an integer overflow, but this seems sufficiently unlikely that I thought checking each wire score once was better than checking each proposal, while still allowing for a fanout of almost 90000 bits from a single wire.

_If applicable, please suggest to reviewers how they can test the change._
