### PR TITLE
Update CI, windows-2019 is deprecated

### DIFF
--- a/.github/workflows/extra-builds.yml
+++ b/.github/workflows/extra-builds.yml
@@ -36,7 +36,7 @@ jobs:
   
   vs-build:
     name: Visual Studio build
-    runs-on: windows-2019
+    runs-on: windows-latest
     needs: [vs-prep, pre_job]
     if: needs.pre_job.outputs.should_skip != 'true'
     steps:  


### PR DESCRIPTION
The Windows Server 2019 runner image will be fully unsupported by June 30, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Windows Server 2019. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:

June 10 13:00-21:00 UTC
June 17 13:00-21:00 UTC
June 24 13:00-21:00 UTC

Updating our CI scripts in time due to this.


