### PR TITLE
Update verilog_frontend.cc

### DIFF
--- a/frontends/verilog/verilog_frontend.cc
+++ b/frontends/verilog/verilog_frontend.cc
@@ -753,7 +753,7 @@ struct VerilogFileList : public Pass {
 			break;
 		}
 
-		extra_args(args, argidx, design);
+		extra_args(args, argidx, design, false);
 	}
 } VerilogFilelist;
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
Trying to pass a file without a `-f|-F` flag is misleading, in the best case giving a warning about the selection not matching any module, or in worst case just doing nothing (if the filename is a valid selection).

_Explain how this is achieved._
Set `select` option in `extra_args()` to `false`.

_If applicable, please suggest to reviewers how they can test the change._
`read_verilog_file_list <file>`.