### PR TITLE
opt_mem: Adding external-init to opt_mem

### DIFF
--- a/passes/memory/memory.cc
+++ b/passes/memory/memory.cc
@@ -31,7 +31,7 @@ struct MemoryPass : public Pass {
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
-		log("    memory [-norom] [-nomap] [-nordff] [-nowiden] [-nosat] [-memx] [-no-rw-check] [-bram <bram_rules>] [selection]\n");
+		log("    memory [-external-init] [-norom] [-nomap] [-nordff] [-nowiden] [-nosat] [-memx] [-no-rw-check] [-bram <bram_rules>] [selection]\n");
 		log("\n");
 		log("This pass calls all the other memory_* passes in a useful order:\n");
 		log("\n");
@@ -59,6 +59,7 @@ struct MemoryPass : public Pass {
 		bool flag_nomap = false;
 		bool flag_nordff = false;
 		bool flag_memx = false;
+		string opt_mem_opts;
 		string memory_dff_opts;
 		string memory_bram_opts;
 		string memory_share_opts;
@@ -68,6 +69,10 @@ struct MemoryPass : public Pass {
 
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++) {
+			if (args[argidx] == "-external-init") {
+				opt_mem_opts += " -external-init";
+				continue;
+			}
 			if (args[argidx] == "-norom") {
 				flag_norom = true;
 				continue;
@@ -105,7 +110,7 @@ struct MemoryPass : public Pass {
 		}
 		extra_args(args, argidx, design);
 
-		Pass::call(design, "opt_mem");
+		Pass::call(design, "opt_mem" + opt_mem_opts);
 		Pass::call(design, "opt_mem_priority");
 		Pass::call(design, "opt_mem_feedback");
 		if (!flag_norom)

--- a/tests/opt/opt_mem_external.ys
+++ b/tests/opt/opt_mem_external.ys
@@ -1,0 +1,55 @@
+read_verilog << EOF
+module Mem #(
+    parameter WIDTH = 8,
+    parameter SIZE = 16,
+    parameter IDX_SIZE = 16
+) (
+    input wire [WIDTH-1:0] addr,
+    input wire [WIDTH-1:0] write_data,
+    input wire write_en,
+
+    input wire clk,
+
+    output reg [WIDTH-1:0] read_data,
+
+);
+  reg [WIDTH-1:0] mem[SIZE-1:0];
+
+  always @(posedge clk) begin
+    if (write_en)
+      mem[addr0[IDX_SIZE-1:0]] <= write_data;
+
+    read_data <= mem[addr0[IDX_SIZE-1:0]];
+  end
+
+endmodule
+
+module test_keep_at_instance (clk, addr, data);
+
+input wire clk;
+input wire [15:0] addr;
+output wire[7:0] data;
+
+Mem mem (
+    .clk(clk),
+    .addr(addr),
+    .read_data(data),
+    .write_en(1'b0),
+    .write_data()
+);
+
+endmodule
+
+EOF
+
+hierarchy -auto-top;
+flatten;
+proc;
+
+select -assert-any t:$mem*
+opt_mem -external-init
+select -assert-any t:$mem*
+
+select -assert-any t:$mem*
+opt_mem
+select -assert-none t:$mem*


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
The aim is to add a way to prevent memory that has never been written/initialised by the design itself, but might be initialised by the external (CPU/DMA writing to the memory directly in a SoC system).  

_Explain how this is achieved._
A new flag is added for the `memory` pass and `opt_mem` pass. At the stage of removing lanes, if the flag is presented, it will add the lane to `swizzle` and preserve the lane. 

