### PR TITLE
Strip trailing slashes when checking for directories on Windows.

### DIFF
--- a/kernel/io.cc
+++ b/kernel/io.cc
@@ -251,7 +251,15 @@ bool check_is_directory(const std::string& dirname)
 {
 #if defined(_WIN32)
 	struct _stat info;
-	if (_stat(dirname.c_str(), &info) != 0)
+	auto dirname_ = dirname;
+
+	/* On old versions of Visual Studio and current versions on MinGW,
+	   _stat will fail if the path ends with a trailing slash. */
+	if (dirname.back() == '/' || dirname.back() == '\\') {
+		dirname_ = dirname.substr(0, dirname.length() - 1);
+	}
+
+	if (_stat(dirname_.c_str(), &info) != 0)
 	{
 		return false;
 	}


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

I bisected a [bug](https://github.com/YosysHQ/nextpnr/pull/1479#issuecomment-2878583483) back to commit b05c0c70af50, where `yosys` just plain fails to initialize and thinks its `share/` directory doesn't exist (when it almost certainly does exist):

```
$ python3 -m amaranth_boards.orangecrab_r0_2
ERROR: init_share_dirname: unable to determine share/ directory!
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:/msys64/home/William/Projects/FPGA/amaranth/amaranth-boards/amaranth_boards/orangecrab_r0_2.py", line 140, in <module>
    OrangeCrabR0_2Platform().build(Blinky(), do_program=True)
  File "C:/msys64/mingw64/lib/python3.12/site-packages/amaranth/build/plat.py", line 103, in build
    products = plan.execute_local(build_dir)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/amaranth/build/run.py", line 115, in execute_local
    subprocess.check_call(["cmd", "/c", f"call {self.script}.bat"],
  File "C:/msys64/mingw64/lib/python3.12/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['cmd', '/c', 'call build_top.bat']' returned non-zero exit status 1.
```

By doing some `printf` debugging, I figured out what's going on. [According to](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/stat-functions?view=msvc-170) Microsoft, old versions of the CRT would return `ENOENT` for directories if the path passed to `_stat` ends with a trailing slash:

> _wstat does not work with Windows Vista symbolic links. In these cases, _wstat will always report a file size of 0. _stat does work correctly with symbolic links. The _stat family of functions use CreateFile in Visual Studio 2015, instead of FindFirstFile as in Visual Studio 2013 and earlier. This means that _stat on a path ending with a slash succeeds if the path refers to a directory, as opposed to before when the function would error with errno set to ENOENT.

While this is apparently fixed in new versions of the CRT, I've seen the old behavior in practice on up-to-date MinGW systems. Perhaps it's not fully fixed to do backwards-compat concerns?

_Explain how this is achieved._

On Windows, the `check_is_directory` function now strips a trailing slashes from the path to be checked before passing it to `_stat`.

_If applicable, please suggest to reviewers how they can test the change._

Once I've applied this patch, I get the expected behavior of the blinky build dying at the programming step- instead of the yosys step- because my OrangeCrab isn't attached :D.

```
$ python3 -m amaranth_boards.orangecrab_r0_2
Warning: Ignoring boxed module $paramod$68581f66a8fa831820fa7633bd24ba569ae9d7e3\TRELLIS_FF.
dfu-suffix (dfu-util) 0.11-dev

Copyright 2011-2012 Stefan Schmidt, 2013-2020 Tormod Volden
This program is Free Software and has ABSOLUTELY NO WARRANTY
Please report bugs to https://sourceforge.net/p/dfu-util/tickets/

Suffix successfully added to file
dfu-util 0.11-dev

Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.
Copyright 2010-2021 Tormod Volden and Stefan Schmidt
This program is Free Software and has ABSOLUTELY NO WARRANTY
Please report bugs to https://sourceforge.net/p/dfu-util/tickets/

Match vendor ID from file: 1209
Match product ID from file: 5af0
No DFU capable USB device available
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:/msys64/home/William/Projects/FPGA/amaranth/amaranth-boards/amaranth_boards/orangecrab_r0_2.py", line 140, in <module>
    OrangeCrabR0_2Platform().build(Blinky(), do_program=True)
  File "C:/msys64/mingw64/lib/python3.12/site-packages/amaranth/build/plat.py", line 107, in build
    self.toolchain_program(products, name, **(program_opts or {}))
  File "C:/msys64/home/William/Projects/FPGA/amaranth/amaranth-boards/amaranth_boards/orangecrab_r0_2.py", line 127, in toolchain_progr

am
    subprocess.check_call([dfu_util, "-a 0", "-D", bitstream_filename])
  File "C:/msys64/mingw64/lib/python3.12/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['dfu-util', '-a 0', '-D', 'C:/msys64/tmp/amaranth_n3yg26me_top.bit']' returned non-zero exit s

tatus 74.
```
