### PR TITLE
Use Booth multipliers for GateMate

### DIFF
--- a/techlibs/gatemate/synth_gatemate.cc
+++ b/techlibs/gatemate/synth_gatemate.cc
@@ -237,6 +237,7 @@ struct SynthGateMatePass : public ScriptPass
 
 		if (check_label("coarse"))
 		{
+			run("booth");
 			run("alumacc");
 			run("opt");
 			run("memory -nomap");


### PR DESCRIPTION
To cover soft logic implementation of multipliers using now Booth multipliers due to better resource usage. This makes some larger designs to place and route easier. This affects only leftovers or all multipliers in case `-nomult` is provided.

@pu-cc please check if you see any issues with this.