### PR TITLE
Himbaechel for Xilinx uarch : Improve mapping of multiplexers

### DIFF
--- a/tests/arch/common/mux.v
+++ b/tests/arch/common/mux.v
@@ -51,10 +51,32 @@ module mux8 ( S, D, Y );
     end
 endmodule
 
+module mux12 (D, S, Y);
+    input  [11:0] D;
+    input  [3:0] S;
+    output Y;
+
+    wire[15:0] D16;
+
+    assign D16 = {4'bx, D};
+    assign Y = D16[S];
+endmodule
+
 module mux16 (D, S, Y);
- 	input  [15:0] D;
- 	input  [3:0] S;
- 	output Y;
+    input  [15:0] D;
+    input  [3:0] S;
+    output Y;
 
     assign Y = D[S];
+endmodule
+
+module mux20 (D, S, Y);
+    input  [19:0] D;
+    input  [4:0] S;
+    output Y;
+
+    wire[31:0] D32;
+
+    assign D32 = {12'bx, D};
+    assign Y = D32[S];
 endmodule

--- a/tests/arch/xilinx/mux.ys
+++ b/tests/arch/xilinx/mux.ys
@@ -1,5 +1,9 @@
+
 read_verilog ../common/mux.v
 design -save read
+
+
+# mux2
 
 hierarchy -top mux2
 proc
@@ -8,8 +12,11 @@ design -load postopt # load the post-opt design (otherwise equiv_opt loads the p
 cd mux2 # Constrain all select calls below inside the top module
 select -assert-count 1 t:LUT3
 
+# Ensure there are no other cells
 select -assert-none t:LUT3 %% t:* %D
 
+
+# mux4
 
 design -load read
 hierarchy -top mux4
@@ -19,8 +26,11 @@ design -load postopt # load the post-opt design (otherwise equiv_opt loads the p
 cd mux4 # Constrain all select calls below inside the top module
 select -assert-count 1 t:LUT6
 
+# Ensure there are no other cells
 select -assert-none t:LUT6 %% t:* %D
 
+
+# mux8 without widemux
 
 design -load read
 hierarchy -top mux8
@@ -31,8 +41,42 @@ cd mux8 # Constrain all select calls below inside the top module
 select -assert-count 1 t:LUT3
 select -assert-count 2 t:LUT6
 
+# Ensure there are no other cells
 select -assert-none t:LUT3 t:LUT6 %% t:* %D
 
+
+# mux8 with widemux 5
+
+design -load read
+hierarchy -top mux8
+proc
+equiv_opt -assert -map +/xilinx/cells_sim.v synth_xilinx -noiopad -widemux 5 # equivalency check
+design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
+cd mux8 # Constrain all select calls below inside the top module
+select -assert-count 2 t:LUT6
+select -assert-count 1 t:MUXF7
+
+# Ensure there are no other cells
+select -assert-none t:LUT6 t:MUXF7 %% t:* %D
+
+
+# mux12 with widemux 5
+# There is no equivalence check because selection values 12 to 15 are unspecified
+
+design -load read
+hierarchy -top mux12
+proc
+synth_xilinx -noiopad -widemux 5
+cd mux12 # Constrain all select calls below inside the top module
+select -assert-count 3 t:LUT6
+select -assert-max   2 t:MUXF7
+select -assert-count 1 t:MUXF8
+
+# Ensure there are no other cells
+select -assert-none t:LUT6 t:MUXF7 t:MUXF8 %% t:* %D
+
+
+# mux16 without widemux
 
 design -load read
 hierarchy -top mux16
@@ -47,4 +91,45 @@ select -assert-max 7 t:LUT6
 select -assert-max 2 t:MUXF7
 dump
 
+# Ensure there are no other cells
 select -assert-none t:LUT6 t:LUT4 t:LUT3 t:MUXF7 %% t:* %D
+
+
+# mux16 with widemux 5
+
+design -load read
+hierarchy -top mux16
+proc
+equiv_opt -assert -map +/xilinx/cells_sim.v synth_xilinx -noiopad -widemux 5 # equivalency check
+design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
+cd mux16 # Constrain all select calls below inside the top module
+select -assert-count 4 t:LUT6
+select -assert-count 2 t:MUXF7
+select -assert-count 1 t:MUXF8
+dump
+
+# Ensure there are no other cells
+select -assert-none t:LUT6 t:MUXF7 t:MUXF8 %% t:* %D
+
+
+# mux20 with widemux 5
+# Expect one mux16 (4 lut6 + 2 muxf7 + muxf8) + one mux4 (one lut6), then one mux2 (one lut3)
+# These mapping results are achieved only with abc9 (without abc, we get undesired additional muxf7/muxf8)
+# There is no equivalence check because selection values 20 to 31 are unspecified
+
+design -load read
+hierarchy -top mux20
+proc
+scratchpad -set abc9.D 5000 # Set a period high enough so we get area-optimized result
+synth_xilinx -noiopad -widemux 5 -abc9
+cd mux20 # Constrain all select calls below inside the top module
+select -assert-count 1 t:LUT3
+select -assert-count 5 t:LUT6
+select -assert-count 2 t:MUXF7
+select -assert-count 1 t:MUXF8
+dump
+
+# Ensure there are no other cells
+select -assert-none t:LUT3 t:LUT6 t:MUXF7 t:MUXF8 %% t:* %D
+
+


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Implementation of multiplexers for uarch XIlinx is currently often suboptimal or excessively biased for minor speed gain at the cost of a significant area increase. Stress on nextpnr is also unnecessarily high with large proportion of muxf7/muxf8.

This contribution brings area reduction in personal test design (not that much mux-intensive) of 1.1% of SLICE_LUTX and 17.7% of SELMUX2_1 as reported by nextpnr.

_Explain how this is achieved._

- Add explicitly handling of A_WIDTH=1 for completeness
- mux2 uses one LUT3 instead of a hard mux (which did use LUTs anyway)
- mux4 uses one LUT4 instead of hard muxes (which did use LUTs anyway)
- mux8 uses only bottom half of a slice
- Add a mux12 for intermediate variant between mux8 and mux16
- For sizes larger than 16 inputs, instantiate the right mux size
- More comments about implementation choices
- More tests including with -widemux and -abc9, and more comments

_If applicable, please suggest to reviewers how they can test the change._

Tests are included.

TODO : Find how to specify a range for inputs to do equivalence check for mux12 and mux20
