### PR TITLE
Track wire drivers in cutpoint

### DIFF
--- a/tests/various/cutpoint_blackbox.ys
+++ b/tests/various/cutpoint_blackbox.ys
@@ -87,3 +87,27 @@ end
 EOT
 cutpoint -blackbox
 check -assert
+
+# also concatenated signals, and signals between two inout ports
+design -load hier
+delete top =bb
+read_verilog << EOT
+module top(input [1:0] a, b, output [1:0] o);
+    wire [1:0] c, d, e;
+    bb #(.SOME_PARAM(1)) bb1 (.a ({a[0], e[1]}), .b (b), .o (c));
+    bb #(.SOME_PARAM(2)) bb2 (.a ({c[1], a[0]}), .b (c), .o (d));
+    wb wb1 (.a (a), .b (b), .o (e));
+    some_mod some_inst (.a (c), .b (d), .c (e), .o (o));
+endmodule
+EOT
+read_rtlil << EOT
+attribute \blackbox 1
+module \bb
+    parameter \SOME_PARAM 0
+    wire inout 3 width 2 \o
+    wire inout 2 width 2 \b
+    wire inout 1 width 2 \a
+end
+EOT
+cutpoint -blackbox
+check -assert

--- a/tests/various/cutpoint_blackbox.ys
+++ b/tests/various/cutpoint_blackbox.ys
@@ -70,3 +70,20 @@ design -load gold
 select -read cutpoint.gate.sel
 # nothing in gold but not gate
 select -assert-none % %n
+
+# replacing the blackbox with a verific-style unknown module should work too
+# (note this specific example loses the values of SOME_PARAM which would
+#  normally be retained by verific)
+design -load hier
+delete =bb
+read_rtlil << EOT
+attribute \blackbox 1
+module \bb
+    parameter \SOME_PARAM 0
+    wire inout 3 \o
+    wire inout 2 \b
+    wire inout 1 \a
+end
+EOT
+cutpoint -blackbox
+check -assert


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Fix #5235, and more generally: wires connected to inout ports end up with multiple drivers after `cutpoint`.

_Explain how this is achieved._

We iterate over the design and find all `SigBit`s corresponding to a cell output port (not inout), or a module input.  If any bits of an inout port have a known driver, treat the port as an input.  If there are no bits with a known driver, treat the port as an output, and mark each bit as having a driver.

_If applicable, please suggest to reviewers how they can test the change._

The extra test should fail without this change.
With Verific, use `verific -set-info VERI-1063` to downgrade the error, and then load the same test design but with the `bb` module removed (no need to have the extra `read_rtlil` since that will automatically be produced when importing from Verific).  Then run `hierarchy -top top; cutpoint -blackbox; check -assert` after loading the design.
