### PR TITLE
verilog_parser.y: Delete unused TOK_ID

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -2249,7 +2249,8 @@ cell_parameter:
 		node->children.push_back($1);
 	} |
 	'.' TOK_ID '(' ')' {
-		// just ignore empty parameters
+		// delete unused TOK_ID
+		delete $2;
 	} |
 	'.' TOK_ID '(' expr ')' {
 		AstNode *node = new AstNode(AST_PARASET);

--- a/tests/verilog/param_default.ys
+++ b/tests/verilog/param_default.ys
@@ -1,0 +1,24 @@
+logger -expect-no-warnings
+read_verilog << EOF
+module bar (
+	input portname
+);
+	parameter paramname = 7;
+endmodule
+ 
+module empty (
+);
+ 	bar #() barinstance ();
+endmodule
+
+module implicit (
+);
+ 	bar #(.paramname()) barinstance (.portname());
+endmodule
+
+module explicit (
+	input a
+);
+	bar #(.paramname(3)) barinstance (.portname(a));
+endmodule
+EOF


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Fix #5069, problem appears to be that the `TOK_ID` is created (and allocated space in memory) but never cleaned up, leading to ASAN detected memory leak.

_Explain how this is achieved._

Delete the `TOK_ID` (`$2`), similarly to other cases such as:
```
non_opt_delay:
	'#' TOK_ID { delete $2; } |
```

_If applicable, please suggest to reviewers how they can test the change._

Test file included as `tests/verilog/param_default.ys`.  Running tests in directory *without* fix fails ASAN on this file and `tests/verilog/typedef_{across_files, const_shadow, legacy_conflict}.ys`.