### PR TITLE
Revert log_debug back to macro from function

### DIFF
--- a/kernel/log.h
+++ b/kernel/log.h
@@ -148,7 +148,7 @@ static inline bool ys_debug(int n = 0) { if (log_force_debug) return true; log_d
 #else
 static inline bool ys_debug(int = 0) { return false; }
 #endif
-static inline void log_debug(const char *format, ...) { if (ys_debug(1)) { va_list args; va_start(args, format); logv(format, args); va_end(args); } }
+#  define log_debug(...) do { if (ys_debug(1)) log(__VA_ARGS__); } while (0)
 
 static inline void log_suppressed() {
 	if (log_debug_suppressed && !log_make_debug) {


### PR DESCRIPTION
This reverts commit 15cfce061a118111 from #5078. The concern is that we're using log_debug in hot loops of important passes like opt_expr and the change I'm reverting forces the arguments to `log` to be evaluated even when the log will not be executed