### PR TITLE
simplify.cc: Fix mem leak

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1932,6 +1932,8 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 			// Prepare replacement node.
 			newNode = template_node->clone();
 			newNode->str = str;
+			if (newNode->attributes.count(ID::wiretype))
+				delete newNode->attributes[ID::wiretype];
 			newNode->set_attribute(ID::wiretype, mkconst_str(resolved_type_node->str));
 			newNode->is_input = is_input;
 			newNode->is_output = is_output;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

From #5020, LeakSanitizer: detected memory leaks in `Yosys::AST::AstNode::clone() const frontends/ast/ast.cc:256:18`.  Identified as being due to the redefinition of the wiretype attribute on the new AstNode when resolving recursive typedef.

Minimal reproducer:
```
read_verilog -sv <<EOF
typedef logic T;
typedef T [3:0] S;
module top;
    S s;
endmodule
EOF
```

_Explain how this is achieved._

Delete the wiretype attribute if it already exists, as is done just above.

Alternatively, the `set_attribute()` method should just do this automatically?  There are enough calls to it that are immediately preceded by either this exact check, the inverse (only adding the attribute if it isn't already), or deleting all children and making the check unnecessary, that this seems like it should just be a standard operation. I pushed [a branch that does this](https://github.com/YosysHQ/yosys/tree/krys/alt_ast_asan) to check CI, so will see if that passes.

_If applicable, please suggest to reviewers how they can test the change._

Build with ASAN, run minimal reproducer above.