### PR TITLE
Add keyword-based inputs struct constructor into Rosette backend 

### DIFF
--- a/backends/functional/smtlib_rosette.cc
+++ b/backends/functional/smtlib_rosette.cc
@@ -114,6 +114,13 @@ public:
 		size_t i = field_names.at(name);
 		return list(fields[i].accessor, std::move(record));
 	}
+	std::vector<std::string> get_field_names()
+	{
+		std::vector<std::string> names;
+		for (auto field : fields)
+			names.push_back(field.name);
+		return names;
+	}
 };
 
 std::string smt_const(RTLIL::Const const &c) {


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Currently, the Rosette code emitted by Yosys requires the user to ensure they order their module inputs correctly when constructing the "inputs" struct to be passed to the Rosette function generated for the module. This makes it difficult to use the backend in an automated way, and may lead to silent failures -- e.g., if we provide the right number of ports but in the wrong order, it won't be clear why our module isn't behaving as expected. (As an aside: even more confusingly, it seems like the backend may currently reverse the order of the ports!)

This change adds an optional helper function (guarded by a flag) that can construct the inputs struct using a keyword-based function. Users can thus explicitly specify each port by name. This allows users to be more confident that they are constructing the input struct correctly.

_Explain how this is achieved._

A new Rosette/Racket function is (optionally) written out which constructs an input struct.

_If applicable, please suggest to reviewers how they can test the change._

I would appreciate feedback on how to test. I see that the Python tests currently run the generated Racket files. Here are two options:
1. Add the new `-keyword-constructor` flag in the existing tests, which will not actually cause the keyword constructors to be used, but it will cause them to be generated. This will at least test that we do not have syntax errors.
2. Add another set of nearly-identical Python tests that instantiate the input structs via the helper function, rather than the original constructor. 

TODO
- [ ] Add tests (see above, need guidance from maintainers)