### PR TITLE
In the ABC pass, avoid scanning the entire module for each ABC run

### DIFF
--- a/kernel/ffinit.h
+++ b/kernel/ffinit.h
@@ -27,10 +27,10 @@ YOSYS_NAMESPACE_BEGIN
 
 struct FfInitVals
 {
-	const SigMap *sigmap;
+	const SigMapView *sigmap;
 	dict<SigBit, std::pair<State,SigBit>> initbits;
 
-	void set(const SigMap *sigmap_, RTLIL::Module *module)
+	void set(const SigMapView *sigmap_, RTLIL::Module *module)
 	{
 		sigmap = sigmap_;
 		initbits.clear();
@@ -126,7 +126,7 @@ struct FfInitVals
 		initbits.clear();
 	}
 
-	FfInitVals (const SigMap *sigmap, RTLIL::Module *module)
+	FfInitVals (const SigMapView *sigmap, RTLIL::Module *module)
 	{
 		set(sigmap, module);
 	}

--- a/kernel/ffmerge.h
+++ b/kernel/ffmerge.h
@@ -58,7 +58,7 @@ YOSYS_NAMESPACE_BEGIN
 
 struct FfMergeHelper
 {
-	const SigMap *sigmap;
+	const SigMapView *sigmap;
 	RTLIL::Module *module;
 	FfInitVals *initvals;
 

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -1353,7 +1353,8 @@ public:
 		return p;
 	}
 
-	// Merge sets if the given indices belong to different sets
+	// Merge sets if the given indices belong to different sets.
+	// Makes ifind(j) the root of the merged set.
 	void imerge(int i, int j)
 	{
 		i = ifind(i);

--- a/kernel/sigtools.h
+++ b/kernel/sigtools.h
@@ -237,6 +237,42 @@ using sort_by_name_id_guard = typename std::enable_if<std::is_same<T,RTLIL::Cell
 template<typename T>
 class SigSet<T, sort_by_name_id_guard<T>> : public SigSet<T, RTLIL::sort_by_name_id<typename std::remove_pointer<T>::type>> {};
 
+struct SigMapView
+{
+	mfp<SigBit> database;
+
+	// Modify bit to its representative
+	void apply(RTLIL::SigBit &bit) const
+	{
+		bit = database.find(bit);
+	}
+
+	void apply(RTLIL::SigSpec &sig) const
+	{
+		for (auto &bit : sig)
+			apply(bit);
+	}
+
+	RTLIL::SigBit operator()(RTLIL::SigBit bit) const
+	{
+		apply(bit);
+		return bit;
+	}
+
+	RTLIL::SigSpec operator()(RTLIL::SigSpec sig) const
+	{
+		apply(sig);
+		return sig;
+	}
+
+	RTLIL::SigSpec operator()(RTLIL::Wire *wire) const
+	{
+		SigSpec sig(wire);
+		apply(sig);
+		return sig;
+	}
+};
+
 /**
  * SigMap wraps a union-find "database"
  * to map SigBits of a module to canonical representative SigBits.
@@ -244,10 +280,8 @@ class SigSet<T, sort_by_name_id_guard<T>> : public SigSet<T, RTLIL::sort_by_name
  * If a SigBit has a const state (impl: bit.wire is nullptr),
  * it's promoted to a representative.
  */
-struct SigMap
+struct SigMap final : public SigMapView
 {
-	mfp<SigBit> database;
-
 	SigMap(RTLIL::Module *module = NULL)
 	{
 		if (module != NULL)
@@ -320,37 +354,6 @@ struct SigMap
 
 	inline void add(Wire *wire) { return add(RTLIL::SigSpec(wire)); }
 
-	// Modify bit to its representative
-	void apply(RTLIL::SigBit &bit) const
-	{
-		bit = database.find(bit);
-	}
-
-	void apply(RTLIL::SigSpec &sig) const
-	{
-		for (auto &bit : sig)
-			apply(bit);
-	}
-
-	RTLIL::SigBit operator()(RTLIL::SigBit bit) const
-	{
-		apply(bit);
-		return bit;
-	}
-
-	RTLIL::SigSpec operator()(RTLIL::SigSpec sig) const
-	{
-		apply(sig);
-		return sig;
-	}
-
-	RTLIL::SigSpec operator()(RTLIL::Wire *wire) const
-	{
-		SigSpec sig(wire);
-		apply(sig);
-		return sig;
-	}
-
 	// All non-const bits
 	RTLIL::SigSpec allbits() const
 	{
@@ -359,6 +362,107 @@ struct SigMap
 			if (bit.wire != nullptr)
 				sig.append(bit);
 		return sig;
+	}
+};
+
+/**
+ * SiValgMap wraps a union-find "database" to map SigBits of a module to
+ * canonical representative SigBits plus some optional Val value associated with the bits.
+ * Val has a commutative, associative, idempotent operator|=, a default constructor
+ * which constructs an identity element, and a copy constructor.
+ * SigBits that are connected share a set in the underlying database;
+ * the associated value is the "sum" of all the values associated with the contributing bits.
+ * If any of the SigBits in a set are a constant, the canonical SigBit is a constant.
+ */
+template <class Val>
+struct SigValMap final : public SigMapView
+{
+	dict<SigBit, Val> values;
+
+	void swap(SigValMap<Val> &other)
+	{
+		database.swap(other.database);
+		values.swap(other.values);
+	}
+
+	void clear()
+	{
+		database.clear();
+		values.clear();
+	}
+
+	// Rebuild SigMap for all connections in module
+	void set(RTLIL::Module *module)
+	{
+		int bitcount = 0;
+		for (auto &it : module->connections())
+			bitcount += it.first.size();
+
+		database.clear();
+		values.clear();
+		database.reserve(bitcount);
+
+		for (auto &it : module->connections())
+			add(it.first, it.second);
+	}
+
+	// Add connections from "from" to "to", bit-by-bit.
+	void add(const RTLIL::SigSpec& from, const RTLIL::SigSpec& to)
+	{
+		log_assert(GetSize(from) == GetSize(to));
+
+		for (int i = 0; i < GetSize(from); i++)
+		{
+			int bfi = database.lookup(from[i]);
+			int bti = database.lookup(to[i]);
+			if (bfi == bti) {
+				continue;
+			}
+
+			const RTLIL::SigBit &bf = database[bfi];
+			const RTLIL::SigBit &bt = database[bti];
+			if (bf.wire == nullptr) {
+				// bf is constant so make it the canonical representative.
+				database.imerge(bti, bfi);
+				merge_value(bt, bf);
+			} else {
+				// Make bt the canonical representative.
+				database.imerge(bfi, bti);
+				merge_value(bf, bt);
+			}
+		}
+	}
+
+	void addVal(const RTLIL::SigBit &bit, const Val &val)
+	{
+		values[database.find(bit)] |= val;
+	}
+
+	void addVal(const RTLIL::SigSpec &sig, const Val &val)
+	{
+		for (const auto &bit : sig)
+			addVal(bit, val);
+	}
+
+	Val apply_and_get_value(RTLIL::SigBit &bit) const
+	{
+		bit = database.find(bit);
+		auto it = values.find(bit);
+		return it == values.end() ? Val() : it->second;
+	}
+
+private:
+	void merge_value(const RTLIL::SigBit &from, const RTLIL::SigBit &to)
+	{
+		auto it = values.find(from);
+		if (it == values.end()) {
+			return;
+		}
+		// values[to] could resize the underlying `entries` so
+		// finish using `it` first.
+		Val v = it->second;
+		values.erase(it);
+		values[to] |= v;
 	}
 };
 

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -947,8 +947,8 @@ void AbcModuleState::abc_module(RTLIL::Design *design, RTLIL::Module *module, co
 	}
 
 	for (auto cell : module->cells())
-	for (auto &port_it : cell->connections())
-		mark_port(port_it.second);
+		for (auto &port_it : cell->connections())
+			mark_port(port_it.second);
 
 	if (clk_sig.size() != 0)
 		mark_port(clk_sig);

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -291,12 +291,15 @@ void AbcModuleState::extract_cell(RTLIL::Module *module, RTLIL::Cell *cell, bool
 				return;
 		}
 
-		if (keepff)
-			for (auto &c : ff.sig_q.chunks())
-				if (c.wire != nullptr)
-					c.wire->attributes[ID::keep] = 1;
-
-		map_signal(ff.sig_q, type, map_signal(ff.sig_d));
+		int gate_id = map_signal(ff.sig_q, type, map_signal(ff.sig_d));
+		if (keepff) {
+			SigBit bit = ff.sig_q;
+			if (assign_map(bit).wire != nullptr) {
+				signal_list[gate_id].is_port = true;
+			}
+			if (bit.wire != nullptr)
+				bit.wire->attributes[ID::keep] = 1;
+		}
 
 		ff.remove();
 		return;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

We have some large modules where a single ABC pass runs ABC thousands of times. The pass is very slow because in a couple of places it scans the entire module each time it runs ABC. Without too much work we can avoid this and get significant speedups. For example on one of our real-world examples this PR speeds up the ABC pass by 6x.

_Explain how this is achieved._

One problem is rebuilding `assign_map` from scratch for every ABC call. Instead we can build it once and maintain it incrementally as the module is modified.

Another problem is scanning all module wires and cells to call `mark_port()`. This is a bit trickier; we need to introduce a reverse map from canonical `SigBit`s to the module wires and cells associated with each bit, and maintain that as the module is modified.

Another problem is that constructing `FfInitVals` requires iterating over all module wires, and we were constructing one of these in every ABC run. We don't really need to, because the wires don't meaningfully change during this pass. So just construct a single `FfInitVals` for the module and use it for all ABC runs.

The use of global variables and the very large `abc_module()` function make things a bit less clear than they need to be, so I started off the PR by cleaning that up a bit.

_If applicable, please suggest to reviewers how they can test the change._

This PR is intended to not change results at all, and in my limited testing it doesn't. I have checked that some of our very large circuits are not affected by this PR.