### PR TITLE
Remove redundant construction of `assign_map`.

### DIFF
--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -227,7 +227,7 @@ struct OptMergeWorker
 	}
 
 	OptMergeWorker(RTLIL::Design *design, RTLIL::Module *module, bool mode_nomux, bool mode_share_all, bool mode_keepdc) :
-		design(design), module(module), assign_map(module), mode_share_all(mode_share_all)
+		design(design), module(module), mode_share_all(mode_share_all)
 	{
 		total_count = 0;
 		ct.setup_internals();


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

We call 'assign_map.set()' below which wipes the `SigMap` and reconstructs it. This operation is expensive because it scans the whole module. I think it's better to make heavyweight operations more visible so I'm removing the less obvious operation.