### PR TITLE
Add genlib support to abc_new

### DIFF
--- a/passes/techmap/abc_new.cc
+++ b/passes/techmap/abc_new.cc
@@ -68,6 +68,7 @@ struct AbcNewPass : public ScriptPass {
 		log("    -constr <file>\n");
 		log("    -dont_use <cell_name>\n");
 		log("    -liberty <file>\n");
+		log("    -genlib <file>\n");
 		log("        these options are passed on to the 'abc9_exe' command which invokes\n");
 		log("        the ABC tool on individual modules of the design. please see\n");
 		log("        'help abc9_exe' for more details\n");
@@ -90,7 +91,7 @@ struct AbcNewPass : public ScriptPass {
 			if (args[argidx] == "-exe" || args[argidx] == "-script" ||
 					args[argidx] == "-D" ||
 					args[argidx] == "-constr" || args[argidx] == "-dont_use" ||
-					args[argidx] == "-liberty") {
+					args[argidx] == "-liberty" || args[argidx] == "-genlib") {
 				abc_exe_options += " " + args[argidx] + " " + args[argidx + 1];
 				argidx++;
 			} else if (args[argidx] == "-run" && argidx + 1 < args.size()) {


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

I'd like to experiment with a box-aware flow for `synth_gatemate`, but the generated "cell" library for it is in the genlib format. The easiest way to achieve this is to extend `abc_new` to accept a genlib library.

_Explain how this is achieved._

It's handled pretty similarly to Liberty libraries, although I took the opportunity to add a `rewrite_filename` call to correctly handle `+/...` paths.

_If applicable, please suggest to reviewers how they can test the change._

I've been using a quick hack of `synth_gatemate` to use `abc_new` for this:

```diff
diff --git a/techlibs/gatemate/synth_gatemate.cc b/techlibs/gatemate/synth_gatemate.cc
index fa36252f5..406997631 100644
--- a/techlibs/gatemate/synth_gatemate.cc
+++ b/techlibs/gatemate/synth_gatemate.cc
@@ -308,11 +308,11 @@ struct SynthGateMatePass : public ScriptPass
                if (check_label("map_luts"))
                {
                        if (luttree || help_mode) {
-                               std::string abc_args = " -genlib +/gatemate/lut_tree_cells.genlib";
+                               std::string abc_args = " -genlib +/gatemate/lut_tree_cells.genlib -script \"+&sweep;&dc2;&nf\"";
                                if (dff) {
                                        abc_args += " -dff";
                                }
-                               run("abc " + abc_args, "(with -luttree)");
+                               run("abc_new " + abc_args, "(with -luttree)");
                                run("techmap -map +/gatemate/lut_tree_map.v", "(with -luttree)");
                                run("gatemate_foldinv", "(with -luttree)");
                                run("techmap -map +/gatemate/inv_map.v", "(with -luttree)");
```