### PR TITLE
Make `dict` and `pool` const lookup methods never rehash the hashtable

### DIFF
--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -919,16 +919,21 @@ protected:
 		return 1;
 	}
 
-	int do_lookup(const K &key, Hasher::hash_t &hash) const
+	int do_lookup(const K &key, Hasher::hash_t &hash)
 	{
 		if (hashtable.empty())
 			return -1;
 
 		if (entries.size() * hashtable_size_trigger > hashtable.size()) {
-			((pool*)this)->do_rehash();
+			do_rehash();
 			hash = do_hash(key);
 		}
 
+		return do_lookup_internal(key, hash);
+	}
+
+	int do_lookup_internal(const K &key, Hasher::hash_t hash) const
+	{
 		int index = hashtable[hash];
 
 		while (index >= 0 && !ops.cmp(entries[index].udata, key)) {
@@ -937,6 +942,14 @@ protected:
 		}
 
 		return index;
+	}
+
+	int do_lookup_no_rehash(const K &key, Hasher::hash_t hash) const
+	{
+		if (hashtable.empty())
+			return -1;
+
+		return do_lookup_internal(key, hash);
 	}
 
 	int do_insert(const K &value, Hasher::hash_t &hash)
@@ -1100,14 +1113,14 @@ public:
 	int count(const K &key) const
 	{
 		Hasher::hash_t hash = do_hash(key);
-		int i = do_lookup(key, hash);
+		int i = do_lookup_no_rehash(key, hash);
 		return i < 0 ? 0 : 1;
 	}
 
 	int count(const K &key, const_iterator it) const
 	{
 		Hasher::hash_t hash = do_hash(key);
-		int i = do_lookup(key, hash);
+		int i = do_lookup_no_rehash(key, hash);
 		return i < 0 || i > it.index ? 0 : 1;
 	}
 
@@ -1123,7 +1136,7 @@ public:
 	const_iterator find(const K &key) const
 	{
 		Hasher::hash_t hash = do_hash(key);
-		int i = do_lookup(key, hash);
+		int i = do_lookup_no_rehash(key, hash);
 		if (i < 0)
 			return end();
 		return const_iterator(this, i);
@@ -1235,7 +1248,7 @@ public:
 	int at(const K &key) const
 	{
 		Hasher::hash_t hash = database.do_hash(key);
-		int i = database.do_lookup(key, hash);
+		int i = database.do_lookup_no_rehash(key, hash);
 		if (i < 0)
 			throw std::out_of_range("idict::at()");
 		return i + offset;
@@ -1244,7 +1257,7 @@ public:
 	int at(const K &key, int defval) const
 	{
 		Hasher::hash_t hash = database.do_hash(key);
-		int i = database.do_lookup(key, hash);
+		int i = database.do_lookup_no_rehash(key, hash);
 		if (i < 0)
 			return defval;
 		return i + offset;
@@ -1253,7 +1266,7 @@ public:
 	int count(const K &key) const
 	{
 		Hasher::hash_t hash = database.do_hash(key);
-		int i = database.do_lookup(key, hash);
+		int i = database.do_lookup_no_rehash(key, hash);
 		return i < 0 ? 0 : 1;
 	}
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Casting away const is dirty and it's pretty easy to avoid in this case.
It's also probably a tiny bit faster to avoid rehashes if we're only doing lookups.

_Explain how this is achieved._

Just refactor the code a little.