### PR TITLE
memory_libmap: Fix use of uninitialized value for async read ports

### DIFF
--- a/passes/memory/memlib.cc
+++ b/passes/memory/memlib.cc
@@ -855,7 +855,9 @@ struct Parser {
 			PortVariant var;
 			var.options = portopts;
 			var.kind = pdef.kind;
-			if (pdef.kind != PortKind::Ar) {
+			if (pdef.kind == PortKind::Ar) {
+				var.clk_en = false;
+			} else {
 				const ClockDef *cdef = find_single_cap(pdef.clock, cram.options, portopts, "clock");
 				if (!cdef)
 					log_error("%s:%d: missing clock capability.\n", filename.c_str(), orig_line);


### PR DESCRIPTION
The code in memory_libmap expects `clk_en` to be initialized for all `PortVariant`s but the parsing in memlib.cc didn't initialize it for variants of kind `PortKind::Ar` (async read ports).

While this fixes the immediate CI failure (which is non-deterministic since it depends on an uninitialized value), it would be best to refactor the code so it becomes obvious if something isn't initialized.