### PR TITLE
verilog: Lower required bison version to 3.6

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -33,7 +33,7 @@
  *
  */
 
-%require "3.8"
+%require "3.6"
 %language "c++"
 %define api.value.type variant
 %define api.prefix {frontend_verilog_yy}


### PR DESCRIPTION

_What are the reasons/motivation for this change?_
We're currently on version 3.6 of bison at Google, and Yosys still correctly builds with it. This should better reflect the actual requirements rather than an overly restrictive check. If features from 3.8 are required it seems like bumping would be appropriate.

_Explain how this is achieved._
Lowering the required version to 3.6
