### PR TITLE
Suppress several spurious warnings

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3489,6 +3489,14 @@ struct VerificPass : public Pass {
 			// WARNING: instantiating unknown module 'XYZ' (VERI-1063)
 			Message::SetMessageType("VERI-1063", VERIFIC_ERROR);
 
+			// Downgrade warnings about things that are normal
+			// VERIFIC-WARNING [VERI-1209] foo.sv:98: expression size 7 truncated to fit in target size 6
+			Message::SetMessageType("VERI-1209", VERIFIC_INFO);
+			// VERIFIC-WARNING [VERI-1142] foo.sv:55: system task 'display' is ignored for synthesis
+			Message::SetMessageType("VERI-1142", VERIFIC_INFO);
+			// VERIFIC-WARNING [VERI-2418] foo.svh:503: parameter 'all_cfgs_gp' declared inside package 'bp_common_pkg' shall be treated as localparam
+			Message::SetMessageType("VERI-2418", VERIFIC_INFO);
+
 			// https://github.com/YosysHQ/yosys/issues/1055
 			RuntimeFlags::SetVar("veri_elaborate_top_level_modules_having_interface_ports", 1) ;
 #endif
@@ -3547,6 +3555,9 @@ struct VerificPass : public Pass {
 				} else if (Strings::compare(args[argidx].c_str(), "warnings")) {
 					Message::SetAllMessageType(VERIFIC_WARNING, new_type);
 				} else if (Strings::compare(args[argidx].c_str(), "infos")) {
+					Message::SetMessageType("VERI-1209", new_type);
+					Message::SetMessageType("VERI-1142", new_type);
+					Message::SetMessageType("VERI-2418", new_type);
 					Message::SetAllMessageType(VERIFIC_INFO, new_type);
 				} else if (Strings::compare(args[argidx].c_str(), "comments")) {
 					Message::SetAllMessageType(VERIFIC_COMMENT, new_type);

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -2409,7 +2409,14 @@ void RTLIL::Module::check()
 			// assertion check below to make sure that there are no
 			// cases where a cell has a blackbox attribute since
 			// that is deprecated
+			#ifdef __GNUC__
+			#pragma GCC diagnostic push
+			#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+			#endif
 			log_assert(!it.second->get_blackbox_attribute());
+			#ifdef __GNUC__
+			#pragma GCC diagnostic pop
+			#endif
 		}
 	}
 

--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -1452,7 +1452,7 @@ struct HierarchyPass : public Pass {
 
 					bool resize_widths = !keep_portwidths && GetSize(w) != GetSize(conn.second);
 					if (resize_widths && verific_mod && boxed_params)
-						log_warning("Ignoring width mismatch on %s.%s.%s from verific, is port width parametrizable?\n",
+						log_debug("Ignoring width mismatch on %s.%s.%s from verific, is port width parametrizable?\n",
 								log_id(module), log_id(cell), log_id(conn.first)
 						);
 					else if (resize_widths) {


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

A grab bag of warnings that have been annoying me:
1) Since #4854, `hierarchy` warns on every parametrizable blackbox coming from verific. Having a blackbox in a design is normal, I'm not sure what I'm supposed to do with this warning.

2) #4324

3) The compiler warning in `rtlil.cc:2412` where a deprecated function is called to sanity-check that the deprecated infrastructure isn't used any more.

This probably should have been 3 separate PRs but I'm lazy.

_Explain how this is achieved._

1) Change `log_warning` to `log_debug` (someone can figure out later if there's something more to do here, but in the meantime let's stop annoying/scaring users).

2) Same approach as for increasing the severity of `VERI-1063` (cf #3568)

3) `#pragma GCC diagnostic push` (we already use this in other places in the codebase - and clang understands the GCC style pragma too)
