### PR TITLE
Logging: Add log sink system to replace ostreams

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -8,7 +8,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install gperf build-essential bison flex libfl-dev libreadline-dev gawk tcl-dev libffi-dev git graphviz xdot pkg-config python3 libboost-system-dev libboost-python-dev libboost-filesystem-dev zlib1g-dev libbz2-dev libgtest-dev libgmock-dev
+        sudo apt-get install -y gperf build-essential bison flex libfl-dev libreadline-dev gawk tcl-dev libffi-dev git graphviz xdot pkg-config python3 libboost-system-dev libboost-python-dev libboost-filesystem-dev zlib1g-dev libbz2-dev libgtest-dev libgmock-dev
 
     - name: Install macOS Dependencies
       if: runner.os == 'macOS'

--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -8,7 +8,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install gperf build-essential bison flex libfl-dev libreadline-dev gawk tcl-dev libffi-dev git graphviz xdot pkg-config python3 libboost-system-dev libboost-python-dev libboost-filesystem-dev zlib1g-dev libbz2-dev libgtest-dev
+        sudo apt-get install gperf build-essential bison flex libfl-dev libreadline-dev gawk tcl-dev libffi-dev git graphviz xdot pkg-config python3 libboost-system-dev libboost-python-dev libboost-filesystem-dev zlib1g-dev libbz2-dev libgtest-dev libgmock-dev
 
     - name: Install macOS Dependencies
       if: runner.os == 'macOS'

--- a/.github/workflows/test-verific.yml
+++ b/.github/workflows/test-verific.yml
@@ -36,8 +36,7 @@ jobs:
           persist-credentials: false
           submodules: true
       - name: Runtime environment
-        run: |
-          echo "procs=$(nproc)" >> $GITHUB_ENV
+        uses: ./.github/actions/setup-build-env
 
       - name: Build Yosys
         run: |

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -435,7 +435,7 @@ void log_formatted_cmd_error(std::string str)
 			pop_errfile = true;
 		}
 
-		log_formatted_string("ERROR: %s", log_last_error, LogSeverity::LOG_ERROR);
+		log_formatted_string("%s", stringf("ERROR: %s", log_last_error), LogSeverity::LOG_ERROR);
 		log_flush();
 
 		if (pop_errfile)

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -94,8 +94,15 @@ YOSYS_NAMESPACE_BEGIN
 
 struct log_cmd_error_exception { };
 
+enum LogSeverity {
+	LOG_INFO,
+	LOG_WARNING,
+	LOG_ERROR
+};
+
 extern std::vector<FILE*> log_files;
 extern std::vector<std::ostream*> log_streams;
+extern std::vector<std::ostream*> log_warning_streams;
 extern std::vector<std::string> log_scratchpads;
 extern std::map<std::string, std::set<std::string>> log_hdump;
 extern std::vector<std::regex> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
@@ -132,12 +139,10 @@ static inline bool ys_debug(int = 0) { return false; }
 #endif
 #  define log_debug(...) do { if (ys_debug(1)) log(__VA_ARGS__); } while (0)
 
-void log_formatted_string(std::string_view format, std::string str);
+void log_formatted_string(std::string_view format, std::string str, LogSeverity severity = LogSeverity::LOG_INFO);
 template <typename... Args>
 inline void log(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	if (log_make_debug && !ys_debug(1))
-		return;
 	log_formatted_string(fmt.format_string(), fmt.format(args...));
 }
 

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -100,9 +100,22 @@ enum LogSeverity {
 	LOG_ERROR
 };
 
+struct LogMessage {
+	LogMessage(LogSeverity severity, std::string_view message) :
+		severity(severity), timestamp(std::time(nullptr)), message(message) {}
+	LogSeverity severity;
+	std::time_t timestamp;
+	std::string message;
+};
+
+class LogSink {
+ public:
+	virtual void log(const LogMessage& message) = 0;
+};
+
 extern std::vector<FILE*> log_files;
 extern std::vector<std::ostream*> log_streams;
-extern std::vector<std::ostream*> log_warning_streams;
+extern std::vector<LogSink*> log_sinks;
 extern std::vector<std::string> log_scratchpads;
 extern std::map<std::string, std::set<std::string>> log_hdump;
 extern std::vector<std::regex> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -4,10 +4,10 @@ UNAME_S := $(shell uname -s)
 GTEST_PREFIX := $(shell brew --prefix googletest 2>/dev/null)
 ifeq ($(GTEST_PREFIX),)
   GTEST_CXXFLAGS :=
-  GTEST_LDFLAGS := -lgtest -lgtest_main
+  GTEST_LDFLAGS := -lgtest -lgtest_main -lgmock
 else
   GTEST_CXXFLAGS := -I$(GTEST_PREFIX)/include
-  GTEST_LDFLAGS := -L$(GTEST_PREFIX)/lib -lgtest -lgtest_main
+  GTEST_LDFLAGS := -L$(GTEST_PREFIX)/lib -lgtest -lgtest_main -lgmock
 endif
 
 ifeq ($(UNAME_S),Darwin)

--- a/tests/unit/kernel/logTest.cc
+++ b/tests/unit/kernel/logTest.cc
@@ -1,3 +1,4 @@
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "kernel/yosys.h"
@@ -9,6 +10,40 @@ TEST(KernelLogTest, logvValidValues)
 {
 	//TODO: Implement log test
 	EXPECT_EQ(7, 7);
+}
+
+class TestSink : public LogSink {
+ public:
+	void log(const LogMessage& message) override {
+		messages_.push_back(message);
+	}
+	std::vector<LogMessage> messages_;
+};
+
+TEST(KernelLogTest, logToSink)
+{
+	TestSink sink;
+	log_sinks.push_back(&sink);
+	log("test info log");
+	log_warning("test warning log");
+
+	std::vector<LogMessage> expected{
+		LogMessage(LogSeverity::LOG_INFO, "test info log"),
+		LogMessage(LogSeverity::LOG_WARNING, "test warning log"),
+	};
+	// Certain calls to the log.h interface may prepend a string to
+	// the provided string. We should ensure that the expected string
+	// is a subset of the actual string. Additionally, we don't want to
+	// compare timestamps. So, we use a custom comparator.
+	for (const LogMessage& expected_msg : expected) {
+		EXPECT_THAT(sink.messages_, ::testing::Contains(::testing::Truly(
+			[&](const LogMessage& actual) {
+				return actual.severity == expected_msg.severity &&
+					actual.message.find(expected_msg.message) != std::string::npos;
+			}
+		)));
+	}
+	EXPECT_NE(sink.messages_[0].timestamp, 0);
 }
 
 YOSYS_NAMESPACE_END


### PR DESCRIPTION
This PR adds a LogSink class that aims to be more versatile than ostream sinks. See https://yosyshq.discourse.group/t/cleaning-up-log-sinks/86 for the discussion.

The old description can be found below:

~~We'd like to subscribe to only the most critical logs. Currently, there is no way to specify a log level threshold. This PR provides a stopgap solution.~~

~~In addition to the log_streams vector that new log sinks can push to, this PR adds a log_warning_streams vector that behaves similarly, but ostreams in this new vector only receive warning and error logs.~~