### PR TITLE
Allow installing headers and `yosys-config` without the rest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -981,6 +981,12 @@ unit-test: libyosys.so
 clean-unit-test:
 	@$(MAKE) -C $(UNITESTPATH) clean
 
+install-dev: $(PROGRAM_PREFIX)yosys-config share
+	$(INSTALL_SUDO) mkdir -p $(DESTDIR)$(BINDIR)
+	$(INSTALL_SUDO) cp $(PROGRAM_PREFIX)yosys-config $(DESTDIR)$(BINDIR)
+	$(INSTALL_SUDO) mkdir -p $(DESTDIR)$(DATDIR)
+	$(INSTALL_SUDO) cp -r share/. $(DESTDIR)$(DATDIR)/.
+
 install: $(TARGETS) $(EXTRA_TARGETS)
 	$(INSTALL_SUDO) mkdir -p $(DESTDIR)$(BINDIR)
 	$(INSTALL_SUDO) cp $(filter-out libyosys.so,$(TARGETS)) $(DESTDIR)$(BINDIR)
@@ -1223,5 +1229,5 @@ echo-cxx:
 
 FORCE:
 
-.PHONY: all top-all abc test install install-abc docs clean mrproper qtcreator coverage vcxsrc
+.PHONY: all top-all abc test install-dev install install-abc docs clean mrproper qtcreator coverage vcxsrc
 .PHONY: config-clean config-clang config-gcc config-gcc-static config-gprof config-sudo


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

This is useful to be able to build a plugin like yosys-slang without having to build the entirety of Yosys, which can save a lot of time.

Although I don't expect Yosys itself to support it any time soon, for YoWASP I'd like to embed yosys-slang directly in the main Yosys binary, which also needs this feature to avoid loops in the dependency graph.

_Explain how this is achieved._

A new make target `install-dev` is introduced which only installs `yosys-config` and `share` (which are sufficient to build any C++ extension, I believe).
