### PR TITLE
driver.cc: Don't split options on commas

### DIFF
--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -20,6 +20,7 @@
 #include "kernel/yosys.h"
 #include "kernel/hashlib.h"
 #include "libs/sha1/sha1.h"
+#define CXXOPTS_VECTOR_DELIMITER '\0'
 #include "libs/cxxopts/include/cxxopts.hpp"
 #include <iostream>
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

cxxopts has this 'cool feature' where you can use a comma separator between multiple arguments for the same option (see also https://github.com/jarro2783/cxxopts/issues/228), even if the comma is inside a quoted string.  This is problematic for some commands like `eval` which can use a comma.

Take this very simple example `test.v`:
```verilog
module top(input a, b, output o);
assign o = a ^ b;
endmodule
```
Say you want to to call `yosys test.v -p prep -p 'eval -table a,b'`.  The arguments passed to main are
```
yosys
test.v
-p
prep
-p
eval -table a,b
```
The resulting `result["p"]` is
```
prep
eval -table a
b
```
Which breaks the `eval` call, and then fails on the unrecognised `b` ccommand.

_Explain how this is achieved._

By setting the `CXXOPTS_VECTOR_DELIMITER` to the null character `'\0'`, no options are split by comma.  As far as I know we don't actually rely on or advertise this feature at all (given that it wasn't possible before switching to cxxopts), so removing it shouldn't be a problem.

_If applicable, please suggest to reviewers how they can test the change._

Use the test from above.  Without this change it fails, with this change it works as expected.
