### PR TITLE
write_firrtl: clear used names cache each invocation

### DIFF
--- a/backends/firrtl/firrtl.cc
+++ b/backends/firrtl/firrtl.cc
@@ -1223,6 +1223,7 @@ struct FirrtlBackend : public Backend {
 		Pass::call(design, "demuxmap");
 		Pass::call(design, "bwmuxmap");
 
+		used_names.clear();
 		namecache.clear();
 		autoid_counter = 0;
 
@@ -1262,6 +1263,7 @@ struct FirrtlBackend : public Backend {
 			}
 		}
 
+		used_names.clear();
 		namecache.clear();
 		autoid_counter = 0;
 	}


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Fixes #5231 

_Explain how this is achieved._

The cache of names that have been used when exporting the current design is global and was not being cleared on each invocation (namecache was cleared, used_names was not), so now we clear it each time. Ideally this probably wants the code being restructured to not depend on global variables, but I am not familiar with the name aliasing rules in firrtl and don't want to get stuck refactoring a pass its not clear if anyone uses, so this fix should work for now.

_If applicable, please suggest to reviewers how they can test the change._
