### PR TITLE
cutpoint: Re-add whole module optimization

### DIFF
--- a/passes/sat/cutpoint.cc
+++ b/passes/sat/cutpoint.cc
@@ -86,6 +86,20 @@ struct CutpointPass : public Pass {
 
 		for (auto module : design->all_selected_modules())
 		{
+			if (module->is_selected_whole()) {
+				log("Making all outputs of module %s cut points, removing module contents.\n", log_id(module));
+				module->new_connections(std::vector<RTLIL::SigSig>());
+				for (auto cell : vector<Cell*>(module->cells()))
+					module->remove(cell);
+				vector<Wire*> output_wires;
+				for (auto wire : module->wires())
+					if (wire->port_output)
+						output_wires.push_back(wire);
+				for (auto wire : output_wires)
+					module->connect(wire, flag_undef ? Const(State::Sx, GetSize(wire)) : module->Anyseq(NEW_ID, GetSize(wire)));
+				continue;
+			}
+
 			SigMap sigmap(module);
 			pool<SigBit> cutpoint_bits;
 

--- a/tests/various/cutpoint_whole.ys
+++ b/tests/various/cutpoint_whole.ys
@@ -1,0 +1,50 @@
+read_verilog << EOT
+module top(input a, b, output o);
+    wire c, d, e;
+    bb bb1 (.a (a), .b (b), .o (c));
+    sub_mod sub_inst (.a (a), .b (b), .o (e));
+    some_mod some_inst (.a (c), .b (d), .c (e), .o (o));
+endmodule
+
+(* blackbox *)
+module bb #( parameter SOME_PARAM=0 ) (input a, b, output o);
+endmodule
+
+module sub_mod(input a, b, output o);
+    bb bb2 (.a (a), .b (b), .o (o));
+endmodule
+
+module some_mod(input a, b, c, output o);
+assign o = a & (b | c);
+endmodule
+EOT
+
+hierarchy -top top
+design -stash hier
+
+# removing cell
+design -load hier
+logger -expect log "Removing cell .*, making all cell outputs cutpoints" 1
+cutpoint sub_mod/bb2
+logger -check-expected
+logger -werror "Removing cell .*, making all cell outputs cutpoints"
+
+# removing wires
+design -load hier
+logger -expect log "Making wire .* a cutpoint" 1
+cutpoint top/c
+logger -check-expected
+logger -werror "Making wire .* a cutpoint"
+
+# removing output wires
+design -load hier
+logger -expect log "Making output wire .* a cutpoint" 1
+cutpoint sub_mod/o
+logger -check-expected
+logger -werror "Making output wire .* a cutpoint"
+
+# whole module optimization, doesn't do any of the previous
+design -load hier
+logger -expect log "Making all outputs of module .* cut points, removing module contents" 1
+cutpoint sub_mod
+logger -check-expected


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

#4854 inadvertently removed the optimization for when a whole module was selected.

_Explain how this is achieved._

Adds whole module optimization back, as well as a test script for it.

_If applicable, please suggest to reviewers how they can test the change._

Run following script:
```
read_verilog << EOT
(* blackbox *)
module bb (input a, b, output o);
endmodule

module sub_mod(input a, b, output o);
    bb bb2 (.a (a), .b (b), .o (o));
endmodule
EOT

hierarchy -top sub_mod
cutpoint sub_mod
```

With latest Yosys (before this change):
```
3. Executing CUTPOINT pass.
Removing cell sub_mod.bb2, making all cell outputs cutpoints.
Making wire sub_mod.$auto$rtlil.cc:3769:Anyseq$2 a cutpoint.
Making output wire sub_mod.o a cutpoint.
Making wire sub_mod.b a cutpoint.
Making wire sub_mod.a a cutpoint.
```
Note that `sub_mod.$auto$rtlil.cc:3769:Anyseq$2` was added by cutpoint when removing cell `sub_mod.bb2`, only to be removed immediately after.

With Yosys before #4854 (e.g. 0.51), and with this change:
```
3. Executing CUTPOINT pass.
Making all outputs of module sub_mod cut points, removing module contents.
```