### PR TITLE
verilog: fix string literal regular expression

### DIFF
--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -336,7 +336,7 @@ TIME_SCALE_SUFFIX [munpf]?s
 }
 
 \"		{ BEGIN(STRING); }
-<STRING>([^\"]|\\.)+	{ yymore(); real_location = old_location; }
+<STRING>([^\\"]|\\.)+	{ yymore(); real_location = old_location; }
 <STRING>\"	{
 	BEGIN(0);
 	char *yystr = strdup(yytext);

--- a/tests/verilog/bug5160.v
+++ b/tests/verilog/bug5160.v
@@ -1,0 +1,5 @@
+// Regression test for bug mentioned in #5160:
+// https://github.com/YosysHQ/yosys/pull/5160#issuecomment-2983643084
+module top;
+    initial $display( "\\" );
+endmodule


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
Fix the bug reported in #5160, where a closing quote on a string literal failed to terminate the string when preceded by an escaped backslash.
_Originally posted by @mmicko in https://github.com/YosysHQ/yosys/issues/5160#issuecomment-2983643084_

_Explain how this is achieved._
Properly escape the backslash in the regular expression in `verilog_lexer.l`.

_If applicable, please suggest to reviewers how they can test the change._
See the included regression test `tests/verilog/bug5160.v`, or @mmicko's test case in the original report.

With this fix applied, both cases work properly.  Before the fix, parsing would fail with a spurious syntax error.