### PR TITLE
libparse/filterlib: mark LibertyParser::error() as weak

### DIFF
--- a/passes/techmap/libparse.cc
+++ b/passes/techmap/libparse.cc
@@ -676,12 +676,15 @@ void LibertyParser::error(const std::string &str) const
 
 #else
 
+YS_ATTRIBUTE(weak)
 void LibertyParser::error() const
 {
 	fprintf(stderr, "Syntax error in liberty file on line %d.\n", line);
 	exit(1);
 }
 
+
+YS_ATTRIBUTE(weak)
 void LibertyParser::error(const std::string &str) const
 {
 	std::stringstream ss;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Admittedly a niche use-case: I use `libparse.cc` as a standalone library. Problem is, the default `error()` methods exit the process altogether.

_Explain how this is achieved._

When FILTERLIB is defined (attempts to compile libparse more or less standalone,) mark the `LibertyParser::error()` as weak so utilities using libparse as a library can override its behavior.

As the code is quite performance-critical, I've elected to not modify it to raise an exception or have a callback or similar and simply allow for a link-time replacement.

EDIT: Virtual methods also can't work for two reasons:
- performance
- c++ doesn't do virtual dispatch in constructors and parse() is called in a constructor

_If applicable, please suggest to reviewers how they can test the change._

There should be no functional change to Yosys from this at all. Doubly so since FILTERLIB is not normally defined.