### PR TITLE
Cleanup `RTLIL::Const`

### DIFF
--- a/backends/btor/btor.cc
+++ b/backends/btor/btor.cc
@@ -705,12 +705,13 @@ struct BtorWorker
 				}
 			}
 
-			Const initval;
+			Const::Builder initval_bits(GetSize(sig_q));
 			for (int i = 0; i < GetSize(sig_q); i++)
 				if (initbits.count(sig_q[i]))
-					initval.bits().push_back(initbits.at(sig_q[i]) ? State::S1 : State::S0);
+					initval_bits.push_back(initbits.at(sig_q[i]) ? State::S1 : State::S0);
 				else
-					initval.bits().push_back(State::Sx);
+					initval_bits.push_back(State::Sx);
+			Const initval = initval_bits.build();
 
 			int nid_init_val = -1;
 
@@ -1039,10 +1040,11 @@ struct BtorWorker
 				{
 					if (bit.wire == nullptr)
 					{
-						Const c(bit.data);
-
-						while (i+GetSize(c) < GetSize(sig) && sig[i+GetSize(c)].wire == nullptr)
-							c.bits().push_back(sig[i+GetSize(c)].data);
+						Const::Builder c_bits;
+						c_bits.push_back(bit.data);
+						while (i + GetSize(c_bits) < GetSize(sig) && sig[i + GetSize(c_bits)].wire == nullptr)
+							c_bits.push_back(sig[i + GetSize(c_bits)].data);
+						Const c = c_bits.build();
 
 						if (consts.count(c) == 0) {
 							int sid = get_bv_sid(GetSize(c));

--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -1668,26 +1668,29 @@ struct CxxrtlWorker {
 						f << signal_temp << " == ";
 						dump_sigspec(compare, /*is_lhs=*/false, for_debug);
 					} else if (compare.is_fully_const()) {
-						RTLIL::Const compare_mask, compare_value;
+						RTLIL::Const::Builder compare_mask_builder(compare.size());
+						RTLIL::Const::Builder compare_value_builder(compare.size());
 						for (auto bit : compare.as_const()) {
 							switch (bit) {
 								case RTLIL::S0:
 								case RTLIL::S1:
-									compare_mask.bits().push_back(RTLIL::S1);
-									compare_value.bits().push_back(bit);
+									compare_mask_builder.push_back(RTLIL::S1);
+									compare_value_builder.push_back(bit);
 									break;
 
 								case RTLIL::Sx:
 								case RTLIL::Sz:
 								case RTLIL::Sa:
-									compare_mask.bits().push_back(RTLIL::S0);
-									compare_value.bits().push_back(RTLIL::S0);
+									compare_mask_builder.push_back(RTLIL::S0);
+									compare_value_builder.push_back(RTLIL::S0);
 									break;
 
 								default:
 									log_assert(false);
 							}
 						}
+						RTLIL::Const compare_mask = compare_mask_builder.build();
+						RTLIL::Const compare_value = compare_value_builder.build();
 						f << "and_uu<" << compare.size() << ">(" << signal_temp << ", ";
 						dump_const(compare_mask);
 						f << ") == ";
@@ -3042,7 +3045,7 @@ struct CxxrtlWorker {
 								if (init == RTLIL::Const()) {
 									init = RTLIL::Const(State::Sx, GetSize(bit.wire));
 								}
-								init.bits()[bit.offset] = port.init_value[i];
+								init.set(bit.offset, port.init_value[i]);
 							}
 						}
 					}

--- a/backends/functional/test_generic.cc
+++ b/backends/functional/test_generic.cc
@@ -105,7 +105,7 @@ struct MemContentsTest {
 				RTLIL::Const values;
 				for(addr_t addr = low; addr <= high; addr++) {
 					RTLIL::Const word(data_dist(rnd), data_width);
-					values.bits().insert(values.bits().end(), word.begin(), word.end());
+					values.append(word);
 				}
 				insert_concatenated(low, values);
 			}

--- a/backends/simplec/simplec.cc
+++ b/backends/simplec/simplec.cc
@@ -657,7 +657,7 @@ struct SimplecWorker
 			{
 				SigSpec sig = sigmaps.at(module)(w);
 				Const val = w->attributes.at(ID::init);
-				val.bits().resize(GetSize(sig), State::Sx);
+				val.resize(GetSize(sig), State::Sx);
 
 				for (int i = 0; i < GetSize(sig); i++)
 					if (val[i] == State::S0 || val[i] == State::S1) {

--- a/backends/smt2/smt2.cc
+++ b/backends/smt2/smt2.cc
@@ -1079,14 +1079,14 @@ struct Smt2Worker
 
 				RTLIL::SigSpec sig = sigmap(wire);
 				Const val = wire->attributes.at(ID::init);
-				val.bits().resize(GetSize(sig), State::Sx);
+				val.resize(GetSize(sig), State::Sx);
 				if (bvmode && GetSize(sig) > 1) {
 					Const mask(State::S1, GetSize(sig));
 					bool use_mask = false;
 					for (int i = 0; i < GetSize(sig); i++)
 						if (val[i] != State::S0 && val[i] != State::S1) {
-							val.bits()[i] = State::S0;
-							mask.bits()[i] = State::S0;
+							val.set(i, State::S0);
+							mask.set(i, State::S0);
 							use_mask = true;
 						}
 					if (use_mask)
@@ -1361,10 +1361,10 @@ struct Smt2Worker
 					for (int k = 0; k < GetSize(initword); k++) {
 						if (initword[k] == State::S0 || initword[k] == State::S1) {
 							gen_init_constr = true;
-							initmask.bits()[k] = State::S1;
+							initmask.set(k, State::S1);
 						} else {
-							initmask.bits()[k] = State::S0;
-							initword.bits()[k] = State::S0;
+							initmask.set(k, State::S0);
+							initword.set(k, State::S0);
 						}
 					}
 

--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -327,19 +327,20 @@ void dump_const(std::ostream &f, const RTLIL::Const &data, int width = -1, int o
 
 void dump_reg_init(std::ostream &f, SigSpec sig)
 {
-	Const initval;
 	bool gotinit = false;
 
+	Const::Builder initval_bits(sig.size());
 	for (auto bit : active_sigmap(sig)) {
 		if (active_initdata.count(bit)) {
-			initval.bits().push_back(active_initdata.at(bit));
+			initval_bits.push_back(active_initdata.at(bit));
 			gotinit = true;
 		} else {
-			initval.bits().push_back(State::Sx);
+			initval_bits.push_back(State::Sx);
 		}
 	}
 
 	if (gotinit) {
+		Const initval = initval_bits.build();
 		f << " = ";
 		dump_const(f, initval);
 	}
@@ -767,9 +768,10 @@ void dump_memory(std::ostream &f, std::string indent, Mem &mem)
 					dump_sigspec(os, port.data.extract(sub * mem.width, mem.width));
 					os << stringf(" = %s[", mem_id);;
 					if (port.wide_log2) {
-						Const addr_lo;
+						Const::Builder addr_lo_builder(port.wide_log2);
 						for (int i = 0; i < port.wide_log2; i++)
-							addr_lo.bits().push_back(State(sub >> i & 1));
+							addr_lo_builder.push_back(State(sub >> i & 1));
+						Const addr_lo = addr_lo_builder.build();
 						os << "{";
 						os << temp_id;
 						os << ", ";

--- a/frontends/aiger/aigerparse.cc
+++ b/frontends/aiger/aigerparse.cc
@@ -448,7 +448,7 @@ void AigerReader::parse_xaiger()
 					bool success = ce.eval(o);
 					log_assert(success);
 					log_assert(o.wire == nullptr);
-					lut_mask.bits()[gray] = o.data;
+					lut_mask.set(gray, o.data);
 				}
 				RTLIL::Cell *output_cell = module->cell(stringf("$and$aiger%d$%d", aiger_autoidx, rootNodeID));
 				log_assert(output_cell);

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -1076,8 +1076,10 @@ RTLIL::Const AstNode::realAsConst(int width)
 		bool is_negative = v < 0;
 		if (is_negative)
 			v *= -1;
+		RTLIL::Const::Builder b(width);
 		for (int i = 0; i < width; i++, v /= 2)
-			result.bits().push_back((fmod(floor(v), 2) != 0) ? RTLIL::State::S1 : RTLIL::State::S0);
+			b.push_back((fmod(floor(v), 2) != 0) ? RTLIL::State::S1 : RTLIL::State::S0);
+		result = b.build();
 		if (is_negative)
 			result = const_neg(result, result, false, false, result.size());
 	}

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -732,16 +732,17 @@ struct AST_INTERNAL::ProcessGenerator
 				current_case->actions.push_back(SigSig(en, true));
 
 				RTLIL::SigSpec triggers;
-				RTLIL::Const polarity;
+				RTLIL::Const::Builder polarity_builder;
 				for (auto sync : proc->syncs) {
 					if (sync->type == RTLIL::STp) {
 						triggers.append(sync->signal);
-						polarity.bits().push_back(RTLIL::S1);
+						polarity_builder.push_back(RTLIL::S1);
 					} else if (sync->type == RTLIL::STn) {
 						triggers.append(sync->signal);
-						polarity.bits().push_back(RTLIL::S0);
+						polarity_builder.push_back(RTLIL::S0);
 					}
 				}
+				RTLIL::Const polarity = polarity_builder.build();
 
 				RTLIL::Cell *cell = current_module->addCell(sstr.str(), ID($print));
 				set_src_attr(cell, ast);
@@ -829,16 +830,17 @@ struct AST_INTERNAL::ProcessGenerator
 				current_case->actions.push_back(SigSig(en, true));
 
 				RTLIL::SigSpec triggers;
-				RTLIL::Const polarity;
+				RTLIL::Const::Builder polarity_builder;
 				for (auto sync : proc->syncs) {
 					if (sync->type == RTLIL::STp) {
 						triggers.append(sync->signal);
-						polarity.bits().push_back(RTLIL::S1);
+						polarity_builder.push_back(RTLIL::S1);
 					} else if (sync->type == RTLIL::STn) {
 						triggers.append(sync->signal);
-						polarity.bits().push_back(RTLIL::S0);
+						polarity_builder.push_back(RTLIL::S0);
 					}
 				}
+				RTLIL::Const polarity = polarity_builder.build();
 
 				RTLIL::Cell *cell = current_module->addCell(cellname, ID($check));
 				set_src_attr(cell, ast);
@@ -893,7 +895,7 @@ struct AST_INTERNAL::ProcessGenerator
 				RTLIL::Const priority_mask = RTLIL::Const(0, cur_idx);
 				for (int i = 0; i < portid; i++) {
 					int new_bit = port_map[std::make_pair(memid, i)];
-					priority_mask.bits()[new_bit] = orig_priority_mask[i];
+					priority_mask.set(new_bit, orig_priority_mask[i]);
 				}
 				action.priority_mask = priority_mask;
 				sync->mem_write_actions.push_back(action);

--- a/frontends/json/jsonparse.cc
+++ b/frontends/json/jsonparse.cc
@@ -258,7 +258,7 @@ Const json_parse_attr_param_value(JsonNode *node)
 		}
 	} else
 	if (node->type == 'N') {
-		value = Const(node->data_number, 32);
+		value = Const(node->data_number);
 		if (node->data_number < 0)
 			value.flags |= RTLIL::CONST_FLAG_SIGNED;
 	} else

--- a/frontends/rtlil/rtlil_parser.y
+++ b/frontends/rtlil/rtlil_parser.y
@@ -455,9 +455,10 @@ constant:
 		}
 		while ((int)bits.size() > width)
 			bits.pop_back();
-		$$ = new RTLIL::Const;
-		for (auto it = bits.begin(); it != bits.end(); it++)
-			$$->bits().push_back(*it);
+		RTLIL::Const::Builder builder(bits.size());
+		for (RTLIL::State bit : bits)
+			builder.push_back(bit);
+		$$ = new RTLIL::Const(builder.build());
 		if (is_signed) {
 			$$->flags |= RTLIL::CONST_FLAG_SIGNED;
 		}

--- a/frontends/rtlil/rtlil_parser.y
+++ b/frontends/rtlil/rtlil_parser.y
@@ -465,7 +465,7 @@ constant:
 		free($1);
 	} |
 	TOK_INT {
-		$$ = new RTLIL::Const($1, 32);
+		$$ = new RTLIL::Const($1);
 	} |
 	TOK_STRING {
 		$$ = new RTLIL::Const($1);

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -267,13 +267,13 @@ static const RTLIL::Const extract_vhdl_bit_vector(std::string &val, std::string 
 static const RTLIL::Const extract_vhdl_integer(std::string &val)
 {
 	char *end;
-	return RTLIL::Const((int)std::strtol(val.c_str(), &end, 10), 32);
+	return RTLIL::Const((int)std::strtol(val.c_str(), &end, 10));
 }
 
 static const RTLIL::Const extract_vhdl_char(std::string &val)
 {
 	if (val.size()==3 && val[0]=='\"' && val.back()=='\"')
-		return RTLIL::Const((int)val[1], 32);
+		return RTLIL::Const((int)val[1]);
 	log_error("Error parsing VHDL character.\n");
 }
 
@@ -311,7 +311,7 @@ static const  RTLIL::Const extract_vhdl_const(const char *value, bool output_sig
 	} else if ((value[0] == '-' || (value[0] >= '0' && value[0] <= '9')) &&
 			((decimal = std::strtol(value, &end, 10)), !end[0])) {
 		is_signed = output_signed;
-		c = RTLIL::Const((int)decimal, 32);
+		c = RTLIL::Const((int)decimal);
 	} else if (val == "false") {
 		c = RTLIL::Const::from_string("0");
 	} else if (val == "true") {
@@ -344,7 +344,7 @@ static const  RTLIL::Const extract_verilog_const(const char *value, bool allow_s
 	} else if ((value[0] == '-' || (value[0] >= '0' && value[0] <= '9')) &&
 			((decimal = std::strtol(value, &end, 10)), !end[0])) {
 		is_signed = output_signed;
-		c = RTLIL::Const((int)decimal, 32);
+		c = RTLIL::Const((int)decimal);
 	} else if (allow_string) {
 		c = RTLIL::Const(val);
 	} else {

--- a/kernel/bitpattern.h
+++ b/kernel/bitpattern.h
@@ -100,7 +100,7 @@ struct BitPatternPool
 	bits_t sig2bits(RTLIL::SigSpec sig)
 	{
 		bits_t bits;
-		bits.bitdata = sig.as_const().bits();
+		bits.bitdata = sig.as_const().to_bits();
 		for (auto &b : bits.bitdata)
 			if (b > RTLIL::State::S1)
 				b = RTLIL::State::Sa;

--- a/kernel/celltypes.h
+++ b/kernel/celltypes.h
@@ -328,7 +328,7 @@ struct CellTypes
 
 	static RTLIL::Const eval_not(RTLIL::Const v)
 	{
-		for (auto &bit : v.bits())
+		for (auto bit : v)
 			if (bit == State::S0) bit = State::S1;
 			else if (bit == State::S1) bit = State::S0;
 		return v;
@@ -421,16 +421,14 @@ struct CellTypes
 	static RTLIL::Const eval(RTLIL::Cell *cell, const RTLIL::Const &arg1, const RTLIL::Const &arg2, bool *errp = nullptr)
 	{
 		if (cell->type == ID($slice)) {
-			RTLIL::Const ret;
 			int width = cell->parameters.at(ID::Y_WIDTH).as_int();
 			int offset = cell->parameters.at(ID::OFFSET).as_int();
-			ret.bits().insert(ret.bits().end(), arg1.begin()+offset, arg1.begin()+offset+width);
-			return ret;
+			return arg1.extract(offset, width);
 		}
 
 		if (cell->type == ID($concat)) {
 			RTLIL::Const ret = arg1;
-			ret.bits().insert(ret.bits().end(), arg2.begin(), arg2.end());
+			ret.append(arg2);
 			return ret;
 		}
 

--- a/kernel/consteval.h
+++ b/kernel/consteval.h
@@ -115,7 +115,7 @@ struct ConstEval
 
 				for (int i = 0; i < GetSize(coval); i++) {
 					carry = (sig_g[i] == State::S1) || (sig_p[i] == RTLIL::S1 && carry);
-					coval.bits()[i] = carry ? State::S1 : State::S0;
+					coval.set(i, carry ? State::S1 : State::S0);
 				}
 
 				set(sig_co, coval);
@@ -249,7 +249,7 @@ struct ConstEval
 
 			for (int i = 0; i < GetSize(val_y); i++)
 				if (val_y[i] == RTLIL::Sx)
-					val_x.bits()[i] = RTLIL::Sx;
+					val_x.set(i, RTLIL::Sx);
 
 			set(sig_y, val_y);
 			set(sig_x, val_x);

--- a/kernel/drivertools.cc
+++ b/kernel/drivertools.cc
@@ -260,7 +260,7 @@ bool DriveChunkMultiple::try_append(DriveBitMultiple const &bit)
 		switch (single.type())
 		{
 			case DriveType::CONSTANT: {
-				single.constant().bits().push_back(constant);
+				single.constant().append(RTLIL::Const(constant));
 			} break;
 			case DriveType::WIRE: {
 				single.wire().width += 1;
@@ -295,8 +295,7 @@ bool DriveChunkMultiple::try_append(DriveChunkMultiple const &chunk)
 		switch (single.type())
 		{
 			case DriveType::CONSTANT: {
-				auto &bits = single.constant().bits();
-				bits.insert(bits.end(), constant.bits().begin(), constant.bits().end());
+				single.constant().append(constant);
 			} break;
 			case DriveType::WIRE: {
 				single.wire().width += width;
@@ -349,7 +348,7 @@ bool DriveChunk::try_append(DriveBit const &bit)
 			none_ += 1;
 			return true;
 		case DriveType::CONSTANT:
-			constant_.bits().push_back(bit.constant());
+			constant_.append(RTLIL::Const(bit.constant()));
 			return true;
 		case DriveType::WIRE:
 			return wire_.try_append(bit.wire());
@@ -375,7 +374,7 @@ bool DriveChunk::try_append(DriveChunk const &chunk)
 			none_ += chunk.none_;
 			return true;
 		case DriveType::CONSTANT:
-			constant_.bits().insert(constant_.bits().end(), chunk.constant_.begin(), chunk.constant_.end());
+			constant_.append(chunk.constant_);
 			return true;
 		case DriveType::WIRE:
 			return wire_.try_append(chunk.wire());

--- a/kernel/ffinit.h
+++ b/kernel/ffinit.h
@@ -74,10 +74,10 @@ struct FfInitVals
 
 	RTLIL::Const operator()(const RTLIL::SigSpec &sig) const
 	{
-		RTLIL::Const res;
+		RTLIL::Const::Builder res_bits(GetSize(sig));
 		for (auto bit : sig)
-			res.bits().push_back((*this)(bit));
-		return res;
+			res_bits.push_back((*this)(bit));
+		return res_bits.build();
 	}
 
 	void set_init(RTLIL::SigBit bit, RTLIL::State val)
@@ -93,12 +93,12 @@ struct FfInitVals
 		initbits[mbit] = std::make_pair(val,abit);
 		auto it2 = abit.wire->attributes.find(ID::init);
 		if (it2 != abit.wire->attributes.end()) {
-			it2->second.bits()[abit.offset] = val;
+			it2->second.set(abit.offset, val);
 			if (it2->second.is_fully_undef())
 				abit.wire->attributes.erase(it2);
 		} else if (val != State::Sx) {
 			Const cval(State::Sx, GetSize(abit.wire));
-			cval.bits()[abit.offset] = val;
+			cval.set(abit.offset, val);
 			abit.wire->attributes[ID::init] = cval;
 		}
 	}

--- a/kernel/ffmerge.cc
+++ b/kernel/ffmerge.cc
@@ -42,9 +42,9 @@ bool FfMergeHelper::find_output_ff(RTLIL::SigSpec sig, FfData &ff, pool<std::pai
 			ff.sig_d.append(bit);
 			ff.sig_clr.append(State::Sx);
 			ff.sig_set.append(State::Sx);
-			ff.val_init.bits().push_back(State::Sx);
-			ff.val_srst.bits().push_back(State::Sx);
-			ff.val_arst.bits().push_back(State::Sx);
+			ff.val_init.append(RTLIL::Const(State::Sx));
+			ff.val_srst.append(RTLIL::Const(State::Sx));
+			ff.val_arst.append(RTLIL::Const(State::Sx));
 			continue;
 		}
 
@@ -147,9 +147,9 @@ bool FfMergeHelper::find_output_ff(RTLIL::SigSpec sig, FfData &ff, pool<std::pai
 		ff.sig_q.append(cur_ff.sig_q[idx]);
 		ff.sig_clr.append(ff.has_sr ? cur_ff.sig_clr[idx] : State::S0);
 		ff.sig_set.append(ff.has_sr ? cur_ff.sig_set[idx] : State::S0);
-		ff.val_arst.bits().push_back(ff.has_arst ? cur_ff.val_arst[idx] : State::Sx);
-		ff.val_srst.bits().push_back(ff.has_srst ? cur_ff.val_srst[idx] : State::Sx);
-		ff.val_init.bits().push_back(cur_ff.val_init[idx]);
+		ff.val_arst.append(RTLIL::Const(ff.has_arst ? cur_ff.val_arst[idx] : State::Sx));
+		ff.val_srst.append(RTLIL::Const(ff.has_srst ? cur_ff.val_srst[idx] : State::Sx));
+		ff.val_init.append(RTLIL::Const(cur_ff.val_init[idx]));
 		found = true;
 	}
 
@@ -174,9 +174,9 @@ bool FfMergeHelper::find_input_ff(RTLIL::SigSpec sig, FfData &ff, pool<std::pair
 			// These two will be fixed up later.
 			ff.sig_clr.append(State::Sx);
 			ff.sig_set.append(State::Sx);
-			ff.val_init.bits().push_back(bit.data);
-			ff.val_srst.bits().push_back(bit.data);
-			ff.val_arst.bits().push_back(bit.data);
+			ff.val_init.append(RTLIL::Const(bit.data));
+			ff.val_srst.append(RTLIL::Const(bit.data));
+			ff.val_arst.append(RTLIL::Const(bit.data));
 			continue;
 		}
 
@@ -274,9 +274,9 @@ bool FfMergeHelper::find_input_ff(RTLIL::SigSpec sig, FfData &ff, pool<std::pair
 		ff.sig_q.append(cur_ff.sig_q[idx]);
 		ff.sig_clr.append(ff.has_sr ? cur_ff.sig_clr[idx] : State::S0);
 		ff.sig_set.append(ff.has_sr ? cur_ff.sig_set[idx] : State::S0);
-		ff.val_arst.bits().push_back(ff.has_arst ? cur_ff.val_arst[idx] : State::Sx);
-		ff.val_srst.bits().push_back(ff.has_srst ? cur_ff.val_srst[idx] : State::Sx);
-		ff.val_init.bits().push_back(cur_ff.val_init[idx]);
+		ff.val_arst.append(RTLIL::Const(ff.has_arst ? cur_ff.val_arst[idx] : State::Sx));
+		ff.val_srst.append(RTLIL::Const(ff.has_srst ? cur_ff.val_srst[idx] : State::Sx));
+		ff.val_init.append(RTLIL::Const(cur_ff.val_init[idx]));
 		found = true;
 	}
 

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -168,8 +168,17 @@ struct hash_ops {
 		} else if constexpr (std::is_pointer_v<T>) {
 			return hash_ops<uintptr_t>::hash_into((uintptr_t) a, h);
 		} else if constexpr (std::is_same_v<T, std::string>) {
-			for (auto c : a)
-				h.hash32(c);
+			int size = a.size();
+			int i = 0;
+			while (i + 8 < size) {
+				uint64_t v;
+				memcpy(&v, a.data() + i, 8);
+				h.hash64(v);
+				i += 8;
+			}
+			uint64_t v = 0;
+			memcpy(&v, a.data() + i, size - i);
+			h.hash64(v);
 			return h;
 		} else {
 			return a.hash_into(h);

--- a/kernel/macc.h
+++ b/kernel/macc.h
@@ -262,7 +262,7 @@ struct Macc
 
 	bool eval(RTLIL::Const &result) const
 	{
-		for (auto &bit : result.bits())
+		for (auto bit : result)
 			bit = State::S0;
 
 		for (auto &port : terms)

--- a/kernel/mem.cc
+++ b/kernel/mem.cc
@@ -131,9 +131,6 @@ void Mem::emit() {
 		cell->parameters[ID::WIDTH] = Const(width);
 		cell->parameters[ID::OFFSET] = Const(start_offset);
 		cell->parameters[ID::SIZE] = Const(size);
-		Const rd_wide_continuation, rd_clk_enable, rd_clk_polarity, rd_transparency_mask, rd_collision_x_mask;
-		Const wr_wide_continuation, wr_clk_enable, wr_clk_polarity, wr_priority_mask;
-		Const rd_ce_over_srst, rd_arst_value, rd_srst_value, rd_init_value;
 		SigSpec rd_clk, rd_en, rd_addr, rd_data;
 		SigSpec wr_clk, wr_en, wr_addr, wr_data;
 		SigSpec rd_arst, rd_srst;
@@ -147,6 +144,15 @@ void Mem::emit() {
 		for (int i = 0; i < GetSize(wr_ports); i++)
 			for (int j = 0; j < (1 << wr_ports[i].wide_log2); j++)
 				wr_port_xlat.push_back(i);
+		Const::Builder rd_wide_continuation_builder;
+		Const::Builder rd_clk_enable_builder;
+		Const::Builder rd_clk_polarity_builder;
+		Const::Builder rd_transparency_mask_builder;
+		Const::Builder rd_collision_x_mask_builder;
+		Const::Builder rd_ce_over_srst_builder;
+		Const::Builder rd_arst_value_builder;
+		Const::Builder rd_srst_value_builder;
+		Const::Builder rd_init_value_builder;
 		for (auto &port : rd_ports) {
 			for (auto attr: port.attributes)
 				if (!cell->has_attribute(attr.first))
@@ -157,10 +163,10 @@ void Mem::emit() {
 			}
 			for (int sub = 0; sub < (1 << port.wide_log2); sub++)
 			{
-				rd_wide_continuation.bits().push_back(State(sub != 0));
-				rd_clk_enable.bits().push_back(State(port.clk_enable));
-				rd_clk_polarity.bits().push_back(State(port.clk_polarity));
-				rd_ce_over_srst.bits().push_back(State(port.ce_over_srst));
+				rd_wide_continuation_builder.push_back(State(sub != 0));
+				rd_clk_enable_builder.push_back(State(port.clk_enable));
+				rd_clk_polarity_builder.push_back(State(port.clk_polarity));
+				rd_ce_over_srst_builder.push_back(State(port.ce_over_srst));
 				rd_clk.append(port.clk);
 				rd_arst.append(port.arst);
 				rd_srst.append(port.srst);
@@ -170,18 +176,27 @@ void Mem::emit() {
 				rd_addr.append(addr);
 				log_assert(GetSize(addr) == abits);
 				for (auto idx : wr_port_xlat) {
-					rd_transparency_mask.bits().push_back(State(bool(port.transparency_mask[idx])));
-					rd_collision_x_mask.bits().push_back(State(bool(port.collision_x_mask[idx])));
+					rd_transparency_mask_builder.push_back(State(bool(port.transparency_mask[idx])));
+					rd_collision_x_mask_builder.push_back(State(bool(port.collision_x_mask[idx])));
 				}
 			}
 			rd_data.append(port.data);
 			for (auto bit : port.arst_value)
-				rd_arst_value.bits().push_back(bit);
+				rd_arst_value_builder.push_back(bit);
 			for (auto bit : port.srst_value)
-				rd_srst_value.bits().push_back(bit);
+				rd_srst_value_builder.push_back(bit);
 			for (auto bit : port.init_value)
-				rd_init_value.bits().push_back(bit);
+				rd_init_value_builder.push_back(bit);
 		}
+		Const rd_wide_continuation = rd_wide_continuation_builder.build();
+		Const rd_clk_enable = rd_clk_enable_builder.build();
+		Const rd_clk_polarity = rd_clk_polarity_builder.build();
+		Const rd_transparency_mask = rd_transparency_mask_builder.build();
+		Const rd_collision_x_mask = rd_collision_x_mask_builder.build();
+		Const rd_ce_over_srst = rd_ce_over_srst_builder.build();
+		Const rd_arst_value = rd_arst_value_builder.build();
+		Const rd_srst_value = rd_srst_value_builder.build();
+		Const rd_init_value = rd_init_value_builder.build();
 		if (rd_ports.empty()) {
 			rd_wide_continuation = State::S0;
 			rd_clk_enable = State::S0;
@@ -212,6 +227,10 @@ void Mem::emit() {
 		cell->setPort(ID::RD_SRST, rd_srst);
 		cell->setPort(ID::RD_ADDR, rd_addr);
 		cell->setPort(ID::RD_DATA, rd_data);
+		Const::Builder wr_wide_continuation_builder;
+		Const::Builder wr_clk_enable_builder;
+		Const::Builder wr_clk_polarity_builder;
+		Const::Builder wr_priority_mask_builder;
 		for (auto &port : wr_ports) {
 			for (auto attr: port.attributes)
 				if (!cell->has_attribute(attr.first))
@@ -222,12 +241,12 @@ void Mem::emit() {
 			}
 			for (int sub = 0; sub < (1 << port.wide_log2); sub++)
 			{
-				wr_wide_continuation.bits().push_back(State(sub != 0));
-				wr_clk_enable.bits().push_back(State(port.clk_enable));
-				wr_clk_polarity.bits().push_back(State(port.clk_polarity));
+				wr_wide_continuation_builder.push_back(State(sub != 0));
+				wr_clk_enable_builder.push_back(State(port.clk_enable));
+				wr_clk_polarity_builder.push_back(State(port.clk_polarity));
 				wr_clk.append(port.clk);
 				for (auto idx : wr_port_xlat)
-					wr_priority_mask.bits().push_back(State(bool(port.priority_mask[idx])));
+					wr_priority_mask_builder.push_back(State(bool(port.priority_mask[idx])));
 				SigSpec addr = port.sub_addr(sub);
 				addr.extend_u0(abits, false);
 				wr_addr.append(addr);
@@ -236,6 +255,10 @@ void Mem::emit() {
 			wr_en.append(port.en);
 			wr_data.append(port.data);
 		}
+		Const wr_wide_continuation = wr_wide_continuation_builder.build();
+		Const wr_clk_enable = wr_clk_enable_builder.build();
+		Const wr_clk_polarity = wr_clk_polarity_builder.build();
+		Const wr_priority_mask = wr_priority_mask_builder.build();
 		if (wr_ports.empty()) {
 			wr_wide_continuation = State::S0;
 			wr_clk_enable = State::S0;
@@ -414,7 +437,7 @@ void Mem::coalesce_inits() {
 			if (!init.en.is_fully_ones()) {
 				for (int i = 0; i < GetSize(init.data); i++)
 					if (init.en[i % width] != State::S1)
-						init.data.bits()[i] = State::Sx;
+						init.data.set(i, State::Sx);
 				init.en = Const(State::S1, width);
 			}
 			continue;
@@ -427,7 +450,7 @@ void Mem::coalesce_inits() {
 			log_assert(offset + GetSize(init.data) <= GetSize(cdata));
 			for (int i = 0; i < GetSize(init.data); i++)
 				if (init.en[i % width] == State::S1)
-					cdata.bits()[i+offset] = init.data[i];
+					cdata.set(i+offset, init.data[i]);
 			init.removed = true;
 		}
 		MemInit new_init;
@@ -446,7 +469,7 @@ Const Mem::get_init_data() const {
 		int offset = (init.addr.as_int() - start_offset) * width;
 		for (int i = 0; i < GetSize(init.data); i++)
 			if (0 <= i+offset && i+offset < GetSize(init_data) && init.en[i % width] == State::S1)
-				init_data.bits()[i+offset] = init.data[i];
+				init_data.set(i+offset, init.data[i]);
 	}
 	return init_data;
 }
@@ -1700,7 +1723,7 @@ MemContents::MemContents(Mem *mem) :
 				RTLIL::Const previous = (*this)[addr + i];
 				for(int j = 0; j < _data_width; j++)
 					if(init.en[j] != State::S1)
-						data.bits()[_data_width * i + j] = previous[j];
+						data.set(_data_width * i + j, previous[j]);
 			}
 			insert_concatenated(init.addr.as_int(), data);
 		}
@@ -1846,7 +1869,7 @@ std::map<MemContents::addr_t, RTLIL::Const>::iterator MemContents::_reserve_rang
 		// we have two different ranges touching at either end, we need to merge them
 		auto upper_end = _range_end(upper_it);
 		// make range bigger (maybe reserve here instead of resize?)
-		lower_it->second.bits().resize(_range_offset(lower_it, upper_end), State::Sx);
+		lower_it->second.resize(_range_offset(lower_it, upper_end), State::Sx);
 		// copy only the data beyond our range
 		std::copy(_range_data(upper_it, end_addr), _range_data(upper_it, upper_end), _range_data(lower_it, end_addr));
 		// keep lower_it, but delete upper_it
@@ -1854,16 +1877,16 @@ std::map<MemContents::addr_t, RTLIL::Const>::iterator MemContents::_reserve_rang
 		return lower_it;
 	} else if (lower_touch) {
 		// we have a range to the left, just make it bigger and delete any other that may exist.
-		lower_it->second.bits().resize(_range_offset(lower_it, end_addr), State::Sx);
+		lower_it->second.resize(_range_offset(lower_it, end_addr), State::Sx);
 		// keep lower_it and upper_it
 		_values.erase(std::next(lower_it), upper_it);
 		return lower_it;
 	} else if (upper_touch) {
 		// we have a range to the right, we need to expand it
 		// since we need to erase and reinsert to a new address, steal the data
-		RTLIL::Const data = std::move(upper_it->second);
 		// note that begin_addr is not in upper_it, otherwise the whole range covered check would have tripped
-		data.bits().insert(data.bits().begin(), (_range_begin(upper_it) - begin_addr) * _data_width, State::Sx);
+		RTLIL::Const data(State::Sx, (_range_begin(upper_it) - begin_addr) * _data_width);
+		data.append(std::move(upper_it->second));
 		// delete lower_it and upper_it, then reinsert
 		_values.erase(lower_it, std::next(upper_it));
 		return _values.emplace(begin_addr, std::move(data)).first;
@@ -1886,7 +1909,7 @@ void MemContents::insert_concatenated(addr_t addr, RTLIL::Const const &values) {
 	std::fill(to_begin + values.size(), to_begin + words * _data_width, State::S0);
 }
 
-std::vector<State>::iterator MemContents::_range_write(std::vector<State>::iterator it, RTLIL::Const const &word) {
+RTLIL::Const::iterator MemContents::_range_write(RTLIL::Const::iterator it, RTLIL::Const const &word) {
 	auto from_end = word.size() <= _data_width ? word.end() : word.begin() + _data_width;
 	auto to_end = std::copy(word.begin(), from_end, it);
 	auto it_next = std::next(it, _data_width);

--- a/kernel/mem.h
+++ b/kernel/mem.h
@@ -255,11 +255,13 @@ private:
 	// return the offset the addr would have in the range at `it`
 	size_t _range_offset(std::map<addr_t, RTLIL::Const>::iterator it, addr_t addr) const { return (addr - it->first) * _data_width; }
 	// assuming _range_contains(it, addr), return an iterator pointing to the data at addr
-	std::vector<State>::iterator _range_data(std::map<addr_t, RTLIL::Const>::iterator it, addr_t addr) { return it->second.bits().begin() + _range_offset(it, addr); }
+	RTLIL::Const::iterator _range_data(std::map<addr_t, RTLIL::Const>::iterator it, addr_t addr) {
+		return RTLIL::Const::iterator(it->second, _range_offset(it, addr));
+	}
 	// internal version of reserve_range that returns an iterator to the range
 	std::map<addr_t, RTLIL::Const>::iterator _reserve_range(addr_t begin_addr, addr_t end_addr);
 	// write a single word at addr, return iterator to next word
-	std::vector<State>::iterator _range_write(std::vector<State>::iterator it, RTLIL::Const const &data);
+	RTLIL::Const::iterator _range_write(RTLIL::Const::iterator it, RTLIL::Const const &data);
 public:
 	class range {
 		int _data_width;

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -579,7 +579,6 @@ std::string RTLIL::Const::decode_string() const
 	if (auto str = get_if_str())
 		return *str;
 
-	bitvectorize_internal();
 	bitvectype& bv = get_bits();
 	const int n = GetSize(bv);
 	const int n_over_8 = n / 8;

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -615,11 +615,11 @@ void RTLIL::Const::append(const RTLIL::Const &other) {
 }
 
 RTLIL::State RTLIL::Const::const_iterator::operator*() const {
-	if (auto bv = parent.get_if_bits())
+	if (auto bv = parent->get_if_bits())
 		return (*bv)[idx];
 
-	int char_idx = parent.get_str().size() - idx / 8 - 1;
-	bool bit = (parent.get_str()[char_idx] & (1 << (idx % 8)));
+	int char_idx = parent->get_str().size() - idx / 8 - 1;
+	bool bit = (parent->get_str()[char_idx] & (1 << (idx % 8)));
 	return bit ? State::S1 : State::S0;
 }
 

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -388,6 +388,11 @@ bool RTLIL::Const::operator<(const RTLIL::Const &other) const
 
 bool RTLIL::Const::operator ==(const RTLIL::Const &other) const
 {
+	if (is_str() && other.is_str())
+		return get_str() == other.get_str();
+	if (is_bits() && other.is_bits())
+		return get_bits() == other.get_bits();
+
 	if (size() != other.size())
 		return false;
 

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -380,7 +380,7 @@ bool RTLIL::Const::operator !=(const RTLIL::Const &other) const
 
 std::vector<RTLIL::State>& RTLIL::Const::bits_internal()
 {
-	bitvectorize();
+	bitvectorize_internal();
 	return get_bits();
 }
 
@@ -394,7 +394,7 @@ std::vector<RTLIL::State> RTLIL::Const::to_bits() const
 
 bool RTLIL::Const::as_bool() const
 {
-	bitvectorize();
+	bitvectorize_internal();
 	bitvectype& bv = get_bits();
 	for (size_t i = 0; i < bv.size(); i++)
 		if (bv[i] == State::S1)
@@ -404,7 +404,7 @@ bool RTLIL::Const::as_bool() const
 
 int RTLIL::Const::as_int(bool is_signed) const
 {
-	bitvectorize();
+	bitvectorize_internal();
 	bitvectype& bv = get_bits();
 	int32_t ret = 0;
 	for (size_t i = 0; i < bv.size() && i < 32; i++)
@@ -496,7 +496,7 @@ std::optional<int> RTLIL::Const::as_int_compress(bool is_signed) const
 
 std::string RTLIL::Const::as_string(const char* any) const
 {
-	bitvectorize();
+	bitvectorize_internal();
 	bitvectype& bv = get_bits();
 	std::string ret;
 	ret.reserve(bv.size());
@@ -534,7 +534,7 @@ std::string RTLIL::Const::decode_string() const
 	if (auto str = get_if_str())
 		return *str;
 
-	bitvectorize();
+	bitvectorize_internal();
 	bitvectype& bv = get_bits();
 	const int n = GetSize(bv);
 	const int n_over_8 = n / 8;
@@ -583,7 +583,7 @@ bool RTLIL::Const::empty() const {
 	}
 }
 
-void RTLIL::Const::bitvectorize() const {
+void RTLIL::Const::bitvectorize_internal() const {
 	if (tag == backing_tag::bits)
 		return;
 
@@ -609,7 +609,7 @@ void RTLIL::Const::bitvectorize() const {
 }
 
 void RTLIL::Const::append(const RTLIL::Const &other) {
-	bitvectorize();
+	bitvectorize_internal();
 	bitvectype& bv = get_bits();
 	bv.insert(bv.end(), other.begin(), other.end());
 }
@@ -625,7 +625,7 @@ RTLIL::State RTLIL::Const::const_iterator::operator*() const {
 
 bool RTLIL::Const::is_fully_zero() const
 {
-	bitvectorize();
+	bitvectorize_internal();
 	bitvectype& bv = get_bits();
 	cover("kernel.rtlil.const.is_fully_zero");
 
@@ -638,7 +638,7 @@ bool RTLIL::Const::is_fully_zero() const
 
 bool RTLIL::Const::is_fully_ones() const
 {
-	bitvectorize();
+	bitvectorize_internal();
 	bitvectype& bv = get_bits();
 	cover("kernel.rtlil.const.is_fully_ones");
 
@@ -653,7 +653,7 @@ bool RTLIL::Const::is_fully_def() const
 {
 	cover("kernel.rtlil.const.is_fully_def");
 
-	bitvectorize();
+	bitvectorize_internal();
 	bitvectype& bv = get_bits();
 
 	for (const auto &bit : bv)
@@ -667,7 +667,7 @@ bool RTLIL::Const::is_fully_undef() const
 {
 	cover("kernel.rtlil.const.is_fully_undef");
 
-	bitvectorize();
+	bitvectorize_internal();
 	bitvectype& bv = get_bits();
 
 	for (const auto &bit : bv)
@@ -681,7 +681,7 @@ bool RTLIL::Const::is_fully_undef_x_only() const
 {
 	cover("kernel.rtlil.const.is_fully_undef_x_only");
 
-	bitvectorize();
+	bitvectorize_internal();
 	bitvectype& bv = get_bits();
 
 	for (const auto &bit : bv)
@@ -695,7 +695,7 @@ bool RTLIL::Const::is_onehot(int *pos) const
 {
 	cover("kernel.rtlil.const.is_onehot");
 
-	bitvectorize();
+	bitvectorize_internal();
 	bitvectype& bv = get_bits();
 
 	bool found = false;

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -486,7 +486,7 @@ int RTLIL::Const::get_min_size(bool is_signed) const
 void RTLIL::Const::compress(bool is_signed)
 {
 	auto idx = get_min_size(is_signed);
-	bits().erase(bits().begin() + idx, bits().end());
+	resize(idx, RTLIL::State::S0);
 }
 
 std::optional<int> RTLIL::Const::as_int_compress(bool is_signed) const

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -378,7 +378,7 @@ bool RTLIL::Const::operator !=(const RTLIL::Const &other) const
 	return !(*this == other);
 }
 
-std::vector<RTLIL::State>& RTLIL::Const::bits()
+std::vector<RTLIL::State>& RTLIL::Const::bits_internal()
 {
 	bitvectorize();
 	return get_bits();

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -542,18 +542,17 @@ std::optional<int> RTLIL::Const::as_int_compress(bool is_signed) const
 
 std::string RTLIL::Const::as_string(const char* any) const
 {
-	bitvectorize_internal();
-	bitvectype& bv = get_bits();
+	int sz = size();
 	std::string ret;
-	ret.reserve(bv.size());
-	for (size_t i = bv.size(); i > 0; i--)
-		switch (bv[i-1]) {
-			case S0: ret += "0"; break;
-			case S1: ret += "1"; break;
-			case Sx: ret += "x"; break;
-			case Sz: ret += "z"; break;
+	ret.reserve(sz);
+	for (int i = sz - 1; i >= 0; --i)
+		switch ((*this)[i]) {
+			case S0: ret.push_back('0'); break;
+			case S1: ret.push_back('1'); break;
+			case Sx: ret.push_back('x'); break;
+			case Sz: ret.push_back('z'); break;
 			case Sa: ret += any; break;
-			case Sm: ret += "m"; break;
+			case Sm: ret.push_back('m'); break;
 		}
 	return ret;
 }

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -837,6 +837,8 @@ private:
 
 	bitvectype& get_bits() const;
 	std::string& get_str() const;
+	std::vector<RTLIL::State>& bits_internal();
+
 public:
 	Const() : flags(RTLIL::CONST_FLAG_NONE), tag(backing_tag::bits), bits_(std::vector<RTLIL::State>()) {}
 	Const(const std::string &str);
@@ -864,7 +866,8 @@ public:
 	bool operator ==(const RTLIL::Const &other) const;
 	bool operator !=(const RTLIL::Const &other) const;
 
-	std::vector<RTLIL::State>& bits();
+	[[deprecated]]
+	std::vector<RTLIL::State>& bits() { return bits_internal(); }
 	bool as_bool() const;
 
 	// Convert the constant value to a C++ int.
@@ -897,10 +900,10 @@ public:
 
 	void append(const RTLIL::Const &other);
 	void set(int i, RTLIL::State state) {
-		bits()[i] = state;
+		bits_internal()[i] = state;
 	}
 	void resize(int size, RTLIL::State fill) {
-		bits().resize(size, fill);
+		bits_internal().resize(size, fill);
 	}
 
 	class const_iterator {

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -838,6 +838,7 @@ private:
 	bitvectype& get_bits() const;
 	std::string& get_str() const;
 	std::vector<RTLIL::State>& bits_internal();
+	void bitvectorize_internal() const;
 
 public:
 	Const() : flags(RTLIL::CONST_FLAG_NONE), tag(backing_tag::bits), bits_(std::vector<RTLIL::State>()) {}
@@ -866,8 +867,11 @@ public:
 	bool operator ==(const RTLIL::Const &other) const;
 	bool operator !=(const RTLIL::Const &other) const;
 
-	[[deprecated]]
+	[[deprecated("Don't use direct access to the internal std::vector<State>, that's an implementation detail.")]]
 	std::vector<RTLIL::State>& bits() { return bits_internal(); }
+	[[deprecated("Don't call bitvectorize() directly, it's an implementation detail.")]]
+	void bitvectorize() const { bitvectorize_internal(); }
+
 	bool as_bool() const;
 
 	// Convert the constant value to a C++ int.
@@ -896,7 +900,6 @@ public:
 	std::string decode_string() const;
 	int size() const;
 	bool empty() const;
-	void bitvectorize() const;
 
 	void append(const RTLIL::Const &other);
 	void set(int i, RTLIL::State state) {

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -843,7 +843,8 @@ private:
 public:
 	Const() : flags(RTLIL::CONST_FLAG_NONE), tag(backing_tag::bits), bits_(std::vector<RTLIL::State>()) {}
 	Const(const std::string &str);
-	Const(long long val, int width = 32);
+	Const(long long val); // default width is 32
+	Const(long long val, int width);
 	Const(RTLIL::State bit, int width = 1);
 	Const(std::vector<RTLIL::State> bits) : flags(RTLIL::CONST_FLAG_NONE), tag(backing_tag::bits), bits_(std::move(bits)) {}
 	Const(const std::vector<bool> &bits);

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1052,12 +1052,7 @@ public:
 		resize(width, empty() ? RTLIL::State::Sx : back());
 	}
 
-	[[nodiscard]] Hasher hash_into(Hasher h) const {
-		h.eat(size());
-		for (auto b : *this)
-			h.eat(b);
-		return h;
-	}
+	[[nodiscard]] Hasher hash_into(Hasher h) const;
 };
 
 struct RTLIL::AttrObject

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -904,8 +904,8 @@ public:
 
 		const_iterator& operator++() { ++idx; return *this; }
 		const_iterator& operator--() { --idx; return *this; }
-		const_iterator& operator++(int) { ++idx; return *this; }
-		const_iterator& operator--(int) { --idx; return *this; }
+		const_iterator operator++(int) { const_iterator result(*this); ++idx; return result; }
+		const_iterator operator--(int) { const_iterator result(*this); --idx; return result; }
 		const_iterator& operator+=(int i) { idx += i; return *this; }
 
 		const_iterator operator+(int add) {

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -822,23 +822,27 @@ private:
 	using bitvectype = std::vector<RTLIL::State>;
 	enum class backing_tag: bool { bits, string };
 	// Do not access the union or tag even in Const methods unless necessary
-	mutable backing_tag tag;
+	backing_tag tag;
 	union {
-		mutable bitvectype bits_;
-		mutable std::string str_;
+		bitvectype bits_;
+		std::string str_;
 	};
 
 	// Use these private utilities instead
 	bool is_bits() const { return tag == backing_tag::bits; }
 	bool is_str() const { return tag == backing_tag::string; }
 
-	bitvectype* get_if_bits() const { return is_bits() ? &bits_ : NULL; }
-	std::string* get_if_str() const { return is_str() ? &str_ : NULL; }
+	bitvectype* get_if_bits() { return is_bits() ? &bits_ : NULL; }
+	std::string* get_if_str() { return is_str() ? &str_ : NULL; }
+	const bitvectype* get_if_bits() const { return is_bits() ? &bits_ : NULL; }
+	const std::string* get_if_str() const { return is_str() ? &str_ : NULL; }
 
-	bitvectype& get_bits() const;
-	std::string& get_str() const;
+	bitvectype& get_bits();
+	std::string& get_str();
+	const bitvectype& get_bits() const;
+	const std::string& get_str() const;
 	std::vector<RTLIL::State>& bits_internal();
-	void bitvectorize_internal() const;
+	void bitvectorize_internal();
 
 public:
 	Const() : flags(RTLIL::CONST_FLAG_NONE), tag(backing_tag::bits), bits_(std::vector<RTLIL::State>()) {}
@@ -871,7 +875,7 @@ public:
 	[[deprecated("Don't use direct access to the internal std::vector<State>, that's an implementation detail.")]]
 	std::vector<RTLIL::State>& bits() { return bits_internal(); }
 	[[deprecated("Don't call bitvectorize() directly, it's an implementation detail.")]]
-	void bitvectorize() const { bitvectorize_internal(); }
+	void bitvectorize() const { const_cast<Const*>(this)->bitvectorize_internal(); }
 
 	bool as_bool() const;
 

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -888,17 +888,17 @@ public:
 
 	class const_iterator {
 	private:
-		const Const& parent;
+		const Const* parent;
 		size_t idx;
 
 	public:
-		using iterator_category = std::input_iterator_tag;
+		using iterator_category = std::bidirectional_iterator_tag;
 		using value_type = State;
 		using difference_type = std::ptrdiff_t;
 		using pointer = const State*;
 		using reference = const State&;
 
-		const_iterator(const Const& c, size_t i) : parent(c), idx(i) {}
+		const_iterator(const Const& c, size_t i) : parent(&c), idx(i) {}
 
 		State operator*() const;
 
@@ -909,10 +909,10 @@ public:
 		const_iterator& operator+=(int i) { idx += i; return *this; }
 
 		const_iterator operator+(int add) {
-			return const_iterator(parent, idx + add);
+			return const_iterator(*parent, idx + add);
 		}
 		const_iterator operator-(int sub) {
-			return const_iterator(parent, idx - sub);
+			return const_iterator(*parent, idx - sub);
 		}
 		int operator-(const const_iterator& other) {
 			return idx - other.idx;

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1112,7 +1112,8 @@ struct RTLIL::SigChunk
 	SigChunk(RTLIL::Wire *wire) : wire(wire), width(GetSize(wire)), offset(0) {}
 	SigChunk(RTLIL::Wire *wire, int offset, int width = 1) : wire(wire), width(width), offset(offset) {}
 	SigChunk(const std::string &str) : SigChunk(RTLIL::Const(str)) {}
-	SigChunk(int val, int width = 32) : SigChunk(RTLIL::Const(val, width)) {}
+	SigChunk(int val) /*default width 32*/ : SigChunk(RTLIL::Const(val)) {}
+	SigChunk(int val, int width) : SigChunk(RTLIL::Const(val, width)) {}
 	SigChunk(RTLIL::State bit, int width = 1) : SigChunk(RTLIL::Const(bit, width)) {}
 	SigChunk(const RTLIL::SigBit &bit);
 

--- a/kernel/tclapi.cc
+++ b/kernel/tclapi.cc
@@ -214,18 +214,19 @@ bool mp_int_to_const(mp_int *a, Const &b, bool is_signed)
 	buf.resize(mp_unsigned_bin_size(a));
 	mp_to_unsigned_bin(a, buf.data());
 
-	b.bits().reserve(mp_count_bits(a) + is_signed);
+	Const::Builder b_bits(mp_count_bits(a) + is_signed);
 	for (int i = 0; i < mp_count_bits(a);) {
 		for (int j = 0; j < 8 && i < mp_count_bits(a); j++, i++) {
 			bool bv = ((buf.back() & (1 << j)) != 0) ^ negative;
-			b.bits().push_back(bv ? RTLIL::S1 : RTLIL::S0);
+			b_bits.push_back(bv ? RTLIL::S1 : RTLIL::S0);
 		}
 		buf.pop_back();
 	}
 
 	if (is_signed) {
-		b.bits().push_back(negative ? RTLIL::S1 : RTLIL::S0);
+		b_bits.push_back(negative ? RTLIL::S1 : RTLIL::S0);
 	}
+	b = b_bits.build();
 
 	return true;
 }

--- a/kernel/yw.cc
+++ b/kernel/yw.cc
@@ -185,7 +185,6 @@ RTLIL::Const ReadWitness::get_bits(int t, int bits_offset, int width) const
 	const std::string &bits = steps[t].bits;
 
 	RTLIL::Const result(State::Sa, width);
-	result.bits().reserve(width);
 
 	int read_begin = GetSize(bits) - 1 - bits_offset;
 	int read_end = max(-1, read_begin - width);
@@ -200,7 +199,7 @@ RTLIL::Const ReadWitness::get_bits(int t, int bits_offset, int width) const
 			default:
 				log_abort();
 		}
-		result.bits()[j] = bit;
+		result.set(j, bit);
 	}
 
 	return result;

--- a/passes/cmds/bugpoint.cc
+++ b/passes/cmds/bugpoint.cc
@@ -405,7 +405,11 @@ struct BugpointPass : public Pass {
 								for (auto it2 = sy->mem_write_actions.begin(); it2 != sy->mem_write_actions.end(); ++it2) {
 									auto &mask = it2->priority_mask;
 									if (GetSize(mask) > i) {
-										mask.bits().erase(mask.bits().begin() + i);
+										RTLIL::Const::Builder new_mask_builder(GetSize(mask) - 1);
+										for (int k = 0; k < GetSize(mask); k++)
+											if (k != i)
+												new_mask_builder.push_back(mask[k]);
+										mask = new_mask_builder.build();
 									}
 								}
 								return design_copy;

--- a/passes/cmds/clean_zerowidth.cc
+++ b/passes/cmds/clean_zerowidth.cc
@@ -158,11 +158,11 @@ struct CleanZeroWidthPass : public Pass {
 							continue;
 						if (GetSize(memwr.address) == 0)
 							memwr.address = State::S0;
-						Const priority_mask;
+						RTLIL::Const::Builder new_mask_bits(swizzle.size());
 						for (auto x : swizzle) {
-							priority_mask.bits().push_back(memwr.priority_mask[x]);
+							new_mask_bits.push_back(memwr.priority_mask[x]);
 						}
-						memwr.priority_mask = priority_mask;
+						memwr.priority_mask = new_mask_bits.build();
 						swizzle.push_back(i);
 						new_memwr_actions.push_back(memwr);
 					}

--- a/passes/cmds/dft_tag.cc
+++ b/passes/cmds/dft_tag.cc
@@ -884,8 +884,10 @@ struct DftTagWorker {
 	{
 		if (sig_a.is_fully_const()) {
 			auto const_val = sig_a.as_const();
-			for (State& bit : const_val.bits())
-				bit = bit == State::S0 ? State::S1 : bit == State::S1 ? State::S0 : bit;
+			for (auto bit : const_val) {
+				State b = bit;
+				bit = b == State::S0 ? State::S1 : b == State::S1 ? State::S0 : b;
+			}
 			return const_val;
 		}
 		return module->Not(name, sig_a);

--- a/passes/cmds/setundef.cc
+++ b/passes/cmds/setundef.cc
@@ -243,7 +243,7 @@ struct SetundefPass : public Pass {
 			{
 				for (auto *cell : module->selected_cells()) {
 					for (auto &parameter : cell->parameters) {
-						for (auto &bit : parameter.second.bits()) {
+						for (auto bit : parameter.second) {
 							if (bit > RTLIL::State::S1)
 								bit = worker.next_bit();
 						}
@@ -390,12 +390,12 @@ struct SetundefPass : public Pass {
 					for (auto wire : initwires)
 					{
 						Const &initval = wire->attributes[ID::init];
-						initval.bits().resize(GetSize(wire), State::Sx);
+						initval.resize(GetSize(wire), State::Sx);
 
 						for (int i = 0; i < GetSize(wire); i++) {
 							SigBit bit = sigmap(SigBit(wire, i));
 							if (initval[i] == State::Sx && ffbits.count(bit)) {
-								initval.bits()[i] = worker.next_bit();
+								initval.set(i, worker.next_bit());
 								ffbits.erase(bit);
 							}
 						}
@@ -421,7 +421,7 @@ struct SetundefPass : public Pass {
 								continue;
 
 							Const &initval = wire->attributes[ID::init];
-							initval.bits().resize(GetSize(wire), State::Sx);
+							initval.resize(GetSize(wire), State::Sx);
 
 							if (initval.is_fully_undef()) {
 								wire->attributes.erase(ID::init);

--- a/passes/cmds/splitnets.cc
+++ b/passes/cmds/splitnets.cc
@@ -75,10 +75,11 @@ struct SplitnetsWorker
 
 		it = wire->attributes.find(ID::init);
 		if (it != wire->attributes.end()) {
-			Const old_init = it->second, new_init;
+			Const old_init = it->second;
+			RTLIL::Const::Builder new_init_bits_builder(width);
 			for (int i = offset; i < offset+width; i++)
-				new_init.bits().push_back(i < GetSize(old_init) ? old_init.at(i) : State::Sx);
-			new_wire->attributes.emplace(ID::init, new_init);
+				new_init_bits_builder.push_back(i < GetSize(old_init) ? old_init.at(i) : State::Sx);
+			new_wire->attributes.emplace(ID::init, new_init_bits_builder.build());
 		}
 
 		std::vector<RTLIL::SigBit> sigvec = RTLIL::SigSpec(new_wire).to_sigbit_vector();

--- a/passes/cmds/xprop.cc
+++ b/passes/cmds/xprop.cc
@@ -828,9 +828,9 @@ struct XpropWorker
 			auto init_q_is_1 = init_q;
 			auto init_q_is_x = init_q;
 
-			for (auto &bit : init_q_is_1.bits())
+			for (auto bit : init_q_is_1)
 				bit = bit == State::S1 ? State::S1 : State::S0;
-			for (auto &bit : init_q_is_x.bits())
+			for (auto bit : init_q_is_x)
 				bit = bit == State::Sx ? State::S1 : State::S0;
 
 			initvals.remove_init(sig_q);
@@ -865,14 +865,14 @@ struct XpropWorker
 					auto init_q_is_x = init_q;
 
 					if (ff.is_anyinit) {
-						for (auto &bit : init_q_is_1.bits())
+						for (auto bit : init_q_is_1)
 							bit = State::Sx;
-						for (auto &bit : init_q_is_x.bits())
+						for (auto bit : init_q_is_x)
 							bit = State::S0;
 					} else {
-						for (auto &bit : init_q_is_1.bits())
+						for (auto bit : init_q_is_1)
 							bit = bit == State::S1 ? State::S1 : State::S0;
-						for (auto &bit : init_q_is_x.bits())
+						for (auto bit : init_q_is_x)
 							bit = bit == State::Sx ? State::S1 : State::S0;
 					}
 

--- a/passes/fsm/fsm_extract.cc
+++ b/passes/fsm/fsm_extract.cc
@@ -171,7 +171,7 @@ undef_bit_in_next_state:
 			if (tr.ctrl_in.at(it.second) == State::S1 && exclusive_ctrls.count(it.first) != 0)
 				for (auto &dc_bit : exclusive_ctrls.at(it.first))
 					if (ctrl_in_bit_indices.count(dc_bit))
-						tr.ctrl_in.bits().at(ctrl_in_bit_indices.at(dc_bit)) = RTLIL::State::Sa;
+						tr.ctrl_in.set(ctrl_in_bit_indices.at(dc_bit), RTLIL::State::Sa);
 
 		RTLIL::Const log_state_in = RTLIL::Const(RTLIL::State::Sx, fsm_data.state_bits);
 		if (state_in >= 0)

--- a/passes/fsm/fsm_map.cc
+++ b/passes/fsm/fsm_map.cc
@@ -176,7 +176,7 @@ static void map_fsm(RTLIL::Cell *fsm_cell, RTLIL::Module *module)
 		state_dff->type = ID($adff);
 		state_dff->parameters[ID::ARST_POLARITY] = fsm_cell->parameters[ID::ARST_POLARITY];
 		state_dff->parameters[ID::ARST_VALUE] = fsm_data.state_table[fsm_data.reset_state];
-		for (auto &bit : state_dff->parameters[ID::ARST_VALUE].bits())
+		for (auto bit : state_dff->parameters[ID::ARST_VALUE])
 			if (bit != RTLIL::State::S1)
 				bit = RTLIL::State::S0;
 		state_dff->setPort(ID::ARST, fsm_cell->getPort(ID::ARST));

--- a/passes/fsm/fsm_opt.cc
+++ b/passes/fsm/fsm_opt.cc
@@ -169,13 +169,16 @@ struct FsmOpt
 
 				for (auto tr : fsm_data.transition_table)
 				{
-					RTLIL::State &si = tr.ctrl_in.bits()[i];
-					RTLIL::State &sj = tr.ctrl_in.bits()[j];
+					RTLIL::State si = tr.ctrl_in[i];
+					RTLIL::State sj = tr.ctrl_in[j];
 
-					if (si > RTLIL::State::S1)
+					if (si > RTLIL::State::S1) {
 						si = sj;
-					else if (sj > RTLIL::State::S1)
+						tr.ctrl_in.set(i, si);
+					} else if (sj > RTLIL::State::S1) {
 						sj = si;
+						tr.ctrl_in.set(j, sj);
+					}
 
 					if (si == sj) {
 						RTLIL::SigSpec tmp(tr.ctrl_in);
@@ -207,8 +210,8 @@ struct FsmOpt
 
 				for (auto tr : fsm_data.transition_table)
 				{
-					RTLIL::State &si = tr.ctrl_in.bits()[i];
-					RTLIL::State &sj = tr.ctrl_out.bits()[j];
+					RTLIL::State si = tr.ctrl_in[i];
+					RTLIL::State sj = tr.ctrl_out[j];
 
 					if (si > RTLIL::State::S1 || si == sj) {
 						RTLIL::SigSpec tmp(tr.ctrl_in);
@@ -240,14 +243,14 @@ struct FsmOpt
 			RTLIL::Const other_pattern = pattern;
 
 			if (pattern[bit] == RTLIL::State::S1)
-				other_pattern.bits()[bit] = RTLIL::State::S0;
+				other_pattern.set(bit, RTLIL::State::S0);
 			else
-				other_pattern.bits()[bit] = RTLIL::State::S1;
+				other_pattern.set(bit, RTLIL::State::S1);
 
 			if (set.count(other_pattern) > 0) {
 				log("  Merging pattern %s and %s from group (%d %d %s).\n", log_signal(pattern), log_signal(other_pattern),
 						tr.state_in, tr.state_out, log_signal(tr.ctrl_out));
-				other_pattern.bits()[bit] = RTLIL::State::Sa;
+				other_pattern.set(bit, RTLIL::State::Sa);
 				new_set.insert(other_pattern);
 				did_something = true;
 				continue;

--- a/passes/fsm/fsm_recode.cc
+++ b/passes/fsm/fsm_recode.cc
@@ -106,7 +106,7 @@ static void fsm_recode(RTLIL::Cell *cell, RTLIL::Module *module, FILE *fm_set_fs
 
 		if (encoding == "one-hot") {
 			new_code = RTLIL::Const(RTLIL::State::Sa, fsm_data.state_bits);
-			new_code.bits()[state_idx] = RTLIL::State::S1;
+			new_code.set(state_idx, RTLIL::State::S1);
 		} else
 		if (encoding == "binary") {
 			new_code = RTLIL::Const(state_idx, fsm_data.state_bits);

--- a/passes/fsm/fsmdata.h
+++ b/passes/fsm/fsmdata.h
@@ -45,35 +45,27 @@ struct FsmData
 		cell->parameters[ID::STATE_NUM] = RTLIL::Const(state_table.size());
 		cell->parameters[ID::STATE_NUM_LOG2] = RTLIL::Const(state_num_log2);
 		cell->parameters[ID::STATE_RST] = RTLIL::Const(reset_state);
-		cell->parameters[ID::STATE_TABLE] = RTLIL::Const();
-
-		for (int i = 0; i < int(state_table.size()); i++) {
-			std::vector<RTLIL::State> &bits_table = cell->parameters[ID::STATE_TABLE].bits();
-			std::vector<RTLIL::State> &bits_state = state_table[i].bits();
-			bits_table.insert(bits_table.end(), bits_state.begin(), bits_state.end());
-		}
+		RTLIL::Const cell_state_table;
+		for (const RTLIL::Const &c : state_table)
+			cell_state_table.append(c);
+		cell->parameters[ID::STATE_TABLE] = std::move(cell_state_table);
 
 		cell->parameters[ID::TRANS_NUM] = RTLIL::Const(transition_table.size());
-		cell->parameters[ID::TRANS_TABLE] = RTLIL::Const();
+		RTLIL::Const cell_trans_table;
 		for (int i = 0; i < int(transition_table.size()); i++)
 		{
-			std::vector<RTLIL::State> &bits_table = cell->parameters[ID::TRANS_TABLE].bits();
 			transition_t &tr = transition_table[i];
 
 			RTLIL::Const const_state_in = RTLIL::Const(tr.state_in, state_num_log2);
 			RTLIL::Const const_state_out = RTLIL::Const(tr.state_out, state_num_log2);
-			std::vector<RTLIL::State> &bits_state_in = const_state_in.bits();
-			std::vector<RTLIL::State> &bits_state_out = const_state_out.bits();
-
-			std::vector<RTLIL::State> &bits_ctrl_in = tr.ctrl_in.bits();
-			std::vector<RTLIL::State> &bits_ctrl_out = tr.ctrl_out.bits();
 
 			// append lsb first
-			bits_table.insert(bits_table.end(), bits_ctrl_out.begin(), bits_ctrl_out.end());
-			bits_table.insert(bits_table.end(), bits_state_out.begin(), bits_state_out.end());
-			bits_table.insert(bits_table.end(), bits_ctrl_in.begin(), bits_ctrl_in.end());
-			bits_table.insert(bits_table.end(), bits_state_in.begin(), bits_state_in.end());
+			cell_trans_table.append(tr.ctrl_out);
+			cell_trans_table.append(const_state_out);
+			cell_trans_table.append(tr.ctrl_in);
+			cell_trans_table.append(const_state_in);
 		}
+		cell->parameters[ID::TRANS_TABLE] = std::move(cell_trans_table);
 	}
 
 	void copy_from_cell(RTLIL::Cell *cell)
@@ -95,25 +87,18 @@ struct FsmData
 		const RTLIL::Const &trans_table = cell->parameters[ID::TRANS_TABLE];
 
 		for (int i = 0; i < state_num; i++) {
-			RTLIL::Const state_code;
-			int off_begin = i*state_bits, off_end = off_begin + state_bits;
-			state_code.bits().insert(state_code.bits().begin(), state_table.begin()+off_begin, state_table.begin()+off_end);
+			int off_begin = i*state_bits;
+			RTLIL::Const state_code = state_table.extract(off_begin, state_bits);
 			this->state_table.push_back(state_code);
 		}
 
 		for (int i = 0; i < trans_num; i++)
 		{
-			auto off_ctrl_out = trans_table.begin() + i*(num_inputs+num_outputs+2*state_num_log2);
-			auto off_state_out = off_ctrl_out + num_outputs;
-			auto off_ctrl_in = off_state_out + state_num_log2;
-			auto off_state_in = off_ctrl_in + num_inputs;
-			auto off_end = off_state_in + state_num_log2;
-
-			RTLIL::Const state_in, state_out, ctrl_in, ctrl_out;
-			ctrl_out.bits().insert(ctrl_out.bits().begin(), off_ctrl_out, off_state_out);
-			state_out.bits().insert(state_out.bits().begin(), off_state_out, off_ctrl_in);
-			ctrl_in.bits().insert(ctrl_in.bits().begin(), off_ctrl_in, off_state_in);
-			state_in.bits().insert(state_in.bits().begin(), off_state_in, off_end);
+			int base_offset = i*(num_inputs+num_outputs+2*state_num_log2);
+			RTLIL::Const ctrl_out = trans_table.extract(base_offset, num_outputs);
+			RTLIL::Const state_out = trans_table.extract(base_offset + num_outputs, state_num_log2);
+			RTLIL::Const ctrl_in = trans_table.extract(base_offset + num_outputs + state_num_log2, num_inputs);
+			RTLIL::Const state_in = trans_table.extract(base_offset + num_outputs + state_num_log2 + num_inputs, state_num_log2);
 
 			transition_t tr;
 			tr.state_in = state_in.as_int();

--- a/passes/hierarchy/submod.cc
+++ b/passes/hierarchy/submod.cc
@@ -79,7 +79,7 @@ struct SubmodWorker
 				flag_wire(c.wire, create, set_int_used, set_ext_driven, set_ext_used);
 				if (set_int_driven)
 					for (int i = c.offset; i < c.offset+c.width; i++) {
-						wire_flags.at(c.wire).is_int_driven.bits()[i] = State::S1;
+						wire_flags.at(c.wire).is_int_driven.set(i, State::S1);
 						flag_found_something = true;
 					}
 			}
@@ -185,8 +185,8 @@ struct SubmodWorker
 					auto it = sig[i].wire->attributes.find(ID::init);
 					if (it != sig[i].wire->attributes.end()) {
 						auto jt = new_wire->attributes.insert(std::make_pair(ID::init, Const(State::Sx, GetSize(sig)))).first;
-						jt->second.bits()[i] = it->second[sig[i].offset];
-						it->second.bits()[sig[i].offset] = State::Sx;
+						jt->second.set(i, it->second[sig[i].offset]);
+						it->second.set(sig[i].offset, State::Sx);
 					}
 				}
 			}

--- a/passes/memory/memory_bram.cc
+++ b/passes/memory/memory_bram.cc
@@ -848,9 +848,9 @@ grow_read_ports:;
 		for (int i = 0; i < mem.width; i++)
 			if (shuffle_map[i] != -1) {
 				module->connect(port.data[shuffle_map[i]], new_data[i]);
-				new_init_value.bits()[i] = port.init_value[shuffle_map[i]];
-				new_arst_value.bits()[i] = port.arst_value[shuffle_map[i]];
-				new_srst_value.bits()[i] = port.srst_value[shuffle_map[i]];
+				new_init_value.set(i, port.init_value[shuffle_map[i]]);
+				new_arst_value.set(i, port.arst_value[shuffle_map[i]]);
+				new_srst_value.set(i, port.srst_value[shuffle_map[i]]);
 			}
 		port.data = new_data;
 		port.init_value = new_init_value;
@@ -887,9 +887,9 @@ grow_read_ports:;
 				for (int i = 0; i < init_size; i++)
 					for (int j = 0; j < bram.dbits; j++)
 						if (init_offset+i < GetSize(initdata) && init_offset+i >= 0)
-							initparam.bits()[i*bram.dbits+j] = initdata[init_offset+i][init_shift+j];
+							initparam.set(i*bram.dbits+j, initdata[init_offset+i][init_shift+j]);
 						else
-							initparam.bits()[i*bram.dbits+j] = State::Sx;
+							initparam.set(i*bram.dbits+j, State::Sx);
 				c->setParam(ID::INIT, initparam);
 			}
 

--- a/passes/memory/memory_share.cc
+++ b/passes/memory/memory_share.cc
@@ -60,16 +60,17 @@ struct MemoryShareWorker
 	bool merge_rst_value(Mem &mem, Const &res, int wide_log2, const Const &src1, int sub1, const Const &src2, int sub2) {
 		res = Const(State::Sx, mem.width << wide_log2);
 		for (int i = 0; i < GetSize(src1); i++)
-			res.bits()[i + sub1 * mem.width] = src1[i];
+			res.set(i + sub1 * mem.width, src1[i]);
 		for (int i = 0; i < GetSize(src2); i++) {
 			if (src2[i] == State::Sx)
 				continue;
-			auto &dst = res.bits()[i + sub2 * mem.width];
+			int idx = i + sub2 * mem.width;
+			RTLIL::State dst = res[idx];
 			if (dst == src2[i])
 				continue;
 			if (dst != State::Sx)
 				return false;
-			dst = src2[i];
+			res.set(idx, src2[i]);
 		}
 		return true;
 	}

--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -406,7 +406,7 @@ bool rmunused_module_signals(RTLIL::Module *module, bool purge_mode, bool verbos
 		for (int i = 0; i < wire->width; i++) {
 			auto it = init_bits.find(RTLIL::SigBit(wire, i));
 			if (it != init_bits.end()) {
-				val.bits()[i] = it->second;
+				val.set(i, it->second);
 				found = true;
 			}
 		}
@@ -425,7 +425,7 @@ bool rmunused_module_signals(RTLIL::Module *module, bool purge_mode, bool verbos
 		if (wire->attributes.count(ID::init))
 			initval = wire->attributes.at(ID::init);
 		if (GetSize(initval) != GetSize(wire))
-			initval.bits().resize(GetSize(wire), State::Sx);
+			initval.resize(GetSize(wire), State::Sx);
 		if (initval.is_fully_undef())
 			wire->attributes.erase(ID::init);
 
@@ -457,7 +457,7 @@ bool rmunused_module_signals(RTLIL::Module *module, bool purge_mode, bool verbos
 				if (s1[i] != s2[i]) {
 					if (s2[i] == State::Sx && (initval[i] == State::S0 || initval[i] == State::S1)) {
 						s2[i] = initval[i];
-						initval.bits()[i] = State::Sx;
+						initval.set(i, State::Sx);
 					}
 					new_conn.first.append(s1[i]);
 					new_conn.second.append(s2[i]);

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -83,7 +83,7 @@ void replace_undriven(RTLIL::Module *module, const CellTypes &ct)
 			auto cursor = initbits.find(bit);
 			if (cursor != initbits.end()) {
 				revisit_initwires.insert(cursor->second.first);
-				val.bits()[i] = cursor->second.second;
+				val.set(i, cursor->second.second);
 			}
 		}
 
@@ -101,7 +101,7 @@ void replace_undriven(RTLIL::Module *module, const CellTypes &ct)
 			Const initval = wire->attributes.at(ID::init);
 			for (int i = 0; i < GetSize(initval) && i < GetSize(wire); i++) {
 				if (SigBit(initval[i]) == sig[i])
-					initval.bits()[i] = State::Sx;
+					initval.set(i, State::Sx);
 			}
 			if (initval.is_fully_undef()) {
 				log_debug("Removing init attribute from %s/%s.\n", log_id(module), log_id(wire));

--- a/passes/opt/opt_ffinv.cc
+++ b/passes/opt/opt_ffinv.cc
@@ -96,10 +96,10 @@ struct OptFfInvWorker
 					}
 				}
 				Const mask = lut->getParam(ID::LUT);
-				Const new_mask;
-				for (int j = 0; j < (1 << GetSize(sig_a)); j++) {
-					new_mask.bits().push_back(mask[j ^ flip_mask]);
-				}
+				Const::Builder new_mask_builder(1 << GetSize(sig_a));
+				for (int j = 0; j < (1 << GetSize(sig_a)); j++)
+					new_mask_builder.push_back(mask[j ^ flip_mask]);
+				Const new_mask = new_mask_builder.build();
 				if (GetSize(sig_a) == 1 && new_mask.as_int() == 2) {
 					module->connect(lut->getPort(ID::Y), ff.sig_q);
 					module->remove(lut);
@@ -178,13 +178,14 @@ struct OptFfInvWorker
 
 		if (d_lut->type == ID($lut)) {
 			Const mask = d_lut->getParam(ID::LUT);
-			Const new_mask;
+			Const::Builder new_mask_builder(GetSize(mask));
 			for (int i = 0; i < GetSize(mask); i++) {
 				if (mask[i] == State::S0)
-					new_mask.bits().push_back(State::S1);
+					new_mask_builder.push_back(State::S1);
 				else
-					new_mask.bits().push_back(State::S0);
+					new_mask_builder.push_back(State::S0);
 			}
+			Const new_mask = new_mask_builder.build();
 			d_lut->setParam(ID::LUT, new_mask);
 			if (d_lut->getParam(ID::WIDTH) == 1 && new_mask.as_int() == 2) {
 				module->connect(ff.sig_d, d_lut->getPort(ID::A));

--- a/passes/opt/opt_lut.cc
+++ b/passes/opt/opt_lut.cc
@@ -493,7 +493,7 @@ struct OptLutWorker
 							eval_inputs[lutM_new_inputs[i]] = (eval >> i) & 1;
 						}
 						eval_inputs[lutA_output] = evaluate_lut(lutA, eval_inputs);
-						lutM_new_table.bits()[eval] = (RTLIL::State) evaluate_lut(lutB, eval_inputs);
+						lutM_new_table.set(eval, (RTLIL::State) evaluate_lut(lutB, eval_inputs));
 					}
 
 					log_debug("  Cell A truth table: %s.\n", lutA->getParam(ID::LUT).as_string().c_str());

--- a/passes/opt/opt_lut_ins.cc
+++ b/passes/opt/opt_lut_ins.cc
@@ -213,7 +213,7 @@ struct OptLutInsPass : public Pass {
 						}
 						lidx |= val << j;
 					}
-					new_lut.bits()[i] = lut[lidx];
+					new_lut.set(i, lut[lidx]);
 				}
 				// For lattice, and gowin do not replace with a const driver — the nextpnr
 				// packer requires a complete set of LUTs for wide LUT muxes.

--- a/passes/opt/opt_mem.cc
+++ b/passes/opt/opt_mem.cc
@@ -175,36 +175,36 @@ struct OptMemPass : public Pass {
 					}
 					for (auto &port: mem.rd_ports) {
 						SigSpec new_data;
-						Const new_init;
-						Const new_arst;
-						Const new_srst;
+						Const::Builder new_init_bits;
+						Const::Builder new_arst_bits;
+						Const::Builder new_srst_bits;
 						for (int sub = 0; sub < (1 << port.wide_log2); sub++) {
 							for (auto i: swizzle) {
 								int bidx = sub * mem.width + i;
 								new_data.append(port.data[bidx]);
-								new_init.bits().push_back(port.init_value[bidx]);
-								new_arst.bits().push_back(port.arst_value[bidx]);
-								new_srst.bits().push_back(port.srst_value[bidx]);
+								new_init_bits.push_back(port.init_value[bidx]);
+								new_arst_bits.push_back(port.arst_value[bidx]);
+								new_srst_bits.push_back(port.srst_value[bidx]);
 							}
 						}
 						port.data = new_data;
-						port.init_value = new_init;
-						port.arst_value = new_arst;
-						port.srst_value = new_srst;
+						port.init_value = new_init_bits.build();
+						port.arst_value = new_arst_bits.build();
+						port.srst_value = new_srst_bits.build();
 					}
 					for (auto &init: mem.inits) {
-						Const new_data;
-						Const new_en;
+						Const::Builder new_data_bits;
 						for (int s = 0; s < GetSize(init.data); s += mem.width) {
 							for (auto i: swizzle) {
-								new_data.bits().push_back(init.data[s + i]);
+								new_data_bits.push_back(init.data[s + i]);
 							}
 						}
+						init.data = new_data_bits.build();
+						Const::Builder new_en_bits;
 						for (auto i: swizzle) {
-							new_en.bits().push_back(init.en[i]);
+							new_en_bits.push_back(init.en[i]);
 						}
-						init.data = new_data;
-						init.en = new_en;
+						init.en = new_en_bits.build();
 					}
 					mem.width = GetSize(swizzle);
 					changed = true;

--- a/passes/opt/pmux2shiftx.cc
+++ b/passes/opt/pmux2shiftx.cc
@@ -321,11 +321,12 @@ struct Pmux2ShiftxPass : public Pass {
 
 					bits.sort();
 					pair<SigSpec, Const> entry;
-
+					RTLIL::Const::Builder entry_bits_builder(GetSize(bits));
 					for (auto it : bits) {
 						entry.first.append(it.first);
-						entry.second.bits().push_back(it.second);
+						entry_bits_builder.push_back(it.second);
 					}
+					entry.second = entry_bits_builder.build();
 
 					eqdb[sigmap(cell->getPort(ID::Y)[0])] = entry;
 					goto next_cell;
@@ -342,11 +343,12 @@ struct Pmux2ShiftxPass : public Pass {
 
 					bits.sort();
 					pair<SigSpec, Const> entry;
-
+					RTLIL::Const::Builder entry_bits_builder(GetSize(bits));
 					for (auto it : bits) {
 						entry.first.append(it.first);
-						entry.second.bits().push_back(it.second);
+						entry_bits_builder.push_back(it.second);
 					}
+					entry.second = entry_bits_builder.build();
 
 					eqdb[sigmap(cell->getPort(ID::Y)[0])] = entry;
 					goto next_cell;
@@ -591,7 +593,7 @@ struct Pmux2ShiftxPass : public Pass {
 
 							used_src_columns[best_src_col] = true;
 							perm_new_from_old[dst_col] = best_src_col;
-							perm_xormask.bits()[dst_col] = best_inv ? State::S1 : State::S0;
+							perm_xormask.set(dst_col, best_inv ? State::S1 : State::S0);
 						}
 					}
 
@@ -614,7 +616,7 @@ struct Pmux2ShiftxPass : public Pass {
 						Const new_c(State::S0, GetSize(old_c));
 
 						for (int i = 0; i < GetSize(old_c); i++)
-							new_c.bits()[i] = old_c[perm_new_from_old[i]];
+							new_c.set(i, old_c[perm_new_from_old[i]]);
 
 						Const new_c_before_xor = new_c;
 						new_c = const_xor(new_c, perm_xormask, false, false, GetSize(new_c));
@@ -687,7 +689,7 @@ struct Pmux2ShiftxPass : public Pass {
 					if (!full_case) {
 						Const enable_mask(State::S0, max_choice+1);
 						for (auto &it : perm_choices)
-							enable_mask.bits()[it.first.as_int()] = State::S1;
+							enable_mask.set(it.first.as_int(), State::S1);
 						en = module->addWire(NEW_ID);
 						module->addShift(NEW_ID, enable_mask, cmp, en, false, src);
 					}

--- a/passes/opt/wreduce.cc
+++ b/passes/opt/wreduce.cc
@@ -220,10 +220,10 @@ struct WreduceWorker
 
 		// Narrow ARST_VALUE parameter to new size.
 		if (cell->parameters.count(ID::ARST_VALUE)) {
-			rst_value.bits().resize(GetSize(sig_q));
+			rst_value.resize(GetSize(sig_q), State::S0);
 			cell->setParam(ID::ARST_VALUE, rst_value);
 		} else if (cell->parameters.count(ID::SRST_VALUE)) {
-			rst_value.bits().resize(GetSize(sig_q));
+			rst_value.resize(GetSize(sig_q), State::S0);
 			cell->setParam(ID::SRST_VALUE, rst_value);
 		}
 

--- a/passes/proc/proc_init.cc
+++ b/passes/proc/proc_init.cc
@@ -52,17 +52,15 @@ void proc_init(RTLIL::Module *mod, SigMap &sigmap, RTLIL::Process *proc)
 
 						Const value = valuesig.as_const();
 						Const &wireinit = lhs_c.wire->attributes[ID::init];
-
-						while (GetSize(wireinit) < lhs_c.wire->width)
-							wireinit.bits().push_back(State::Sx);
-
+						if (GetSize(wireinit) < lhs_c.wire->width)
+							wireinit.resize(lhs_c.wire->width, State::Sx);
 						for (int i = 0; i < lhs_c.width; i++) {
-							auto &initbit = wireinit.bits()[i + lhs_c.offset];
+							int index = i + lhs_c.offset;
+							State initbit = wireinit[index];
 							if (initbit != State::Sx && initbit != value[i])
 								log_cmd_error("Conflicting initialization values for %s.\n", log_signal(lhs_c));
-							initbit = value[i];
+							wireinit.set(index, value[i]);
 						}
-
 						log("  Set init value: %s = %s\n", log_signal(lhs_c.wire), log_signal(wireinit));
 					}
 					offset += lhs_c.width;

--- a/passes/proc/proc_memwr.cc
+++ b/passes/proc/proc_memwr.cc
@@ -39,7 +39,7 @@ void proc_memwr(RTLIL::Module *mod, RTLIL::Process *proc, dict<IdString, int> &n
 			Const priority_mask(State::S0, port_id);
 			for (int i = 0; i < GetSize(prev_port_ids); i++)
 				if (memwr.priority_mask[i] == State::S1)
-					priority_mask.bits()[prev_port_ids[i]] = State::S1;
+					priority_mask.set(prev_port_ids[i], State::S1);
 			prev_port_ids.push_back(port_id);
 
 			RTLIL::Cell *cell = mod->addCell(NEW_ID, ID($memwr_v2));

--- a/passes/sat/eval.cc
+++ b/passes/sat/eval.cc
@@ -256,7 +256,7 @@ struct VlogHammerReporter
 					for (int j = input_widths[i]-1; j >= 0; j--) {
 						ce.set(RTLIL::SigSpec(wire, j), bits.back());
 						recorded_set_vars.append(RTLIL::SigSpec(wire, j));
-						recorded_set_vals.bits().push_back(bits.back());
+						recorded_set_vars.append(RTLIL::Const(bits.back()));
 						bits.pop_back();
 					}
 					if (module == modules.front()) {
@@ -346,7 +346,7 @@ struct VlogHammerReporter
 				log_error("Pattern %s is to short!\n", pattern);
 			patterns.push_back(sig.as_const());
 			if (invert_pattern) {
-				for (auto &bit : patterns.back().bits())
+				for (auto bit : patterns.back())
 					if (bit == RTLIL::State::S0)
 						bit = RTLIL::State::S1;
 					else if (bit == RTLIL::State::S1)

--- a/passes/sat/formalff.cc
+++ b/passes/sat/formalff.cc
@@ -851,7 +851,7 @@ struct FormalFfPass : public Pass {
 						auto before = ff.val_init;
 						for (int i = 0; i < ff.width; i++)
 							if (ff.val_init[i] == State::Sx && !worker.is_initval_used(ff.sig_q[i]))
-								ff.val_init.bits()[i] = State::S0;
+								ff.val_init.set(i, State::S0);
 
 						if (ff.val_init != before) {
 							log("Setting unused undefined initial value of %s.%s (%s) from %s to %s\n",

--- a/passes/sat/sat.cc
+++ b/passes/sat/sat.cc
@@ -620,14 +620,18 @@ struct SatHelper
 		int last_timestep = -2;
 		for (auto &info : modelInfo)
 		{
-			RTLIL::Const value;
 			bool found_undef = false;
 
+			RTLIL::Const::Builder value_builder(info.width);
 			for (int i = 0; i < info.width; i++) {
-				value.bits().push_back(modelValues.at(info.offset+i) ? RTLIL::State::S1 : RTLIL::State::S0);
-				if (enable_undef && modelValues.at(modelExpressions.size()/2 + info.offset + i))
-					value.bits().back() = RTLIL::State::Sx, found_undef = true;
+				RTLIL::State bit = modelValues.at(info.offset+i) ? RTLIL::State::S1 : RTLIL::State::S0;
+				if (enable_undef && modelValues.at(modelExpressions.size()/2 + info.offset + i)) {
+					bit = RTLIL::State::Sx;
+					found_undef = true;
+				}
+				value_builder.push_back(bit);
 			}
+			RTLIL::Const value = value_builder.build();
 
 			if (info.timestep != last_timestep) {
 				const char *hline = "---------------------------------------------------------------------------------------------------"
@@ -732,13 +736,14 @@ struct SatHelper
 		int last_timestep = -2;
 		for (auto &info : modelInfo)
 		{
-			RTLIL::Const value;
-
+			RTLIL::Const::Builder value_builder(info.width);
 			for (int i = 0; i < info.width; i++) {
-				value.bits().push_back(modelValues.at(info.offset+i) ? RTLIL::State::S1 : RTLIL::State::S0);
+				RTLIL::State bit = modelValues.at(info.offset+i) ? RTLIL::State::S1 : RTLIL::State::S0;
 				if (enable_undef && modelValues.at(modelExpressions.size()/2 + info.offset + i))
-					value.bits().back() = RTLIL::State::Sx;
+					bit = RTLIL::State::Sx;
+				value_builder.push_back(bit);
 			}
+			RTLIL::Const value = value_builder.build();
 
 			if (info.timestep != last_timestep) {
 				if(last_timestep == 0)
@@ -779,12 +784,14 @@ struct SatHelper
 
 		for (auto &info : modelInfo)
 		{
-			Const value;
+			RTLIL::Const::Builder value_builder(info.width);
 			for (int i = 0; i < info.width; i++) {
-				value.bits().push_back(modelValues.at(info.offset+i) ? RTLIL::State::S1 : RTLIL::State::S0);
+				RTLIL::State bit = modelValues.at(info.offset+i) ? RTLIL::State::S1 : RTLIL::State::S0;
 				if (enable_undef && modelValues.at(modelExpressions.size()/2 + info.offset + i))
-					value.bits().back() = RTLIL::State::Sx;
+					bit = RTLIL::State::Sx;
+				value_builder.push_back(bit);
 			}
+			Const value = value_builder.build();
 
 			wavedata[info.description].first = info.width;
 			wavedata[info.description].second[info.timestep] = value;

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -1216,7 +1216,7 @@ void reintegrate(RTLIL::Module *module, bool dff_mode)
 			auto Qi = initmap(Q);
 			auto it = Qi.wire->attributes.find(ID::init);
 			if (it != Qi.wire->attributes.end())
-				it->second.bits()[Qi.offset] = State::Sx;
+				it->second.set(Qi.offset, State::Sx);
 		}
 		else if (cell->type.in(ID($_AND_), ID($_NOT_)))
 			module->remove(cell);
@@ -1526,8 +1526,11 @@ void reintegrate(RTLIL::Module *module, bool dff_mode)
 			log_assert(index < GetSize(A));
 			int i = 0;
 			while (i < GetSize(mask)) {
-				for (int j = 0; j < (1 << index); j++)
-					std::swap(mask.bits()[i+j], mask.bits()[i+j+(1 << index)]);
+				for (int j = 0; j < (1 << index); j++) {
+					State bit = mask[i+j];
+					mask.set(i+j, mask[i+j+(1 << index)]);
+					mask.set(i+j+(1 << index), bit);
+				}
 				i += 1 << (index+1);
 			}
 			A[index] = y_bit;
@@ -1542,7 +1545,7 @@ void reintegrate(RTLIL::Module *module, bool dff_mode)
 		// and get cleaned away
 clone_lut:
 		driver_mask = driver_lut->getParam(ID::LUT);
-		for (auto &b : driver_mask.bits()) {
+		for (auto b : driver_mask) {
 			if (b == RTLIL::State::S0) b = RTLIL::State::S1;
 			else if (b == RTLIL::State::S1) b = RTLIL::State::S0;
 		}

--- a/passes/techmap/dffinit.cc
+++ b/passes/techmap/dffinit.cc
@@ -118,13 +118,13 @@ struct DffinitPass : public Pass {
 					for (int i = 0; i < GetSize(sig); i++) {
 						if (initval[i] == State::Sx)
 							continue;
-						while (GetSize(value) <= i)
-							value.bits().push_back(State::S0);
+						if (GetSize(value) <= i)
+							value.resize(i + 1, State::S0);
 						if (noreinit && value[i] != State::Sx && value[i] != initval[i])
 							log_error("Trying to assign a different init value for %s.%s.%s which technically "
 									"have a conflicted init value.\n",
 									log_id(module), log_id(cell), log_id(it.second));
-						value.bits()[i] = initval[i];
+						value.set(i, initval[i]);
 					}
 
 					if (highlow_mode && GetSize(value) != 0) {

--- a/passes/techmap/dfflegalize.cc
+++ b/passes/techmap/dfflegalize.cc
@@ -869,17 +869,17 @@ struct DffLegalizePass : public Pass {
 			if (ff.has_arst) {
 				if (ff.val_arst[i] == State::Sx) {
 					if (!(supported & (mask << 8)))
-						ff.val_arst.bits()[i] = State::S0;
+						ff.val_arst.set(i, State::S0);
 					if (!(supported & (mask << 4)))
-						ff.val_arst.bits()[i] = State::S1;
+						ff.val_arst.set(i, State::S1);
 				}
 			}
 			if (ff.has_srst) {
 				if (ff.val_srst[i] == State::Sx) {
 					if (!(supported & (mask << 8)))
-						ff.val_srst.bits()[i] = State::S0;
+						ff.val_srst.set(i, State::S0);
 					if (!(supported & (mask << 4)))
-						ff.val_srst.bits()[i] = State::S1;
+						ff.val_srst.set(i, State::S1);
 				}
 			}
 		}

--- a/passes/techmap/flowmap.cc
+++ b/passes/techmap/flowmap.cc
@@ -1401,7 +1401,7 @@ struct FlowmapWorker
 					          log_signal(node), log_signal(undef), env.c_str());
 				}
 
-				lut_table.bits()[i] = value.as_bool() ? State::S1 : State::S0;
+				lut_table.set(i, value.as_bool() ? State::S1 : State::S0);
 				ce.pop();
 			}
 

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -680,15 +680,16 @@ struct TechmapWorker
 
 					for (auto &conn : cell->connections())
 						if (tpl->avail_parameters.count(stringf("\\_TECHMAP_CONNMAP_%s_", log_id(conn.first))) != 0) {
-							RTLIL::Const value;
-							for (auto &bit : sigmap(conn.second)) {
+							SigSpec sm = sigmap(conn.second);
+							RTLIL::Const::Builder builder(GetSize(sm) * bits);
+							for (auto &bit : sm) {
 								int val = unique_bit_id.at(bit);
 								for (int i = 0; i < bits; i++) {
-									value.bits().push_back((val & 1) != 0 ? State::S1 : State::S0);
+									builder.push_back((val & 1) != 0 ? State::S1 : State::S0);
 									val = val >> 1;
 								}
 							}
-							parameters.emplace(stringf("\\_TECHMAP_CONNMAP_%s_", log_id(conn.first)), value);
+							parameters.emplace(stringf("\\_TECHMAP_CONNMAP_%s_", log_id(conn.first)), builder.build());
 						}
 				}
 

--- a/passes/techmap/zinit.cc
+++ b/passes/techmap/zinit.cc
@@ -76,7 +76,7 @@ struct ZinitPass : public Pass {
 					if (ff.val_init[i] == State::S1)
 						bits.insert(i);
 					else if (ff.val_init[i] != State::S0 && all_mode)
-						ff.val_init.bits()[i] = State::S0;
+						ff.val_init.set(i, State::S0);
 				}
 				ff.flip_bits(bits);
 				ff.emit();

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -641,15 +641,16 @@ static void run_eval_test(RTLIL::Design *design, bool verbose, bool nosat, std::
 			if (!gold_wire->port_input)
 				continue;
 
-			RTLIL::Const in_value;
+			RTLIL::Const::Builder in_value_builder(GetSize(gold_wire));
 			for (int i = 0; i < GetSize(gold_wire); i++)
-				in_value.bits().push_back(xorshift32(2) ? State::S1 : State::S0);
+				in_value_builder.push_back(xorshift32(2) ? State::S1 : State::S0);
+			RTLIL::Const in_value = in_value_builder.build();
 
 			if (xorshift32(4) == 0) {
 				int inv_chance = 1 + xorshift32(8);
 				for (int i = 0; i < GetSize(gold_wire); i++)
 					if (xorshift32(inv_chance) == 0)
-						in_value.bits()[i] = RTLIL::Sx;
+						in_value.set(i, RTLIL::Sx);
 			}
 
 			if (verbose)

--- a/techlibs/gatemate/gatemate_foldinv.cc
+++ b/techlibs/gatemate/gatemate_foldinv.cc
@@ -82,7 +82,7 @@ struct FoldInvWorker {
         Const result(State::S0, GetSize(lut));
         for (int i = 0; i < GetSize(lut); i++) {
             int j = i ^ (1 << bit);
-            result.bits()[j] = lut[i];
+            result.set(j, lut[i]);
         }
         return result;
     }
@@ -91,7 +91,7 @@ struct FoldInvWorker {
     {
         Const result(State::S0, GetSize(lut));
         for (int i = 0; i < GetSize(lut); i++)
-            result.bits()[i] = (lut[i] == State::S1) ? State::S0 : State::S1;
+            result.set(i, (lut[i] == State::S1) ? State::S0 : State::S1);
         return result;
     }
 

--- a/techlibs/greenpak4/greenpak4_dffinv.cc
+++ b/techlibs/greenpak4/greenpak4_dffinv.cc
@@ -36,9 +36,9 @@ void invert_gp_dff(Cell *cell, bool invert_input)
 		Const initval = cell->getParam(ID::INIT);
 		if (GetSize(initval) >= 1) {
 			if (initval[0] == State::S0)
-				initval.bits()[0] = State::S1;
+				initval.set(0, State::S1);
 			else if (initval[0] == State::S1)
-				initval.bits()[0] = State::S0;
+				initval.set(0, State::S0);
 			cell->setParam(ID::INIT, initval);
 		}
 
@@ -47,9 +47,9 @@ void invert_gp_dff(Cell *cell, bool invert_input)
 			Const srmode = cell->getParam(ID(SRMODE));
 			if (GetSize(srmode) >= 1) {
 				if (srmode[0] == State::S0)
-					srmode.bits()[0] = State::S1;
+					srmode.set(0, State::S1);
 				else if (srmode[0] == State::S1)
-					srmode.bits()[0] = State::S0;
+					srmode.set(0, State::S0);
 				cell->setParam(ID(SRMODE), srmode);
 			}
 		}

--- a/techlibs/ice40/ice40_dsp.cc
+++ b/techlibs/ice40/ice40_dsp.cc
@@ -82,7 +82,7 @@ void create_ice40_dsp(ice40_dsp_pm &pm)
 
 	SigSpec CD = st.sigCD;
 	if (CD.empty())
-		CD = RTLIL::Const(0, 32);
+		CD = RTLIL::Const(0);
 	else
 		log_assert(GetSize(CD) == 32);
 

--- a/techlibs/microchip/microchip_dffopt.cc
+++ b/techlibs/microchip/microchip_dffopt.cc
@@ -93,7 +93,7 @@ bool merge_lut(LutData &result, const LutData &data, const LutData select, bool 
 			int lut_idx = i >> idx_data & ((1 << GetSize(data.second)) - 1);
 			new_bit = data.first[lut_idx] == State::S1;
 		}
-		result.first.bits()[i] = new_bit ? State::S1 : State::S0;
+		result.first.set(i, new_bit ? State::S1 : State::S0);
 	}
 	return true;
 }

--- a/techlibs/microchip/microchip_dsp.cc
+++ b/techlibs/microchip/microchip_dsp.cc
@@ -128,7 +128,7 @@ void microchip_dsp_pack(microchip_dsp_pm &pm)
 					continue;
 				for (int i = c.offset; i < c.offset + c.width; i++) {
 					log_assert(it->second[i] == State::S0 || it->second[i] == State::Sx);
-					it->second.bits()[i] = State::Sx;
+					it->second.set(i, State::Sx);
 				}
 			}
 		};
@@ -244,7 +244,7 @@ void microchip_dsp_packC(microchip_dsp_CREG_pm &pm)
 					continue;
 				for (int i = c.offset; i < c.offset + c.width; i++) {
 					log_assert(it->second[i] == State::S0 || it->second[i] == State::Sx);
-					it->second.bits()[i] = State::Sx;
+					it->second.set(i, State::Sx);
 				}
 			}
 		};

--- a/techlibs/quicklogic/ql_bram_merge.cc
+++ b/techlibs/quicklogic/ql_bram_merge.cc
@@ -45,7 +45,7 @@ struct QlBramMergeWorker {
 		{
 			if(cell->type != split_cell_type) continue;
 			if(!cell->hasParam(ID(OPTION_SPLIT))) continue;
-			if(cell->getParam(ID(OPTION_SPLIT)) != RTLIL::Const(1, 32)) continue;
+			if(cell->getParam(ID(OPTION_SPLIT)) != RTLIL::Const(1)) continue;
 			mergeable_groups[get_key(cell)].insert(cell);
 		}
 	}

--- a/techlibs/quicklogic/ql_dsp_simd.cc
+++ b/techlibs/quicklogic/ql_dsp_simd.cc
@@ -200,10 +200,8 @@ struct QlDspSimdPass : public Pass {
 						auto val_a = dsp_a->getParam(it);
 						auto val_b = dsp_b->getParam(it);
 
-						mode_bits.bits().insert(mode_bits.bits().end(),
-							val_a.begin(), val_a.end());
-						mode_bits.bits().insert(mode_bits.bits().end(),
-							val_b.begin(), val_b.end());
+						mode_bits.append(val_a);
+						mode_bits.append(val_b);
 					}
 
 					// Enable the fractured mode by connecting the control

--- a/techlibs/xilinx/xilinx_dffopt.cc
+++ b/techlibs/xilinx/xilinx_dffopt.cc
@@ -92,7 +92,7 @@ bool merge_lut(LutData &result, const LutData &data, const LutData select, bool 
 			int lut_idx = i >> idx_data & ((1 << GetSize(data.second)) - 1);
 			new_bit = data.first[lut_idx] == State::S1;
 		}
-		result.first.bits()[i] = new_bit ? State::S1 : State::S0;
+		result.first.set(i, new_bit ? State::S1 : State::S0);
 	}
 	return true;
 }
@@ -211,8 +211,8 @@ lut_sigin_done:
 				Cell *cell_d = it_D->second.second;
 				if (cell->hasParam(ID(IS_D_INVERTED)) && cell->getParam(ID(IS_D_INVERTED)).as_bool()) {
 					// Flip all bits in the LUT.
-					for (int i = 0; i < GetSize(lut_d.first); i++)
-						lut_d.first.bits()[i] = (lut_d.first[i] == State::S1) ? State::S0 : State::S1;
+					for (auto bit : lut_d.first)
+						bit = (bit == State::S1) ? State::S0 : State::S1;
 				}
 
 				LutData lut_d_post_ce;

--- a/techlibs/xilinx/xilinx_dsp.cc
+++ b/techlibs/xilinx/xilinx_dsp.cc
@@ -343,7 +343,7 @@ void xilinx_dsp_pack(xilinx_dsp_pm &pm)
 			// Since B is an exact power of 2, subtract 1
 			//   by inverting all bits up until hitting
 			//   that one hi bit
-			for (auto &b : B.bits())
+			for (auto b : B)
 				if (b == State::S0) b = State::S1;
 				else if (b == State::S1) {
 					b = State::S0;
@@ -392,7 +392,7 @@ void xilinx_dsp_pack(xilinx_dsp_pm &pm)
 					continue;
 				for (int i = c.offset; i < c.offset+c.width; i++) {
 					log_assert(it->second[i] == State::S0 || it->second[i] == State::Sx);
-					it->second.bits()[i] = State::Sx;
+					it->second.set(i, State::Sx);
 				}
 			}
 		};
@@ -579,7 +579,7 @@ void xilinx_dsp48a_pack(xilinx_dsp48a_pm &pm)
 					continue;
 				for (int i = c.offset; i < c.offset+c.width; i++) {
 					log_assert(it->second[i] == State::S0 || it->second[i] == State::Sx);
-					it->second.bits()[i] = State::Sx;
+					it->second.set(i, State::Sx);
 				}
 			}
 		};
@@ -702,7 +702,7 @@ void xilinx_dsp_packC(xilinx_dsp_CREG_pm &pm)
 					continue;
 				for (int i = c.offset; i < c.offset+c.width; i++) {
 					log_assert(it->second[i] == State::S0 || it->second[i] == State::Sx);
-					it->second.bits()[i] = State::Sx;
+					it->second.set(i, State::Sx);
 				}
 			}
 		};

--- a/techlibs/xilinx/xilinx_srl.cc
+++ b/techlibs/xilinx/xilinx_srl.cc
@@ -40,9 +40,8 @@ void run_fixed(xilinx_srl_pm &pm)
 			log_assert(Q.wire);
 			auto it = Q.wire->attributes.find(ID::init);
 			if (it != Q.wire->attributes.end()) {
-				auto &i = it->second.bits()[Q.offset];
-				initval.append(i);
-				i = State::Sx;
+				initval.append(it->second[Q.offset]);
+				it->second.set(Q.offset, State::Sx);
 			}
 			else
 				initval.append(State::Sx);
@@ -121,9 +120,8 @@ void run_variable(xilinx_srl_pm &pm)
 			log_assert(Q.wire);
 			auto it = Q.wire->attributes.find(ID::init);
 			if (it != Q.wire->attributes.end()) {
-				auto &i = it->second.bits()[Q.offset];
-				initval.append(i);
-				i = State::Sx;
+				initval.append(it->second[Q.offset]);
+				it->second.set(Q.offset, State::Sx);
 			}
 			else
 				initval.append(State::Sx);

--- a/tests/unit/kernel/rtlilTest.cc
+++ b/tests/unit/kernel/rtlilTest.cc
@@ -157,6 +157,50 @@ namespace RTLIL {
 			Const c(v);
 			EXPECT_EQ(c.decode_string(), " ");
 		}
+
+		{
+			Const c(" ");
+			EXPECT_TRUE(c.is_str());
+			EXPECT_FALSE(c.is_fully_zero());
+			EXPECT_TRUE(c.is_str());
+		}
+
+		{
+			Const c(" ");
+			EXPECT_TRUE(c.is_str());
+			EXPECT_FALSE(c.is_fully_ones());
+			EXPECT_TRUE(c.is_str());
+		}
+
+		{
+			Const c(" ");
+			EXPECT_TRUE(c.is_str());
+			EXPECT_TRUE(c.is_fully_def());
+			EXPECT_TRUE(c.is_str());
+		}
+
+		{
+			Const c(" ");
+			EXPECT_TRUE(c.is_str());
+			EXPECT_FALSE(c.is_fully_undef());
+			EXPECT_TRUE(c.is_str());
+		}
+
+		{
+			Const c(" ");
+			EXPECT_TRUE(c.is_str());
+			EXPECT_FALSE(c.is_fully_undef_x_only());
+			EXPECT_TRUE(c.is_str());
+		}
+
+		{
+			Const c(" ");
+			EXPECT_TRUE(c.is_str());
+			int pos;
+			EXPECT_TRUE(c.is_onehot(&pos));
+			EXPECT_EQ(pos, 5);
+			EXPECT_TRUE(c.is_str());
+		}
 	}
 
 	TEST_F(KernelRtlilTest, ConstConstIteratorWorks) {
@@ -265,6 +309,53 @@ namespace RTLIL {
 		std::vector<State> v1 = {S0, S0, S0, S0, S0, S1, S0, S0};
 		EXPECT_EQ(hash(Const(v1)), hash(Const(" ")));
 		EXPECT_NE(hash(Const(v1)), hash(Const("a")));
+	}
+
+	TEST_F(KernelRtlilTest, ConstIsFullyZero) {
+		EXPECT_TRUE(Const(0, 8).is_fully_zero());
+		EXPECT_FALSE(Const(8, 8).is_fully_zero());
+		EXPECT_TRUE(Const().is_fully_zero());
+	}
+
+	TEST_F(KernelRtlilTest, ConstIsFullyOnes) {
+		EXPECT_TRUE(Const(0xf, 4).is_fully_ones());
+		EXPECT_FALSE(Const(3, 4).is_fully_ones());
+		EXPECT_TRUE(Const().is_fully_ones());
+	}
+
+	TEST_F(KernelRtlilTest, ConstIsFullyDef) {
+		EXPECT_TRUE(Const(0xf, 4).is_fully_def());
+		std::vector<State> v1 = {S0, Sx};
+		EXPECT_FALSE(Const(v1).is_fully_def());
+		EXPECT_TRUE(Const().is_fully_def());
+	}
+
+	TEST_F(KernelRtlilTest, ConstIsFullyUndef) {
+		std::vector<State> v1 = {S0, Sx};
+		EXPECT_FALSE(Const(v1).is_fully_undef());
+		EXPECT_TRUE(Const(Sz, 2).is_fully_undef());
+		EXPECT_TRUE(Const().is_fully_undef());
+	}
+
+	TEST_F(KernelRtlilTest, ConstIsFullyUndefXOnly) {
+		std::vector<State> v1 = {Sx, Sz};
+		EXPECT_FALSE(Const(v1).is_fully_undef_x_only());
+		EXPECT_TRUE(Const(Sx, 2).is_fully_undef_x_only());
+		EXPECT_TRUE(Const().is_fully_undef_x_only());
+	}
+
+	TEST_F(KernelRtlilTest, ConstIsOnehot) {
+		int pos;
+		EXPECT_TRUE(Const(0x80, 8).is_onehot(&pos));
+		EXPECT_EQ(pos, 7);
+		EXPECT_FALSE(Const(0x82, 8).is_onehot(&pos));
+		EXPECT_FALSE(Const(0, 8).is_onehot(&pos));
+		EXPECT_TRUE(Const(1, 1).is_onehot(&pos));
+		EXPECT_EQ(pos, 0);
+		EXPECT_FALSE(Const(Sx, 1).is_onehot(&pos));
+		std::vector<State> v1 = {Sx, S1};
+		EXPECT_FALSE(Const(v1).is_onehot(&pos));
+		EXPECT_FALSE(Const().is_onehot(&pos));
 	}
 
 	class WireRtlVsHdlIndexConversionTest :

--- a/tests/unit/kernel/rtlilTest.cc
+++ b/tests/unit/kernel/rtlilTest.cc
@@ -222,6 +222,18 @@ namespace RTLIL {
 		EXPECT_NE(Const(v1), Const("a"));
 	}
 
+	static Hasher::hash_t hash(const Const &c) {
+		Hasher h;
+		h = c.hash_into(h);
+		return h.yield();
+	}
+
+	TEST_F(KernelRtlilTest, ConstEqualHashStrBits) {
+		std::vector<State> v1 = {S0, S0, S0, S0, S0, S1, S0, S0};
+		EXPECT_EQ(hash(Const(v1)), hash(Const(" ")));
+		EXPECT_NE(hash(Const(v1)), hash(Const("a")));
+	}
+
 	class WireRtlVsHdlIndexConversionTest :
 		public KernelRtlilTest,
 		public testing::WithParamInterface<std::tuple<bool, int, int>>

--- a/tests/unit/kernel/rtlilTest.cc
+++ b/tests/unit/kernel/rtlilTest.cc
@@ -88,6 +88,31 @@ namespace RTLIL {
 			EXPECT_TRUE(cs1.is_bits());
 		}
 
+		{
+			Const c(0x12345678);
+			EXPECT_TRUE(c.is_str());
+			EXPECT_EQ(c.as_int(), 0x12345678);
+		}
+
+		{
+			Const c(0xab, 8);
+			EXPECT_TRUE(c.is_str());
+			EXPECT_EQ(c.as_int(), 0xab);
+		}
+
+		{
+			Const c(0x12345678, 80);
+			EXPECT_TRUE(c.is_str());
+			EXPECT_EQ(c.as_int(), 0x12345678);
+			EXPECT_EQ(c[79], S0);
+		}
+
+		{
+			Const c(-1, 80);
+			EXPECT_TRUE(c.is_str());
+			EXPECT_EQ(c.as_int(), -1);
+			EXPECT_EQ(c[79], S1);
+		}
 	}
 
 	TEST_F(KernelRtlilTest, ConstConstIteratorWorks) {

--- a/tests/unit/kernel/rtlilTest.cc
+++ b/tests/unit/kernel/rtlilTest.cc
@@ -92,12 +92,14 @@ namespace RTLIL {
 			Const c(0x12345678);
 			EXPECT_TRUE(c.is_str());
 			EXPECT_EQ(c.as_int(), 0x12345678);
+			EXPECT_TRUE(c.is_str());
 		}
 
 		{
 			Const c(0xab, 8);
 			EXPECT_TRUE(c.is_str());
 			EXPECT_EQ(c.as_int(), 0xab);
+			EXPECT_TRUE(c.is_str());
 		}
 
 		{
@@ -105,6 +107,7 @@ namespace RTLIL {
 			EXPECT_TRUE(c.is_str());
 			EXPECT_EQ(c.as_int(), 0x12345678);
 			EXPECT_EQ(c[79], S0);
+			EXPECT_TRUE(c.is_str());
 		}
 
 		{
@@ -112,6 +115,14 @@ namespace RTLIL {
 			EXPECT_TRUE(c.is_str());
 			EXPECT_EQ(c.as_int(), -1);
 			EXPECT_EQ(c[79], S1);
+			EXPECT_TRUE(c.is_str());
+		}
+
+		{
+			Const c(1 << 24);
+			EXPECT_TRUE(c.is_str());
+			EXPECT_TRUE(c.as_bool());
+			EXPECT_TRUE(c.is_str());
 		}
 	}
 

--- a/tests/unit/kernel/rtlilTest.cc
+++ b/tests/unit/kernel/rtlilTest.cc
@@ -114,6 +114,60 @@ namespace RTLIL {
 		EXPECT_EQ(*it++, State::S0);
 	}
 
+	TEST_F(KernelRtlilTest, ConstIteratorWorks) {
+		Const c(0x2, 2);
+		Const::iterator it = c.begin();
+		ASSERT_NE(it, c.end());
+		EXPECT_EQ(*it, State::S0);
+		++it;
+		ASSERT_NE(it, c.end());
+		EXPECT_EQ(*it, State::S1);
+		++it;
+		ASSERT_EQ(it, c.end());
+	}
+
+	TEST_F(KernelRtlilTest, ConstIteratorPreincrement) {
+		Const c(0x2, 2);
+		Const::iterator it = c.begin();
+		EXPECT_EQ(*++it, State::S1);
+	}
+
+	TEST_F(KernelRtlilTest, ConstIteratorPostincrement) {
+		Const c(0x2, 2);
+		Const::iterator it = c.begin();
+		EXPECT_EQ(*it++, State::S0);
+	}
+
+	TEST_F(KernelRtlilTest, ConstIteratorWriteWorks) {
+		Const c(0x2, 2);
+		Const::iterator it = c.begin();
+		EXPECT_EQ(*it, State::S0);
+		*it = State::S1;
+		EXPECT_EQ(*it, State::S1);
+	}
+
+	TEST_F(KernelRtlilTest, ConstBuilder) {
+		Const::Builder b;
+		EXPECT_EQ(GetSize(b), 0);
+		b.push_back(S0);
+		EXPECT_EQ(GetSize(b), 1);
+		b.push_back(S1);
+		EXPECT_EQ(GetSize(b), 2);
+		EXPECT_EQ(b.build(), Const(0x2, 2));
+	}
+
+	TEST_F(KernelRtlilTest, ConstSet) {
+		Const c(0x2, 2);
+		c.set(0, S1);
+		EXPECT_EQ(c, Const(0x3, 2));
+	}
+
+	TEST_F(KernelRtlilTest, ConstResize) {
+		Const c(0x2, 2);
+		c.resize(4, S1);
+		EXPECT_EQ(c, Const(0xe, 4));
+	}
+
 	class WireRtlVsHdlIndexConversionTest :
 		public KernelRtlilTest,
 		public testing::WithParamInterface<std::tuple<bool, int, int>>

--- a/tests/unit/kernel/rtlilTest.cc
+++ b/tests/unit/kernel/rtlilTest.cc
@@ -90,6 +90,30 @@ namespace RTLIL {
 
 	}
 
+	TEST_F(KernelRtlilTest, ConstConstIteratorWorks) {
+		const Const c(0x2, 2);
+		Const::const_iterator it = c.begin();
+		ASSERT_NE(it, c.end());
+		EXPECT_EQ(*it, State::S0);
+		++it;
+		ASSERT_NE(it, c.end());
+		EXPECT_EQ(*it, State::S1);
+		++it;
+		EXPECT_EQ(it, c.end());
+	}
+
+	TEST_F(KernelRtlilTest, ConstConstIteratorPreincrement) {
+		const Const c(0x2, 2);
+		Const::const_iterator it = c.begin();
+		EXPECT_EQ(*++it, State::S1);
+	}
+
+	TEST_F(KernelRtlilTest, ConstConstIteratorPostincrement) {
+		const Const c(0x2, 2);
+		Const::const_iterator it = c.begin();
+		EXPECT_EQ(*it++, State::S0);
+	}
+
 	class WireRtlVsHdlIndexConversionTest :
 		public KernelRtlilTest,
 		public testing::WithParamInterface<std::tuple<bool, int, int>>

--- a/tests/unit/kernel/rtlilTest.cc
+++ b/tests/unit/kernel/rtlilTest.cc
@@ -204,6 +204,24 @@ namespace RTLIL {
 		EXPECT_EQ(c, Const(0xe, 4));
 	}
 
+	TEST_F(KernelRtlilTest, ConstEqualStr) {
+		EXPECT_EQ(Const("abc"), Const("abc"));
+		EXPECT_NE(Const("abc"), Const("def"));
+	}
+
+	TEST_F(KernelRtlilTest, ConstEqualBits) {
+		std::vector<State> v1 = {S0, S1};
+		std::vector<State> v2 = {S1, S0};
+		EXPECT_EQ(Const(v1), Const(v1));
+		EXPECT_NE(Const(v1), Const(v2));
+	}
+
+	TEST_F(KernelRtlilTest, ConstEqualStrBits) {
+		std::vector<State> v1 = {S0, S0, S0, S0, S0, S1, S0, S0};
+		EXPECT_EQ(Const(v1), Const(" "));
+		EXPECT_NE(Const(v1), Const("a"));
+	}
+
 	class WireRtlVsHdlIndexConversionTest :
 		public KernelRtlilTest,
 		public testing::WithParamInterface<std::tuple<bool, int, int>>

--- a/tests/unit/kernel/rtlilTest.cc
+++ b/tests/unit/kernel/rtlilTest.cc
@@ -131,6 +131,32 @@ namespace RTLIL {
 			EXPECT_EQ(c.as_string(), "00000010");
 			EXPECT_TRUE(c.is_str());
 		}
+
+		{
+			Const c(" ");
+			EXPECT_TRUE(c.is_str());
+			EXPECT_EQ(c.decode_string(), " ");
+			EXPECT_TRUE(c.is_str());
+		}
+
+		{
+			Const c(" ");
+			EXPECT_TRUE(c.is_str());
+			EXPECT_EQ(c.decode_string(), " ");
+			EXPECT_TRUE(c.is_str());
+		}
+
+		{
+			std::vector<State> v = {S0, S0, S0, S0, S0, S1, S0, S0};
+			Const c(v);
+			EXPECT_EQ(c.decode_string(), " ");
+		}
+
+		{
+			std::vector<State> v = {S0, S0, S0, S0, S0, S1, S0, Sx};
+			Const c(v);
+			EXPECT_EQ(c.decode_string(), " ");
+		}
 	}
 
 	TEST_F(KernelRtlilTest, ConstConstIteratorWorks) {

--- a/tests/unit/kernel/rtlilTest.cc
+++ b/tests/unit/kernel/rtlilTest.cc
@@ -80,10 +80,10 @@ namespace RTLIL {
 			EXPECT_EQ(i, 16);
 			EXPECT_TRUE(cs1.is_str());
 
-			// It can be mutated with the bits() view
-			// and decays into unpacked
-			for (auto& bit : cs1.bits()) {
-				bit = State::Sx;
+			// It can be mutated via bit iteration and decays into unpacked
+			// when an non-defined bit is set.
+			for (auto b : cs1) {
+				b = State::Sx;
 			}
 			EXPECT_TRUE(cs1.is_bits());
 		}

--- a/tests/unit/kernel/rtlilTest.cc
+++ b/tests/unit/kernel/rtlilTest.cc
@@ -124,6 +124,13 @@ namespace RTLIL {
 			EXPECT_TRUE(c.as_bool());
 			EXPECT_TRUE(c.is_str());
 		}
+
+		{
+			Const c(0x2, 8);
+			EXPECT_TRUE(c.is_str());
+			EXPECT_EQ(c.as_string(), "00000010");
+			EXPECT_TRUE(c.is_str());
+		}
 	}
 
 	TEST_F(KernelRtlilTest, ConstConstIteratorWorks) {


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

https://github.com/YosysHQ/yosys/issues/5312 explains how `Const` is currently very inefficient. This PR fixes a lot of that.

_Explain how this is achieved._

The main piece of work here is to remove all direct calls to `Const::bits()`. We add some new APIs to `Const` that callers can use instead. Then we make the `Const(long long)` constructor use the packed bits representation (i.e. `std::string`), and update various `Const` methods to work with that representation instead of downconverting to `vector<State>`. On one of our large circuits, this significantly reduces the time spend in `OptMergePass::hash_cell_parameters()`.

I realize this is a huge PR. I should probably break it up into smaller PRs for actual review and merging. I'm putting it here so people can see what it looks like.

_If applicable, please suggest to reviewers how they can test the change._

This shouldn't change any behavior. FWIW, after I created all the big patches to remove all calls to `Const::bits()` and got them to compile, Yosys tests only revealed one bug. So the number of latent bugs not caught by tests should hopefully be correspondingly low.