### PR TITLE
Bump nix on CI

### DIFF
--- a/.github/workflows/extra-builds.yml
+++ b/.github/workflows/extra-builds.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           submodules: true
           persist-credentials: false
-      - uses: cachix/install-nix-action@v26
+      - uses: cachix/install-nix-action@v31
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.18.1/install
+          install_url: https://releases.nixos.org/nix/nix-2.30.0/install
       - run: nix build .?submodules=1 -L


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Current version of nix is missing support for macos-15 (sequoia).  macos-latest is currently transitioning to macos-15.  nix builds on macos are failing.

_Explain how this is achieved._

Bump the nix version so that it has sequoia support.

_If applicable, please suggest to reviewers how they can test the change._

CI should pass: https://github.com/YosysHQ/yosys/actions/runs/16842411384/job/47716064329?pr=5276
