### PR TITLE
verilog: Fix missing sstream include

### DIFF
--- a/frontends/verilog/verilog_location.h
+++ b/frontends/verilog/verilog_location.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <stack>
 #include <string>
+#include <sstream>
 
 /**
  * Provide frontend-wide location tracking like what bison generates


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
This header file is missing when running with inclusion checking.

_Explain how this is achieved._
Adding the correct include for sstream.
