### PR TITLE
SystemVerilog: Fix typedef struct in global space

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1433,6 +1433,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 				current_ast_mod->children.push_back(wnode);
 			}
 			basic_prep = true;
+			is_custom_type = false;
 		}
 		break;
 

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -1855,7 +1855,7 @@ struct_decl:
 	}
 	;
 
-struct_type: struct_union { astbuf2 = $1; } struct_body { $$ = astbuf2; }
+struct_type: struct_union { astbuf2 = $1; astbuf2->is_custom_type = true; } struct_body { $$ = astbuf2; }
 	;
 
 struct_union:

--- a/tests/svtypes/typedef_struct_global.ys
+++ b/tests/svtypes/typedef_struct_global.ys
@@ -1,0 +1,13 @@
+read_verilog -sv << EOF
+typedef struct packed {
+	logic y;
+	logic x;
+} Vec_2_B;
+
+module top;
+
+	Vec_2_B two_dee;
+	wire foo = two_dee.x;
+
+endmodule
+EOF


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

When the `typedef struct` is inside the module, it is before the AST node that uses that type and so the custom type is fully resolved.

When the `typedef struct` is inside a package, the package is resolved before the module, so it is again fully resolved.

In the case from #4653, the `typedef struct` is in the global space, and ends up appended to the module so isn't fully resolved until _after_ the nodes that reference it are resolved, so indexing into it ends up with a range of `[-1:0]`, causing it to throw an assertion error.

_Explain how this is achieved._

By marking `struct`s with `is_custom_type`, the code will fully resolve the `typedef struct` before any nodes that reference it, thereby avoiding the assertion error and fixing #4653.

_If applicable, please suggest to reviewers how they can test the change._

`tests/svtypes/typedef_struct_global.ys` should fail on main with an assertion error and pass with this fix.
