### PR TITLE
Add state_dependent_path_declaration so that `ifnone` can be parsed

### DIFF
--- a/frontends/verilog/Makefile.inc
+++ b/frontends/verilog/Makefile.inc
@@ -6,7 +6,7 @@ GENFILES += frontends/verilog/verilog_lexer.cc
 
 frontends/verilog/verilog_parser.tab.cc: frontends/verilog/verilog_parser.y
 	$(Q) mkdir -p $(dir $@)
-	$(P) $(BISON) -Wall -Werror -o $@ -d -r all -b frontends/verilog/verilog_parser $<
+	$(P) $(BISON) -Wall -Wcex -Werror -o $@ -d -r all -b frontends/verilog/verilog_parser $<
 
 frontends/verilog/verilog_parser.tab.hh: frontends/verilog/verilog_parser.tab.cc
 

--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -224,6 +224,7 @@ TIME_SCALE_SUFFIX [munpf]?s
 "begin"	       { return TOK_BEGIN; }
 "end"          { return TOK_END; }
 "if"           { return TOK_IF; }
+"ifnone"       { return TOK_IFNONE; }
 "else"         { return TOK_ELSE; }
 "for"          { return TOK_FOR; }
 "posedge"      { return TOK_POSEDGE; }


### PR DESCRIPTION
The parser crashed when an `ifnone`-statement occured. See Bug #5092 .

The `state_dependen_path_declaration` from the specification was added to the parser file.