### PR TITLE
Increase muxtree glob eval attempts to 10M.

### DIFF
--- a/passes/opt/opt_muxtree.cc
+++ b/passes/opt/opt_muxtree.cc
@@ -64,7 +64,7 @@ struct OptMuxtreeWorker
 	RTLIL::Module *module;
 	SigMap assign_map;
 	int removed_count;
-	int glob_evals_left = 100000;
+	int glob_evals_left = 10000000;
 
 	struct bitinfo_t {
 		// Is bit directly used by non-mux cells or ports?


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

With @rocallahan 's change in https://github.com/YosysHQ/yosys/pull/5290, the performance of this pass greatly increased for larger designs. On some of these larger designs, the existing glob eval attempt limit of 100k is sometimes too few to realize an optimization. With the runtime improvement, it is not costly even on larger designs to increase this limit, which can find timing improvements of up to 6%.

For small designs, I would not expect this change to make a difference.