### PR TITLE
const2ast: prove tests cover error filenames

### DIFF
--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -1342,7 +1342,7 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 	// be instantiated for this type of AST node.
 	IdString type_name;
 
-	current_filename = filename;
+	// current_filename = filename;
 
 	switch (type)
 	{

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1036,7 +1036,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 		return false;
 	}
 
-	current_filename = filename;
+	// current_filename = filename;
 
 	// we do not look inside a task or function
 	// (but as soon as a task or function is instantiated we process the generated AST as usual)
@@ -1844,7 +1844,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 			current_scope[it->first] = it->second;
 	}
 
-	current_filename = filename;
+	// current_filename = filename;
 
 	if (type == AST_MODULE || type == AST_INTERFACE)
 		current_scope.clear();


### PR DESCRIPTION
The deletion of uses of the AST layer global state member `current_filename` should be caught by tests. I will close this draft PR when rebasing onto main makes the tests fail.

> we have mutation testing at home
mutation testing at home: