### PR TITLE
fix(parse): #5234 adjust width of rhs according to lhs

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -5974,7 +5974,11 @@ bool RTLIL::SigSpec::parse_rhs(const RTLIL::SigSpec &lhs, RTLIL::SigSpec &sig, R
 		}
 	}
 
-	return parse(sig, module, str);
+	if (!parse(sig, module, str))
+		return false;
+	if (sig.width_ > lhs.width_)
+		sig.remove(lhs.width_, sig.width_ - lhs.width_);
+	return true;
 }
 
 RTLIL::CaseRule::~CaseRule()

--- a/tests/sat/fminit_noexpand.ys
+++ b/tests/sat/fminit_noexpand.ys
@@ -1,0 +1,10 @@
+read_verilog -sv <<EOF
+module thing(input [2:0] in, output reg [2:0] out);
+    assign out = in;
+endmodule
+EOF
+
+select -assert-count 0 t:$eq
+fminit -set out 1'b1
+select -assert-count 1 t:$eq
+select -assert-count 1 t:$eq r:A_WIDTH=1 %i

--- a/tests/sat/fminit_seq_width.ys
+++ b/tests/sat/fminit_seq_width.ys
@@ -1,0 +1,17 @@
+read_verilog -sv -formal <<EOF
+module counter(input clk, input [2:0] rst, input [0:3] rst_val, output logic is_full);
+    logic [1:0] ctr;
+
+    always @(posedge clk)
+        if (rst)
+            ctr <= 0;
+        else
+            ctr <= ctr+1;
+
+    assign is_full = (ctr == 2'b11);
+endmodule
+EOF
+
+hierarchy -check -top counter
+prep -top counter
+fminit -seq rst 0,1,2'b11,2'sb11,rst_val


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

#5234 

_Explain how this is achieved._

Add code in `SigSpec::parse_rhs` to adjust the width of RHS.

_If applicable, please suggest to reviewers how they can test the change._

Try different combinations of width and signedness of the arguments of `-seq`

