### PR TITLE
Remove some `c_str()` calls where they're no longer needed as parameters to `stringf()`

### DIFF
--- a/backends/btor/btor.cc
+++ b/backends/btor/btor.cc
@@ -129,7 +129,7 @@ struct BtorWorker
 				std::replace(src.begin(), src.end(), ' ', '_');
 				if (srcsymbols.count(src) || module->count_id("\\" + src)) {
 					for (int i = 1;; i++) {
-						string s = stringf("%s-%d", src.c_str(), i);
+						string s = stringf("%s-%d", src, i);
 						if (!srcsymbols.count(s) && !module->count_id("\\" + s)) {
 							src = s;
 							break;
@@ -192,7 +192,7 @@ struct BtorWorker
 	void btorf_push(const string &id)
 	{
 		if (verbose) {
-			f << indent << stringf("  ; begin %s\n", id.c_str());
+			f << indent << stringf("  ; begin %s\n", id);
 			indent += "    ";
 		}
 	}
@@ -201,7 +201,7 @@ struct BtorWorker
 	{
 		if (verbose) {
 			indent = indent.substr(4);
-			f << indent << stringf("  ; end %s\n", id.c_str());
+			f << indent << stringf("  ; end %s\n", id);
 		}
 	}
 

--- a/backends/firrtl/firrtl.cc
+++ b/backends/firrtl/firrtl.cc
@@ -253,7 +253,7 @@ void emit_extmodule(RTLIL::Cell *cell, RTLIL::Module *mod_instance, std::ostream
 	const std::string extmoduleFileinfo = getFileinfo(cell);
 
 	// Emit extmodule header.
-	f << stringf("  extmodule %s: %s\n", exported_name.c_str(), extmoduleFileinfo.c_str());
+	f << stringf("  extmodule %s: %s\n", exported_name, extmoduleFileinfo);
 
 	// Emit extmodule ports.
 	for (auto wire : mod_instance->wires())
@@ -280,7 +280,7 @@ void emit_extmodule(RTLIL::Cell *cell, RTLIL::Module *mod_instance, std::ostream
 	// Emit extmodule "defname" field. This is the name of the verilog blackbox
 	// that is used when verilog is emitted, so we use the name of mod_instance
 	// here.
-	f << stringf("%sdefname = %s\n", indent.c_str(), blackbox_name.c_str());
+	f << stringf("%sdefname = %s\n", indent, blackbox_name);
 
 	// Emit extmodule generic parameters.
 	for (const auto &p : cell->parameters)
@@ -301,7 +301,7 @@ void emit_extmodule(RTLIL::Cell *cell, RTLIL::Module *mod_instance, std::ostream
 			param_name.end()
 		);
 
-		f << stringf("%sparameter %s = %s\n", indent.c_str(), param_name.c_str(), param_value.c_str());
+		f << stringf("%sparameter %s = %s\n", indent, param_name, param_value);
 	}
 
 	f << "\n";
@@ -417,7 +417,7 @@ struct FirrtlWorker
 			else
 			{
 				string wire_id = make_id(chunk.wire->name);
-				new_expr = stringf("bits(%s, %d, %d)", wire_id.c_str(), chunk.offset + chunk.width - 1, chunk.offset);
+				new_expr = stringf("bits(%s, %d, %d)", wire_id, chunk.offset + chunk.width - 1, chunk.offset);
 			}
 
 			if (expr.empty())
@@ -477,7 +477,7 @@ struct FirrtlWorker
 			instanceOf;
 
 		std::string cellFileinfo = getFileinfo(cell);
-		wire_exprs.push_back(stringf("%s" "inst %s%s of %s %s", indent.c_str(), cell_name.c_str(), cell_name_comment.c_str(), instanceName.c_str(), cellFileinfo.c_str()));
+		wire_exprs.push_back(stringf("%s" "inst %s%s of %s %s", indent, cell_name, cell_name_comment, instanceName, cellFileinfo));
 
 		for (auto it = cell->connections().begin(); it != cell->connections().end(); ++it) {
 			if (it->second.size() > 0) {
@@ -518,7 +518,7 @@ struct FirrtlWorker
 					//  as part of the coalesced subfield assignments for this wire.
 					register_reverse_wire_map(sourceExpr, *sinkSig);
 				} else {
-					wire_exprs.push_back(stringf("\n%s%s <= %s %s", indent.c_str(), sinkExpr.c_str(), sourceExpr.c_str(), cellFileinfo.c_str()));
+					wire_exprs.push_back(stringf("\n%s%s <= %s %s", indent, sinkExpr, sourceExpr, cellFileinfo));
 				}
 			}
 		}
@@ -535,7 +535,7 @@ struct FirrtlWorker
 			int max_shift_width_bits = FIRRTL_MAX_DSH_WIDTH_ERROR - 1;
 			string max_shift_string = stringf("UInt<%d>(%d)", max_shift_width_bits, (1<<max_shift_width_bits) - 1);
 			// Deal with the difference in semantics between FIRRTL and verilog
-			result = stringf("mux(gt(%s, %s), %s, bits(%s, %d, 0))", b_expr.c_str(), max_shift_string.c_str(), max_shift_string.c_str(), b_expr.c_str(), max_shift_width_bits - 1);
+			result = stringf("mux(gt(%s, %s), %s, bits(%s, %d, 0))", b_expr, max_shift_string, max_shift_string, b_expr, max_shift_width_bits - 1);
 		}
 		return result;
 	}
@@ -543,7 +543,7 @@ struct FirrtlWorker
 	void emit_module()
 	{
 		std::string moduleFileinfo = getFileinfo(module);
-		f << stringf("  module %s: %s\n", make_id(module->name), moduleFileinfo.c_str());
+		f << stringf("  module %s: %s\n", make_id(module->name), moduleFileinfo);
 		vector<string> port_decls, wire_decls, mem_exprs, cell_exprs, wire_exprs;
 
 		std::vector<Mem> memories = Mem::get_all_memories(module);
@@ -602,7 +602,7 @@ struct FirrtlWorker
 			if (cell->type.in(ID($not), ID($logic_not), ID($_NOT_), ID($neg), ID($reduce_and), ID($reduce_or), ID($reduce_xor), ID($reduce_bool), ID($reduce_xnor)))
 			{
 				string a_expr = make_expr(cell->getPort(ID::A));
-				wire_decls.push_back(stringf("%swire %s: UInt<%d> %s\n", indent.c_str(), y_id.c_str(), y_width, cellFileinfo.c_str()));
+				wire_decls.push_back(stringf("%swire %s: UInt<%d> %s\n", indent, y_id, y_width, cellFileinfo));
 
 				if (a_signed) {
 					a_expr = "asSInt(" + a_expr + ")";
@@ -610,7 +610,7 @@ struct FirrtlWorker
 
 				// Don't use the results of logical operations (a single bit) to control padding
 				if (!(cell->type.in(ID($eq), ID($eqx), ID($gt), ID($ge), ID($lt), ID($le), ID($ne), ID($nex), ID($reduce_bool), ID($logic_not)) && y_width == 1) ) {
-					a_expr = stringf("pad(%s, %d)", a_expr.c_str(), y_width);
+					a_expr = stringf("pad(%s, %d)", a_expr, y_width);
 				}
 
 				// Assume the FIRRTL width is a single bit.
@@ -622,27 +622,27 @@ struct FirrtlWorker
 					firrtl_width = a_width;
 				} else if (cell->type == ID($logic_not)) {
 					primop = "eq";
-					a_expr = stringf("%s, UInt(0)", a_expr.c_str());
+					a_expr = stringf("%s, UInt(0)", a_expr);
 				}
 				else if (cell->type == ID($reduce_and)) primop = "andr";
 				else if (cell->type == ID($reduce_or)) primop = "orr";
 				else if (cell->type == ID($reduce_xor)) primop = "xorr";
 				else if (cell->type == ID($reduce_xnor)) {
 					primop = "not";
-					a_expr = stringf("xorr(%s)", a_expr.c_str());
+					a_expr = stringf("xorr(%s)", a_expr);
 				}
 				else if (cell->type == ID($reduce_bool)) {
 					primop = "neq";
 					// Use the sign of the a_expr and its width as the type (UInt/SInt) and width of the comparand.
-					a_expr = stringf("%s, %cInt<%d>(0)", a_expr.c_str(), a_signed ? 'S' : 'U', a_width);
+					a_expr = stringf("%s, %cInt<%d>(0)", a_expr, a_signed ? 'S' : 'U', a_width);
 				}
 
-				string expr = stringf("%s(%s)", primop.c_str(), a_expr.c_str());
+				string expr = stringf("%s(%s)", primop, a_expr);
 
 				if ((firrtl_is_signed && !always_uint))
-					expr = stringf("asUInt(%s)", expr.c_str());
+					expr = stringf("asUInt(%s)", expr);
 
-				cell_exprs.push_back(stringf("%s%s <= %s %s\n", indent.c_str(), y_id.c_str(), expr.c_str(), cellFileinfo.c_str()));
+				cell_exprs.push_back(stringf("%s%s <= %s %s\n", indent, y_id, expr, cellFileinfo));
 				register_reverse_wire_map(y_id, cell->getPort(ID::Y));
 
 				continue;
@@ -654,13 +654,13 @@ struct FirrtlWorker
 				string a_expr = make_expr(cell->getPort(ID::A));
 				string b_expr = make_expr(cell->getPort(ID::B));
 				std::string cellFileinfo = getFileinfo(cell);
-				wire_decls.push_back(stringf("%swire %s: UInt<%d> %s\n", indent.c_str(), y_id.c_str(), y_width, cellFileinfo.c_str()));
+				wire_decls.push_back(stringf("%swire %s: UInt<%d> %s\n", indent, y_id, y_width, cellFileinfo));
 
 				if (a_signed) {
 					a_expr = "asSInt(" + a_expr + ")";
 					// Expand the "A" operand to the result width
 					if (a_width < y_width) {
-						a_expr = stringf("pad(%s, %d)", a_expr.c_str(), y_width);
+						a_expr = stringf("pad(%s, %d)", a_expr, y_width);
 						a_width = y_width;
 					}
 				}
@@ -670,7 +670,7 @@ struct FirrtlWorker
 					b_expr = "asSInt(" + b_expr + ")";
 					// Expand the "B" operand to the result width
 					if (b_width < y_width) {
-						b_expr = stringf("pad(%s, %d)", b_expr.c_str(), y_width);
+						b_expr = stringf("pad(%s, %d)", b_expr, y_width);
 						b_width = y_width;
 					}
 				}
@@ -680,11 +680,11 @@ struct FirrtlWorker
 				if (cell->type.in(ID($add), ID($sub), ID($mul), ID($div), ID($mod), ID($xor), ID($_XOR_), ID($xnor), ID($and), ID($_AND_), ID($or), ID($_OR_)))
 				{
 					if (a_width < y_width) {
-						a_expr = stringf("pad(%s, %d)", a_expr.c_str(), y_width);
+						a_expr = stringf("pad(%s, %d)", a_expr, y_width);
 						a_width = y_width;
 					}
 					if (b_width < y_width) {
-						b_expr = stringf("pad(%s, %d)", b_expr.c_str(), y_width);
+						b_expr = stringf("pad(%s, %d)", b_expr, y_width);
 						b_width = y_width;
 					}
 				}
@@ -856,23 +856,23 @@ struct FirrtlWorker
 				string expr;
 				// Deal with $xnor == ~^ (not xor)
 				if (primop == "xnor") {
-					expr = stringf("not(xor(%s, %s))", a_expr.c_str(), b_expr.c_str());
+					expr = stringf("not(xor(%s, %s))", a_expr, b_expr);
 				} else {
-					expr = stringf("%s(%s, %s)", primop.c_str(), a_expr.c_str(), b_expr.c_str());
+					expr = stringf("%s(%s, %s)", primop, a_expr, b_expr);
 				}
 
 				// Deal with FIRRTL's "shift widens" semantics, or the need to widen the FIRRTL result.
 				// If the operation is signed, the FIRRTL width will be 1 one bit larger.
 				if (extract_y_bits) {
-					expr = stringf("bits(%s, %d, 0)", expr.c_str(), y_width - 1);
+					expr = stringf("bits(%s, %d, 0)", expr, y_width - 1);
 				} else if (firrtl_is_signed && (firrtl_width + 1) < y_width) {
-					expr = stringf("pad(%s, %d)", expr.c_str(), y_width);
+					expr = stringf("pad(%s, %d)", expr, y_width);
 				}
 
 				if ((firrtl_is_signed && !always_uint))
-					expr = stringf("asUInt(%s)", expr.c_str());
+					expr = stringf("asUInt(%s)", expr);
 
-				cell_exprs.push_back(stringf("%s%s <= %s %s\n", indent.c_str(), y_id.c_str(), expr.c_str(), cellFileinfo.c_str()));
+				cell_exprs.push_back(stringf("%s%s <= %s %s\n", indent, y_id, expr, cellFileinfo));
 				register_reverse_wire_map(y_id, cell->getPort(ID::Y));
 
 				continue;
@@ -887,9 +887,9 @@ struct FirrtlWorker
 				string s_expr = make_expr(cell->getPort(ID::S));
 				wire_decls.push_back(stringf("%swire %s: UInt<%d> %s\n", indent.c_str(), y_id.c_str(), width, cellFileinfo.c_str()));
 
-				string expr = stringf("mux(%s, %s, %s)", s_expr.c_str(), b_expr.c_str(), a_expr.c_str());
+				string expr = stringf("mux(%s, %s, %s)", s_expr, b_expr, a_expr);
 
-				cell_exprs.push_back(stringf("%s%s <= %s %s\n", indent.c_str(), y_id.c_str(), expr.c_str(), cellFileinfo.c_str()));
+				cell_exprs.push_back(stringf("%s%s <= %s %s\n", indent, y_id, expr, cellFileinfo));
 				register_reverse_wire_map(y_id, cell->getPort(ID::Y));
 
 				continue;
@@ -911,9 +911,9 @@ struct FirrtlWorker
 				string expr = make_expr(cell->getPort(ID::D));
 				string clk_expr = "asClock(" + make_expr(cell->getPort(ID::CLK)) + ")";
 
-				wire_decls.push_back(stringf("%sreg %s: UInt<%d>, %s %s\n", indent.c_str(), y_id.c_str(), width, clk_expr.c_str(), cellFileinfo.c_str()));
+				wire_decls.push_back(stringf("%sreg %s: UInt<%d>, %s %s\n", indent, y_id, width, clk_expr, cellFileinfo));
 
-				cell_exprs.push_back(stringf("%s%s <= %s %s\n", indent.c_str(), y_id.c_str(), expr.c_str(), cellFileinfo.c_str()));
+				cell_exprs.push_back(stringf("%s%s <= %s %s\n", indent, y_id, expr, cellFileinfo));
 				register_reverse_wire_map(y_id, cell->getPort(ID::Q));
 
 				continue;
@@ -934,7 +934,7 @@ struct FirrtlWorker
 					int b_sign = cell->parameters.at(ID::B_WIDTH).as_int() - 1;
 					b_expr = stringf("validif(not(bits(%s, %d, %d)), %s)", b_string, b_sign, b_sign, b_string);
 				}
-				string expr = stringf("dshr(%s, %s)", a_expr.c_str(), b_expr.c_str());
+				string expr = stringf("dshr(%s, %s)", a_expr, b_expr);
 
 				cell_exprs.push_back(stringf("%s%s <= %s\n", indent.c_str(), y_id.c_str(), expr.c_str()));
 				register_reverse_wire_map(y_id, cell->getPort(ID::Y));
@@ -973,7 +973,7 @@ struct FirrtlWorker
 				// Verilog appears to treat the result as signed, so if the result is wider than "A",
 				//  we need to pad.
 				if (a_width < y_width) {
-					a_expr = stringf("pad(%s, %d)", a_expr.c_str(), y_width);
+					a_expr = stringf("pad(%s, %d)", a_expr, y_width);
 				}
 				wire_decls.push_back(stringf("%swire %s: UInt<%d>\n", indent.c_str(), y_id.c_str(), y_width));
 				cell_exprs.push_back(stringf("%s%s <= %s\n", indent.c_str(), y_id.c_str(), a_expr.c_str()));

--- a/backends/intersynth/intersynth.cc
+++ b/backends/intersynth/intersynth.cc
@@ -172,7 +172,7 @@ struct IntersynthBackend : public Backend {
 					if (sig.size() != 0) {
 						conntypes_code.insert(stringf("conntype b%d %d 2 %d\n", sig.size(), sig.size(), sig.size()));
 						celltype_code += stringf(" b%d %s%s", sig.size(), ct.cell_output(cell->type, port.first) ? "*" : "", log_id(port.first));
-						node_code += stringf(" %s %s", log_id(port.first), netname(conntypes_code, celltypes_code, constcells_code, sig).c_str());
+						node_code += stringf(" %s %s", log_id(port.first), netname(conntypes_code, celltypes_code, constcells_code, sig));
 					}
 				}
 				for (auto &param : cell->parameters) {
@@ -199,13 +199,13 @@ struct IntersynthBackend : public Backend {
 		if (!flag_notypes) {
 			*f << stringf("### Connection Types\n");
 			for (auto code : conntypes_code)
-				*f << stringf("%s", code.c_str());
+				*f << stringf("%s", code);
 			*f << stringf("\n### Cell Types\n");
 			for (auto code : celltypes_code)
-				*f << stringf("%s", code.c_str());
+				*f << stringf("%s", code);
 		}
 		*f << stringf("\n### Netlists\n");
-		*f << stringf("%s", netlists_code.c_str());
+		*f << stringf("%s", netlists_code);
 
 		for (auto lib : libs)
 			delete lib;

--- a/backends/spice/spice.cc
+++ b/backends/spice/spice.cc
@@ -51,16 +51,16 @@ static void print_spice_net(std::ostream &f, RTLIL::SigBit s, std::string &neg, 
 		if (s.wire->port_id)
 			use_inames = true;
 		if (s.wire->width > 1)
-			f << stringf(" %s.%d", spice_id2str(s.wire->name, use_inames, inums).c_str(), s.offset);
+			f << stringf(" %s.%d", spice_id2str(s.wire->name, use_inames, inums), s.offset);
 		else
-			f << stringf(" %s", spice_id2str(s.wire->name, use_inames, inums).c_str());
+			f << stringf(" %s", spice_id2str(s.wire->name, use_inames, inums));
 	} else {
 		if (s == RTLIL::State::S0)
-			f << stringf(" %s", neg.c_str());
+			f << stringf(" %s", neg);
 		else if (s == RTLIL::State::S1)
-			f << stringf(" %s", pos.c_str());
+			f << stringf(" %s", pos);
 		else
-			f << stringf(" %s%d", ncpf.c_str(), nc_counter++);
+			f << stringf(" %s%d", ncpf, nc_counter++);
 	}
 }
 
@@ -119,7 +119,7 @@ static void print_spice_module(std::ostream &f, RTLIL::Module *module, RTLIL::De
 			}
 		}
 
-		f << stringf(" %s\n", spice_id2str(cell->type).c_str());
+		f << stringf(" %s\n", spice_id2str(cell->type));
 	}
 
 	for (auto &conn : module->connections())
