### PR TITLE
Makefile: Conditional assignment of python exe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ endif
 include Makefile.conf
 endif
 
-PYTHON_EXECUTABLE := $(shell if python3 -c ""; then echo "python3"; else echo "python"; fi)
+PYTHON_EXECUTABLE ?= $(shell if python3 -c ""; then echo "python3"; else echo "python"; fi)
 ifeq ($(ENABLE_PYOSYS),1)
 PYTHON_VERSION_TESTCODE := "import sys;t='{v[0]}.{v[1]}'.format(v=list(sys.version_info[:2]));print(t)"
 PYTHON_VERSION := $(shell $(PYTHON_EXECUTABLE) -c ""$(PYTHON_VERSION_TESTCODE)"")


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Using `:=` while providing an override in Makefile.conf does not correctly apply the override in other simply expanded variables (using `:=`).  Instead, setting an explicit `PYTHON_EXECUTABLE := python3.15` while leaving `PYTHON_CONFIG` implicitly defined results in it being set to `python3-config` instead of the expected `python3.15-config`.

_Explain how this is achieved._

Using `?=` instead uses the explicit assignment in simply expanded variables as expected.

_If applicable, please suggest to reviewers how they can test the change._

Add the following target to the Makefile:
```makefile
echo-python-vars:
	@echo "$(PYTHON_EXECUTABLE)"
	@echo "$(PYTHON_CONFIG)"
```

And an explicit `PYTHON_EXECUTABLE := <path/to/python>` to `Makefile.conf`.

Then call `make echo-python-vars` with and without patch.