### PR TITLE
Replaced `Yosys::RTLIL::Cell::module` with `Yosys::RTLIL::Cell::upscope_module`

### DIFF
--- a/kernel/ff.cc
+++ b/kernel/ff.cc
@@ -21,7 +21,7 @@
 
 USING_YOSYS_NAMESPACE
 
-FfData::FfData(FfInitVals *initvals, Cell *cell_) : FfData(cell_->module, initvals, cell_->name)
+FfData::FfData(FfInitVals *initvals, Cell *cell_) : FfData(cell_->upscope_module, initvals, cell_->name)
 {
 	cell = cell_;
 	sig_q = cell->getPort(ID::Q);
@@ -460,31 +460,31 @@ void FfData::convert_ce_over_srst(bool val) {
 		if (!is_fine) {
 			if (pol_srst) {
 				if (pol_ce) {
-					sig_srst = cell->module->And(NEW_ID, sig_srst, sig_ce);
+					sig_srst = cell->upscope_module->And(NEW_ID, sig_srst, sig_ce);
 				} else {
 					SigSpec tmp = module->Not(NEW_ID, sig_ce);
-					sig_srst = cell->module->And(NEW_ID, sig_srst, tmp);
+					sig_srst = cell->upscope_module->And(NEW_ID, sig_srst, tmp);
 				}
 			} else {
 				if (pol_ce) {
 					SigSpec tmp = module->Not(NEW_ID, sig_ce);
-					sig_srst = cell->module->Or(NEW_ID, sig_srst, tmp);
+					sig_srst = cell->upscope_module->Or(NEW_ID, sig_srst, tmp);
 				} else {
-					sig_srst = cell->module->Or(NEW_ID, sig_srst, sig_ce);
+					sig_srst = cell->upscope_module->Or(NEW_ID, sig_srst, sig_ce);
 				}
 			}
 		} else {
 			if (pol_srst) {
 				if (pol_ce) {
-					sig_srst = cell->module->AndGate(NEW_ID, sig_srst, sig_ce);
+					sig_srst = cell->upscope_module->AndGate(NEW_ID, sig_srst, sig_ce);
 				} else {
-					sig_srst = cell->module->AndnotGate(NEW_ID, sig_srst, sig_ce);
+					sig_srst = cell->upscope_module->AndnotGate(NEW_ID, sig_srst, sig_ce);
 				}
 			} else {
 				if (pol_ce) {
-					sig_srst = cell->module->OrnotGate(NEW_ID, sig_srst, sig_ce);
+					sig_srst = cell->upscope_module->OrnotGate(NEW_ID, sig_srst, sig_ce);
 				} else {
-					sig_srst = cell->module->OrGate(NEW_ID, sig_srst, sig_ce);
+					sig_srst = cell->upscope_module->OrGate(NEW_ID, sig_srst, sig_ce);
 				}
 			}
 		}

--- a/kernel/mem.cc
+++ b/kernel/mem.cc
@@ -693,7 +693,7 @@ namespace {
 	}
 
 	Mem mem_from_cell(Cell *cell) {
-		Mem res(cell->module, cell->parameters.at(ID::MEMID).decode_string(),
+		Mem res(cell->upscope_module, cell->parameters.at(ID::MEMID).decode_string(),
 			cell->parameters.at(ID::WIDTH).as_int(),
 			cell->parameters.at(ID::OFFSET).as_int(),
 			cell->parameters.at(ID::SIZE).as_int()

--- a/kernel/modtools.h
+++ b/kernel/modtools.h
@@ -163,7 +163,7 @@ struct ModIndex : public RTLIL::Monitor
 
 	void notify_connect(RTLIL::Cell *cell, const RTLIL::IdString &port, const RTLIL::SigSpec &old_sig, const RTLIL::SigSpec &sig) override
 	{
-		log_assert(module == cell->module);
+		log_assert(module == cell->upscope_module);
 
 		if (auto_reload_module)
 			return;

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1884,7 +1884,7 @@ public:
 	Cell(RTLIL::Cell &other) = delete;
 	void operator=(RTLIL::Cell &other) = delete;
 
-	RTLIL::Module *module;
+	RTLIL::Module *upscope_module;
 	RTLIL::IdString type;
 	dict<RTLIL::IdString, RTLIL::SigSpec> connections_;
 	dict<RTLIL::IdString, RTLIL::Const> parameters;
@@ -1911,9 +1911,16 @@ public:
 	void check();
 	void fixup_parameters(bool set_a_signed = false, bool set_b_signed = false);
 
+	RTLIL::Module *get_proto_module() const {
+		if (upscope_module && upscope_module->design) {
+			return upscope_module->design->module(type);
+		}
+		return nullptr;
+	}
+
 	bool has_keep_attr() const {
-		return get_bool_attribute(ID::keep) || (module && module->design && module->design->module(type) &&
-				module->design->module(type)->get_bool_attribute(ID::keep));
+		return get_bool_attribute(ID::keep) || (upscope_module && upscope_module->design && upscope_module->design->module(type) &&
+				upscope_module->design->module(type)->get_bool_attribute(ID::keep));
 	}
 
 	template<typename T> void rewrite_sigspecs(T &functor);

--- a/passes/cmds/trace.cc
+++ b/passes/cmds/trace.cc
@@ -37,7 +37,7 @@ struct TraceMonitor : public RTLIL::Monitor
 
 	void notify_connect(RTLIL::Cell *cell, const RTLIL::IdString &port, const RTLIL::SigSpec &old_sig, const RTLIL::SigSpec &sig) override
 	{
-		log("#TRACE# Cell connect: %s.%s.%s = %s (was: %s)\n", log_id(cell->module), log_id(cell), log_id(port), log_signal(sig), log_signal(old_sig));
+		log("#TRACE# Cell connect: %s.%s.%s = %s (was: %s)\n", log_id(cell->upscope_module), log_id(cell), log_id(port), log_signal(sig), log_signal(old_sig));
 	}
 
 	void notify_connect(RTLIL::Module *module, const RTLIL::SigSig &sigsig) override

--- a/passes/equiv/equiv_simple.cc
+++ b/passes/equiv/equiv_simple.cc
@@ -41,7 +41,7 @@ struct EquivSimpleWorker
 	pool<pair<Cell*, int>> imported_cells_cache;
 
 	EquivSimpleWorker(const vector<Cell*> &equiv_cells, SigMap &sigmap, dict<SigBit, Cell*> &bit2driver, int max_seq, bool short_cones, bool verbose, bool model_undef) :
-			module(equiv_cells.front()->module), equiv_cells(equiv_cells), equiv_cell(nullptr),
+			module(equiv_cells.front()->upscope_module), equiv_cells(equiv_cells), equiv_cell(nullptr),
 			sigmap(sigmap), bit2driver(bit2driver), satgen(ez.get(), &sigmap), max_seq(max_seq), short_cones(short_cones), verbose(verbose)
 	{
 		satgen.model_undef = model_undef;

--- a/passes/fsm/fsm_expand.cc
+++ b/passes/fsm/fsm_expand.cc
@@ -189,12 +189,12 @@ struct FsmExpand
 
 		if (GetSize(input_sig) > 10)
 			log_warning("Cell %s.%s (%s) has %d input bits, merging into FSM %s.%s might be problematic.\n",
-					log_id(cell->module), log_id(cell), log_id(cell->type),
-					GetSize(input_sig), log_id(fsm_cell->module), log_id(fsm_cell));
+					log_id(cell->upscope_module), log_id(cell), log_id(cell->type),
+					GetSize(input_sig), log_id(fsm_cell->upscope_module), log_id(fsm_cell));
 
 		if (GetSize(fsm_data.transition_table) > 10000)
 			log_warning("Transition table for FSM %s.%s already has %d rows, merging more cells "
-					"into this FSM might be problematic.\n", log_id(fsm_cell->module), log_id(fsm_cell),
+					"into this FSM might be problematic.\n", log_id(fsm_cell->upscope_module), log_id(fsm_cell),
 					GetSize(fsm_data.transition_table));
 
 		std::vector<FsmData::transition_t> new_transition_table;

--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -93,8 +93,8 @@ struct keep_cache_t
 		if (!purge_mode && cell->type == ID($scopeinfo))
 			return true;
 
-		if (cell->module && cell->module->design)
-			return query(cell->module->design->module(cell->type));
+		if (cell->upscope_module && cell->upscope_module->design)
+			return query(cell->upscope_module->design->module(cell->type));
 
 		return false;
 	}

--- a/passes/opt/opt_demorgan.cc
+++ b/passes/opt/opt_demorgan.cc
@@ -30,7 +30,7 @@ void demorgan_worker(
 	unsigned int& cells_changed)
 {
 	SigMap& sigmap = index.sigmap;
-	auto m = cell->module;
+	auto m = cell->upscope_module;
 
 	//TODO: Add support for reduce_xor
 	//DeMorgan of XOR is either XOR (if even number of inputs) or XNOR (if odd number)

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -309,7 +309,7 @@ void handle_polarity_inv(Cell *cell, IdString port, IdString param, const SigMap
 	SigSpec sig = assign_map(cell->getPort(port));
 	if (invert_map.count(sig)) {
 		log_debug("Inverting %s of %s cell `%s' in module `%s': %s -> %s\n",
-				log_id(port), log_id(cell->type), log_id(cell), log_id(cell->module),
+				log_id(port), log_id(cell->type), log_id(cell), log_id(cell->upscope_module),
 				log_signal(sig), log_signal(invert_map.at(sig)));
 		cell->setPort(port, (invert_map.at(sig)));
 		cell->setParam(param, !cell->getParam(param).as_bool());
@@ -338,7 +338,7 @@ void handle_clkpol_celltype_swap(Cell *cell, string type1, string type2, IdStrin
 		SigSpec sig = assign_map(cell->getPort(port));
 		if (invert_map.count(sig)) {
 			log_debug("Inverting %s of %s cell `%s' in module `%s': %s -> %s\n",
-					log_id(port), log_id(cell->type), log_id(cell), log_id(cell->module),
+					log_id(port), log_id(cell->type), log_id(cell), log_id(cell->upscope_module),
 					log_signal(sig), log_signal(invert_map.at(sig)));
 			cell->setPort(port, (invert_map.at(sig)));
 			cell->type = cell->type == type1 ? type2 : type1;

--- a/passes/opt/opt_lut.cc
+++ b/passes/opt/opt_lut.cc
@@ -511,7 +511,7 @@ struct OptLutWorker
 					worklist.insert(lutM);
 					worklist.erase(lutR);
 
-					lutR->module->remove(lutR);
+					lutR->upscope_module->remove(lutR);
 
 					combined_count++;
 					if (limit > 0)

--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -798,7 +798,7 @@ struct SimInstance
 
 	void log_cell_w_hierarchy(std::string opening_verbiage, RTLIL::Cell *cell)
 	{
-		log_assert(cell->module == module);
+		log_assert(cell->upscope_module == module);
 		bool has_src = cell->has_attribute(ID::src);
 		log("%s %s%s\n", opening_verbiage.c_str(),
 			log_id(cell), has_src ? " at" : "");

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -659,7 +659,7 @@ void prep_delays(RTLIL::Design *design, bool dff_mode)
 	Module *delay_module = design->module(ID($__ABC9_DELAY));
 	log_assert(delay_module);
 	for (auto cell : cells) {
-		auto module = cell->module;
+		auto module = cell->upscope_module;
 		auto inst_module = design->module(cell->type);
 		log_assert(inst_module);
 

--- a/passes/techmap/alumacc.cc
+++ b/passes/techmap/alumacc.cc
@@ -52,7 +52,7 @@ struct AlumaccWorker
 				if (is_signed) {
 					get_of();
 					get_sf();
-					cached_lt = alu_cell->module->Xor(NEW_ID, cached_of, cached_sf);
+					cached_lt = alu_cell->upscope_module->Xor(NEW_ID, cached_of, cached_sf);
 				}
 				else
 					cached_lt = get_cf();
@@ -64,21 +64,21 @@ struct AlumaccWorker
 			if (GetSize(cached_gt) == 0) {
 				get_lt();
 				get_eq();
-				SigSpec Or = alu_cell->module->Or(NEW_ID, cached_lt, cached_eq);
-				cached_gt = alu_cell->module->Not(NEW_ID, Or, false, alu_cell->get_src_attribute());
+				SigSpec Or = alu_cell->upscope_module->Or(NEW_ID, cached_lt, cached_eq);
+				cached_gt = alu_cell->upscope_module->Not(NEW_ID, Or, false, alu_cell->get_src_attribute());
 			}
 			return cached_gt;
 		}
 
 		RTLIL::SigSpec get_eq() {
 			if (GetSize(cached_eq) == 0)
-				cached_eq = alu_cell->module->ReduceAnd(NEW_ID, alu_cell->getPort(ID::X), false, alu_cell->get_src_attribute());
+				cached_eq = alu_cell->upscope_module->ReduceAnd(NEW_ID, alu_cell->getPort(ID::X), false, alu_cell->get_src_attribute());
 			return cached_eq;
 		}
 
 		RTLIL::SigSpec get_ne() {
 			if (GetSize(cached_ne) == 0)
-				cached_ne = alu_cell->module->Not(NEW_ID, get_eq(), false, alu_cell->get_src_attribute());
+				cached_ne = alu_cell->upscope_module->Not(NEW_ID, get_eq(), false, alu_cell->get_src_attribute());
 			return cached_ne;
 		}
 
@@ -86,7 +86,7 @@ struct AlumaccWorker
 			if (GetSize(cached_cf) == 0) {
 				cached_cf = alu_cell->getPort(ID::CO);
 				log_assert(GetSize(cached_cf) >= 1);
-				cached_cf = alu_cell->module->Not(NEW_ID, cached_cf[GetSize(cached_cf)-1], false, alu_cell->get_src_attribute());
+				cached_cf = alu_cell->upscope_module->Not(NEW_ID, cached_cf[GetSize(cached_cf)-1], false, alu_cell->get_src_attribute());
 			}
 			return cached_cf;
 		}
@@ -95,7 +95,7 @@ struct AlumaccWorker
 			if (GetSize(cached_of) == 0) {
 				cached_of = {alu_cell->getPort(ID::CO), alu_cell->getPort(ID::CI)};
 				log_assert(GetSize(cached_of) >= 2);
-				cached_of = alu_cell->module->Xor(NEW_ID, cached_of[GetSize(cached_of)-1], cached_of[GetSize(cached_of)-2]);
+				cached_of = alu_cell->upscope_module->Xor(NEW_ID, cached_of[GetSize(cached_of)-1], cached_of[GetSize(cached_of)-2]);
 			}
 			return cached_of;
 		}

--- a/passes/techmap/extract_counter.cc
+++ b/passes/techmap/extract_counter.cc
@@ -639,8 +639,8 @@ void counter_worker(
 		//If the reset is active low, infer an inverter ($__COUNT_ cells always have active high reset)
 		if(extract.rst_inverted)
 		{
-			auto realreset = cell->module->addWire(NEW_ID);
-			cell->module->addNot(NEW_ID, extract.rst, RTLIL::SigSpec(realreset));
+			auto realreset = cell->upscope_module->addWire(NEW_ID);
+			cell->upscope_module->addNot(NEW_ID, extract.rst, RTLIL::SigSpec(realreset));
 			cell->setPort(ID(RST), realreset);
 		}
 		else
@@ -665,8 +665,8 @@ void counter_worker(
 		cell->setParam(ID(HAS_CE), RTLIL::Const(1));
 		if(extract.ce_inverted)
 		{
-			auto realce = cell->module->addWire(NEW_ID);
-			cell->module->addNot(NEW_ID, extract.ce, RTLIL::SigSpec(realce));
+			auto realce = cell->upscope_module->addWire(NEW_ID);
+			cell->upscope_module->addNot(NEW_ID, extract.ce, RTLIL::SigSpec(realce));
 			cell->setPort(ID(CE), realce);
 		}
 		else

--- a/passes/techmap/flatten.cc
+++ b/passes/techmap/flatten.cc
@@ -43,7 +43,7 @@ IdString concat_name(RTLIL::Cell *cell, IdString object_name, const std::string 
 template<class T>
 IdString map_name(RTLIL::Cell *cell, T *object, const std::string &separator = ".")
 {
-	return cell->module->uniquify(concat_name(cell, object->name, separator));
+	return cell->upscope_module->uniquify(concat_name(cell, object->name, separator));
 }
 
 void map_sigspec(const dict<RTLIL::Wire*, RTLIL::Wire*> &map, RTLIL::SigSpec &sig, RTLIL::Module *into = nullptr)

--- a/passes/techmap/lut2mux.cc
+++ b/passes/techmap/lut2mux.cc
@@ -32,25 +32,25 @@ int lut2mux(Cell *cell)
 
 	if (GetSize(sig_a) == 1)
 	{
-		cell->module->addMuxGate(NEW_ID, lut.extract(0)[0], lut.extract(1)[0], sig_a, sig_y);
+		cell->upscope_module->addMuxGate(NEW_ID, lut.extract(0)[0], lut.extract(1)[0], sig_a, sig_y);
 	}
 	else
 	{
 		SigSpec sig_a_hi = sig_a[GetSize(sig_a)-1];
 		SigSpec sig_a_lo = sig_a.extract(0, GetSize(sig_a)-1);
-		SigSpec sig_y1 = cell->module->addWire(NEW_ID);
-		SigSpec sig_y2 = cell->module->addWire(NEW_ID);
+		SigSpec sig_y1 = cell->upscope_module->addWire(NEW_ID);
+		SigSpec sig_y2 = cell->upscope_module->addWire(NEW_ID);
 
 		Const lut1 = lut.extract(0, GetSize(lut)/2);
 		Const lut2 = lut.extract(GetSize(lut)/2, GetSize(lut)/2);
 
-		count += lut2mux(cell->module->addLut(NEW_ID, sig_a_lo, sig_y1, lut1));
-		count += lut2mux(cell->module->addLut(NEW_ID, sig_a_lo, sig_y2, lut2));
+		count += lut2mux(cell->upscope_module->addLut(NEW_ID, sig_a_lo, sig_y1, lut1));
+		count += lut2mux(cell->upscope_module->addLut(NEW_ID, sig_a_lo, sig_y2, lut2));
 
-		cell->module->addMuxGate(NEW_ID, sig_y1, sig_y2, sig_a_hi, sig_y);
+		cell->upscope_module->addMuxGate(NEW_ID, sig_y1, sig_y2, sig_a_hi, sig_y);
 	}
 
-	cell->module->remove(cell);
+	cell->upscope_module->remove(cell);
 	return count;
 }
 

--- a/passes/techmap/shregmap.cc
+++ b/passes/techmap/shregmap.cc
@@ -75,7 +75,7 @@ struct ShregmapTechGreenpak4 : ShregmapTech
 		auto D = cell->getPort(ID::D);
 		auto C = cell->getPort(ID::C);
 
-		auto newcell = cell->module->addCell(NEW_ID, ID(GP_SHREG));
+		auto newcell = cell->upscope_module->addCell(NEW_ID, ID(GP_SHREG));
 		newcell->setPort(ID(nRST), State::S1);
 		newcell->setPort(ID::CLK, C);
 		newcell->setPort(ID(IN), D);

--- a/techlibs/greenpak4/greenpak4_dffinv.cc
+++ b/techlibs/greenpak4/greenpak4_dffinv.cc
@@ -86,7 +86,7 @@ void invert_gp_dff(Cell *cell, bool invert_input)
 		cell->type = stringf("\\GP_DFF%s%s%s", cell_type_s ? "S" : "", cell_type_r ? "R" : "", cell_type_i ? "I" : "");
 
 	log("Merged %s inverter into cell %s.%s: %s -> %s\n", invert_input ? "input" : "output",
-			log_id(cell->module), log_id(cell), cell_type.c_str()+1, log_id(cell->type));
+			log_id(cell->upscope_module), log_id(cell), cell_type.c_str()+1, log_id(cell->type));
 }
 
 struct Greenpak4DffInvPass : public Pass {

--- a/techlibs/quicklogic/ql_dsp_simd.cc
+++ b/techlibs/quicklogic/ql_dsp_simd.cc
@@ -242,7 +242,7 @@ struct QlDspSimdPass : public Pass {
 
 		// Get the module defining the cell (the previous condition ensures
 		// that the pointers are valid)
-		RTLIL::Module *mod = a_Cell->module->design->module(a_Cell->type);
+		RTLIL::Module *mod = a_Cell->upscope_module->design->module(a_Cell->type);
 		if (mod == nullptr) {
 			return std::make_pair(0, false);
 		}


### PR DESCRIPTION
Replaced `Yosys::RTLIL::Cell::module` with `Yosys::RTLIL::Cell::upscope_module` to avoid misunderstanding due to unfamiliarity with implementation details. And added the `Yosys::RTLIL::Cell::get_proto_module()` interface to obtain the module prototype corresponding to the instance.

_What are the reasons/motivation for this change?_
`Yosys::RTLIL::Cell::module` is often misleading to developers who are not familiar with the implementation details. It is also a non-standard name, that is, its purpose cannot be inferred from the name alone. I recommend replacing the original name with the more clear `upscope_module`.

_Explain how this is achieved._
Careful renaming and refactoring, and added a convenient query method to get the module corresponding to the instance.

_If applicable, please suggest to reviewers how they can test the change._
Just run the regression test once.
