### PR TITLE
splitnets: handle single-bit vectors consistently

### DIFF
--- a/passes/cmds/splitnets.cc
+++ b/passes/cmds/splitnets.cc
@@ -207,8 +207,12 @@ struct SplitnetsPass : public Pass {
 			else
 			{
 				for (auto wire : module->wires()) {
-					if (wire->width > 1 && (wire->port_id == 0 || flag_ports) && design->selected(module, wire))
+					if (((wire->width > 1) || (wire->has_attribute(ID::single_bit_vector)))
+						&& (wire->port_id == 0 || flag_ports)
+						&& design->selected(module, wire)) {
+						wire->attributes.erase(ID::single_bit_vector);
 						worker.splitmap[wire] = std::vector<RTLIL::SigBit>();
+					}
 				}
 
 				for (auto &it : worker.splitmap)

--- a/tests/various/splitnets.ys
+++ b/tests/various/splitnets.ys
@@ -1,0 +1,32 @@
+read_verilog <<EOT
+module test_module (
+  a,
+  b,
+  x,
+  y
+);
+  input [0:0] a;
+  output [0:0] b;
+  input [1:0] x;
+  output [1:0] y;
+  assign b = a;
+  assign y = x;
+endmodule
+EOT
+proc
+
+splitnets -ports -format __:
+
+select -assert-count 0 w:a;
+select -assert-count 1 w:a_0_;
+select -assert-count 0 w:a_1_;
+select -assert-count 0 w:b;
+select -assert-count 1 w:b_0_;
+select -assert-count 0 w:b_1_;
+
+select -assert-count 0 w:x;
+select -assert-count 1 w:x_0_;
+select -assert-count 1 w:x_1_;
+select -assert-count 0 w:y;
+select -assert-count 1 w:y_0_;
+select -assert-count 1 w:y_1_;


### PR DESCRIPTION
Fixes #5166