### PR TITLE
verificsva: check -L value is small enough for code to work

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -4124,6 +4124,9 @@ struct VerificPass : public Pass {
 			if (argidx > GetSize(args) && args[argidx].compare(0, 1, "-") == 0)
 				cmd_error(args, argidx, "unknown option");
 
+			if ((unsigned long)verific_sva_fsm_limit >= sizeof(1ull)*8)
+				log_cmd_error("-L %d: limit too large; maximum allowed value is %zu.\n", verific_sva_fsm_limit, sizeof(1ull)*8-1);
+
 			std::set<std::string> top_mod_names;
 
 			if (mode_all)

--- a/frontends/verific/verificsva.cc
+++ b/frontends/verific/verificsva.cc
@@ -479,14 +479,14 @@ struct SvaFsm
 					GetSize(dnode.ctrl), verific_sva_fsm_limit);
 		}
 
-		for (int i = 0; i < (1 << GetSize(dnode.ctrl)); i++)
+		for (unsigned long long i = 0; i < (1ull << GetSize(dnode.ctrl)); i++)
 		{
 			Const ctrl_val(i, GetSize(dnode.ctrl));
 			pool<SigBit> ctrl_bits;
 
-			for (int i = 0; i < GetSize(dnode.ctrl); i++)
-				if (ctrl_val[i] == State::S1)
-					ctrl_bits.insert(dnode.ctrl[i]);
+			for (int j = 0; j < GetSize(dnode.ctrl); j++)
+				if (ctrl_val[j] == State::S1)
+					ctrl_bits.insert(dnode.ctrl[j]);
 
 			vector<int> new_state;
 			bool accept = false, cond = false;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Passing a too-large SVA FSM limit to `verific -L` would cause the generation code to be silently skipped due to integer overflow in the condition of the for loop. It would be better to produce an error.

_Explain how this is achieved._

Add a check that the value is smaller than the maximum loop value that can be represented.

_If applicable, please suggest to reviewers how they can test the change._

Use `and` several times on the RHS of an implication to create a property that exceeds the size limit.