### PR TITLE
synth_gatemate: add -noconstmult option

### DIFF
--- a/techlibs/gatemate/mul_map.v
+++ b/techlibs/gatemate/mul_map.v
@@ -26,6 +26,9 @@ module \$__MULMXN (A, B, Y);
 	parameter B_WIDTH = 1;
 	parameter Y_WIDTH = 1;
 
+	parameter [A_WIDTH-1:0] _TECHMAP_CONSTMSK_A_ = {A_WIDTH{1'b0}};
+	parameter [A_WIDTH-1:0] _TECHMAP_CONSTMSK_B_ = {B_WIDTH{1'b0}};
+
 	(* force_downto *)
 	input [A_WIDTH-1:0] A;
 	(* force_downto *)
@@ -37,6 +40,11 @@ module \$__MULMXN (A, B, Y);
 	localparam B_ADJWIDTH = B_WIDTH + (B_SIGNED ? 0 : 1);
 
 	generate
+`ifdef NO_CONST_MULT
+		if (|_TECHMAP_CONSTMSK_A_ != 0 || |_TECHMAP_CONSTMSK_B_ != 0) begin
+			wire _TECHMAP_FAIL_ = 1'b1;
+		end
+`endif
 		if (A_SIGNED) begin: blkA
 			wire signed [A_ADJWIDTH-1:0] Aext = $signed(A);
 		end


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
With the CC_MULT instantiation in nextpnr implemented, it was noticed by some testers that design area increased. For at least one design, this is because multiplication by a constant with a low number of 1 bits was mapped to a CC_MULT, so many of the multiplier columns were redundant. In this context, it seems like a reasonable idea to map variable-by-variable multiplication to CC_MULT, but let Yosys handle variable-by-constant multiplication (presumably through shift-and-add).

_Explain how this is achieved._
When `-noconstmult` is enabled and we detect constant bits on either side, we fall back to letting Yosys handle the multiplication. This is an *incredibly* rough heuristic, but it's still a finer grain than all-or-nothing.

_If applicable, please suggest to reviewers how they can test the change._
Compare area usage between full inference (the default), `-noconstmult` and `-nomult` on a design.

Here's 108-litex-linux with full inference:
```
Info: Device utilisation:
Info:               USR_RSTN:       1/      1   100%
Info:               CPE_COMP:     218/  20480     1%
Info:            CPE_CPLINES:     359/  20480     1%
Info:                   GPIO:      38/    162    23%
Info:                  CLKIN:       1/      1   100%
Info:                 GLBOUT:       1/      1   100%
Info:                    PLL:       1/      4    25%
Info:               CFG_CTRL:       0/      1     0%
Info:                    RAM:      16/     32    50%
Info:                 SERDES:       0/      1     0%
Info:                 CPE_LT:   21718/  40960    53%
Info:                 CPE_FF:    6613/  40960    16%
Info:              CPE_RAMIO:    2690/  40960     6%
```

with `-noconstmult`:
```
Info: Device utilisation:
Info:               USR_RSTN:       1/      1   100%
Info:               CPE_COMP:     118/  20480     0%
Info:            CPE_CPLINES:     241/  20480     1%
Info:                   GPIO:      38/    162    23%
Info:                  CLKIN:       1/      1   100%
Info:                 GLBOUT:       1/      1   100%
Info:                    PLL:       1/      4    25%
Info:               CFG_CTRL:       0/      1     0%
Info:                    RAM:      16/     32    50%
Info:                 SERDES:       0/      1     0%
Info:                 CPE_LT:   23682/  40960    57%
Info:                 CPE_FF:    6613/  40960    16%
Info:              CPE_RAMIO:    2690/  40960     6%
```

with `-nomult`
```
Info: Device utilisation:
Info:               USR_RSTN:       1/      1   100%
Info:               CPE_COMP:       0/  20480     0%
Info:            CPE_CPLINES:     102/  20480     0%
Info:                   GPIO:      38/    162    23%
Info:                  CLKIN:       1/      1   100%
Info:                 GLBOUT:       1/      1   100%
Info:                    PLL:       1/      4    25%
Info:               CFG_CTRL:       0/      1     0%
Info:                    RAM:      16/     32    50%
Info:                 SERDES:       0/      1     0%
Info:                 CPE_LT:   25388/  40960    61%
Info:                 CPE_FF:    6613/  40960    16%
Info:              CPE_RAMIO:    2690/  40960     6%
```