### PR TITLE
Fix typo ("exist" -> "exit").

### DIFF
--- a/passes/cmds/logger.cc
+++ b/passes/cmds/logger.cc
@@ -67,7 +67,7 @@ struct LoggerPass : public Pass {
 		log("    -check-expected\n");
 		log("        verifies that the patterns previously set up by -expect have actually\n");
 		log("        been met, then clears the expected log list.  If this is not called\n");
-		log("        manually, the check will happen at yosys exist time instead.\n");
+		log("        manually, the check will happen at yosys exit time instead.\n");
 		log("\n");
 	}
 


### PR DESCRIPTION
I think there's a typo in the "help logger" output (describing the comparison between the expected and actual patterns: it reads "...check will happen at yosys *exist* time...", which seems like it should be "...check will happen at yosys *exit* time...").

_What are the reasons/motivation for this change?_
To correct an apparent error in the built-in help.

_Explain how this is achieved._
A trivial change to a string literal in `passes/cmds/logger.cc`.

_If applicable, please suggest to reviewers how they can test the change._
Run `yosys -p 'help logger'` and read the output for `-check-expected`.