### PR TITLE
verilog: improve string literal matching speed (fixes #5076)

### DIFF
--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -336,7 +336,7 @@ TIME_SCALE_SUFFIX [munpf]?s
 }
 
 \"		{ BEGIN(STRING); }
-<STRING>\\.	{ yymore(); real_location = old_location; }
+<STRING>([^\"]|\\.)+	{ yymore(); real_location = old_location; }
 <STRING>\"	{
 	BEGIN(0);
 	char *yystr = strdup(yytext);
@@ -376,7 +376,6 @@ TIME_SCALE_SUFFIX [munpf]?s
 	free(yystr);
 	return TOK_STRING;
 }
-<STRING>.	{ yymore(); real_location = old_location; }
 
 and|nand|or|nor|xor|xnor|not|buf|bufif0|bufif1|notif0|notif1 {
 	yylval->string = new std::string(yytext);


### PR DESCRIPTION
Use a greedy regular expression to match input inside a string literal, so that flex can accumulate a longer match instead of invoking a rule for each individual character.

_What are the reasons/motivation for this change?_
Before this change, matching long string literals was slow (see issue #5706).

_Explain how this is achieved._
A small regexp is added to match the body of string literals while in the `<STRING>` state; this allows the DFA to do the work of analysing the string so it doesn't have to suspend processing between characters.

From the `flex` manual:
> Another area where the user can increase a scanner's performance (and one that's easier to implement) arises from the fact that the longer the tokens matched, the faster the scanner will run.  This is because with long tokens the processing of most input characters takes place in the (short) inner scanning loop, and does not often have to go through the additional work of setting up the scanning environment (e.g., 'yytext') for the action.

_If applicable, please suggest to reviewers how they can test the change._
Try the test case attached to #5076, or use the following shell script.  There should be a significant speedup (say 50-100x) after applying this change.

```
#!/bin/sh
a='Hello, world.   ' # 16 chars
b="$a$a$a$a$a$a$a$a$a$a$a$a$a$a$a$a" # 256 chars
c="$b$b$b$b$b$b$b$b$b$b$b$b$b$b$b$b" # 4096 chars
d="$c$c$c$c$c$c$c$c" # 32768 chars
echo "module big;" > big.v
echo "    initial if( 0 ) \$display( \"$d\" );" >> big.v
echo "    initial if( 0 ) \$display( \"$d\" );" >> big.v
echo "    initial if( 0 ) \$display( \"$d\" );" >> big.v
echo "    initial if( 0 ) \$display( \"$d\" );" >> big.v
echo "    initial if( 0 ) \$display( \"$d\" );" >> big.v
echo "    initial if( 0 ) \$display( \"$d\" );" >> big.v
echo "    initial if( 0 ) \$display( \"$d\" );" >> big.v
echo "    initial if( 0 ) \$display( \"$d\" );" >> big.v
echo "endmodule" >> big.v
${YOSYS:-yosys} -p "read_verilog big.v"
```