### PR TITLE
Maintain port ordering for functional backend

### DIFF
--- a/kernel/functional.cc
+++ b/kernel/functional.cc
@@ -518,8 +518,8 @@ public:
 			if (cell->type.in(ID($assert), ID($assume), ID($live), ID($fair), ID($cover), ID($check)))
 				queue.emplace_back(cell);
 		}
-		for (auto port : module->ports) {
-			auto *wire = module->wire(port);
+		for (auto riter = module->ports.rbegin(); riter != module->ports.rend(); ++riter) {
+			auto *wire = module->wire(*riter);
 			if (wire && wire->port_input) {
 				factory.add_input(wire->name, ID($input), Sort(wire->width));
 			}

--- a/kernel/functional.cc
+++ b/kernel/functional.cc
@@ -518,10 +518,12 @@ public:
 			if (cell->type.in(ID($assert), ID($assume), ID($live), ID($fair), ID($cover), ID($check)))
 				queue.emplace_back(cell);
 		}
-		for (auto wire : module->wires()) {
-			if (wire->port_input)
+		for (auto port : module->ports) {
+			auto *wire = module->wire(port);
+			if (wire && wire->port_input) {
 				factory.add_input(wire->name, ID($input), Sort(wire->width));
-			if (wire->port_output) {
+			}
+			if (wire && wire->port_output) {
 				auto &output = factory.add_output(wire->name, ID($output), Sort(wire->width));
 				output.set_value(enqueue(DriveChunk(DriveChunkWire(wire, 0, wire->width))));
 			}


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

As per https://github.com/YosysHQ/yosys/pull/5128#issuecomment-2896398286,
```
read_verilog << EOF
module top (A, C, B, X, Z, Y);

input A, C, B;
output X, Z, Y;

assign X = C;
assign Y = B;
assign Z = A;

endmodule
EOF
hierarchy
opt_clean
write_functional_rosette
```
returns ports in reverse alphabetical order:
```racket
(struct top_Inputs (C B A) #:transparent
  ; C (bitvector 1)
  ; B (bitvector 1)
  ; A (bitvector 1)
)
(struct top_Outputs (Z Y X) #:transparent
  ; Z (bitvector 1)
  ; Y (bitvector 1)
  ; X (bitvector 1)
)
```
(without the `opt_clean` then the order is the same as input).


_Explain how this is achieved._

1. Use `module->ports` instead of `module->wires()` to get the ordered list of ports.
2. Use reverse iterators to compensate for `hashlib::dict` iterating backwards.

_If applicable, please suggest to reviewers how they can test the change._
