### PR TITLE
Support `IdString` parameters in `stringf()` and remove `.c_str()` in a lot of places

### DIFF
--- a/backends/blif/blif.cc
+++ b/backends/blif/blif.cc
@@ -157,14 +157,14 @@ struct BlifDumper
 						f << stringf("%c", ch);
 				f << stringf("\"\n");
 			} else
-				f << stringf("%s\n", param.second.as_string().c_str());
+				f << stringf("%s\n", param.second.as_string());
 		}
 	}
 
 	void dump()
 	{
 		f << stringf("\n");
-		f << stringf(".model %s\n", str(module->name).c_str());
+		f << stringf(".model %s\n", str(module->name));
 
 		std::map<int, RTLIL::Wire*> inputs, outputs;
 
@@ -179,7 +179,7 @@ struct BlifDumper
 		for (auto &it : inputs) {
 			RTLIL::Wire *wire = it.second;
 			for (int i = 0; i < wire->width; i++)
-				f << stringf(" %s", str(RTLIL::SigSpec(wire, i)).c_str());
+				f << stringf(" %s", str(RTLIL::SigSpec(wire, i)));
 		}
 		f << stringf("\n");
 
@@ -187,7 +187,7 @@ struct BlifDumper
 		for (auto &it : outputs) {
 			RTLIL::Wire *wire = it.second;
 			for (int i = 0; i < wire->width; i++)
-				f << stringf(" %s", str(RTLIL::SigSpec(wire, i)).c_str());
+				f << stringf(" %s", str(RTLIL::SigSpec(wire, i)));
 		}
 		f << stringf("\n");
 
@@ -200,7 +200,7 @@ struct BlifDumper
 		if (!config->impltf_mode) {
 			if (!config->false_type.empty()) {
 				if (config->false_type == "+")
-					f << stringf(".names %s\n", config->false_out.c_str());
+					f << stringf(".names %s\n", config->false_out);
 				else if (config->false_type != "-")
 					f << stringf(".%s %s %s=$false\n", subckt_or_gate(config->false_type),
 							config->false_type.c_str(), config->false_out.c_str());
@@ -208,7 +208,7 @@ struct BlifDumper
 				f << stringf(".names $false\n");
 			if (!config->true_type.empty()) {
 				if (config->true_type == "+")
-					f << stringf(".names %s\n1\n", config->true_out.c_str());
+					f << stringf(".names %s\n1\n", config->true_out);
 				else if (config->true_type != "-")
 					f << stringf(".%s %s %s=$true\n", subckt_or_gate(config->true_type),
 							config->true_type.c_str(), config->true_out.c_str());
@@ -216,7 +216,7 @@ struct BlifDumper
 				f << stringf(".names $true\n1\n");
 			if (!config->undef_type.empty()) {
 				if (config->undef_type == "+")
-					f << stringf(".names %s\n", config->undef_out.c_str());
+					f << stringf(".names %s\n", config->undef_out);
 				else if (config->undef_type != "-")
 					f << stringf(".%s %s %s=$undef\n", subckt_or_gate(config->undef_type),
 							config->undef_type.c_str(), config->undef_out.c_str());
@@ -331,31 +331,31 @@ struct BlifDumper
 			}
 
 			if (!config->icells_mode && cell->type == ID($_FF_)) {
-				f << stringf(".latch %s %s%s\n", str(cell->getPort(ID::D)).c_str(), str(cell->getPort(ID::Q)).c_str(),
+				f << stringf(".latch %s %s%s\n", str(cell->getPort(ID::D)), str(cell->getPort(ID::Q)),
 						str_init(cell->getPort(ID::Q)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_DFF_N_)) {
-				f << stringf(".latch %s %s fe %s%s\n", str(cell->getPort(ID::D)).c_str(), str(cell->getPort(ID::Q)).c_str(),
+				f << stringf(".latch %s %s fe %s%s\n", str(cell->getPort(ID::D)), str(cell->getPort(ID::Q)),
 						str(cell->getPort(ID::C)).c_str(), str_init(cell->getPort(ID::Q)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_DFF_P_)) {
-				f << stringf(".latch %s %s re %s%s\n", str(cell->getPort(ID::D)).c_str(), str(cell->getPort(ID::Q)).c_str(),
+				f << stringf(".latch %s %s re %s%s\n", str(cell->getPort(ID::D)), str(cell->getPort(ID::Q)),
 						str(cell->getPort(ID::C)).c_str(), str_init(cell->getPort(ID::Q)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_DLATCH_N_)) {
-				f << stringf(".latch %s %s al %s%s\n", str(cell->getPort(ID::D)).c_str(), str(cell->getPort(ID::Q)).c_str(),
+				f << stringf(".latch %s %s al %s%s\n", str(cell->getPort(ID::D)), str(cell->getPort(ID::Q)),
 						str(cell->getPort(ID::E)).c_str(), str_init(cell->getPort(ID::Q)).c_str());
 				goto internal_cell;
 			}
 
 			if (!config->icells_mode && cell->type == ID($_DLATCH_P_)) {
-				f << stringf(".latch %s %s ah %s%s\n", str(cell->getPort(ID::D)).c_str(), str(cell->getPort(ID::Q)).c_str(),
+				f << stringf(".latch %s %s ah %s%s\n", str(cell->getPort(ID::D)), str(cell->getPort(ID::Q)),
 						str(cell->getPort(ID::E)).c_str(), str_init(cell->getPort(ID::Q)).c_str());
 				goto internal_cell;
 			}
@@ -366,10 +366,10 @@ struct BlifDumper
 				auto width = cell->parameters.at(ID::WIDTH).as_int();
 				log_assert(inputs.size() == width);
 				for (int i = width-1; i >= 0; i--)
-					f << stringf(" %s", str(inputs.extract(i, 1)).c_str());
+					f << stringf(" %s", str(inputs.extract(i, 1)));
 				auto &output = cell->getPort(ID::Y);
 				log_assert(output.size() == 1);
-				f << stringf(" %s", str(output).c_str());
+				f << stringf(" %s", str(output));
 				f << stringf("\n");
 				RTLIL::SigSpec mask = cell->parameters.at(ID::LUT);
 				for (int i = 0; i < (1 << width); i++)
@@ -392,10 +392,10 @@ struct BlifDumper
 					table.push_back(State::S0);
 				log_assert(inputs.size() == width);
 				for (int i = 0; i < width; i++)
-					f << stringf(" %s", str(inputs.extract(i, 1)).c_str());
+					f << stringf(" %s", str(inputs.extract(i, 1)));
 				auto &output = cell->getPort(ID::Y);
 				log_assert(output.size() == 1);
-				f << stringf(" %s", str(output).c_str());
+				f << stringf(" %s", str(output));
 				f << stringf("\n");
 				for (int i = 0; i < depth; i++) {
 					for (int j = 0; j < width; j++) {
@@ -410,11 +410,11 @@ struct BlifDumper
 				goto internal_cell;
 			}
 
-			f << stringf(".%s %s", subckt_or_gate(cell->type.str()), str(cell->type).c_str());
+			f << stringf(".%s %s", subckt_or_gate(cell->type.str()), str(cell->type));
 			for (auto &conn : cell->connections())
 			{
 				if (conn.second.size() == 1) {
-					f << stringf(" %s=%s", str(conn.first).c_str(), str(conn.second[0]).c_str());
+					f << stringf(" %s=%s", str(conn.first), str(conn.second[0]));
 					continue;
 				}
 
@@ -423,11 +423,11 @@ struct BlifDumper
 
 				if (w == nullptr) {
 					for (int i = 0; i < GetSize(conn.second); i++)
-						f << stringf(" %s[%d]=%s", str(conn.first).c_str(), i, str(conn.second[i]).c_str());
+						f << stringf(" %s[%d]=%s", str(conn.first), i, str(conn.second[i]));
 				} else {
 					for (int i = 0; i < std::min(GetSize(conn.second), GetSize(w)); i++) {
 						SigBit sig(w, i);
-						f << stringf(" %s[%d]=%s", str(conn.first).c_str(), sig.wire->upto ?
+						f << stringf(" %s[%d]=%s", str(conn.first), sig.wire->upto ?
 								sig.wire->start_offset+sig.wire->width-sig.offset-1 :
 								sig.wire->start_offset+sig.offset, str(conn.second[i]).c_str());
 					}
@@ -436,7 +436,7 @@ struct BlifDumper
 			f << stringf("\n");
 
 			if (config->cname_mode)
-				f << stringf(".cname %s\n", str(cell->name).c_str());
+				f << stringf(".cname %s\n", str(cell->name));
 			if (config->attr_mode)
 				dump_params(".attr", cell->attributes);
 			if (config->param_mode)
@@ -445,7 +445,7 @@ struct BlifDumper
 			if (0) {
 		internal_cell:
 				if (config->iname_mode)
-					f << stringf(".cname %s\n", str(cell->name).c_str());
+					f << stringf(".cname %s\n", str(cell->name));
 				if (config->iattr_mode)
 					dump_params(".attr", cell->attributes);
 			}
@@ -461,12 +461,12 @@ struct BlifDumper
 				continue;
 
 			if (config->conn_mode)
-				f << stringf(".conn %s %s\n", str(rhs_bit).c_str(), str(lhs_bit).c_str());
+				f << stringf(".conn %s %s\n", str(rhs_bit), str(lhs_bit));
 			else if (!config->buf_type.empty())
-				f << stringf(".%s %s %s=%s %s=%s\n", subckt_or_gate(config->buf_type), config->buf_type.c_str(),
+				f << stringf(".%s %s %s=%s %s=%s\n", subckt_or_gate(config->buf_type), config->buf_type,
 						config->buf_in.c_str(), str(rhs_bit).c_str(), config->buf_out.c_str(), str(lhs_bit).c_str());
 			else
-				f << stringf(".names %s %s\n1 1\n", str(rhs_bit).c_str(), str(lhs_bit).c_str());
+				f << stringf(".names %s %s\n1 1\n", str(rhs_bit), str(lhs_bit));
 		}
 
 		f << stringf(".end\n");

--- a/backends/edif/edif.cc
+++ b/backends/edif/edif.cc
@@ -48,8 +48,8 @@ struct EdifNames
 		if (define) {
 			std::string new_id = operator()(id, false);
 			if (port_rename)
-				return stringf("(rename %s \"%s%c%d:%d%c\")", new_id.c_str(), id.c_str(), delim_left, range_left, range_right, delim_right);
-			return new_id != id ? stringf("(rename %s \"%s\")", new_id.c_str(), id.c_str()) : id;
+				return stringf("(rename %s \"%s%c%d:%d%c\")", new_id, id, delim_left, range_left, range_right, delim_right);
+			return new_id != id ? stringf("(rename %s \"%s\")", new_id, id) : id;
 		}
 
 		if (name_map.count(id) > 0)
@@ -334,7 +334,7 @@ struct EdifBackend : public Backend {
 
 		auto add_prop = [&](IdString name, Const val) {
 			if ((val.flags & RTLIL::CONST_FLAG_STRING) != 0)
-				*f << stringf("\n            (property %s (string \"%s\"))", EDIF_DEF(name), val.decode_string().c_str());
+				*f << stringf("\n            (property %s (string \"%s\"))", EDIF_DEF(name), val.decode_string());
 			else if (val.size() <= 32 && RTLIL::SigSpec(val).is_fully_def())
 				*f << stringf("\n            (property %s (integer %u))", EDIF_DEF(name), val.as_int());
 			else {
@@ -348,7 +348,7 @@ struct EdifBackend : public Backend {
 					char digit_str[2] = { "0123456789abcdef"[digit_value], 0 };
 					hex_string = std::string(digit_str) + hex_string;
 				}
-				*f << stringf("\n            (property %s (string \"%d'h%s\"))", EDIF_DEF(name), GetSize(val), hex_string.c_str());
+				*f << stringf("\n            (property %s (string \"%d'h%s\"))", EDIF_DEF(name), GetSize(val), hex_string);
 			}
 		};
 		for (auto module : sorted_modules)
@@ -536,7 +536,7 @@ struct EdifBackend : public Backend {
 				}
 				*f << stringf("          (net %s (joined\n", EDIF_DEF(netname));
 				for (auto &ref : it.second)
-					*f << stringf("              %s\n", ref.first.c_str());
+					*f << stringf("              %s\n", ref.first);
 				if (sig.wire == NULL) {
 					if (nogndvcc)
 						log_error("Design contains constant nodes (map with \"hilomap\" first).\n");
@@ -577,7 +577,7 @@ struct EdifBackend : public Backend {
 						auto &refs = net_join_db.at(mapped_sig);
 						for (auto &ref : refs)
 							if (ref.second)
-								*f << stringf("              %s\n", ref.first.c_str());
+								*f << stringf("              %s\n", ref.first);
 						*f << stringf("            )");
 
 						if (attr_properties && raw_sig.wire != NULL)

--- a/backends/firrtl/firrtl.cc
+++ b/backends/firrtl/firrtl.cc
@@ -565,12 +565,12 @@ struct FirrtlWorker
 			{
 				if (wire->port_input && wire->port_output)
 					log_error("Module port %s.%s is inout!\n", log_id(module), log_id(wire));
-				port_decls.push_back(stringf("%s%s %s: UInt<%d> %s\n", indent.c_str(), wire->port_input ? "input" : "output",
+				port_decls.push_back(stringf("%s%s %s: UInt<%d> %s\n", indent, wire->port_input ? "input" : "output",
 						wireName, wire->width, wireFileinfo.c_str()));
 			}
 			else
 			{
-				wire_decls.push_back(stringf("%swire %s: UInt<%d> %s\n", indent.c_str(), wireName, wire->width, wireFileinfo.c_str()));
+				wire_decls.push_back(stringf("%swire %s: UInt<%d> %s\n", indent, wireName, wire->width, wireFileinfo));
 			}
 		}
 
@@ -885,7 +885,7 @@ struct FirrtlWorker
 				string a_expr = make_expr(cell->getPort(ID::A));
 				string b_expr = make_expr(cell->getPort(ID::B));
 				string s_expr = make_expr(cell->getPort(ID::S));
-				wire_decls.push_back(stringf("%swire %s: UInt<%d> %s\n", indent.c_str(), y_id.c_str(), width, cellFileinfo.c_str()));
+				wire_decls.push_back(stringf("%swire %s: UInt<%d> %s\n", indent, y_id, width, cellFileinfo));
 
 				string expr = stringf("mux(%s, %s, %s)", s_expr, b_expr, a_expr);
 
@@ -926,7 +926,7 @@ struct FirrtlWorker
 				string a_expr = make_expr(cell->getPort(ID::A));
 				// Get the initial bit selector
 				string b_expr = make_expr(cell->getPort(ID::B));
-				wire_decls.push_back(stringf("%swire %s: UInt<%d>\n", indent.c_str(), y_id.c_str(), y_width));
+				wire_decls.push_back(stringf("%swire %s: UInt<%d>\n", indent, y_id, y_width));
 
 				if (cell->getParam(ID::B_SIGNED).as_bool()) {
 					// Use validif to constrain the selection (test the sign bit)
@@ -936,7 +936,7 @@ struct FirrtlWorker
 				}
 				string expr = stringf("dshr(%s, %s)", a_expr, b_expr);
 
-				cell_exprs.push_back(stringf("%s%s <= %s\n", indent.c_str(), y_id.c_str(), expr.c_str()));
+				cell_exprs.push_back(stringf("%s%s <= %s\n", indent, y_id, expr));
 				register_reverse_wire_map(y_id, cell->getPort(ID::Y));
 				continue;
 			}
@@ -948,21 +948,21 @@ struct FirrtlWorker
 				string b_expr = make_expr(cell->getPort(ID::B));
 				auto b_string = b_expr.c_str();
 				string expr;
-				wire_decls.push_back(stringf("%swire %s: UInt<%d>\n", indent.c_str(), y_id.c_str(), y_width));
+				wire_decls.push_back(stringf("%swire %s: UInt<%d>\n", indent, y_id, y_width));
 
 				if (cell->getParam(ID::B_SIGNED).as_bool()) {
 					// We generate a left or right shift based on the sign of b.
-					std::string dshl = stringf("bits(dshl(%s, %s), 0, %d)", a_expr.c_str(), gen_dshl(b_expr, b_width).c_str(), y_width);
-					std::string dshr = stringf("dshr(%s, %s)", a_expr.c_str(), b_string);
+					std::string dshl = stringf("bits(dshl(%s, %s), 0, %d)", a_expr, gen_dshl(b_expr, b_width), y_width);
+					std::string dshr = stringf("dshr(%s, %s)", a_expr, b_string);
 					expr = stringf("mux(%s < 0, %s, %s)",
 									 b_string,
 									 dshl.c_str(),
 									 dshr.c_str()
 									 );
 				} else {
-					expr = stringf("dshr(%s, %s)", a_expr.c_str(), b_string);
+					expr = stringf("dshr(%s, %s)", a_expr, b_string);
 				}
-				cell_exprs.push_back(stringf("%s%s <= %s\n", indent.c_str(), y_id.c_str(), expr.c_str()));
+				cell_exprs.push_back(stringf("%s%s <= %s\n", indent, y_id, expr));
 				register_reverse_wire_map(y_id, cell->getPort(ID::Y));
 				continue;
 			}
@@ -975,8 +975,8 @@ struct FirrtlWorker
 				if (a_width < y_width) {
 					a_expr = stringf("pad(%s, %d)", a_expr, y_width);
 				}
-				wire_decls.push_back(stringf("%swire %s: UInt<%d>\n", indent.c_str(), y_id.c_str(), y_width));
-				cell_exprs.push_back(stringf("%s%s <= %s\n", indent.c_str(), y_id.c_str(), a_expr.c_str()));
+				wire_decls.push_back(stringf("%swire %s: UInt<%d>\n", indent, y_id, y_width));
+				cell_exprs.push_back(stringf("%s%s <= %s\n", indent, y_id, a_expr));
 				register_reverse_wire_map(y_id, cell->getPort(ID::Y));
 				continue;
 			}
@@ -999,7 +999,7 @@ struct FirrtlWorker
 			for (int i = 0; i < GetSize(mem.rd_ports); i++)
 			{
 				auto &port = mem.rd_ports[i];
-				string port_name(stringf("%s.r%d", mem_id.c_str(), i));
+				string port_name(stringf("%s.r%d", mem_id, i));
 
 				if (port.clk_enable)
 					log_error("Clocked read port %d on memory %s.%s.\n", i, log_id(module), log_id(mem.memid));
@@ -1010,17 +1010,17 @@ struct FirrtlWorker
 				string ena_expr = make_expr(State::S1);
 				string clk_expr = make_expr(State::S0);
 
-				rpe << stringf("%s%s.addr <= %s\n", indent.c_str(), port_name.c_str(), addr_expr.c_str());
-				rpe << stringf("%s%s.en <= %s\n", indent.c_str(), port_name.c_str(), ena_expr.c_str());
-				rpe << stringf("%s%s.clk <= asClock(%s)\n", indent.c_str(), port_name.c_str(), clk_expr.c_str());
+				rpe << stringf("%s%s.addr <= %s\n", indent, port_name, addr_expr);
+				rpe << stringf("%s%s.en <= %s\n", indent, port_name, ena_expr);
+				rpe << stringf("%s%s.clk <= asClock(%s)\n", indent, port_name, clk_expr);
 				cell_exprs.push_back(rpe.str());
-				register_reverse_wire_map(stringf("%s.data", port_name.c_str()), port.data);
+				register_reverse_wire_map(stringf("%s.data", port_name), port.data);
 			}
 
 			for (int i = 0; i < GetSize(mem.wr_ports); i++)
 			{
 				auto &port = mem.wr_ports[i];
-				string port_name(stringf("%s.w%d", mem_id.c_str(), i));
+				string port_name(stringf("%s.w%d", mem_id, i));
 
 				if (!port.clk_enable)
 					log_error("Unclocked write port %d on memory %s.%s.\n", i, log_id(module), log_id(mem.memid));
@@ -1037,18 +1037,18 @@ struct FirrtlWorker
 				string ena_expr = make_expr(port.en[0]);
 				string clk_expr = make_expr(port.clk);
 				string mask_expr = make_expr(State::S1);
-				wpe << stringf("%s%s.data <= %s\n", indent.c_str(), port_name.c_str(), data_expr.c_str());
-				wpe << stringf("%s%s.addr <= %s\n", indent.c_str(), port_name.c_str(), addr_expr.c_str());
-				wpe << stringf("%s%s.en <= %s\n", indent.c_str(), port_name.c_str(), ena_expr.c_str());
-				wpe << stringf("%s%s.clk <= asClock(%s)\n", indent.c_str(), port_name.c_str(), clk_expr.c_str());
-				wpe << stringf("%s%s.mask <= %s\n", indent.c_str(), port_name.c_str(), mask_expr.c_str());
+				wpe << stringf("%s%s.data <= %s\n", indent, port_name, data_expr);
+				wpe << stringf("%s%s.addr <= %s\n", indent, port_name, addr_expr);
+				wpe << stringf("%s%s.en <= %s\n", indent, port_name, ena_expr);
+				wpe << stringf("%s%s.clk <= asClock(%s)\n", indent, port_name, clk_expr);
+				wpe << stringf("%s%s.mask <= %s\n", indent, port_name, mask_expr);
 
 				cell_exprs.push_back(wpe.str());
 			}
 
 			std::ostringstream me;
 
-			me << stringf("    mem %s:\n", mem_id.c_str());
+			me << stringf("    mem %s:\n", mem_id);
 			me << stringf("      data-type => UInt<%d>\n", mem.width);
 			me << stringf("      depth => %d\n", mem.size);
 			for (int i = 0; i < GetSize(mem.rd_ports); i++)
@@ -1068,8 +1068,8 @@ struct FirrtlWorker
 			int y_width =  GetSize(conn.first);
 			string expr = make_expr(conn.second);
 
-			wire_decls.push_back(stringf("%swire %s: UInt<%d>\n", indent.c_str(), y_id.c_str(), y_width));
-			cell_exprs.push_back(stringf("%s%s <= %s\n", indent.c_str(), y_id.c_str(), expr.c_str()));
+			wire_decls.push_back(stringf("%swire %s: UInt<%d>\n", indent, y_id, y_width));
+			cell_exprs.push_back(stringf("%s%s <= %s\n", indent, y_id, expr));
 			register_reverse_wire_map(y_id, conn.first);
 		}
 
@@ -1112,7 +1112,7 @@ struct FirrtlWorker
 						chunk_width++;
 					}
 
-					new_expr = stringf("bits(%s, %d, %d)", start_map.first.c_str(),
+					new_expr = stringf("bits(%s, %d, %d)", start_map.first,
 							start_map.second + chunk_width - 1, start_map.second);
 					is_valid = true;
 				}
@@ -1135,13 +1135,13 @@ struct FirrtlWorker
 
 			if (is_valid) {
 				if (make_unconn_id) {
-					wire_decls.push_back(stringf("%swire %s: UInt<1> %s\n", indent.c_str(), unconn_id.c_str(), wireFileinfo.c_str()));
+					wire_decls.push_back(stringf("%swire %s: UInt<1> %s\n", indent, unconn_id, wireFileinfo));
 					// `invalid` is a firrtl construction for simulation so we will not
 					// tag it with a @[fileinfo] tag as it doesn't directly correspond to
 					// a specific line of verilog code.
-					wire_decls.push_back(stringf("%s%s is invalid\n", indent.c_str(), unconn_id.c_str()));
+					wire_decls.push_back(stringf("%s%s is invalid\n", indent, unconn_id));
 				}
-				wire_exprs.push_back(stringf("%s%s <= %s %s\n", indent.c_str(), make_id(wire->name), expr.c_str(), wireFileinfo.c_str()));
+				wire_exprs.push_back(stringf("%s%s <= %s %s\n", indent, make_id(wire->name), expr, wireFileinfo));
 			} else {
 				if (make_unconn_id) {
 					unconn_id.clear();
@@ -1149,7 +1149,7 @@ struct FirrtlWorker
 				// `invalid` is a firrtl construction for simulation so we will not
 				// tag it with a @[fileinfo] tag as it doesn't directly correspond to
 				// a specific line of verilog code.
-				wire_decls.push_back(stringf("%s%s is invalid\n", indent.c_str(), make_id(wire->name)));
+				wire_decls.push_back(stringf("%s%s is invalid\n", indent, make_id(wire->name)));
 			}
 		}
 
@@ -1249,7 +1249,7 @@ struct FirrtlBackend : public Backend {
 			log_cmd_error("There is no top module in this design!\n");
 
 		std::string circuitFileinfo = getFileinfo(top);
-		*f << stringf("circuit %s: %s\n", make_id(top->name), circuitFileinfo.c_str());
+		*f << stringf("circuit %s: %s\n", make_id(top->name), circuitFileinfo);
 
 		emit_elaborated_extmodules(design, *f);
 

--- a/backends/jny/jny.cc
+++ b/backends/jny/jny.cc
@@ -125,7 +125,7 @@ struct JnyWriter
 
         f << "{\n";
         f << "  \"$schema\": \"https://raw.githubusercontent.com/YosysHQ/yosys/main/misc/jny.schema.json\",\n";
-        f << stringf("  \"generator\": \"%s\",\n", escape_string(yosys_maybe_version()).c_str());
+        f << stringf("  \"generator\": \"%s\",\n", escape_string(yosys_maybe_version()));
         f << "  \"version\": \"0.0.1\",\n";
         f << "  \"invocation\": \"" << escape_string(invk) << "\",\n";
         f << "  \"features\": [";
@@ -232,7 +232,7 @@ struct JnyWriter
         const auto _indent = gen_indent(indent_level);
 
         f << _indent << "{\n";
-        f << stringf("  %s\"name\": \"%s\",\n", _indent.c_str(), escape_string(RTLIL::unescape_id(mod->name)).c_str());
+        f << stringf("  %s\"name\": \"%s\",\n", _indent, escape_string(RTLIL::unescape_id(mod->name)));
         f << _indent << "  \"cell_sorts\": [\n";
 
         bool first_sort{true};
@@ -280,7 +280,7 @@ struct JnyWriter
                 f << ",\n";
 
             f << _indent << "  {\n";
-            f << stringf("    %s\"name\": \"%s\",\n", _indent.c_str(), escape_string(RTLIL::unescape_id(con.first)).c_str());
+            f << stringf("    %s\"name\": \"%s\",\n", _indent, escape_string(RTLIL::unescape_id(con.first)));
             f << _indent << "    \"direction\": \"";
             if (port_cell->input(con.first))
                 f << "i";
@@ -290,7 +290,7 @@ struct JnyWriter
             if (con.second.size() == 1)
                 f << _indent << "    \"range\": [0, 0]\n";
             else
-                f << stringf("    %s\"range\": [%d, %d]\n", _indent.c_str(), con.second.size(), 0);
+                f << stringf("    %s\"range\": [%d, %d]\n", _indent, con.second.size(), 0);
             f << _indent << "  }";
 
             first_port = false;
@@ -304,7 +304,7 @@ struct JnyWriter
         const auto _indent = gen_indent(indent_level);
 
         f << _indent << "{\n";
-        f << stringf("  %s\"type\": \"%s\",\n", _indent.c_str(), sort.first.c_str());
+        f << stringf("  %s\"type\": \"%s\",\n", _indent, sort.first);
         f << _indent << "  \"ports\": [\n";
 
         write_cell_ports(port_cell, indent_level + 2);
@@ -351,10 +351,10 @@ struct JnyWriter
                 f << stringf(",\n");
             const auto param_val = param.second;
             if (!param_val.empty()) {
-                f << stringf("  %s\"%s\": ", _indent.c_str(), escape_string(RTLIL::unescape_id(param.first)).c_str());
+                f << stringf("  %s\"%s\": ", _indent, escape_string(RTLIL::unescape_id(param.first)));
                 write_param_val(param_val);
             } else {
-                f << stringf("  %s\"%s\": true", _indent.c_str(), escape_string(RTLIL::unescape_id(param.first)).c_str());
+                f << stringf("  %s\"%s\": true", _indent, escape_string(RTLIL::unescape_id(param.first)));
             }
 
             first_param = false;
@@ -366,7 +366,7 @@ struct JnyWriter
         log_assert(cell != nullptr);
 
         f << _indent << "  {\n";
-        f << stringf("    %s\"name\": \"%s\"", _indent.c_str(), escape_string(RTLIL::unescape_id(cell->name)).c_str());
+        f << stringf("    %s\"name\": \"%s\"", _indent, escape_string(RTLIL::unescape_id(cell->name)));
 
         if (_include_connections) {
             f << ",\n" << _indent << "    \"connections\": [\n";

--- a/backends/json/json.cc
+++ b/backends/json/json.cc
@@ -135,7 +135,7 @@ struct JsonWriter
 		bool first = true;
 		for (auto &param : parameters) {
 			f << stringf("%s\n", first ? "" : ",");
-			f << stringf("        %s%s: ", for_module ? "" : "    ", get_name(param.first).c_str());
+			f << stringf("        %s%s: ", for_module ? "" : "    ", get_name(param.first));
 			write_parameter_value(param.second);
 			first = false;
 		}
@@ -155,7 +155,7 @@ struct JsonWriter
 			log_error("Module %s contains processes, which are not supported by JSON backend (run `proc` first).\n", log_id(module));
 		}
 
-		f << stringf("    %s: {\n", get_name(module->name).c_str());
+		f << stringf("    %s: {\n", get_name(module->name));
 
 		f << stringf("      \"attributes\": {");
 		write_parameters(module->attributes, /*for_module=*/true);
@@ -174,7 +174,7 @@ struct JsonWriter
 			if (use_selection && !module->selected(w))
 				continue;
 			f << stringf("%s\n", first ? "" : ",");
-			f << stringf("        %s: {\n", get_name(n).c_str());
+			f << stringf("        %s: {\n", get_name(n));
 			f << stringf("          \"direction\": \"%s\",\n", w->port_input ? w->port_output ? "inout" : "input" : "output");
 			if (w->start_offset)
 				f << stringf("          \"offset\": %d,\n", w->start_offset);
@@ -182,7 +182,7 @@ struct JsonWriter
 				f << stringf("          \"upto\": 1,\n");
 			if (w->is_signed)
 				f << stringf("          \"signed\": %d,\n", w->is_signed);
-			f << stringf("          \"bits\": %s\n", get_bits(w).c_str());
+			f << stringf("          \"bits\": %s\n", get_bits(w));
 			f << stringf("        }");
 			first = false;
 		}
@@ -196,13 +196,13 @@ struct JsonWriter
 			if (!scopeinfo_mode && c->type == ID($scopeinfo))
 				continue;
 			f << stringf("%s\n", first ? "" : ",");
-			f << stringf("        %s: {\n", get_name(c->name).c_str());
+			f << stringf("        %s: {\n", get_name(c->name));
 			f << stringf("          \"hide_name\": %s,\n", c->name[0] == '$' ? "1" : "0");
-			f << stringf("          \"type\": %s,\n", get_name(c->type).c_str());
+			f << stringf("          \"type\": %s,\n", get_name(c->type));
 			if (aig_mode) {
 				Aig aig(c);
 				if (!aig.name.empty()) {
-					f << stringf("          \"model\": \"%s\",\n", aig.name.c_str());
+					f << stringf("          \"model\": \"%s\",\n", aig.name);
 					aig_models.insert(aig);
 				}
 			}
@@ -220,7 +220,7 @@ struct JsonWriter
 					if (c->input(conn.first))
 						direction = c->output(conn.first) ? "inout" : "input";
 					f << stringf("%s\n", first2 ? "" : ",");
-					f << stringf("            %s: \"%s\"", get_name(conn.first).c_str(), direction.c_str());
+					f << stringf("            %s: \"%s\"", get_name(conn.first), direction);
 					first2 = false;
 				}
 				f << stringf("\n          },\n");
@@ -229,7 +229,7 @@ struct JsonWriter
 			bool first2 = true;
 			for (auto &conn : c->connections()) {
 				f << stringf("%s\n", first2 ? "" : ",");
-				f << stringf("            %s: %s", get_name(conn.first).c_str(), get_bits(conn.second).c_str());
+				f << stringf("            %s: %s", get_name(conn.first), get_bits(conn.second));
 				first2 = false;
 			}
 			f << stringf("\n          }\n");
@@ -245,7 +245,7 @@ struct JsonWriter
 				if (use_selection && !module->selected(it.second))
 					continue;
 				f << stringf("%s\n", first ? "" : ",");
-				f << stringf("        %s: {\n", get_name(it.second->name).c_str());
+				f << stringf("        %s: {\n", get_name(it.second->name));
 				f << stringf("          \"hide_name\": %s,\n", it.second->name[0] == '$' ? "1" : "0");
 				f << stringf("          \"attributes\": {");
 				write_parameters(it.second->attributes);
@@ -265,9 +265,9 @@ struct JsonWriter
 			if (use_selection && !module->selected(w))
 				continue;
 			f << stringf("%s\n", first ? "" : ",");
-			f << stringf("        %s: {\n", get_name(w->name).c_str());
+			f << stringf("        %s: {\n", get_name(w->name));
 			f << stringf("          \"hide_name\": %s,\n", w->name[0] == '$' ? "1" : "0");
-			f << stringf("          \"bits\": %s,\n", get_bits(w).c_str());
+			f << stringf("          \"bits\": %s,\n", get_bits(w));
 			if (w->start_offset)
 				f << stringf("          \"offset\": %d,\n", w->start_offset);
 			if (w->upto)
@@ -291,7 +291,7 @@ struct JsonWriter
 		design->sort();
 
 		f << stringf("{\n");
-		f << stringf("  \"creator\": %s,\n", get_string(yosys_maybe_version()).c_str());
+		f << stringf("  \"creator\": %s,\n", get_string(yosys_maybe_version()));
 		f << stringf("  \"modules\": {\n");
 		vector<Module*> modules = use_selection ? design->selected_modules() : design->modules();
 		bool first_module = true;
@@ -308,7 +308,7 @@ struct JsonWriter
 			for (auto &aig : aig_models) {
 				if (!first_model)
 					f << stringf(",\n");
-				f << stringf("    \"%s\": [\n", aig.name.c_str());
+				f << stringf("    \"%s\": [\n", aig.name);
 				int node_idx = 0;
 				for (auto &node : aig.nodes) {
 					if (node_idx != 0)

--- a/backends/rtlil/rtlil_backend.cc
+++ b/backends/rtlil/rtlil_backend.cc
@@ -96,11 +96,11 @@ void RTLIL_BACKEND::dump_sigchunk(std::ostream &f, const RTLIL::SigChunk &chunk,
 		dump_const(f, chunk.data, chunk.width, chunk.offset, autoint);
 	} else {
 		if (chunk.width == chunk.wire->width && chunk.offset == 0)
-			f << stringf("%s", chunk.wire->name.c_str());
+			f << stringf("%s", chunk.wire->name);
 		else if (chunk.width == 1)
-			f << stringf("%s [%d]", chunk.wire->name.c_str(), chunk.offset);
+			f << stringf("%s [%d]", chunk.wire->name, chunk.offset);
 		else
-			f << stringf("%s [%d:%d]", chunk.wire->name.c_str(), chunk.offset+chunk.width-1, chunk.offset);
+			f << stringf("%s [%d:%d]", chunk.wire->name, chunk.offset+chunk.width-1, chunk.offset);
 	}
 }
 
@@ -121,15 +121,15 @@ void RTLIL_BACKEND::dump_sigspec(std::ostream &f, const RTLIL::SigSpec &sig, boo
 void RTLIL_BACKEND::dump_wire(std::ostream &f, std::string indent, const RTLIL::Wire *wire)
 {
 	for (auto &it : wire->attributes) {
-		f << stringf("%s" "attribute %s ", indent.c_str(), it.first.c_str());
+		f << stringf("%s" "attribute %s ", indent, it.first);
 		dump_const(f, it.second);
 		f << stringf("\n");
 	}
 	if (wire->driverCell_) {
-		f << stringf("%s" "# driver %s %s\n", indent.c_str(),
+		f << stringf("%s" "# driver %s %s\n", indent,
 				wire->driverCell()->name.c_str(), wire->driverPort().c_str());
 	}
-	f << stringf("%s" "wire ", indent.c_str());
+	f << stringf("%s" "wire ", indent);
 	if (wire->width != 1)
 		f << stringf("width %d ", wire->width);
 	if (wire->upto)
@@ -144,36 +144,36 @@ void RTLIL_BACKEND::dump_wire(std::ostream &f, std::string indent, const RTLIL::
 		f << stringf("inout %d ", wire->port_id);
 	if (wire->is_signed)
 		f << stringf("signed ");
-	f << stringf("%s\n", wire->name.c_str());
+	f << stringf("%s\n", wire->name);
 }
 
 void RTLIL_BACKEND::dump_memory(std::ostream &f, std::string indent, const RTLIL::Memory *memory)
 {
 	for (auto &it : memory->attributes) {
-		f << stringf("%s" "attribute %s ", indent.c_str(), it.first.c_str());
+		f << stringf("%s" "attribute %s ", indent, it.first);
 		dump_const(f, it.second);
 		f << stringf("\n");
 	}
-	f << stringf("%s" "memory ", indent.c_str());
+	f << stringf("%s" "memory ", indent);
 	if (memory->width != 1)
 		f << stringf("width %d ", memory->width);
 	if (memory->size != 0)
 		f << stringf("size %d ", memory->size);
 	if (memory->start_offset != 0)
 		f << stringf("offset %d ", memory->start_offset);
-	f << stringf("%s\n", memory->name.c_str());
+	f << stringf("%s\n", memory->name);
 }
 
 void RTLIL_BACKEND::dump_cell(std::ostream &f, std::string indent, const RTLIL::Cell *cell)
 {
 	for (auto &it : cell->attributes) {
-		f << stringf("%s" "attribute %s ", indent.c_str(), it.first.c_str());
+		f << stringf("%s" "attribute %s ", indent, it.first);
 		dump_const(f, it.second);
 		f << stringf("\n");
 	}
-	f << stringf("%s" "cell %s %s\n", indent.c_str(), cell->type.c_str(), cell->name.c_str());
+	f << stringf("%s" "cell %s %s\n", indent, cell->type, cell->name);
 	for (auto &it : cell->parameters) {
-		f << stringf("%s  parameter%s%s %s ", indent.c_str(),
+		f << stringf("%s  parameter%s%s %s ", indent,
 				(it.second.flags & RTLIL::CONST_FLAG_SIGNED) != 0 ? " signed" : "",
 				(it.second.flags & RTLIL::CONST_FLAG_REAL) != 0 ? " real" : "",
 				it.first.c_str());
@@ -181,18 +181,18 @@ void RTLIL_BACKEND::dump_cell(std::ostream &f, std::string indent, const RTLIL::
 		f << stringf("\n");
 	}
 	for (auto &it : cell->connections()) {
-		f << stringf("%s  connect %s ", indent.c_str(), it.first.c_str());
+		f << stringf("%s  connect %s ", indent, it.first);
 		dump_sigspec(f, it.second);
 		f << stringf("\n");
 	}
-	f << stringf("%s" "end\n", indent.c_str());
+	f << stringf("%s" "end\n", indent);
 }
 
 void RTLIL_BACKEND::dump_proc_case_body(std::ostream &f, std::string indent, const RTLIL::CaseRule *cs)
 {
 	for (auto it = cs->actions.begin(); it != cs->actions.end(); ++it)
 	{
-		f << stringf("%s" "assign ", indent.c_str());
+		f << stringf("%s" "assign ", indent);
 		dump_sigspec(f, it->first);
 		f << stringf(" ");
 		dump_sigspec(f, it->second);
@@ -206,23 +206,23 @@ void RTLIL_BACKEND::dump_proc_case_body(std::ostream &f, std::string indent, con
 void RTLIL_BACKEND::dump_proc_switch(std::ostream &f, std::string indent, const RTLIL::SwitchRule *sw)
 {
 	for (auto it = sw->attributes.begin(); it != sw->attributes.end(); ++it) {
-		f << stringf("%s" "attribute %s ", indent.c_str(), it->first.c_str());
+		f << stringf("%s" "attribute %s ", indent, it->first);
 		dump_const(f, it->second);
 		f << stringf("\n");
 	}
 
-	f << stringf("%s" "switch ", indent.c_str());
+	f << stringf("%s" "switch ", indent);
 	dump_sigspec(f, sw->signal);
 	f << stringf("\n");
 
 	for (auto it = sw->cases.begin(); it != sw->cases.end(); ++it)
 	{
 		for (auto ait = (*it)->attributes.begin(); ait != (*it)->attributes.end(); ++ait) {
-			f << stringf("%s  attribute %s ", indent.c_str(), ait->first.c_str());
+			f << stringf("%s  attribute %s ", indent, ait->first);
 			dump_const(f, ait->second);
 			f << stringf("\n");
 		}
-		f << stringf("%s  case ", indent.c_str());
+		f << stringf("%s  case ", indent);
 		for (size_t i = 0; i < (*it)->compare.size(); i++) {
 			if (i > 0)
 				f << stringf(" , ");
@@ -233,12 +233,12 @@ void RTLIL_BACKEND::dump_proc_switch(std::ostream &f, std::string indent, const 
 		dump_proc_case_body(f, indent + "    ", *it);
 	}
 
-	f << stringf("%s" "end\n", indent.c_str());
+	f << stringf("%s" "end\n", indent);
 }
 
 void RTLIL_BACKEND::dump_proc_sync(std::ostream &f, std::string indent, const RTLIL::SyncRule *sy)
 {
-	f << stringf("%s" "sync ", indent.c_str());
+	f << stringf("%s" "sync ", indent);
 	switch (sy->type) {
 	case RTLIL::ST0: f << stringf("low ");
 	if (0) case RTLIL::ST1: f << stringf("high ");
@@ -254,7 +254,7 @@ void RTLIL_BACKEND::dump_proc_sync(std::ostream &f, std::string indent, const RT
 	}
 
 	for (auto &it: sy->actions) {
-		f << stringf("%s  update ", indent.c_str());
+		f << stringf("%s  update ", indent);
 		dump_sigspec(f, it.first);
 		f << stringf(" ");
 		dump_sigspec(f, it.second);
@@ -263,11 +263,11 @@ void RTLIL_BACKEND::dump_proc_sync(std::ostream &f, std::string indent, const RT
 
 	for (auto &it: sy->mem_write_actions) {
 		for (auto it2 = it.attributes.begin(); it2 != it.attributes.end(); ++it2) {
-			f << stringf("%s  attribute %s ", indent.c_str(), it2->first.c_str());
+			f << stringf("%s  attribute %s ", indent, it2->first);
 			dump_const(f, it2->second);
 			f << stringf("\n");
 		}
-		f << stringf("%s  memwr %s ", indent.c_str(), it.memid.c_str());
+		f << stringf("%s  memwr %s ", indent, it.memid);
 		dump_sigspec(f, it.address);
 		f << stringf(" ");
 		dump_sigspec(f, it.data);
@@ -282,20 +282,20 @@ void RTLIL_BACKEND::dump_proc_sync(std::ostream &f, std::string indent, const RT
 void RTLIL_BACKEND::dump_proc(std::ostream &f, std::string indent, const RTLIL::Process *proc)
 {
 	for (auto it = proc->attributes.begin(); it != proc->attributes.end(); ++it) {
-		f << stringf("%s" "attribute %s ", indent.c_str(), it->first.c_str());
+		f << stringf("%s" "attribute %s ", indent, it->first);
 		dump_const(f, it->second);
 		f << stringf("\n");
 	}
-	f << stringf("%s" "process %s\n", indent.c_str(), proc->name.c_str());
+	f << stringf("%s" "process %s\n", indent, proc->name);
 	dump_proc_case_body(f, indent + "  ", &proc->root_case);
 	for (auto it = proc->syncs.begin(); it != proc->syncs.end(); ++it)
 		dump_proc_sync(f, indent + "  ", *it);
-	f << stringf("%s" "end\n", indent.c_str());
+	f << stringf("%s" "end\n", indent);
 }
 
 void RTLIL_BACKEND::dump_conn(std::ostream &f, std::string indent, const RTLIL::SigSpec &left, const RTLIL::SigSpec &right)
 {
-	f << stringf("%s" "connect ", indent.c_str());
+	f << stringf("%s" "connect ", indent);
 	dump_sigspec(f, left);
 	f << stringf(" ");
 	dump_sigspec(f, right);
@@ -310,12 +310,12 @@ void RTLIL_BACKEND::dump_module(std::ostream &f, std::string indent, RTLIL::Modu
 	if (print_header)
 	{
 		for (auto it = module->attributes.begin(); it != module->attributes.end(); ++it) {
-			f << stringf("%s" "attribute %s ", indent.c_str(), it->first.c_str());
+			f << stringf("%s" "attribute %s ", indent, it->first);
 			dump_const(f, it->second);
 			f << stringf("\n");
 		}
 
-		f << stringf("%s" "module %s\n", indent.c_str(), module->name.c_str());
+		f << stringf("%s" "module %s\n", indent, module->name);
 
 		if (!module->avail_parameters.empty()) {
 			if (only_selected)
@@ -323,9 +323,9 @@ void RTLIL_BACKEND::dump_module(std::ostream &f, std::string indent, RTLIL::Modu
 			for (const auto &p : module->avail_parameters) {
 				const auto &it = module->parameter_default_values.find(p);
 				if (it == module->parameter_default_values.end()) {
-					f << stringf("%s" "  parameter %s\n", indent.c_str(), p.c_str());
+					f << stringf("%s" "  parameter %s\n", indent, p);
 				} else {
-					f << stringf("%s" "  parameter %s ", indent.c_str(), p.c_str());
+					f << stringf("%s" "  parameter %s ", indent, p);
 					dump_const(f, it->second);
 					f << stringf("\n");
 				}
@@ -385,7 +385,7 @@ void RTLIL_BACKEND::dump_module(std::ostream &f, std::string indent, RTLIL::Modu
 	}
 
 	if (print_header)
-		f << stringf("%s" "end\n", indent.c_str());
+		f << stringf("%s" "end\n", indent);
 }
 
 void RTLIL_BACKEND::dump_design(std::ostream &f, RTLIL::Design *design, bool only_selected, bool flag_m, bool flag_n)

--- a/backends/smt2/smt2.cc
+++ b/backends/smt2/smt2.cc
@@ -82,27 +82,27 @@ struct Smt2Worker
 		if (statebv)
 		{
 			if (width == 0) {
-				decl_str = stringf("(define-fun |%s| ((state |%s_s|)) Bool (= ((_ extract %d %d) state) #b1))", name.c_str(), get_id(module), statebv_width, statebv_width);
+				decl_str = stringf("(define-fun |%s| ((state |%s_s|)) Bool (= ((_ extract %d %d) state) #b1))", name, get_id(module), statebv_width, statebv_width);
 				statebv_width += 1;
 			} else {
-				decl_str = stringf("(define-fun |%s| ((state |%s_s|)) (_ BitVec %d) ((_ extract %d %d) state))", name.c_str(), get_id(module), width, statebv_width+width-1, statebv_width);
+				decl_str = stringf("(define-fun |%s| ((state |%s_s|)) (_ BitVec %d) ((_ extract %d %d) state))", name, get_id(module), width, statebv_width+width-1, statebv_width);
 				statebv_width += width;
 			}
 		}
 		else if (statedt)
 		{
 			if (width == 0) {
-				decl_str = stringf("  (|%s| Bool)", name.c_str());
+				decl_str = stringf("  (|%s| Bool)", name);
 			} else {
-				decl_str = stringf("  (|%s| (_ BitVec %d))", name.c_str(), width);
+				decl_str = stringf("  (|%s| (_ BitVec %d))", name, width);
 			}
 		}
 		else
 		{
 			if (width == 0) {
-				decl_str = stringf("(declare-fun |%s| (|%s_s|) Bool)", name.c_str(), get_id(module));
+				decl_str = stringf("(declare-fun |%s| (|%s_s|) Bool)", name, get_id(module));
 			} else {
-				decl_str = stringf("(declare-fun |%s| (|%s_s|) (_ BitVec %d))", name.c_str(), get_id(module), width);
+				decl_str = stringf("(declare-fun |%s| (|%s_s|) (_ BitVec %d))", name, get_id(module), width);
 			}
 		}
 
@@ -383,7 +383,7 @@ struct Smt2Worker
 			}
 
 			if (fcache.count(sig[i]) && fcache.at(sig[i]).second == -1) {
-				subexpr.push_back(stringf("(ite %s #b1 #b0)", get_bool(sig[i], state_name).c_str()));
+				subexpr.push_back(stringf("(ite %s #b1 #b0)", get_bool(sig[i], state_name)));
 				continue;
 			}
 
@@ -495,7 +495,7 @@ struct Smt2Worker
 		}
 
 		if (width != GetSize(sig_y) && type != 'b')
-			processed_expr = stringf("((_ extract %d 0) %s)", GetSize(sig_y)-1, processed_expr.c_str());
+			processed_expr = stringf("((_ extract %d 0) %s)", GetSize(sig_y)-1, processed_expr);
 
 		if (verbose)
 			log("%*s-> import cell: %s\n", 2+2*GetSize(recursive_cells), "", log_id(cell));
@@ -617,7 +617,7 @@ struct Smt2Worker
 				string infostr = cell->attributes.count(ID::src) ? cell->attributes.at(ID::src).decode_string().c_str() : get_id(cell);
 				if (cell->attributes.count(ID::reg))
 					infostr += " " + cell->attributes.at(ID::reg).decode_string();
-				decls.push_back(stringf("; yosys-smt2-%s %s#%d %d %s\n", cell->type.c_str() + 1, get_id(module), idcounter, GetSize(cell->getPort(QY)), infostr.c_str()));
+				decls.push_back(stringf("; yosys-smt2-%s %s#%d %d %s\n", cell->type.c_str() + 1, get_id(module), idcounter, GetSize(cell->getPort(QY)), infostr));
 				if (cell->getPort(QY).is_wire() && cell->getPort(QY).as_wire()->get_bool_attribute(ID::maximize)){
 					decls.push_back(stringf("; yosys-smt2-maximize %s#%d\n", get_id(module), idcounter));
 					log("Wire %s is maximized\n", cell->getPort(QY).as_wire()->name.str().c_str());
@@ -722,7 +722,7 @@ struct Smt2Worker
 					2*GetSize(cell->getPort(ID::A).chunks()) < GetSize(cell->getPort(ID::A))) {
 				bool is_and = cell->type == ID($reduce_and);
 				string bits(GetSize(cell->getPort(ID::A)), is_and ? '1' : '0');
-				return export_bvop(cell, stringf("(%s A #b%s)", is_and ? "=" : "distinct", bits.c_str()), 'b');
+				return export_bvop(cell, stringf("(%s A #b%s)", is_and ? "=" : "distinct", bits), 'b');
 			}
 
 			if (cell->type == ID($reduce_and)) return export_reduce(cell, "(and A)", true);
@@ -746,7 +746,7 @@ struct Smt2Worker
 				get_bv(sig_s);
 
 				for (int i = 0; i < GetSize(sig_s); i++)
-					processed_expr = stringf("(ite %s %s %s)", get_bool(sig_s[i]).c_str(),
+					processed_expr = stringf("(ite %s %s %s)", get_bool(sig_s[i]),
 							get_bv(sig_b.extract(i*width, width)).c_str(), processed_expr.c_str());
 
 				if (verbose)
@@ -1090,13 +1090,13 @@ struct Smt2Worker
 							use_mask = true;
 						}
 					if (use_mask)
-						init_list.push_back(stringf("(= (bvand %s #b%s) #b%s) ; %s", get_bv(sig).c_str(), mask.as_string().c_str(), val.as_string().c_str(), get_id(wire)));
+						init_list.push_back(stringf("(= (bvand %s #b%s) #b%s) ; %s", get_bv(sig), mask.as_string(), val.as_string(), get_id(wire)));
 					else
-						init_list.push_back(stringf("(= %s #b%s) ; %s", get_bv(sig).c_str(), val.as_string().c_str(), get_id(wire)));
+						init_list.push_back(stringf("(= %s #b%s) ; %s", get_bv(sig), val.as_string(), get_id(wire)));
 				} else {
 					for (int i = 0; i < GetSize(sig); i++)
 						if (val[i] == State::S0 || val[i] == State::S1)
-							init_list.push_back(stringf("(= %s %s) ; %s", get_bool(sig[i]).c_str(), val[i] == State::S1 ? "true" : "false", get_id(wire)));
+							init_list.push_back(stringf("(= %s %s) ; %s", get_bool(sig[i]), val[i] == State::S1 ? "true" : "false", get_id(wire)));
 				}
 			}
 
@@ -1131,7 +1131,7 @@ struct Smt2Worker
 				}
 
 				if (private_name && cell->attributes.count(ID::src))
-					decls.push_back(stringf("; yosys-smt2-%s %d %s %s\n", cell->type.c_str() + 1, id, get_id(cell), cell->attributes.at(ID::src).decode_string().c_str()));
+					decls.push_back(stringf("; yosys-smt2-%s %d %s %s\n", cell->type.c_str() + 1, id, get_id(cell), cell->attributes.at(ID::src).decode_string()));
 				else
 					decls.push_back(stringf("; yosys-smt2-%s %d %s\n", cell->type.c_str() + 1, id, get_id(cell)));
 
@@ -1180,11 +1180,11 @@ struct Smt2Worker
 					SigSpec sig = sigmap(conn.second);
 
 					if (bvmode || GetSize(w) == 1) {
-						hier.push_back(stringf("  (= %s (|%s_n %s| %s)) ; %s.%s\n", (GetSize(w) > 1 ? get_bv(sig) : get_bool(sig)).c_str(),
+						hier.push_back(stringf("  (= %s (|%s_n %s| %s)) ; %s.%s\n", (GetSize(w) > 1 ? get_bv(sig) : get_bool(sig)),
 								get_id(cell->type), get_id(w), cell_state.c_str(), get_id(cell->type), get_id(w)));
 					} else {
 						for (int i = 0; i < GetSize(w); i++)
-							hier.push_back(stringf("  (= %s (|%s_n %s %d| %s)) ; %s.%s[%d]\n", get_bool(sig[i]).c_str(),
+							hier.push_back(stringf("  (= %s (|%s_n %s %d| %s)) ; %s.%s[%d]\n", get_bool(sig[i]),
 									get_id(cell->type), get_id(w), i, cell_state.c_str(), get_id(cell->type), get_id(w), i));
 					}
 				}
@@ -1204,25 +1204,25 @@ struct Smt2Worker
 				{
 					std::string expr_d = get_bool(cell->getPort(ID::D));
 					std::string expr_q = get_bool(cell->getPort(ID::Q), "next_state");
-					trans.push_back(stringf("  (= %s %s) ; %s %s\n", expr_d.c_str(), expr_q.c_str(), get_id(cell), log_signal(cell->getPort(ID::Q))));
-					ex_state_eq.push_back(stringf("(= %s %s)", get_bool(cell->getPort(ID::Q)).c_str(), get_bool(cell->getPort(ID::Q), "other_state").c_str()));
+					trans.push_back(stringf("  (= %s %s) ; %s %s\n", expr_d, expr_q, get_id(cell), log_signal(cell->getPort(ID::Q))));
+					ex_state_eq.push_back(stringf("(= %s %s)", get_bool(cell->getPort(ID::Q)), get_bool(cell->getPort(ID::Q), "other_state")));
 				}
 
 				if (cell->type.in(ID($ff), ID($dff), ID($anyinit)))
 				{
 					std::string expr_d = get_bv(cell->getPort(ID::D));
 					std::string expr_q = get_bv(cell->getPort(ID::Q), "next_state");
-					trans.push_back(stringf("  (= %s %s) ; %s %s\n", expr_d.c_str(), expr_q.c_str(), get_id(cell), log_signal(cell->getPort(ID::Q))));
-					ex_state_eq.push_back(stringf("(= %s %s)", get_bv(cell->getPort(ID::Q)).c_str(), get_bv(cell->getPort(ID::Q), "other_state").c_str()));
+					trans.push_back(stringf("  (= %s %s) ; %s %s\n", expr_d, expr_q, get_id(cell), log_signal(cell->getPort(ID::Q))));
+					ex_state_eq.push_back(stringf("(= %s %s)", get_bv(cell->getPort(ID::Q)), get_bv(cell->getPort(ID::Q), "other_state")));
 				}
 
 				if (cell->type.in(ID($anyconst), ID($allconst)))
 				{
 					std::string expr_d = get_bv(cell->getPort(ID::Y));
 					std::string expr_q = get_bv(cell->getPort(ID::Y), "next_state");
-					trans.push_back(stringf("  (= %s %s) ; %s %s\n", expr_d.c_str(), expr_q.c_str(), get_id(cell), log_signal(cell->getPort(ID::Y))));
+					trans.push_back(stringf("  (= %s %s) ; %s %s\n", expr_d, expr_q, get_id(cell), log_signal(cell->getPort(ID::Y))));
 					if (cell->type == ID($anyconst))
-						ex_state_eq.push_back(stringf("(= %s %s)", get_bv(cell->getPort(ID::Y)).c_str(), get_bv(cell->getPort(ID::Y), "other_state").c_str()));
+						ex_state_eq.push_back(stringf("(= %s %s)", get_bv(cell->getPort(ID::Y)), get_bv(cell->getPort(ID::Y), "other_state")));
 				}
 			}
 
@@ -1341,11 +1341,11 @@ struct Smt2Worker
 
 				std::string expr_d = stringf("(|%s#%d#%d| state)", get_id(module), arrayid, GetSize(mem->wr_ports));
 				std::string expr_q = stringf("(|%s#%d#0| next_state)", get_id(module), arrayid);
-				trans.push_back(stringf("  (= %s %s) ; %s\n", expr_d.c_str(), expr_q.c_str(), get_id(mem->memid)));
+				trans.push_back(stringf("  (= %s %s) ; %s\n", expr_d, expr_q, get_id(mem->memid)));
 				ex_state_eq.push_back(stringf("(= (|%s#%d#0| state) (|%s#%d#0| other_state))", get_id(module), arrayid, get_id(module), arrayid));
 
 				if (has_async_wr)
-					hier.push_back(stringf("  (= %s (|%s| state)) ; %s\n", expr_d.c_str(), final_memstate.c_str(), get_id(mem->memid)));
+					hier.push_back(stringf("  (= %s (|%s| state)) ; %s\n", expr_d, final_memstate, get_id(mem->memid)));
 
 				Const init_data = mem->get_init_data();
 
@@ -1402,7 +1402,7 @@ struct Smt2Worker
 					expr = "\n  " + ex_state_eq.front() + "\n";
 				} else {
 					for (auto &str : ex_state_eq)
-						expr += stringf("\n  %s", str.c_str());
+						expr += stringf("\n  %s", str);
 					expr += "\n)";
 				}
 			}
@@ -1415,7 +1415,7 @@ struct Smt2Worker
 					expr = "\n  " + ex_input_eq.front() + "\n";
 				} else {
 					for (auto &str : ex_input_eq)
-						expr += stringf("\n  %s", str.c_str());
+						expr += stringf("\n  %s", str);
 					expr += "\n)";
 				}
 			}
@@ -1429,7 +1429,7 @@ struct Smt2Worker
 				assert_expr = "\n  " + assert_list.front() + "\n";
 			} else {
 				for (auto &str : assert_list)
-					assert_expr += stringf("\n  %s", str.c_str());
+					assert_expr += stringf("\n  %s", str);
 				assert_expr += "\n)";
 			}
 		}
@@ -1442,7 +1442,7 @@ struct Smt2Worker
 				assume_expr = "\n  " + assume_list.front() + "\n";
 			} else {
 				for (auto &str : assume_list)
-					assume_expr += stringf("\n  %s", str.c_str());
+					assume_expr += stringf("\n  %s", str);
 				assume_expr += "\n)";
 			}
 		}
@@ -1455,7 +1455,7 @@ struct Smt2Worker
 				init_expr = "\n  " + init_list.front() + "\n";
 			} else {
 				for (auto &str : init_list)
-					init_expr += stringf("\n  %s", str.c_str());
+					init_expr += stringf("\n  %s", str);
 				init_expr += "\n)";
 			}
 		}
@@ -1846,7 +1846,7 @@ struct Smt2Backend : public Backend {
 			*f << stringf("; yosys-smt2-stdt\n");
 
 		for (auto &it : solver_options)
-			*f << stringf("; yosys-smt2-solver-option %s %s\n", it.first.c_str(), it.second.c_str());
+			*f << stringf("; yosys-smt2-solver-option %s %s\n", it.first, it.second);
 
 		std::vector<RTLIL::Module*> sorted_modules;
 
@@ -1913,7 +1913,7 @@ struct Smt2Backend : public Backend {
 		}
 
 		if (topmod)
-			*f << stringf("; yosys-smt2-topmod %s\n", topmod_id.c_str());
+			*f << stringf("; yosys-smt2-topmod %s\n", topmod_id);
 
 		*f << stringf("; end of yosys output\n");
 

--- a/backends/smv/smv.cc
+++ b/backends/smv/smv.cc
@@ -59,7 +59,7 @@ struct SmvWorker
 	{
 		if (!idcache.count(id))
 		{
-			string name = stringf("_%s", id.c_str());
+			string name = stringf("_%s", id);
 
 			if (name.compare(0, 2, "_\\") == 0)
 				name = "_" + name.substr(2);
@@ -163,15 +163,15 @@ struct SmvWorker
 		if (width >= 0) {
 			if (is_signed) {
 				if (GetSize(sig) > width)
-					s = stringf("signed(resize(%s, %d))", s.c_str(), width);
+					s = stringf("signed(resize(%s, %d))", s, width);
 				else
-					s = stringf("resize(signed(%s), %d)", s.c_str(), width);
+					s = stringf("resize(signed(%s), %d)", s, width);
 			} else
-				s = stringf("resize(%s, %d)", s.c_str(), width);
+				s = stringf("resize(%s, %d)", s, width);
 		} else if (is_signed)
-			s = stringf("signed(%s)", s.c_str());
+			s = stringf("signed(%s)", s);
 		else if (count_chunks > 1)
-			s = stringf("(%s)", s.c_str());
+			s = stringf("(%s)", s);
 
 		strbuf.push_back(s);
 		return strbuf.back().c_str();
@@ -262,7 +262,7 @@ struct SmvWorker
 				if (cell->type == ID($sshr) && signed_a)
 				{
 					expr_a = rvalue_s(sig_a, width);
-					expr = stringf("resize(unsigned(%s %s %s), %d)", expr_a.c_str(), op.c_str(), rvalue(sig_b.extract(0, shift_b_width)), width_y);
+					expr = stringf("resize(unsigned(%s %s %s), %d)", expr_a, op, rvalue(sig_b.extract(0, shift_b_width)), width_y);
 					if (shift_b_width < GetSize(sig_b))
 						expr = stringf("%s != 0ud%d_0 ? (bool(%s) ? !0ud%d_0 : 0ud%d_0) : %s",
 								rvalue(sig_b.extract(shift_b_width, GetSize(sig_b) - shift_b_width)), GetSize(sig_b) - shift_b_width,
@@ -278,8 +278,8 @@ struct SmvWorker
 //					f << stringf("    %s : unsigned word[%d]; -- neg(%s)\n", b_shl, GetSize(sig_b), log_signal(sig_b));
 					definitions.push_back(stringf("%s := unsigned(-%s);", b_shl, rvalue_s(sig_b)));
 
-					string expr_shl = stringf("resize(%s << %s[%d:0], %d)", expr_a.c_str(), b_shl, shift_b_width-1, width_y);
-					string expr_shr = stringf("resize(%s >> %s[%d:0], %d)", expr_a.c_str(), b_shr, shift_b_width-1, width_y);
+					string expr_shl = stringf("resize(%s << %s[%d:0], %d)", expr_a, b_shl, shift_b_width-1, width_y);
+					string expr_shr = stringf("resize(%s >> %s[%d:0], %d)", expr_a, b_shr, shift_b_width-1, width_y);
 
 					if (shift_b_width < GetSize(sig_b)) {
 						expr_shl = stringf("%s[%d:%d] != 0ud%d_0 ? 0ud%d_0 : %s", b_shl, GetSize(sig_b)-1, shift_b_width,
@@ -288,7 +288,7 @@ struct SmvWorker
 								GetSize(sig_b)-shift_b_width, width_y, expr_shr.c_str());
 					}
 
-					expr = stringf("bool(%s) ? %s : %s", rvalue(sig_b[GetSize(sig_b)-1]), expr_shl.c_str(), expr_shr.c_str());
+					expr = stringf("bool(%s) ? %s : %s", rvalue(sig_b[GetSize(sig_b)-1]), expr_shl, expr_shr);
 				}
 				else
 				{
@@ -297,13 +297,13 @@ struct SmvWorker
 					else
 						expr_a = stringf("resize(unsigned(%s), %d)", rvalue_s(sig_a, width_ay), width);
 
-					expr = stringf("resize(%s %s %s[%d:0], %d)", expr_a.c_str(), op.c_str(), rvalue_u(sig_b), shift_b_width-1, width_y);
+					expr = stringf("resize(%s %s %s[%d:0], %d)", expr_a, op, rvalue_u(sig_b), shift_b_width-1, width_y);
 					if (shift_b_width < GetSize(sig_b))
 						expr = stringf("%s[%d:%d] != 0ud%d_0 ? 0ud%d_0 : %s", rvalue_u(sig_b), GetSize(sig_b)-1, shift_b_width,
 								GetSize(sig_b)-shift_b_width, width_y, expr.c_str());
 				}
 
-				definitions.push_back(stringf("%s := %s;", lvalue(cell->getPort(ID::Y)), expr.c_str()));
+				definitions.push_back(stringf("%s := %s;", lvalue(cell->getPort(ID::Y)), expr));
 
 				continue;
 			}
@@ -426,7 +426,7 @@ struct SmvWorker
 				if (cell->type == ID($reduce_or))   expr = stringf("%s != 0ub%d_0", expr_a, width_a);
 				if (cell->type == ID($reduce_bool)) expr = stringf("%s != 0ub%d_0", expr_a, width_a);
 
-				definitions.push_back(stringf("%s := resize(word1(%s), %d);", expr_y, expr.c_str(), width_y));
+				definitions.push_back(stringf("%s := resize(word1(%s), %d);", expr_y, expr, width_y));
 				continue;
 			}
 
@@ -445,7 +445,7 @@ struct SmvWorker
 				if (cell->type == ID($reduce_xnor))
 					expr = "!(" + expr + ")";
 
-				definitions.push_back(stringf("%s := resize(%s, %d);", expr_y, expr.c_str(), width_y));
+				definitions.push_back(stringf("%s := resize(%s, %d);", expr_y, expr, width_y));
 				continue;
 			}
 
@@ -463,7 +463,7 @@ struct SmvWorker
 				if (cell->type == ID($logic_and)) expr = expr_a + " & " + expr_b;
 				if (cell->type == ID($logic_or))  expr = expr_a + " | " + expr_b;
 
-				definitions.push_back(stringf("%s := resize(word1(%s), %d);", expr_y, expr.c_str(), width_y));
+				definitions.push_back(stringf("%s := resize(word1(%s), %d);", expr_y, expr, width_y));
 				continue;
 			}
 
@@ -475,7 +475,7 @@ struct SmvWorker
 				string expr_a = stringf("(%s = 0ub%d_0)", rvalue(cell->getPort(ID::A)), width_a);
 				const char *expr_y = lvalue(cell->getPort(ID::Y));
 
-				definitions.push_back(stringf("%s := resize(word1(%s), %d);", expr_y, expr_a.c_str(), width_y));
+				definitions.push_back(stringf("%s := resize(word1(%s), %d);", expr_y, expr_a, width_y));
 				continue;
 			}
 
@@ -491,7 +491,7 @@ struct SmvWorker
 					expr += stringf("bool(%s) ? %s : ", rvalue(sig_s[i]), rvalue(sig_b.extract(i*width, width)));
 				expr += rvalue(sig_a);
 
-				definitions.push_back(stringf("%s := %s;", lvalue(cell->getPort(ID::Y)), expr.c_str()));
+				definitions.push_back(stringf("%s := %s;", lvalue(cell->getPort(ID::Y)), expr));
 				continue;
 			}
 
@@ -505,7 +505,7 @@ struct SmvWorker
 			if (cell->type.in(ID($_BUF_), ID($_NOT_)))
 			{
 				string op = cell->type == ID($_NOT_) ? "!" : "";
-				definitions.push_back(stringf("%s := %s%s;", lvalue(cell->getPort(ID::Y)), op.c_str(), rvalue(cell->getPort(ID::A))));
+				definitions.push_back(stringf("%s := %s%s;", lvalue(cell->getPort(ID::Y)), op, rvalue(cell->getPort(ID::A))));
 				continue;
 			}
 
@@ -650,7 +650,7 @@ struct SmvWorker
 					for (int k = GetSize(sig)-1; k >= 0; k--)
 						bits += sig[k] == State::S1 ? '1' : '0';
 
-					expr = stringf("0ub%d_%s", GetSize(bits), bits.c_str()) + expr;
+					expr = stringf("0ub%d_%s", GetSize(bits), bits) + expr;
 				}
 				else if (sigmap(SigBit(wire, i)) == SigBit(wire, i))
 				{
@@ -683,36 +683,36 @@ struct SmvWorker
 				}
 			}
 
-			definitions.push_back(stringf("%s := %s;", cid(wire->name), expr.c_str()));
+			definitions.push_back(stringf("%s := %s;", cid(wire->name), expr));
 		}
 
 		if (!inputvars.empty()) {
 			f << stringf("  IVAR\n");
 			for (const string &line : inputvars)
-				f << stringf("    %s\n", line.c_str());
+				f << stringf("    %s\n", line);
 		}
 
 		if (!vars.empty()) {
 			f << stringf("  VAR\n");
 			for (const string &line : vars)
-				f << stringf("    %s\n", line.c_str());
+				f << stringf("    %s\n", line);
 		}
 
 		if (!definitions.empty()) {
 			f << stringf("  DEFINE\n");
 			for (const string &line : definitions)
-				f << stringf("    %s\n", line.c_str());
+				f << stringf("    %s\n", line);
 		}
 
 		if (!assignments.empty()) {
 			f << stringf("  ASSIGN\n");
 			for (const string &line : assignments)
-				f << stringf("    %s\n", line.c_str());
+				f << stringf("    %s\n", line);
 		}
 
 		if (!invarspecs.empty()) {
 			for (const string &line : invarspecs)
-				f << stringf("  INVARSPEC %s\n", line.c_str());
+				f << stringf("  INVARSPEC %s\n", line);
 		}
 	}
 };

--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -158,7 +158,7 @@ void reset_auto_counter(RTLIL::Module *module)
 
 std::string next_auto_id()
 {
-	return stringf("%s_%0*d_", auto_prefix.c_str(), auto_name_digits, auto_name_offset + auto_name_counter++);
+	return stringf("%s_%0*d_", auto_prefix, auto_name_digits, auto_name_offset + auto_name_counter++);
 }
 
 std::string id(RTLIL::IdString internal_id, bool may_rename = true)
@@ -166,7 +166,7 @@ std::string id(RTLIL::IdString internal_id, bool may_rename = true)
 	const char *str = internal_id.c_str();
 
 	if (may_rename && auto_name_map.count(internal_id) != 0)
-		return stringf("%s_%0*d_", auto_prefix.c_str(), auto_name_digits, auto_name_offset + auto_name_map[internal_id]);
+		return stringf("%s_%0*d_", auto_prefix, auto_name_digits, auto_name_offset + auto_name_map[internal_id]);
 
 	if (*str == '\\')
 		str++;
@@ -351,19 +351,19 @@ void dump_sigchunk(std::ostream &f, const RTLIL::SigChunk &chunk, bool no_decima
 		dump_const(f, chunk.data, chunk.width, chunk.offset, no_decimal);
 	} else {
 		if (chunk.width == chunk.wire->width && chunk.offset == 0) {
-			f << stringf("%s", id(chunk.wire->name).c_str());
+			f << stringf("%s", id(chunk.wire->name));
 		} else if (chunk.width == 1) {
 			if (chunk.wire->upto)
-				f << stringf("%s[%d]", id(chunk.wire->name).c_str(), (chunk.wire->width - chunk.offset - 1) + chunk.wire->start_offset);
+				f << stringf("%s[%d]", id(chunk.wire->name), (chunk.wire->width - chunk.offset - 1) + chunk.wire->start_offset);
 			else
-				f << stringf("%s[%d]", id(chunk.wire->name).c_str(), chunk.offset + chunk.wire->start_offset);
+				f << stringf("%s[%d]", id(chunk.wire->name), chunk.offset + chunk.wire->start_offset);
 		} else {
 			if (chunk.wire->upto)
-				f << stringf("%s[%d:%d]", id(chunk.wire->name).c_str(),
+				f << stringf("%s[%d:%d]", id(chunk.wire->name),
 						(chunk.wire->width - (chunk.offset + chunk.width - 1) - 1) + chunk.wire->start_offset,
 						(chunk.wire->width - chunk.offset - 1) + chunk.wire->start_offset);
 			else
-				f << stringf("%s[%d:%d]", id(chunk.wire->name).c_str(),
+				f << stringf("%s[%d:%d]", id(chunk.wire->name),
 						(chunk.offset + chunk.width - 1) + chunk.wire->start_offset,
 						chunk.offset + chunk.wire->start_offset);
 		}
@@ -399,7 +399,7 @@ void dump_attributes(std::ostream &f, std::string indent, dict<RTLIL::IdString, 
 	for (auto it = attributes.begin(); it != attributes.end(); ++it) {
 		if (it->first == ID::single_bit_vector) continue;
 		if (it->first == ID::init && regattr) continue;
-		f << stringf("%s" "%s %s", indent.c_str(), as_comment ? "/*" : "(*", id(it->first).c_str());
+		f << stringf("%s" "%s %s", indent, as_comment ? "/*" : "(*", id(it->first));
 		f << stringf(" = ");
 		if (modattr && (it->second == State::S0 || it->second == Const(0)))
 			f << stringf(" 0 ");
@@ -407,7 +407,7 @@ void dump_attributes(std::ostream &f, std::string indent, dict<RTLIL::IdString, 
 			f << stringf(" 1 ");
 		else
 			dump_const(f, it->second, -1, 0, false, as_comment);
-		f << stringf(" %s%s", as_comment ? "*/" : "*)", term.c_str());
+		f << stringf(" %s%s", as_comment ? "*/" : "*)", term);
 	}
 }
 
@@ -416,16 +416,16 @@ void dump_wire(std::ostream &f, std::string indent, RTLIL::Wire *wire)
 	dump_attributes(f, indent, wire->attributes, "\n", /*modattr=*/false, /*regattr=*/reg_wires.count(wire->name));
 #if 0
 	if (wire->port_input && !wire->port_output)
-		f << stringf("%s" "input %s", indent.c_str(), reg_wires.count(wire->name) ? "reg " : "");
+		f << stringf("%s" "input %s", indent, reg_wires.count(wire->name) ? "reg " : "");
 	else if (!wire->port_input && wire->port_output)
-		f << stringf("%s" "output %s", indent.c_str(), reg_wires.count(wire->name) ? "reg " : "");
+		f << stringf("%s" "output %s", indent, reg_wires.count(wire->name) ? "reg " : "");
 	else if (wire->port_input && wire->port_output)
-		f << stringf("%s" "inout %s", indent.c_str(), reg_wires.count(wire->name) ? "reg " : "");
+		f << stringf("%s" "inout %s", indent, reg_wires.count(wire->name) ? "reg " : "");
 	else
-		f << stringf("%s" "%s ", indent.c_str(), reg_wires.count(wire->name) ? "reg" : "wire");
+		f << stringf("%s" "%s ", indent, reg_wires.count(wire->name) ? "reg" : "wire");
 	if (wire->width != 1)
 		f << stringf("[%d:%d] ", wire->width - 1 + wire->start_offset, wire->start_offset);
-	f << stringf("%s;\n", id(wire->name).c_str());
+	f << stringf("%s;\n", id(wire->name));
 #else
 	// do not use Verilog-2k "output reg" syntax in Verilog export
 	std::string range = "";
@@ -439,20 +439,20 @@ void dump_wire(std::ostream &f, std::string indent, RTLIL::Wire *wire)
 			range = stringf(" [%d:%d]", wire->start_offset, wire->start_offset);
 	}
 	if (wire->port_input && !wire->port_output)
-		f << stringf("%s" "input%s %s;\n", indent.c_str(), range.c_str(), id(wire->name).c_str());
+		f << stringf("%s" "input%s %s;\n", indent, range, id(wire->name));
 	if (!wire->port_input && wire->port_output)
-		f << stringf("%s" "output%s %s;\n", indent.c_str(), range.c_str(), id(wire->name).c_str());
+		f << stringf("%s" "output%s %s;\n", indent, range, id(wire->name));
 	if (wire->port_input && wire->port_output)
-		f << stringf("%s" "inout%s %s;\n", indent.c_str(), range.c_str(), id(wire->name).c_str());
+		f << stringf("%s" "inout%s %s;\n", indent, range, id(wire->name));
 	if (reg_wires.count(wire->name)) {
-		f << stringf("%s" "reg%s %s", indent.c_str(), range.c_str(), id(wire->name).c_str());
+		f << stringf("%s" "reg%s %s", indent, range, id(wire->name));
 		if (wire->attributes.count(ID::init)) {
 			f << stringf(" = ");
 			dump_const(f, wire->attributes.at(ID::init));
 		}
 		f << stringf(";\n");
 	} else
-		f << stringf("%s" "wire%s %s;\n", indent.c_str(), range.c_str(), id(wire->name).c_str());
+		f << stringf("%s" "wire%s %s;\n", indent, range, id(wire->name));
 #endif
 }
 
@@ -461,7 +461,7 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 	std::string mem_id = id(mem.memid);
 
 	dump_attributes(f, indent, mem.attributes);
-	f << stringf("%s" "reg [%d:0] %s [%d:%d];\n", indent.c_str(), mem.width-1, mem_id.c_str(), mem.size+mem.start_offset-1, mem.start_offset);
+	f << stringf("%s" "reg [%d:0] %s [%d:%d];\n", indent, mem.width-1, mem_id, mem.size+mem.start_offset-1, mem.start_offset);
 
 	// for memory block make something like:
 	//  reg [7:0] memid [3:0];
@@ -472,7 +472,7 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 	{
 		if (extmem)
 		{
-			std::string extmem_filename = stringf("%s-%d.mem", extmem_prefix.c_str(), extmem_counter++);
+			std::string extmem_filename = stringf("%s-%d.mem", extmem_prefix, extmem_counter++);
 
 			std::string extmem_filename_esc;
 			for (auto c : extmem_filename)
@@ -490,7 +490,7 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 				else
 					extmem_filename_esc += c;
 			}
-			f << stringf("%s" "initial $readmemb(\"%s\", %s);\n", indent.c_str(), extmem_filename_esc.c_str(), mem_id.c_str());
+			f << stringf("%s" "initial $readmemb(\"%s\", %s);\n", indent, extmem_filename_esc, mem_id);
 
 			std::ofstream extmem_f(extmem_filename, std::ofstream::trunc);
 			if (extmem_f.fail())
@@ -519,7 +519,7 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 		}
 		else
 		{
-			f << stringf("%s" "initial begin\n", indent.c_str());
+			f << stringf("%s" "initial begin\n", indent);
 			for (auto &init : mem.inits) {
 				int words = GetSize(init.data) / mem.width;
 				int start = init.addr.as_int();
@@ -536,16 +536,16 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 							j++, width++;
 
 						if (width == mem.width) {
-							f << stringf("%s" "  %s[%d] = ", indent.c_str(), mem_id.c_str(), i + start);
+							f << stringf("%s" "  %s[%d] = ", indent, mem_id, i + start);
 						} else {
-							f << stringf("%s" "  %s[%d][%d:%d] = ", indent.c_str(), mem_id.c_str(), i + start, j, start_j);
+							f << stringf("%s" "  %s[%d][%d:%d] = ", indent, mem_id, i + start, j, start_j);
 						}
 						dump_const(f, init.data.extract(i*mem.width+start_j, width));
 						f << stringf(";\n");
 					}
 				}
 			}
-			f << stringf("%s" "end\n", indent.c_str());
+			f << stringf("%s" "end\n", indent);
 		}
 	}
 
@@ -566,11 +566,11 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 			{
 				std::ostringstream os;
 				dump_sigspec(os, port.clk);
-				clk_domain_str = stringf("%sedge %s", port.clk_polarity ? "pos" : "neg", os.str().c_str());
+				clk_domain_str = stringf("%sedge %s", port.clk_polarity ? "pos" : "neg", os.str());
 				if (port.arst != State::S0) {
 					std::ostringstream os2;
 					dump_sigspec(os2, port.arst);
-					clk_domain_str += stringf(", posedge %s", os2.str().c_str());
+					clk_domain_str += stringf(", posedge %s", os2.str());
 					clk_to_arst_cond[clk_domain_str] = os2.str();
 				}
 			}
@@ -595,13 +595,13 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 				//      if (rd_en) temp_id <= array_reg[r_addr];
 				//   assign r_data = temp_id;
 				std::string temp_id = next_auto_id();
-				lof_reg_declarations.push_back( stringf("reg [%d:0] %s;\n", port.data.size() - 1, temp_id.c_str()) );
+				lof_reg_declarations.push_back( stringf("reg [%d:0] %s;\n", port.data.size() - 1, temp_id) );
 
 				bool has_indent = false;
 
 				if (port.arst != State::S0) {
 					std::ostringstream os;
-					os << stringf("%s <= ", temp_id.c_str());
+					os << stringf("%s <= ", temp_id);
 					dump_sigspec(os, port.arst_value);
 					os << ";\n";
 					clk_to_arst_body[clk_domain_str].push_back(os.str());
@@ -614,7 +614,7 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 					os << stringf(")\n");
 					clk_to_lof_body[clk_domain_str].push_back(os.str());
 					std::ostringstream os2;
-					os2 << stringf("%s" "%s <= ", indent.c_str(), temp_id.c_str());
+					os2 << stringf("%s" "%s <= ", indent, temp_id);
 					dump_sigspec(os2, port.srst_value);
 					os2 << ";\n";
 					clk_to_lof_body[clk_domain_str].push_back(os2.str());
@@ -646,7 +646,7 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 					os << temp_id;
 					if (port.wide_log2)
 						os << stringf("[%d:%d]", (sub + 1) * mem.width - 1, sub * mem.width);
-					os << stringf(" <= %s[", mem_id.c_str());
+					os << stringf(" <= %s[", mem_id);
 					dump_sigspec(os, addr);
 					os << stringf("];\n");
 					clk_to_lof_body[clk_domain_str].push_back(os.str());
@@ -721,7 +721,7 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 					std::ostringstream os2;
 					if (has_indent)
 						os2 << indent;
-					os2 << stringf("%s" "%s <= ", indent.c_str(), temp_id.c_str());
+					os2 << stringf("%s" "%s <= ", indent, temp_id);
 					dump_sigspec(os2, port.srst_value);
 					os2 << ";\n";
 					clk_to_lof_body[clk_domain_str].push_back(os2.str());
@@ -734,14 +734,14 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 				{
 					std::ostringstream os;
 					dump_sigspec(os, port.init_value);
-					std::string line = stringf("initial %s = %s;\n", temp_id.c_str(), os.str().c_str());
+					std::string line = stringf("initial %s = %s;\n", temp_id, os.str());
 					clk_to_lof_body[""].push_back(line);
 				}
 
 				{
 					std::ostringstream os;
 					dump_sigspec(os, port.data);
-					std::string line = stringf("assign %s = %s;\n", os.str().c_str(), temp_id.c_str());
+					std::string line = stringf("assign %s = %s;\n", os.str(), temp_id);
 					clk_to_lof_body[""].push_back(line);
 				}
 			}
@@ -753,11 +753,11 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 				//     temp_id <= r_addr;
 				//   assign r_data = array_reg[temp_id];
 				std::string temp_id = next_auto_id();
-				lof_reg_declarations.push_back( stringf("reg [%d:0] %s;\n", port.addr.size() - 1 - port.wide_log2, temp_id.c_str()) );
+				lof_reg_declarations.push_back( stringf("reg [%d:0] %s;\n", port.addr.size() - 1 - port.wide_log2, temp_id) );
 				{
 					std::ostringstream os;
 					dump_sigspec(os, port.addr.extract_end(port.wide_log2));
-					std::string line = stringf("%s <= %s;\n", temp_id.c_str(), os.str().c_str());
+					std::string line = stringf("%s <= %s;\n", temp_id, os.str());
 					clk_to_lof_body[clk_domain_str].push_back(line);
 				}
 				for (int sub = 0; sub < (1 << port.wide_log2); sub++)
@@ -765,7 +765,7 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 					std::ostringstream os;
 					os << "assign ";
 					dump_sigspec(os, port.data.extract(sub * mem.width, mem.width));
-					os << stringf(" = %s[", mem_id.c_str());;
+					os << stringf(" = %s[", mem_id);;
 					if (port.wide_log2) {
 						Const addr_lo;
 						for (int i = 0; i < port.wide_log2; i++)
@@ -792,7 +792,7 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 				std::ostringstream os, os2;
 				dump_sigspec(os, port.data.extract(sub * mem.width, mem.width));
 				dump_sigspec(os2, addr);
-				std::string line = stringf("assign %s = %s[%s];\n", os.str().c_str(), mem_id.c_str(), os2.str().c_str());
+				std::string line = stringf("assign %s = %s[%s];\n", os.str(), mem_id, os2.str());
 				clk_to_lof_body[""].push_back(line);
 			}
 		}
@@ -841,11 +841,11 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 		}
 
 		if (root.clk_enable) {
-			f << stringf("%s" "always%s @(%sedge ", indent.c_str(), systemverilog ? "_ff" : "", root.clk_polarity ? "pos" : "neg");
+			f << stringf("%s" "always%s @(%sedge ", indent, systemverilog ? "_ff" : "", root.clk_polarity ? "pos" : "neg");
 			dump_sigspec(f, root.clk);
 			f << ") begin\n";
 		} else {
-			f << stringf("%s" "always%s begin\n", indent.c_str(), systemverilog ? "_latch" : " @*");
+			f << stringf("%s" "always%s begin\n", indent, systemverilog ? "_latch" : " @*");
 		}
 
 		for (int pidx = 0; pidx < GetSize(mem.wr_ports); pidx++)
@@ -879,15 +879,15 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 					if (wen_bit == State::S0)
 						continue;
 
-					f << stringf("%s%s", indent.c_str(), indent.c_str());
+					f << stringf("%s%s", indent, indent);
 					if (wen_bit != State::S1)
 					{
 						f << stringf("if (");
 						dump_sigspec(f, wen_bit);
 						f << stringf(")\n");
-						f << stringf("%s%s%s", indent.c_str(), indent.c_str(), indent.c_str());
+						f << stringf("%s%s%s", indent, indent, indent);
 					}
-					f << stringf("%s[", mem_id.c_str());
+					f << stringf("%s[", mem_id);
 					dump_sigspec(f, addr);
 					if (width == GetSize(port.en))
 						f << stringf("] <= ");
@@ -899,7 +899,7 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 			}
 		}
 
-		f << stringf("%s" "end\n", indent.c_str());
+		f << stringf("%s" "end\n", indent);
 	}
 	// Output Verilog that looks something like this:
 	// reg [..] _3_;
@@ -922,7 +922,7 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 	// the reg ... definitions
 	for(auto &reg : lof_reg_declarations)
 	{
-		f << stringf("%s" "%s", indent.c_str(), reg.c_str());
+		f << stringf("%s" "%s", indent, reg);
 	}
 	// the block of expressions by clock domain
 	for(auto &pair : clk_to_lof_body)
@@ -931,27 +931,27 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 		std::vector<std::string> lof_lines = pair.second;
 		if( clk_domain != "")
 		{
-			f << stringf("%s" "always%s @(%s) begin\n", indent.c_str(), systemverilog ? "_ff" : "", clk_domain.c_str());
+			f << stringf("%s" "always%s @(%s) begin\n", indent, systemverilog ? "_ff" : "", clk_domain);
 			bool has_arst = clk_to_arst_cond.count(clk_domain) != 0;
 			if (has_arst) {
-				f << stringf("%s%s" "if (%s) begin\n", indent.c_str(), indent.c_str(), clk_to_arst_cond[clk_domain].c_str());
+				f << stringf("%s%s" "if (%s) begin\n", indent, indent, clk_to_arst_cond[clk_domain]);
 				for(auto &line : clk_to_arst_body[clk_domain])
-					f << stringf("%s%s%s" "%s", indent.c_str(), indent.c_str(), indent.c_str(), line.c_str());
-				f << stringf("%s%s" "end else begin\n", indent.c_str(), indent.c_str());
+					f << stringf("%s%s%s" "%s", indent, indent, indent, line);
+				f << stringf("%s%s" "end else begin\n", indent, indent);
 				for(auto &line : lof_lines)
-					f << stringf("%s%s%s" "%s", indent.c_str(), indent.c_str(), indent.c_str(), line.c_str());
-				f << stringf("%s%s" "end\n", indent.c_str(), indent.c_str());
+					f << stringf("%s%s%s" "%s", indent, indent, indent, line);
+				f << stringf("%s%s" "end\n", indent, indent);
 			} else {
 				for(auto &line : lof_lines)
-					f << stringf("%s%s" "%s", indent.c_str(), indent.c_str(), line.c_str());
+					f << stringf("%s%s" "%s", indent, indent, line);
 			}
-			f << stringf("%s" "end\n", indent.c_str());
+			f << stringf("%s" "end\n", indent);
 		}
 		else
 		{
 			// the non-clocked assignments
 			for(auto &line : lof_lines)
-				f << stringf("%s" "%s", indent.c_str(), line.c_str());
+				f << stringf("%s" "%s", indent, line);
 		}
 	}
 }
@@ -1004,9 +1004,9 @@ no_special_reg_name:
 
 void dump_cell_expr_uniop(std::ostream &f, std::string indent, RTLIL::Cell *cell, std::string op)
 {
-	f << stringf("%s" "assign ", indent.c_str());
+	f << stringf("%s" "assign ", indent);
 	dump_sigspec(f, cell->getPort(ID::Y));
-	f << stringf(" = %s ", op.c_str());
+	f << stringf(" = %s ", op);
 	dump_attributes(f, "", cell->attributes, " ");
 	dump_cell_expr_port(f, cell, "A", true);
 	f << stringf(";\n");
@@ -1014,11 +1014,11 @@ void dump_cell_expr_uniop(std::ostream &f, std::string indent, RTLIL::Cell *cell
 
 void dump_cell_expr_binop(std::ostream &f, std::string indent, RTLIL::Cell *cell, std::string op)
 {
-	f << stringf("%s" "assign ", indent.c_str());
+	f << stringf("%s" "assign ", indent);
 	dump_sigspec(f, cell->getPort(ID::Y));
 	f << stringf(" = ");
 	dump_cell_expr_port(f, cell, "A", true);
-	f << stringf(" %s ", op.c_str());
+	f << stringf(" %s ", op);
 	dump_attributes(f, "", cell->attributes, " ");
 	dump_cell_expr_port(f, cell, "B", true);
 	f << stringf(";\n");
@@ -1030,7 +1030,7 @@ void dump_cell_expr_print(std::ostream &f, std::string indent, const RTLIL::Cell
 	fmt.parse_rtlil(cell);
 	std::vector<VerilogFmtArg> args = fmt.emit_verilog();
 
-	f << stringf("%s" "$write(", indent.c_str());
+	f << stringf("%s" "$write(", indent);
 	bool first = true;
 	for (auto &arg : args) {
 		if (first) {
@@ -1064,19 +1064,19 @@ void dump_cell_expr_check(std::ostream &f, std::string indent, const RTLIL::Cell
 	std::string flavor = cell->getParam(ID(FLAVOR)).decode_string();
 	std::string label = "";
 	if (cell->name.isPublic()) {
-		label = stringf("%s: ", id(cell->name).c_str());
+		label = stringf("%s: ", id(cell->name));
 	}
 
 	if (flavor == "assert")
-		f << stringf("%s" "%s" "assert (", indent.c_str(), label.c_str());
+		f << stringf("%s" "%s" "assert (", indent, label);
 	else if (flavor == "assume")
-		f << stringf("%s" "%s" "assume (", indent.c_str(), label.c_str());
+		f << stringf("%s" "%s" "assume (", indent, label);
 	else if (flavor == "live")
-		f << stringf("%s" "%s" "assert (eventually ", indent.c_str(), label.c_str());
+		f << stringf("%s" "%s" "assert (eventually ", indent, label);
 	else if (flavor == "fair")
-		f << stringf("%s" "%s" "assume (eventually ", indent.c_str(), label.c_str());
+		f << stringf("%s" "%s" "assume (eventually ", indent, label);
 	else if (flavor == "cover")
-		f << stringf("%s" "%s" "cover (", indent.c_str(), label.c_str());
+		f << stringf("%s" "%s" "cover (", indent, label);
 	else
 		log_abort();
 	dump_sigspec(f, cell->getPort(ID::A));
@@ -1086,7 +1086,7 @@ void dump_cell_expr_check(std::ostream &f, std::string indent, const RTLIL::Cell
 bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 {
 	if (cell->type == ID($_NOT_)) {
-		f << stringf("%s" "assign ", indent.c_str());
+		f << stringf("%s" "assign ", indent);
 		dump_sigspec(f, cell->getPort(ID::Y));
 		f << stringf(" = ");
 		f << stringf("~");
@@ -1097,7 +1097,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 	}
 
 	if (cell->type.in(ID($_BUF_), ID($buf))) {
-		f << stringf("%s" "assign ", indent.c_str());
+		f << stringf("%s" "assign ", indent);
 		dump_sigspec(f, cell->getPort(ID::Y));
 		f << stringf(" = ");
 		dump_cell_expr_port(f, cell, "A", false);
@@ -1106,7 +1106,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 	}
 
 	if (cell->type.in(ID($_AND_), ID($_NAND_), ID($_OR_), ID($_NOR_), ID($_XOR_), ID($_XNOR_), ID($_ANDNOT_), ID($_ORNOT_))) {
-		f << stringf("%s" "assign ", indent.c_str());
+		f << stringf("%s" "assign ", indent);
 		dump_sigspec(f, cell->getPort(ID::Y));
 		f << stringf(" = ");
 		if (cell->type.in(ID($_NAND_), ID($_NOR_), ID($_XNOR_)))
@@ -1131,7 +1131,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 	}
 
 	if (cell->type == ID($_MUX_)) {
-		f << stringf("%s" "assign ", indent.c_str());
+		f << stringf("%s" "assign ", indent);
 		dump_sigspec(f, cell->getPort(ID::Y));
 		f << stringf(" = ");
 		dump_cell_expr_port(f, cell, "S", false);
@@ -1145,7 +1145,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 	}
 
 	if (cell->type == ID($_NMUX_)) {
-		f << stringf("%s" "assign ", indent.c_str());
+		f << stringf("%s" "assign ", indent);
 		dump_sigspec(f, cell->getPort(ID::Y));
 		f << stringf(" = !(");
 		dump_cell_expr_port(f, cell, "S", false);
@@ -1159,7 +1159,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 	}
 
 	if (cell->type.in(ID($_AOI3_), ID($_OAI3_))) {
-		f << stringf("%s" "assign ", indent.c_str());
+		f << stringf("%s" "assign ", indent);
 		dump_sigspec(f, cell->getPort(ID::Y));
 		f << stringf(" = ~((");
 		dump_cell_expr_port(f, cell, "A", false);
@@ -1174,7 +1174,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 	}
 
 	if (cell->type.in(ID($_AOI4_), ID($_OAI4_))) {
-		f << stringf("%s" "assign ", indent.c_str());
+		f << stringf("%s" "assign ", indent);
 		dump_sigspec(f, cell->getPort(ID::Y));
 		f << stringf(" = ~((");
 		dump_cell_expr_port(f, cell, "A", false);
@@ -1259,32 +1259,32 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 			int size_max = std::max(size_a, std::max(size_b, size_y));
 
 			// intentionally one wider than maximum width
-			f << stringf("%s" "wire [%d:0] %s, %s, %s;\n", indent.c_str(), size_max, buf_a.c_str(), buf_b.c_str(), buf_num.c_str());
-			f << stringf("%s" "assign %s = ", indent.c_str(), buf_a.c_str());
+			f << stringf("%s" "wire [%d:0] %s, %s, %s;\n", indent, size_max, buf_a, buf_b, buf_num);
+			f << stringf("%s" "assign %s = ", indent, buf_a);
 			dump_cell_expr_port(f, cell, "A", true);
 			f << stringf(";\n");
-			f << stringf("%s" "assign %s = ", indent.c_str(), buf_b.c_str());
+			f << stringf("%s" "assign %s = ", indent, buf_b);
 			dump_cell_expr_port(f, cell, "B", true);
 			f << stringf(";\n");
 
-			f << stringf("%s" "assign %s = ", indent.c_str(), buf_num.c_str());
+			f << stringf("%s" "assign %s = ", indent, buf_num);
 			f << stringf("(");
 			dump_sigspec(f, sig_a.extract(sig_a.size()-1));
 			f << stringf(" == ");
 			dump_sigspec(f, sig_b.extract(sig_b.size()-1));
 			f << stringf(") || ");
 			dump_sigspec(f, sig_a);
-			f << stringf(" == 0 ? %s : ", buf_a.c_str());
-			f << stringf("$signed(%s - (", buf_a.c_str());
+			f << stringf(" == 0 ? %s : ", buf_a);
+			f << stringf("$signed(%s - (", buf_a);
 			dump_sigspec(f, sig_b.extract(sig_b.size()-1));
-			f << stringf(" ? %s + 1 : %s - 1));\n", buf_b.c_str(), buf_b.c_str());
+			f << stringf(" ? %s + 1 : %s - 1));\n", buf_b, buf_b);
 
 
-			f << stringf("%s" "assign ", indent.c_str());
+			f << stringf("%s" "assign ", indent);
 			dump_sigspec(f, cell->getPort(ID::Y));
-			f << stringf(" = $signed(%s) / ", buf_num.c_str());
+			f << stringf(" = $signed(%s) / ", buf_num);
 			dump_attributes(f, "", cell->attributes, " ");
-			f << stringf("$signed(%s);\n", buf_b.c_str());
+			f << stringf("$signed(%s);\n", buf_b);
 			return true;
 		} else {
 			// same as truncating division
@@ -1303,22 +1303,22 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 			SigSpec sig_b = cell->getPort(ID::B);
 
 			std::string temp_id = next_auto_id();
-			f << stringf("%s" "wire [%d:0] %s = ", indent.c_str(), GetSize(cell->getPort(ID::A))-1, temp_id.c_str());
+			f << stringf("%s" "wire [%d:0] %s = ", indent, GetSize(cell->getPort(ID::A))-1, temp_id);
 			dump_cell_expr_port(f, cell, "A", true);
 			f << stringf(" %% ");
 			dump_attributes(f, "", cell->attributes, " ");
 			dump_cell_expr_port(f, cell, "B", true);
 			f << stringf(";\n");
 
-			f << stringf("%s" "assign ", indent.c_str());
+			f << stringf("%s" "assign ", indent);
 			dump_sigspec(f, cell->getPort(ID::Y));
 			f << stringf(" = (");
 			dump_sigspec(f, sig_a.extract(sig_a.size()-1));
 			f << stringf(" == ");
 			dump_sigspec(f, sig_b.extract(sig_b.size()-1));
-			f << stringf(") || %s == 0 ? $signed(%s) : ", temp_id.c_str(), temp_id.c_str());
+			f << stringf(") || %s == 0 ? $signed(%s) : ", temp_id, temp_id);
 			dump_cell_expr_port(f, cell, "B", true);
-			f << stringf(" + $signed(%s);\n", temp_id.c_str());
+			f << stringf(" + $signed(%s);\n", temp_id);
 			return true;
 		} else {
 			// same as truncating modulo
@@ -1329,7 +1329,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 
 	if (cell->type == ID($shift))
 	{
-		f << stringf("%s" "assign ", indent.c_str());
+		f << stringf("%s" "assign ", indent);
 		dump_sigspec(f, cell->getPort(ID::Y));
 		f << stringf(" = ");
 		if (cell->getParam(ID::B_SIGNED).as_bool())
@@ -1357,13 +1357,13 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 	if (cell->type == ID($shiftx))
 	{
 		std::string temp_id = next_auto_id();
-		f << stringf("%s" "wire [%d:0] %s = ", indent.c_str(), GetSize(cell->getPort(ID::A))-1, temp_id.c_str());
+		f << stringf("%s" "wire [%d:0] %s = ", indent, GetSize(cell->getPort(ID::A))-1, temp_id);
 		dump_sigspec(f, cell->getPort(ID::A));
 		f << stringf(";\n");
 
-		f << stringf("%s" "assign ", indent.c_str());
+		f << stringf("%s" "assign ", indent);
 		dump_sigspec(f, cell->getPort(ID::Y));
-		f << stringf(" = %s[", temp_id.c_str());
+		f << stringf(" = %s[", temp_id);
 		if (cell->getParam(ID::B_SIGNED).as_bool())
 			f << stringf("$signed(");
 		dump_sigspec(f, cell->getPort(ID::B));
@@ -1376,7 +1376,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 
 	if (cell->type == ID($mux))
 	{
-		f << stringf("%s" "assign ", indent.c_str());
+		f << stringf("%s" "assign ", indent);
 		dump_sigspec(f, cell->getPort(ID::Y));
 		f << stringf(" = ");
 		dump_sigspec(f, cell->getPort(ID::S));
@@ -1402,44 +1402,44 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 
 		dump_attributes(f, indent + "  ", cell->attributes);
 		if (noparallelcase)
-			f << stringf("%s" "  case (s)\n", indent.c_str());
+			f << stringf("%s" "  case (s)\n", indent);
 		else {
 			if (!noattr)
-				f << stringf("%s" "  (* parallel_case *)\n", indent.c_str());
-			f << stringf("%s" "  casez (s)", indent.c_str());
+				f << stringf("%s" "  (* parallel_case *)\n", indent);
+			f << stringf("%s" "  casez (s)", indent);
 			f << (noattr ? " // synopsys parallel_case\n" : "\n");
 		}
 
 		for (int i = 0; i < s_width; i++)
 		{
-			f << stringf("%s" "    %d'b", indent.c_str(), s_width);
+			f << stringf("%s" "    %d'b", indent, s_width);
 
 			for (int j = s_width-1; j >= 0; j--)
 				f << stringf("%c", j == i ? '1' : noparallelcase ? '0' : '?');
 
 			f << stringf(":\n");
-			f << stringf("%s" "      %s = b[%d:%d];\n", indent.c_str(), func_name.c_str(), (i+1)*width-1, i*width);
+			f << stringf("%s" "      %s = b[%d:%d];\n", indent, func_name, (i+1)*width-1, i*width);
 		}
 
 		if (noparallelcase) {
-			f << stringf("%s" "    %d'b", indent.c_str(), s_width);
+			f << stringf("%s" "    %d'b", indent, s_width);
 			for (int j = s_width-1; j >= 0; j--)
 				f << '0';
 			f << stringf(":\n");
 		} else
-			f << stringf("%s" "    default:\n", indent.c_str());
-		f << stringf("%s" "      %s = a;\n", indent.c_str(), func_name.c_str());
+			f << stringf("%s" "    default:\n", indent);
+		f << stringf("%s" "      %s = a;\n", indent, func_name);
 		if (noparallelcase) {
-			f << stringf("%s" "    default:\n", indent.c_str());
-			f << stringf("%s" "      %s = %d'bx;\n", indent.c_str(), func_name.c_str(), width);
+			f << stringf("%s" "    default:\n", indent);
+			f << stringf("%s" "      %s = %d'bx;\n", indent, func_name, width);
 		}
 
-		f << stringf("%s" "  endcase\n", indent.c_str());
-		f << stringf("%s" "endfunction\n", indent.c_str());
+		f << stringf("%s" "  endcase\n", indent);
+		f << stringf("%s" "endfunction\n", indent);
 
-		f << stringf("%s" "assign ", indent.c_str());
+		f << stringf("%s" "assign ", indent);
 		dump_sigspec(f, cell->getPort(ID::Y));
-		f << stringf(" = %s(", func_name.c_str());
+		f << stringf(" = %s(", func_name);
 		dump_sigspec(f, cell->getPort(ID::A));
 		f << stringf(", ");
 		dump_sigspec(f, cell->getPort(ID::B));
@@ -1451,7 +1451,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 
 	if (cell->type == ID($tribuf))
 	{
-		f << stringf("%s" "assign ", indent.c_str());
+		f << stringf("%s" "assign ", indent);
 		dump_sigspec(f, cell->getPort(ID::Y));
 		f << stringf(" = ");
 		dump_sigspec(f, cell->getPort(ID::EN));
@@ -1463,7 +1463,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 
 	if (cell->type == ID($slice))
 	{
-		f << stringf("%s" "assign ", indent.c_str());
+		f << stringf("%s" "assign ", indent);
 		dump_sigspec(f, cell->getPort(ID::Y));
 		f << stringf(" = ");
 		dump_sigspec(f, cell->getPort(ID::A));
@@ -1473,7 +1473,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 
 	if (cell->type == ID($concat))
 	{
-		f << stringf("%s" "assign ", indent.c_str());
+		f << stringf("%s" "assign ", indent);
 		dump_sigspec(f, cell->getPort(ID::Y));
 		f << stringf(" = { ");
 		dump_sigspec(f, cell->getPort(ID::B));
@@ -1485,7 +1485,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 
 	if (cell->type == ID($lut))
 	{
-		f << stringf("%s" "assign ", indent.c_str());
+		f << stringf("%s" "assign ", indent);
 		dump_sigspec(f, cell->getPort(ID::Y));
 		f << stringf(" = ");
 		dump_const(f, cell->parameters.at(ID::LUT));
@@ -1509,9 +1509,9 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 
 		if (!out_is_reg_wire) {
 			if (ff.width == 1)
-				f << stringf("%s" "reg %s", indent.c_str(), reg_name.c_str());
+				f << stringf("%s" "reg %s", indent, reg_name);
 			else
-				f << stringf("%s" "reg [%d:0] %s", indent.c_str(), ff.width-1, reg_name.c_str());
+				f << stringf("%s" "reg [%d:0] %s", indent, ff.width-1, reg_name);
 			dump_reg_init(f, ff.sig_q);
 			f << ";\n";
 		}
@@ -1526,7 +1526,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 			Const val_arst, val_srst;
 			std::string reg_bit_name, sig_set_name, sig_clr_name, sig_arst_name, sig_aload_name;
 			if (chunky) {
-				reg_bit_name = stringf("%s[%d]", reg_name.c_str(), i);
+				reg_bit_name = stringf("%s[%d]", reg_name, i);
 				if (ff.has_gclk || ff.has_clk)
 					sig_d = ff.sig_d[i];
 				if (ff.has_aload)
@@ -1547,14 +1547,14 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 					if (ff.sig_set[i].wire == NULL)
 					{
 						sig_set_name = next_auto_id();
-						f << stringf("%s" "wire %s = ", indent.c_str(), sig_set_name.c_str());
+						f << stringf("%s" "wire %s = ", indent, sig_set_name);
 						dump_const(f, ff.sig_set[i].data);
 						f << stringf(";\n");
 					}
 					if (ff.sig_clr[i].wire == NULL)
 					{
 						sig_clr_name = next_auto_id();
-						f << stringf("%s" "wire %s = ", indent.c_str(), sig_clr_name.c_str());
+						f << stringf("%s" "wire %s = ", indent, sig_clr_name);
 						dump_const(f, ff.sig_clr[i].data);
 						f << stringf(";\n");
 					}
@@ -1562,7 +1562,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 					if (ff.sig_arst[0].wire == NULL)
 					{
 						sig_arst_name = next_auto_id();
-						f << stringf("%s" "wire %s = ", indent.c_str(), sig_arst_name.c_str());
+						f << stringf("%s" "wire %s = ", indent, sig_arst_name);
 						dump_const(f, ff.sig_arst[0].data);
 						f << stringf(";\n");
 					}
@@ -1570,7 +1570,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 					if (ff.sig_aload[0].wire == NULL)
 					{
 						sig_aload_name = next_auto_id();
-						f << stringf("%s" "wire %s = ", indent.c_str(), sig_aload_name.c_str());
+						f << stringf("%s" "wire %s = ", indent, sig_aload_name);
 						dump_const(f, ff.sig_aload[0].data);
 						f << stringf(";\n");
 					}
@@ -1581,90 +1581,90 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 			if (ff.has_clk)
 			{
 				// FFs.
-				f << stringf("%s" "always%s @(%sedge ", indent.c_str(), systemverilog ? "_ff" : "", ff.pol_clk ? "pos" : "neg");
+				f << stringf("%s" "always%s @(%sedge ", indent, systemverilog ? "_ff" : "", ff.pol_clk ? "pos" : "neg");
 				dump_sigspec(f, ff.sig_clk);
 				if (ff.has_sr) {
 					f << stringf(", %sedge ", ff.pol_set ? "pos" : "neg");
 					if (ff.sig_set[i].wire == NULL)
-						f << stringf("%s", sig_set_name.c_str());
+						f << stringf("%s", sig_set_name);
 					else
 						dump_sigspec(f, ff.sig_set[i]);
 
 					f << stringf(", %sedge ", ff.pol_clr ? "pos" : "neg");
 					if (ff.sig_clr[i].wire == NULL)
-						f << stringf("%s", sig_clr_name.c_str());
+						f << stringf("%s", sig_clr_name);
 					else
 						dump_sigspec(f, ff.sig_clr[i]);
 				} else if (ff.has_arst) {
 					f << stringf(", %sedge ", ff.pol_arst ? "pos" : "neg");
 					if (ff.sig_arst[0].wire == NULL)
-						f << stringf("%s", sig_arst_name.c_str());
+						f << stringf("%s", sig_arst_name);
 					else
 						dump_sigspec(f, ff.sig_arst);
 				} else if (ff.has_aload) {
 					f << stringf(", %sedge ", ff.pol_aload ? "pos" : "neg");
 					if (ff.sig_aload[0].wire == NULL)
-						f << stringf("%s", sig_aload_name.c_str());
+						f << stringf("%s", sig_aload_name);
 					else
 						dump_sigspec(f, ff.sig_aload);
 				}
 				f << stringf(")\n");
 
-				f << stringf("%s" "  ", indent.c_str());
+				f << stringf("%s" "  ", indent);
 				if (ff.has_sr) {
 					f << stringf("if (%s", ff.pol_clr ? "" : "!");
 					if (ff.sig_clr[i].wire == NULL)
-						f << stringf("%s", sig_clr_name.c_str());
+						f << stringf("%s", sig_clr_name);
 					else
 						dump_sigspec(f, ff.sig_clr[i]);
-					f << stringf(") %s <= 1'b0;\n", reg_bit_name.c_str());
-					f << stringf("%s" "  else if (%s", indent.c_str(), ff.pol_set ? "" : "!");
+					f << stringf(") %s <= 1'b0;\n", reg_bit_name);
+					f << stringf("%s" "  else if (%s", indent, ff.pol_set ? "" : "!");
 					if (ff.sig_set[i].wire == NULL)
-						f << stringf("%s", sig_set_name.c_str());
+						f << stringf("%s", sig_set_name);
 					else
 						dump_sigspec(f, ff.sig_set[i]);
-					f << stringf(") %s <= 1'b1;\n", reg_bit_name.c_str());
-					f << stringf("%s" "  else ", indent.c_str());
+					f << stringf(") %s <= 1'b1;\n", reg_bit_name);
+					f << stringf("%s" "  else ", indent);
 				} else if (ff.has_arst) {
 					f << stringf("if (%s", ff.pol_arst ? "" : "!");
 					if (ff.sig_arst[0].wire == NULL)
-						f << stringf("%s", sig_arst_name.c_str());
+						f << stringf("%s", sig_arst_name);
 					else
 						dump_sigspec(f, ff.sig_arst);
-					f << stringf(") %s <= ", reg_bit_name.c_str());
+					f << stringf(") %s <= ", reg_bit_name);
 					dump_sigspec(f, val_arst);
 					f << stringf(";\n");
-					f << stringf("%s" "  else ", indent.c_str());
+					f << stringf("%s" "  else ", indent);
 				} else if (ff.has_aload) {
 					f << stringf("if (%s", ff.pol_aload ? "" : "!");
 					if (ff.sig_aload[0].wire == NULL)
-						f << stringf("%s", sig_aload_name.c_str());
+						f << stringf("%s", sig_aload_name);
 					else
 						dump_sigspec(f, ff.sig_aload);
-					f << stringf(") %s <= ", reg_bit_name.c_str());
+					f << stringf(") %s <= ", reg_bit_name);
 					dump_sigspec(f, sig_ad);
 					f << stringf(";\n");
-					f << stringf("%s" "  else ", indent.c_str());
+					f << stringf("%s" "  else ", indent);
 				}
 
 				if (ff.has_srst && ff.has_ce && ff.ce_over_srst) {
 					f << stringf("if (%s", ff.pol_ce ? "" : "!");
 					dump_sigspec(f, ff.sig_ce);
 					f << stringf(")\n");
-					f << stringf("%s" "    if (%s", indent.c_str(), ff.pol_srst ? "" : "!");
+					f << stringf("%s" "    if (%s", indent, ff.pol_srst ? "" : "!");
 					dump_sigspec(f, ff.sig_srst);
-					f << stringf(") %s <= ", reg_bit_name.c_str());
+					f << stringf(") %s <= ", reg_bit_name);
 					dump_sigspec(f, val_srst);
 					f << stringf(";\n");
-					f << stringf("%s" "    else ", indent.c_str());
+					f << stringf("%s" "    else ", indent);
 				} else {
 					if (ff.has_srst) {
 						f << stringf("if (%s", ff.pol_srst ? "" : "!");
 						dump_sigspec(f, ff.sig_srst);
-						f << stringf(") %s <= ", reg_bit_name.c_str());
+						f << stringf(") %s <= ", reg_bit_name);
 						dump_sigspec(f, val_srst);
 						f << stringf(";\n");
-						f << stringf("%s" "  else ", indent.c_str());
+						f << stringf("%s" "  else ", indent);
 					}
 					if (ff.has_ce) {
 						f << stringf("if (%s", ff.pol_ce ? "" : "!");
@@ -1673,38 +1673,38 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 					}
 				}
 
-				f << stringf("%s <= ", reg_bit_name.c_str());
+				f << stringf("%s <= ", reg_bit_name);
 				dump_sigspec(f, sig_d);
 				f << stringf(";\n");
 			}
 			else
 			{
 				// Latches.
-				f << stringf("%s" "always%s\n", indent.c_str(), systemverilog ? "_latch" : " @*");
+				f << stringf("%s" "always%s\n", indent, systemverilog ? "_latch" : " @*");
 
-				f << stringf("%s" "  ", indent.c_str());
+				f << stringf("%s" "  ", indent);
 				if (ff.has_sr) {
 					f << stringf("if (%s", ff.pol_clr ? "" : "!");
 					dump_sigspec(f, ff.sig_clr[i]);
-					f << stringf(") %s = 1'b0;\n", reg_bit_name.c_str());
-					f << stringf("%s" "  else if (%s", indent.c_str(), ff.pol_set ? "" : "!");
+					f << stringf(") %s = 1'b0;\n", reg_bit_name);
+					f << stringf("%s" "  else if (%s", indent, ff.pol_set ? "" : "!");
 					dump_sigspec(f, ff.sig_set[i]);
-					f << stringf(") %s = 1'b1;\n", reg_bit_name.c_str());
+					f << stringf(") %s = 1'b1;\n", reg_bit_name);
 					if (ff.has_aload)
-						f << stringf("%s" "  else ", indent.c_str());
+						f << stringf("%s" "  else ", indent);
 				} else if (ff.has_arst) {
 					f << stringf("if (%s", ff.pol_arst ? "" : "!");
 					dump_sigspec(f, ff.sig_arst);
-					f << stringf(") %s = ", reg_bit_name.c_str());
+					f << stringf(") %s = ", reg_bit_name);
 					dump_sigspec(f, val_arst);
 					f << stringf(";\n");
 					if (ff.has_aload)
-						f << stringf("%s" "  else ", indent.c_str());
+						f << stringf("%s" "  else ", indent);
 				}
 				if (ff.has_aload) {
 					f << stringf("if (%s", ff.pol_aload ? "" : "!");
 					dump_sigspec(f, ff.sig_aload);
-					f << stringf(") %s = ", reg_bit_name.c_str());
+					f << stringf(") %s = ", reg_bit_name);
 					dump_sigspec(f, sig_ad);
 					f << stringf(";\n");
 				}
@@ -1712,9 +1712,9 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 		}
 
 		if (!out_is_reg_wire) {
-			f << stringf("%s" "assign ", indent.c_str());
+			f << stringf("%s" "assign ", indent);
 			dump_sigspec(f, ff.sig_q);
-			f << stringf(" = %s;\n", reg_name.c_str());
+			f << stringf(" = %s;\n", reg_name);
 		}
 
 		return true;
@@ -1722,7 +1722,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 
 	if (cell->type.in(ID($assert), ID($assume), ID($cover)))
 	{
-		f << stringf("%s" "always%s if (", indent.c_str(), systemverilog ? "_comb" : " @*");
+		f << stringf("%s" "always%s if (", indent, systemverilog ? "_comb" : " @*");
 		dump_sigspec(f, cell->getPort(ID::EN));
 		f << stringf(") %s(", cell->type.c_str()+1);
 		dump_sigspec(f, cell->getPort(ID::A));
@@ -1732,7 +1732,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 
 	if (cell->type.in(ID($specify2), ID($specify3)))
 	{
-		f << stringf("%s" "specify\n%s  ", indent.c_str(), indent.c_str());
+		f << stringf("%s" "specify\n%s  ", indent, indent);
 
 		SigSpec en = cell->getPort(ID::EN);
 		if (en != State::S1) {
@@ -1784,16 +1784,16 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 
 		decimal = bak_decimal;
 
-		f << stringf("%s" "endspecify\n", indent.c_str());
+		f << stringf("%s" "endspecify\n", indent);
 		return true;
 	}
 
 	if (cell->type == ID($specrule))
 	{
-		f << stringf("%s" "specify\n%s  ", indent.c_str(), indent.c_str());
+		f << stringf("%s" "specify\n%s  ", indent, indent);
 
 		IdString spec_type = cell->getParam(ID::TYPE).decode_string();
-		f << stringf("%s(", spec_type.c_str());
+		f << stringf("%s(", spec_type);
 
 		if (cell->getParam(ID::SRC_PEN).as_bool())
 			f << (cell->getParam(ID::SRC_POL).as_bool() ? "posedge ": "negedge ");
@@ -1836,7 +1836,7 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 		f << ");\n";
 		decimal = bak_decimal;
 
-		f << stringf("%s" "endspecify\n", indent.c_str());
+		f << stringf("%s" "endspecify\n", indent);
 		return true;
 	}
 
@@ -1846,9 +1846,9 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 		if (cell->getParam(ID::TRG_ENABLE).as_bool())
 			return true;
 
-		f << stringf("%s" "always @*\n", indent.c_str());
+		f << stringf("%s" "always @*\n", indent);
 
-		f << stringf("%s" "  if (", indent.c_str());
+		f << stringf("%s" "  if (", indent);
 		dump_sigspec(f, cell->getPort(ID::EN));
 		f << stringf(")\n");
 
@@ -1862,9 +1862,9 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 		if (cell->getParam(ID::TRG_ENABLE).as_bool())
 			return true;
 
-		f << stringf("%s" "always @*\n", indent.c_str());
+		f << stringf("%s" "always @*\n", indent);
 
-		f << stringf("%s" "  if (", indent.c_str());
+		f << stringf("%s" "  if (", indent);
 		dump_sigspec(f, cell->getPort(ID::EN));
 		f << stringf(") begin\n");
 
@@ -1873,18 +1873,18 @@ bool dump_cell_expr(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 			Fmt fmt;
 			fmt.parse_rtlil(cell);
 			if (!fmt.parts.empty()) {
-				f << stringf("%s" "    if (!", indent.c_str());
+				f << stringf("%s" "    if (!", indent);
 				dump_sigspec(f, cell->getPort(ID::A));
 				f << stringf(")\n");
 				dump_cell_expr_print(f, indent + "      ", cell);
 			}
 		} else {
-			f << stringf("%s" "  /* message omitted */\n", indent.c_str());
+			f << stringf("%s" "  /* message omitted */\n", indent);
 		}
 
 		dump_cell_expr_check(f, indent + "    ", cell);
 
-		f << stringf("%s" "  end\n", indent.c_str());
+		f << stringf("%s" "  end\n", indent);
 
 		return true;
 	}
@@ -1913,26 +1913,26 @@ void dump_cell(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 	}
 
 	dump_attributes(f, indent, cell->attributes);
-	f << stringf("%s" "%s", indent.c_str(), id(cell->type, false).c_str());
+	f << stringf("%s" "%s", indent, id(cell->type, false));
 
 	if (!defparam && cell->parameters.size() > 0) {
 		f << stringf(" #(");
 		for (auto it = cell->parameters.begin(); it != cell->parameters.end(); ++it) {
 			if (it != cell->parameters.begin())
 				f << stringf(",");
-			f << stringf("\n%s  .%s(", indent.c_str(), id(it->first).c_str());
+			f << stringf("\n%s  .%s(", indent, id(it->first));
 			if (it->second.size() > 0)
 				dump_const(f, it->second);
 			f << stringf(")");
 		}
-		f << stringf("\n%s" ")", indent.c_str());
+		f << stringf("\n%s" ")", indent);
 	}
 
 	std::string cell_name = cellname(cell);
 	if (cell_name != id(cell->name))
-		f << stringf(" %s /* %s */ (", cell_name.c_str(), id(cell->name).c_str());
+		f << stringf(" %s /* %s */ (", cell_name, id(cell->name));
 	else
-		f << stringf(" %s (", cell_name.c_str());
+		f << stringf(" %s (", cell_name);
 
 	bool first_arg = true;
 	std::set<RTLIL::IdString> numbered_ports;
@@ -1945,7 +1945,7 @@ void dump_cell(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 			if (!first_arg)
 				f << stringf(",");
 			first_arg = false;
-			f << stringf("\n%s  ", indent.c_str());
+			f << stringf("\n%s  ", indent);
 			dump_sigspec(f, it->second);
 			numbered_ports.insert(it->first);
 			goto found_numbered_port;
@@ -1959,16 +1959,16 @@ void dump_cell(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 		if (!first_arg)
 			f << stringf(",");
 		first_arg = false;
-		f << stringf("\n%s  .%s(", indent.c_str(), id(it->first).c_str());
+		f << stringf("\n%s  .%s(", indent, id(it->first));
 		if (it->second.size() > 0)
 			dump_sigspec(f, it->second);
 		f << stringf(")");
 	}
-	f << stringf("\n%s" ");\n", indent.c_str());
+	f << stringf("\n%s" ");\n", indent);
 
 	if (defparam && cell->parameters.size() > 0) {
 		for (auto it = cell->parameters.begin(); it != cell->parameters.end(); ++it) {
-			f << stringf("%sdefparam %s.%s = ", indent.c_str(), cell_name.c_str(), id(it->first).c_str());
+			f << stringf("%sdefparam %s.%s = ", indent, cell_name, id(it->first));
 			dump_const(f, it->second);
 			f << stringf(";\n");
 		}
@@ -1978,7 +1978,7 @@ void dump_cell(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 		std::stringstream ss;
 		dump_reg_init(ss, cell->getPort(ID::Q));
 		if (!ss.str().empty()) {
-			f << stringf("%sinitial %s.Q", indent.c_str(), cell_name.c_str());
+			f << stringf("%sinitial %s.Q", indent, cell_name);
 			f << ss.str();
 			f << ";\n";
 		}
@@ -1988,9 +1988,9 @@ void dump_cell(std::ostream &f, std::string indent, RTLIL::Cell *cell)
 void dump_sync_effect(std::ostream &f, std::string indent, const RTLIL::SigSpec &trg, const RTLIL::Const &polarity, std::vector<const RTLIL::Cell*> &cells)
 {
 	if (trg.size() == 0) {
-		f << stringf("%s" "initial begin\n", indent.c_str());
+		f << stringf("%s" "initial begin\n", indent);
 	} else {
-		f << stringf("%s" "always @(", indent.c_str());
+		f << stringf("%s" "always @(", indent);
 		for (int i = 0; i < trg.size(); i++) {
 			if (i != 0)
 				f << " or ";
@@ -2007,7 +2007,7 @@ void dump_sync_effect(std::ostream &f, std::string indent, const RTLIL::SigSpec 
 		return a->getParam(ID::PRIORITY).as_int() > b->getParam(ID::PRIORITY).as_int();
 	});
 	for (auto cell : cells) {
-		f << stringf("%s" "  if (", indent.c_str());
+		f << stringf("%s" "  if (", indent);
 		dump_sigspec(f, cell->getPort(ID::EN));
 		f << stringf(") begin\n");
 
@@ -2019,22 +2019,22 @@ void dump_sync_effect(std::ostream &f, std::string indent, const RTLIL::SigSpec 
 				Fmt fmt;
 				fmt.parse_rtlil(cell);
 				if (!fmt.parts.empty()) {
-					f << stringf("%s" "    if (!", indent.c_str());
+					f << stringf("%s" "    if (!", indent);
 					dump_sigspec(f, cell->getPort(ID::A));
 					f << stringf(")\n");
 					dump_cell_expr_print(f, indent + "      ", cell);
 				}
 			} else {
-				f << stringf("%s" "  /* message omitted */\n", indent.c_str());
+				f << stringf("%s" "  /* message omitted */\n", indent);
 			}
 
 			dump_cell_expr_check(f, indent + "    ", cell);
 		}
 
-		f << stringf("%s" "  end\n", indent.c_str());
+		f << stringf("%s" "  end\n", indent);
 	}
 
-	f << stringf("%s" "end\n", indent.c_str());
+	f << stringf("%s" "end\n", indent);
 }
 
 void dump_conn(std::ostream &f, std::string indent, const RTLIL::SigSpec &left, const RTLIL::SigSpec &right)
@@ -2044,7 +2044,7 @@ void dump_conn(std::ostream &f, std::string indent, const RTLIL::SigSpec &left, 
 		if (chunk.is_wire() && reg_wires.count(chunk.wire->name))
 			all_chunks_wires = false;
 	if (!simple_lhs && all_chunks_wires) {
-		f << stringf("%s" "assign ", indent.c_str());
+		f << stringf("%s" "assign ", indent);
 		dump_sigspec(f, left);
 		f << stringf(" = ");
 		dump_sigspec(f, right);
@@ -2053,9 +2053,9 @@ void dump_conn(std::ostream &f, std::string indent, const RTLIL::SigSpec &left, 
 		int offset = 0;
 		for (auto &chunk : left.chunks()) {
 			if (chunk.is_wire() && reg_wires.count(chunk.wire->name))
-				f << stringf("%s" "always%s\n%s  ", indent.c_str(), systemverilog ? "_comb" : " @*", indent.c_str());
+				f << stringf("%s" "always%s\n%s  ", indent, systemverilog ? "_comb" : " @*", indent);
 			else
-				f << stringf("%s" "assign ", indent.c_str());
+				f << stringf("%s" "assign ", indent);
 			dump_sigspec(f, chunk);
 			f << stringf(" = ");
 			dump_sigspec(f, right.extract(offset, GetSize(chunk)));
@@ -2072,7 +2072,7 @@ void dump_case_actions(std::ostream &f, std::string indent, RTLIL::CaseRule *cs)
 	for (auto it = cs->actions.begin(); it != cs->actions.end(); ++it) {
 		if (it->first.size() == 0)
 			continue;
-		f << stringf("%s  ", indent.c_str());
+		f << stringf("%s  ", indent);
 		dump_sigspec(f, it->first);
 		f << stringf(" = ");
 		dump_sigspec(f, it->second);
@@ -2133,28 +2133,28 @@ void dump_case_body(std::ostream &f, std::string indent, RTLIL::CaseRule *cs, bo
 	int number_of_stmts = cs->switches.size() + cs->actions.size();
 
 	if (!omit_trailing_begin && number_of_stmts >= 2)
-		f << stringf("%s" "begin\n", indent.c_str());
+		f << stringf("%s" "begin\n", indent);
 
 	dump_case_actions(f, indent, cs);
 	for (auto it = cs->switches.begin(); it != cs->switches.end(); ++it)
 		dump_proc_switch(f, indent + "  ", *it);
 
 	if (!omit_trailing_begin && number_of_stmts == 0)
-		f << stringf("%s  /* empty */;\n", indent.c_str());
+		f << stringf("%s  /* empty */;\n", indent);
 
 	if (omit_trailing_begin || number_of_stmts >= 2)
-		f << stringf("%s" "end\n", indent.c_str());
+		f << stringf("%s" "end\n", indent);
 }
 
 void dump_proc_switch(std::ostream &f, std::string indent, RTLIL::SwitchRule *sw)
 {
 	if (sw->signal.size() == 0) {
-		f << stringf("%s" "begin\n", indent.c_str());
+		f << stringf("%s" "begin\n", indent);
 		for (auto it = sw->cases.begin(); it != sw->cases.end(); ++it) {
 			if ((*it)->compare.size() == 0)
 				dump_case_body(f, indent + "  ", *it);
 		}
-		f << stringf("%s" "end\n", indent.c_str());
+		f << stringf("%s" "end\n", indent);
 		return;
 	}
 
@@ -2162,7 +2162,7 @@ void dump_proc_switch(std::ostream &f, std::string indent, RTLIL::SwitchRule *sw
 		return;
 
 	dump_attributes(f, indent, sw->attributes);
-	f << stringf("%s" "casez (", indent.c_str());
+	f << stringf("%s" "casez (", indent);
 	dump_sigspec(f, sw->signal);
 	f << stringf(")\n");
 
@@ -2170,10 +2170,10 @@ void dump_proc_switch(std::ostream &f, std::string indent, RTLIL::SwitchRule *sw
 		bool got_default = false;
 		dump_attributes(f, indent + "  ", (*it)->attributes, "\n", /*modattr=*/false, /*regattr=*/false, /*as_comment=*/true);
 		if ((*it)->compare.size() == 0) {
-			f << stringf("%s  default", indent.c_str());
+			f << stringf("%s  default", indent);
 			got_default = true;
 		} else {
-			f << stringf("%s  ", indent.c_str());
+			f << stringf("%s  ", indent);
 			for (size_t i = 0; i < (*it)->compare.size(); i++) {
 				if (i > 0)
 					f << stringf(", ");
@@ -2194,10 +2194,10 @@ void dump_proc_switch(std::ostream &f, std::string indent, RTLIL::SwitchRule *sw
 
 	if (sw->cases.empty()) {
 		// Verilog does not allow empty cases.
-		f << stringf("%s  default: ;\n", indent.c_str());
+		f << stringf("%s  default: ;\n", indent);
 	}
 
-	f << stringf("%s" "endcase\n", indent.c_str());
+	f << stringf("%s" "endcase\n", indent);
 }
 
 void case_body_find_regs(RTLIL::CaseRule *cs)
@@ -2226,7 +2226,7 @@ void dump_process(std::ostream &f, std::string indent, RTLIL::Process *proc, boo
 		return;
 	}
 
-	f << stringf("%s" "always%s begin\n", indent.c_str(), systemverilog ? "_comb" : " @*");
+	f << stringf("%s" "always%s begin\n", indent, systemverilog ? "_comb" : " @*");
 	if (!systemverilog)
 		f << indent + "  " << "if (" << id(initial_id) << ") begin end\n";
 	dump_case_body(f, indent, &proc->root_case, true);
@@ -2239,11 +2239,11 @@ void dump_process(std::ostream &f, std::string indent, RTLIL::Process *proc, boo
 		indent = backup_indent;
 
 		if (sync->type == RTLIL::STa) {
-			f << stringf("%s" "always%s begin\n", indent.c_str(), systemverilog ? "_comb" : " @*");
+			f << stringf("%s" "always%s begin\n", indent, systemverilog ? "_comb" : " @*");
 		} else if (sync->type == RTLIL::STi) {
-			f << stringf("%s" "initial begin\n", indent.c_str());
+			f << stringf("%s" "initial begin\n", indent);
 		} else {
-			f << stringf("%s" "always%s @(", indent.c_str(), systemverilog ? "_ff" : "");
+			f << stringf("%s" "always%s @(", indent, systemverilog ? "_ff" : "");
 			if (sync->type == RTLIL::STp || sync->type == RTLIL::ST1)
 				f << stringf("posedge ");
 			if (sync->type == RTLIL::STn || sync->type == RTLIL::ST0)
@@ -2255,7 +2255,7 @@ void dump_process(std::ostream &f, std::string indent, RTLIL::Process *proc, boo
 		indent += "  ";
 
 		if (sync->type == RTLIL::ST0 || sync->type == RTLIL::ST1) {
-			f << stringf("%s" "if (%s", indent.c_str(), sync->type == RTLIL::ST0 ? "!" : "");
+			f << stringf("%s" "if (%s", indent, sync->type == RTLIL::ST0 ? "!" : "");
 			dump_sigspec(f, sync->signal);
 			f << stringf(") begin\n");
 			ends = indent + "end\n" + ends;
@@ -2266,7 +2266,7 @@ void dump_process(std::ostream &f, std::string indent, RTLIL::Process *proc, boo
 			for (size_t j = 0; j < proc->syncs.size(); j++) {
 				RTLIL::SyncRule *sync2 = proc->syncs[j];
 				if (sync2->type == RTLIL::ST0 || sync2->type == RTLIL::ST1) {
-					f << stringf("%s" "if (%s", indent.c_str(), sync2->type == RTLIL::ST1 ? "!" : "");
+					f << stringf("%s" "if (%s", indent, sync2->type == RTLIL::ST1 ? "!" : "");
 					dump_sigspec(f, sync2->signal);
 					f << stringf(") begin\n");
 					ends = indent + "end\n" + ends;
@@ -2278,14 +2278,14 @@ void dump_process(std::ostream &f, std::string indent, RTLIL::Process *proc, boo
 		for (auto it = sync->actions.begin(); it != sync->actions.end(); ++it) {
 			if (it->first.size() == 0)
 				continue;
-			f << stringf("%s  ", indent.c_str());
+			f << stringf("%s  ", indent);
 			dump_sigspec(f, it->first);
 			f << stringf(" <= ");
 			dump_sigspec(f, it->second);
 			f << stringf(";\n");
 		}
 
-		f << stringf("%s", ends.c_str());
+		f << stringf("%s", ends);
 	}
 }
 
@@ -2356,14 +2356,14 @@ void dump_module(std::ostream &f, std::string indent, RTLIL::Module *module)
 	}
 
 	dump_attributes(f, indent, module->attributes, "\n", /*modattr=*/true);
-	f << stringf("%s" "module %s(", indent.c_str(), id(module->name, false).c_str());
+	f << stringf("%s" "module %s(", indent, id(module->name, false));
 	int cnt = 0;
 	for (auto port : module->ports) {
 		Wire *wire = module->wire(port);
 		if (wire) {
 			if (port != module->ports[0])
 				f << stringf(", ");
-			f << stringf("%s", id(wire->name).c_str());
+			f << stringf("%s", id(wire->name));
 			if (cnt==20) { f << stringf("\n"); cnt = 0; } else cnt++;
 			continue;
 		}
@@ -2400,7 +2400,7 @@ void dump_module(std::ostream &f, std::string indent, RTLIL::Module *module)
 	for (auto it = module->connections().begin(); it != module->connections().end(); ++it)
 		dump_conn(f, indent + "  ", it->first, it->second);
 
-	f << stringf("%s" "endmodule\n", indent.c_str());
+	f << stringf("%s" "endmodule\n", indent);
 	active_module = NULL;
 	active_sigmap.clear();
 	active_initdata.clear();

--- a/frontends/aiger/aigerparse.cc
+++ b/frontends/aiger/aigerparse.cc
@@ -284,7 +284,7 @@ end_of_header:
 			if ((c == 'i' && l1 > inputs.size()) || (c == 'l' && l1 > latches.size()) || (c == 'o' && l1 > outputs.size()))
 				log_error("Line %u has invalid symbol position!\n", line_count);
 
-			RTLIL::IdString escaped_s = stringf("\\%s", s.c_str());
+			RTLIL::IdString escaped_s = stringf("\\%s", s);
 			RTLIL::Wire* wire;
 			if (c == 'i') wire = inputs[l1];
 			else if (c == 'l') wire = latches[l1];
@@ -830,7 +830,7 @@ void AigerReader::post_process()
 					log_debug(" -> %s\n", log_id(escaped_s));
 				}
 				else {
-					RTLIL::IdString indexed_name = stringf("%s[%d]", escaped_s.c_str(), index);
+					RTLIL::IdString indexed_name = stringf("%s[%d]", escaped_s, index);
 					existing = module->wire(indexed_name);
 					if (!existing)
 						module->rename(wire, indexed_name);
@@ -877,7 +877,7 @@ void AigerReader::post_process()
 					log_debug(" -> %s\n", log_id(escaped_s));
 				}
 				else {
-					RTLIL::IdString indexed_name = stringf("%s[%d]", escaped_s.c_str(), index);
+					RTLIL::IdString indexed_name = stringf("%s[%d]", escaped_s, index);
 					existing = module->wire(indexed_name);
 					if (!existing)
 						module->rename(wire, indexed_name);
@@ -922,7 +922,7 @@ void AigerReader::post_process()
 
 		RTLIL::Wire *wire = module->wire(name);
 		if (wire)
-			module->rename(wire, RTLIL::escape_id(stringf("%s[%d]", name.c_str(), 0)));
+			module->rename(wire, RTLIL::escape_id(stringf("%s[%d]", name, 0)));
 
 		// Do not make ports with a mix of input/output into
 		// wide ports
@@ -942,7 +942,7 @@ void AigerReader::post_process()
 		wire->port_output = port_output;
 
 		for (int i = min; i <= max; i++) {
-			RTLIL::IdString other_name = stringf("%s[%d]", name.c_str(), i);
+			RTLIL::IdString other_name = stringf("%s[%d]", name, i);
 			RTLIL::Wire *other_wire = module->wire(other_name);
 			if (other_wire) {
 				other_wire->port_input = false;
@@ -971,9 +971,9 @@ void AigerReader::post_process()
 		if (cell->type != ID($lut)) continue;
 		auto y_port = cell->getPort(ID::Y).as_bit();
 		if (y_port.wire->width == 1)
-			module->rename(cell, stringf("$lut%s", y_port.wire->name.c_str()));
+			module->rename(cell, stringf("$lut%s", y_port.wire->name));
 		else
-			module->rename(cell, stringf("$lut%s[%d]", y_port.wire->name.c_str(), y_port.offset));
+			module->rename(cell, stringf("$lut%s[%d]", y_port.wire->name, y_port.offset));
 	}
 }
 

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -922,7 +922,7 @@ std::unique_ptr<AstNode> AstNode::mktemp_logic(AstSrcLocType loc, const std::str
 {
 	auto wire_owned = std::make_unique<AstNode>(loc, AST_WIRE, std::make_unique<AstNode>(loc, AST_RANGE, mkconst_int(loc, range_left, true), mkconst_int(loc, range_right, true)));
 	auto* wire = wire_owned.get();
-	wire->str = stringf("%s%s:%d$%d", name.c_str(), RTLIL::encode_filename(*location.begin.filename).c_str(), location.begin.line, autoidx++);
+	wire->str = stringf("%s%s:%d$%d", name, RTLIL::encode_filename(*location.begin.filename), location.begin.line, autoidx++);
 	if (nosync)
 		wire->set_attribute(ID::nosync, AstNode::mkconst_int(loc, 1, false));
 	wire->is_signed = is_signed;
@@ -1773,7 +1773,7 @@ static std::string serialize_param_value(const RTLIL::Const &val) {
 std::string AST::derived_module_name(std::string stripped_name, const std::vector<std::pair<RTLIL::IdString, RTLIL::Const>> &parameters) {
 	std::string para_info;
 	for (const auto &elem : parameters)
-		para_info += stringf("%s=%s", elem.first.c_str(), serialize_param_value(elem.second).c_str());
+		para_info += stringf("%s=%s", elem.first, serialize_param_value(elem.second));
 
 	if (para_info.size() > 60)
 		return "$paramod$" + sha1(para_info) + stripped_name;

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -45,7 +45,7 @@ using namespace AST_INTERNAL;
 // helper function for creating RTLIL code for unary operations
 static RTLIL::SigSpec uniop2rtlil(AstNode *that, IdString type, int result_width, const RTLIL::SigSpec &arg, bool gen_attributes = true)
 {
-	IdString name = stringf("%s$%s:%d$%d", type.c_str(), RTLIL::encode_filename(*that->location.begin.filename).c_str(), that->location.begin.line, autoidx++);
+	IdString name = stringf("%s$%s:%d$%d", type, RTLIL::encode_filename(*that->location.begin.filename), that->location.begin.line, autoidx++);
 	RTLIL::Cell *cell = current_module->addCell(name, type);
 	set_src_attr(cell, that);
 
@@ -77,7 +77,7 @@ static void widthExtend(AstNode *that, RTLIL::SigSpec &sig, int width, bool is_s
 		return;
 	}
 
-	IdString name = stringf("$extend$%s:%d$%d", RTLIL::encode_filename(*that->location.begin.filename).c_str(), that->location.begin.line, autoidx++);
+	IdString name = stringf("$extend$%s:%d$%d", RTLIL::encode_filename(*that->location.begin.filename), that->location.begin.line, autoidx++);
 	RTLIL::Cell *cell = current_module->addCell(name, ID($pos));
 	set_src_attr(cell, that);
 
@@ -104,7 +104,7 @@ static void widthExtend(AstNode *that, RTLIL::SigSpec &sig, int width, bool is_s
 // helper function for creating RTLIL code for binary operations
 static RTLIL::SigSpec binop2rtlil(AstNode *that, IdString type, int result_width, const RTLIL::SigSpec &left, const RTLIL::SigSpec &right)
 {
-	IdString name = stringf("%s$%s:%d$%d", type.c_str(), RTLIL::encode_filename(*that->location.begin.filename).c_str(), that->location.begin.line, autoidx++);
+	IdString name = stringf("%s$%s:%d$%d", type, RTLIL::encode_filename(*that->location.begin.filename), that->location.begin.line, autoidx++);
 	RTLIL::Cell *cell = current_module->addCell(name, type);
 	set_src_attr(cell, that);
 
@@ -199,7 +199,7 @@ struct AST_INTERNAL::LookaheadRewriter
 				for (auto& c : node->id2ast->children)
 					wire->children.push_back(c->clone());
 				wire->fixup_hierarchy_flags();
-				wire->str = stringf("$lookahead%s$%d", node->str.c_str(), autoidx++);
+				wire->str = stringf("$lookahead%s$%d", node->str, autoidx++);
 				wire->set_attribute(ID::nosync, AstNode::mkconst_int(node->location, 1, false));
 				wire->is_logic = true;
 				while (wire->simplify(true, 1, -1, false)) { }
@@ -348,7 +348,7 @@ struct AST_INTERNAL::ProcessGenerator
 		LookaheadRewriter la_rewriter(always.get());
 
 		// generate process and simple root case
-		proc = current_module->addProcess(stringf("$proc$%s:%d$%d", RTLIL::encode_filename(*always->location.begin.filename).c_str(), always->location.begin.line, autoidx++));
+		proc = current_module->addProcess(stringf("$proc$%s:%d$%d", RTLIL::encode_filename(*always->location.begin.filename), always->location.begin.line, autoidx++));
 		set_src_attr(proc, always.get());
 		for (auto &attr : always->attributes) {
 			if (attr.second->type != AST_CONSTANT)
@@ -814,7 +814,7 @@ struct AST_INTERNAL::ProcessGenerator
 
 				IdString cellname;
 				if (ast->str.empty())
-					cellname = stringf("$%s$%s:%d$%d", flavor.c_str(), RTLIL::encode_filename(*ast->location.begin.filename).c_str(), ast->location.begin.line, autoidx++);
+					cellname = stringf("$%s$%s:%d$%d", flavor, RTLIL::encode_filename(*ast->location.begin.filename), ast->location.begin.line, autoidx++);
 				else
 					cellname = ast->str;
 				check_unique_id(current_module, cellname, ast, "procedural assertion");
@@ -1568,7 +1568,7 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 			// This makes it possible for the hierarchy pass to see what are interface connections and then replace them
 			// with the individual signals:
 			if (is_interface) {
-				IdString dummy_wire_name = stringf("$dummywireforinterface%s", str.c_str());
+				IdString dummy_wire_name = stringf("$dummywireforinterface%s", str);
 				RTLIL::Wire *dummy_wire = current_module->wire(dummy_wire_name);
 				if (!dummy_wire) {
 					dummy_wire = current_module->addWire(dummy_wire_name);
@@ -2019,7 +2019,7 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 
 			IdString cellname;
 			if (str.empty())
-				cellname = stringf("$%s$%s:%d$%d", flavor.c_str(), RTLIL::encode_filename(*location.begin.filename).c_str(), location.begin.line, autoidx++);
+				cellname = stringf("$%s$%s:%d$%d", flavor, RTLIL::encode_filename(*location.begin.filename), location.begin.line, autoidx++);
 			else
 				cellname = str;
 			check_unique_id(current_module, cellname, this, "procedural assertion");

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -968,10 +968,10 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 
 			verbose_activate:
 				if (mem2reg_set.count(mem) == 0) {
-					std::string message = stringf("Replacing memory %s with list of registers.", mem->str.c_str());
+					std::string message = stringf("Replacing memory %s with list of registers.", mem->str);
 					bool first_element = true;
 					for (auto &place : mem2reg_places[it.first]) {
-						message += stringf("%s%s", first_element ? " See " : ", ", place.c_str());
+						message += stringf("%s%s", first_element ? " See " : ", ", place);
 						first_element = false;
 					}
 					log_warning("%s\n", message.c_str());
@@ -997,7 +997,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 				for (int i = 0; i < mem_size; i++) {
 					auto reg = std::make_unique<AstNode>(loc, AST_WIRE, std::make_unique<AstNode>(loc, AST_RANGE,
 							mkconst_int(loc, data_range_left, true), mkconst_int(loc, data_range_right, true)));
-					reg->str = stringf("%s[%d]", node->str.c_str(), i);
+					reg->str = stringf("%s[%d]", node->str, i);
 					reg->is_reg = true;
 					reg->is_signed = node->is_signed;
 					for (auto &it : node->attributes)
@@ -2050,7 +2050,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 		const char *second_part = children[1]->str.c_str();
 		if (second_part[0] == '\\')
 			second_part++;
-		newNode->str = stringf("%s[%d].%s", str.c_str(), children[0]->integer, second_part);
+		newNode->str = stringf("%s[%d].%s", str, children[0]->integer, second_part);
 		goto apply_newNode;
 	}
 
@@ -2767,7 +2767,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 			} else {
 				this->dumpAst(NULL, "    ");
 				log_assert(new_cell->children.at(0)->type == AST_CELLTYPE);
-				new_cell->children.at(0)->str = stringf("$array:%d:%d:%s", i, num, new_cell->children.at(0)->str.c_str());
+				new_cell->children.at(0)->str = stringf("$array:%d:%d:%s", i, num, new_cell->children.at(0)->str);
 			}
 		}
 
@@ -3119,7 +3119,7 @@ skip_dynamic_range_lvalue_expansion:;
 
 			auto wire_tmp_owned = std::make_unique<AstNode>(location, AST_WIRE, std::make_unique<AstNode>(location, AST_RANGE, mkconst_int(location, width_hint-1, true), mkconst_int(location, 0, true)));
 			auto wire_tmp = wire_tmp_owned.get();
-			wire_tmp->str = stringf("$splitcmplxassign$%s:%d$%d", RTLIL::encode_filename(*location.begin.filename).c_str(), location.begin.line, autoidx++);
+			wire_tmp->str = stringf("$splitcmplxassign$%s:%d$%d", RTLIL::encode_filename(*location.begin.filename), location.begin.line, autoidx++);
 			current_scope[wire_tmp->str] = wire_tmp;
 			current_ast_mod->children.push_back(std::move(wire_tmp_owned));
 			wire_tmp->set_attribute(ID::nosync, AstNode::mkconst_int(location, 1, false));
@@ -3433,7 +3433,7 @@ skip_dynamic_range_lvalue_expansion:;
 					auto* reg = reg_owned.get();
 					current_ast_mod->children.push_back(std::move(reg_owned));
 
-					reg->str = stringf("$past$%s:%d$%d$%d", RTLIL::encode_filename(*location.begin.filename).c_str(), location.begin.line, myidx, i);
+					reg->str = stringf("$past$%s:%d$%d$%d", RTLIL::encode_filename(*location.begin.filename), location.begin.line, myidx, i);
 					reg->is_reg = true;
 					reg->is_signed = sign_hint;
 
@@ -4754,7 +4754,7 @@ static void mark_memories_assign_lhs_complex(dict<AstNode*, pool<std::string>> &
 	if (that->type == AST_IDENTIFIER && that->id2ast && that->id2ast->type == AST_MEMORY) {
 		AstNode *mem = that->id2ast;
 		if (!(mem2reg_candidates[mem] & AstNode::MEM2REG_FL_CMPLX_LHS))
-			mem2reg_places[mem].insert(stringf("%s:%d", RTLIL::encode_filename(*that->location.begin.filename).c_str(), that->location.begin.line));
+			mem2reg_places[mem].insert(stringf("%s:%d", RTLIL::encode_filename(*that->location.begin.filename), that->location.begin.line));
 		mem2reg_candidates[mem] |= AstNode::MEM2REG_FL_CMPLX_LHS;
 	}
 }
@@ -4782,14 +4782,14 @@ void AstNode::mem2reg_as_needed_pass1(dict<AstNode*, pool<std::string>> &mem2reg
 			// activate mem2reg if this is assigned in an async proc
 			if (flags & AstNode::MEM2REG_FL_ASYNC) {
 				if (!(mem2reg_candidates[mem] & AstNode::MEM2REG_FL_SET_ASYNC))
-					mem2reg_places[mem].insert(stringf("%s:%d", RTLIL::encode_filename(*location.begin.filename).c_str(), location.begin.line));
+					mem2reg_places[mem].insert(stringf("%s:%d", RTLIL::encode_filename(*location.begin.filename), location.begin.line));
 				mem2reg_candidates[mem] |= AstNode::MEM2REG_FL_SET_ASYNC;
 			}
 
 			// remember if this is assigned blocking (=)
 			if (type == AST_ASSIGN_EQ) {
 				if (!(proc_flags[mem] & AstNode::MEM2REG_FL_EQ1))
-					mem2reg_places[mem].insert(stringf("%s:%d", RTLIL::encode_filename(*location.begin.filename).c_str(), location.begin.line));
+					mem2reg_places[mem].insert(stringf("%s:%d", RTLIL::encode_filename(*location.begin.filename), location.begin.line));
 				proc_flags[mem] |= AstNode::MEM2REG_FL_EQ1;
 			}
 
@@ -4806,11 +4806,11 @@ void AstNode::mem2reg_as_needed_pass1(dict<AstNode*, pool<std::string>> &mem2reg
 			// remember where this is
 			if (flags & MEM2REG_FL_INIT) {
 				if (!(mem2reg_candidates[mem] & AstNode::MEM2REG_FL_SET_INIT))
-					mem2reg_places[mem].insert(stringf("%s:%d", RTLIL::encode_filename(*location.begin.filename).c_str(), location.begin.line));
+					mem2reg_places[mem].insert(stringf("%s:%d", RTLIL::encode_filename(*location.begin.filename), location.begin.line));
 				mem2reg_candidates[mem] |= AstNode::MEM2REG_FL_SET_INIT;
 			} else {
 				if (!(mem2reg_candidates[mem] & AstNode::MEM2REG_FL_SET_ELSE))
-					mem2reg_places[mem].insert(stringf("%s:%d", RTLIL::encode_filename(*location.begin.filename).c_str(), location.begin.line));
+					mem2reg_places[mem].insert(stringf("%s:%d", RTLIL::encode_filename(*location.begin.filename), location.begin.line));
 				mem2reg_candidates[mem] |= AstNode::MEM2REG_FL_SET_ELSE;
 			}
 		}
@@ -4827,7 +4827,7 @@ void AstNode::mem2reg_as_needed_pass1(dict<AstNode*, pool<std::string>> &mem2reg
 
 		// flag if used after blocking assignment (in same proc)
 		if ((proc_flags[mem] & AstNode::MEM2REG_FL_EQ1) && !(mem2reg_candidates[mem] & AstNode::MEM2REG_FL_EQ2)) {
-			mem2reg_places[mem].insert(stringf("%s:%d", RTLIL::encode_filename(*location.begin.filename).c_str(), location.begin.line));
+			mem2reg_places[mem].insert(stringf("%s:%d", RTLIL::encode_filename(*location.begin.filename), location.begin.line));
 			mem2reg_candidates[mem] |= AstNode::MEM2REG_FL_EQ2;
 		}
 	}
@@ -5070,7 +5070,7 @@ bool AstNode::mem2reg_as_needed_pass2(pool<AstNode*> &mem2reg_set, AstNode *mod,
 			auto assign_reg = std::make_unique<AstNode>(location, type, std::make_unique<AstNode>(location, AST_IDENTIFIER), std::make_unique<AstNode>(location, AST_IDENTIFIER));
 			if (children[0]->children.size() == 2)
 				assign_reg->children[0]->children.push_back(children[0]->children[1]->clone());
-			assign_reg->children[0]->str = stringf("%s[%d]", children[0]->str.c_str(), i);
+			assign_reg->children[0]->str = stringf("%s[%d]", children[0]->str, i);
 			assign_reg->children[1]->str = id_data;
 			cond_node->children[1]->children.push_back(std::move(assign_reg));
 			case_node->children.push_back(std::move(cond_node));
@@ -5108,7 +5108,7 @@ bool AstNode::mem2reg_as_needed_pass2(pool<AstNode*> &mem2reg_set, AstNode *mod,
 				(right <= id && id <= left);
 			if (valid_const_access)
 			{
-				str = stringf("%s[%d]", str.c_str(), id);
+				str = stringf("%s[%d]", str, id);
 				delete_children();
 				range_valid = false;
 				id2ast = nullptr;
@@ -5185,7 +5185,7 @@ bool AstNode::mem2reg_as_needed_pass2(pool<AstNode*> &mem2reg_set, AstNode *mod,
 				auto assign_reg = std::make_unique<AstNode>(location, AST_ASSIGN_EQ, std::make_unique<AstNode>(location, AST_IDENTIFIER), std::make_unique<AstNode>(location, AST_IDENTIFIER));
 				assign_reg->children[0]->str = id_data;
 				assign_reg->children[0]->was_checked = true;
-				assign_reg->children[1]->str = stringf("%s[%d]", str.c_str(), i);
+				assign_reg->children[1]->str = stringf("%s[%d]", str, i);
 				cond_node->children[1]->children.push_back(std::move(assign_reg));
 				case_node->children.push_back(std::move(cond_node));
 			}

--- a/frontends/rpc/rpc_frontend.cc
+++ b/frontends/rpc/rpc_frontend.cc
@@ -168,7 +168,7 @@ struct RpcModule : RTLIL::Module {
 		std::string parameter_info;
 		for (auto &param : parameters) {
 			log("Parameter %s = %s\n", param.first.c_str(), log_signal(RTLIL::SigSpec(param.second)));
-			parameter_info += stringf("%s=%s", param.first.c_str(), log_signal(RTLIL::SigSpec(param.second)));
+			parameter_info += stringf("%s=%s", param.first, log_signal(RTLIL::SigSpec(param.second)));
 		}
 
 		std::string derived_name;

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -129,7 +129,7 @@ void msg_func(msg_type_t msg_type, const char *message_id, linefile_type linefil
 	message += vstringf(msg, args);
 
 	if (log_verific_callback) {
-		string full_message = stringf("%s%s\n", message_prefix.c_str(), message.c_str());
+		string full_message = stringf("%s%s\n", message_prefix, message);
 #ifdef VERIFIC_LINEFILE_INCLUDES_COLUMNS 
 		log_verific_callback(int(msg_type), message_id, LineFile::GetFileName(linefile), 
 			linefile ? linefile->GetLeftLine() : 0, linefile ? linefile->GetLeftCol() : 0, 
@@ -232,7 +232,7 @@ RTLIL::IdString VerificImporter::new_verific_id(Verific::DesignObj *obj)
 {
 	std::string s = stringf("$verific$%s", obj->Name());
 	if (obj->Linefile())
-		s += stringf("$%s:%d", RTLIL::encode_filename(Verific::LineFile::GetFileName(obj->Linefile())).c_str(), Verific::LineFile::GetLineNo(obj->Linefile()));
+		s += stringf("$%s:%d", RTLIL::encode_filename(Verific::LineFile::GetFileName(obj->Linefile())), Verific::LineFile::GetLineNo(obj->Linefile()));
 	s += stringf("$%d", autoidx++);
 	return s;
 }
@@ -472,7 +472,7 @@ void VerificImporter::import_attributes(dict<RTLIL::IdString, RTLIL::Const> &att
 			if (nl->IsFromVerilog()) {
 				auto const value = verific_const(type_name, v, nl, false);
 
-				attributes.emplace(stringf("\\enum_value_%s", value.as_string().c_str()), RTLIL::escape_id(k));
+				attributes.emplace(stringf("\\enum_value_%s", value.as_string()), RTLIL::escape_id(k));
 			}
 #ifdef VERIFIC_VHDL_SUPPORT
 			else if (nl->IsFromVhdl()) {
@@ -1926,7 +1926,7 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 				RTLIL::SigSpec data = operatorOutput(inst).extract(i * memory->width, memory->width);
 
 				RTLIL::Cell *cell = module->addCell(numchunks == 1 ? inst_name :
-						RTLIL::IdString(stringf("%s_%d", inst_name.c_str(), i)), ID($memrd));
+						RTLIL::IdString(stringf("%s_%d", inst_name, i)), ID($memrd));
 				cell->parameters[ID::MEMID] = memory->name.str();
 				cell->parameters[ID::CLK_ENABLE] = false;
 				cell->parameters[ID::CLK_POLARITY] = true;
@@ -1956,7 +1956,7 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 				RTLIL::SigSpec data = operatorInput2(inst).extract(i * memory->width, memory->width);
 
 				RTLIL::Cell *cell = module->addCell(numchunks == 1 ? inst_name :
-						RTLIL::IdString(stringf("%s_%d", inst_name.c_str(), i)), ID($memwr));
+						RTLIL::IdString(stringf("%s_%d", inst_name, i)), ID($memwr));
 				cell->parameters[ID::MEMID] = memory->name.str();
 				cell->parameters[ID::CLK_ENABLE] = false;
 				cell->parameters[ID::CLK_POLARITY] = true;

--- a/frontends/verific/verificsva.cc
+++ b/frontends/verific/verificsva.cc
@@ -1031,12 +1031,12 @@ struct VerificSvaImporter
 
 	[[noreturn]] void parser_error(std::string errmsg, linefile_type loc)
 	{
-		parser_error(stringf("%s at %s:%d.\n", errmsg.c_str(), LineFile::GetFileName(loc), LineFile::GetLineNo(loc)));
+		parser_error(stringf("%s at %s:%d.\n", errmsg, LineFile::GetFileName(loc), LineFile::GetLineNo(loc)));
 	}
 
 	[[noreturn]] void parser_error(std::string errmsg, Instance *inst)
 	{
-		parser_error(stringf("%s at %s (%s)", errmsg.c_str(), inst->View()->Owner()->Name(), inst->Name()), inst->Linefile());
+		parser_error(stringf("%s at %s (%s)", errmsg, inst->View()->Owner()->Name(), inst->Name()), inst->Linefile());
 	}
 
 	[[noreturn]] void parser_error(Instance *inst)

--- a/frontends/verilog/preproc.cc
+++ b/frontends/verilog/preproc.cc
@@ -265,7 +265,7 @@ struct arg_map_t
 	// (something like macro_foobar_arg2). This doesn't include the leading backtick.
 	static std::string str_token(const std::string &macro_name, int pos)
 	{
-		return stringf("macro_%s_arg%d", macro_name.c_str(), pos);
+		return stringf("macro_%s_arg%d", macro_name, pos);
 	}
 
 	// Return definitions for the macro arguments (so that substituting in the macro body and

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -323,7 +323,7 @@
 
 			// create a unique name for the genvar
 			std::string old_str = decl->str;
-			std::string new_str = stringf("$genfordecl$%d$%s", autoidx++, old_str.c_str());
+			std::string new_str = stringf("$genfordecl$%d$%s", autoidx++, old_str);
 
 			// rename and move the genvar declaration to the containing description
 			decl->str = new_str;

--- a/kernel/fstdata.cc
+++ b/kernel/fstdata.cc
@@ -33,8 +33,8 @@ FstData::FstData(std::string filename) : ctx(nullptr)
 	std::string filename_trim = file_base_name(filename);
 	if (filename_trim.size() > 4 && filename_trim.compare(filename_trim.size()-4, std::string::npos, ".vcd") == 0) {
 		filename_trim.erase(filename_trim.size()-4);
-		tmp_file = stringf("%s/converted_%s.fst", get_base_tmpdir().c_str(), filename_trim.c_str());
-		std::string cmd = stringf("vcd2fst %s %s", filename.c_str(), tmp_file.c_str());
+		tmp_file = stringf("%s/converted_%s.fst", get_base_tmpdir(), filename_trim);
+		std::string cmd = stringf("vcd2fst %s %s", filename, tmp_file);
 		log("Exec: %s\n", cmd.c_str());
 		if (run_command(cmd) != 0)
 			log_cmd_error("Shell command failed!\n");

--- a/kernel/io.cc
+++ b/kernel/io.cc
@@ -307,7 +307,7 @@ bool is_absolute_path(std::string filename)
 void remove_directory(std::string dirname)
 {
 #ifdef _WIN32
-	run_command(stringf("rmdir /s /q \"%s\"", dirname.c_str()));
+	run_command(stringf("rmdir /s /q \"%s\"", dirname));
 #else
 	struct stat stbuf;
 	struct dirent **namelist;
@@ -315,7 +315,7 @@ void remove_directory(std::string dirname)
 	log_assert(n >= 0);
 	for (int i = 0; i < n; i++) {
 		if (strcmp(namelist[i]->d_name, ".") && strcmp(namelist[i]->d_name, "..")) {
-			std::string buffer = stringf("%s/%s", dirname.c_str(), namelist[i]->d_name);
+			std::string buffer = stringf("%s/%s", dirname, namelist[i]->d_name);
 			if (!stat(buffer.c_str(), &stbuf) && S_ISREG(stbuf.st_mode)) {
 				remove(buffer.c_str());
 			} else

--- a/kernel/io.cc
+++ b/kernel/io.cc
@@ -575,6 +575,17 @@ void format_emit_string_view(std::string &result, std::string_view spec, int *dy
 	format_emit_stringf(result, spec, dynamic_ints, num_dynamic_ints, std::string(arg).c_str());
 }
 
+void format_emit_idstring(std::string &result, std::string_view spec, int *dynamic_ints,
+	DynamicIntCount num_dynamic_ints, const IdString &arg)
+{
+	if (spec == "%s") {
+		// Format checking will have guaranteed num_dynamic_ints == 0.
+		result += arg.c_str();
+		return;
+	}
+	format_emit_stringf(result, spec, dynamic_ints, num_dynamic_ints, arg.c_str());
+}
+
 void format_emit_void_ptr(std::string &result, std::string_view spec, int *dynamic_ints,
 	DynamicIntCount num_dynamic_ints, const void *arg)
 {

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -791,7 +791,7 @@ dict<std::string, std::pair<std::string, int>> get_coverage_data()
 	dict<std::string, std::pair<std::string, int>> coverage_data;
 
 	for (auto &it : pass_register) {
-		std::string key = stringf("passes.%s", it.first.c_str());
+		std::string key = stringf("passes.%s", it.first);
 		coverage_data[key].first = stringf("%s:%d:%s", __FILE__, __LINE__, __FUNCTION__);
 		coverage_data[key].second += it.second->call_counter;
 	}

--- a/kernel/mem.cc
+++ b/kernel/mem.cc
@@ -900,7 +900,7 @@ Cell *Mem::extract_rdff(int idx, FfInitVals *initvals) {
 
 		if (width)
 		{
-			SigSpec sig_q = module->addWire(stringf("$%s$rdreg[%d]$q", memid.c_str(), idx), width);
+			SigSpec sig_q = module->addWire(stringf("$%s$rdreg[%d]$q", memid, idx), width);
 			SigSpec sig_d;
 
 			int pos = 0;
@@ -910,7 +910,7 @@ Cell *Mem::extract_rdff(int idx, FfInitVals *initvals) {
 					port.addr[i] = sig_q[pos++];
 				}
 
-			c = module->addDff(stringf("$%s$rdreg[%d]", memid.c_str(), idx), port.clk, sig_d, sig_q, port.clk_polarity);
+			c = module->addDff(stringf("$%s$rdreg[%d]", memid, idx), port.clk, sig_d, sig_q, port.clk_polarity);
 		} else {
 			c = nullptr;
 		}
@@ -919,7 +919,7 @@ Cell *Mem::extract_rdff(int idx, FfInitVals *initvals) {
 	{
 		log_assert(port.arst == State::S0 || port.srst == State::S0);
 
-		SigSpec async_d = module->addWire(stringf("$%s$rdreg[%d]$d", memid.c_str(), idx), GetSize(port.data));
+		SigSpec async_d = module->addWire(stringf("$%s$rdreg[%d]$d", memid, idx), GetSize(port.data));
 		SigSpec sig_d = async_d;
 
 		for (int i = 0; i < GetSize(wr_ports); i++) {
@@ -942,7 +942,7 @@ Cell *Mem::extract_rdff(int idx, FfInitVals *initvals) {
 						raddr = port.sub_addr(sub);
 					SigSpec addr_eq;
 					if (raddr != waddr)
-						addr_eq = module->Eq(stringf("$%s$rdtransen[%d][%d][%d]$d", memid.c_str(), idx, i, sub), raddr, waddr);
+						addr_eq = module->Eq(stringf("$%s$rdtransen[%d][%d][%d]$d", memid, idx, i, sub), raddr, waddr);
 					int pos = 0;
 					int ewidth = width << min_wide_log2;
 					int wsub = wide_write ? sub : 0;
@@ -955,10 +955,10 @@ Cell *Mem::extract_rdff(int idx, FfInitVals *initvals) {
 						SigSpec other = port.transparency_mask[i] ? wport.data.extract(pos + wsub * width, epos-pos) : Const(State::Sx, epos-pos);
 						SigSpec cond;
 						if (raddr != waddr)
-							cond = module->And(stringf("$%s$rdtransgate[%d][%d][%d][%d]$d", memid.c_str(), idx, i, sub, pos), wport.en[pos + wsub * width], addr_eq);
+							cond = module->And(stringf("$%s$rdtransgate[%d][%d][%d][%d]$d", memid, idx, i, sub, pos), wport.en[pos + wsub * width], addr_eq);
 						else
 							cond = wport.en[pos + wsub * width];
-						SigSpec merged = module->Mux(stringf("$%s$rdtransmux[%d][%d][%d][%d]$d", memid.c_str(), idx, i, sub, pos), cur, other, cond);
+						SigSpec merged = module->Mux(stringf("$%s$rdtransmux[%d][%d][%d][%d]$d", memid, idx, i, sub, pos), cur, other, cond);
 						sig_d.replace(pos + rsub * width, merged);
 						pos = epos;
 					}
@@ -966,7 +966,7 @@ Cell *Mem::extract_rdff(int idx, FfInitVals *initvals) {
 			}
 		}
 
-		IdString name = stringf("$%s$rdreg[%d]", memid.c_str(), idx);
+		IdString name = stringf("$%s$rdreg[%d]", memid, idx);
 		FfData ff(module, initvals, name);
 		ff.width = GetSize(port.data);
 		ff.has_clk = true;

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -2773,7 +2773,7 @@ RTLIL::IdString RTLIL::Module::uniquify(RTLIL::IdString name, int &index)
 	}
 
 	while (1) {
-		RTLIL::IdString new_name = stringf("%s_%d", name.c_str(), index);
+		RTLIL::IdString new_name = stringf("%s_%d", name, index);
 		if (count_id(new_name) == 0)
 			return new_name;
 		index++;

--- a/kernel/satgen.h
+++ b/kernel/satgen.h
@@ -103,7 +103,7 @@ struct SatGen
 			} else {
 				std::string wire_name = RTLIL::unescape_id(bit.wire->name);
 				std::string name = pf +
-					(bit.wire->width == 1 ? wire_name : stringf("%s [%d]", wire_name.c_str(), bit.offset));
+					(bit.wire->width == 1 ? wire_name : stringf("%s [%d]", wire_name, bit.offset));
 				vec.push_back(ez->frozen_literal(name));
 				imported_signals[pf][bit] = vec.back();
 			}

--- a/kernel/tclapi.cc
+++ b/kernel/tclapi.cc
@@ -89,7 +89,7 @@ static int tcl_yosys_cmd(ClientData, Tcl_Interp *interp, int argc, const char *a
 			if (Tcl_GetCommandInfo(interp, tcl_command_name.c_str(), &info) != 0) {
 				log("[TCL: yosys -import] Command name collision: found pre-existing command `%s' -> skip.\n", it.first.c_str());
 			} else {
-				std::string tcl_script = stringf("proc %s args { yosys %s {*}$args }", tcl_command_name.c_str(), it.first.c_str());
+				std::string tcl_script = stringf("proc %s args { yosys %s {*}$args }", tcl_command_name, it.first);
 				Tcl_Eval(interp, tcl_script.c_str());
 			}
 		}

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -287,7 +287,7 @@ RTLIL::IdString new_id(std::string file, int line, std::string func)
 	if (pos != std::string::npos)
 		func = func.substr(pos+1);
 
-	return stringf("$auto$%s:%d:%s$%d", file.c_str(), line, func.c_str(), autoidx++);
+	return stringf("$auto$%s:%d:%s$%d", file, line, func, autoidx++);
 }
 
 RTLIL::IdString new_id_suffix(std::string file, int line, std::string func, std::string suffix)
@@ -304,7 +304,7 @@ RTLIL::IdString new_id_suffix(std::string file, int line, std::string func, std:
 	if (pos != std::string::npos)
 		func = func.substr(pos+1);
 
-	return stringf("$auto$%s:%d:%s$%s$%d", file.c_str(), line, func.c_str(), suffix.c_str(), autoidx++);
+	return stringf("$auto$%s:%d:%s$%s$%d", file, line, func, suffix, autoidx++);
 }
 
 RTLIL::Design *yosys_get_design()
@@ -320,7 +320,7 @@ const char *create_prompt(RTLIL::Design *design, int recursion_counter)
 		str += stringf("(%d) ", recursion_counter);
 	str += "yosys";
 	if (!design->selected_active_module.empty())
-		str += stringf(" [%s]", RTLIL::unescape_id(design->selected_active_module).c_str());
+		str += stringf(" [%s]", RTLIL::unescape_id(design->selected_active_module));
 	if (!design->full_selection()) {
 		if (design->selected_active_module.empty())
 			str += "*";

--- a/libs/subcircuit/subcircuit.cc
+++ b/libs/subcircuit/subcircuit.cc
@@ -411,7 +411,7 @@ class SubCircuit::SolverWorker
 
 		std::string toString() const
 		{
-			return my_stringf("%s[%d]:%s[%d]", fromPort.c_str(), fromBit, toPort.c_str(), toBit);
+			return my_stringf("%s[%d]:%s[%d]", fromPort, fromBit, toPort, toBit);
 		}
 	};
 
@@ -444,7 +444,7 @@ class SubCircuit::SolverWorker
 			std::string str;
 			bool firstPort = true;
 			for (const auto &it : portSizes) {
-				str += my_stringf("%s%s[%d]", firstPort ? "" : ",", it.first.c_str(), it.second);
+				str += my_stringf("%s%s[%d]", firstPort ? "" : ",", it.first, it.second);
 				firstPort = false;
 			}
 			return typeId + "(" + str + ")";

--- a/passes/cmds/bugpoint.cc
+++ b/passes/cmds/bugpoint.cc
@@ -126,14 +126,14 @@ struct BugpointPass : public Pass {
 
 		string bugpoint_file = "bugpoint-case";
 		if (suffix.size())
-			bugpoint_file += stringf(".%.8s", suffix.c_str());
+			bugpoint_file += stringf(".%.8s", suffix);
 
 		std::ofstream f(bugpoint_file + ".il");
 		RTLIL_BACKEND::dump_design(f, design, /*only_selected=*/false, /*flag_m=*/true, /*flag_n=*/false);
 		f.close();
 
-		string yosys_cmdline = stringf("%s %s -qq -L %s.log %s %s.il", runner.c_str(), yosys_cmd.c_str(), bugpoint_file.c_str(), yosys_arg.c_str(), bugpoint_file.c_str());
-		if (catch_err) yosys_cmdline += stringf(" 2>%s.err", bugpoint_file.c_str());
+		string yosys_cmdline = stringf("%s %s -qq -L %s.log %s %s.il", runner, yosys_cmd, bugpoint_file, yosys_arg, bugpoint_file);
+		if (catch_err) yosys_cmdline += stringf(" 2>%s.err", bugpoint_file);
 		auto status = run_command(yosys_cmdline);
 		// we're not processing lines, which means we're getting raw system() returns
 		if(WIFEXITED(status))
@@ -156,7 +156,7 @@ struct BugpointPass : public Pass {
 
 		string bugpoint_file = "bugpoint-case";
 		if (suffix.size())
-			bugpoint_file += stringf(".%.8s", suffix.c_str());
+			bugpoint_file += stringf(".%.8s", suffix);
 		bugpoint_file += err ? ".err" : ".log";
 
 		std::ifstream f(bugpoint_file);
@@ -469,13 +469,13 @@ struct BugpointPass : public Pass {
 			if (args[argidx] == "-script" && argidx + 1 < args.size()) {
 				if (!yosys_arg.empty())
 					log_cmd_error("A -script or -command option can be only provided once!\n");
-				yosys_arg = stringf("-s %s", args[++argidx].c_str());
+				yosys_arg = stringf("-s %s", args[++argidx]);
 				continue;
 			}
 			if (args[argidx] == "-command" && argidx + 1 < args.size()) {
 				if (!yosys_arg.empty())
 					log_cmd_error("A -script or -command option can be only provided once!\n");
-				yosys_arg = stringf("-p %s", args[++argidx].c_str());
+				yosys_arg = stringf("-p %s", args[++argidx]);
 				continue;
 			}
 			if (args[argidx] == "-grep" && argidx + 1 < args.size()) {

--- a/passes/cmds/check.cc
+++ b/passes/cmds/check.cc
@@ -315,7 +315,7 @@ struct CheckPass : public Pass {
 				if (wire_drivers.count(state)) {
 					string message = stringf("Drivers conflicting with a constant %s driver:\n", log_signal(state));
 					for (auto str : wire_drivers[state])
-						message += stringf("    %s\n", str.c_str());
+						message += stringf("    %s\n", str);
 					log_warning("%s", message.c_str());
 					counter++;
 				}
@@ -324,7 +324,7 @@ struct CheckPass : public Pass {
 				if (wire_drivers_count[it.first] > 1) {
 					string message = stringf("multiple conflicting drivers for %s.%s:\n", log_id(module), log_signal(it.first));
 					for (auto str : it.second)
-						message += stringf("    %s\n", str.c_str());
+						message += stringf("    %s\n", str);
 					log_warning("%s", message.c_str());
 					counter++;
 				}
@@ -387,10 +387,10 @@ struct CheckPass : public Pass {
 					std::string driver_src;
 					if (driver->has_attribute(ID::src)) {
 						std::string src_attr = driver->get_src_attribute();
-						driver_src = stringf(" source: %s", src_attr.c_str());
+						driver_src = stringf(" source: %s", src_attr);
 					}
 
-					message += stringf("    cell %s (%s)%s\n", log_id(driver), log_id(driver->type), driver_src.c_str());
+					message += stringf("    cell %s (%s)%s\n", log_id(driver), log_id(driver->type), driver_src);
 
 					if (!coarsened_cells.count(driver)) {						
 						MatchingEdgePrinter printer(message, sigmap, prev, bit);
@@ -404,9 +404,9 @@ struct CheckPass : public Pass {
 						std::string wire_src;
 						if (wire->has_attribute(ID::src)) {
 							std::string src_attr = wire->get_src_attribute();
-							wire_src = stringf(" source: %s", src_attr.c_str());
+							wire_src = stringf(" source: %s", src_attr);
 						}
-						message += stringf("    wire %s%s\n", log_signal(SigBit(wire, pair.second)), wire_src.c_str());						
+						message += stringf("    wire %s%s\n", log_signal(SigBit(wire, pair.second)), wire_src);						
 					}
 
 					prev = bit;

--- a/passes/cmds/dft_tag.cc
+++ b/passes/cmds/dft_tag.cc
@@ -372,7 +372,7 @@ struct DftTagWorker {
 	void propagate_tags(Cell *cell)
 	{
 		if (cell->type == ID($set_tag)) {
-			IdString tag = stringf("\\%s", cell->getParam(ID::TAG).decode_string().c_str());
+			IdString tag = stringf("\\%s", cell->getParam(ID::TAG).decode_string());
 			if (all_tags.insert(tag).second) {
 				auto group_sep = tag.str().find(':');
 				IdString tag_group = group_sep != std::string::npos ? tag.str().substr(0, group_sep) : tag;
@@ -478,7 +478,7 @@ struct DftTagWorker {
 	void process_cell(IdString tag, Cell *cell)
 	{
 		if (cell->type == ID($set_tag)) {
-			IdString cell_tag = stringf("\\%s", cell->getParam(ID::TAG).decode_string().c_str());
+			IdString cell_tag = stringf("\\%s", cell->getParam(ID::TAG).decode_string());
 
 			auto tag_sig_a = tag_signal(tag, cell->getPort(ID::A));
 			auto &sig_y = cell->getPort(ID::Y);
@@ -752,7 +752,7 @@ struct DftTagWorker {
 
 		for (auto cell : get_tag_cells) {
 			auto &sig_a = cell->getPort(ID::A);
-			IdString tag = stringf("\\%s", cell->getParam(ID::TAG).decode_string().c_str());
+			IdString tag = stringf("\\%s", cell->getParam(ID::TAG).decode_string());
 
 			tag_signal(tag, sig_a);
 		}
@@ -772,7 +772,7 @@ struct DftTagWorker {
 						continue;
 
 					int index = 0;
-					auto name = module->uniquify(stringf("%s:%s", wire->name.c_str(), tag.c_str() + 1), index);
+					auto name = module->uniquify(stringf("%s:%s", wire->name, tag.c_str() + 1), index);
 					auto hdlname = wire->get_hdlname_attribute();
 
 					if (!hdlname.empty())
@@ -817,7 +817,7 @@ struct DftTagWorker {
 		for (auto cell : get_tag_cells) {
 			auto &sig_a = cell->getPort(ID::A);
 			auto &sig_y = cell->getPort(ID::Y);
-			IdString tag = stringf("\\%s", cell->getParam(ID::TAG).decode_string().c_str());
+			IdString tag = stringf("\\%s", cell->getParam(ID::TAG).decode_string());
 
 			auto tag_sig = tag_signal(tag, sig_a);
 			module->connect(sig_y, tag_sig);

--- a/passes/cmds/glift.cc
+++ b/passes/cmds/glift.cc
@@ -163,7 +163,7 @@ private:
 			std::vector<RTLIL::SigSpec> next_pmux_y_ports, pmux_y_ports(costs.begin(), costs.begin() + exp2(select_width));
 			for (auto i = 0; pmux_y_ports.size() > 1; ++i) {
 				for (auto j = 0; j+1 < GetSize(pmux_y_ports); j += 2) {
-					next_pmux_y_ports.emplace_back(module->Pmux(stringf("%s_mux_%d_%d", metamux_select.as_wire()->name.c_str(), i, j), pmux_y_ports[j], pmux_y_ports[j+1], metamux_select[GetSize(metamux_select) - 1 - i], metamux_select.as_wire()->get_src_attribute()));
+					next_pmux_y_ports.emplace_back(module->Pmux(stringf("%s_mux_%d_%d", metamux_select.as_wire()->name, i, j), pmux_y_ports[j], pmux_y_ports[j+1], metamux_select[GetSize(metamux_select) - 1 - i], metamux_select.as_wire()->get_src_attribute()));
 				}
 				if (GetSize(pmux_y_ports) % 2 == 1)
 					next_pmux_y_ports.push_back(pmux_y_ports[GetSize(pmux_y_ports) - 1]);
@@ -206,7 +206,7 @@ private:
 					int num_versions = opt_instrumentmore? 8 : 4;
 
 					for (auto i = 1; i <= num_versions; ++i)
-						taint_version.emplace_back(RTLIL::SigSpec(module->addWire(stringf("%s_y%d", cell->name.c_str(), i), 1)));
+						taint_version.emplace_back(RTLIL::SigSpec(module->addWire(stringf("%s_y%d", cell->name, i), 1)));
 
 					for (auto i = 0; i < num_versions; ++i) {
 						switch(i) {
@@ -239,7 +239,7 @@ private:
 					std::vector<RTLIL::SigSpec> next_meta_mux_y_ports, meta_mux_y_ports(taint_version);
 					for (auto i = 0; meta_mux_y_ports.size() > 1; ++i) {
 						for (auto j = 0; j+1 < GetSize(meta_mux_y_ports); j += 2) {
-							next_meta_mux_y_ports.emplace_back(module->Mux(stringf("%s_mux_%d_%d", cell->name.c_str(), i, j), meta_mux_y_ports[j], meta_mux_y_ports[j+1], meta_mux_select[GetSize(meta_mux_select) - 1 - i]));
+							next_meta_mux_y_ports.emplace_back(module->Mux(stringf("%s_mux_%d_%d", cell->name, i, j), meta_mux_y_ports[j], meta_mux_y_ports[j+1], meta_mux_select[GetSize(meta_mux_select) - 1 - i]));
 						}
 						if (GetSize(meta_mux_y_ports) % 2 == 1)
 							next_meta_mux_y_ports.push_back(meta_mux_y_ports[GetSize(meta_mux_y_ports) - 1]);
@@ -271,7 +271,7 @@ private:
 					log_assert(exp2(select_width) == num_versions);
 
 					for (auto i = 1; i <= num_versions; ++i)
-						taint_version.emplace_back(RTLIL::SigSpec(module->addWire(stringf("%s_y%d", cell->name.c_str(), i), 1)));
+						taint_version.emplace_back(RTLIL::SigSpec(module->addWire(stringf("%s_y%d", cell->name, i), 1)));
 
 					for (auto i = 0; i < num_versions; ++i) {
 						switch(i) {
@@ -294,7 +294,7 @@ private:
 					std::vector<RTLIL::SigSpec> next_meta_mux_y_ports, meta_mux_y_ports(taint_version);
 					for (auto i = 0; meta_mux_y_ports.size() > 1; ++i) {
 						for (auto j = 0; j+1 < GetSize(meta_mux_y_ports); j += 2) {
-							next_meta_mux_y_ports.emplace_back(module->Mux(stringf("%s_mux_%d_%d", cell->name.c_str(), i, j), meta_mux_y_ports[j], meta_mux_y_ports[j+1], meta_mux_select[GetSize(meta_mux_select) - 1 - i]));
+							next_meta_mux_y_ports.emplace_back(module->Mux(stringf("%s_mux_%d_%d", cell->name, i, j), meta_mux_y_ports[j], meta_mux_y_ports[j+1], meta_mux_select[GetSize(meta_mux_select) - 1 - i]));
 						}
 						if (GetSize(meta_mux_y_ports) % 2 == 1)
 							next_meta_mux_y_ports.push_back(meta_mux_y_ports[GetSize(meta_mux_y_ports) - 1]);

--- a/passes/cmds/portarcs.cc
+++ b/passes/cmds/portarcs.cc
@@ -243,7 +243,7 @@ struct PortarcsPass : Pass {
 
 			if (draw_mode) {
 				auto bit_str = [](SigBit bit) {
-					return stringf("%s%d", RTLIL::unescape_id(bit.wire->name.str()).c_str(), bit.offset);
+					return stringf("%s%d", RTLIL::unescape_id(bit.wire->name.str()), bit.offset);
 				};
 
 				std::vector<std::string> headings;

--- a/passes/cmds/rename.cc
+++ b/passes/cmds/rename.cc
@@ -64,7 +64,7 @@ static std::string derive_name_from_src(const std::string &src, int counter)
 	if (src_base.empty())
 		return stringf("$%d", counter);
 	else
-		return stringf("\\%s$%d", src_base.c_str(), counter);
+		return stringf("\\%s$%d", src_base, counter);
 }
 
 static IdString derive_name_from_cell_output_wire(const RTLIL::Cell *cell, string suffix, bool move_to_cell)
@@ -422,7 +422,7 @@ struct RenamePass : public Pass {
 							if (wire_suffix.empty()) {
 								for (auto const &[port, _] : cell->connections()) {
 									if (cell->output(port)) {
-										wire_suffix += stringf("%s.%s", cell->type.c_str(), port.c_str() + 1);
+										wire_suffix += stringf("%s.%s", cell->type, port.c_str() + 1);
 										break;
 									}
 								}
@@ -449,7 +449,7 @@ struct RenamePass : public Pass {
 				for (auto wire : module->selected_wires())
 					if (wire->name[0] == '$') {
 						RTLIL::IdString buf;
-						do buf = stringf("\\%s%d%s", pattern_prefix.c_str(), counter++, pattern_suffix.c_str());
+						do buf = stringf("\\%s%d%s", pattern_prefix, counter++, pattern_suffix);
 						while (module->wire(buf) != nullptr);
 						new_wire_names[wire] = buf;
 					}
@@ -457,7 +457,7 @@ struct RenamePass : public Pass {
 				for (auto cell : module->selected_cells())
 					if (cell->name[0] == '$') {
 						RTLIL::IdString buf;
-						do buf = stringf("\\%s%d%s", pattern_prefix.c_str(), counter++, pattern_suffix.c_str());
+						do buf = stringf("\\%s%d%s", pattern_prefix, counter++, pattern_suffix);
 						while (module->cell(buf) != nullptr);
 						new_cell_names[cell] = buf;
 					}

--- a/passes/cmds/show.cc
+++ b/passes/cmds/show.cc
@@ -149,7 +149,7 @@ struct ShowWorker
 	{
 		for (auto &s : color_selections)
 			if (s.second.selected_member(module->name, member_name)) {
-				return stringf("color=\"%s\", fontcolor=\"%s\"", s.first.c_str(), s.first.c_str());
+				return stringf("color=\"%s\", fontcolor=\"%s\"", s.first, s.first);
 			}
 
 		RTLIL::Const colorattr_value;
@@ -308,11 +308,11 @@ struct ShowWorker
 
 				std::string repinfo = rep > 1 ? stringf("%dx ", rep) : "";
 				std::string portside = stringf("%d:%d", bitpos, bitpos - rep*c.width + 1);
-				std::string remoteside = stringf("%s%d:%d", repinfo.c_str(), cl, cr);
+				std::string remoteside = stringf("%s%d:%d", repinfo, cl, cr);
 
 				if (driver) {
 					log_assert(!net.empty());
-					label_pieces.push_back(stringf("<s%d> %s - %s ", chunk_idx, portside.c_str(), remoteside.c_str()));
+					label_pieces.push_back(stringf("<s%d> %s - %s ", chunk_idx, portside, remoteside));
 					net_conn_map[net].in.insert({stringf("x%d:s%d", dot_idx, chunk_idx), rep*c.width});
 					net_conn_map[net].color = nextColor(c, net_conn_map[net].color);
 				} else {
@@ -325,7 +325,7 @@ struct ShowWorker
 								c.data.front() == State::Sz ? 'Z' : '?',
 								bitpos, bitpos-rep*c.width+1));
 					} else {
-						label_pieces.push_back(stringf("<s%d> %s - %s ", chunk_idx, remoteside.c_str(), portside.c_str()));
+						label_pieces.push_back(stringf("<s%d> %s - %s ", chunk_idx, remoteside, portside));
 						net_conn_map[net].out.insert({stringf("x%d:s%d", dot_idx, chunk_idx), rep*c.width});
 						net_conn_map[net].color = nextColor(c, net_conn_map[net].color);
 					}
@@ -335,14 +335,14 @@ struct ShowWorker
 			}
 
 			code += stringf("x%d [ shape=record, style=rounded, label=\"", dot_idx) \
-					+ join_label_pieces(label_pieces) + stringf("\", %s ];\n", nextColor(sig).c_str());
+					+ join_label_pieces(label_pieces) + stringf("\", %s ];\n", nextColor(sig));
 
 			if (!port.empty()) {
 				currentColor = xorshift32(currentColor);
 				if (driver)
-					code += stringf("%s:e -> x%d:w [arrowhead=odiamond, arrowtail=odiamond, dir=both, %s, %s];\n", port.c_str(), dot_idx, nextColor(sig).c_str(), widthLabel(sig.size()).c_str());
+					code += stringf("%s:e -> x%d:w [arrowhead=odiamond, arrowtail=odiamond, dir=both, %s, %s];\n", port, dot_idx, nextColor(sig), widthLabel(sig.size()));
 				else
-					code += stringf("x%d:e -> %s:w [arrowhead=odiamond, arrowtail=odiamond, dir=both, %s, %s];\n", dot_idx, port.c_str(), nextColor(sig).c_str(), widthLabel(sig.size()).c_str());
+					code += stringf("x%d:e -> %s:w [arrowhead=odiamond, arrowtail=odiamond, dir=both, %s, %s];\n", dot_idx, port, nextColor(sig), widthLabel(sig.size()));
 			}
 			if (node != nullptr)
 				*node = stringf("x%d", dot_idx);
@@ -490,7 +490,7 @@ struct ShowWorker
 			std::string in_label = join_label_pieces(in_label_pieces);
 			std::string out_label = join_label_pieces(out_label_pieces);
 
-			std::string label_string = stringf("{{%s}|%s\\n%s|{%s}}", in_label.c_str(),
+			std::string label_string = stringf("{{%s}|%s\\n%s|{%s}}", in_label,
 											   findLabel(cell->name.str()), escape(cell->type.str()),
 											   out_label.c_str());
 
@@ -904,8 +904,8 @@ struct ShowPass : public Pass {
 		if (libs.size() > 0)
 			log_header(design, "Continuing show pass.\n");
 
-		std::string dot_file = stringf("%s.dot", prefix.c_str());
-		std::string out_file = stringf("%s.%s", prefix.c_str(), format.empty() ? "svg" : format.c_str());
+		std::string dot_file = stringf("%s.dot", prefix);
+		std::string out_file = stringf("%s.%s", prefix, format.empty() ? "svg" : format);
 
 		log("Writing dot description to `%s'.\n", dot_file.c_str());
 		FILE *f = fopen(dot_file.c_str(), "w");
@@ -932,7 +932,7 @@ struct ShowPass : public Pass {
 			#else
 				#define DOT_CMD "dot -T%s '%s' > '%s.new' && mv '%s.new' '%s'"
 			#endif
-			std::string cmd = stringf(DOT_CMD, format.c_str(), dot_file.c_str(), out_file.c_str(), out_file.c_str(), out_file.c_str());
+			std::string cmd = stringf(DOT_CMD, format, dot_file, out_file, out_file, out_file);
 			#undef DOT_CMD
 			log("Exec: %s\n", cmd.c_str());
 			#if !defined(YOSYS_DISABLE_SPAWN)
@@ -950,9 +950,9 @@ struct ShowPass : public Pass {
 					// system()/cmd.exe does not understand single quotes nor
 					// background tasks on Windows. So we have to pause yosys
 					// until the viewer exits.
-					std::string cmd = stringf("%s \"%s\"", viewer_exe.c_str(), out_file.c_str());
+					std::string cmd = stringf("%s \"%s\"", viewer_exe, out_file);
 				#else
-					std::string cmd = stringf("%s '%s' %s", viewer_exe.c_str(), out_file.c_str(), background.c_str());
+					std::string cmd = stringf("%s '%s' %s", viewer_exe, out_file, background);
 				#endif
 				log("Exec: %s\n", cmd.c_str());
 				if (run_command(cmd) != 0)
@@ -960,9 +960,9 @@ struct ShowPass : public Pass {
 			} else
 			if (format.empty()) {
 				#ifdef __APPLE__
-				std::string cmd = stringf("ps -fu %d | grep -q '[ ]%s' || xdot '%s' %s", getuid(), dot_file.c_str(), dot_file.c_str(), background.c_str());
+				std::string cmd = stringf("ps -fu %d | grep -q '[ ]%s' || xdot '%s' %s", getuid(), dot_file, dot_file, background);
 				#else
-				std::string cmd = stringf("{ test -f '%s.pid' && fuser -s '%s.pid' 2> /dev/null; } || ( echo $$ >&3; exec xdot '%s'; ) 3> '%s.pid' %s", dot_file.c_str(), dot_file.c_str(), dot_file.c_str(), dot_file.c_str(), background.c_str());
+				std::string cmd = stringf("{ test -f '%s.pid' && fuser -s '%s.pid' 2> /dev/null; } || ( echo $$ >&3; exec xdot '%s'; ) 3> '%s.pid' %s", dot_file, dot_file, dot_file, dot_file, background);
 				#endif
 				log("Exec: %s\n", cmd.c_str());
 				if (run_command(cmd) != 0)

--- a/passes/cmds/stat.cc
+++ b/passes/cmds/stat.cc
@@ -193,19 +193,19 @@ struct statdata_t {
 					int width_a = cell->hasPort(ID::A) ? GetSize(cell->getPort(ID::A)) : 0;
 					int width_b = cell->hasPort(ID::B) ? GetSize(cell->getPort(ID::B)) : 0;
 					int width_y = cell->hasPort(ID::Y) ? GetSize(cell->getPort(ID::Y)) : 0;
-					cell_type = stringf("%s_%d", cell_type.c_str(), max<int>({width_a, width_b, width_y}));
+					cell_type = stringf("%s_%d", cell_type, max<int>({width_a, width_b, width_y}));
 				} else if (cell_type.in(ID($mux)))
-					cell_type = stringf("%s_%d", cell_type.c_str(), GetSize(cell->getPort(ID::Y)));
+					cell_type = stringf("%s_%d", cell_type, GetSize(cell->getPort(ID::Y)));
 				else if (cell_type.in(ID($bmux), ID($pmux)))
 					cell_type =
-					  stringf("%s_%d_%d", cell_type.c_str(), GetSize(cell->getPort(ID::Y)), GetSize(cell->getPort(ID::S)));
+					  stringf("%s_%d_%d", cell_type, GetSize(cell->getPort(ID::Y)), GetSize(cell->getPort(ID::S)));
 				else if (cell_type == ID($demux))
 					cell_type =
-					  stringf("%s_%d_%d", cell_type.c_str(), GetSize(cell->getPort(ID::A)), GetSize(cell->getPort(ID::S)));
+					  stringf("%s_%d_%d", cell_type, GetSize(cell->getPort(ID::A)), GetSize(cell->getPort(ID::S)));
 				else if (cell_type.in(ID($sr), ID($ff), ID($dff), ID($dffe), ID($dffsr), ID($dffsre), ID($adff), ID($adffe),
 						      ID($sdff), ID($sdffe), ID($sdffce), ID($aldff), ID($aldffe), ID($dlatch), ID($adlatch),
 						      ID($dlatchsr)))
-					cell_type = stringf("%s_%d", cell_type.c_str(), GetSize(cell->getPort(ID::Q)));
+					cell_type = stringf("%s_%d", cell_type, GetSize(cell->getPort(ID::Q)));
 			}
 
 			if (!cell_area.empty()) {

--- a/passes/cmds/timeest.cc
+++ b/passes/cmds/timeest.cc
@@ -320,7 +320,7 @@ struct EstimateSta {
 					std::string cell_src;
 					if (cell->has_attribute(ID::src)) {
 						std::string src_attr = cell->get_src_attribute();
-						cell_src = stringf(" source: %s", src_attr.c_str());
+						cell_src = stringf(" source: %s", src_attr);
 					}
 					log("    cell %s (%s)%s\n", log_id(cell), log_id(cell->type), cell_src.c_str());
 					printed.insert(cell);
@@ -331,7 +331,7 @@ struct EstimateSta {
 				std::string wire_src;
 				if (bit.wire && bit.wire->has_attribute(ID::src)) {
 					std::string src_attr = bit.wire->get_src_attribute();
-					wire_src = stringf(" source: %s", src_attr.c_str());
+					wire_src = stringf(" source: %s", src_attr);
 				}
 				log("    wire %s%s (level %ld)\n", log_signal(bit), wire_src.c_str(), levels[node]);
 			}

--- a/passes/cmds/viz.cc
+++ b/passes/cmds/viz.cc
@@ -982,8 +982,8 @@ struct VizPass : public Pass {
 		if (modlist.empty())
 			log_cmd_error("Nothing there to show.\n");
 
-		std::string dot_file = stringf("%s.dot", prefix.c_str());
-		std::string out_file = stringf("%s.%s", prefix.c_str(), format.empty() ? "svg" : format.c_str());
+		std::string dot_file = stringf("%s.dot", prefix);
+		std::string out_file = stringf("%s.%s", prefix, format.empty() ? "svg" : format);
 
 		if (custom_prefix)
 			yosys_output_files.insert(dot_file);
@@ -1026,7 +1026,7 @@ struct VizPass : public Pass {
 			#else
 				#define DOT_CMD "dot -T%s '%s' > '%s.new' && mv '%s.new' '%s'"
 			#endif
-			std::string cmd = stringf(DOT_CMD, format.c_str(), dot_file.c_str(), out_file.c_str(), out_file.c_str(), out_file.c_str());
+			std::string cmd = stringf(DOT_CMD, format, dot_file, out_file, out_file, out_file);
 			#undef DOT_CMD
 			log("Exec: %s\n", cmd.c_str());
 			#if !defined(YOSYS_DISABLE_SPAWN)
@@ -1043,9 +1043,9 @@ struct VizPass : public Pass {
 				// system()/cmd.exe does not understand single quotes nor
 				// background tasks on Windows. So we have to pause yosys
 				// until the viewer exits.
-				std::string cmd = stringf("%s \"%s\"", viewer_exe.c_str(), out_file.c_str());
+				std::string cmd = stringf("%s \"%s\"", viewer_exe, out_file);
 			#else
-				std::string cmd = stringf("%s '%s' %s", viewer_exe.c_str(), out_file.c_str(), background.c_str());
+				std::string cmd = stringf("%s '%s' %s", viewer_exe, out_file, background);
 			#endif
 			log("Exec: %s\n", cmd.c_str());
 			if (run_command(cmd) != 0)
@@ -1053,9 +1053,9 @@ struct VizPass : public Pass {
 		} else
 		if (format.empty()) {
 			#ifdef __APPLE__
-			std::string cmd = stringf("ps -fu %d | grep -q '[ ]%s' || xdot '%s' %s", getuid(), dot_file.c_str(), dot_file.c_str(), background.c_str());
+			std::string cmd = stringf("ps -fu %d | grep -q '[ ]%s' || xdot '%s' %s", getuid(), dot_file, dot_file, background);
 			#else
-			std::string cmd = stringf("{ test -f '%s.pid' && fuser -s '%s.pid' 2> /dev/null; } || ( echo $$ >&3; exec xdot '%s'; ) 3> '%s.pid' %s", dot_file.c_str(), dot_file.c_str(), dot_file.c_str(), dot_file.c_str(), background.c_str());
+			std::string cmd = stringf("{ test -f '%s.pid' && fuser -s '%s.pid' 2> /dev/null; } || ( echo $$ >&3; exec xdot '%s'; ) 3> '%s.pid' %s", dot_file, dot_file, dot_file, dot_file, background);
 			#endif
 			log("Exec: %s\n", cmd.c_str());
 			if (run_command(cmd) != 0)

--- a/passes/cmds/wrapcell.cc
+++ b/passes/cmds/wrapcell.cc
@@ -97,9 +97,9 @@ struct Chunk {
 		if (len == cell->getPort(port).size())
 			return port;
 		else if (len == 1)
-			return stringf("%s[%d]", port.c_str(), base);
+			return stringf("%s[%d]", port, base);
 		else
-			return stringf("%s[%d:%d]", port.c_str(), base + len - 1, base);
+			return stringf("%s[%d:%d]", port, base + len - 1, base);
 	}
 
 	SigSpec sample(Cell *cell)

--- a/passes/cmds/xprop.cc
+++ b/passes/cmds/xprop.cc
@@ -978,8 +978,8 @@ struct XpropWorker
 				if (wire->port_input == wire->port_output) {
 					log_warning("Port %s not an input or an output port which is not supported by xprop\n", log_id(wire));
 				} else if ((options.split_inputs && !options.assume_def_inputs && wire->port_input) || (options.split_outputs && wire->port_output)) {
-					auto port_d = module->uniquify(stringf("%s_d", port.c_str()));
-					auto port_x = module->uniquify(stringf("%s_x", port.c_str()));
+					auto port_d = module->uniquify(stringf("%s_d", port));
+					auto port_x = module->uniquify(stringf("%s_x", port));
 
 					auto wire_d = module->addWire(port_d, GetSize(wire));
 					auto wire_x = module->addWire(port_x, GetSize(wire));
@@ -1031,8 +1031,8 @@ struct XpropWorker
 				continue;
 			int index_d = 0;
 			int index_x = 0;
-			auto name_d = module->uniquify(stringf("%s_d", wire->name.c_str()), index_d);
-			auto name_x = module->uniquify(stringf("%s_x", wire->name.c_str()), index_x);
+			auto name_d = module->uniquify(stringf("%s_d", wire->name), index_d);
+			auto name_x = module->uniquify(stringf("%s_x", wire->name), index_x);
 
 			auto hdlname = wire->get_hdlname_attribute();
 

--- a/passes/fsm/fsm_extract.cc
+++ b/passes/fsm/fsm_extract.cc
@@ -368,7 +368,7 @@ static void extract_fsm(RTLIL::Wire *wire)
 
 	// create fsm cell
 
-	RTLIL::Cell *fsm_cell = module->addCell(stringf("$fsm$%s$%d", wire->name.c_str(), autoidx++), ID($fsm));
+	RTLIL::Cell *fsm_cell = module->addCell(stringf("$fsm$%s$%d", wire->name, autoidx++), ID($fsm));
 	fsm_cell->setPort(ID::CLK, clk);
 	fsm_cell->setPort(ID::ARST, arst);
 	fsm_cell->parameters[ID::CLK_POLARITY] = clk_polarity ? State::S1 : State::S0;
@@ -390,7 +390,7 @@ static void extract_fsm(RTLIL::Wire *wire)
 
 	module->wires_.erase(wire->name);
 	wire->attributes.erase(ID::fsm_encoding);
-	wire->name = stringf("$fsm$oldstate%s", wire->name.c_str());
+	wire->name = stringf("$fsm$oldstate%s", wire->name);
 	module->wires_[wire->name] = wire;
 	if(wire->attributes.count(ID::hdlname)) {
 		auto hdlname = wire->get_hdlname_attribute();

--- a/passes/hierarchy/flatten.cc
+++ b/passes/hierarchy/flatten.cc
@@ -281,11 +281,11 @@ struct FlattenWorker
 				if (attr.first == ID::hdlname)
 					scopeinfo->attributes.insert(attr);
 				else
-					scopeinfo->attributes.emplace(stringf("\\cell_%s", RTLIL::unescape_id(attr.first).c_str()), attr.second);
+					scopeinfo->attributes.emplace(stringf("\\cell_%s", RTLIL::unescape_id(attr.first)), attr.second);
 			}
 
 			for (auto const &attr : tpl->attributes)
-				scopeinfo->attributes.emplace(stringf("\\module_%s", RTLIL::unescape_id(attr.first).c_str()), attr.second);
+				scopeinfo->attributes.emplace(stringf("\\module_%s", RTLIL::unescape_id(attr.first)), attr.second);
 
 			scopeinfo->attributes.emplace(ID(module), RTLIL::unescape_id(tpl->name));
 		}

--- a/passes/hierarchy/submod.cc
+++ b/passes/hierarchy/submod.cc
@@ -166,7 +166,7 @@ struct SubmodWorker
 						}
 					}
 				else if (hidden_mode)
-					new_wire_name = stringf("$submod%s", new_wire_name.c_str());
+					new_wire_name = stringf("$submod%s", new_wire_name);
 			}
 
 			RTLIL::Wire *new_wire = new_mod->addWire(new_wire_name, wire->width);

--- a/passes/memory/memory_bram.cc
+++ b/passes/memory/memory_bram.cc
@@ -873,7 +873,7 @@ grow_read_ports:;
 		for (int grid_a = 0; grid_a < acells; grid_a++)
 		for (int dupidx = 0; dupidx < dup_count; dupidx++)
 		{
-			Cell *c = module->addCell(module->uniquify(stringf("%s.%d.%d.%d", mem.memid.c_str(), grid_d, grid_a, dupidx)), bram.name);
+			Cell *c = module->addCell(module->uniquify(stringf("%s.%d.%d.%d", mem.memid, grid_d, grid_a, dupidx)), bram.name);
 			log("      Creating %s cell at grid position <%d %d %d>: %s\n", log_id(bram.name), grid_d, grid_a, dupidx, log_id(c));
 
 			for (auto &vp : variant_params)

--- a/passes/memory/memory_libmap.cc
+++ b/passes/memory/memory_libmap.cc
@@ -1686,7 +1686,7 @@ std::vector<SigSpec> generate_mux(Mem &mem, int rpidx, const Swizzle &swz) {
 void MemMapping::emit_port(const MemConfig &cfg, std::vector<Cell*> &cells, const PortVariant &pdef, const char *name, int wpidx, int rpidx, const std::vector<int> &hw_addr_swizzle) {
 	for (auto &it: pdef.options)
 		for (auto cell: cells)
-			cell->setParam(stringf("\\PORT_%s_OPTION_%s", name, it.first.c_str()), it.second);
+			cell->setParam(stringf("\\PORT_%s_OPTION_%s", name, it.first), it.second);
 	SigSpec addr = Const(State::Sx, cfg.def->abits);
 	int wide_log2 = 0, wr_wide_log2 = 0, rd_wide_log2 = 0;
 	SigSpec clk = State::S0;
@@ -2067,7 +2067,7 @@ void MemMapping::emit(const MemConfig &cfg) {
 	for (int rp = 0; rp < cfg.repl_port; rp++) {
 		std::vector<Cell *> cells;
 		for (int rd = 0; rd < cfg.repl_d; rd++) {
-			Cell *cell = mem.module->addCell(stringf("%s.%d.%d", mem.memid.c_str(), rp, rd), cfg.def->id);
+			Cell *cell = mem.module->addCell(stringf("%s.%d.%d", mem.memid, rp, rd), cfg.def->id);
 			if (cfg.def->width_mode == WidthMode::Global)
 				cell->setParam(ID::WIDTH, cfg.def->dbits[cfg.base_width_log2]);
 			if (cfg.def->widthscale) {
@@ -2077,18 +2077,18 @@ void MemMapping::emit(const MemConfig &cfg) {
 				cell->setParam(ID::BITS_USED, val);
 			}
 			for (auto &it: cfg.def->options)
-				cell->setParam(stringf("\\OPTION_%s", it.first.c_str()), it.second);
+				cell->setParam(stringf("\\OPTION_%s", it.first), it.second);
 			for (int i = 0; i < GetSize(cfg.def->shared_clocks); i++) {
 				auto &cdef = cfg.def->shared_clocks[i];
 				auto &ccfg = cfg.shared_clocks[i];
 				if (cdef.anyedge) {
-					cell->setParam(stringf("\\CLK_%s_POL", cdef.name.c_str()), ccfg.used ? ccfg.polarity : true);
-					cell->setPort(stringf("\\CLK_%s", cdef.name.c_str()), ccfg.used ? ccfg.clk : State::S0);
+					cell->setParam(stringf("\\CLK_%s_POL", cdef.name), ccfg.used ? ccfg.polarity : true);
+					cell->setPort(stringf("\\CLK_%s", cdef.name), ccfg.used ? ccfg.clk : State::S0);
 				} else {
 					SigSpec sig = ccfg.used ? ccfg.clk : State::S0;
 					if (ccfg.used && ccfg.invert)
 						sig = mem.module->Not(NEW_ID, sig);
-					cell->setPort(stringf("\\CLK_%s", cdef.name.c_str()), sig);
+					cell->setPort(stringf("\\CLK_%s", cdef.name), sig);
 				}
 			}
 			if (cfg.def->init == MemoryInitKind::Any || cfg.def->init == MemoryInitKind::NoUndef) {
@@ -2136,11 +2136,11 @@ void MemMapping::emit(const MemConfig &cfg) {
 				}
 				if (pg.optional)
 					for (auto cell: cells)
-						cell->setParam(stringf("\\PORT_%s_USED", pg.names[pi].c_str()), used);
+						cell->setParam(stringf("\\PORT_%s_USED", pg.names[pi]), used);
 				if (pg.optional_rw)
 					for (auto cell: cells) {
-						cell->setParam(stringf("\\PORT_%s_RD_USED", pg.names[pi].c_str()), used_r);
-						cell->setParam(stringf("\\PORT_%s_WR_USED", pg.names[pi].c_str()), used_w);
+						cell->setParam(stringf("\\PORT_%s_RD_USED", pg.names[pi]), used_r);
+						cell->setParam(stringf("\\PORT_%s_WR_USED", pg.names[pi]), used_w);
 					}
 			}
 		}

--- a/passes/memory/memory_map.cc
+++ b/passes/memory/memory_map.cc
@@ -244,7 +244,7 @@ struct MemoryMapWorker
 				data_reg_in[idx] = w_in;
 				c->setPort(ID::D, w_in);
 
-				std::string w_out_name = stringf("%s[%d]", mem.memid.c_str(), addr);
+				std::string w_out_name = stringf("%s[%d]", mem.memid, addr);
 				if (module->wires_.count(w_out_name) > 0)
 					w_out_name = genid(mem.memid, "", addr, "$q");
 

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -2201,7 +2201,7 @@ skip_alu_split:
 						{
 							if (cmp_type == ID($lt)) cmp_name = "<";
 							if (cmp_type == ID($le)) cmp_name = "<=";
-							condition   = stringf("unsigned X[%d:0]%s%s", var_width - 1, cmp_name.c_str(), log_signal(const_sig));
+							condition   = stringf("unsigned X[%d:0]%s%s", var_width - 1, cmp_name, log_signal(const_sig));
 							replacement = "constant 1";
 							replace_sig[0] = State::S1;
 							replace = true;
@@ -2210,7 +2210,7 @@ skip_alu_split:
 						{
 							if (cmp_type == ID($gt)) cmp_name = ">";
 							if (cmp_type == ID($ge)) cmp_name = ">=";
-							condition   = stringf("unsigned X[%d:0]%s%s", var_width - 1, cmp_name.c_str(), log_signal(const_sig));
+							condition   = stringf("unsigned X[%d:0]%s%s", var_width - 1, cmp_name, log_signal(const_sig));
 							replacement = "constant 0";
 							replace_sig[0] = State::S0;
 							replace = true;

--- a/passes/proc/proc_mux.cc
+++ b/passes/proc/proc_mux.cc
@@ -178,7 +178,7 @@ RTLIL::SigSpec gen_cmp(RTLIL::Module *mod, const RTLIL::SigSpec &signal, const s
 		else
 		{
 			// create compare cell
-			RTLIL::Cell *eq_cell = mod->addCell(stringf("%s_CMP%d", sstr.str().c_str(), cmp_wire->width), ifxmode ? ID($eqx) : ID($eq));
+			RTLIL::Cell *eq_cell = mod->addCell(stringf("%s_CMP%d", sstr.str(), cmp_wire->width), ifxmode ? ID($eqx) : ID($eq));
 			apply_attrs(eq_cell, sw, cs);
 
 			eq_cell->parameters[ID::A_SIGNED] = RTLIL::Const(0);

--- a/passes/sat/clk2fflogic.cc
+++ b/passes/sat/clk2fflogic.cc
@@ -72,7 +72,7 @@ struct Clk2fflogicPass : public Pass {
 		}
 		std::string sig_str = log_signal(sig);
 		sig_str.erase(std::remove(sig_str.begin(), sig_str.end(), ' '), sig_str.end());
-		Wire *sampled_sig = module->addWire(NEW_ID_SUFFIX(stringf("%s#sampled", sig_str.c_str())), GetSize(sig));
+		Wire *sampled_sig = module->addWire(NEW_ID_SUFFIX(stringf("%s#sampled", sig_str)), GetSize(sig));
 		sampled_sig->attributes[ID::init] = RTLIL::Const(State::S0, GetSize(sig));
 		if (is_fine)
 			module->addFfGate(NEW_ID, sig, sampled_sig);
@@ -84,7 +84,7 @@ struct Clk2fflogicPass : public Pass {
 	SigSpec sample_control_edge(Module *module, SigSpec sig, bool polarity, bool is_fine) {
 		std::string sig_str = log_signal(sig);
 		sig_str.erase(std::remove(sig_str.begin(), sig_str.end(), ' '), sig_str.end());
-		Wire *sampled_sig = module->addWire(NEW_ID_SUFFIX(stringf("%s#sampled", sig_str.c_str())), GetSize(sig));
+		Wire *sampled_sig = module->addWire(NEW_ID_SUFFIX(stringf("%s#sampled", sig_str)), GetSize(sig));
 		sampled_sig->attributes[ID::init] = RTLIL::Const(polarity ? State::S1 : State::S0, GetSize(sig));
 		if (is_fine)
 			module->addFfGate(NEW_ID, sig, sampled_sig);
@@ -98,7 +98,7 @@ struct Clk2fflogicPass : public Pass {
 		sig_str.erase(std::remove(sig_str.begin(), sig_str.end(), ' '), sig_str.end());
 
 
-		Wire *sampled_sig = module->addWire(NEW_ID_SUFFIX(stringf("%s#sampled", sig_str.c_str())), GetSize(sig));
+		Wire *sampled_sig = module->addWire(NEW_ID_SUFFIX(stringf("%s#sampled", sig_str)), GetSize(sig));
 		sampled_sig->attributes[ID::init] = init;
 
 		Cell *cell;

--- a/passes/sat/cutpoint.cc
+++ b/passes/sat/cutpoint.cc
@@ -129,7 +129,7 @@ struct CutpointPass : public Pass {
 						if (attr.first == ID::hdlname)
 							scopeinfo->attributes.insert(attr);
 						else
-							scopeinfo->attributes.emplace(stringf("\\cell_%s", RTLIL::unescape_id(attr.first).c_str()), attr.second);
+							scopeinfo->attributes.emplace(stringf("\\cell_%s", RTLIL::unescape_id(attr.first)), attr.second);
 					}
 				}
 

--- a/passes/sat/eval.cc
+++ b/passes/sat/eval.cc
@@ -263,7 +263,7 @@ struct VlogHammerReporter
 						RTLIL::SigSpec sig(wire);
 						if (!ce.eval(sig))
 							log_error("Can't read back value for port %s!\n", log_id(inputs[i]));
-						input_pattern_list += stringf(" %s", sig.as_const().as_string().c_str());
+						input_pattern_list += stringf(" %s", sig.as_const().as_string());
 						log("++PAT++ %d %s %s #\n", idx, log_id(inputs[i]), sig.as_const().as_string().c_str());
 					}
 				}

--- a/passes/sat/fmcombine.cc
+++ b/passes/sat/fmcombine.cc
@@ -44,7 +44,7 @@ struct FmcombineWorker
 
 	FmcombineWorker(Design *design, IdString orig_type, const opts_t &opts) :
 			opts(opts), design(design), original(design->module(orig_type)),
-			orig_type(orig_type), combined_type(stringf("$fmcombine%s", orig_type.c_str()))
+			orig_type(orig_type), combined_type(stringf("$fmcombine%s", orig_type))
 	{
 	}
 

--- a/passes/sat/freduce.cc
+++ b/passes/sat/freduce.cc
@@ -595,9 +595,9 @@ struct FreduceWorker
 
 	void dump()
 	{
-		std::string filename = stringf("%s_%s_%05d.il", dump_prefix.c_str(), RTLIL::id2cstr(module->name), reduce_counter);
+		std::string filename = stringf("%s_%s_%05d.il", dump_prefix, RTLIL::id2cstr(module->name), reduce_counter);
 		log("%s    Writing dump file `%s'.\n", reduce_counter ? "  " : "", filename.c_str());
-		Pass::call(design, stringf("dump -outfile %s %s", filename.c_str(), design->selected_active_module.empty() ? module->name.c_str() : ""));
+		Pass::call(design, stringf("dump -outfile %s %s", filename, design->selected_active_module.empty() ? module->name.c_str() : ""));
 	}
 
 	int run()

--- a/passes/sat/mutate.cc
+++ b/passes/sat/mutate.cc
@@ -570,7 +570,7 @@ void mutate_list(Design *design, const mutate_opts_t &opts, const string &filena
 		string str = "mutate";
 		if (!opts.ctrl_name.empty())
 			str += stringf(" -ctrl %s %d %d", log_id(opts.ctrl_name), opts.ctrl_width, ctrl_value++);
-		str += stringf(" -mode %s", entry.mode.c_str());
+		str += stringf(" -mode %s", entry.mode);
 		if (!entry.module.empty())
 			str += stringf(" -module %s", log_id(entry.module));
 		if (!entry.cell.empty())
@@ -586,7 +586,7 @@ void mutate_list(Design *design, const mutate_opts_t &opts, const string &filena
 		if (entry.wirebit >= 0)
 			str += stringf(" -wirebit %d", entry.wirebit);
 		for (auto &s : entry.src)
-			str += stringf(" -src %s", s.c_str());
+			str += stringf(" -src %s", s);
 		if (filename.empty())
 			log("%s\n", str.c_str());
 		else

--- a/passes/sat/qbfsat.cc
+++ b/passes/sat/qbfsat.cc
@@ -219,14 +219,14 @@ QbfSolutionType call_qbf_solver(RTLIL::Module *mod, const QbfSolveOptions &opt, 
 	const std::string smtbmc_warning = "z3: WARNING:";
 	const std::string smtbmc_cmd = stringf("\"%s\" -s %s %s -t 1 -g --binary %s %s/problem%d.smt2 2>&1",
 			yosys_smtbmc_exe.c_str(), opt.get_solver_name().c_str(),
-			(opt.timeout != 0? stringf("--timeout %d", opt.timeout) : "").c_str(),
+			(opt.timeout != 0? stringf("--timeout %d", opt.timeout) : ""),
 			(opt.dump_final_smt2? "--dump-smt2 " + opt.dump_final_smt2_file : "").c_str(),
 			tempdir_name.c_str(), iter_num);
 
 	std::string smt2_command = "write_smt2 -stbv -wires ";
 	for (auto &solver_opt : opt.solver_options)
-		smt2_command += stringf("-solver-option %s %s ", solver_opt.first.c_str(), solver_opt.second.c_str());
-	smt2_command += stringf("%s/problem%d.smt2", tempdir_name.c_str(), iter_num);
+		smt2_command += stringf("-solver-option %s %s ", solver_opt.first, solver_opt.second);
+	smt2_command += stringf("%s/problem%d.smt2", tempdir_name, iter_num);
 	Pass::call(mod->design, smt2_command);
 
 	auto process_line = [&ret, &smtbmc_warning, &opt, &quiet](const std::string &line) {

--- a/passes/sat/recover_names.cc
+++ b/passes/sat/recover_names.cc
@@ -380,7 +380,7 @@ struct RecoverModuleWorker {
             if (root2buffered.count(gate_bit)) {
                 int buf_idx = 0;
                 for (auto buf_bit : root2buffered.at(gate_bit)) {
-                    std::string buf_name_str = stringf("%s_buf_%d", pair.second.bit.name.c_str(), ++buf_idx);
+                    std::string buf_name_str = stringf("%s_buf_%d", pair.second.bit.name, ++buf_idx);
                     if (buf_name_str[0] == '\\')
                         buf_name_str[0] = '$';
                     rename_map[buf_bit] = std::make_pair(
@@ -396,7 +396,7 @@ struct RecoverModuleWorker {
             bool must_invert_name = rule.second.first.inverted;
             while (must_invert_name ||
                     (mod->wire(new_name.name) && !unused_bits.count(SigBit(mod->wire(new_name.name), new_name.bit)))) {
-                std::string new_name_str = stringf("%s_%s_%d", rule.second.first.bit.name.c_str(),
+                std::string new_name_str = stringf("%s_%s_%d", rule.second.first.bit.name,
                     rule.second.first.inverted ? "inv" : "dup", ++dup_idx);
                 if (new_name_str[0] == '\\')
                     new_name_str[0] = '$';

--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -2095,12 +2095,12 @@ struct SimWorker : SimShared
 		std::stringstream f;
 
 		if (wire->width==1)
-			f << stringf("%s", RTLIL::unescape_id(wire->name).c_str());
+			f << stringf("%s", RTLIL::unescape_id(wire->name));
 		else
 			if (wire->upto)
-				f << stringf("[%d:%d] %s", wire->start_offset, wire->width - 1 + wire->start_offset, RTLIL::unescape_id(wire->name).c_str());
+				f << stringf("[%d:%d] %s", wire->start_offset, wire->width - 1 + wire->start_offset, RTLIL::unescape_id(wire->name));
 			else
-				f << stringf("[%d:%d] %s", wire->width - 1 + wire->start_offset, wire->start_offset, RTLIL::unescape_id(wire->name).c_str());
+				f << stringf("[%d:%d] %s", wire->width - 1 + wire->start_offset, wire->start_offset, RTLIL::unescape_id(wire->name));
 		return f.str();
 	}
 
@@ -2108,7 +2108,7 @@ struct SimWorker : SimShared
 	{
 		std::stringstream f;
 		for(auto item=signals.begin();item!=signals.end();item++)
-			f << stringf("%c%s", (item==signals.begin() ? ' ' : ','), RTLIL::unescape_id(item->first->name).c_str());
+			f << stringf("%c%s", (item==signals.begin() ? ' ' : ','), RTLIL::unescape_id(item->first->name));
 		return f.str();
 	}
 
@@ -2207,7 +2207,7 @@ struct SimWorker : SimShared
 
 		std::stringstream f;
 		f << stringf("`timescale 1%s/1%s\n", fst->getTimescaleString(),fst->getTimescaleString());
-		f << stringf("module %s();\n",tb_filename.c_str());
+		f << stringf("module %s();\n",tb_filename);
 		int clk_len = 0;
 		int inputs_len = 0;
 		int outputs_len = 0;
@@ -2225,13 +2225,13 @@ struct SimWorker : SimShared
 		}
 		int data_len = clk_len + inputs_len + outputs_len + 32;
 		f << "\n";
-		f << stringf("\t%s uut(",RTLIL::unescape_id(topmod->name).c_str());
+		f << stringf("\t%s uut(",RTLIL::unescape_id(topmod->name));
 		for(auto item=clocks.begin();item!=clocks.end();item++)
-			f << stringf("%c.%s(%s)", (item==clocks.begin() ? ' ' : ','), RTLIL::unescape_id(item->first->name).c_str(), RTLIL::unescape_id(item->first->name).c_str());
+			f << stringf("%c.%s(%s)", (item==clocks.begin() ? ' ' : ','), RTLIL::unescape_id(item->first->name), RTLIL::unescape_id(item->first->name));
 		for(auto &item : inputs)
-			f << stringf(",.%s(%s)", RTLIL::unescape_id(item.first->name).c_str(), RTLIL::unescape_id(item.first->name).c_str());
+			f << stringf(",.%s(%s)", RTLIL::unescape_id(item.first->name), RTLIL::unescape_id(item.first->name));
 		for(auto &item : outputs)
-			f << stringf(",.%s(%s)", RTLIL::unescape_id(item.first->name).c_str(), RTLIL::unescape_id(item.first->name).c_str());
+			f << stringf(",.%s(%s)", RTLIL::unescape_id(item.first->name), RTLIL::unescape_id(item.first->name));
 		f << ");\n";
 		f << "\n";
 		f << "\tinteger i;\n";
@@ -2242,21 +2242,21 @@ struct SimWorker : SimShared
 		unsigned int end_cycle = cycles_set ? numcycles*2 : INT_MAX;
 		fst->reconstructAllAtTimes(fst_clock, startCount, stopCount, end_cycle, [&](uint64_t time) {
 			for(auto &item : clocks)
-				data_file << stringf("%s",fst->valueOf(item.second).c_str());
+				data_file << stringf("%s",fst->valueOf(item.second));
 			for(auto &item : inputs)
-				data_file << stringf("%s",fst->valueOf(item.second).c_str());
+				data_file << stringf("%s",fst->valueOf(item.second));
 			for(auto &item : outputs)
-				data_file << stringf("%s",fst->valueOf(item.second).c_str());
-			data_file << stringf("%s\n",Const(time-prev_time).as_string().c_str());
+				data_file << stringf("%s",fst->valueOf(item.second));
+			data_file << stringf("%s\n",Const(time-prev_time).as_string());
 
 			if (time==startCount) {
 				// initial state
 				for(auto var : fst->getVars()) {
 					if (var.is_reg && !Const::from_string(fst->valueOf(var.id).c_str()).is_fully_undef()) {
 						if (var.scope == scope) {
-							initstate << stringf("\t\tuut.%s = %d'b%s;\n", var.name.c_str(), var.width, fst->valueOf(var.id).c_str());
+							initstate << stringf("\t\tuut.%s = %d'b%s;\n", var.name, var.width, fst->valueOf(var.id));
 						} else if (var.scope.find(scope+".")==0) {
-							initstate << stringf("\t\tuut.%s.%s = %d'b%s;\n",var.scope.substr(scope.size()+1).c_str(), var.name.c_str(), var.width, fst->valueOf(var.id).c_str());
+							initstate << stringf("\t\tuut.%s.%s = %d'b%s;\n",var.scope.substr(scope.size()+1), var.name, var.width, fst->valueOf(var.id));
 						}
 					}
 				}
@@ -2267,22 +2267,22 @@ struct SimWorker : SimShared
 
 		f << stringf("\treg [0:%d] data [0:%d];\n", data_len-1, cycle-1);
 		f << "\tinitial begin;\n";
-		f << stringf("\t\t$dumpfile(\"%s\");\n",tb_filename.c_str());
-		f << stringf("\t\t$dumpvars(0,%s);\n",tb_filename.c_str());
+		f << stringf("\t\t$dumpfile(\"%s\");\n",tb_filename);
+		f << stringf("\t\t$dumpvars(0,%s);\n",tb_filename);
 		f << initstate.str();
-		f << stringf("\t\t$readmemb(\"%s.txt\", data);\n",tb_filename.c_str());
+		f << stringf("\t\t$readmemb(\"%s.txt\", data);\n",tb_filename);
 
 		f << stringf("\t\t#(data[0][%d:%d]);\n", data_len-32, data_len-1);	
-		f << stringf("\t\t{%s } = data[0][%d:%d];\n", signal_list(clocks).c_str(), 0, clk_len-1);		
-		f << stringf("\t\t{%s } <= data[0][%d:%d];\n", signal_list(inputs).c_str(), clk_len, clk_len+inputs_len-1);
+		f << stringf("\t\t{%s } = data[0][%d:%d];\n", signal_list(clocks), 0, clk_len-1);		
+		f << stringf("\t\t{%s } <= data[0][%d:%d];\n", signal_list(inputs), clk_len, clk_len+inputs_len-1);
 
 		f << stringf("\t\tfor (i = 1; i < %d; i++) begin\n",cycle);
 
 		f << stringf("\t\t\t#(data[i][%d:%d]);\n", data_len-32, data_len-1);	
-		f << stringf("\t\t\t{%s } = data[i][%d:%d];\n", signal_list(clocks).c_str(), 0, clk_len-1);		
-		f << stringf("\t\t\t{%s } <= data[i][%d:%d];\n", signal_list(inputs).c_str(), clk_len, clk_len+inputs_len-1);
+		f << stringf("\t\t\t{%s } = data[i][%d:%d];\n", signal_list(clocks), 0, clk_len-1);		
+		f << stringf("\t\t\t{%s } <= data[i][%d:%d];\n", signal_list(inputs), clk_len, clk_len+inputs_len-1);
 		
-		f << stringf("\t\t\tif ({%s } != data[i-1][%d:%d]) begin\n", signal_list(outputs).c_str(), clk_len+inputs_len, clk_len+inputs_len+outputs_len-1);
+		f << stringf("\t\t\tif ({%s } != data[i-1][%d:%d]) begin\n", signal_list(outputs), clk_len+inputs_len, clk_len+inputs_len+outputs_len-1);
 		f << "\t\t\t\t$error(\"Signal difference detected\\n\");\n";
 		f << "\t\t\tend\n";
 		
@@ -2337,7 +2337,7 @@ struct VCDWriter : public OutputWriter
 		}
 
 		if (!worker->timescale.empty())
-			vcdfile << stringf("$timescale %s $end\n", worker->timescale.c_str());
+			vcdfile << stringf("$timescale %s $end\n", worker->timescale);
 
 		worker->top->write_output_header(
 			[this](IdString name) { vcdfile << stringf("$scope module %s $end\n", log_id(name)); },
@@ -2349,7 +2349,7 @@ struct VCDWriter : public OutputWriter
 				// this is consistent with the range gtkwave makes up if it doesn't find a
 				// range
 				std::string full_name = form_vcd_name(name, size, w);
-				vcdfile << stringf("$var %s %d n%d %s%s $end\n", is_reg ? "reg" : "wire", size, id, name[0] == '$' ? "\\" : "", full_name.c_str());
+				vcdfile << stringf("$var %s %d n%d %s%s $end\n", is_reg ? "reg" : "wire", size, id, name[0] == '$' ? "\\" : "", full_name);
 			}
 		);
 

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -859,27 +859,27 @@ void AbcModuleState::abc_module(RTLIL::Design *design, RTLIL::Module *module, Ab
 	log_header(design, "Extracting gate netlist of module `%s' to `%s/input.blif'..\n",
 			module->name.c_str(), replace_tempdir(tempdir_name, tempdir_name, config.show_tempdir).c_str());
 
-	std::string abc_script = stringf("read_blif \"%s/input.blif\"; ", tempdir_name.c_str());
+	std::string abc_script = stringf("read_blif \"%s/input.blif\"; ", tempdir_name);
 
 	if (!config.liberty_files.empty() || !config.genlib_files.empty()) {
 		std::string dont_use_args;
 		for (std::string dont_use_cell : config.dont_use_cells) {
-			dont_use_args += stringf("-X \"%s\" ", dont_use_cell.c_str());
+			dont_use_args += stringf("-X \"%s\" ", dont_use_cell);
 		}
 		bool first_lib = true;
 		for (std::string liberty_file : config.liberty_files) {
-			abc_script += stringf("read_lib %s %s -w \"%s\" ; ", dont_use_args.c_str(), first_lib ? "" : "-m", liberty_file.c_str());
+			abc_script += stringf("read_lib %s %s -w \"%s\" ; ", dont_use_args, first_lib ? "" : "-m", liberty_file);
 			first_lib = false;
 		}
 		for (std::string liberty_file : config.genlib_files)
-			abc_script += stringf("read_library \"%s\"; ", liberty_file.c_str());
+			abc_script += stringf("read_library \"%s\"; ", liberty_file);
 		if (!config.constr_file.empty())
-			abc_script += stringf("read_constr -v \"%s\"; ", config.constr_file.c_str());
+			abc_script += stringf("read_constr -v \"%s\"; ", config.constr_file);
 	} else
 	if (!config.lut_costs.empty())
-		abc_script += stringf("read_lut %s/lutdefs.txt; ", tempdir_name.c_str());
+		abc_script += stringf("read_lut %s/lutdefs.txt; ", tempdir_name);
 	else
-		abc_script += stringf("read_library %s/stdcells.genlib; ", tempdir_name.c_str());
+		abc_script += stringf("read_library %s/stdcells.genlib; ", tempdir_name);
 
 	if (!config.script_file.empty()) {
 		const std::string &script_file = config.script_file;
@@ -892,7 +892,7 @@ void AbcModuleState::abc_module(RTLIL::Design *design, RTLIL::Module *module, Ab
 				else
 					abc_script += script_file[i];
 		} else
-			abc_script += stringf("source %s", script_file.c_str());
+			abc_script += stringf("source %s", script_file);
 	} else if (!config.lut_costs.empty()) {
 		bool all_luts_cost_same = true;
 		for (int this_cost : config.lut_costs)
@@ -925,15 +925,15 @@ void AbcModuleState::abc_module(RTLIL::Design *design, RTLIL::Module *module, Ab
 	for (size_t pos = abc_script.find("{S}"); pos != std::string::npos; pos = abc_script.find("{S}", pos))
 		abc_script = abc_script.substr(0, pos) + config.lutin_shared + abc_script.substr(pos+3);
 	if (config.abc_dress)
-		abc_script += stringf("; dress \"%s/input.blif\"", tempdir_name.c_str());
-	abc_script += stringf("; write_blif %s/output.blif", tempdir_name.c_str());
+		abc_script += stringf("; dress \"%s/input.blif\"", tempdir_name);
+	abc_script += stringf("; write_blif %s/output.blif", tempdir_name);
 	abc_script = add_echos_to_abc_cmd(abc_script);
 
 	for (size_t i = 0; i+1 < abc_script.size(); i++)
 		if (abc_script[i] == ';' && abc_script[i+1] == ' ')
 			abc_script[i+1] = '\n';
 
-	std::string buffer = stringf("%s/abc.script", tempdir_name.c_str());
+	std::string buffer = stringf("%s/abc.script", tempdir_name);
 	FILE *f = fopen(buffer.c_str(), "wt");
 	if (f == nullptr)
 		log_error("Opening %s for writing failed: %s\n", buffer.c_str(), strerror(errno));
@@ -988,7 +988,7 @@ void AbcModuleState::abc_module(RTLIL::Design *design, RTLIL::Module *module, Ab
 
 	handle_loops(assign_map, module);
 
-	buffer = stringf("%s/input.blif", tempdir_name.c_str());
+	buffer = stringf("%s/input.blif", tempdir_name);
 	f = fopen(buffer.c_str(), "wt");
 	if (f == nullptr)
 		log_error("Opening %s for writing failed: %s\n", buffer.c_str(), strerror(errno));
@@ -1115,7 +1115,7 @@ void AbcModuleState::abc_module(RTLIL::Design *design, RTLIL::Module *module, Ab
 
 		auto &cell_cost = cmos_cost ? CellCosts::cmos_gate_cost() : CellCosts::default_gate_cost();
 
-		buffer = stringf("%s/stdcells.genlib", tempdir_name.c_str());
+		buffer = stringf("%s/stdcells.genlib", tempdir_name);
 		f = fopen(buffer.c_str(), "wt");
 		if (f == nullptr)
 			log_error("Opening %s for writing failed: %s\n", buffer.c_str(), strerror(errno));
@@ -1160,7 +1160,7 @@ void AbcModuleState::abc_module(RTLIL::Design *design, RTLIL::Module *module, Ab
 		fclose(f);
 
 		if (!config.lut_costs.empty()) {
-			buffer = stringf("%s/lutdefs.txt", tempdir_name.c_str());
+			buffer = stringf("%s/lutdefs.txt", tempdir_name);
 			f = fopen(buffer.c_str(), "wt");
 			if (f == nullptr)
 				log_error("Opening %s for writing failed: %s\n", buffer.c_str(), strerror(errno));
@@ -1169,14 +1169,14 @@ void AbcModuleState::abc_module(RTLIL::Design *design, RTLIL::Module *module, Ab
 			fclose(f);
 		}
 
-		buffer = stringf("\"%s\" -s -f %s/abc.script 2>&1", config.exe_file.c_str(), tempdir_name.c_str());
+		buffer = stringf("\"%s\" -s -f %s/abc.script 2>&1", config.exe_file, tempdir_name);
 		log("Running ABC command: %s\n", replace_tempdir(buffer, tempdir_name, config.show_tempdir).c_str());
 
 #ifndef YOSYS_LINK_ABC
 		abc_output_filter filt(*this, tempdir_name, config.show_tempdir);
 		int ret = run_command(buffer, std::bind(&abc_output_filter::next_line, filt, std::placeholders::_1));
 #else
-		string temp_stdouterr_name = stringf("%s/stdouterr.txt", tempdir_name.c_str());
+		string temp_stdouterr_name = stringf("%s/stdouterr.txt", tempdir_name);
 		FILE *temp_stdouterr_w = fopen(temp_stdouterr_name.c_str(), "w");
 		if (temp_stdouterr_w == NULL)
 			log_error("ABC: cannot open a temporary file for output redirection");
@@ -1196,7 +1196,7 @@ void AbcModuleState::abc_module(RTLIL::Design *design, RTLIL::Module *module, Ab
 		fclose(temp_stdouterr_w);
 		// These needs to be mutable, supposedly due to getopt
 		char *abc_argv[5];
-		string tmp_script_name = stringf("%s/abc.script", tempdir_name.c_str());
+		string tmp_script_name = stringf("%s/abc.script", tempdir_name);
 		abc_argv[0] = strdup(config.exe_file.c_str());
 		abc_argv[1] = strdup("-s");
 		abc_argv[2] = strdup("-f");
@@ -1235,7 +1235,7 @@ void AbcModuleState::extract(AbcSigMap &assign_map, RTLIL::Design *design, RTLIL
 		return;
 	}
 
-	std::string buffer = stringf("%s/%s", tempdir_name.c_str(), "output.blif");
+	std::string buffer = stringf("%s/%s", tempdir_name, "output.blif");
 	std::ifstream ifs;
 	ifs.open(buffer);
 	if (ifs.fail())
@@ -2102,7 +2102,7 @@ struct AbcPass : public Pass {
 					goto ok_alias;
 				}
 				if (g_arg_from_cmd)
-					cmd_error(args, g_argidx, stringf("Unsupported gate type: %s", g.c_str()));
+					cmd_error(args, g_argidx, stringf("Unsupported gate type: %s", g));
 				else
 					log_cmd_error("Unsupported gate type: %s", g.c_str());
 			ok_gate:

--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -332,8 +332,8 @@ struct Abc9Pass : public ScriptPass
 						// Rename all submod-s to _TECHMAP_REPLACE_ to inherit name + attrs
 						for (auto module : active_design->selected_modules()) {
 							active_design->selected_active_module = module->name.str();
-							if (module->cell(stringf("%s_$abc9_flop", module->name.c_str())))
-								run(stringf("rename %s_$abc9_flop _TECHMAP_REPLACE_", module->name.c_str()));
+							if (module->cell(stringf("%s_$abc9_flop", module->name)))
+								run(stringf("rename %s_$abc9_flop _TECHMAP_REPLACE_", module->name));
 						}
 						active_design->selected_active_module.clear();
 					}
@@ -418,10 +418,10 @@ struct Abc9Pass : public ScriptPass
 					tempdir_name = make_temp_dir(tempdir_name);
 
 					if (!lut_mode)
-						run_nocheck(stringf("abc9_ops -write_lut %s/input.lut", tempdir_name.c_str()));
+						run_nocheck(stringf("abc9_ops -write_lut %s/input.lut", tempdir_name));
 					if (box_file.empty())
-						run_nocheck(stringf("abc9_ops -write_box %s/input.box", tempdir_name.c_str()));
-					run_nocheck(stringf("write_xaiger -map %s/input.sym %s %s/input.xaig", tempdir_name.c_str(), dff_mode ? "-dff" : "", tempdir_name.c_str()));
+						run_nocheck(stringf("abc9_ops -write_box %s/input.box", tempdir_name));
+					run_nocheck(stringf("write_xaiger -map %s/input.sym %s %s/input.xaig", tempdir_name, dff_mode ? "-dff" : "", tempdir_name));
 
 					int num_outputs = active_design->scratchpad_get_int("write_xaiger.num_outputs");
 
@@ -433,15 +433,15 @@ struct Abc9Pass : public ScriptPass
 							num_outputs);
 					if (num_outputs) {
 						std::string abc9_exe_cmd;
-						abc9_exe_cmd += stringf("%s -cwd %s", exe_cmd.str().c_str(), tempdir_name.c_str());
+						abc9_exe_cmd += stringf("%s -cwd %s", exe_cmd.str(), tempdir_name);
 						if (!lut_mode)
-							abc9_exe_cmd += stringf(" -lut %s/input.lut", tempdir_name.c_str());
+							abc9_exe_cmd += stringf(" -lut %s/input.lut", tempdir_name);
 						if (box_file.empty())
-							abc9_exe_cmd += stringf(" -box %s/input.box", tempdir_name.c_str());
+							abc9_exe_cmd += stringf(" -box %s/input.box", tempdir_name);
 						else
-							abc9_exe_cmd += stringf(" -box %s", box_file.c_str());
+							abc9_exe_cmd += stringf(" -box %s", box_file);
 						run_nocheck(abc9_exe_cmd);
-						run_nocheck(stringf("read_aiger -xaiger -wideports -module_name %s$abc9 -map %s/input.sym %s/output.aig", log_id(mod), tempdir_name.c_str(), tempdir_name.c_str()));
+						run_nocheck(stringf("read_aiger -xaiger -wideports -module_name %s$abc9 -map %s/input.sym %s/output.aig", log_id(mod), tempdir_name, tempdir_name));
 						run_nocheck(stringf("abc9_ops -reintegrate %s", dff_mode ? "-dff" : ""));
 					}
 					else

--- a/passes/techmap/abc9_exe.cc
+++ b/passes/techmap/abc9_exe.cc
@@ -173,28 +173,28 @@ void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe
 	std::string abc9_script;
 
 	if (!lut_costs.empty())
-		abc9_script += stringf("read_lut %s/lutdefs.txt; ", tempdir_name.c_str());
+		abc9_script += stringf("read_lut %s/lutdefs.txt; ", tempdir_name);
 	else if (!lut_file.empty())
-		abc9_script += stringf("read_lut \"%s\"; ", lut_file.c_str());
+		abc9_script += stringf("read_lut \"%s\"; ", lut_file);
 	else if (!liberty_files.empty()) {
 		std::string dont_use_args;
 		for (std::string dont_use_cell : dont_use_cells) {
-			dont_use_args += stringf("-X \"%s\" ", dont_use_cell.c_str());
+			dont_use_args += stringf("-X \"%s\" ", dont_use_cell);
 		}
 		for (std::string liberty_file : liberty_files) {
-			abc9_script += stringf("read_lib %s -w \"%s\" ; ", dont_use_args.c_str(), liberty_file.c_str());
+			abc9_script += stringf("read_lib %s -w \"%s\" ; ", dont_use_args, liberty_file);
 		}
 		if (!constr_file.empty())
-			abc9_script += stringf("read_constr -v \"%s\"; ", constr_file.c_str());
+			abc9_script += stringf("read_constr -v \"%s\"; ", constr_file);
 	} else if (!genlib_files.empty()) {
 		for (std::string genlib_file : genlib_files) {
-			abc9_script += stringf("read_genlib \"%s\"; ", genlib_file.c_str());
+			abc9_script += stringf("read_genlib \"%s\"; ", genlib_file);
 		}
 	}
 
 	log_assert(!box_file.empty());
-	abc9_script += stringf("read_box \"%s\"; ", box_file.c_str());
-	abc9_script += stringf("&read %s/input.xaig; &ps; ", tempdir_name.c_str());
+	abc9_script += stringf("read_box \"%s\"; ", box_file);
+	abc9_script += stringf("&read %s/input.xaig; &ps; ", tempdir_name);
 
 	if (!script_file.empty()) {
 		if (script_file[0] == '+') {
@@ -206,7 +206,7 @@ void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe
 				else
 					abc9_script += script_file[i];
 		} else
-			abc9_script += stringf("source %s", script_file.c_str());
+			abc9_script += stringf("source %s", script_file);
 	} else if (!lut_costs.empty() || !lut_file.empty()) {
 		abc9_script += fast_mode ? RTLIL::constpad.at("abc9.script.default.fast").substr(1,std::string::npos)
 			: RTLIL::constpad.at("abc9.script.default").substr(1,std::string::npos);
@@ -238,14 +238,14 @@ void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe
 		for (size_t pos = abc9_script.find("&mfs"); pos != std::string::npos; pos = abc9_script.find("&mfs", pos))
 			abc9_script = abc9_script.erase(pos, strlen("&mfs"));
 	else {
-		auto s = stringf("&write -n %s/output.aig; ", tempdir_name.c_str());
+		auto s = stringf("&write -n %s/output.aig; ", tempdir_name);
 		for (size_t pos = abc9_script.find("&mfs"); pos != std::string::npos; pos = abc9_script.find("&mfs", pos)) {
 			abc9_script = abc9_script.insert(pos, s);
 			pos += GetSize(s) + strlen("&mfs");
 		}
 	}
 
-	abc9_script += stringf("; &ps -l; &write -n %s/output.aig", tempdir_name.c_str());
+	abc9_script += stringf("; &ps -l; &write -n %s/output.aig", tempdir_name);
 	if (design->scratchpad_get_bool("abc9.verify")) {
 		if (dff_mode)
 			abc9_script += "; &verify -s";
@@ -268,7 +268,7 @@ void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe
 	log_header(design, "Executing ABC9.\n");
 
 	if (!lut_costs.empty()) {
-		buffer = stringf("%s/lutdefs.txt", tempdir_name.c_str());
+		buffer = stringf("%s/lutdefs.txt", tempdir_name);
 		f = fopen(buffer.c_str(), "wt");
 		if (f == NULL)
 			log_error("Opening %s for writing failed: %s\n", buffer.c_str(), strerror(errno));
@@ -277,14 +277,14 @@ void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe
 		fclose(f);
 	}
 
-	buffer = stringf("\"%s\" -s -f %s/abc.script 2>&1", exe_file.c_str(), tempdir_name.c_str());
+	buffer = stringf("\"%s\" -s -f %s/abc.script 2>&1", exe_file, tempdir_name);
 	log("Running ABC command: %s\n", replace_tempdir(buffer, tempdir_name, show_tempdir).c_str());
 
 #ifndef YOSYS_LINK_ABC
 	abc9_output_filter filt(tempdir_name, show_tempdir);
 	int ret = run_command(buffer, std::bind(&abc9_output_filter::next_line, filt, std::placeholders::_1));
 #else
-	string temp_stdouterr_name = stringf("%s/stdouterr.txt", tempdir_name.c_str());
+	string temp_stdouterr_name = stringf("%s/stdouterr.txt", tempdir_name);
 	FILE *temp_stdouterr_w = fopen(temp_stdouterr_name.c_str(), "w");
 	if (temp_stdouterr_w == NULL)
 		log_error("ABC: cannot open a temporary file for output redirection");
@@ -304,7 +304,7 @@ void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe
 	fclose(temp_stdouterr_w);
 	// These needs to be mutable, supposedly due to getopt
 	char *abc9_argv[5];
-	string tmp_script_name = stringf("%s/abc.script", tempdir_name.c_str());
+	string tmp_script_name = stringf("%s/abc.script", tempdir_name);
 	abc9_argv[0] = strdup(exe_file.c_str());
 	abc9_argv[1] = strdup("-s");
 	abc9_argv[2] = strdup("-f");
@@ -328,7 +328,7 @@ void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe
 	temp_stdouterr_r.close();
 #endif
 	if (ret != 0) {
-		if (check_file_exists(stringf("%s/output.aig", tempdir_name.c_str())))
+		if (check_file_exists(stringf("%s/output.aig", tempdir_name)))
 			log_warning("ABC: execution of command \"%s\" failed: return code %d.\n", buffer.c_str(), ret);
 		else
 			log_error("ABC: execution of command \"%s\" failed: return code %d.\n", buffer.c_str(), ret);

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -856,7 +856,7 @@ void prep_xaiger(RTLIL::Module *module, bool dff)
 						}
 					}
 					else if (w->port_output)
-						conn = holes_module->addWire(stringf("%s.%s", cell->type.c_str(), log_id(port_name)), GetSize(w));
+						conn = holes_module->addWire(stringf("%s.%s", cell->type, log_id(port_name)), GetSize(w));
 				}
 			}
 			else // box_module is a blackbox
@@ -868,7 +868,7 @@ void prep_xaiger(RTLIL::Module *module, bool dff)
 			log_assert(w);
 			if (!w->port_output)
 				continue;
-			Wire *holes_wire = holes_module->addWire(stringf("$abc%s.%s", cell->name.c_str(), log_id(port_name)), GetSize(w));
+			Wire *holes_wire = holes_module->addWire(stringf("$abc%s.%s", cell->name, log_id(port_name)), GetSize(w));
 			holes_wire->port_output = true;
 			holes_wire->port_id = port_id++;
 			holes_module->ports.push_back(holes_wire->name);
@@ -1143,7 +1143,7 @@ void reintegrate(RTLIL::Module *module, bool dff_mode)
 
 	map_autoidx = autoidx++;
 
-	RTLIL::Module *mapped_mod = design->module(stringf("%s$abc9", module->name.c_str()));
+	RTLIL::Module *mapped_mod = design->module(stringf("%s$abc9", module->name));
 	if (mapped_mod == NULL)
 		log_error("ABC output file does not contain a module `%s$abc'.\n", log_id(module));
 
@@ -1271,16 +1271,16 @@ void reintegrate(RTLIL::Module *module, bool dff_mode)
 					// (TODO: Optimise by not cloning unless will increase depth)
 					RTLIL::IdString driver_name;
 					if (GetSize(a_bit.wire) == 1)
-						driver_name = stringf("$lut%s", a_bit.wire->name.c_str());
+						driver_name = stringf("$lut%s", a_bit.wire->name);
 					else
-						driver_name = stringf("$lut%s[%d]", a_bit.wire->name.c_str(), a_bit.offset);
+						driver_name = stringf("$lut%s[%d]", a_bit.wire->name, a_bit.offset);
 					driver_lut = mapped_mod->cell(driver_name);
 				}
 
 				if (!driver_lut) {
 					// If a driver couldn't be found (could be from PI or box CI)
 					// then implement using a LUT
-					RTLIL::Cell *cell = module->addLut(remap_name(stringf("$lut%s", mapped_cell->name.c_str())),
+					RTLIL::Cell *cell = module->addLut(remap_name(stringf("$lut%s", mapped_cell->name)),
 							RTLIL::SigBit(module->wires_.at(remap_name(a_bit.wire->name)), a_bit.offset),
 							RTLIL::SigBit(module->wires_.at(remap_name(y_bit.wire->name)), y_bit.offset),
 							RTLIL::Const::from_string("01"));

--- a/passes/techmap/abc_new.cc
+++ b/passes/techmap/abc_new.cc
@@ -168,9 +168,9 @@ struct AbcNewPass : public ScriptPass {
 						mod->get_string_attribute(ID(abc9_script)));
 				}
 
-				run(stringf("  abc9_ops -write_box %s/input.box", tmpdir.c_str()));
-				run(stringf("  write_xaiger2 -mapping_prep -map2 %s/input.map2 %s/input.xaig", tmpdir.c_str(), tmpdir.c_str()));
-				run(stringf("  abc9_exe %s -cwd %s -box %s/input.box", exe_options.c_str(), tmpdir.c_str(), tmpdir.c_str()));
+				run(stringf("  abc9_ops -write_box %s/input.box", tmpdir));
+				run(stringf("  write_xaiger2 -mapping_prep -map2 %s/input.map2 %s/input.xaig", tmpdir, tmpdir));
+				run(stringf("  abc9_exe %s -cwd %s -box %s/input.box", exe_options, tmpdir, tmpdir));
 				run(stringf("  read_xaiger2 -sc_mapping -module_name %s -map2 %s/input.map2 %s/output.aig",
 							modname.c_str(), tmpdir.c_str(), tmpdir.c_str()));
 

--- a/passes/techmap/booth.cc
+++ b/passes/techmap/booth.cc
@@ -201,7 +201,7 @@ struct BoothPassWorker {
 		log_assert(sig_a.size() == sig_y.size());
 
 		for (int i = 0; i < sig_a.size(); i++)
-			mod->addFa(stringf("%s[%d]", name.c_str(), i), sig_a[i], sig_b[i],
+			mod->addFa(stringf("%s[%d]", name, i), sig_a[i], sig_b[i],
 				   sig_c[i], sig_x[i], sig_y[i], src);
 	}
 

--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -553,7 +553,7 @@ static void dfflibmap(RTLIL::Design *design, RTLIL::Module *module)
 			new_cell->setPort("\\" + port.first, sig);
 		}
 
-		stats[stringf("  mapped %%d %s cells to %s cells.\n", cell_type.c_str(), new_cell->type.c_str())]++;
+		stats[stringf("  mapped %%d %s cells to %s cells.\n", cell_type, new_cell->type)]++;
 	}
 
 	for (auto &stat: stats)
@@ -687,7 +687,7 @@ struct DfflibmapPass : public Pass {
 		if (!map_only_mode) {
 			std::string dfflegalize_cmd = "dfflegalize";
 			for (auto it : cell_mappings)
-				dfflegalize_cmd += stringf(" -cell %s 01", it.first.c_str());
+				dfflegalize_cmd += stringf(" -cell %s 01", it.first);
 			dfflegalize_cmd += " t:$_DFF* t:$_SDFF*";
 			if (info_mode) {
 				log("dfflegalize command line: %s\n", dfflegalize_cmd.c_str());

--- a/passes/techmap/extract.cc
+++ b/passes/techmap/extract.cc
@@ -292,7 +292,7 @@ RTLIL::Cell *replace(RTLIL::Module *needle, RTLIL::Module *haystack, SubCircuit:
 	SigSet<std::pair<RTLIL::IdString, int>> sig2port;
 
 	// create new cell
-	RTLIL::Cell *cell = haystack->addCell(stringf("$extract$%s$%d", needle->name.c_str(), autoidx++), needle->name);
+	RTLIL::Cell *cell = haystack->addCell(stringf("$extract$%s$%d", needle->name, autoidx++), needle->name);
 
 	// create cell ports
 	for (auto wire : needle->wires()) {

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -42,9 +42,9 @@ PRIVATE_NAMESPACE_BEGIN
 void apply_prefix(IdString prefix, IdString &id)
 {
 	if (id[0] == '\\')
-		id = stringf("%s.%s", prefix.c_str(), id.c_str()+1);
+		id = stringf("%s.%s", prefix, id.c_str()+1);
 	else
-		id = stringf("$techmap%s.%s", prefix.c_str(), id.c_str());
+		id = stringf("$techmap%s.%s", prefix, id);
 }
 
 void apply_prefix(IdString prefix, RTLIL::SigSpec &sig, RTLIL::Module *module)
@@ -107,7 +107,7 @@ struct TechmapWorker
 				}
 			}
 
-		return stringf("$paramod$constmap:%s%s", sha1(constmap_info).c_str(), tpl->name.c_str());
+		return stringf("$paramod$constmap:%s%s", sha1(constmap_info), tpl->name);
 	}
 
 	TechmapWires techmap_find_special_wires(RTLIL::Module *module)
@@ -222,7 +222,7 @@ struct TechmapWorker
 			design->select(module, w);
 
 			if (const char *p = strstr(tpl_w->name.c_str(), "_TECHMAP_REPLACE_.")) {
-				IdString replace_name = stringf("%s%s", orig_cell_name.c_str(), p + strlen("_TECHMAP_REPLACE_"));
+				IdString replace_name = stringf("%s%s", orig_cell_name, p + strlen("_TECHMAP_REPLACE_"));
 				Wire *replace_w = module->addWire(replace_name, tpl_w);
 				module->connect(replace_w, w);
 			}
@@ -327,7 +327,7 @@ struct TechmapWorker
 			if (techmap_replace_cell)
 				c_name = orig_cell_name;
 			else if (const char *p = strstr(tpl_cell->name.c_str(), "_TECHMAP_REPLACE_."))
-				c_name = stringf("%s%s", orig_cell_name.c_str(), p + strlen("_TECHMAP_REPLACE_"));
+				c_name = stringf("%s%s", orig_cell_name, p + strlen("_TECHMAP_REPLACE_"));
 			else
 				apply_prefix(cell->name, c_name);
 
@@ -512,7 +512,7 @@ struct TechmapWorker
 
 					if ((extern_mode && !in_recursion) || extmapper_name == "wrap")
 					{
-						std::string m_name = stringf("$extern:%s:%s", extmapper_name.c_str(), log_id(cell->type));
+						std::string m_name = stringf("$extern:%s:%s", extmapper_name, log_id(cell->type));
 
 						for (auto &c : cell->parameters)
 							m_name += stringf(":%s=%s", log_id(c.first), log_signal(c.second));
@@ -586,7 +586,7 @@ struct TechmapWorker
 					}
 					else
 					{
-						auto msg = stringf("Using extmapper %s for cells of type %s.", extmapper_name.c_str(), log_id(cell->type));
+						auto msg = stringf("Using extmapper %s for cells of type %s.", extmapper_name, log_id(cell->type));
 						if (!log_msg_cache.count(msg)) {
 							log_msg_cache.insert(msg);
 							log("%s\n", msg.c_str());

--- a/passes/tests/test_autotb.cc
+++ b/passes/tests/test_autotb.cc
@@ -114,7 +114,7 @@ static void autotest(std::ostream &f, RTLIL::Design *design, int num_iter, int s
 			if (wire->port_output) {
 				count_ports++;
 				signal_out[idy("sig", mod->name.str(), wire->name.str())] = wire->width;
-				f << stringf("wire [%d:0] %s;\n", wire->width-1, idy("sig", mod->name.str(), wire->name.str()).c_str());
+				f << stringf("wire [%d:0] %s;\n", wire->width-1, idy("sig", mod->name.str(), wire->name.str()));
 			} else if (wire->port_input) {
 				count_ports++;
 				bool is_clksignal = wire->get_bool_attribute(ID::gentb_clock);
@@ -134,73 +134,73 @@ static void autotest(std::ostream &f, RTLIL::Design *design, int num_iter, int s
 					if (wire->attributes.count(ID::gentb_constant) != 0)
 						signal_const[idy("sig", mod->name.str(), wire->name.str())] = wire->attributes[ID::gentb_constant].as_string();
 				}
-				f << stringf("reg [%d:0] %s;\n", wire->width-1, idy("sig", mod->name.str(), wire->name.str()).c_str());
+				f << stringf("reg [%d:0] %s;\n", wire->width-1, idy("sig", mod->name.str(), wire->name.str()));
 			}
 		}
-		f << stringf("%s %s(\n", id(mod->name.str()).c_str(), idy("uut", mod->name.str()).c_str());
+		f << stringf("%s %s(\n", id(mod->name.str()), idy("uut", mod->name.str()));
 		for (auto wire : mod->wires()) {
 			if (wire->port_output || wire->port_input)
-				f << stringf("\t.%s(%s)%s\n", id(wire->name.str()).c_str(),
+				f << stringf("\t.%s(%s)%s\n", id(wire->name.str()),
 						idy("sig", mod->name.str(), wire->name.str()).c_str(), --count_ports ? "," : "");
 		}
 		f << stringf(");\n\n");
 
-		f << stringf("task %s;\n", idy(mod->name.str(), "reset").c_str());
+		f << stringf("task %s;\n", idy(mod->name.str(), "reset"));
 		f << stringf("begin\n");
 		int delay_counter = 0;
 		for (auto it = signal_in.begin(); it != signal_in.end(); ++it)
-			f << stringf("\t%s <= #%d 0;\n", it->first.c_str(), ++delay_counter*2);
+			f << stringf("\t%s <= #%d 0;\n", it->first, ++delay_counter*2);
 		for (auto it = signal_clk.begin(); it != signal_clk.end(); ++it)
-			f << stringf("\t%s <= #%d 0;\n", it->first.c_str(), ++delay_counter*2);
+			f << stringf("\t%s <= #%d 0;\n", it->first, ++delay_counter*2);
 		f << stringf("\t#%d;\n", ((2*delay_counter+99)/100)*100);
 		for (auto it = signal_clk.begin(); it != signal_clk.end(); ++it) {
-			f << stringf("\t#100; %s <= 1;\n", it->first.c_str());
-			f << stringf("\t#100; %s <= 0;\n", it->first.c_str());
+			f << stringf("\t#100; %s <= 1;\n", it->first);
+			f << stringf("\t#100; %s <= 0;\n", it->first);
 		}
 		delay_counter = 0;
 		for (auto it = signal_in.begin(); it != signal_in.end(); ++it)
-			f << stringf("\t%s <= #%d ~0;\n", it->first.c_str(), ++delay_counter*2);
+			f << stringf("\t%s <= #%d ~0;\n", it->first, ++delay_counter*2);
 		f << stringf("\t#%d;\n", ((2*delay_counter+99)/100)*100);
 		for (auto it = signal_clk.begin(); it != signal_clk.end(); ++it) {
-			f << stringf("\t#100; %s <= 1;\n", it->first.c_str());
-			f << stringf("\t#100; %s <= 0;\n", it->first.c_str());
+			f << stringf("\t#100; %s <= 1;\n", it->first);
+			f << stringf("\t#100; %s <= 0;\n", it->first);
 		}
 		delay_counter = 0;
 		for (auto it = signal_in.begin(); it != signal_in.end(); ++it) {
 			if (signal_const.count(it->first) == 0)
 				continue;
-			f << stringf("\t%s <= #%d 'b%s;\n", it->first.c_str(), ++delay_counter*2, signal_const[it->first].c_str());
+			f << stringf("\t%s <= #%d 'b%s;\n", it->first, ++delay_counter*2, signal_const[it->first]);
 		}
 		f << stringf("\t#%d;\n", ((2*delay_counter+99)/100)*100);
 		f << stringf("end\n");
 		f << stringf("endtask\n\n");
 
-		f << stringf("task %s;\n", idy(mod->name.str(), "update_data").c_str());
+		f << stringf("task %s;\n", idy(mod->name.str(), "update_data"));
 		f << stringf("begin\n");
 		delay_counter = 0;
 		for (auto it = signal_in.begin(); it != signal_in.end(); it++) {
 			if (signal_const.count(it->first) > 0)
 				continue;
 			f << stringf("\txorshift128;\n");
-			f << stringf("\t%s <= #%d { xorshift128_x, xorshift128_y, xorshift128_z, xorshift128_w };\n", it->first.c_str(), ++delay_counter*2);
+			f << stringf("\t%s <= #%d { xorshift128_x, xorshift128_y, xorshift128_z, xorshift128_w };\n", it->first, ++delay_counter*2);
 		}
 		f << stringf("\t#%d;\n", ((2*delay_counter+99)/100)*100);
 		f << stringf("end\n");
 		f << stringf("endtask\n\n");
 
-		f << stringf("task %s;\n", idy(mod->name.str(), "update_clock").c_str());
+		f << stringf("task %s;\n", idy(mod->name.str(), "update_clock"));
 		f << stringf("begin\n");
 		if (signal_clk.size()) {
 			f << stringf("\txorshift128;\n");
 			f << stringf("\t{");
 			int total_clock_bits = 0;
 			for (auto it = signal_clk.begin(); it != signal_clk.end(); it++) {
-				f << stringf("%s %s", it == signal_clk.begin() ? "" : ",", it->first.c_str());
+				f << stringf("%s %s", it == signal_clk.begin() ? "" : ",", it->first);
 				total_clock_bits += it->second;
 			}
 			f << stringf(" } = {");
 			for (auto it = signal_clk.begin(); it != signal_clk.end(); it++)
-				f << stringf("%s %s", it == signal_clk.begin() ? "" : ",", it->first.c_str());
+				f << stringf("%s %s", it == signal_clk.begin() ? "" : ",", it->first);
 			f << stringf(" } ^ (%d'b1 << (xorshift128_w %% %d));\n", total_clock_bits, total_clock_bits + 1);
 		}
 		f << stringf("end\n");
@@ -210,12 +210,12 @@ static void autotest(std::ostream &f, RTLIL::Design *design, int num_iter, int s
 		std::vector<std::string> header1;
 		std::string header2 = "";
 
-		f << stringf("task %s;\n", idy(mod->name.str(), "print_status").c_str());
+		f << stringf("task %s;\n", idy(mod->name.str(), "print_status"));
 		f << stringf("begin\n");
 		f << stringf("\t$fdisplay(file, \"#OUT# %%b %%b %%b %%t %%d\", {");
 		if (signal_in.size())
 			for (auto it = signal_in.begin(); it != signal_in.end(); it++) {
-				f << stringf("%s %s", it == signal_in.begin() ? "" : ",", it->first.c_str());
+				f << stringf("%s %s", it == signal_in.begin() ? "" : ",", it->first);
 				int len = it->second;
 				header2 += ", \"";
 				if (len > 1)
@@ -237,7 +237,7 @@ static void autotest(std::ostream &f, RTLIL::Design *design, int num_iter, int s
 		header2 += ", \" \"";
 		if (signal_clk.size()) {
 			for (auto it = signal_clk.begin(); it != signal_clk.end(); it++) {
-				f << stringf("%s %s", it == signal_clk.begin() ? "" : ",", it->first.c_str());
+				f << stringf("%s %s", it == signal_clk.begin() ? "" : ",", it->first);
 				int len = it->second;
 				header2 += ", \"";
 				if (len > 1)
@@ -259,7 +259,7 @@ static void autotest(std::ostream &f, RTLIL::Design *design, int num_iter, int s
 		header2 += ", \" \"";
 		if (signal_out.size()) {
 			for (auto it = signal_out.begin(); it != signal_out.end(); it++) {
-				f << stringf("%s %s", it == signal_out.begin() ? "" : ",", it->first.c_str());
+				f << stringf("%s %s", it == signal_out.begin() ? "" : ",", it->first);
 				int len = it->second;
 				header2 += ", \"";
 				if (len > 1)
@@ -281,25 +281,25 @@ static void autotest(std::ostream &f, RTLIL::Design *design, int num_iter, int s
 		f << stringf("end\n");
 		f << stringf("endtask\n\n");
 
-		f << stringf("task %s;\n", idy(mod->name.str(), "print_header").c_str());
+		f << stringf("task %s;\n", idy(mod->name.str(), "print_header"));
 		f << stringf("begin\n");
 		f << stringf("\t$fdisplay(file, \"#OUT#\");\n");
 		for (auto &hdr : header1)
-			f << stringf("\t$fdisplay(file, \"#OUT#   %s\");\n", hdr.c_str());
+			f << stringf("\t$fdisplay(file, \"#OUT#   %s\");\n", hdr);
 		f << stringf("\t$fdisplay(file, \"#OUT#\");\n");
-		f << stringf("\t$fdisplay(file, {\"#OUT# \"%s});\n", header2.c_str());
+		f << stringf("\t$fdisplay(file, {\"#OUT# \"%s});\n", header2);
 		f << stringf("end\n");
 		f << stringf("endtask\n\n");
 
-		f << stringf("task %s;\n", idy(mod->name.str(), "test").c_str());
+		f << stringf("task %s;\n", idy(mod->name.str(), "test"));
 		f << stringf("begin\n");
-		f << stringf("\t$fdisplay(file, \"#OUT#\\n#OUT# ==== %s ====\");\n", idy(mod->name.str()).c_str());
-		f << stringf("\t%s;\n", idy(mod->name.str(), "reset").c_str());
+		f << stringf("\t$fdisplay(file, \"#OUT#\\n#OUT# ==== %s ====\");\n", idy(mod->name.str()));
+		f << stringf("\t%s;\n", idy(mod->name.str(), "reset"));
 		f << stringf("\tfor (i=0; i<%d; i=i+1) begin\n", num_iter);
-		f << stringf("\t\tif (i %% 20 == 0) %s;\n", idy(mod->name.str(), "print_header").c_str());
-		f << stringf("\t\t#100; %s;\n", idy(mod->name.str(), "update_data").c_str());
-		f << stringf("\t\t#100; %s;\n", idy(mod->name.str(), "update_clock").c_str());
-		f << stringf("\t\t#100; %s;\n", idy(mod->name.str(), "print_status").c_str());
+		f << stringf("\t\tif (i %% 20 == 0) %s;\n", idy(mod->name.str(), "print_header"));
+		f << stringf("\t\t#100; %s;\n", idy(mod->name.str(), "update_data"));
+		f << stringf("\t\t#100; %s;\n", idy(mod->name.str(), "update_clock"));
+		f << stringf("\t\t#100; %s;\n", idy(mod->name.str(), "print_status"));
 		f << stringf("\tend\n");
 		f << stringf("end\n");
 		f << stringf("endtask\n\n");
@@ -317,7 +317,7 @@ static void autotest(std::ostream &f, RTLIL::Design *design, int num_iter, int s
 	f << stringf("\tend\n");
 	for (auto module : design->modules())
 		if (!module->get_bool_attribute(ID::gentb_skip))
-			f << stringf("\t%s;\n", idy(module->name.str(), "test").c_str());
+			f << stringf("\t%s;\n", idy(module->name.str(), "test"));
 	f << stringf("\t$fclose(file);\n");
 	f << stringf("\t$finish;\n");
 	f << stringf("end\n\n");

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -591,7 +591,7 @@ static void run_eval_test(RTLIL::Design *design, bool verbose, bool nosat, std::
 
 	if (vlog_file.is_open())
 	{
-		vlog_file << stringf("\nmodule %s;\n", uut_name.c_str());
+		vlog_file << stringf("\nmodule %s;\n", uut_name);
 
 		for (auto port : gold_mod->ports) {
 			RTLIL::Wire *wire = gold_mod->wire(port);
@@ -601,13 +601,13 @@ static void run_eval_test(RTLIL::Design *design, bool verbose, bool nosat, std::
 				vlog_file << stringf("  wire [%d:0] %s_expr, %s_noexpr;\n", GetSize(wire)-1, log_id(wire), log_id(wire));
 		}
 
-		vlog_file << stringf("  %s_expr uut_expr(", uut_name.c_str());
+		vlog_file << stringf("  %s_expr uut_expr(", uut_name);
 		for (int i = 0; i < GetSize(gold_mod->ports); i++)
 			vlog_file << stringf("%s.%s(%s%s)", i ? ", " : "", log_id(gold_mod->ports[i]), log_id(gold_mod->ports[i]),
 					gold_mod->wire(gold_mod->ports[i])->port_input ? "" : "_expr");
 		vlog_file << stringf(");\n");
 
-		vlog_file << stringf("  %s_expr uut_noexpr(", uut_name.c_str());
+		vlog_file << stringf("  %s_expr uut_noexpr(", uut_name);
 		for (int i = 0; i < GetSize(gold_mod->ports); i++)
 			vlog_file << stringf("%s.%s(%s%s)", i ? ", " : "", log_id(gold_mod->ports[i]), log_id(gold_mod->ports[i]),
 					gold_mod->wire(gold_mod->ports[i])->port_input ? "" : "_noexpr");
@@ -615,7 +615,7 @@ static void run_eval_test(RTLIL::Design *design, bool verbose, bool nosat, std::
 
 		vlog_file << stringf("  task run;\n");
 		vlog_file << stringf("    begin\n");
-		vlog_file << stringf("      $display(\"%s\");\n", uut_name.c_str());
+		vlog_file << stringf("      $display(\"%s\");\n", uut_name);
 	}
 
 	for (int i = 0; i < 64; i++)
@@ -662,7 +662,7 @@ static void run_eval_test(RTLIL::Design *design, bool verbose, bool nosat, std::
 			gate_ce.set(gate_wire, in_value);
 
 			if (vlog_file.is_open() && GetSize(in_value) > 0) {
-				vlog_file << stringf("      %s = 'b%s;\n", log_id(gold_wire), in_value.as_string().c_str());
+				vlog_file << stringf("      %s = 'b%s;\n", log_id(gold_wire), in_value.as_string());
 				if (!vlog_pattern_info.empty())
 					vlog_pattern_info += " ";
 				vlog_pattern_info += stringf("%s=%s", log_id(gold_wire), log_signal(in_value));
@@ -716,8 +716,8 @@ static void run_eval_test(RTLIL::Design *design, bool verbose, bool nosat, std::
 			if (vlog_file.is_open()) {
 				vlog_file << stringf("      $display(\"[%s] %s expected: %%b, expr: %%b, noexpr: %%b\", %d'b%s, %s_expr, %s_noexpr);\n",
 						vlog_pattern_info.c_str(), log_id(gold_wire), GetSize(gold_outval), gold_outval.as_string().c_str(), log_id(gold_wire), log_id(gold_wire));
-				vlog_file << stringf("      if (%s_expr !== %d'b%s) begin $display(\"ERROR\"); $finish; end\n", log_id(gold_wire), GetSize(gold_outval), gold_outval.as_string().c_str());
-				vlog_file << stringf("      if (%s_noexpr !== %d'b%s) begin $display(\"ERROR\"); $finish; end\n", log_id(gold_wire), GetSize(gold_outval), gold_outval.as_string().c_str());
+				vlog_file << stringf("      if (%s_expr !== %d'b%s) begin $display(\"ERROR\"); $finish; end\n", log_id(gold_wire), GetSize(gold_outval), gold_outval.as_string());
+				vlog_file << stringf("      if (%s_noexpr !== %d'b%s) begin $display(\"ERROR\"); $finish; end\n", log_id(gold_wire), GetSize(gold_outval), gold_outval.as_string());
 			}
 		}
 
@@ -1142,12 +1142,12 @@ struct TestCellPass : public Pass {
 				else
 					uut = create_gold_module(design, cell_type, cell_types.at(cell_type), constmode, muxdiv);
 				if (!write_prefix.empty()) {
-					Pass::call(design, stringf("write_rtlil %s_%s_%05d.il", write_prefix.c_str(), cell_type.c_str()+1, i));
+					Pass::call(design, stringf("write_rtlil %s_%s_%05d.il", write_prefix, cell_type.c_str()+1, i));
 				} else if (edges) {
 					Pass::call(design, "dump gold");
 					run_edges_test(design, verbose);
 				} else {
-					Pass::call(design, stringf("copy gold gate; cd gate; %s; cd ..", techmap_cmd.c_str()));
+					Pass::call(design, stringf("copy gold gate; cd gate; %s; cd ..", techmap_cmd));
 					if (!noopt)
 						Pass::call(design, "opt -fast gate");
 					if (!nosat)
@@ -1157,11 +1157,11 @@ struct TestCellPass : public Pass {
 					Pass::call(design, "dump gold");
 					if (!nosat)
 						Pass::call(design, "sat -verify -enable_undef -prove trigger 0 -show-inputs -show-outputs miter");
-					std::string uut_name = stringf("uut_%s_%d", cell_type.substr(1).c_str(), i);
+					std::string uut_name = stringf("uut_%s_%d", cell_type.substr(1), i);
 					if (vlog_file.is_open()) {
-						Pass::call(design, stringf("copy gold %s_expr; select %s_expr", uut_name.c_str(), uut_name.c_str()));
+						Pass::call(design, stringf("copy gold %s_expr; select %s_expr", uut_name, uut_name));
 						Backend::backend_call(design, &vlog_file, "<test_cell -vlog>", "verilog -selected");
-						Pass::call(design, stringf("copy gold %s_noexpr; select %s_noexpr", uut_name.c_str(), uut_name.c_str()));
+						Pass::call(design, stringf("copy gold %s_noexpr; select %s_noexpr", uut_name, uut_name));
 						Backend::backend_call(design, &vlog_file, "<test_cell -vlog>", "verilog -selected -noexpr");
 						uut_names.push_back(uut_name);
 					}
@@ -1208,7 +1208,7 @@ struct TestCellPass : public Pass {
 		if (vlog_file.is_open()) {
 			vlog_file << "\nmodule testbench;\n";
 			for (auto &uut : uut_names)
-				vlog_file << stringf("  %s %s ();\n", uut.c_str(), uut.c_str());
+				vlog_file << stringf("  %s %s ();\n", uut, uut);
 			vlog_file << "  initial begin\n";
 			for (auto &uut : uut_names)
 				vlog_file << "    " << uut << ".run;\n";

--- a/techlibs/achronix/synth_achronix.cc
+++ b/techlibs/achronix/synth_achronix.cc
@@ -123,7 +123,7 @@ struct SynthAchronixPass : public ScriptPass {
     if (check_label("begin"))
       {
         run("read_verilog -sv -lib +/achronix/speedster22i/cells_sim.v");
-        run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+        run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt));
       }
 
     if (flatten && check_label("flatten", "(unless -noflatten)"))

--- a/techlibs/anlogic/synth_anlogic.cc
+++ b/techlibs/anlogic/synth_anlogic.cc
@@ -150,7 +150,7 @@ struct SynthAnlogicPass : public ScriptPass
 		if (check_label("begin"))
 		{
 			run("read_verilog -lib +/anlogic/cells_sim.v +/anlogic/eagle_bb.v");
-			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt));
 		}
 
 		if (flatten && check_label("flatten", "(unless -noflatten)"))
@@ -233,13 +233,13 @@ struct SynthAnlogicPass : public ScriptPass
 		if (check_label("edif"))
 		{
 			if (!edif_file.empty() || help_mode)
-				run(stringf("write_edif %s", help_mode ? "<file-name>" : edif_file.c_str()));
+				run(stringf("write_edif %s", help_mode ? "<file-name>" : edif_file));
 		}
 
 		if (check_label("json"))
 		{
 			if (!json_file.empty() || help_mode)
-				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file.c_str()));
+				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file));
 		}
 	}
 } SynthAnlogicPass;

--- a/techlibs/common/prep.cc
+++ b/techlibs/common/prep.cc
@@ -177,7 +177,7 @@ struct PrepPass : public ScriptPass
 					else
 						run("hierarchy -check");
 				} else
-					run(stringf("hierarchy -check -top %s", top_module.c_str()));
+					run(stringf("hierarchy -check -top %s", top_module));
 			}
 		}
 

--- a/techlibs/common/synth.cc
+++ b/techlibs/common/synth.cc
@@ -249,7 +249,7 @@ struct SynthPass : public ScriptPass {
 					else
 						run("hierarchy -check");
 				} else
-					run(stringf("hierarchy -check -top %s", top_module.c_str()));
+					run(stringf("hierarchy -check -top %s", top_module));
 			}
 		}
 
@@ -294,7 +294,7 @@ struct SynthPass : public ScriptPass {
 				if (!techmap_maps.empty())
 					techmap_opts += " -map +/techmap.v";
 				for (auto fn : techmap_maps)
-					techmap_opts += stringf(" -map %s", fn.c_str());
+					techmap_opts += stringf(" -map %s", fn);
 				run("techmap" + techmap_opts);
 			}
 			if (help_mode) {
@@ -316,7 +316,7 @@ struct SynthPass : public ScriptPass {
 					run(abc + " -fast -lut k", "(unless -noabc, if -lut)");
 				} else {
 					if (lut)
-						run(stringf("%s -fast -lut %d", abc.c_str(), lut));
+						run(stringf("%s -fast -lut %d", abc, lut));
 					else
 						run(abc + " -fast");
 				}

--- a/techlibs/coolrunner2/synth_coolrunner2.cc
+++ b/techlibs/coolrunner2/synth_coolrunner2.cc
@@ -126,7 +126,7 @@ struct SynthCoolrunner2Pass : public ScriptPass
 		if (check_label("begin"))
 		{
 			run("read_verilog -lib +/coolrunner2/cells_sim.v");
-			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt));
 		}
 
 		if (flatten && check_label("flatten", "(unless -noflatten)"))
@@ -198,7 +198,7 @@ struct SynthCoolrunner2Pass : public ScriptPass
 		if (check_label("json"))
 		{
 			if (!json_file.empty() || help_mode)
-				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file.c_str()));
+				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file));
 		}
 	}
 } SynthCoolrunner2Pass;

--- a/techlibs/easic/synth_easic.cc
+++ b/techlibs/easic/synth_easic.cc
@@ -129,14 +129,14 @@ struct SynthEasicPass : public ScriptPass
 
 	void script() override
 	{
-		string phys_clk_lib = stringf("%s/data_ruby28/design_libs/logical/timing/gp/n3x_phys_clk_0v893ff125c.lib", etools_path.c_str());
-		string logic_lut_lib = stringf("%s/data_ruby28/design_libs/logical/timing/gp/n3x_logic_lut_0v893ff125c.lib", etools_path.c_str());
+		string phys_clk_lib = stringf("%s/data_ruby28/design_libs/logical/timing/gp/n3x_phys_clk_0v893ff125c.lib", etools_path);
+		string logic_lut_lib = stringf("%s/data_ruby28/design_libs/logical/timing/gp/n3x_logic_lut_0v893ff125c.lib", etools_path);
 
 		if (check_label("begin"))
 		{
-			run(stringf("read_liberty -lib %s", help_mode ? "<etools_phys_clk_lib>" : phys_clk_lib.c_str()));
-			run(stringf("read_liberty -lib %s", help_mode ? "<etools_logic_lut_lib>" : logic_lut_lib.c_str()));
-			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+			run(stringf("read_liberty -lib %s", help_mode ? "<etools_phys_clk_lib>" : phys_clk_lib));
+			run(stringf("read_liberty -lib %s", help_mode ? "<etools_logic_lut_lib>" : logic_lut_lib));
+			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt));
 		}
 
 		if (flatten && check_label("flatten", "(unless -noflatten)"))
@@ -165,8 +165,8 @@ struct SynthEasicPass : public ScriptPass
 
 		if (check_label("map"))
 		{
-			run(stringf("dfflibmap -liberty %s", help_mode ? "<etools_phys_clk_lib>" : phys_clk_lib.c_str()));
-			run(stringf("abc -liberty %s", help_mode ? "<etools_logic_lut_lib>" : logic_lut_lib.c_str()));
+			run(stringf("dfflibmap -liberty %s", help_mode ? "<etools_phys_clk_lib>" : phys_clk_lib));
+			run(stringf("abc -liberty %s", help_mode ? "<etools_logic_lut_lib>" : logic_lut_lib));
 			run("opt_clean");
 		}
 
@@ -181,7 +181,7 @@ struct SynthEasicPass : public ScriptPass
 		if (check_label("vlog"))
 		{
 			if (!vlog_file.empty() || help_mode)
-				run(stringf("write_verilog -noexpr -attr2comment %s", help_mode ? "<file-name>" : vlog_file.c_str()));
+				run(stringf("write_verilog -noexpr -attr2comment %s", help_mode ? "<file-name>" : vlog_file));
 		}
 	}
 } SynthEasicPass;

--- a/techlibs/ecp5/synth_ecp5.cc
+++ b/techlibs/ecp5/synth_ecp5.cc
@@ -272,7 +272,7 @@ struct SynthEcp5Pass : public ScriptPass
 		if (check_label("begin"))
 		{
 			run("read_verilog -lib -specify +/ecp5/cells_sim.v +/ecp5/cells_bb.v");
-			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt));
 		}
 
 		if (check_label("coarse"))
@@ -383,9 +383,9 @@ struct SynthEcp5Pass : public ScriptPass
 					abc9_opts += " -maxlut 4";
 				std::string k = "synth_ecp5.abc9.W";
 				if (active_design && active_design->scratchpad.count(k))
-					abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k).c_str());
+					abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k));
 				else
-					abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k).c_str());
+					abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k));
 				if (nowidelut)
 					abc9_opts += " -maxlut 4";
 				if (dff)
@@ -443,13 +443,13 @@ struct SynthEcp5Pass : public ScriptPass
 		if (check_label("edif"))
 		{
 			if (!edif_file.empty() || help_mode)
-				run(stringf("write_edif %s", help_mode ? "<file-name>" : edif_file.c_str()));
+				run(stringf("write_edif %s", help_mode ? "<file-name>" : edif_file));
 		}
 
 		if (check_label("json"))
 		{
 			if (!json_file.empty() || help_mode)
-				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file.c_str()));
+				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file));
 		}
 	}
 } SynthEcp5Pass;

--- a/techlibs/efinix/synth_efinix.cc
+++ b/techlibs/efinix/synth_efinix.cc
@@ -142,7 +142,7 @@ struct SynthEfinixPass : public ScriptPass
 		if (check_label("begin"))
 		{
 			run("read_verilog -lib +/efinix/cells_sim.v");
-			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt));
 		}
 
 		if (flatten && check_label("flatten", "(unless -noflatten)"))
@@ -225,13 +225,13 @@ struct SynthEfinixPass : public ScriptPass
 		if (check_label("edif"))
 		{
 			if (!edif_file.empty() || help_mode)
-				run(stringf("write_edif %s", help_mode ? "<file-name>" : edif_file.c_str()));
+				run(stringf("write_edif %s", help_mode ? "<file-name>" : edif_file));
 		}
 
 		if (check_label("json"))
 		{
 			if (!json_file.empty() || help_mode)
-				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file.c_str()));
+				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file));
 		}
 	}
 } SynthEfinixPass;

--- a/techlibs/fabulous/synth_fabulous.cc
+++ b/techlibs/fabulous/synth_fabulous.cc
@@ -278,7 +278,7 @@ struct SynthPass : public ScriptPass
 				else
 					run("hierarchy -check");
 			} else
-				run(stringf("hierarchy -check -top %s", top_module.c_str()));
+				run(stringf("hierarchy -check -top %s", top_module));
 			run("proc");
 		}
 
@@ -365,7 +365,7 @@ struct SynthPass : public ScriptPass
 			} else if (!extra_map.empty()) {
 				std::string map_str = "techmap";
 				for (auto map : extra_map)
-					map_str += stringf(" -map %s", map.c_str());
+					map_str += stringf(" -map %s", map);
 				run(map_str);
 			}
 			run("clean");
@@ -399,7 +399,7 @@ struct SynthPass : public ScriptPass
 		if (check_label("json"))
 		{
 			if (!json_file.empty() || help_mode)
-				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file.c_str()));
+				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file));
 		}
 	}
 } SynthPass;

--- a/techlibs/gatemate/synth_gatemate.cc
+++ b/techlibs/gatemate/synth_gatemate.cc
@@ -203,7 +203,7 @@ struct SynthGateMatePass : public ScriptPass
 		if (check_label("begin"))
 		{
 			run("read_verilog -lib -specify +/gatemate/cells_sim.v +/gatemate/cells_bb.v");
-			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt));
 		}
 
 		if (check_label("prepare"))
@@ -351,14 +351,14 @@ struct SynthGateMatePass : public ScriptPass
 		{
 			run("opt_clean -purge");
 			if (!vlog_file.empty() || help_mode) {
-				run(stringf("write_verilog -noattr %s", help_mode ? "<file-name>" : vlog_file.c_str()));
+				run(stringf("write_verilog -noattr %s", help_mode ? "<file-name>" : vlog_file));
 			}
 		}
 
 		if (check_label("json"))
 		{
 			if (!json_file.empty() || help_mode) {
-				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file.c_str()));
+				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file));
 			}
 		}
 	}

--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -219,8 +219,8 @@ struct SynthGowinPass : public ScriptPass
 		if (check_label("begin"))
 		{
 			run("read_verilog -specify -lib +/gowin/cells_sim.v");
-			run(stringf("read_verilog -specify -lib +/gowin/cells_xtra_%s.v", help_mode ? "<family>" : family.c_str()));
-			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+			run(stringf("read_verilog -specify -lib +/gowin/cells_xtra_%s.v", help_mode ? "<family>" : family));
+			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt));
 		}
 
 		if (flatten && check_label("flatten", "(unless -noflatten)"))

--- a/techlibs/greenpak4/synth_greenpak4.cc
+++ b/techlibs/greenpak4/synth_greenpak4.cc
@@ -138,7 +138,7 @@ struct SynthGreenPAK4Pass : public ScriptPass
 		if (check_label("begin"))
 		{
 			run("read_verilog -lib +/greenpak4/cells_sim.v");
-			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt));
 		}
 
 		if (flatten && check_label("flatten", "(unless -noflatten)"))
@@ -202,7 +202,7 @@ struct SynthGreenPAK4Pass : public ScriptPass
 		if (check_label("json"))
 		{
 			if (!json_file.empty() || help_mode)
-				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file.c_str()));
+				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file));
 		}
 	}
 } SynthGreenPAK4Pass;

--- a/techlibs/ice40/ice40_wrapcarry.cc
+++ b/techlibs/ice40/ice40_wrapcarry.cc
@@ -59,9 +59,9 @@ void create_ice40_wrapcarry(ice40_wrapcarry_pm &pm)
 	cell->setParam(ID::LUT, st.lut->getParam(ID(LUT_INIT)));
 
 	for (const auto &a : st.carry->attributes)
-		cell->attributes[stringf("\\SB_CARRY.%s", a.first.c_str())] = a.second;
+		cell->attributes[stringf("\\SB_CARRY.%s", a.first)] = a.second;
 	for (const auto &a : st.lut->attributes)
-		cell->attributes[stringf("\\SB_LUT4.%s", a.first.c_str())] = a.second;
+		cell->attributes[stringf("\\SB_LUT4.%s", a.first)] = a.second;
 	cell->attributes[ID(SB_LUT4.name)] = Const(st.lut->name.str());
 	if (st.carry->get_bool_attribute(ID::keep) || st.lut->get_bool_attribute(ID::keep))
 		cell->attributes[ID::keep] = true;

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -302,7 +302,7 @@ struct SynthIce40Pass : public ScriptPass
 		if (check_label("begin"))
 		{
 			run("read_verilog " + define + " -lib -specify +/ice40/cells_sim.v");
-			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt));
 			run("proc");
 		}
 
@@ -419,10 +419,10 @@ struct SynthIce40Pass : public ScriptPass
 					std::string abc9_opts;
 					std::string k = "synth_ice40.abc9.W";
 					if (active_design && active_design->scratchpad.count(k))
-						abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k).c_str());
+						abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k));
 					else {
-						k = stringf("synth_ice40.abc9.%s.W", device_opt.c_str());
-						abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k).c_str());
+						k = stringf("synth_ice40.abc9.%s.W", device_opt);
+						abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k));
 					}
 					if (dff)
 						abc9_opts += " -dff";
@@ -475,13 +475,13 @@ struct SynthIce40Pass : public ScriptPass
 		if (check_label("edif"))
 		{
 			if (!edif_file.empty() || help_mode)
-				run(stringf("write_edif %s", help_mode ? "<file-name>" : edif_file.c_str()));
+				run(stringf("write_edif %s", help_mode ? "<file-name>" : edif_file));
 		}
 
 		if (check_label("json"))
 		{
 			if (!json_file.empty() || help_mode)
-				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file.c_str()));
+				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file));
 		}
 	}
 } SynthIce40Pass;

--- a/techlibs/intel/synth_intel.cc
+++ b/techlibs/intel/synth_intel.cc
@@ -188,12 +188,12 @@ struct SynthIntelPass : public ScriptPass {
 	{
 		if (check_label("begin")) {
 			if (check_label("family"))
-				run(stringf("read_verilog -sv -lib +/intel/%s/cells_sim.v", family_opt.c_str()));
+				run(stringf("read_verilog -sv -lib +/intel/%s/cells_sim.v", family_opt));
 
 			// Misc and common cells
 			run("read_verilog -sv -lib +/intel/common/m9k_bb.v");
 			run("read_verilog -sv -lib +/intel/common/altpll_bb.v");
-			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt));
 		}
 
 		if (check_label("coarse")) {
@@ -225,7 +225,7 @@ struct SynthIntelPass : public ScriptPass {
 					run("techmap -map +/mul2dsp.v -D DSP_A_MAXWIDTH=9 -D DSP_B_MAXWIDTH=9  -D DSP_A_MINWIDTH=4 -D DSP_B_MINWIDTH=4 -D DSP_NAME=$__MUL9X9");
 					run("chtype -set $mul t:$__soft_mul");
 				run("alumacc");
-				run(stringf("techmap -map +/intel/%s/dsp_map.v", family_opt.c_str()));
+				run(stringf("techmap -map +/intel/%s/dsp_map.v", family_opt));
 			} else {
 				run("alumacc");
 			}
@@ -274,7 +274,7 @@ struct SynthIntelPass : public ScriptPass {
 		if (check_label("map_cells")) {
 			if (iopads || help_mode)
 				run("iopadmap -bits -outpad $__outpad I:O -inpad $__inpad O:I", "(if -iopads)");
-			run(stringf("techmap -map +/intel/%s/cells_map.v", family_opt.c_str()));
+			run(stringf("techmap -map +/intel/%s/cells_map.v", family_opt));
 			run("clean -purge");
 		}
 
@@ -294,7 +294,7 @@ struct SynthIntelPass : public ScriptPass {
 		if (check_label("vpr")) {
 			if (!blif_file.empty() || help_mode) {
 				run(stringf("opt_clean -purge"));
-				run(stringf("write_blif %s", help_mode ? "<file-name>" : blif_file.c_str()));
+				run(stringf("write_blif %s", help_mode ? "<file-name>" : blif_file));
 			}
 		}
 	}

--- a/techlibs/intel_alm/synth_intel_alm.cc
+++ b/techlibs/intel_alm/synth_intel_alm.cc
@@ -169,17 +169,17 @@ struct SynthIntelALMPass : public ScriptPass {
 
 		if (check_label("begin")) {
 			if (family_opt == "cyclonev")
-				run(stringf("read_verilog -sv -lib +/intel_alm/%s/cells_sim.v", family_opt.c_str()));
-			run(stringf("read_verilog -specify -lib -D %s +/intel_alm/common/alm_sim.v", family_opt.c_str()));
-			run(stringf("read_verilog -specify -lib -D %s +/intel_alm/common/dff_sim.v", family_opt.c_str()));
-			run(stringf("read_verilog -specify -lib -D %s +/intel_alm/common/dsp_sim.v", family_opt.c_str()));
-			run(stringf("read_verilog -specify -lib -D %s +/intel_alm/common/mem_sim.v", family_opt.c_str()));
-			run(stringf("read_verilog -specify -lib -D %s +/intel_alm/common/misc_sim.v", family_opt.c_str()));
-			run(stringf("read_verilog -specify -lib -D %s -icells +/intel_alm/common/abc9_model.v", family_opt.c_str()));
+				run(stringf("read_verilog -sv -lib +/intel_alm/%s/cells_sim.v", family_opt));
+			run(stringf("read_verilog -specify -lib -D %s +/intel_alm/common/alm_sim.v", family_opt));
+			run(stringf("read_verilog -specify -lib -D %s +/intel_alm/common/dff_sim.v", family_opt));
+			run(stringf("read_verilog -specify -lib -D %s +/intel_alm/common/dsp_sim.v", family_opt));
+			run(stringf("read_verilog -specify -lib -D %s +/intel_alm/common/mem_sim.v", family_opt));
+			run(stringf("read_verilog -specify -lib -D %s +/intel_alm/common/misc_sim.v", family_opt));
+			run(stringf("read_verilog -specify -lib -D %s -icells +/intel_alm/common/abc9_model.v", family_opt));
 			// Misc and common cells
 			run("read_verilog -lib +/intel/common/altpll_bb.v");
 			run("read_verilog -lib +/intel_alm/common/megafunction_bb.v");
-			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt));
 		}
 
 		if (check_label("coarse")) {
@@ -225,8 +225,8 @@ struct SynthIntelALMPass : public ScriptPass {
 		}
 
 		if (!nobram && check_label("map_bram", "(skip if -nobram)")) {
-			run(stringf("memory_bram -rules +/intel_alm/common/bram_%s.txt", bram_type.c_str()));
-			run(stringf("techmap -map +/intel_alm/common/bram_%s_map.v", bram_type.c_str()));
+			run(stringf("memory_bram -rules +/intel_alm/common/bram_%s.txt", bram_type));
+			run(stringf("techmap -map +/intel_alm/common/bram_%s_map.v", bram_type));
 		}
 
 		if (!nolutram && check_label("map_lutram", "(skip if -nolutram)")) {

--- a/techlibs/lattice/synth_lattice.cc
+++ b/techlibs/lattice/synth_lattice.cc
@@ -333,7 +333,7 @@ struct SynthLatticePass : public ScriptPass
 		if (check_label("begin"))
 		{
 			run("read_verilog -lib -specify +/lattice/cells_sim" + postfix + ".v +/lattice/cells_bb" + postfix + ".v");
-			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt));
 		}
 
 		if (check_label("coarse"))
@@ -449,9 +449,9 @@ struct SynthLatticePass : public ScriptPass
 					abc9_opts += " -maxlut 4";
 				std::string k = "synth_lattice.abc9.W";
 				if (active_design && active_design->scratchpad.count(k))
-					abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k).c_str());
+					abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k));
 				else
-					abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k).c_str());
+					abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k));
 				if (nowidelut)
 					abc9_opts += " -maxlut 4";
 				if (dff)
@@ -489,13 +489,13 @@ struct SynthLatticePass : public ScriptPass
 		if (check_label("edif"))
 		{
 			if (!edif_file.empty() || help_mode)
-				run(stringf("write_edif %s", help_mode ? "<file-name>" : edif_file.c_str()));
+				run(stringf("write_edif %s", help_mode ? "<file-name>" : edif_file));
 		}
 
 		if (check_label("json"))
 		{
 			if (!json_file.empty() || help_mode)
-				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file.c_str()));
+				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file));
 		}
 	}
 } SynthLatticePass;

--- a/techlibs/microchip/synth_microchip.cc
+++ b/techlibs/microchip/synth_microchip.cc
@@ -262,7 +262,7 @@ struct SynthMicrochipPass : public ScriptPass {
 			read_args += " -lib -specify +/microchip/cells_sim.v";
 			run("read_verilog" + read_args);
 
-			run(stringf("hierarchy -check %s", top_opt.c_str()));
+			run(stringf("hierarchy -check %s", top_opt));
 		}
 
 		if (check_label("prepare")) {
@@ -534,18 +534,18 @@ struct SynthMicrochipPass : public ScriptPass {
 
 		if (check_label("edif")) {
 			if (!edif_file.empty() || help_mode)
-				run(stringf("write_edif -pvector bra %s", edif_file.c_str()));
+				run(stringf("write_edif -pvector bra %s", edif_file));
 		}
 
 		if (check_label("blif")) {
 			if (!blif_file.empty() || help_mode)
-				run(stringf("write_blif %s", blif_file.c_str()));
+				run(stringf("write_blif %s", blif_file));
 		}
 
 		if (check_label("vlog"))
 		{
 			if (!vlog_file.empty() || help_mode)
-				run(stringf("write_verilog %s", help_mode ? "<file-name>" : vlog_file.c_str()));
+				run(stringf("write_verilog %s", help_mode ? "<file-name>" : vlog_file));
 		}
 	}
 } SynthMicrochipPass;

--- a/techlibs/nanoxplore/synth_nanoxplore.cc
+++ b/techlibs/nanoxplore/synth_nanoxplore.cc
@@ -244,7 +244,7 @@ struct SynthNanoXplorePass : public ScriptPass
 			run("read_verilog -lib -specify +/nanoxplore/cells_sim.v +/nanoxplore/cells_sim" + postfix + ".v +/nanoxplore/cells_bb.v +/nanoxplore/cells_bb" + postfix + ".v");
 			run("techmap -map +/nanoxplore/cells_wrap.v");
 			run("techmap -map +/nanoxplore/cells_wrap" + postfix + ".v");
-			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt));
 		}
 
 		if (check_label("coarse"))
@@ -335,9 +335,9 @@ struct SynthNanoXplorePass : public ScriptPass
 				std::string abc9_opts = " -maxlut 4";
 				std::string k = "synth_nanoxplore.abc9.W";
 				if (active_design && active_design->scratchpad.count(k))
-					abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k).c_str());
+					abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k));
 				else
-					abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k).c_str());
+					abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k));
 				run("abc9" + abc9_opts);
 			} else {
 				std::string abc_args = " -dress";
@@ -362,7 +362,7 @@ struct SynthNanoXplorePass : public ScriptPass
 		if (check_label("json"))
 		{
 			if (!json_file.empty() || help_mode)
-				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file.c_str()));
+				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file));
 		}
 	}
 } SynthNanoXplorePass;

--- a/techlibs/nexus/synth_nexus.cc
+++ b/techlibs/nexus/synth_nexus.cc
@@ -254,7 +254,7 @@ struct SynthNexusPass : public ScriptPass
 		if (check_label("begin"))
 		{
 			run("read_verilog -lib -specify +/nexus/cells_sim.v +/nexus/cells_xtra.v");
-			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt));
 		}
 
 		if (check_label("coarse"))
@@ -361,9 +361,9 @@ struct SynthNexusPass : public ScriptPass
 					abc9_opts += " -maxlut 4";
 				std::string k = "synth_nexus.abc9.W";
 				if (active_design && active_design->scratchpad.count(k))
-					abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k).c_str());
+					abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k));
 				else
-					abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k).c_str());
+					abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k));
 				if (nowidelut)
 					abc9_opts += " -maxlut 4";
 				if (dff)
@@ -405,13 +405,13 @@ struct SynthNexusPass : public ScriptPass
 		if (check_label("json"))
 		{
 			if (!json_file.empty() || help_mode)
-				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file.c_str()));
+				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file));
 		}
 
 		if (check_label("vm"))
 		{
 			if (!vm_file.empty() || help_mode)
-				run(stringf("write_verilog %s", help_mode ? "<file-name>" : vm_file.c_str()));
+				run(stringf("write_verilog %s", help_mode ? "<file-name>" : vm_file));
 		}
 	}
 } SynthNexusPass;

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -193,16 +193,16 @@ struct SynthQuickLogicPass : public ScriptPass {
 		}
 
 		if (check_label("begin")) {
-			std::string read_simlibs = stringf("read_verilog -lib -specify %scommon/cells_sim.v %s%s/cells_sim.v", lib_path.c_str(), lib_path.c_str(), family.c_str());
+			std::string read_simlibs = stringf("read_verilog -lib -specify %scommon/cells_sim.v %s%s/cells_sim.v", lib_path, lib_path, family);
 			if (family == "qlf_k6n10f") {
-				read_simlibs += stringf(" %sqlf_k6n10f/brams_sim.v", lib_path.c_str());
+				read_simlibs += stringf(" %sqlf_k6n10f/brams_sim.v", lib_path);
 				if (bramTypes)
-					read_simlibs += stringf(" %sqlf_k6n10f/bram_types_sim.v", lib_path.c_str());
+					read_simlibs += stringf(" %sqlf_k6n10f/bram_types_sim.v", lib_path);
 				if (dsp)
-					read_simlibs += stringf(" %sqlf_k6n10f/dsp_sim.v", lib_path.c_str());
+					read_simlibs += stringf(" %sqlf_k6n10f/dsp_sim.v", lib_path);
 			}
 			run(read_simlibs);
-			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt));
 		}
 
 		if (check_label("prepare")) {
@@ -367,13 +367,13 @@ struct SynthQuickLogicPass : public ScriptPass {
 
 		if (check_label("blif", "(if -blif)")) {
 			if (!blif_file.empty() || help_mode) {
-				run(stringf("write_blif -attr -param %s %s", top_opt.c_str(), blif_file.c_str()));
+				run(stringf("write_blif -attr -param %s %s", top_opt, blif_file));
 			}
 		}
 
 		if (check_label("verilog", "(if -verilog)")) {
 			if (!verilog_file.empty() || help_mode) {
-				run(stringf("write_verilog -noattr -nohex %s", help_mode ? "<file-name>" : verilog_file.c_str()));
+				run(stringf("write_verilog -noattr -nohex %s", help_mode ? "<file-name>" : verilog_file));
 			}
 		}
 	}

--- a/techlibs/sf2/synth_sf2.cc
+++ b/techlibs/sf2/synth_sf2.cc
@@ -166,7 +166,7 @@ struct SynthSf2Pass : public ScriptPass
 		if (check_label("begin"))
 		{
 			run("read_verilog -lib +/sf2/cells_sim.v");
-			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt));
 		}
 
 		if (flatten && check_label("flatten", "(unless -noflatten)"))
@@ -244,19 +244,19 @@ struct SynthSf2Pass : public ScriptPass
 		if (check_label("edif"))
 		{
 			if (!edif_file.empty() || help_mode)
-				run(stringf("write_edif -gndvccy %s", help_mode ? "<file-name>" : edif_file.c_str()));
+				run(stringf("write_edif -gndvccy %s", help_mode ? "<file-name>" : edif_file));
 		}
 
 		if (check_label("vlog"))
 		{
 			if (!vlog_file.empty() || help_mode)
-				run(stringf("write_verilog %s", help_mode ? "<file-name>" : vlog_file.c_str()));
+				run(stringf("write_verilog %s", help_mode ? "<file-name>" : vlog_file));
 		}
 
 		if (check_label("json"))
 		{
 			if (!json_file.empty() || help_mode)
-				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file.c_str()));
+				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file));
 		}
 	}
 } SynthSf2Pass;

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -350,7 +350,7 @@ struct SynthXilinxPass : public ScriptPass
 
 			run("read_verilog -lib +/xilinx/cells_xtra.v");
 
-			run(stringf("hierarchy -check %s", top_opt.c_str()));
+			run(stringf("hierarchy -check %s", top_opt));
 		}
 
 		if (check_label("prepare")) {
@@ -649,10 +649,10 @@ struct SynthXilinxPass : public ScriptPass
 				std::string abc9_opts;
 				std::string k = "synth_xilinx.abc9.W";
 				if (active_design && active_design->scratchpad.count(k))
-					abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k).c_str());
+					abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k));
 				else {
-					k = stringf("synth_xilinx.abc9.%s.W", family.c_str());
-					abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k, RTLIL::constpad.at("synth_xilinx.abc9.xc7.W")).c_str());
+					k = stringf("synth_xilinx.abc9.%s.W", family);
+					abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k, RTLIL::constpad.at("synth_xilinx.abc9.xc7.W")));
 				}
 				if (nowidelut)
 					abc9_opts += stringf(" -maxlut %d", lut_size);
@@ -718,18 +718,18 @@ struct SynthXilinxPass : public ScriptPass
 
 		if (check_label("edif")) {
 			if (!edif_file.empty() || help_mode)
-				run(stringf("write_edif -pvector bra %s", edif_file.c_str()));
+				run(stringf("write_edif -pvector bra %s", edif_file));
 		}
 
 		if (check_label("blif")) {
 			if (!blif_file.empty() || help_mode)
-				run(stringf("write_blif %s", blif_file.c_str()));
+				run(stringf("write_blif %s", blif_file));
 		}
 
 		if (check_label("json"))
 		{
 			if (!json_file.empty() || help_mode)
-				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file.c_str()));
+				run(stringf("write_json %s", help_mode ? "<file-name>" : json_file));
 		}
 	}
 } SynthXilinxPass;

