### PR TITLE
CODEOWNERS: add myself for the ABC doc

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,6 +20,7 @@ passes/opt/opt_lut.cc          @whitequark
 passes/techmap/abc9*.cc        @eddiehung @Ravenslofty
 backends/aiger/xaiger.cc       @eddiehung
 docs/                          @KrystalDelusion
+docs/source/using_yosys/synthesis/abc.rst @KrystalDelusion @Ravenslofty
 .github/workflows/*.yml        @mmicko
 
 ## External Contributors


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
#5153 contained a small but incorrect change to the ABC9 docs; since it slipped through the net, add myself to CODEOWNERS to get notified in the future.

_Explain how this is achieved._
By adding a slightly-too-long line to CODEOWNERS.