### PR TITLE
raise_error: Add -always

### DIFF
--- a/tests/bugpoint/raise_error.ys
+++ b/tests/bugpoint/raise_error.ys
@@ -14,6 +14,12 @@ EOF
 select -assert-mod-count 3 =*
 design -stash read
 
+# empty design does not raise_error
+design -reset
+logger -expect log "'raise_error' attribute not found" 1
+raise_error
+logger -check-expected
+
 # raise_error with int exits with status
 design -load read
 bugpoint -suffix error -yosys ../../yosys -command raise_error -expect-return 7
@@ -41,3 +47,8 @@ rename top abc
 bugpoint -suffix error -yosys ../../yosys -command "raise_error -stderr" -err-grep "help me" -expect-return 1
 select -assert-mod-count 1 =*
 select -assert-mod-count 1 other
+
+# empty design can raise_error -always
+design -reset
+bugpoint -suffix error -yosys ../../yosys -command "raise_error -always" -grep "ERROR: No 'raise_error' attribute found" -expect-return 1
+bugpoint -suffix error -yosys ../../yosys -command "raise_error -always -stderr" -err-grep "No 'raise_error' attribute found" -expect-return 1

--- a/tests/bugpoint/raise_error.ys
+++ b/tests/bugpoint/raise_error.ys
@@ -26,6 +26,12 @@ bugpoint -suffix error -yosys ../../yosys -command raise_error -expect-return 7
 select -assert-mod-count 1 =*
 select -assert-mod-count 1 top
 
+# raise_error -always still uses 'raise_error' attribute if possible
+design -load read
+bugpoint -suffix error -yosys ../../yosys -command "raise_error -always" -expect-return 7
+select -assert-mod-count 1 =*
+select -assert-mod-count 1 top
+
 # raise_error with string prints message and exits with 1
 design -load read
 rename top abc


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

> I would have expected for raise_error to have a primary mode of behavior to just raise an error rather than to raise it based on an attribute

_Originally posted by @widlarizer in https://github.com/YosysHQ/yosys/pull/5068#pullrequestreview-3064178058_

_Explain how this is achieved._

Calling `raise_error -always` will always raise an error, even if there is no `raise_error` attribute in the design.  If the attribute does exist, it will still use it, but otherwise it falls back to a default error message.

_If applicable, please suggest to reviewers how they can test the change._
