### PR TITLE
Fix GCC compiler warning

### DIFF
--- a/kernel/io.h
+++ b/kernel/io.h
@@ -392,7 +392,7 @@ template <typename... Args>
 inline std::string format_emit_toplevel(std::string_view fmt, bool has_escapes, const FoundFormatSpec* specs, const Args &... args)
 {
 	std::string result;
-	int dynamic_ints[2] = { 0, 0 };
+	int dynamic_ints[3] = { 0, 0, 0 };
 	format_emit(result, fmt, 0, has_escapes, specs, dynamic_ints, DynamicIntCount::NONE, args...);
 	return result;
 }


### PR DESCRIPTION
This is warning introduced in https://github.com/YosysHQ/yosys/pull/5221 so please @rocallahan check if this seems right for you.

```
[test-compile (ubuntu-latest, gcc-10): kernel/io.h#L373](https://github.com/YosysHQ/yosys/commit/1d229ae254eae9a8042f6c73a424a61e40fcb381#annotation_37197972849)
array subscript 2 is outside array bounds of ‘int [2]’ [-Warray-bounds]
```