### PR TITLE
write_aiger: Add no-sort option

### DIFF
--- a/backends/aiger/aiger.cc
+++ b/backends/aiger/aiger.cc
@@ -153,6 +153,9 @@ struct AigerWriter
 				sigmap.add(wire);
 
 		// handle ports
+		// provided the input_bits and output_bits don't get sorted they
+		// will be returned in reverse order, so add them in reverse to
+		// match
 		for (auto riter = module->ports.rbegin(); riter != module->ports.rend(); ++riter) {
 			auto *wire = module->wire(*riter);
 			for (int i = 0; i < GetSize(wire); i++)
@@ -353,6 +356,7 @@ struct AigerWriter
 		}
 
 		init_map.sort();
+		// we are relying here on unsorted pools iterating last-in-first-out
 		if (!no_sort) {
 			input_bits.sort();
 			output_bits.sort();


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

```
read_verilog << EOF
module top (input X, C, B, output A, Z, Y);

assign A = C;
assign Z = X;
assign Y = B & C;

endmodule
EOF
prep
aigmap
write_aiger -ascii -symbols
```
gives the following:
```
aag 4 3 0 3 1
2
4
6
4
8
6
8 4 2
i0 B
i1 C
i2 X
o0 A
o1 Y
o2 Z
c
```

As with #5133, the input and output ports are alphabetically sorted, rather than in the same order as the input design.

_Explain how this is achieved._

Add `-no-sort` option, which prevents sorting input/output bits.  Also use the `module->ports` to get inputs/outputs in order, separating the ports from the rest of the wires.

_If applicable, please suggest to reviewers how they can test the change._

Test above script, adding `-no-sort` with the changes from this PR and get the following instead:
```
aag 4 3 0 3 1
2
4
6
4
2
8
8 6 4
i0 X
i1 C
i2 B
o0 A
o1 Z
o2 Y
c
```
