### PR TITLE
verilog: demote some parser errors to warnings again

### DIFF
--- a/frontends/verilog/verilog_error.cc
+++ b/frontends/verilog/verilog_error.cc
@@ -42,11 +42,27 @@ static void verr_at(std::string filename, int begin_line, char const *fmt, va_li
     exit(1);
 }
 
+static void vwarn_at(std::string filename, int begin_line, char const *fmt, va_list ap)
+{
+    char buffer[1024];
+    char *p = buffer;
+    p += vsnprintf(p, buffer + sizeof(buffer) - p, fmt, ap);
+    p += snprintf(p, buffer + sizeof(buffer) - p, "\n");
+    YOSYS_NAMESPACE_PREFIX log_file_warning(filename, begin_line, "%s", buffer);
+}
+
 [[noreturn]]
 void VERILOG_FRONTEND::err_at_loc(Location loc, char const *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
     verr_at(loc.begin.filename ? *(loc.begin.filename) : "UNKNOWN", loc.begin.line, fmt, args);
+}
+void VERILOG_FRONTEND::warn_at_loc(Location loc, char const *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    vwarn_at(loc.begin.filename ? *(loc.begin.filename) : "UNKNOWN", loc.begin.line, fmt, args);
+    va_end(args);
 }
 

--- a/frontends/verilog/verilog_error.h
+++ b/frontends/verilog/verilog_error.h
@@ -11,6 +11,7 @@ namespace VERILOG_FRONTEND
 {
     [[noreturn]]
     void err_at_loc(Location loc, char const *fmt, ...);
+    void warn_at_loc(Location loc, char const *fmt, ...);
 };
 
 YOSYS_NAMESPACE_END

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -2585,7 +2585,7 @@ assert:
 				node->str = *$1;
 		}
 		if (!$3)
-			warn_at_loc(@$, "SystemVerilog does not allow \"restrict\" without \"property\".");
+			warn_at_loc(@3, "SystemVerilog does not allow \"restrict\" without \"property\".");
 	} |
 	opt_sva_label TOK_RESTRICT opt_property TOK_LPAREN TOK_EVENTUALLY expr TOK_RPAREN TOK_SEMICOL {
 		if (mode->norestrict) {
@@ -2596,7 +2596,7 @@ assert:
 				node->str = *$1;
 		}
 		if (!$3)
-			warn_at_loc(@$, "SystemVerilog does not allow \"restrict\" without \"property\".");
+			warn_at_loc(@3, "SystemVerilog does not allow \"restrict\" without \"property\".");
 	};
 
 assert_property:

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -1304,7 +1304,7 @@ specify_item:
 		specify_rise_fall_ptr_t timing = std::move($9);
 
 		if (specify_edge != 0 && target->dat == nullptr)
-			err_at_loc(@3, "Found specify edge but no data spec.\n");
+			err_at_loc(@3, "Found specify edge but no data spec.");
 
 		auto cell_owned = std::make_unique<AstNode>(@$, AST_CELL);
 		auto cell = cell_owned.get();
@@ -1379,7 +1379,7 @@ specify_item:
 	TOK_ID TOK_LPAREN specify_edge expr specify_condition TOK_COMMA specify_edge expr specify_condition TOK_COMMA specify_triple specify_opt_triple TOK_RPAREN TOK_SEMICOL {
 		if (*$1 != "$setup" && *$1 != "$hold" && *$1 != "$setuphold" && *$1 != "$removal" && *$1 != "$recovery" &&
 				*$1 != "$recrem" && *$1 != "$skew" && *$1 != "$timeskew" && *$1 != "$fullskew" && *$1 != "$nochange")
-			err_at_loc(@1, "Unsupported specify rule type: %s\n", $1->c_str());
+			err_at_loc(@1, "Unsupported specify rule type: %s", $1->c_str());
 
 		auto src_pen = AstNode::mkconst_int(@3, $3 != 0, false, 1);
 		auto src_pol = AstNode::mkconst_int(@3, $3 == 'p', false, 1);
@@ -1518,19 +1518,19 @@ specify_rise_fall:
 		$$ = std::make_unique<struct specify_rise_fall>();
 		$$->rise = std::move(*$2);
 		$$->fall = std::move(*$4);
-		err_at_loc(@$, "Path delay expressions beyond rise/fall not currently supported. Ignoring.\n");
+		warn_at_loc(@$, "Path delay expressions beyond rise/fall not currently supported. Ignoring.");
 	} |
 	TOK_LPAREN specify_triple TOK_COMMA specify_triple TOK_COMMA specify_triple TOK_COMMA specify_triple TOK_COMMA specify_triple TOK_COMMA specify_triple TOK_RPAREN {
 		$$ = std::make_unique<struct specify_rise_fall>();
 		$$->rise = std::move(*$2);
 		$$->fall = std::move(*$4);
-		err_at_loc(@$, "Path delay expressions beyond rise/fall not currently supported. Ignoring.\n");
+		warn_at_loc(@$, "Path delay expressions beyond rise/fall not currently supported. Ignoring.");
 	} |
 	TOK_LPAREN specify_triple TOK_COMMA specify_triple TOK_COMMA specify_triple TOK_COMMA specify_triple TOK_COMMA specify_triple TOK_COMMA specify_triple TOK_COMMA specify_triple TOK_COMMA specify_triple TOK_COMMA specify_triple TOK_COMMA specify_triple TOK_COMMA specify_triple TOK_COMMA specify_triple TOK_RPAREN {
 		$$ = std::make_unique<struct specify_rise_fall>();
 		$$->rise = std::move(*$2);
 		$$->fall = std::move(*$4);
-		err_at_loc(@$, "Path delay expressions beyond rise/fall not currently supported. Ignoring.\n");
+		warn_at_loc(@$, "Path delay expressions beyond rise/fall not currently supported. Ignoring.");
 	}
 
 specify_triple:
@@ -2585,7 +2585,7 @@ assert:
 				node->str = *$1;
 		}
 		if (!$3)
-			err_at_loc(@$, "SystemVerilog does not allow \"restrict\" without \"property\".\n");
+			warn_at_loc(@$, "SystemVerilog does not allow \"restrict\" without \"property\".");
 	} |
 	opt_sva_label TOK_RESTRICT opt_property TOK_LPAREN TOK_EVENTUALLY expr TOK_RPAREN TOK_SEMICOL {
 		if (mode->norestrict) {
@@ -2596,7 +2596,7 @@ assert:
 				node->str = *$1;
 		}
 		if (!$3)
-			err_at_loc(@$, "SystemVerilog does not allow \"restrict\" without \"property\".\n");
+			warn_at_loc(@$, "SystemVerilog does not allow \"restrict\" without \"property\".");
 	};
 
 assert_property:


### PR DESCRIPTION
In #5135 I accidentally promoted some parser warnings to errors so I'm fixing the ones I can see