### PR TITLE
opt_dff: implement simplify_patterns

### DIFF
--- a/tests/arch/quicklogic/pp3/fsm.ys
+++ b/tests/arch/quicklogic/pp3/fsm.ys
@@ -11,8 +11,8 @@ sat -verify -prove-asserts -show-public -set-at 1 in_reset 1 -seq 20 -prove-skip
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd fsm # Constrain all select calls below inside the top module
 
-select -assert-count 1 t:LUT2
-select -assert-count 9 t:LUT3
+select -assert-count 2 t:LUT2
+select -assert-count 4 t:LUT3
 select -assert-count 4 t:dffepc
 select -assert-count 1 t:logic_0
 select -assert-count 1 t:logic_1
@@ -20,4 +20,4 @@ select -assert-count 3 t:inpad
 select -assert-count 2 t:outpad
 select -assert-count 1 t:ckpad
 
-select -assert-none t:LUT2 t:LUT3 t:dffepc t:logic_0 t:logic_1 t:inpad t:outpad t:ckpad %% t:* %D
+select -assert-none t:LUT2 t:LUT3 t:LUT4 t:dffepc t:logic_0 t:logic_1 t:inpad t:outpad t:ckpad %% t:* %D


### PR DESCRIPTION
This change implements `simplify_patterns` function from `opt_dff`. Activation patterns for dff can be viewed as boolean formulas in CNF, and so can be optimized with some rules. This implementation uses two of them: 

- Removing complimentary variables - so for example `(A + !B)(A + B + C)` becomes `(A + !B)(A + C)`
- Removing redundant terms - so for example `(A)(A + B + C)` becomes `(A)`

This pr also include changes for `quicklogic/pp3/fsm.ys` test, the reason for this is that the new activation patterns for some dff in design, maps differently to logic primitives. Using same `iverilog` testing technique as in `tests/asicworld/` shows that they both share the same behavior. 