@@ -127,7 +127,7 @@ static void print_spice_module(std::ostream &f, RTLIL::Module *module, RTLIL::De
 		f << (buf == "DC" ? stringf("V%d", conn_counter++) : stringf("X%d", cell_counter++));
 		print_spice_net(f, conn.second.extract(i, 1), neg, pos, ncpf, nc_counter, use_inames, inums);
 		print_spice_net(f, conn.first.extract(i, 1), neg, pos, ncpf, nc_counter, use_inames, inums);
-		f << (buf == "DC" ? " DC 0\n" : stringf(" %s\n", buf.c_str()));
+		f << (buf == "DC" ? " DC 0\n" : stringf(" %s\n", buf));
 	}
 }
 
@@ -242,18 +242,18 @@ struct SpiceBackend : public Backend {
 				ports.at(wire->port_id-1) = wire;
 			}
 
-			*f << stringf(".SUBCKT %s", spice_id2str(module->name).c_str());
+			*f << stringf(".SUBCKT %s", spice_id2str(module->name));
 			for (RTLIL::Wire *wire : ports) {
 				log_assert(wire != NULL);
 				if (wire->width > 1) {
 					for (int i = 0; i < wire->width; i++)
-						*f << stringf(" %s.%d", spice_id2str(wire->name).c_str(), big_endian ? wire->width - 1 - i : i);
+						*f << stringf(" %s.%d", spice_id2str(wire->name), big_endian ? wire->width - 1 - i : i);
 				} else
-					*f << stringf(" %s", spice_id2str(wire->name).c_str());
+					*f << stringf(" %s", spice_id2str(wire->name));
 			}
 			*f << stringf("\n");
 			print_spice_module(*f, module, design, neg, pos, buf, ncpf, big_endian, use_inames);
-			*f << stringf(".ENDS %s\n\n", spice_id2str(module->name).c_str());
+			*f << stringf(".ENDS %s\n\n", spice_id2str(module->name));
 		}
 
 		if (!top_module_name.empty()) {


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

The code is easier to read and it should be more efficient, since `std::string` knows its length but `.c_str()` forgets the length and string formatting needs to recover it again.

There are a *lot* more calls to `c_str()` that can be removed, but I need to figure out an easier way to find all the right ones to remove.