### PR TITLE
verilog: support newline and hex escapes in string literals

### DIFF
--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -336,13 +336,24 @@ TIME_SCALE_SUFFIX [munpf]?s
 }
 
 \"		{ BEGIN(STRING); }
-<STRING>([^\\"]|\\.)+	{ yymore(); real_location = old_location; }
+<STRING>([^\\"]|\\.|\\\n)+	{ yymore(); real_location = old_location; }
 <STRING>\"	{
 	BEGIN(0);
 	char *yystr = strdup(yytext);
 	yystr[strlen(yytext) - 1] = 0;
 	int i = 0, j = 0;
 	while (yystr[i]) {
+		if (yystr[i] == '\n' || yystr[i] =='\r') {
+			static bool printed_warning = false;
+			if (!printed_warning) {
+				log_warning(
+					"Multi-line string literals are not "
+					"legal Verilog unless escaped with "
+					"\\ (backslash).\n"
+				);
+				printed_warning = true;
+			}
+		 }
 		if (yystr[i] == '\\' && yystr[i + 1]) {
 			i++;
 			if (yystr[i] == 'a')
@@ -357,7 +368,17 @@ TIME_SCALE_SUFFIX [munpf]?s
 				yystr[i] = '\t';
 			else if (yystr[i] == 'v')
 				yystr[i] = '\v';
-			else if ('0' <= yystr[i] && yystr[i] <= '7') {
+			else if (yystr[i] == '\n') {
+				i++;
+				if (yystr[i] == '\r')
+					i++;
+				continue;
+			} else if (yystr[i] == '\r') {
+				i++;
+				if (yystr[i] == '\n')
+					i++;
+				continue;
+			} else if ('0' <= yystr[i] && yystr[i] <= '7') {
 				yystr[i] = yystr[i] - '0';
 				if ('0' <= yystr[i + 1] && yystr[i + 1] <= '7') {
 					yystr[i + 1] = yystr[i] * 8 + yystr[i + 1] - '0';

--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -41,6 +41,7 @@
 #pragma clang diagnostic ignored "-Wmisleading-indentation"
 #endif
 
+#include <cctype>
 #include "kernel/log.h"
 #include "frontends/verilog/verilog_frontend.h"
 #include "frontends/ast/ast.h"
@@ -388,7 +389,20 @@ TIME_SCALE_SUFFIX [munpf]?s
 					yystr[i + 1] = yystr[i] * 8 + yystr[i + 1] - '0';
 					i++;
 				}
-			}
+			} else if (yystr[i] == 'x' && isxdigit(yystr[i + 1])) {
+				i++;
+				if (isdigit(yystr[i]))
+					yystr[i] = yystr[i] - '0';
+				else
+					yystr[i] = (yystr[i] | 0x20) - 'a' + 0xA;
+				if (isxdigit(yystr[i + 1])) {
+					if (isdigit(yystr[i + 1]))
+						yystr[i + 1] = yystr[i] * 0x10 + yystr[i + 1] - '0';
+					else
+						yystr[i + 1] = yystr[i] * 0x10 + (yystr[i + 1] | 0x20) - 'a' + 0xA;
+					i++;
+				}
+			}			
 		}
 		yystr[j++] = yystr[i++];
 	}

--- a/tests/verilog/hex_escape.ys
+++ b/tests/verilog/hex_escape.ys
@@ -1,0 +1,7 @@
+read_verilog << EOF
+module top;
+	wire[7:0] a = "\x2A";
+	wire[7:0] b = 42;
+endmodule
+EOF
+sat -prove a b

--- a/tests/verilog/multiline_strings.ys
+++ b/tests/verilog/multiline_strings.ys
@@ -1,0 +1,21 @@
+logger -expect-no-warnings
+read_verilog << EOF
+module top;
+	wire[31:0] a = "ab\
+cd";
+	wire [31:0] b = 32'h61626364;
+endmodule
+EOF
+sat -prove a b
+logger -check-expected
+design -reset
+
+logger -expect warning "Multi-line string literals are not legal Verilog" 1
+read_verilog << EOF
+module top;
+	reg[31:0] a = "x
+yz";
+endmodule
+EOF
+logger -check-expected
+


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
To add support for multi-line strings (i.e., those containing a backslash-newline), and \x hex escapes to string literals.  This should bring string literal handling into conformance with 1800-2012 sec 5.9 and 5.9.1.

_Explain how this is achieved._
By modifying `verilog_lexer.l` to match newline characters within strings, and detecting escape sequences within the literal as appropriate.

_If applicable, please suggest to reviewers how they can test the change._
`make test`; see `tests/verilog/multiline_strings.ys` and `tests/verilog/hex_escape.ys`.