### PR TITLE
rename.cc: Fixup ports after -unescape

### DIFF
--- a/passes/cmds/rename.cc
+++ b/passes/cmds/rename.cc
@@ -598,6 +598,8 @@ struct RenamePass : public Pass {
 
 				for (auto &it : new_cell_names)
 					module->rename(it.first, it.second);
+
+				module->fixup_ports();
 			}
 		}
 		else

--- a/tests/various/rename_unescape.ys
+++ b/tests/various/rename_unescape.ys
@@ -39,3 +39,18 @@ select -assert-count 1 w:d__1
 select -assert-count 1 w:_e
 select -assert-count 1 w:wire_
 select -assert-count 1 w:$add$<<EOF:*$1_Y
+
+# Ports are updated during rename
+design -reset
+read_verilog << EOT
+module top(output \$e );
+submod \a$ (\$e );
+endmodule
+
+module submod(output \a[0] );
+    assign \a[0] = 0;
+endmodule
+EOT
+
+rename -unescape
+check


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

The following test fails with an assertion error:
```
read_verilog << EOT
module top(output \$e );
submod \a$ (\$e );
endmodule

module submod(output \a[0] );
    assign \a[0] = 0;
endmodule
EOT

rename -unescape
check
```

_Explain how this is achieved._

If a port is renamed, we need to call `module->fixup_ports()`.

_If applicable, please suggest to reviewers how they can test the change._

`tests/various/rename_unescape.ys` has been updated with the above testcase.