### PR TITLE
verificsva: Fix typo in the cover only followed-by operator support

### DIFF
--- a/frontends/verific/verificsva.cc
+++ b/frontends/verific/verificsva.cc
@@ -1616,7 +1616,7 @@ struct VerificSvaImporter
 				inst->Type() == PRIM_SVA_NON_OVERLAPPED_IMPLICATION ||
 				(mode_cover && (
 					inst->Type() == PRIM_SVA_OVERLAPPED_FOLLOWED_BY ||
-					inst->Type() == PRIM_SVA_NON_OVERLAPPED_IMPLICATION)))
+					inst->Type() == PRIM_SVA_NON_OVERLAPPED_FOLLOWED_BY)))
 		{
 			Net *antecedent_net = inst->GetInput1();
 			Net *consequent_net = inst->GetInput2();


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

The code added in f019e44e7 contains a tab-completion typo, meaning it only added support for the overlapped followed-by operator, not the non-overlapped one.

_Explain how this is achieved._

Obvious typo fix

_If applicable, please suggest to reviewers how they can test the change._

@mmicko is currently working on a feature that will make use of the operator and exercise this functionality.