### PR TITLE
pyosys: support trailing defaulted source_location arguments

### DIFF
--- a/kernel/register.h
+++ b/kernel/register.h
@@ -116,7 +116,7 @@ struct ScriptPass : Pass
 	RTLIL::Design *active_design;
 	std::string active_run_from, active_run_to;
 
-	ScriptPass(std::string name, std::string short_help = "** document me **", source_location location = source_location::current()) : 
+	ScriptPass(std::string name, std::string short_help = "** document me **", source_location location = source_location::current()) :
 		Pass(name, short_help, location) { }
 
 	virtual void script() = 0;

--- a/misc/py_wrap_generator.py
+++ b/misc/py_wrap_generator.py
@@ -200,7 +200,7 @@ class WType:
 
 			t.cont = candidate
 			if(t.name not in known_containers):
-				return None	
+				return None
 			return t
 
 		prefix = ""
@@ -447,7 +447,7 @@ class PythonDictTranslator(Translator):
 			if types[0].attr_type != attr_types.star:
 				text += "*"
 			text += key_tmp_name + "->get_cpp_obj()"
-		
+
 		text += ", "
 		if types[1].name not in classnames:
 			text += val_tmp_name
@@ -457,7 +457,7 @@ class PythonDictTranslator(Translator):
 			text += val_tmp_name + "->get_cpp_obj()"
 		text += "));\n" + prefix + "}"
 		return text
-	
+
 	#Generate c++ code to translate to a boost::python::dict
 	@classmethod
 	def translate_cpp(c, varname, types, prefix, ref):
@@ -498,7 +498,7 @@ class DictTranslator(PythonDictTranslator):
 #Sub_type for std::map
 class MapTranslator(PythonDictTranslator):
 	insert_name = "insert"
-	orig_name = "std::map"	
+	orig_name = "std::map"
 
 #Translator for std::pair. Derived from PythonDictTranslator because the
 #gen_type function is the same (because both have two template parameters)
@@ -684,7 +684,7 @@ class Attribute:
 		if self.wtype.name in known_containers:
 			return known_containers[self.wtype.name].typename
 		return prefix + self.wtype.name
-		
+
 	#Generate Translation code for the attribute
 	def gen_translation(self):
 		if self.wtype.name in known_containers:
@@ -948,7 +948,7 @@ class WClass:
 			text = "\n\t\tclass_<" + self.name + base_info + ">(\"" + self.name + "\""
 			text += body
 		return text
-	
+
 
 	def contains_default_constr(self):
 		for c in self.found_constrs:
@@ -1773,7 +1773,7 @@ class WMember:
 		if self.wtype.name in classnames:
 			text += ")"
 		text += ";"
-		
+
 		if self.wtype.name in classnames:
 			text += "\n\t\treturn *ret_;"
 		elif self.wtype.name in known_containers:
@@ -1795,12 +1795,12 @@ class WMember:
 		text += "\n\t{"
 		text += ret.gen_translation()
 		text += "\n\t\tthis->get_cpp_obj()->" + self.name + " = " + ret.gen_call() + ";"
-		text += "\n\t}\n"		
+		text += "\n\t}\n"
 
 		return text;
 
 	def gen_boost_py(self):
-		text = "\n\t\t\t.add_property(\"" + self.name + "\", &" + self.member_of.name + "::get_var_py_" + self.name 
+		text = "\n\t\t\t.add_property(\"" + self.name + "\", &" + self.member_of.name + "::get_var_py_" + self.name
 		if not self.is_const:
 			text += ", &" + self.member_of.name + "::set_var_py_" + self.name
 		text += ")"
@@ -1926,7 +1926,7 @@ class WGlobal:
 		if self.wtype.name in classnames:
 			text += ")"
 		text += ";"
-		
+
 		if self.wtype.name in classnames:
 			text += "\n\t\treturn *ret_;"
 		elif self.wtype.name in known_containers:
@@ -1948,12 +1948,12 @@ class WGlobal:
 		text += "\n\t{"
 		text += ret.gen_translation()
 		text += "\n\t\t" + self.namespace + "::" + self.name + " = " + ret.gen_call() + ";"
-		text += "\n\t}\n"		
+		text += "\n\t}\n"
 
 		return text;
 
 	def gen_boost_py(self):
-		text = "\n\t\t\t.add_static_property(\"" + self.name + "\", &" + "YOSYS_PYTHON::get_var_py_" + self.name 
+		text = "\n\t\t\t.add_static_property(\"" + self.name + "\", &" + "YOSYS_PYTHON::get_var_py_" + self.name
 		if not self.is_const:
 			text += ", &YOSYS_PYTHON::set_var_py_" + self.name
 		text += ")"


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

pyosys broke with 6fdefee35ba7b1a63ab3f83e891f6f317ccd0fc3 as the generator couldn't interpret `source_location` arguments. This is for two reasons, the first that it doesn't recognise the type, but even if it did it would require a user to pass a `source_location` argument in from python as default arguments aren't supported in the wrapper.

_Explain how this is achieved._

This is fixed by special casing `source_location` when it is a trailing, defaulted argument for functions/classes, leaving it to take its default value. I also fix some trailing whitespace issues in the first two commits.

Before `6fdefee35` this generated:
```c++
// WRAPPED from "Pass(std::string name, std::string short_help = "** document me **");" in kernel/register
Pass(string name, string short_help) : YOSYS_NAMESPACE::Pass(name, short_help){}
```

After `6fdefee35` this generated (which doesn't compile):
```c++
// WRAPPED from "Auto generated default constructor" in kernel/register
Pass(){}
```

After the fix, this generates:
```c++
// WRAPPED from "Pass(std::string name, std::string short_help = "** document me **", source_location location = source_location::current());" in kernel/register
Pass(string name, string short_help) : YOSYS_NAMESPACE::Pass(name, short_help){}
```

_If applicable, please suggest to reviewers how they can test the change._

Do a pyosys build
