### PR TITLE
Add ASAN to CI

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -40,6 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        sanitizer: [undefined, address]
       fail-fast: false
     steps:
       - name: Checkout Yosys
@@ -57,7 +58,7 @@ jobs:
           mkdir build
           cd build
           make -f ../Makefile config-$CC
-          echo 'SANITIZER = undefined' >> Makefile.conf
+          echo 'SANITIZER = ${{ matrix.sanitizer }}' >> Makefile.conf
           make -f ../Makefile -j$procs ENABLE_LTO=1
 
       - name: Log yosys-config output
@@ -73,7 +74,7 @@ jobs:
       - name: Store build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-${{ matrix.os }}
+          name: build-${{ matrix.os }}-${{ matrix.sanitizer }}
           path: build.tar
           retention-days: 1
 
@@ -84,10 +85,12 @@ jobs:
     if: needs.pre_job.outputs.should_skip != 'true'
     env:
       CC: clang
+      ASAN_OPTIONS: halt_on_error=1
       UBSAN_OPTIONS: halt_on_error=1
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        sanitizer: [undefined, address]
       fail-fast: false
     steps:
       - name: Checkout Yosys
@@ -136,7 +139,7 @@ jobs:
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
-          name: build-${{ matrix.os }}
+          name: build-${{ matrix.os }}-${{ matrix.sanitizer }}
 
       - name: Uncompress build
         shell: bash
@@ -168,6 +171,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        sanitizer: [undefined, address]
       fail-fast: false
     steps:
       - name: Checkout Yosys
@@ -181,7 +185,7 @@ jobs:
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
-          name: build-${{ matrix.os }}
+          name: build-${{ matrix.os }}-${{ matrix.sanitizer }}
 
       - name: Uncompress build
         shell: bash

--- a/tests/verific/run-test.sh
+++ b/tests/verific/run-test.sh
@@ -2,3 +2,4 @@
 set -eu
 source ../gen-tests-makefile.sh
 generate_mk --yosys-scripts --bash
+sed -i '1i\export ASAN_OPTIONS=halt_on_error=0' run-test.mk


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

We have UBSAN running on CI, but sometimes ASAN issues slip through as well (e.g. #5020, #5163).

_Explain how this is achieved._

Define the sanitizer as part of the test strategy matrix in the `test-build.yml` family of CI jobs.

There are still memory leaks being picked up in the Verific tests, but I added a (hopefully temporary) patch to `tests/verific/run-test.sh` to disable `halt_on_error` for the tests in that directory.  The sanitizer builds are running on the open source runner, so they shouldn't actually hit the Verific tests _anyway_, but better safe than sorry.

_If applicable, please suggest to reviewers how they can test the change._

CI should pass, having run the test suite with ASAN.