### PR TITLE
libcache: add -quiet and -verbose

### DIFF
--- a/passes/techmap/libcache.cc
+++ b/passes/techmap/libcache.cc
@@ -29,7 +29,7 @@
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
-		log("    libcache {-enable|-disable|-purge} { -all | [path]... }\n");
+		log("    libcache [-verbose] {-enable|-disable|-purge} { -all | [path]... }\n");
 		log("\n");
 		log("Controls the default and per path caching of liberty file data.\n");
 		log("\n");
@@ -47,6 +47,13 @@
 		log("\n");
 		log("Displays the current cache settings and cached paths.\n");
 		log("\n");
+		log("    libcache {-verbose|-quiet}\n");
+		log("\n");
+		log("Controls cache use logging.\n");
+		log("\n");
+		log("    -verbose   Enable printing info when cache is used\n");
+		log("    -quiet     Disable printing info when cache is used (default)\n");
+		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *) override
 	{
@@ -55,6 +62,8 @@
 		bool purge = false;
 		bool all = false;
 		bool list = false;
+		bool verbose = false;
+		bool quiet = false;
 		std::vector<std::string> paths;
 
 		size_t argidx;
@@ -79,16 +88,24 @@
 				list = true;
 				continue;
 			}
+			if (args[argidx] == "-verbose") {
+				verbose = true;
+				continue;
+			}
+			if (args[argidx] == "-quiet") {
+				quiet = true;
+				continue;
+			}
 			std::string fname = args[argidx];
 			rewrite_filename(fname);
 			paths.push_back(fname);
 			break;
 		}
-		int modes = enable + disable + purge + list;
+		int modes = enable + disable + purge + list + verbose + quiet;
 		if (modes == 0)
-			log_cmd_error("At least one of -enable, -disable, -purge or -list is required.\n");
+			log_cmd_error("At least one of -enable, -disable, -purge, -list,\n-verbose, or -quiet is required.\n");
 		if (modes > 1)
-			log_cmd_error("Only one of -enable, -disable, -purge or -list may be present.\n");
+			log_cmd_error("Only one of -enable, -disable, -purge, -list,\n-verbose, or -quiet may be present.\n");
 
 		if (all && !paths.empty())
 			log_cmd_error("The -all option cannot be combined with a list of paths.\n");
@@ -121,6 +138,10 @@
 					LibertyAstCache::instance.cache_path.erase(path);
 				}
 			}
+		} else if (verbose) {
+			LibertyAstCache::instance.verbose = true;
+		} else if (quiet) {
+			LibertyAstCache::instance.verbose = false;
 		} else {
 			log_assert(false);
 		}

--- a/passes/techmap/libcache.cc
+++ b/passes/techmap/libcache.cc
@@ -29,7 +29,7 @@
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
-		log("    libcache [-verbose] {-enable|-disable|-purge} { -all | [path]... }\n");
+		log("    libcache {-enable|-disable|-purge} { -all | [path]... }\n");
 		log("\n");
 		log("Controls the default and per path caching of liberty file data.\n");
 		log("\n");

--- a/passes/techmap/libparse.cc
+++ b/passes/techmap/libparse.cc
@@ -41,7 +41,8 @@ std::shared_ptr<const LibertyAst> LibertyAstCache::cached_ast(const std::string 
 	auto it = cached.find(fname);
 	if (it == cached.end())
 		return nullptr;
-	log("Using cached data for liberty file `%s'\n", fname.c_str());
+	if (verbose)
+		log("Using cached data for liberty file `%s'\n", fname.c_str());
 	return it->second;
 }
 
@@ -51,7 +52,8 @@ void LibertyAstCache::parsed_ast(const std::string &fname, const std::shared_ptr
 	bool should_cache = it == cache_path.end() ? cache_by_default : it->second;
 	if (!should_cache)
 		return;
-	log("Caching data for liberty file `%s'\n", fname.c_str());
+	if (verbose)
+		log("Caching data for liberty file `%s'\n", fname.c_str());
 	cached.emplace(fname, ast);
 }
 

--- a/passes/techmap/libparse.h
+++ b/passes/techmap/libparse.h
@@ -140,6 +140,7 @@ namespace Yosys
 		dict<std::string, std::shared_ptr<const LibertyAst>> cached;
 
 		bool cache_by_default = false;
+		bool verbose = false;
 		dict<std::string, bool> cache_path;
 
 		std::shared_ptr<const LibertyAst> cached_ast(const std::string &fname);

--- a/tests/liberty/libcache.ys
+++ b/tests/liberty/libcache.ys
@@ -1,3 +1,4 @@
+libcache -verbose
 libcache -enable busdef.lib
 
 logger -expect log "Caching is disabled by default." 1
@@ -14,14 +15,21 @@ logger -expect log "Caching data" 1
 read_liberty -lib busdef.lib; design -reset
 logger -check-expected
 
-logger -expect log "Using caching data" 1
-log Using caching data
+logger -expect log "Using cached data" 1
+log Using cached data
 read_liberty normal.lib; design -reset
 logger -check-expected
 
 logger -expect log "Using cached data" 1
 read_liberty -lib busdef.lib; design -reset
 logger -check-expected
+
+libcache -quiet
+logger -expect log "Using cached data" 1
+log Using cached data
+read_liberty -lib busdef.lib; design -reset
+logger -check-expected
+libcache -verbose
 
 libcache -purge busdef.lib
 


### PR DESCRIPTION
Using #4986 broke `stat -json -liberty`. This PR silences the log prints unless a verbose mode is enabled. Fixes #5104

