### PR TITLE
Use unordered_map instead of dict for IdString's char* to index storage.

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -35,7 +35,7 @@ YOSYS_NAMESPACE_BEGIN
 bool RTLIL::IdString::destruct_guard_ok = false;
 RTLIL::IdString::destruct_guard_t RTLIL::IdString::destruct_guard;
 std::vector<char*> RTLIL::IdString::global_id_storage_;
-dict<char*, int> RTLIL::IdString::global_id_index_;
+std::unordered_map<std::string_view, int> RTLIL::IdString::global_id_index_;
 #ifndef YOSYS_NO_IDS_REFCNT
 std::vector<int> RTLIL::IdString::global_refcount_storage_;
 std::vector<int> RTLIL::IdString::global_free_idx_list_;

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -23,6 +23,9 @@
 #include "kernel/yosys_common.h"
 #include "kernel/yosys.h"
 
+#include <string_view>
+#include <unordered_map>
+
 YOSYS_NAMESPACE_BEGIN
 
 namespace RTLIL
@@ -122,7 +125,7 @@ struct RTLIL::IdString
 	} destruct_guard;
 
 	static std::vector<char*> global_id_storage_;
-	static dict<char*, int> global_id_index_;
+	static std::unordered_map<std::string_view, int> global_id_index_;
 #ifndef YOSYS_NO_IDS_REFCNT
 	static std::vector<int> global_refcount_storage_;
 	static std::vector<int> global_free_idx_list_;


### PR DESCRIPTION
`dict` is pretty slow when you don't ever need to iterate the container and the hash function for `char*` in `dict` hashes for every single byte in the string, likely doing significantly more work than `std::hash`.

## What are the reasons/motivation for this change? 

A private flatten benchmark shows that this change provides a 2-4x improvement in `IdString`s constructor:
<img width="1267" height="284" alt="Screenshot 2025-07-22 at 3 56 41 PM" src="https://github.com/user-attachments/assets/89ae76b6-4e8f-438a-aa47-b2682e2c6153" />
<img width="449" height="130" alt="Screenshot 2025-07-22 at 3 57 14 PM" src="https://github.com/user-attachments/assets/ae6890e8-70c1-464a-8f1e-d479faa89ee5" />



