### PR TITLE
Emil/fix simplify initstate

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -3369,13 +3369,14 @@ skip_dynamic_range_lvalue_expansion:;
 				wire->str = stringf("$initstate$%d_wire", myidx);
 				while (wire->simplify(true, 1, -1, false)) { }
 
-				auto cell = std::make_unique<AstNode>(location, AST_CELL, std::make_unique<AstNode>(location, AST_CELLTYPE), std::make_unique<AstNode>(location, AST_ARGUMENT, std::make_unique<AstNode>(location, AST_IDENTIFIER)));
+				auto cell_owned = std::make_unique<AstNode>(location, AST_CELL, std::make_unique<AstNode>(location, AST_CELLTYPE), std::make_unique<AstNode>(location, AST_ARGUMENT, std::make_unique<AstNode>(location, AST_IDENTIFIER)));
+				auto* cell = cell_owned.get();
 				cell->str = stringf("$initstate$%d", myidx);
 				cell->children[0]->str = "$initstate";
 				cell->children[1]->str = "\\Y";
 				cell->children[1]->children[0]->str = wire->str;
 				cell->children[1]->children[0]->id2ast = wire;
-				current_ast_mod->children.push_back(std::move(cell));
+				current_ast_mod->children.push_back(std::move(cell_owned));
 				while (cell->simplify(true, 1, -1, false)) { }
 
 				newNode = std::make_unique<AstNode>(location, AST_IDENTIFIER);

--- a/tests/verilog/fcall_smoke.ys
+++ b/tests/verilog/fcall_smoke.ys
@@ -1,0 +1,15 @@
+read_verilog -sv <<EOT
+module smoke_initstate (
+	input resetn,
+    input clk,
+    input a
+);
+    always @(posedge clk) begin
+        assert property ($stable(a));
+        assert property ($changed(a));
+        assert property ($rose(a));
+        assert property ($fell(a));
+		assume(resetn == !$initstate);
+	end
+endmodule
+EOT


### PR DESCRIPTION
Crash bugfix for #5135 which wasn't discovered due to missing coverage for features used in SBY. Add a smoke test that only checks that none of the used system functions crash the frontend