### PR TITLE
verificsva: Support the followed-by operator in cover mode

### DIFF
--- a/frontends/verific/verificsva.cc
+++ b/frontends/verific/verificsva.cc
@@ -1613,7 +1613,10 @@ struct VerificSvaImporter
 		}
 		else
 		if (inst->Type() == PRIM_SVA_OVERLAPPED_IMPLICATION ||
-				inst->Type() == PRIM_SVA_NON_OVERLAPPED_IMPLICATION)
+				inst->Type() == PRIM_SVA_NON_OVERLAPPED_IMPLICATION ||
+				(mode_cover && (
+					inst->Type() == PRIM_SVA_OVERLAPPED_FOLLOWED_BY ||
+					inst->Type() == PRIM_SVA_NON_OVERLAPPED_IMPLICATION)))
 		{
 			Net *antecedent_net = inst->GetInput1();
 			Net *consequent_net = inst->GetInput2();
@@ -1621,7 +1624,7 @@ struct VerificSvaImporter
 
 			SvaFsm antecedent_fsm(clocking, trig);
 			node = parse_sequence(antecedent_fsm, antecedent_fsm.createStartNode(), antecedent_net);
-			if (inst->Type() == PRIM_SVA_NON_OVERLAPPED_IMPLICATION) {
+			if (inst->Type() == PRIM_SVA_NON_OVERLAPPED_IMPLICATION || inst->Type() == PRIM_SVA_NON_OVERLAPPED_FOLLOWED_BY) {
 				int next_node = antecedent_fsm.createNode();
 				antecedent_fsm.createEdge(node, next_node);
 				node = next_node;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

To support the SVA properties produced by the `verific -rewrite gen-witness-covers` rewriter. 

_Explain how this is achieved._

The implementation for the implication operator in cover mode actually implements the followed-by operator, so we can re-use it unchanged.

It is not always the correct behavior for the implication operator in cover mode, but a) it will only cause false positives not miss anything so if the behavior is unexpected it will be visible in the produced traces, b) it is unlikely to make a difference for most properties one would practically use in cover mode, c) at least one other widely used SVA implementations behaves the same way and d) it's not clear whether we can fix this without rewriting most of verificsva.cc

_If applicable, please suggest to reviewers how they can test the change._

By testing `verific -rewrite gen-witness-cover` on any existing FV project that uses SVA.