### PR TITLE
check: Limit detailed cell edge checking for $pmux and $bmux

### DIFF
--- a/passes/cmds/check.cc
+++ b/passes/cmds/check.cc
@@ -195,16 +195,23 @@ struct CheckPass : public Pass {
 					// in port widths are those for us to check.
 					if (!cell->type.in(
 							ID($add), ID($sub),
-							ID($shl), ID($shr), ID($sshl), ID($sshr), ID($shift), ID($shiftx)))
+							ID($shl), ID($shr), ID($sshl), ID($sshr), ID($shift), ID($shiftx),
+							ID($pmux), ID($bmux)))
 						return false;
 
 					int in_widths = 0, out_widths = 0;
 
-					for (auto &conn : cell->connections()) {
-						if (cell->input(conn.first))
-							in_widths += conn.second.size();
-						if (cell->output(conn.first))
-							out_widths += conn.second.size();
+					if (cell->type.in(ID($pmux), ID($bmux))) {
+						// We're skipping inputs A and B, since each of their bits contributes only one edge
+						in_widths = GetSize(cell->getPort(ID::S));
+						out_widths = GetSize(cell->getPort(ID::Y));
+					} else {
+						for (auto &conn : cell->connections()) {
+							if (cell->input(conn.first))
+								in_widths += conn.second.size();
+							if (cell->output(conn.first))
+								out_widths += conn.second.size();
+						}
 					}
 
 					const int threshold = 1024;


### PR DESCRIPTION
This limit detailed cell edge checking for $pmux and $bmux when their S and Y ports become too large. While these cells can't have a quadratic number of edges between A, B and Y, they do have a quadratic number of edges between S and Y.

_What are the reasons/motivation for this change?_

Yosys getting stuck when running `check` on some real world designs, see #5282.

_Explain how this is achieved._

We already exclude other cell types that can have a quadratic number of cell edges from detailed analysis within `check`. This adds `$pmux` and `$bmux` to those cell types, but for them, we exclude ports A and B from the threshold computation, as those don't contribute to the quadratic behavior. 

_If applicable, please suggest to reviewers how they can test the change._

Fixes #5282