### PR TITLE
Fix `subcircuit` building without `#define _YOSYS_`

### DIFF
--- a/libs/subcircuit/subcircuit.cc
+++ b/libs/subcircuit/subcircuit.cc
@@ -411,7 +411,7 @@ class SubCircuit::SolverWorker
 
 		std::string toString() const
 		{
-			return my_stringf("%s[%d]:%s[%d]", fromPort, fromBit, toPort, toBit);
+			return my_stringf("%s[%d]:%s[%d]", fromPort.c_str(), fromBit, toPort.c_str(), toBit);
 		}
 	};
 
@@ -444,7 +444,7 @@ class SubCircuit::SolverWorker
 			std::string str;
 			bool firstPort = true;
 			for (const auto &it : portSizes) {
-				str += my_stringf("%s%s[%d]", firstPort ? "" : ",", it.first, it.second);
+				str += my_stringf("%s%s[%d]", firstPort ? "" : ",", it.first.c_str(), it.second);
 				firstPort = false;
 			}
 			return typeId + "(" + str + ")";


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

We can't use the new stringf functionality with `my_sprintf()` since in some builds that falls back to C-style varargs. We need to unbreak those builds.