### PR TITLE
Makefile: fix hardcoded -soname for libyosys.so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -747,7 +747,7 @@ libyosys.so: $(filter-out kernel/driver.o,$(OBJS))
 ifeq ($(OS), Darwin)
 	$(P) $(CXX) -o libyosys.so -shared -undefined dynamic_lookup -Wl,-install_name,$(LIBDIR)/libyosys.so $(LINKFLAGS) $^ $(LIBS) $(LIBS_VERIFIC)
 else
-	$(P) $(CXX) -o libyosys.so -shared -Wl,-soname,$(LIBDIR)/libyosys.so $(LINKFLAGS) $^ $(LIBS) $(LIBS_VERIFIC)
+	$(P) $(CXX) -o libyosys.so -shared -Wl,-soname,libyosys.so $(LINKFLAGS) $^ $(LIBS) $(LIBS_VERIFIC)
 endif
 
 %.o: %.cc


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

I am using the Yosys API in my project through `libyosys.so`. However, the current Makefile always hardcodes `soname` to `$PREFIX/lib/yosys/libyosys.so`. Unless the `libyosys.so` is exactly in that location, the runtime linking will fail even if the `LD_LIBRARY_PATH` contains the shared lib.

_Explain how this is achieved._

This PR removes the hardcoded prefix.

_If applicable, please suggest to reviewers how they can test the change._