--- a/tests/unit/kernel/ioTest.cc
+++ b/tests/unit/kernel/ioTest.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "kernel/io.h"
+#include "kernel/rtlil.h"
 
 YOSYS_NAMESPACE_BEGIN
 
@@ -42,6 +43,12 @@ TEST(KernelStringfTest, stringParam)
 TEST(KernelStringfTest, stringViewParam)
 {
         EXPECT_EQ(stringf("%s", std::string_view("hello")), "hello");
+}
+
+TEST(KernelStringfTest, idStringParam)
+{
+        RTLIL::IdString id("$hello");
+        EXPECT_EQ(stringf("%s", id), "$hello");
 }
 
 TEST(KernelStringfTest, escapePercent)


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Removing `.c_str()` makes code more readable.

_Explain how this is achieved._

It's easiest to remove `.c_str()` from `stringf()` parameters if at the same time we make `stringf()` support `const IdString &` parameters. So, we do that.

I just used a regex search-and-replace to remove `.c_str()` in some places. That missed a few places, e.g. where the `.c_str()` is on a different line to the `stringf()`. Those can be cleaned up later.

I ran the `read_rtlil jpeg.synth.il` performance test and there is no detectable difference (after I fixed `stringf()` to take parameters by reference so we don't juggle refcounts on `IdString`!). Removing `.c_str()` should actually make `stringf()` more efficient for `std::string` parameters, since `.c_str()` forgets the length and requires an extra `strlen()` call, but I don't have any benchmarks showing that.

Possibly we should change the `IdString` global storage to be `std::string`s, in which case we might get some speedup from this. I'll investigate that separately.