### PR TITLE
Fix space leak in `SatGen::importSigSpecWorker()` by avoiding `log_id…

### DIFF
--- a/kernel/satgen.h
+++ b/kernel/satgen.h
@@ -101,7 +101,9 @@ struct SatGen
 				else
 					vec.push_back(bit == (undef_mode ? RTLIL::State::Sx : RTLIL::State::S1) ? ez->CONST_TRUE : ez->CONST_FALSE);
 			} else {
-				std::string name = pf + (bit.wire->width == 1 ? stringf("%s", log_id(bit.wire)) : stringf("%s [%d]", log_id(bit.wire->name), bit.offset));
+				std::string wire_name = RTLIL::unescape_id(bit.wire->name);
+				std::string name = pf +
+					(bit.wire->width == 1 ? wire_name : stringf("%s [%d]", wire_name.c_str(), bit.offset));
 				vec.push_back(ez->frozen_literal(name));
 				imported_signals[pf][bit] = vec.back();
 			}


### PR DESCRIPTION
…()`.

_What are the reasons/motivation for this change?_

Calling `log_id()` leaks a copy of the ID into `log_id_cache` until the end of the pass, which causes exorbitant memory usage. See issue #5210.

_Explain how this is achieved._

Avoid using `log_id()`.