### PR TITLE
Fix `proc` handling of whiteboxes

### DIFF
--- a/passes/proc/proc_clean.cc
+++ b/passes/proc/proc_clean.cc
@@ -208,19 +208,15 @@ struct ProcCleanPass : public Pass {
 		}
 		extra_args(args, argidx, design);
 
-		for (auto mod : design->modules()) {
+		for (auto mod : design->all_selected_modules()) {
 			std::vector<RTLIL::Process *> delme;
-			if (!design->selected(mod))
-				continue;
-			for (auto &proc_it : mod->processes) {
-				if (!design->selected(mod, proc_it.second))
-					continue;
-				proc_clean(mod, proc_it.second, total_count, quiet);
-				if (proc_it.second->syncs.size() == 0 && proc_it.second->root_case.switches.size() == 0 &&
-						proc_it.second->root_case.actions.size() == 0) {
+			for (auto proc : mod->selected_processes()) {
+				proc_clean(mod, proc, total_count, quiet);
+				if (proc->syncs.size() == 0 && proc->root_case.switches.size() == 0 &&
+						proc->root_case.actions.size() == 0) {
 					if (!quiet)
-						log("Removing empty process `%s.%s'.\n", log_id(mod), proc_it.second->name.c_str());
-					delme.push_back(proc_it.second);
+						log("Removing empty process `%s.%s'.\n", log_id(mod), proc->name.c_str());
+					delme.push_back(proc);
 				}
 			}
 			for (auto proc : delme) {

--- a/passes/proc/proc_dff.cc
+++ b/passes/proc/proc_dff.cc
@@ -306,13 +306,11 @@ struct ProcDffPass : public Pass {
 
 		extra_args(args, 1, design);
 
-		for (auto mod : design->modules())
-			if (design->selected(mod)) {
-				ConstEval ce(mod);
-				for (auto &proc_it : mod->processes)
-					if (design->selected(mod, proc_it.second))
-						proc_dff(mod, proc_it.second, ce);
-			}
+		for (auto mod : design->all_selected_modules()) {
+			ConstEval ce(mod);
+			for (auto proc : mod->selected_processes())
+				proc_dff(mod, proc, ce);
+		}
 	}
 } ProcDffPass;
 

--- a/passes/proc/proc_dlatch.cc
+++ b/passes/proc/proc_dlatch.cc
@@ -463,11 +463,10 @@ struct ProcDlatchPass : public Pass {
 
 		extra_args(args, 1, design);
 
-		for (auto module : design->selected_modules()) {
-			proc_dlatch_db_t db(module);
-			for (auto &proc_it : module->processes)
-				if (design->selected(module, proc_it.second))
-					proc_dlatch(db, proc_it.second);
+		for (auto mod : design->all_selected_modules()) {
+			proc_dlatch_db_t db(mod);
+			for (auto proc : mod->selected_processes())
+				proc_dlatch(db, proc);
 			db.fixup_muxes();
 		}
 	}

--- a/passes/proc/proc_init.cc
+++ b/passes/proc/proc_init.cc
@@ -91,13 +91,11 @@ struct ProcInitPass : public Pass {
 
 		extra_args(args, 1, design);
 
-		for (auto mod : design->modules())
-			if (design->selected(mod)) {
-				SigMap sigmap(mod);
-				for (auto &proc_it : mod->processes)
-					if (design->selected(mod, proc_it.second))
-						proc_init(mod, sigmap, proc_it.second);
-			}
+		for (auto mod : design->all_selected_modules()) {
+			SigMap sigmap(mod);
+			for (auto proc : mod->selected_processes())
+				proc_init(mod, sigmap, proc);
+		}
 	}
 } ProcInitPass;
 

--- a/passes/proc/proc_memwr.cc
+++ b/passes/proc/proc_memwr.cc
@@ -99,9 +99,9 @@ struct ProcMemWrPass : public Pass {
 
 		extra_args(args, 1, design);
 
-		for (auto module : design->selected_modules()) {
+		for (auto mod : design->all_selected_modules()) {
 			dict<IdString, int> next_port_id;
-			for (auto cell : module->cells()) {
+			for (auto cell : mod->cells()) {
 				if (cell->type.in(ID($memwr), ID($memwr_v2))) {
 					bool is_compat = cell->type == ID($memwr);
 					IdString memid = cell->parameters.at(ID::MEMID).decode_string();
@@ -110,9 +110,8 @@ struct ProcMemWrPass : public Pass {
 						next_port_id[memid] = port_id + 1;
 				}
 			}
-			for (auto &proc_it : module->processes)
-				if (design->selected(module, proc_it.second))
-					proc_memwr(module, proc_it.second, next_port_id);
+			for (auto proc : mod->selected_processes())
+				proc_memwr(mod, proc, next_port_id);
 		}
 	}
 } ProcMemWrPass;

--- a/passes/proc/proc_mux.cc
+++ b/passes/proc/proc_mux.cc
@@ -468,11 +468,9 @@ struct ProcMuxPass : public Pass {
 		}
 		extra_args(args, argidx, design);
 
-		for (auto mod : design->modules())
-			if (design->selected(mod))
-				for (auto &proc_it : mod->processes)
-					if (design->selected(mod, proc_it.second))
-						proc_mux(mod, proc_it.second, ifxmode);
+		for (auto mod : design->all_selected_modules())
+			for (auto proc : mod->selected_processes())
+				proc_mux(mod, proc, ifxmode);
 	}
 } ProcMuxPass;
 

--- a/passes/proc/proc_prune.cc
+++ b/passes/proc/proc_prune.cc
@@ -127,15 +127,10 @@ struct ProcPrunePass : public Pass {
 
 		extra_args(args, 1, design);
 
-		for (auto mod : design->modules()) {
-			if (!design->selected(mod))
-				continue;
+		for (auto mod : design->all_selected_modules()) {
 			PruneWorker worker(mod);
-			for (auto &proc_it : mod->processes) {
-				if (!design->selected(mod, proc_it.second))
-					continue;
-				worker.do_process(proc_it.second);
-			}
+			for (auto proc : mod->selected_processes())
+				worker.do_process(proc);
 			total_removed_count += worker.removed_count;
 			total_promoted_count += worker.promoted_count;
 		}

--- a/passes/proc/proc_rmdead.cc
+++ b/passes/proc/proc_rmdead.cc
@@ -147,21 +147,17 @@ struct ProcRmdeadPass : public Pass {
 		extra_args(args, 1, design);
 
 		int total_counter = 0;
-		for (auto mod : design->modules()) {
-			if (!design->selected(mod))
-				continue;
-			for (auto &proc_it : mod->processes) {
-				if (!design->selected(mod, proc_it.second))
-					continue;
+		for (auto mod : design->all_selected_modules()) {
+			for (auto proc : mod->selected_processes()) {
 				int counter = 0, full_case_counter = 0;
-				for (auto switch_it : proc_it.second->root_case.switches)
+				for (auto switch_it : proc->root_case.switches)
 					proc_rmdead(switch_it, counter, full_case_counter);
 				if (counter > 0)
 					log("Removed %d dead cases from process %s in module %s.\n", counter,
-							log_id(proc_it.first), log_id(mod));
+							log_id(proc), log_id(mod));
 				if (full_case_counter > 0)
 					log("Marked %d switch rules as full_case in process %s in module %s.\n",
-							full_case_counter, log_id(proc_it.first), log_id(mod));
+							full_case_counter, log_id(proc), log_id(mod));
 				total_counter += counter;
 			}
 		}

--- a/passes/proc/proc_rom.cc
+++ b/passes/proc/proc_rom.cc
@@ -243,15 +243,10 @@ struct ProcRomPass : public Pass {
 
 		extra_args(args, 1, design);
 
-		for (auto mod : design->modules()) {
-			if (!design->selected(mod))
-				continue;
+		for (auto mod : design->all_selected_modules()) {
 			RomWorker worker(mod);
-			for (auto &proc_it : mod->processes) {
-				if (!design->selected(mod, proc_it.second))
-					continue;
-				worker.do_process(proc_it.second);
-			}
+			for (auto proc : mod->selected_processes())
+				worker.do_process(proc);
 			total_count += worker.count;
 		}
 

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -123,7 +123,7 @@ void check(RTLIL::Design *design, bool dff_mode)
 					log_error("Module '%s' with (* abc9_flop *) is a blackbox.\n", log_id(derived_type));
 
 				if (derived_module->has_processes())
-					Pass::call_on_module(design, derived_module, "proc");
+					Pass::call_on_module(design, derived_module, "proc -noopt");
 
 				bool found = false;
 				for (auto derived_cell : derived_module->cells()) {
@@ -204,7 +204,7 @@ void prep_hier(RTLIL::Design *design, bool dff_mode)
 
 			if (!unmap_design->module(derived_type)) {
 				if (derived_module->has_processes())
-					Pass::call_on_module(design, derived_module, "proc");
+					Pass::call_on_module(design, derived_module, "proc -noopt");
 
 				if (derived_module->get_bool_attribute(ID::abc9_flop)) {
 					for (auto derived_cell : derived_module->cells())
@@ -834,7 +834,7 @@ void prep_xaiger(RTLIL::Module *module, bool dff)
 				holes_cell = holes_module->addCell(NEW_ID, cell->type);
 
 				if (box_module->has_processes())
-					Pass::call_on_module(design, box_module, "proc");
+					Pass::call_on_module(design, box_module, "proc -noopt");
 
 				int box_inputs = 0;
 				for (auto port_name : box_ports.at(cell->type)) {


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

With the recent change to selections (#4768), a number of passes now give a warning when they ignore boxed modules, instead of doing so silently.  #5142 reveals that many of the `proc_*` passes ignore boxes, raising warnings when `abc9_ops` calls `proc` on the derived modules.  It seems like the major `proc_*` passes handled boxes but some of the newer optimizations used `selected_modules`, potentially without realizing that it was silently ignoring boxes.

_Explain how this is achieved._

All of the `proc_*` passes have now been updated to be consistent, universally accepting all selected modules, including boxes.

```c++
for (auto mod : design->all_selected_modules()) {
    // ...
    for (auto proc : mod->selected_processes()) {
        // ...
    }
    // ...
}
```

`opt_expr`, which is called at the end of `proc` by default, *also* emits a warning if the selection includes boxes.  However, unlike the `proc_*` passes, *none* of the `opt_*` passes operate on boxes.  Rather than changing `opt_expr` I instead changed `abc9_ops` to call `proc -noopt` and skip the `opt_expr` call entirely.

These two changes are sufficient to close #5142.

_If applicable, please suggest to reviewers how they can test the change._

Following the instructions for #5142 should not produce any warnings with the changes from this PR, and none of the existing tests should break.