### PR TITLE
design.cc: Use on_shutdown method

### DIFF
--- a/kernel/register.h
+++ b/kernel/register.h
@@ -29,6 +29,7 @@ struct Pass
 {
 	std::string pass_name, short_help;
 	Pass(std::string name, std::string short_help = "** document me **");
+	// Prefer overriding 'Pass::on_shutdown()' if possible
 	virtual ~Pass();
 
 	virtual void help();

--- a/passes/cmds/design.cc
+++ b/passes/cmds/design.cc
@@ -28,7 +28,7 @@ std::vector<RTLIL::Design*> pushed_designs;
 
 struct DesignPass : public Pass {
 	DesignPass() : Pass("design", "save, restore and reset current design") { }
-	~DesignPass() override {
+	void on_shutdown() override {
 		for (auto &it : saved_designs)
 			delete it.second;
 		saved_designs.clear();


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Fix #5088.

When building `WITH_PYTHON`, where a global list of modules is maintained, deleting a module also erases the entry in said global list.  This can lead to memory corruption if the global list is destructed before the module.

_Explain how this is achieved._

Using `on_shutdown()` instead means the module destructor is explicitly called before the global list can be destructed, preventing the issue.

Also add a comment to `Pass::~Pass()` to suggest the same for future passes that might try to use that (and see this commit/PR in the blame if they need a reason why).  

_If applicable, please suggest to reviewers how they can test the change._
