### PR TITLE
docs: mention Yosys Discourse group and blog

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,8 @@
 contact_links:
-  - name: Discussions
-    url: https://github.com/YosysHQ/yosys/discussions
-    about: "Have a question? Ask it on our discussions page!"
-  - name: Community Slack
-    url: https://join.slack.com/t/yosyshq/shared_invite/zt-1aopkns2q-EiQ97BeQDt_pwvE41sGSuA
-    about: "Yosys Community Slack"
+  - name: Discourse
+    url: https://yosyshq.discourse.group
+    about: "Have a question? Ask it on our Discourse group!"
   - name: IRC Channel
     url: https://web.libera.chat/#yosys
     about: "#yosys on irc.libera.chat"
- 
+

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Web Site and Other Resources
 More information and documentation can be found on the Yosys web site:
 - https://yosyshq.net/yosys/
 
+If you have any Yosys-related questions, please post them on the Discourse group:
+- https://yosyshq.discourse.group
+
 Documentation from this repository is automatically built and available on Read
 the Docs:
 - https://yosyshq.readthedocs.io/projects/yosys
@@ -33,6 +36,9 @@ Users interested in formal verification might want to use the formal
 verification front-end for Yosys, SBY:
 - https://yosyshq.readthedocs.io/projects/sby/
 - https://github.com/YosysHQ/sby
+
+The Yosys blog has news and articles from users:
+- https://blog.yosyshq.com
 
 
 Installation
@@ -242,7 +248,7 @@ Note that there is no need to build the manual if you just want to read it.
 Simply visit https://yosys.readthedocs.io/en/latest/ instead.
 
 In addition to those packages listed above for building Yosys from source, the
-following are used for building the website: 
+following are used for building the website:
 
 	$ sudo apt install pdf2svg faketime
 
@@ -258,7 +264,7 @@ build process for the website.  Or, run the following:
 Or for MacOS, using homebrew:
 
   $ brew install basictex
-  $ sudo tlmgr update --self   
+  $ sudo tlmgr update --self
   $ sudo tlmgr install collection-latexextra latexmk tex-gyre
 
 The Python package, Sphinx, is needed along with those listed in
@@ -268,5 +274,5 @@ The Python package, Sphinx, is needed along with those listed in
 
 From the root of the repository, run `make docs`.  This will build/rebuild yosys
 as necessary before generating the website documentation from the yosys help
-commands.  To build for pdf instead of html, call 
+commands.  To build for pdf instead of html, call
 `make docs DOC_TARGET=latexpdf`.


### PR DESCRIPTION
Since the Slack has been deprecated, I thought it might be a good idea to direct users to the Discourse in the readme. I couldn't find any other direct links to it on the Yosys website or elsewhere. This is similar for the blog too.

Happy to adjust wording if needed.

My editor has removed some trailing whitespace later in the file, that is the reason for those diffs.

_(this is the same as #5261, but my fork was severely outdated, so I've redone the PR to clean things up)_
