### PR TITLE
abstract: Add -initstates option

### DIFF
--- a/tests/various/abstract_initstates.ys
+++ b/tests/various/abstract_initstates.ys
@@ -1,0 +1,30 @@
+read_verilog <<EOT
+
+module half_clock (CLK, Q, magic);
+	input CLK;
+	output reg Q = 0;
+	input magic;
+	always @(posedge CLK)
+		Q <= ~Q;
+endmodule
+
+EOT
+proc
+design -save half_clock
+
+sat -set-init-undef -enable_undef -verify -seq 5 -set-at 1 Q 0
+sat -set-init-undef -enable_undef -falsify -seq 5 -set-at 1 Q 0 -set-at 2 Q 0
+sat -set-init-undef -enable_undef -falsify -seq 5 -set-at 2 Q 0 -set-at 3 Q 0
+abstract -state -initstates 1 */Q
+sat -set-init-undef -enable_undef -verify -seq 5 -set-at 1 Q 0 -set-at 2 Q 0
+sat -set-init-undef -enable_undef -falsify -seq 5 -set-at 2 Q 0 -set-at 3 Q 0
+
+design -load half_clock
+
+sat -set-init-undef -enable_undef -falsify -seq 5 -set-at 1 Q 0 -set-at 2 Q 0
+sat -set-init-undef -enable_undef -falsify -seq 5 -set-at 2 Q 0 -set-at 3 Q 0
+sat -set-init-undef -enable_undef -falsify -seq 5 -set-at 3 Q 0 -set-at 4 Q 0
+abstract -state -initstates 2 */Q
+sat -set-init-undef -enable_undef -verify -seq 5 -set-at 1 Q 0 -set-at 2 Q 0
+sat -set-init-undef -enable_undef -verify -seq 5 -set-at 1 Q 0 -set-at 2 Q 0 -set-at 3 Q 0
+sat -set-init-undef -enable_undef -falsify -seq 5 -set-at 3 Q 0 -set-at 4 Q 0


### PR DESCRIPTION
This adds a new `-initstates <n>` option to `abstract` which causes the enable condition for the abstraction to remain high for `n` initial (global clock) time steps.

_What are the reasons/motivation for this change?_

To support use cases of `abstract` where the enable condition is a fixed number of FV time steps, independent of any signals present in the target module. This is useful for scripts that are supposed to work across different designs and thus there may not be a known local enable condition present in the target module.

_Explain how this is achieved._

To obtain the signal for the enable condition, we add an `$initstate` and for values of `n > 1` we delay it by chaining `n - 1` `$ff` cells with an initial value of 1.

_If applicable, please suggest to reviewers how they can test the change._

This PR includes tests that verify the correct operation. Testing with other modes besides `-state` shouldn't be necessary, since this required no mode specific changes.