### PR TITLE
hashlib: don't build an unused hash for expired value in do_insert

### DIFF
--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -509,12 +509,11 @@ class dict {
 		return do_lookup_internal(key, hash);
 	}
 
-	int do_insert(const K &key, Hasher::hash_t &hash)
+	int do_insert(const K &key, const Hasher::hash_t &hash)
 	{
 		if (hashtable.empty()) {
 			entries.emplace_back(std::pair<K, T>(key, T()), -1);
 			do_rehash();
-			hash = do_hash(key);
 		} else {
 			entries.emplace_back(std::pair<K, T>(key, T()), hashtable[hash]);
 			hashtable[hash] = entries.size() - 1;
@@ -522,12 +521,11 @@ class dict {
 		return entries.size() - 1;
 	}
 
-	int do_insert(const std::pair<K, T> &value, Hasher::hash_t &hash)
+	int do_insert(const std::pair<K, T> &value, const Hasher::hash_t &hash)
 	{
 		if (hashtable.empty()) {
 			entries.emplace_back(value, -1);
 			do_rehash();
-			hash = do_hash(value.first);
 		} else {
 			entries.emplace_back(value, hashtable[hash]);
 			hashtable[hash] = entries.size() - 1;
@@ -535,13 +533,11 @@ class dict {
 		return entries.size() - 1;
 	}
 
-	int do_insert(std::pair<K, T> &&rvalue, Hasher::hash_t &hash)
+	int do_insert(std::pair<K, T> &&rvalue, const Hasher::hash_t &hash)
 	{
 		if (hashtable.empty()) {
-			auto key = rvalue.first;
 			entries.emplace_back(std::forward<std::pair<K, T>>(rvalue), -1);
 			do_rehash();
-			hash = do_hash(key);
 		} else {
 			entries.emplace_back(std::forward<std::pair<K, T>>(rvalue), hashtable[hash]);
 			hashtable[hash] = entries.size() - 1;


### PR DESCRIPTION
Fix #5318, may only negatively affect plugin developers with custom data structures inheriting from dict/pool