### PR TITLE
smt backend option --dump-vlogtb produces Verilator error

### DIFF
--- a/backends/smt2/smtbmc.py
+++ b/backends/smt2/smtbmc.py
@@ -1161,7 +1161,6 @@ def write_vlogtb_trace(steps, index):
         print("  initial genclock = 1;", file=f)
         print("`endif", file=f)
 
-        print("  reg genclock = 1;", file=f)
         print("  reg [31:0] cycle = 0;", file=f)
 
         primary_inputs = list()


### PR DESCRIPTION
Duplicate definition of genclock causes Verilator simulation failure. 

It looks like this option is only used with option `--dump-vlogtb` of `yosys-smtbmc`, and the test for it is in examples/smtbmc with Makefile target `demo2`; but this test only runs the resulting testbench with Icarus, which appears to be more accepting of such redefinitions(?).

I think this can be greatly simplified - Verilator DOES now cover `#` style delays. It looks like this DUT instantiation also does not use the full compliment of inputs and outputs, and I can't determine why in one case it is a "standalone" testbench module and in the `Verilator` case it has inputs/outputs (`genclock` and `clock`).

If someone could point me in the right direction I'd be glad to help out with further changes. Thank you! 