### PR TITLE
Allows calling yosys_shutdown and then yosys_setup to restart.

### DIFF
--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -187,12 +187,14 @@ int run_command(const std::string &command, std::function<void(const std::string
 #endif
 
 bool already_setup = false;
+bool already_shutdown = false;
 
 void yosys_setup()
 {
 	if(already_setup)
 		return;
 	already_setup = true;
+	already_shutdown = false;
 
 #ifdef WITH_PYTHON
 	// With Python 3.12, calling PyImport_AppendInittab on an already
@@ -224,12 +226,11 @@ bool yosys_already_setup()
 	return already_setup;
 }
 
-bool already_shutdown = false;
-
 void yosys_shutdown()
 {
 	if(already_shutdown)
 		return;
+	already_setup = false;
 	already_shutdown = true;
 	log_pop();
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

When using yosys as a dynamic library, the yosys environment is sometimes opened and closed multiple times for different purposes, and the already_setup flag is not maintained correctly.

_Explain how this is achieved._

Simply maintain the already_setup and already_shutdown flags.

_If applicable, please suggest to reviewers how they can test the change._

Only one regression test needs to be executed. I don't know if there is any place that takes advantage of the side effects of the previous commit changes (although that feature doesn't make common sense).
