### PR TITLE
design: ensure all_modules outlives pass when building WITH_PYTHON

### DIFF
--- a/passes/cmds/design.cc
+++ b/passes/cmds/design.cc
@@ -23,11 +23,17 @@
 
 YOSYS_NAMESPACE_BEGIN
 
+// TODO refactor such scattered program state
 std::map<std::string, RTLIL::Design*> saved_designs;
 std::vector<RTLIL::Design*> pushed_designs;
 
 struct DesignPass : public Pass {
-	DesignPass() : Pass("design", "save, restore and reset current design") { }
+	DesignPass() : Pass("design", "save, restore and reset current design") {
+#ifdef WITH_PYTHON
+		// Ensure the index to outlive this pass so that we can free saved designs
+		(void)RTLIL::Module::get_all_modules();
+#endif
+	}
 	~DesignPass() override {
 		for (auto &it : saved_designs)
 			delete it.second;


### PR DESCRIPTION
Alternative to #5112, without using `on_shutdown`. I haven't reproduced the issue yet so I'm not 100% sure this also fixes it but I think it should. The C++ implementation allocates statics with respect to accesses and deallocates in reverse order, so accessing it in the constructor guarantees `all_modules` outlives the `design` pass