### PR TITLE
opt_expr: fix shift optimization with 

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -380,6 +380,30 @@ int RTLIL::Const::as_int(bool is_signed) const
 	return ret;
 }
 
+bool RTLIL::Const::convertible_to_int(bool is_signed) const
+{
+	auto size = get_min_size(is_signed);
+	return (size > 0 && size <= 32);
+}
+
+std::optional<int> RTLIL::Const::try_as_int(bool is_signed) const
+{
+	if (!convertible_to_int(is_signed))
+		return std::nullopt;
+	return as_int(is_signed);
+}
+
+int RTLIL::Const::as_int_saturating(bool is_signed) const
+{
+	if (!convertible_to_int(is_signed)) {
+		const auto min_size = get_min_size(is_signed);
+		log_assert(min_size > 0);
+		const auto neg = get_bits().at(min_size - 1);
+		return neg ? std::numeric_limits<int>::min() : std::numeric_limits<int>::max();
+	}
+	return as_int(is_signed);
+}
+
 int RTLIL::Const::get_min_size(bool is_signed) const
 {
 	if (empty()) return 0;
@@ -5460,6 +5484,38 @@ int RTLIL::SigSpec::as_int(bool is_signed) const
 	if (width_)
 		return RTLIL::Const(chunks_[0].data).as_int(is_signed);
 	return 0;
+}
+
+bool RTLIL::SigSpec::convertible_to_int(bool is_signed) const
+{
+	cover("kernel.rtlil.sigspec.convertible_to_int");
+
+	pack();
+	if (!is_fully_const())
+		return false;
+
+	return RTLIL::Const(chunks_[0].data).convertible_to_int(is_signed);
+}
+
+std::optional<int> RTLIL::SigSpec::try_as_int(bool is_signed) const
+{
+	cover("kernel.rtlil.sigspec.try_as_int");
+
+	pack();
+	if (!is_fully_const())
+		return std::nullopt;
+
+	return RTLIL::Const(chunks_[0].data).try_as_int(is_signed);
+}
+
+int RTLIL::SigSpec::as_int_saturating(bool is_signed) const
+{
+	cover("kernel.rtlil.sigspec.try_as_int");
+
+	pack();
+	log_assert(is_fully_const() && GetSize(chunks_) <= 1);
+	log_assert(!empty());
+	return RTLIL::Const(chunks_[0].data).as_int_saturating(is_signed);
 }
 
 std::string RTLIL::SigSpec::as_string() const

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -754,6 +754,9 @@ public:
 	std::vector<RTLIL::State>& bits();
 	bool as_bool() const;
 	int as_int(bool is_signed = false) const;
+	bool convertible_to_int(bool is_signed = false) const;
+	std::optional<int> try_as_int(bool is_signed = false) const;
+	int as_int_saturating(bool is_signed = false) const;
 	std::string as_string(const char* any = "-") const;
 	static Const from_string(const std::string &str);
 	std::vector<RTLIL::State> to_bits() const;
@@ -1131,6 +1134,9 @@ public:
 
 	bool as_bool() const;
 	int as_int(bool is_signed = false) const;
+	bool convertible_to_int(bool is_signed = false) const;
+	std::optional<int> try_as_int(bool is_signed = false) const;
+	int as_int_saturating(bool is_signed = false) const;
 	std::string as_string() const;
 	RTLIL::Const as_const() const;
 	RTLIL::Wire *as_wire() const;

--- a/tests/opt/opt_expr_shift.ys
+++ b/tests/opt/opt_expr_shift.ys
@@ -48,3 +48,25 @@ select -assert-none t:$shl
 select -assert-none t:$shr
 select -assert-none t:$sshl
 select -assert-none t:$sshr
+
+design -reset
+
+read_verilog <<EOT
+module top (in, out1, out2);
+	input wire in;
+	output wire [7:0] out1;
+	output wire [7:0] out2;
+
+	assign out1 = (in >> 36'hfffffffff);
+	wire signed [35:0] shamt = 36'hfffffffff;
+	assign out2 = (in >> shamt);
+endmodule
+EOT
+
+equiv_opt opt_expr
+
+design -load postopt
+select -assert-none t:$shl
+select -assert-none t:$shr
+select -assert-none t:$sshl
+select -assert-none t:$sshr


### PR DESCRIPTION
Fixes #5099 by limiting the constant shift amount to int max/min so they don't overflow. This could misoptimize in the case that the signal being shifted is in the range of `2^32` bits wide but that is incredibly unlikely (and plenty of other things likely break around there anyway).

In the process I add a few helper methods to the kernel for more safely calling `as_int`: `try_as_int` that returns an optional value only if the conversion is valid, `convertible_to_int` that returns true if the conversion can be done safely, and `as_int_saturating` that clamps values to int's max/min if they are too large/small.

Note that `as_int_compress` actually already does the same as `try_as_int` but it isn't used anywhere in Yosys and I think the naming is such that its function really isn't clear, so hopefully people would be more likely to see that `try_as_int` is an option over `as_int`.