### PR TITLE
Remove `string_buf` by making `log_signal()` and `log_const()` return `std::string`

### DIFF
--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -68,8 +68,6 @@ int log_debug_suppressed = 0;
 
 vector<int> header_count;
 vector<char*> log_id_cache;
-vector<shared_str> string_buf;
-int string_buf_index = -1;
 
 static struct timeval initial_tv = { 0, 0 };
 static bool next_print_log = false;
@@ -447,8 +445,6 @@ void log_pop()
 {
 	header_count.pop_back();
 	log_id_cache_clear();
-	string_buf.clear();
-	string_buf_index = -1;
 	log_flush();
 }
 
@@ -554,8 +550,6 @@ void log_reset_stack()
 	while (header_count.size() > 1)
 		header_count.pop_back();
 	log_id_cache_clear();
-	string_buf.clear();
-	string_buf_index = -1;
 	log_flush();
 }
 
@@ -580,38 +574,19 @@ void log_dump_val_worker(RTLIL::State v) {
 	log("%s", log_signal(v));
 }
 
-const char *log_signal(const RTLIL::SigSpec &sig, bool autoint)
+std::string log_signal(const RTLIL::SigSpec &sig, bool autoint)
 {
 	std::stringstream buf;
 	RTLIL_BACKEND::dump_sigspec(buf, sig, autoint);
-
-	if (string_buf.size() < 100) {
-		string_buf.push_back(buf.str());
-		return string_buf.back().c_str();
-	} else {
-		if (++string_buf_index == 100)
-			string_buf_index = 0;
-		string_buf[string_buf_index] = buf.str();
-		return string_buf[string_buf_index].c_str();
-	}
+	return buf.str();
 }
 
-const char *log_const(const RTLIL::Const &value, bool autoint)
+std::string log_const(const RTLIL::Const &value, bool autoint)
 {
 	if ((value.flags & RTLIL::CONST_FLAG_STRING) == 0)
 		return log_signal(value, autoint);
 
-	std::string str = "\"" + value.decode_string() + "\"";
-
-	if (string_buf.size() < 100) {
-		string_buf.push_back(str);
-		return string_buf.back().c_str();
-	} else {
-		if (++string_buf_index == 100)
-			string_buf_index = 0;
-		string_buf[string_buf_index] = str;
-		return string_buf[string_buf_index].c_str();
-	}
+	return "\"" + value.decode_string() + "\"";
 }
 
 const char *log_id(const RTLIL::IdString &str)

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -253,8 +253,8 @@ extern dict<std::string, LogExpectedItem> log_expect_log, log_expect_warning, lo
 extern dict<std::string, LogExpectedItem> log_expect_prefix_log, log_expect_prefix_warning, log_expect_prefix_error;
 void log_check_expected();
 
-const char *log_signal(const RTLIL::SigSpec &sig, bool autoint = true);
-const char *log_const(const RTLIL::Const &value, bool autoint = true);
+std::string log_signal(const RTLIL::SigSpec &sig, bool autoint = true);
+std::string log_const(const RTLIL::Const &value, bool autoint = true);
 const char *log_id(const RTLIL::IdString &id);
 
 template<typename T> static inline const char *log_id(T *obj, const char *nullstr = nullptr) {

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -755,7 +755,7 @@ void AbcModuleState::handle_loops(AbcSigMap &assign_map, RTLIL::Module *module)
 					log("Breaking loop using new signal %s: %s -> %s\n", log_signal(RTLIL::SigSpec(wire)),
 							run_abc.signal_list[id1].bit_str, run_abc.signal_list[id2].bit_str);
 				else
-					log("                               %*s  %s -> %s\n", int(strlen(log_signal(RTLIL::SigSpec(wire)))), "",
+					log("                               %*s  %s -> %s\n", int(log_signal(RTLIL::SigSpec(wire)).size()), "",
 							run_abc.signal_list[id1].bit_str, run_abc.signal_list[id2].bit_str);
 				first_line = false;
 			}


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

See #5215

_Explain how this is achieved._

Easy. We only have to fix one caller in-tree so this probably has very low impact on out-of-tree plugins.