### PR TITLE
Add --no-private-id-locs and new NEW_ID macro

### DIFF
--- a/backends/aiger2/aiger.cc
+++ b/backends/aiger2/aiger.cc
@@ -1040,7 +1040,7 @@ struct XAigerWriter : AigerWriter {
 		for (auto [cursor, box, def] : opaque_boxes)
 			append_box_ports(box, cursor, false);
 
-		holes_module = design->addModule(NEW_ID);
+		holes_module = design->addModule(NEWER_ID);
 		std::vector<RTLIL::Wire *> holes_pis;
 		int boxes_ci_num = 0, boxes_co_num = 0;
 
@@ -1058,7 +1058,7 @@ struct XAigerWriter : AigerWriter {
 
 		for (auto [cursor, box, def] : nonopaque_boxes) {
 			// use `def->name` not `box->type` as we want the derived type
-			Cell *holes_wb = holes_module->addCell(NEW_ID, def->name);
+			Cell *holes_wb = holes_module->addCell(NEWER_ID, def->name);
 			int holes_pi_idx = 0;
 
 			if (map_file.is_open()) {
@@ -1097,7 +1097,7 @@ struct XAigerWriter : AigerWriter {
 					SigSpec in_conn;
 					for (int i = 0; i < port->width; i++) {
 						while (holes_pi_idx >= (int) holes_pis.size()) {
-							Wire *w = holes_module->addWire(NEW_ID, 1);
+							Wire *w = holes_module->addWire(NEWER_ID, 1);
 							w->port_input = true;
 							holes_module->ports.push_back(w->name);
 							holes_pis.push_back(w);
@@ -1126,7 +1126,7 @@ struct XAigerWriter : AigerWriter {
 					boxes_ci_num += port->width;
 
 					// holes
-					Wire *w = holes_module->addWire(NEW_ID, port->width);
+					Wire *w = holes_module->addWire(NEWER_ID, port->width);
 					w->port_output = true;
 					holes_module->ports.push_back(w->name);
 					holes_wb->setPort(port_id, w);

--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -2372,7 +2372,7 @@ void dump_module(std::ostream &f, std::string indent, RTLIL::Module *module)
 	}
 	f << stringf(");\n");
 	if (!systemverilog && !module->processes.empty()) {
-		initial_id = NEW_ID;
+		initial_id = NEWER_ID;
 		f << indent + "  " << "reg " << id(initial_id) << " = 0;\n";
 	}
 

--- a/docs/source/code_examples/extensions/my_cmd.cc
+++ b/docs/source/code_examples/extensions/my_cmd.cc
@@ -38,9 +38,9 @@ struct Test1Pass : public Pass {
         y->port_output = true;
         y->port_id = 2;
 
-        RTLIL::Wire *a_inv = module->addWire(NEW_ID, 4);
-        module->addNeg(NEW_ID, a, a_inv, true);
-        module->addMux(NEW_ID, a, a_inv, RTLIL::SigSpec(a, 3), y);
+        RTLIL::Wire *a_inv = module->addWire(NEWER_ID, 4);
+        module->addNeg(NEWER_ID, a, a_inv, true);
+        module->addMux(NEWER_ID, a, a_inv, RTLIL::SigSpec(a, 3), y);
 
 	module->fixup_ports();
     }

--- a/frontends/aiger/aigerparse.cc
+++ b/frontends/aiger/aigerparse.cc
@@ -559,9 +559,9 @@ void AigerReader::parse_aiger_ascii()
 		RTLIL::Wire *d_wire = createWireIfNotExists(module, l2);
 
 		if (clk_wire)
-			module->addDffGate(NEW_ID, clk_wire, d_wire, q_wire);
+			module->addDffGate(NEWER_ID, clk_wire, d_wire, q_wire);
 		else
-			module->addFfGate(NEW_ID, d_wire, q_wire);
+			module->addFfGate(NEWER_ID, d_wire, q_wire);
 
 		// Reset logic is optional in AIGER 1.9
 		if (f.peek() == ' ') {
@@ -683,9 +683,9 @@ void AigerReader::parse_aiger_binary()
 		RTLIL::Wire *d_wire = createWireIfNotExists(module, l2);
 
 		if (clk_wire)
-			module->addDff(NEW_ID, clk_wire, d_wire, q_wire);
+			module->addDff(NEWER_ID, clk_wire, d_wire, q_wire);
 		else
-			module->addFf(NEW_ID, d_wire, q_wire);
+			module->addFf(NEWER_ID, d_wire, q_wire);
 
 		// Reset logic is optional in AIGER 1.9
 		if (f.peek() == ' ') {
@@ -795,7 +795,7 @@ void AigerReader::post_process()
 		log_assert(q->port_input);
 		q->port_input = false;
 
-		Cell* ff = module->addFfGate(NEW_ID, d, q);
+		Cell* ff = module->addFfGate(NEWER_ID, d, q);
 		ff->attributes[ID::abc9_mergeability] = mergeability[i];
 		q->attributes[ID::init] = initial_state[i];
 	}

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -822,7 +822,7 @@ struct AST_INTERNAL::ProcessGenerator
 
 				RTLIL::SigSpec check = ast->children[0]->genWidthRTLIL(-1, false, &subst_rvalue_map.stdmap());
 				if (GetSize(check) != 1)
-					check = current_module->ReduceBool(NEW_ID, check);
+					check = current_module->ReduceBool(NEWER_ID, check);
 
 				Wire *en = current_module->addWire(cellname.str() + "_EN", 1);
 				set_src_attr(en, ast);
@@ -1626,11 +1626,11 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 					RTLIL::SigSpec shift_val = fake_ast->children[1]->genRTLIL(fake_ast_width, fake_ast_sign);
 
 					if (source_offset != 0) {
-						shift_val = current_module->Sub(NEW_ID, shift_val, source_offset, fake_ast_sign);
+						shift_val = current_module->Sub(NEWER_ID, shift_val, source_offset, fake_ast_sign);
 						fake_ast->children[1]->is_signed = true;
 					}
 					if (id2ast->range_swapped) {
-						shift_val = current_module->Sub(NEW_ID, RTLIL::SigSpec(source_width - width), shift_val, fake_ast_sign);
+						shift_val = current_module->Sub(NEWER_ID, RTLIL::SigSpec(source_width - width), shift_val, fake_ast_sign);
 						fake_ast->children[1]->is_signed = true;
 					}
 					if (GetSize(shift_val) >= 32)
@@ -2028,7 +2028,7 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 
 			RTLIL::SigSpec check = children[0]->genRTLIL();
 			if (GetSize(check) != 1)
-				check = current_module->ReduceBool(NEW_ID, check);
+				check = current_module->ReduceBool(NEWER_ID, check);
 
 			RTLIL::Cell *cell = current_module->addCell(cellname, ID($check));
 			set_src_attr(cell, this);
@@ -2130,7 +2130,7 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 						} else if (arg->is_signed) {
 							// non-trivial signed nodes are indirected through
 							// signed wires to enable sign extension
-							RTLIL::IdString wire_name = NEW_ID;
+							RTLIL::IdString wire_name = NEWER_ID;
 							RTLIL::Wire *wire = current_module->addWire(wire_name, GetSize(sig));
 							wire->is_signed = true;
 							current_module->connect(wire, sig);

--- a/frontends/blif/blifparse.cc
+++ b/frontends/blif/blifparse.cc
@@ -363,19 +363,19 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 					goto no_latch_clock;
 
 				if (!strcmp(edge, "re"))
-					cell = module->addDff(NEW_ID, blif_wire(clock), blif_wire(d), blif_wire(q));
+					cell = module->addDff(NEWER_ID, blif_wire(clock), blif_wire(d), blif_wire(q));
 				else if (!strcmp(edge, "fe"))
-					cell = module->addDff(NEW_ID, blif_wire(clock), blif_wire(d), blif_wire(q), false);
+					cell = module->addDff(NEWER_ID, blif_wire(clock), blif_wire(d), blif_wire(q), false);
 				else if (!strcmp(edge, "ah"))
-					cell = module->addDlatch(NEW_ID, blif_wire(clock), blif_wire(d), blif_wire(q));
+					cell = module->addDlatch(NEWER_ID, blif_wire(clock), blif_wire(d), blif_wire(q));
 				else if (!strcmp(edge, "al"))
-					cell = module->addDlatch(NEW_ID, blif_wire(clock), blif_wire(d), blif_wire(q), false);
+					cell = module->addDlatch(NEWER_ID, blif_wire(clock), blif_wire(d), blif_wire(q), false);
 				else {
 			no_latch_clock:
 					if (dff_name.empty()) {
-						cell = module->addFf(NEW_ID, blif_wire(d), blif_wire(q));
+						cell = module->addFf(NEWER_ID, blif_wire(d), blif_wire(q));
 					} else {
-						cell = module->addCell(NEW_ID, dff_name);
+						cell = module->addCell(NEWER_ID, dff_name);
 						cell->setPort(ID::D, blif_wire(d));
 						cell->setPort(ID::Q, blif_wire(q));
 					}
@@ -394,7 +394,7 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 					goto error;
 
 				IdString celltype = RTLIL::escape_id(p);
-				RTLIL::Cell *cell = module->addCell(NEW_ID, celltype);
+				RTLIL::Cell *cell = module->addCell(NEWER_ID, celltype);
 				RTLIL::Module *cell_mod = design->module(celltype);
 
 				dict<RTLIL::IdString, dict<int, SigBit>> cell_wideports_cache;
@@ -441,7 +441,7 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 						if (it.second.count(idx))
 							sig.append(it.second.at(idx));
 						else
-							sig.append(module->addWire(NEW_ID));
+							sig.append(module->addWire(NEWER_ID));
 					}
 
 					cell->setPort(it.first, sig);
@@ -517,7 +517,7 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 
 				if (sop_mode)
 				{
-					sopcell = module->addCell(NEW_ID, ID($sop));
+					sopcell = module->addCell(NEWER_ID, ID($sop));
 					sopcell->parameters[ID::WIDTH] = RTLIL::Const(input_sig.size());
 					sopcell->parameters[ID::DEPTH] = 0;
 					sopcell->parameters[ID::TABLE] = RTLIL::Const();
@@ -533,7 +533,7 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 				}
 				else
 				{
-					RTLIL::Cell *cell = module->addCell(NEW_ID, ID($lut));
+					RTLIL::Cell *cell = module->addCell(NEWER_ID, ID($lut));
 					cell->parameters[ID::WIDTH] = RTLIL::Const(input_sig.size());
 					cell->parameters[ID::LUT] = RTLIL::Const(RTLIL::State::Sx, 1 << input_sig.size());
 					cell->setPort(ID::A, input_sig);
@@ -586,8 +586,8 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 				sopmode = (*output == '1');
 				if (!sopmode) {
 					SigSpec outnet = sopcell->getPort(ID::Y);
-					SigSpec tempnet = module->addWire(NEW_ID);
-					module->addNotGate(NEW_ID, tempnet, outnet);
+					SigSpec tempnet = module->addWire(NEWER_ID);
+					module->addNotGate(NEWER_ID, tempnet, outnet);
 					sopcell->setPort(ID::Y, tempnet);
 				}
 			} else

--- a/frontends/json/jsonparse.cc
+++ b/frontends/json/jsonparse.cc
@@ -549,7 +549,7 @@ void json_import(Design *design, string &modname, JsonNode *node)
 					if (bitval_node->type == 'N') {
 						int bitidx = bitval_node->data_number;
 						if (signal_bits.count(bitidx) == 0)
-							signal_bits[bitidx] = module->addWire(NEW_ID);
+							signal_bits[bitidx] = module->addWire(NEWER_ID);
 						sig.append(signal_bits.at(bitidx));
 					} else
 						log_error("JSON cells node '%s' connection '%s' has invalid bit value on bit %d.\n",

--- a/frontends/liberty/liberty.cc
+++ b/frontends/liberty/liberty.cc
@@ -58,7 +58,7 @@ static bool parse_func_reduce(RTLIL::Module *module, std::vector<token_t> &stack
 	int top = int(stack.size())-1;
 
 	if (0 <= top-1 && stack[top].type == 0 && stack[top-1].type == '!') {
-		token_t t = token_t(0, module->NotGate(NEW_ID, stack[top].sig));
+		token_t t = token_t(0, module->NotGate(NEWER_ID, stack[top].sig));
 		stack.pop_back();
 		stack.pop_back();
 		stack.push_back(t);
@@ -66,7 +66,7 @@ static bool parse_func_reduce(RTLIL::Module *module, std::vector<token_t> &stack
 	}
 
 	if (0 <= top-1 && stack[top].type == '\'' && stack[top-1].type == 0) {
-		token_t t = token_t(0, module->NotGate(NEW_ID, stack[top-1].sig));
+		token_t t = token_t(0, module->NotGate(NEWER_ID, stack[top-1].sig));
 		stack.pop_back();
 		stack.pop_back();
 		stack.push_back(t);
@@ -81,7 +81,7 @@ static bool parse_func_reduce(RTLIL::Module *module, std::vector<token_t> &stack
 	}
 
 	if (0 <= top-2 && stack[top-2].type == 1 && stack[top-1].type == '^' && stack[top].type == 1) {
-		token_t t = token_t(1, module->XorGate(NEW_ID, stack[top-2].sig, stack[top].sig));
+		token_t t = token_t(1, module->XorGate(NEWER_ID, stack[top-2].sig, stack[top].sig));
 		stack.pop_back();
 		stack.pop_back();
 		stack.pop_back();
@@ -97,7 +97,7 @@ static bool parse_func_reduce(RTLIL::Module *module, std::vector<token_t> &stack
 	}
 
 	if (0 <= top-1 && stack[top-1].type == 2 && stack[top].type == 2) {
-		token_t t = token_t(2, module->AndGate(NEW_ID, stack[top-1].sig, stack[top].sig));
+		token_t t = token_t(2, module->AndGate(NEWER_ID, stack[top-1].sig, stack[top].sig));
 		stack.pop_back();
 		stack.pop_back();
 		stack.push_back(t);
@@ -105,7 +105,7 @@ static bool parse_func_reduce(RTLIL::Module *module, std::vector<token_t> &stack
 	}
 
 	if (0 <= top-2 && stack[top-2].type == 2 && (stack[top-1].type == '*' || stack[top-1].type == '&') && stack[top].type == 2) {
-		token_t t = token_t(2, module->AndGate(NEW_ID, stack[top-2].sig, stack[top].sig));
+		token_t t = token_t(2, module->AndGate(NEWER_ID, stack[top-2].sig, stack[top].sig));
 		stack.pop_back();
 		stack.pop_back();
 		stack.pop_back();
@@ -121,7 +121,7 @@ static bool parse_func_reduce(RTLIL::Module *module, std::vector<token_t> &stack
 	}
 
 	if (0 <= top-2 && stack[top-2].type == 3 && (stack[top-1].type == '+' || stack[top-1].type == '|') && stack[top].type == 3) {
-		token_t t = token_t(3, module->OrGate(NEW_ID, stack[top-2].sig, stack[top].sig));
+		token_t t = token_t(3, module->OrGate(NEWER_ID, stack[top-2].sig, stack[top].sig));
 		stack.pop_back();
 		stack.pop_back();
 		stack.pop_back();
@@ -183,11 +183,11 @@ static RTLIL::SigSpec create_tristate(RTLIL::Module *module, RTLIL::SigSpec func
 {
 	RTLIL::SigSpec three_state = parse_func_expr(module, three_state_expr);
 
-	RTLIL::Cell *cell = module->addCell(NEW_ID, ID($tribuf));
+	RTLIL::Cell *cell = module->addCell(NEWER_ID, ID($tribuf));
 	cell->setParam(ID::WIDTH, GetSize(func));
 	cell->setPort(ID::A, func);
-	cell->setPort(ID::EN, module->NotGate(NEW_ID, three_state));
-	cell->setPort(ID::Y, module->addWire(NEW_ID));
+	cell->setPort(ID::EN, module->NotGate(NEWER_ID, three_state));
+	cell->setPort(ID::Y, module->addWire(NEWER_ID));
 	return cell->getPort(ID::Y);
 }
 
@@ -236,11 +236,11 @@ static void create_ff(RTLIL::Module *module, const LibertyAst *node)
 		}
 	}
 
-	RTLIL::Cell *cell = module->addCell(NEW_ID, ID($_NOT_));
+	RTLIL::Cell *cell = module->addCell(NEWER_ID, ID($_NOT_));
 	cell->setPort(ID::A, iq_sig);
 	cell->setPort(ID::Y, iqn_sig);
 
-	cell = module->addCell(NEW_ID, "");
+	cell = module->addCell(NEWER_ID, "");
 	cell->setPort(ID::D, data_sig);
 	cell->setPort(ID::Q, iq_sig);
 	cell->setPort(ID::C, clk_sig);
@@ -319,7 +319,7 @@ static bool create_latch(RTLIL::Module *module, const LibertyAst *node, bool fla
 		}
 	}
 
-	RTLIL::Cell *cell = module->addCell(NEW_ID, ID($_NOT_));
+	RTLIL::Cell *cell = module->addCell(NEWER_ID, ID($_NOT_));
 	cell->setPort(ID::A, iq_sig);
 	cell->setPort(ID::Y, iqn_sig);
 
@@ -330,9 +330,9 @@ static bool create_latch(RTLIL::Module *module, const LibertyAst *node, bool fla
 
 		if (clear_polarity == true || clear_polarity != enable_polarity)
 		{
-			RTLIL::Cell *inv = module->addCell(NEW_ID, ID($_NOT_));
+			RTLIL::Cell *inv = module->addCell(NEWER_ID, ID($_NOT_));
 			inv->setPort(ID::A, clear_sig);
-			inv->setPort(ID::Y, module->addWire(NEW_ID));
+			inv->setPort(ID::Y, module->addWire(NEWER_ID));
 
 			if (clear_polarity == true)
 				clear_negative = inv->getPort(ID::Y);
@@ -340,15 +340,15 @@ static bool create_latch(RTLIL::Module *module, const LibertyAst *node, bool fla
 				clear_enable = inv->getPort(ID::Y);
 		}
 
-		RTLIL::Cell *data_gate = module->addCell(NEW_ID, ID($_AND_));
+		RTLIL::Cell *data_gate = module->addCell(NEWER_ID, ID($_AND_));
 		data_gate->setPort(ID::A, data_sig);
 		data_gate->setPort(ID::B, clear_negative);
-		data_gate->setPort(ID::Y, data_sig = module->addWire(NEW_ID));
+		data_gate->setPort(ID::Y, data_sig = module->addWire(NEWER_ID));
 
-		RTLIL::Cell *enable_gate = module->addCell(NEW_ID, enable_polarity ? ID($_OR_) : ID($_AND_));
+		RTLIL::Cell *enable_gate = module->addCell(NEWER_ID, enable_polarity ? ID($_OR_) : ID($_AND_));
 		enable_gate->setPort(ID::A, enable_sig);
 		enable_gate->setPort(ID::B, clear_enable);
-		enable_gate->setPort(ID::Y, enable_sig = module->addWire(NEW_ID));
+		enable_gate->setPort(ID::Y, enable_sig = module->addWire(NEWER_ID));
 	}
 
 	if (preset_sig.size() == 1)
@@ -358,9 +358,9 @@ static bool create_latch(RTLIL::Module *module, const LibertyAst *node, bool fla
 
 		if (preset_polarity == false || preset_polarity != enable_polarity)
 		{
-			RTLIL::Cell *inv = module->addCell(NEW_ID, ID($_NOT_));
+			RTLIL::Cell *inv = module->addCell(NEWER_ID, ID($_NOT_));
 			inv->setPort(ID::A, preset_sig);
-			inv->setPort(ID::Y, module->addWire(NEW_ID));
+			inv->setPort(ID::Y, module->addWire(NEWER_ID));
 
 			if (preset_polarity == false)
 				preset_positive = inv->getPort(ID::Y);
@@ -368,18 +368,18 @@ static bool create_latch(RTLIL::Module *module, const LibertyAst *node, bool fla
 				preset_enable = inv->getPort(ID::Y);
 		}
 
-		RTLIL::Cell *data_gate = module->addCell(NEW_ID, ID($_OR_));
+		RTLIL::Cell *data_gate = module->addCell(NEWER_ID, ID($_OR_));
 		data_gate->setPort(ID::A, data_sig);
 		data_gate->setPort(ID::B, preset_positive);
-		data_gate->setPort(ID::Y, data_sig = module->addWire(NEW_ID));
+		data_gate->setPort(ID::Y, data_sig = module->addWire(NEWER_ID));
 
-		RTLIL::Cell *enable_gate = module->addCell(NEW_ID, enable_polarity ? ID($_OR_) : ID($_AND_));
+		RTLIL::Cell *enable_gate = module->addCell(NEWER_ID, enable_polarity ? ID($_OR_) : ID($_AND_));
 		enable_gate->setPort(ID::A, enable_sig);
 		enable_gate->setPort(ID::B, preset_enable);
-		enable_gate->setPort(ID::Y, enable_sig = module->addWire(NEW_ID));
+		enable_gate->setPort(ID::Y, enable_sig = module->addWire(NEWER_ID));
 	}
 
-	cell = module->addCell(NEW_ID, stringf("$_DLATCH_%c_", enable_polarity ? 'P' : 'N'));
+	cell = module->addCell(NEWER_ID, stringf("$_DLATCH_%c_", enable_polarity ? 'P' : 'N'));
 	cell->setPort(ID::D, data_sig);
 	cell->setPort(ID::Q, iq_sig);
 	cell->setPort(ID::E, enable_sig);
@@ -734,7 +734,7 @@ struct LibertyFrontend : public Frontend {
 					if (wi->port_input) {
 						for (auto wo : module->wires())
 						if (wo->port_output) {
-							RTLIL::Cell *spec = module->addCell(NEW_ID, ID($specify2));
+							RTLIL::Cell *spec = module->addCell(NEWER_ID, ID($specify2));
 							spec->setParam(ID::SRC_WIDTH, wi->width);
 							spec->setParam(ID::DST_WIDTH, wo->width);
 							spec->setParam(ID::T_FALL_MAX, 1000);

--- a/frontends/verific/verificsva.cc
+++ b/frontends/verific/verificsva.cc
@@ -166,7 +166,7 @@ struct SvaFsm
 		if (disable_sig == State::S0)
 			disable_sig = sig;
 		else
-			disable_sig = module->Or(NEW_ID, disable_sig, sig);
+			disable_sig = module->Or(NEWER_ID, disable_sig, sig);
 	}
 
 	void popDisable()
@@ -187,7 +187,7 @@ struct SvaFsm
 		if (throughout_sig == State::S1)
 			throughout_sig = sig;
 		else
-			throughout_sig = module->And(NEW_ID, throughout_sig, sig);
+			throughout_sig = module->And(NEWER_ID, throughout_sig, sig);
 	}
 
 	void popThroughout()
@@ -232,7 +232,7 @@ struct SvaFsm
 
 		if (throughout_sig != State::S1) {
 			if (ctrl != State::S1)
-				ctrl = module->And(NEW_ID, throughout_sig, ctrl);
+				ctrl = module->And(NEWER_ID, throughout_sig, ctrl);
 			else
 				ctrl = throughout_sig;
 		}
@@ -254,7 +254,7 @@ struct SvaFsm
 
 		if (throughout_sig != State::S1) {
 			if (ctrl != State::S1)
-				ctrl = module->And(NEW_ID, throughout_sig, ctrl);
+				ctrl = module->And(NEWER_ID, throughout_sig, ctrl);
 			else
 				ctrl = throughout_sig;
 		}
@@ -287,19 +287,19 @@ struct SvaFsm
 			SigBit not_disable = State::S1;
 
 			if (disable_sig != State::S0)
-				not_disable = module->Not(NEW_ID, disable_sig);
+				not_disable = module->Not(NEWER_ID, disable_sig);
 
 			for (int i = 0; i < GetSize(nodes); i++)
 			{
-				Wire *w = module->addWire(NEW_ID);
+				Wire *w = module->addWire(NEWER_ID);
 				state_wire[i] = w;
 				state_sig[i] = w;
 
 				if (i == startNode)
-					state_sig[i] = module->Or(NEW_ID, state_sig[i], trigger_sig);
+					state_sig[i] = module->Or(NEWER_ID, state_sig[i], trigger_sig);
 
 				if (disable_sig != State::S0)
-					state_sig[i] = module->And(NEW_ID, state_sig[i], not_disable);
+					state_sig[i] = module->And(NEWER_ID, state_sig[i], not_disable);
 			}
 		}
 
@@ -327,9 +327,9 @@ struct SvaFsm
 					SigBit ctrl = state_sig[node];
 
 					if (it.second != State::S1)
-						ctrl = module->And(NEW_ID, ctrl, it.second);
+						ctrl = module->And(NEWER_ID, ctrl, it.second);
 
-					state_sig[target] = module->Or(NEW_ID, state_sig[target], ctrl);
+					state_sig[target] = module->Or(NEWER_ID, state_sig[target], ctrl);
 				}
 			}
 		}
@@ -342,7 +342,7 @@ struct SvaFsm
 
 			for (int i = 0; i < GetSize(nodes); i++) {
 				for (auto &it : nodes[i].edges)
-					activate_sig[it.first].append(module->And(NEW_ID, state_sig[i], it.second));
+					activate_sig[it.first].append(module->And(NEWER_ID, state_sig[i], it.second));
 			}
 
 			for (int i = 0; i < GetSize(nodes); i++) {
@@ -351,7 +351,7 @@ struct SvaFsm
 				else if (GetSize(activate_sig[i]) == 1)
 					next_state_sig[i] = activate_sig[i];
 				else
-					next_state_sig[i] = module->ReduceOr(NEW_ID, activate_sig[i]);
+					next_state_sig[i] = module->ReduceOr(NEWER_ID, activate_sig[i]);
 			}
 		}
 
@@ -360,7 +360,7 @@ struct SvaFsm
 		for (int i = 0; i < GetSize(nodes); i++)
 		{
 			if (next_state_sig[i] != State::S0) {
-				clocking.addDff(NEW_ID, next_state_sig[i], state_wire[i], State::S0);
+				clocking.addDff(NEWER_ID, next_state_sig[i], state_wire[i], State::S0);
 			} else {
 				module->connect(state_wire[i], State::S0);
 			}
@@ -626,9 +626,9 @@ struct SvaFsm
 			if (sig_b == State::S1)
 				cond_eq_cache[key] = sig_a;
 			else if (sig_b == State::S0)
-				cond_eq_cache[key] = module->Not(NEW_ID, sig_a);
+				cond_eq_cache[key] = module->Not(NEWER_ID, sig_a);
 			else
-				cond_eq_cache[key] = module->Eq(NEW_ID, sig_a, sig_b);
+				cond_eq_cache[key] = module->Eq(NEWER_ID, sig_a, sig_b);
 
 			if (verific_verbose >= 2) {
 				log("    Cond: %s := %s == %s\n", log_signal(cond_eq_cache[key]),
@@ -665,11 +665,11 @@ struct SvaFsm
 		for (auto &it : dnodes)
 		{
 			SvaDFsmNode &dnode = it.second;
-			dnode.ffoutwire = module->addWire(NEW_ID);
+			dnode.ffoutwire = module->addWire(NEWER_ID);
 			dnode.statesig = dnode.ffoutwire;
 
 			if (it.first == vector<int>{startNode})
-				dnode.statesig = module->Or(NEW_ID, dnode.statesig, trigger_sig);
+				dnode.statesig = module->Or(NEWER_ID, dnode.statesig, trigger_sig);
 		}
 
 		for (auto &it : dnodes)
@@ -708,10 +708,10 @@ struct SvaFsm
 				module->connect(dnode.ffoutwire, State::S0);
 			} else
 			if (GetSize(dnode.nextstate) == 1) {
-				clocking.addDff(NEW_ID, dnode.nextstate, dnode.ffoutwire, State::S0);
+				clocking.addDff(NEWER_ID, dnode.nextstate, dnode.ffoutwire, State::S0);
 			} else {
-				SigSpec nextstate = module->ReduceOr(NEW_ID, dnode.nextstate);
-				clocking.addDff(NEW_ID, nextstate, dnode.ffoutwire, State::S0);
+				SigSpec nextstate = module->ReduceOr(NEWER_ID, dnode.nextstate);
+				clocking.addDff(NEWER_ID, nextstate, dnode.ffoutwire, State::S0);
 			}
 		}
 
@@ -722,7 +722,7 @@ struct SvaFsm
 			else if (GetSize(accept_sig) == 1)
 				final_accept_sig = accept_sig;
 			else
-				final_accept_sig = module->ReduceOr(NEW_ID, accept_sig);
+				final_accept_sig = module->ReduceOr(NEWER_ID, accept_sig);
 			*accept_p = final_accept_sig;
 		}
 
@@ -733,7 +733,7 @@ struct SvaFsm
 			else if (GetSize(reject_sig) == 1)
 				final_reject_sig = reject_sig;
 			else
-				final_reject_sig = module->ReduceOr(NEW_ID, reject_sig);
+				final_reject_sig = module->ReduceOr(NEWER_ID, reject_sig);
 			*reject_p = final_reject_sig;
 		}
 	}
@@ -1135,14 +1135,14 @@ struct VerificSvaImporter
 			return parse_expression(inst->GetInput());
 
 		if (inst->Type() == PRIM_SVA_NOT)
-			return module->Not(NEW_ID, parse_expression(inst->GetInput()));
+			return module->Not(NEWER_ID, parse_expression(inst->GetInput()));
 
 		if (inst->Type() == PRIM_SVA_SEQ_OR || inst->Type() == PRIM_SVA_OR)
-			return module->Or(NEW_ID, parse_expression(inst->GetInput1()), parse_expression(inst->GetInput2()));
+			return module->Or(NEWER_ID, parse_expression(inst->GetInput1()), parse_expression(inst->GetInput2()));
 
 		if (inst->Type() == PRIM_SVA_SEQ_AND || inst->Type() == PRIM_SVA_AND || inst->Type() == PRIM_SVA_INTERSECT ||
 				inst->Type() == PRIM_SVA_WITHIN || inst->Type() == PRIM_SVA_THROUGHOUT || inst->Type() == PRIM_SVA_SEQ_CONCAT)
-			return module->And(NEW_ID, parse_expression(inst->GetInput1()), parse_expression(inst->GetInput2()));
+			return module->And(NEWER_ID, parse_expression(inst->GetInput1()), parse_expression(inst->GetInput2()));
 
 		log_abort();
 	}
@@ -1364,7 +1364,7 @@ struct VerificSvaImporter
 			int node = fsm.createNode(start_node);
 
 			SigBit cond = parse_expression(body_net);
-			SigBit not_cond = module->Not(NEW_ID, cond);
+			SigBit not_cond = module->Not(NEWER_ID, cond);
 
 			for (int i = 0; i < sva_low; i++)
 			{
@@ -1526,7 +1526,7 @@ struct VerificSvaImporter
 		if (clocking.cond_net != nullptr) {
 			trig = importer->net_map_at(clocking.cond_net);
 			if (!clocking.cond_pol)
-				trig = module->Not(NEW_ID, trig);
+				trig = module->Not(NEWER_ID, trig);
 		} else {
 			trig = State::S1;
 		}
@@ -1594,21 +1594,21 @@ struct VerificSvaImporter
 		if (clocking.cond_net != nullptr) {
 			trig = importer->net_map_at(clocking.cond_net);
 			if (!clocking.cond_pol)
-				trig = module->Not(NEW_ID, trig);
+				trig = module->Not(NEWER_ID, trig);
 		}
 
 		if (inst == nullptr)
 		{
 			if (trig != State::S1) {
 				if (accept_p != nullptr)
-					*accept_p = module->And(NEW_ID, trig, importer->net_map_at(net));
+					*accept_p = module->And(NEWER_ID, trig, importer->net_map_at(net));
 				if (reject_p != nullptr)
-					*reject_p = module->And(NEW_ID, trig, module->Not(NEW_ID, importer->net_map_at(net)));
+					*reject_p = module->And(NEWER_ID, trig, module->Not(NEWER_ID, importer->net_map_at(net)));
 			} else {
 				if (accept_p != nullptr)
 					*accept_p = importer->net_map_at(net);
 				if (reject_p != nullptr)
-					*reject_p = module->Not(NEW_ID, importer->net_map_at(net));
+					*reject_p = module->Not(NEWER_ID, importer->net_map_at(net));
 			}
 		}
 		else
@@ -1652,7 +1652,7 @@ struct VerificSvaImporter
 				}
 
 				SigBit until_sig = until_net ? parse_expression(until_net) : RTLIL::S0;
-				SigBit not_until_sig = module->Not(NEW_ID, until_sig);
+				SigBit not_until_sig = module->Not(NEWER_ID, until_sig);
 				antecedent_fsm.createEdge(node, node, not_until_sig);
 
 				antecedent_fsm.createLink(node, antecedent_fsm.acceptNode, until_with ? State::S1 : not_until_sig);
@@ -1732,7 +1732,7 @@ struct VerificSvaImporter
 				}
 			}
 
-			RTLIL::IdString root_name = module->uniquify(importer->mode_names || is_user_declared ? RTLIL::escape_id(root->Name()) : NEW_ID);
+			RTLIL::IdString root_name = module->uniquify(importer->mode_names || is_user_declared ? RTLIL::escape_id(root->Name()) : NEWER_ID);
 
 			// parse SVA sequence into trigger signal
 
@@ -1745,7 +1745,7 @@ struct VerificSvaImporter
 					parser_error(stringf("Failed to parse SVA clocking"), root);
 
 				if (mode_assert || mode_assume) {
-					reject_bit = module->Not(NEW_ID, parse_expression(root->GetInput()));
+					reject_bit = module->Not(NEWER_ID, parse_expression(root->GetInput()));
 				} else {
 					accept_bit = parse_expression(root->GetInput());
 				}
@@ -1768,16 +1768,16 @@ struct VerificSvaImporter
 						sig_a_q = sig_a;
 						sig_en_q = sig_en;
 					} else {
-						sig_a_q = module->addWire(NEW_ID);
-						sig_en_q = module->addWire(NEW_ID);
-						clocking.addDff(NEW_ID, sig_a, sig_a_q, State::S0);
-						clocking.addDff(NEW_ID, sig_en, sig_en_q, State::S0);
+						sig_a_q = module->addWire(NEWER_ID);
+						sig_en_q = module->addWire(NEWER_ID);
+						clocking.addDff(NEWER_ID, sig_a, sig_a_q, State::S0);
+						clocking.addDff(NEWER_ID, sig_en, sig_en_q, State::S0);
 					}
 
 					// accept in disable case
 
 					if (clocking.disable_sig != State::S0)
-						sig_a_q = module->Or(NEW_ID, sig_a_q, clocking.disable_sig);
+						sig_a_q = module->Or(NEWER_ID, sig_a_q, clocking.disable_sig);
 
 					// generate fair/live cell
 
@@ -1806,8 +1806,8 @@ struct VerificSvaImporter
 			}
 			else
 			{
-				SigBit sig_a = module->Not(NEW_ID, reject_bit);
-				SigBit sig_en = module->Or(NEW_ID, accept_bit, reject_bit);
+				SigBit sig_a = module->Not(NEWER_ID, reject_bit);
+				SigBit sig_en = module->Or(NEWER_ID, accept_bit, reject_bit);
 
 				// add final FF stage
 
@@ -1817,10 +1817,10 @@ struct VerificSvaImporter
 					sig_a_q = sig_a;
 					sig_en_q = sig_en;
 				} else {
-					sig_a_q = module->addWire(NEW_ID);
-					sig_en_q = module->addWire(NEW_ID);
-					clocking.addDff(NEW_ID, sig_a, sig_a_q, State::S0);
-					clocking.addDff(NEW_ID, sig_en, sig_en_q, State::S0);
+					sig_a_q = module->addWire(NEWER_ID);
+					sig_en_q = module->addWire(NEWER_ID);
+					clocking.addDff(NEWER_ID, sig_a, sig_a_q, State::S0);
+					clocking.addDff(NEWER_ID, sig_en, sig_en_q, State::S0);
 				}
 
 				// generate assert/assume/cover cell

--- a/guidelines/GettingStarted
+++ b/guidelines/GettingStarted
@@ -98,8 +98,8 @@ single signal bit can have multiple valid names. The SigMap object can be used
 to map SigSpecs or SigBits to unique SigSpecs and SigBits that consistently
 only use one wire from such a group of connected wires. For example:
 
-	SigBit a = module->addWire(NEW_ID);
-	SigBit b = module->addWire(NEW_ID);
+	SigBit a = module->addWire(NEWER_ID);
+	SigBit b = module->addWire(NEWER_ID);
 	module->connect(a, b);
 
 	log("%d\n", a == b); // will print 0

--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -292,6 +292,7 @@ int main(int argc, char **argv)
 			cxxopts::value<std::vector<std::string>>(), "<feature>")
 		("g,debug", "globally enable debug log messages")
 		("perffile", "write a JSON performance log to <perffile>", cxxopts::value<std::string>(), "<perffile>")
+		("no-private-id-locs", "turn off putting source file locations into object IDs")
 	;
 
 	options.parse_positional({"infile"});
@@ -436,6 +437,7 @@ int main(int argc, char **argv)
 			log_experimentals_ignored.insert(ignores.begin(), ignores.end());
 		}
 		if (result.count("perffile")) perffile = result["perffile"].as<std::string>();
+		if (result.count("no-private-id-locs")) yosys_private_id_locs = false;
 		if (result.count("infile")) {
 			frontend_files = result["infile"].as<std::vector<std::string>>();
 		}

--- a/kernel/ff.cc
+++ b/kernel/ff.cc
@@ -263,7 +263,7 @@ FfData::FfData(FfInitVals *initvals, Cell *cell_) : FfData(cell_->module, initva
 }
 
 FfData FfData::slice(const std::vector<int> &bits) {
-	FfData res(module, initvals, NEW_ID);
+	FfData res(module, initvals, NEWER_ID);
 	res.sig_clk = sig_clk;
 	res.sig_ce = sig_ce;
 	res.sig_aload = sig_aload;
@@ -417,21 +417,21 @@ void FfData::aload_to_sr() {
 		pol_clr = false;
 		pol_set = true;
 		if (pol_aload) {
-			sig_clr = module->Mux(NEW_ID, Const(State::S1, width), sig_ad, sig_aload);
-			sig_set = module->Mux(NEW_ID, Const(State::S0, width), sig_ad, sig_aload);
+			sig_clr = module->Mux(NEWER_ID, Const(State::S1, width), sig_ad, sig_aload);
+			sig_set = module->Mux(NEWER_ID, Const(State::S0, width), sig_ad, sig_aload);
 		} else {
-			sig_clr = module->Mux(NEW_ID, sig_ad, Const(State::S1, width), sig_aload);
-			sig_set = module->Mux(NEW_ID, sig_ad, Const(State::S0, width), sig_aload);
+			sig_clr = module->Mux(NEWER_ID, sig_ad, Const(State::S1, width), sig_aload);
+			sig_set = module->Mux(NEWER_ID, sig_ad, Const(State::S0, width), sig_aload);
 		}
 	} else {
 		pol_clr = pol_aload;
 		pol_set = pol_aload;
 		if (pol_aload) {
-			sig_clr = module->AndnotGate(NEW_ID, sig_aload, sig_ad);
-			sig_set = module->AndGate(NEW_ID, sig_aload, sig_ad);
+			sig_clr = module->AndnotGate(NEWER_ID, sig_aload, sig_ad);
+			sig_set = module->AndGate(NEWER_ID, sig_aload, sig_ad);
 		} else {
-			sig_clr = module->OrGate(NEW_ID, sig_aload, sig_ad);
-			sig_set = module->OrnotGate(NEW_ID, sig_aload, sig_ad);
+			sig_clr = module->OrGate(NEWER_ID, sig_aload, sig_ad);
+			sig_set = module->OrnotGate(NEWER_ID, sig_aload, sig_ad);
 		}
 	}
 }
@@ -444,31 +444,31 @@ void FfData::convert_ce_over_srst(bool val) {
 		if (!is_fine) {
 			if (pol_ce) {
 				if (pol_srst) {
-					sig_ce = module->Or(NEW_ID, sig_ce, sig_srst);
+					sig_ce = module->Or(NEWER_ID, sig_ce, sig_srst);
 				} else {
-					SigSpec tmp = module->Not(NEW_ID, sig_srst);
-					sig_ce = module->Or(NEW_ID, sig_ce, tmp);
+					SigSpec tmp = module->Not(NEWER_ID, sig_srst);
+					sig_ce = module->Or(NEWER_ID, sig_ce, tmp);
 				}
 			} else {
 				if (pol_srst) {
-					SigSpec tmp = module->Not(NEW_ID, sig_srst);
-					sig_ce = module->And(NEW_ID, sig_ce, tmp);
+					SigSpec tmp = module->Not(NEWER_ID, sig_srst);
+					sig_ce = module->And(NEWER_ID, sig_ce, tmp);
 				} else {
-					sig_ce = module->And(NEW_ID, sig_ce, sig_srst);
+					sig_ce = module->And(NEWER_ID, sig_ce, sig_srst);
 				}
 			}
 		} else {
 			if (pol_ce) {
 				if (pol_srst) {
-					sig_ce = module->OrGate(NEW_ID, sig_ce, sig_srst);
+					sig_ce = module->OrGate(NEWER_ID, sig_ce, sig_srst);
 				} else {
-					sig_ce = module->OrnotGate(NEW_ID, sig_ce, sig_srst);
+					sig_ce = module->OrnotGate(NEWER_ID, sig_ce, sig_srst);
 				}
 			} else {
 				if (pol_srst) {
-					sig_ce = module->AndnotGate(NEW_ID, sig_ce, sig_srst);
+					sig_ce = module->AndnotGate(NEWER_ID, sig_ce, sig_srst);
 				} else {
-					sig_ce = module->AndGate(NEW_ID, sig_ce, sig_srst);
+					sig_ce = module->AndGate(NEWER_ID, sig_ce, sig_srst);
 				}
 			}
 		}
@@ -477,31 +477,31 @@ void FfData::convert_ce_over_srst(bool val) {
 		if (!is_fine) {
 			if (pol_srst) {
 				if (pol_ce) {
-					sig_srst = cell->module->And(NEW_ID, sig_srst, sig_ce);
+					sig_srst = cell->module->And(NEWER_ID, sig_srst, sig_ce);
 				} else {
-					SigSpec tmp = module->Not(NEW_ID, sig_ce);
-					sig_srst = cell->module->And(NEW_ID, sig_srst, tmp);
+					SigSpec tmp = module->Not(NEWER_ID, sig_ce);
+					sig_srst = cell->module->And(NEWER_ID, sig_srst, tmp);
 				}
 			} else {
 				if (pol_ce) {
-					SigSpec tmp = module->Not(NEW_ID, sig_ce);
-					sig_srst = cell->module->Or(NEW_ID, sig_srst, tmp);
+					SigSpec tmp = module->Not(NEWER_ID, sig_ce);
+					sig_srst = cell->module->Or(NEWER_ID, sig_srst, tmp);
 				} else {
-					sig_srst = cell->module->Or(NEW_ID, sig_srst, sig_ce);
+					sig_srst = cell->module->Or(NEWER_ID, sig_srst, sig_ce);
 				}
 			}
 		} else {
 			if (pol_srst) {
 				if (pol_ce) {
-					sig_srst = cell->module->AndGate(NEW_ID, sig_srst, sig_ce);
+					sig_srst = cell->module->AndGate(NEWER_ID, sig_srst, sig_ce);
 				} else {
-					sig_srst = cell->module->AndnotGate(NEW_ID, sig_srst, sig_ce);
+					sig_srst = cell->module->AndnotGate(NEWER_ID, sig_srst, sig_ce);
 				}
 			} else {
 				if (pol_ce) {
-					sig_srst = cell->module->OrnotGate(NEW_ID, sig_srst, sig_ce);
+					sig_srst = cell->module->OrnotGate(NEWER_ID, sig_srst, sig_ce);
 				} else {
-					sig_srst = cell->module->OrGate(NEW_ID, sig_srst, sig_ce);
+					sig_srst = cell->module->OrGate(NEWER_ID, sig_srst, sig_ce);
 				}
 			}
 		}
@@ -518,14 +518,14 @@ void FfData::unmap_ce() {
 
 	if (!is_fine) {
 		if (pol_ce)
-			sig_d = module->Mux(NEW_ID, sig_q, sig_d, sig_ce);
+			sig_d = module->Mux(NEWER_ID, sig_q, sig_d, sig_ce);
 		else
-			sig_d = module->Mux(NEW_ID, sig_d, sig_q, sig_ce);
+			sig_d = module->Mux(NEWER_ID, sig_d, sig_q, sig_ce);
 	} else {
 		if (pol_ce)
-			sig_d = module->MuxGate(NEW_ID, sig_q, sig_d, sig_ce);
+			sig_d = module->MuxGate(NEWER_ID, sig_q, sig_d, sig_ce);
 		else
-			sig_d = module->MuxGate(NEW_ID, sig_d, sig_q, sig_ce);
+			sig_d = module->MuxGate(NEWER_ID, sig_d, sig_q, sig_ce);
 	}
 	has_ce = false;
 }
@@ -538,14 +538,14 @@ void FfData::unmap_srst() {
 
 	if (!is_fine) {
 		if (pol_srst)
-			sig_d = module->Mux(NEW_ID, sig_d, val_srst, sig_srst);
+			sig_d = module->Mux(NEWER_ID, sig_d, val_srst, sig_srst);
 		else
-			sig_d = module->Mux(NEW_ID, val_srst, sig_d, sig_srst);
+			sig_d = module->Mux(NEWER_ID, val_srst, sig_d, sig_srst);
 	} else {
 		if (pol_srst)
-			sig_d = module->MuxGate(NEW_ID, sig_d, val_srst[0], sig_srst);
+			sig_d = module->MuxGate(NEWER_ID, sig_d, val_srst[0], sig_srst);
 		else
-			sig_d = module->MuxGate(NEW_ID, val_srst[0], sig_d, sig_srst);
+			sig_d = module->MuxGate(NEWER_ID, val_srst[0], sig_d, sig_srst);
 	}
 	has_srst = false;
 }
@@ -718,7 +718,7 @@ void FfData::flip_bits(const pool<int> &bits) {
 
 	flip_rst_bits(bits);
 
-	Wire *new_q = module->addWire(NEW_ID, width);
+	Wire *new_q = module->addWire(NEWER_ID, width);
 
 	if (has_sr && cell) {
 		log_warning("Flipping D/Q/init and inserting priority fixup to legalize %s.%s [%s].\n", log_id(module->name), log_id(cell->name), log_id(cell->type));
@@ -730,15 +730,15 @@ void FfData::flip_bits(const pool<int> &bits) {
 			SigSpec new_sig_clr;
 			if (pol_set) {
 				if (pol_clr) {
-					new_sig_clr = module->AndnotGate(NEW_ID, sig_set, sig_clr);
+					new_sig_clr = module->AndnotGate(NEWER_ID, sig_set, sig_clr);
 				} else {
-					new_sig_clr = module->AndGate(NEW_ID, sig_set, sig_clr);
+					new_sig_clr = module->AndGate(NEWER_ID, sig_set, sig_clr);
 				}
 			} else {
 				if (pol_clr) {
-					new_sig_clr = module->OrGate(NEW_ID, sig_set, sig_clr);
+					new_sig_clr = module->OrGate(NEWER_ID, sig_set, sig_clr);
 				} else {
-					new_sig_clr = module->OrnotGate(NEW_ID, sig_set, sig_clr);
+					new_sig_clr = module->OrnotGate(NEWER_ID, sig_set, sig_clr);
 				}
 			}
 			pol_set = pol_clr;
@@ -747,10 +747,10 @@ void FfData::flip_bits(const pool<int> &bits) {
 			sig_clr = new_sig_clr;
 		}
 		if (has_clk || has_gclk)
-			sig_d = module->NotGate(NEW_ID, sig_d);
+			sig_d = module->NotGate(NEWER_ID, sig_d);
 		if (has_aload)
-			sig_ad = module->NotGate(NEW_ID, sig_ad);
-		module->addNotGate(NEW_ID, new_q, sig_q);
+			sig_ad = module->NotGate(NEWER_ID, sig_ad);
+		module->addNotGate(NEWER_ID, new_q, sig_q);
 	}
 	else
 	{
@@ -758,17 +758,17 @@ void FfData::flip_bits(const pool<int> &bits) {
 			SigSpec not_clr;
 			if (!pol_clr) {
 				not_clr = sig_clr;
-				sig_clr = module->Not(NEW_ID, sig_clr);
+				sig_clr = module->Not(NEWER_ID, sig_clr);
 				pol_clr = true;
 			} else {
-				not_clr = module->Not(NEW_ID, sig_clr);
+				not_clr = module->Not(NEWER_ID, sig_clr);
 			}
 			if (!pol_set) {
-				sig_set = module->Not(NEW_ID, sig_set);
+				sig_set = module->Not(NEWER_ID, sig_set);
 				pol_set = true;
 			}
 
-			SigSpec masked_set = module->And(NEW_ID, sig_set, not_clr);
+			SigSpec masked_set = module->And(NEWER_ID, sig_set, not_clr);
 			for (auto bit: bits) {
 				sig_set[bit] = sig_clr[bit];
 				sig_clr[bit] = masked_set[bit];
@@ -780,10 +780,10 @@ void FfData::flip_bits(const pool<int> &bits) {
 			mask.set(bit, State::S1);
 
 		if (has_clk || has_gclk)
-			sig_d = module->Xor(NEW_ID, sig_d, mask);
+			sig_d = module->Xor(NEWER_ID, sig_d, mask);
 		if (has_aload)
-			sig_ad = module->Xor(NEW_ID, sig_ad, mask);
-		module->addXor(NEW_ID, new_q, mask, sig_q);
+			sig_ad = module->Xor(NEWER_ID, sig_ad, mask);
+		module->addXor(NEWER_ID, new_q, mask, sig_q);
 	}
 
 	sig_q = new_q;

--- a/kernel/ffmerge.cc
+++ b/kernel/ffmerge.cc
@@ -29,7 +29,7 @@ bool FfMergeHelper::is_output_unused(RTLIL::SigSpec sig) {
 }
 
 bool FfMergeHelper::find_output_ff(RTLIL::SigSpec sig, FfData &ff, pool<std::pair<Cell *, int>> &bits) {
-	ff = FfData(module, initvals, NEW_ID);
+	ff = FfData(module, initvals, NEWER_ID);
 	sigmap->apply(sig);
 
 	bool found = false;
@@ -157,7 +157,7 @@ bool FfMergeHelper::find_output_ff(RTLIL::SigSpec sig, FfData &ff, pool<std::pai
 }
 
 bool FfMergeHelper::find_input_ff(RTLIL::SigSpec sig, FfData &ff, pool<std::pair<Cell *, int>> &bits) {
-	ff = FfData(module, initvals, NEW_ID);
+	ff = FfData(module, initvals, NEWER_ID);
 	sigmap->apply(sig);
 
 	bool found = false;

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -3090,7 +3090,7 @@ RTLIL::Process *RTLIL::Module::addProcess(RTLIL::IdString name, const RTLIL::Pro
 		return cell;                                        \
 	} \
 	RTLIL::SigSpec RTLIL::Module::_func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, bool is_signed, const std::string &src) { \
-		RTLIL::SigSpec sig_y = addWire(NEW_ID, _y_size);    \
+		RTLIL::SigSpec sig_y = addWire(NEWER_ID, _y_size);    \
 		add ## _func(name, sig_a, sig_y, is_signed, src);   \
 		return sig_y;                                       \
 	}
@@ -3115,7 +3115,7 @@ DEF_METHOD(LogicNot,   1, ID($logic_not))
 		return cell;                                        \
 	} \
 	RTLIL::SigSpec RTLIL::Module::_func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, bool is_signed, const std::string &src) { \
-		RTLIL::SigSpec sig_y = addWire(NEW_ID, _y_size);    \
+		RTLIL::SigSpec sig_y = addWire(NEWER_ID, _y_size);    \
 		add ## _func(name, sig_a, sig_y, is_signed, src);   \
 		return sig_y;                                       \
 	}
@@ -3137,7 +3137,7 @@ DEF_METHOD(Buf, sig_a.size(), ID($buf))
 		return cell;                                        \
 	} \
 	RTLIL::SigSpec RTLIL::Module::_func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, bool is_signed, const std::string &src) { \
-		RTLIL::SigSpec sig_y = addWire(NEW_ID, _y_size);         \
+		RTLIL::SigSpec sig_y = addWire(NEWER_ID, _y_size);         \
 		add ## _func(name, sig_a, sig_b, sig_y, is_signed, src); \
 		return sig_y;                                            \
 	}
@@ -3180,7 +3180,7 @@ DEF_METHOD(LogicOr,  1, ID($logic_or))
 		return cell;                                        \
 	} \
 	RTLIL::SigSpec RTLIL::Module::_func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, bool is_signed, const std::string &src) { \
-		RTLIL::SigSpec sig_y = addWire(NEW_ID, _y_size);         \
+		RTLIL::SigSpec sig_y = addWire(NEWER_ID, _y_size);         \
 		add ## _func(name, sig_a, sig_b, sig_y, is_signed, src); \
 		return sig_y;                                            \
 	}
@@ -3205,7 +3205,7 @@ DEF_METHOD(Sshr,     sig_a.size(), ID($sshr))
 		return cell;                                        \
 	} \
 	RTLIL::SigSpec RTLIL::Module::_func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, bool is_signed, const std::string &src) { \
-		RTLIL::SigSpec sig_y = addWire(NEW_ID, _y_size);         \
+		RTLIL::SigSpec sig_y = addWire(NEWER_ID, _y_size);         \
 		add ## _func(name, sig_a, sig_b, sig_y, is_signed, src); \
 		return sig_y;                                            \
 	}
@@ -3225,7 +3225,7 @@ DEF_METHOD(Shiftx,      sig_a.size(), ID($shiftx))
 		return cell;                                              \
 	} \
 	RTLIL::SigSpec RTLIL::Module::_func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_b, const RTLIL::SigSpec &sig_s, const std::string &src) { \
-		RTLIL::SigSpec sig_y = addWire(NEW_ID, sig_a.size());     \
+		RTLIL::SigSpec sig_y = addWire(NEWER_ID, sig_a.size());     \
 		add ## _func(name, sig_a, sig_b, sig_s, sig_y, src);      \
 		return sig_y;                                             \
 	}
@@ -3246,7 +3246,7 @@ DEF_METHOD(Pmux,     ID($pmux),       1)
 		return cell;                                              \
 	} \
 	RTLIL::SigSpec RTLIL::Module::_func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_s, const std::string &src) { \
-		RTLIL::SigSpec sig_y = addWire(NEW_ID, _demux ? sig_a.size() << sig_s.size() : sig_a.size() >> sig_s.size()); \
+		RTLIL::SigSpec sig_y = addWire(NEWER_ID, _demux ? sig_a.size() << sig_s.size() : sig_a.size() >> sig_s.size()); \
 		add ## _func(name, sig_a, sig_s, sig_y, src);             \
 		return sig_y;                                             \
 	}
@@ -3265,7 +3265,7 @@ DEF_METHOD(Demux,    ID($demux),      1)
 		return cell;                                              \
 	} \
 	RTLIL::SigSpec RTLIL::Module::_func(RTLIL::IdString name, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_s, const std::string &src) { \
-		RTLIL::SigSpec sig_y = addWire(NEW_ID, sig_a.size());     \
+		RTLIL::SigSpec sig_y = addWire(NEWER_ID, sig_a.size());     \
 		add ## _func(name, sig_a, sig_s, sig_y, src);             \
 		return sig_y;                                             \
 	}
@@ -3281,7 +3281,7 @@ DEF_METHOD(Bweqx,    ID($bweqx))
 		return cell;                                      \
 	} \
 	RTLIL::SigBit RTLIL::Module::_func(RTLIL::IdString name, const RTLIL::SigBit &sig1, const std::string &src) { \
-		RTLIL::SigBit sig2 = addWire(NEW_ID);             \
+		RTLIL::SigBit sig2 = addWire(NEWER_ID);             \
 		add ## _func(name, sig1, sig2, src);              \
 		return sig2;                                      \
 	}
@@ -3295,7 +3295,7 @@ DEF_METHOD(Bweqx,    ID($bweqx))
 		return cell;                                      \
 	} \
 	RTLIL::SigBit RTLIL::Module::_func(RTLIL::IdString name, const RTLIL::SigBit &sig1, const RTLIL::SigBit &sig2, const std::string &src) { \
-		RTLIL::SigBit sig3 = addWire(NEW_ID);             \
+		RTLIL::SigBit sig3 = addWire(NEWER_ID);             \
 		add ## _func(name, sig1, sig2, sig3, src);        \
 		return sig3;                                      \
 	}
@@ -3310,7 +3310,7 @@ DEF_METHOD(Bweqx,    ID($bweqx))
 		return cell;                                      \
 	} \
 	RTLIL::SigBit RTLIL::Module::_func(RTLIL::IdString name, const RTLIL::SigBit &sig1, const RTLIL::SigBit &sig2, const RTLIL::SigBit &sig3, const std::string &src) { \
-		RTLIL::SigBit sig4 = addWire(NEW_ID);             \
+		RTLIL::SigBit sig4 = addWire(NEWER_ID);             \
 		add ## _func(name, sig1, sig2, sig3, sig4, src);  \
 		return sig4;                                      \
 	}
@@ -3326,7 +3326,7 @@ DEF_METHOD(Bweqx,    ID($bweqx))
 		return cell;                                      \
 	} \
 	RTLIL::SigBit RTLIL::Module::_func(RTLIL::IdString name, const RTLIL::SigBit &sig1, const RTLIL::SigBit &sig2, const RTLIL::SigBit &sig3, const RTLIL::SigBit &sig4, const std::string &src) { \
-		RTLIL::SigBit sig5 = addWire(NEW_ID);                  \
+		RTLIL::SigBit sig5 = addWire(NEWER_ID);                  \
 		add ## _func(name, sig1, sig2, sig3, sig4, sig5, src); \
 		return sig5;                                           \
 	}
@@ -3935,7 +3935,7 @@ RTLIL::Cell* RTLIL::Module::addAnyinit(RTLIL::IdString name, const RTLIL::SigSpe
 
 RTLIL::SigSpec RTLIL::Module::Anyconst(RTLIL::IdString name, int width, const std::string &src)
 {
-	RTLIL::SigSpec sig = addWire(NEW_ID, width);
+	RTLIL::SigSpec sig = addWire(NEWER_ID, width);
 	Cell *cell = addCell(name, ID($anyconst));
 	cell->setParam(ID::WIDTH, width);
 	cell->setPort(ID::Y, sig);
@@ -3945,7 +3945,7 @@ RTLIL::SigSpec RTLIL::Module::Anyconst(RTLIL::IdString name, int width, const st
 
 RTLIL::SigSpec RTLIL::Module::Anyseq(RTLIL::IdString name, int width, const std::string &src)
 {
-	RTLIL::SigSpec sig = addWire(NEW_ID, width);
+	RTLIL::SigSpec sig = addWire(NEWER_ID, width);
 	Cell *cell = addCell(name, ID($anyseq));
 	cell->setParam(ID::WIDTH, width);
 	cell->setPort(ID::Y, sig);
@@ -3955,7 +3955,7 @@ RTLIL::SigSpec RTLIL::Module::Anyseq(RTLIL::IdString name, int width, const std:
 
 RTLIL::SigSpec RTLIL::Module::Allconst(RTLIL::IdString name, int width, const std::string &src)
 {
-	RTLIL::SigSpec sig = addWire(NEW_ID, width);
+	RTLIL::SigSpec sig = addWire(NEWER_ID, width);
 	Cell *cell = addCell(name, ID($allconst));
 	cell->setParam(ID::WIDTH, width);
 	cell->setPort(ID::Y, sig);
@@ -3965,7 +3965,7 @@ RTLIL::SigSpec RTLIL::Module::Allconst(RTLIL::IdString name, int width, const st
 
 RTLIL::SigSpec RTLIL::Module::Allseq(RTLIL::IdString name, int width, const std::string &src)
 {
-	RTLIL::SigSpec sig = addWire(NEW_ID, width);
+	RTLIL::SigSpec sig = addWire(NEWER_ID, width);
 	Cell *cell = addCell(name, ID($allseq));
 	cell->setParam(ID::WIDTH, width);
 	cell->setPort(ID::Y, sig);
@@ -3975,7 +3975,7 @@ RTLIL::SigSpec RTLIL::Module::Allseq(RTLIL::IdString name, int width, const std:
 
 RTLIL::SigSpec RTLIL::Module::Initstate(RTLIL::IdString name, const std::string &src)
 {
-	RTLIL::SigSpec sig = addWire(NEW_ID);
+	RTLIL::SigSpec sig = addWire(NEWER_ID);
 	Cell *cell = addCell(name, ID($initstate));
 	cell->setPort(ID::Y, sig);
 	cell->set_src_attribute(src);
@@ -3984,7 +3984,7 @@ RTLIL::SigSpec RTLIL::Module::Initstate(RTLIL::IdString name, const std::string 
 
 RTLIL::SigSpec RTLIL::Module::SetTag(RTLIL::IdString name, const std::string &tag, const RTLIL::SigSpec &sig_a, const RTLIL::SigSpec &sig_s, const RTLIL::SigSpec &sig_c, const std::string &src)
 {
-	RTLIL::SigSpec sig = addWire(NEW_ID, sig_a.size());
+	RTLIL::SigSpec sig = addWire(NEWER_ID, sig_a.size());
 	Cell *cell = addCell(name, ID($set_tag));
 	cell->parameters[ID::WIDTH] = sig_a.size();
 	cell->parameters[ID::TAG] = tag;
@@ -4011,7 +4011,7 @@ RTLIL::Cell* RTLIL::Module::addSetTag(RTLIL::IdString name, const std::string &t
 
 RTLIL::SigSpec RTLIL::Module::GetTag(RTLIL::IdString name, const std::string &tag, const RTLIL::SigSpec &sig_a, const std::string &src)
 {
-	RTLIL::SigSpec sig = addWire(NEW_ID, sig_a.size());
+	RTLIL::SigSpec sig = addWire(NEWER_ID, sig_a.size());
 	Cell *cell = addCell(name, ID($get_tag));
 	cell->parameters[ID::WIDTH] = sig_a.size();
 	cell->parameters[ID::TAG] = tag;
@@ -4035,7 +4035,7 @@ RTLIL::Cell* RTLIL::Module::addOverwriteTag(RTLIL::IdString name, const std::str
 
 RTLIL::SigSpec RTLIL::Module::OriginalTag(RTLIL::IdString name, const std::string &tag, const RTLIL::SigSpec &sig_a, const std::string &src)
 {
-	RTLIL::SigSpec sig = addWire(NEW_ID, sig_a.size());
+	RTLIL::SigSpec sig = addWire(NEWER_ID, sig_a.size());
 	Cell *cell = addCell(name, ID($original_tag));
 	cell->parameters[ID::WIDTH] = sig_a.size();
 	cell->parameters[ID::TAG] = tag;
@@ -4047,7 +4047,7 @@ RTLIL::SigSpec RTLIL::Module::OriginalTag(RTLIL::IdString name, const std::strin
 
 RTLIL::SigSpec RTLIL::Module::FutureFF(RTLIL::IdString name, const RTLIL::SigSpec &sig_e, const std::string &src)
 {
-	RTLIL::SigSpec sig = addWire(NEW_ID, sig_e.size());
+	RTLIL::SigSpec sig = addWire(NEWER_ID, sig_e.size());
 	Cell *cell = addCell(name, ID($future_ff));
 	cell->parameters[ID::WIDTH] = sig_e.size();
 	cell->setPort(ID::A, sig_e);
@@ -4255,7 +4255,7 @@ void RTLIL::Module::bufNormalize()
 			for (auto &chunk : sig.chunks())
 				if (chunk.wire) outWires.insert(chunk.wire);
 
-			Wire *wire = addWire(NEW_ID, GetSize(sig));
+			Wire *wire = addWire(NEWER_ID, GetSize(sig));
 			sigmap.add(sig, wire);
 			cell->setPort(portname, wire);
 
@@ -4268,7 +4268,7 @@ void RTLIL::Module::bufNormalize()
 			for (int i = 0; i < GetSize(wire); i++)
 				if (insig[i] == outsig[i])
 					insig[i] = State::Sx;
-			addBuf(NEW_ID, insig, outsig);
+			addBuf(NEWER_ID, insig, outsig);
 		}
 	}
 }

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -82,6 +82,7 @@ YOSYS_NAMESPACE_BEGIN
 int autoidx = 1;
 int yosys_xtrace = 0;
 bool yosys_write_versions = true;
+bool yosys_private_id_locs = true;
 const char* yosys_maybe_version() {
 	if (yosys_write_versions)
 		return yosys_version_str;
@@ -273,6 +274,16 @@ void yosys_shutdown()
 
 RTLIL::IdString new_id(std::string file, int line, std::string func)
 {
+	return newer_id(file, line, func);
+}
+
+RTLIL::IdString new_id_suffix(std::string file, int line, std::string func, std::string suffix)
+{
+	return newer_id_suffix(file, line, func, suffix);
+}
+
+RTLIL::IdString newer_id(std::string file, int line, std::string func)
+{
 #ifdef _WIN32
 	size_t pos = file.find_last_of("/\\");
 #else
@@ -288,7 +299,7 @@ RTLIL::IdString new_id(std::string file, int line, std::string func)
 	return stringf("$auto$%s:%d:%s$%d", file, line, func, autoidx++);
 }
 
-RTLIL::IdString new_id_suffix(std::string file, int line, std::string func, std::string suffix)
+RTLIL::IdString newer_id_suffix(std::string file, int line, std::string func, std::string suffix)
 {
 #ifdef _WIN32
 	size_t pos = file.find_last_of("/\\");

--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -268,14 +268,29 @@ inline int GetSize(RTLIL::Wire *wire);
 extern int autoidx;
 extern int yosys_xtrace;
 extern bool yosys_write_versions;
+extern bool yosys_private_id_locs;
 
+RTLIL::IdString newer_id(std::string file, int line, std::string func);
+RTLIL::IdString newer_id_suffix(std::string file, int line, std::string func, std::string suffix);
+[[deprecated("Use NEWER_ID instead of NEW_ID")]]
 RTLIL::IdString new_id(std::string file, int line, std::string func);
+[[deprecated("Use NEWER_ID_SUFFIX instead of NEW_ID_SUFFIX")]]
 RTLIL::IdString new_id_suffix(std::string file, int line, std::string func, std::string suffix);
 
 #define NEW_ID \
 	YOSYS_NAMESPACE_PREFIX new_id(__FILE__, __LINE__, __FUNCTION__)
 #define NEW_ID_SUFFIX(suffix) \
 	YOSYS_NAMESPACE_PREFIX new_id_suffix(__FILE__, __LINE__, __FUNCTION__, suffix)
+
+#define NEWER_ID \
+	(YOSYS_NAMESPACE_PREFIX yosys_private_id_locs ? \
+	YOSYS_NAMESPACE_PREFIX newer_id(__FILE__, __LINE__, __FUNCTION__) : \
+	YOSYS_NAMESPACE_PREFIX newer_id("?", 0, "?"))
+
+#define NEWER_ID_SUFFIX(suffix) \
+	(YOSYS_NAMESPACE_PREFIX yosys_private_id_locs ? \
+	YOSYS_NAMESPACE_PREFIX newer_id_suffix(__FILE__, __LINE__, __FUNCTION__, suffix) : \
+	YOSYS_NAMESPACE_PREFIX newer_id_suffix("?", 0, "?", suffix))
 
 namespace ID = RTLIL::ID;
 

--- a/passes/cmds/abstract.cc
+++ b/passes/cmds/abstract.cc
@@ -82,7 +82,7 @@ struct Slice {
 };
 
 void emit_mux_anyseq(Module* mod, const SigSpec& mux_input, const SigSpec& mux_output, EnableLogic enable) {
-	auto anyseq = mod->Anyseq(NEW_ID, mux_input.size());
+	auto anyseq = mod->Anyseq(NEWER_ID, mux_input.size());
 	if (enable.bit == (enable.pol ? State::S1 : State::S0)) {
 		mod->connect(mux_output, anyseq);
 	}
@@ -94,7 +94,7 @@ void emit_mux_anyseq(Module* mod, const SigSpec& mux_input, const SigSpec& mux_o
 		mux_a = anyseq;
 		mux_b = mux_input;
 	}
-	(void)mod->addMux(NEW_ID,
+	(void)mod->addMux(NEWER_ID,
 		mux_a,
 		mux_b,
 		enable.bit,
@@ -102,7 +102,7 @@ void emit_mux_anyseq(Module* mod, const SigSpec& mux_input, const SigSpec& mux_o
 }
 
 bool abstract_state_port(FfData& ff, SigSpec& port_sig, std::set<int> offsets, EnableLogic enable) {
-	Wire* abstracted = ff.module->addWire(NEW_ID, offsets.size());
+	Wire* abstracted = ff.module->addWire(NEWER_ID, offsets.size());
 	SigSpec mux_input;
 	int abstracted_idx = 0;
 	for (int d_idx = 0; d_idx < ff.width; d_idx++) {
@@ -213,7 +213,7 @@ unsigned int abstract_state(Module* mod, EnableLogic enable, const std::vector<S
 }
 
 bool abstract_value_cell_port(Module* mod, Cell* cell, std::set<int> offsets, IdString port_name, EnableLogic enable) {
-	Wire* to_abstract = mod->addWire(NEW_ID, offsets.size());
+	Wire* to_abstract = mod->addWire(NEWER_ID, offsets.size());
 	SigSpec mux_input;
 	SigSpec mux_output;
 	const SigSpec& old_port = cell->getPort(port_name);
@@ -235,7 +235,7 @@ bool abstract_value_cell_port(Module* mod, Cell* cell, std::set<int> offsets, Id
 }
 
 bool abstract_value_mod_port(Module* mod, Wire* wire, std::set<int> offsets, EnableLogic enable) {
-	Wire* to_abstract = mod->addWire(NEW_ID, wire);
+	Wire* to_abstract = mod->addWire(NEWER_ID, wire);
 	to_abstract->port_input = true;
 	to_abstract->port_id = wire->port_id;
 	wire->port_input = false;
@@ -501,10 +501,10 @@ struct AbstractPass : public Pass {
 						enable_logic = { enable_wire, enable == Enable::ActiveHigh };
 					} break;
 					case Enable::Initstates: {
-						SigBit in_init_states = mod->Initstate(NEW_ID);
+						SigBit in_init_states = mod->Initstate(NEWER_ID);
 						for (int i = 1; i < initstates; i++) {
-							Wire *in_init_states_q = mod->addWire(NEW_ID);
-							mod->addFf(NEW_ID, in_init_states, in_init_states_q);
+							Wire *in_init_states_q = mod->addWire(NEWER_ID);
+							mod->addFf(NEWER_ID, in_init_states, in_init_states_q);
 							in_init_states_q->attributes[ID::init] = State::S1;
 							in_init_states = in_init_states_q;
 						}

--- a/passes/cmds/add.cc
+++ b/passes/cmds/add.cc
@@ -41,7 +41,7 @@ static void add_formal(RTLIL::Module *module, const std::string &celltype, const
 		log_error("Could not find wire with name \"%s\".\n", name);
 	}
 	else {
-		RTLIL::Cell *formal_cell = module->addCell(NEW_ID, "$" + celltype);
+		RTLIL::Cell *formal_cell = module->addCell(NEWER_ID, "$" + celltype);
 		formal_cell->setPort(ID::A, wire);
 		if(enable_name == "") {
 			formal_cell->setPort(ID::EN, State::S1);

--- a/passes/cmds/bugpoint.cc
+++ b/passes/cmds/bugpoint.cc
@@ -306,7 +306,7 @@ struct BugpointPass : public Pass {
 						if (!stage2 && (cell->input(it.first) || cell->output(it.first)) && index++ == seed)
 						{
 							log_header(design, "Trying to expose cell port %s.%s.%s as module port.\n", log_id(mod), log_id(cell), log_id(it.first));
-							RTLIL::Wire *wire = mod->addWire(NEW_ID, port.size());
+							RTLIL::Wire *wire = mod->addWire(NEWER_ID, port.size());
 							wire->set_bool_attribute(ID($bugpoint));
 							wire->port_input = cell->input(it.first);
 							wire->port_output = cell->output(it.first);

--- a/passes/cmds/chformal.cc
+++ b/passes/cmds/chformal.cc
@@ -337,12 +337,12 @@ struct ChformalPass : public Pass {
 						SigSpec orig_a = cell->getPort(ID::A);
 						SigSpec orig_en = cell->getPort(ID::EN);
 
-						Wire *new_a = module->addWire(NEW_ID);
-						Wire *new_en = module->addWire(NEW_ID);
+						Wire *new_a = module->addWire(NEWER_ID);
+						Wire *new_en = module->addWire(NEWER_ID);
 						new_en->attributes[ID::init] = State::S0;
 
-						module->addFf(NEW_ID, orig_a, new_a);
-						module->addFf(NEW_ID, orig_en, new_en);
+						module->addFf(NEWER_ID, orig_a, new_a);
+						module->addFf(NEWER_ID, orig_en, new_en);
 
 						cell->setPort(ID::A, new_a);
 						cell->setPort(ID::EN, new_en);
@@ -355,14 +355,14 @@ struct ChformalPass : public Pass {
 				SigSpec en = State::S1;
 
 				for (int i = 0; i < mode_arg; i++) {
-					Wire *w = module->addWire(NEW_ID);
+					Wire *w = module->addWire(NEWER_ID);
 					w->attributes[ID::init] = State::S0;
-					module->addFf(NEW_ID, en, w);
+					module->addFf(NEWER_ID, en, w);
 					en = w;
 				}
 
 				for (auto cell : constr_cells)
-					cell->setPort(ID::EN, module->LogicAnd(NEW_ID, en, cell->getPort(ID::EN)));
+					cell->setPort(ID::EN, module->LogicAnd(NEWER_ID, en, cell->getPort(ID::EN)));
 			}
 			else
 			if (mode =='p')
@@ -370,7 +370,7 @@ struct ChformalPass : public Pass {
 				for (auto cell : constr_cells)
 				{
 					if (cell->type == ID($check)) {
-						Cell *cover = module->addCell(NEW_ID_SUFFIX("coverenable"), ID($check));
+						Cell *cover = module->addCell(NEWER_ID_SUFFIX("coverenable"), ID($check));
 						cover->attributes = cell->attributes;
 						cover->parameters = cell->parameters;
 						cover->setParam(ID(FLAVOR), Const("cover"));
@@ -381,7 +381,7 @@ struct ChformalPass : public Pass {
 						cover->setPort(ID::A, cell->getPort(ID::EN));
 						cover->setPort(ID::EN, State::S1);
 					} else {
-						module->addCover(NEW_ID_SUFFIX("coverenable"),
+						module->addCover(NEWER_ID_SUFFIX("coverenable"),
 							cell->getPort(ID::EN), State::S1, cell->get_src_attribute());
 					}
 				}
@@ -414,7 +414,7 @@ struct ChformalPass : public Pass {
 						log_error("Cannot lower edge triggered $check cell %s, run async2sync or clk2fflogic first.\n", log_id(cell));
 
 
-					Cell *plain_cell = module->addCell(NEW_ID, formal_flavor(cell));
+					Cell *plain_cell = module->addCell(NEWER_ID, formal_flavor(cell));
 
 					plain_cell->attributes = cell->attributes;
 
@@ -425,9 +425,9 @@ struct ChformalPass : public Pass {
 					plain_cell->setPort(ID::EN, sig_en);
 
 					if (plain_cell->type.in(ID($assert), ID($assume)))
-						sig_a = module->Not(NEW_ID, sig_a);
+						sig_a = module->Not(NEWER_ID, sig_a);
 
-					SigBit combined_en = module->And(NEW_ID, sig_a, sig_en);
+					SigBit combined_en = module->And(NEWER_ID, sig_a, sig_en);
 
 					module->swap_names(cell, plain_cell);
 

--- a/passes/cmds/connect.cc
+++ b/passes/cmds/connect.cc
@@ -30,7 +30,7 @@ static void unset_drivers(RTLIL::Design *design, RTLIL::Module *module, SigMap &
 {
 	CellTypes ct(design);
 
-	RTLIL::Wire *dummy_wire = module->addWire(NEW_ID, sig.size());
+	RTLIL::Wire *dummy_wire = module->addWire(NEWER_ID, sig.size());
 
 	for (auto cell : module->cells())
 	for (auto &port : cell->connections_)

--- a/passes/cmds/glift.cc
+++ b/passes/cmds/glift.cc
@@ -144,7 +144,7 @@ private:
 			//In this case, a nonzero hole metamux select value means less logic.
 			//Thus we should invert the ReduceOr over the metamux_select signal.
 			RTLIL::SigSpec pmux_select = module->ReduceOr(metamux_select.as_wire()->name.str() + "_nonzero", metamux_select);
-			return module->Pmux(NEW_ID, RTLIL::Const(1), RTLIL::Const(0), pmux_select, metamux_select.as_wire()->get_src_attribute());
+			return module->Pmux(NEWER_ID, RTLIL::Const(1), RTLIL::Const(0), pmux_select, metamux_select.as_wire()->get_src_attribute());
 		} else {
 			auto select_width = metamux_select.as_wire()->width;
 

--- a/passes/cmds/portarcs.cc
+++ b/passes/cmds/portarcs.cc
@@ -291,7 +291,7 @@ struct PortarcsPass : Pass {
 					int *p = annotations.at(canonical_bit(bit));
 					for (auto i = 0; i < inputs.size(); i++) {
 						if (p[i] >= 0) {
-							Cell *spec = m->addCell(NEW_ID, ID($specify2));
+							Cell *spec = m->addCell(NEWER_ID, ID($specify2));
 							spec->setParam(ID::SRC_WIDTH, 1);
 							spec->setParam(ID::DST_WIDTH, 1);
 							spec->setParam(ID::T_FALL_MAX, p[i]);

--- a/passes/cmds/rename.cc
+++ b/passes/cmds/rename.cc
@@ -494,11 +494,11 @@ struct RenamePass : public Pass {
 
 				for (auto wire : module->selected_wires())
 					if (wire->name.isPublic() && wire->port_id == 0)
-						new_wire_names[wire] = NEW_ID;
+						new_wire_names[wire] = NEWER_ID;
 
 				for (auto cell : module->selected_cells())
 					if (cell->name.isPublic())
-						new_cell_names[cell] = NEW_ID;
+						new_cell_names[cell] = NEWER_ID;
 
 				for (auto &it : new_wire_names)
 					module->rename(it.first, it.second);

--- a/passes/cmds/scatter.cc
+++ b/passes/cmds/scatter.cc
@@ -51,7 +51,7 @@ struct ScatterPass : public Pass {
 			for (auto cell : module->cells()) {
 				dict<RTLIL::IdString, RTLIL::SigSig> new_connections;
 				for (auto conn : cell->connections())
-					new_connections.emplace(conn.first, RTLIL::SigSig(conn.second, module->addWire(NEW_ID, GetSize(conn.second))));
+					new_connections.emplace(conn.first, RTLIL::SigSig(conn.second, module->addWire(NEWER_ID, GetSize(conn.second))));
 				for (auto &it : new_connections) {
 					if (ct.cell_output(cell->type, it.first))
 						module->connect(RTLIL::SigSig(it.second.first, it.second.second));

--- a/passes/cmds/setundef.cc
+++ b/passes/cmds/setundef.cc
@@ -345,9 +345,9 @@ struct SetundefPass : public Pass {
 					for (auto &c : sig.chunks()) {
 						RTLIL::SigSpec bits;
 						if (worker.next_bit_mode == MODE_ANYSEQ)
-							bits = module->Anyseq(NEW_ID, c.width);
+							bits = module->Anyseq(NEWER_ID, c.width);
 						else if (worker.next_bit_mode == MODE_ANYCONST)
-							bits = module->Anyconst(NEW_ID, c.width);
+							bits = module->Anyconst(NEWER_ID, c.width);
 						else
 							for (int i = 0; i < c.width; i++)
 								bits.append(worker.next_bit());
@@ -530,9 +530,9 @@ struct SetundefPass : public Pass {
 
 						if (width > 0) {
 							if (worker.next_bit_mode == MODE_ANYSEQ)
-								sig.replace(cursor, module->Anyseq(NEW_ID, width));
+								sig.replace(cursor, module->Anyseq(NEWER_ID, width));
 							else
-								sig.replace(cursor, module->Anyconst(NEW_ID, width));
+								sig.replace(cursor, module->Anyconst(NEWER_ID, width));
 							cursor += width;
 						} else {
 							cursor++;

--- a/passes/cmds/splice.cc
+++ b/passes/cmds/splice.cc
@@ -75,12 +75,12 @@ struct SpliceWorker
 		RTLIL::SigSpec new_sig = sig;
 
 		if (sig_a.size() != sig.size()) {
-			RTLIL::Cell *cell = module->addCell(NEW_ID, ID($slice));
+			RTLIL::Cell *cell = module->addCell(NEWER_ID, ID($slice));
 			cell->parameters[ID::OFFSET] = offset;
 			cell->parameters[ID::A_WIDTH] = sig_a.size();
 			cell->parameters[ID::Y_WIDTH] = sig.size();
 			cell->setPort(ID::A, sig_a);
-			cell->setPort(ID::Y, module->addWire(NEW_ID, sig.size()));
+			cell->setPort(ID::Y, module->addWire(NEWER_ID, sig.size()));
 			new_sig = cell->getPort(ID::Y);
 		}
 
@@ -132,12 +132,12 @@ struct SpliceWorker
 		RTLIL::SigSpec new_sig = get_sliced_signal(chunks.front());
 		for (size_t i = 1; i < chunks.size(); i++) {
 			RTLIL::SigSpec sig2 = get_sliced_signal(chunks[i]);
-			RTLIL::Cell *cell = module->addCell(NEW_ID, ID($concat));
+			RTLIL::Cell *cell = module->addCell(NEWER_ID, ID($concat));
 			cell->parameters[ID::A_WIDTH] = new_sig.size();
 			cell->parameters[ID::B_WIDTH] = sig2.size();
 			cell->setPort(ID::A, new_sig);
 			cell->setPort(ID::B, sig2);
-			cell->setPort(ID::Y, module->addWire(NEW_ID, new_sig.size() + sig2.size()));
+			cell->setPort(ID::Y, module->addWire(NEWER_ID, new_sig.size() + sig2.size()));
 			new_sig = cell->getPort(ID::Y);
 		}
 
@@ -232,7 +232,7 @@ struct SpliceWorker
 		for (auto &it : rework_wires)
 		{
 			RTLIL::IdString orig_name = it.first->name;
-			module->rename(it.first, NEW_ID);
+			module->rename(it.first, NEWER_ID);
 
 			RTLIL::Wire *new_port = module->addWire(orig_name, it.first);
 			it.first->port_id = 0;

--- a/passes/equiv/equiv_add.cc
+++ b/passes/equiv/equiv_add.cc
@@ -84,10 +84,10 @@ struct EquivAddPass : public Pass {
 
 				if (gold_cell->input(port) && gate_cell->input(port))
 				{
-					SigSpec combined_sig = module->addWire(NEW_ID, width);
+					SigSpec combined_sig = module->addWire(NEWER_ID, width);
 
 					for (int i = 0; i < width; i++) {
-						module->addEquiv(NEW_ID, gold_sig[i], gate_sig[i], combined_sig[i]);
+						module->addEquiv(NEWER_ID, gold_sig[i], gate_sig[i], combined_sig[i]);
 						gold_sig[i] = gate_sig[i] = combined_sig[i];
 					}
 
@@ -98,12 +98,12 @@ struct EquivAddPass : public Pass {
 
 				if (gold_cell->output(port) && gate_cell->output(port))
 				{
-					SigSpec new_gold_wire = module->addWire(NEW_ID, width);
-					SigSpec new_gate_wire = module->addWire(NEW_ID, width);
+					SigSpec new_gold_wire = module->addWire(NEWER_ID, width);
+					SigSpec new_gate_wire = module->addWire(NEWER_ID, width);
 					SigSig gg_conn;
 
 					for (int i = 0; i < width; i++) {
-						module->addEquiv(NEW_ID, new_gold_wire[i], new_gold_wire[i], gold_sig[i]);
+						module->addEquiv(NEWER_ID, new_gold_wire[i], new_gold_wire[i], gold_sig[i]);
 						gg_conn.first.append(gate_sig[i]);
 						gg_conn.second.append(gold_sig[i]);
 						gold_sig[i] = new_gold_wire[i];
@@ -141,7 +141,7 @@ struct EquivAddPass : public Pass {
 			}
 
 			log_assert(GetSize(gold_signal) == GetSize(gate_signal));
-			SigSpec equiv_signal = module->addWire(NEW_ID, GetSize(gold_signal));
+			SigSpec equiv_signal = module->addWire(NEWER_ID, GetSize(gold_signal));
 
 			SigMap sigmap(module);
 			sigmap.apply(gold_signal);
@@ -151,7 +151,7 @@ struct EquivAddPass : public Pass {
 			pool<Cell*> added_equiv_cells;
 
 			for (int i = 0; i < GetSize(gold_signal); i++) {
-				Cell *equiv_cell = module->addEquiv(NEW_ID, gold_signal[i], gate_signal[i], equiv_signal[i]);
+				Cell *equiv_cell = module->addEquiv(NEWER_ID, gold_signal[i], gate_signal[i], equiv_signal[i]);
 				equiv_cell->set_bool_attribute(ID::keep);
 				to_equiv_bits[gold_signal[i]] = equiv_signal[i];
 				to_equiv_bits[gate_signal[i]] = equiv_signal[i];

--- a/passes/equiv/equiv_make.cc
+++ b/passes/equiv/equiv_make.cc
@@ -136,8 +136,8 @@ struct EquivMakeWorker
 
 	void add_eq_assertion(const SigSpec &gold_sig, const SigSpec &gate_sig)
 	{
-		auto eq_wire = equiv_mod->Eqx(NEW_ID, gold_sig, gate_sig);
-		equiv_mod->addAssert(NEW_ID_SUFFIX("assert"), eq_wire, State::S1);
+		auto eq_wire = equiv_mod->Eqx(NEWER_ID, gold_sig, gate_sig);
+		equiv_mod->addAssert(NEWER_ID_SUFFIX("assert"), eq_wire, State::S1);
 	}
 
 	void find_same_wires()
@@ -205,11 +205,11 @@ struct EquivMakeWorker
 					for (auto &bit : enc_result)
 						if (bit != State::S1) bit = State::S0;
 
-					SigSpec dec_eq = equiv_mod->addWire(NEW_ID);
-					SigSpec enc_eq = equiv_mod->addWire(NEW_ID);
+					SigSpec dec_eq = equiv_mod->addWire(NEWER_ID);
+					SigSpec enc_eq = equiv_mod->addWire(NEWER_ID);
 
-					equiv_mod->addEq(NEW_ID, reduced_dec_sig, reduced_dec_pat, dec_eq);
-					cells_list.push_back(equiv_mod->addEq(NEW_ID, reduced_enc_sig, reduced_enc_pat, enc_eq));
+					equiv_mod->addEq(NEWER_ID, reduced_dec_sig, reduced_dec_pat, dec_eq);
+					cells_list.push_back(equiv_mod->addEq(NEWER_ID, reduced_enc_sig, reduced_enc_pat, enc_eq));
 
 					dec_s.append(dec_eq);
 					enc_s.append(enc_eq);
@@ -217,8 +217,8 @@ struct EquivMakeWorker
 					enc_b.append(enc_result);
 				}
 
-				equiv_mod->addPmux(NEW_ID, dec_a, dec_b, dec_s, dec_wire);
-				equiv_mod->addPmux(NEW_ID, enc_a, enc_b, enc_s, enc_wire);
+				equiv_mod->addPmux(NEWER_ID, dec_a, dec_b, dec_s, dec_wire);
+				equiv_mod->addPmux(NEWER_ID, enc_a, enc_b, enc_s, enc_wire);
 
 				rd_signal_map.add(assign_map(gate_wire), enc_wire);
 				gate_wire = dec_wire;
@@ -254,7 +254,7 @@ struct EquivMakeWorker
 				else
 				{
 					for (int i = 0; i < wire->width; i++)
-						equiv_mod->addEquiv(NEW_ID, SigSpec(gold_wire, i), SigSpec(gate_wire, i), SigSpec(wire, i));
+						equiv_mod->addEquiv(NEWER_ID, SigSpec(gold_wire, i), SigSpec(gate_wire, i), SigSpec(wire, i));
 				}
 
 				rd_signal_map.add(assign_map(gold_wire), wire);
@@ -291,7 +291,7 @@ struct EquivMakeWorker
 							log("  Skipping signal bit %s [%d]: undriven on gate side.\n", id2cstr(gate_wire->name), i);
 							continue;
 						}
-						equiv_mod->addEquiv(NEW_ID, SigSpec(gold_wire, i), SigSpec(gate_wire, i), SigSpec(wire, i));
+						equiv_mod->addEquiv(NEWER_ID, SigSpec(gold_wire, i), SigSpec(gate_wire, i), SigSpec(wire, i));
 						rdmap_gold.append(SigBit(gold_wire, i));
 						rdmap_gate.append(SigBit(gate_wire, i));
 						rdmap_equiv.append(SigBit(wire, i));
@@ -365,8 +365,8 @@ struct EquivMakeWorker
 				{
 					for (int i = 0; i < GetSize(gold_sig); i++)
 						if (gold_sig[i] != gate_sig[i]) {
-							Wire *w = equiv_mod->addWire(NEW_ID);
-							equiv_mod->addEquiv(NEW_ID, gold_sig[i], gate_sig[i], w);
+							Wire *w = equiv_mod->addWire(NEWER_ID);
+							equiv_mod->addEquiv(NEWER_ID, gold_sig[i], gate_sig[i], w);
 							gold_sig[i] = w;
 						}
 				}

--- a/passes/equiv/equiv_miter.cc
+++ b/passes/equiv/equiv_miter.cc
@@ -219,9 +219,9 @@ struct EquivMiterWorker
 		for (auto c : equiv_cells)
 		{
 			SigSpec cmp = mode_undef ?
-					miter_module->LogicOr(NEW_ID, miter_module->Eqx(NEW_ID, c->getPort(ID::A), State::Sx),
-							miter_module->Eqx(NEW_ID, c->getPort(ID::A), c->getPort(ID::B))) :
-					miter_module->Eq(NEW_ID, c->getPort(ID::A), c->getPort(ID::B));
+					miter_module->LogicOr(NEWER_ID, miter_module->Eqx(NEWER_ID, c->getPort(ID::A), State::Sx),
+							miter_module->Eqx(NEWER_ID, c->getPort(ID::A), c->getPort(ID::B))) :
+					miter_module->Eq(NEWER_ID, c->getPort(ID::A), c->getPort(ID::B));
 
 			if (mode_cmp) {
 				string cmp_name = stringf("\\cmp%s", log_signal(c->getPort(ID::Y)));
@@ -236,15 +236,15 @@ struct EquivMiterWorker
 			}
 
 			if (mode_assert)
-				miter_module->addAssert(NEW_ID, cmp, State::S1);
+				miter_module->addAssert(NEWER_ID, cmp, State::S1);
 
-			trigger_signals.append(miter_module->Not(NEW_ID, cmp));
+			trigger_signals.append(miter_module->Not(NEWER_ID, cmp));
 		}
 
 		if (mode_trigger) {
 			auto w = miter_module->addWire(ID(trigger));
 			w->port_output = true;
-			miter_module->addReduceOr(NEW_ID, trigger_signals, w);
+			miter_module->addReduceOr(NEWER_ID, trigger_signals, w);
 		}
 
 		miter_module->fixup_ports();

--- a/passes/equiv/equiv_purge.cc
+++ b/passes/equiv/equiv_purge.cc
@@ -67,7 +67,7 @@ struct EquivPurgeWorker
 					log("  Module input: %s\n", log_signal(wire));
 					wire->port_input = true;
 				}
-				return module->addWire(NEW_ID, GetSize(sig));
+				return module->addWire(NEWER_ID, GetSize(sig));
 			}
 		}
 
@@ -81,7 +81,7 @@ struct EquivPurgeWorker
 			wire->port_input = true;
 			module->connect(sig, wire);
 			log("  Module input: %s (%s)\n", log_signal(wire), log_signal(sig));
-			return module->addWire(NEW_ID, GetSize(sig));
+			return module->addWire(NEWER_ID, GetSize(sig));
 		}
 	}
 

--- a/passes/equiv/equiv_struct.cc
+++ b/passes/equiv/equiv_struct.cc
@@ -85,10 +85,10 @@ struct EquivStructWorker
 
 		for (int i = 0; i < GetSize(inputs_a); i++) {
 			SigBit bit_a = inputs_a[i], bit_b = inputs_b[i];
-			SigBit bit_y = module->addWire(NEW_ID);
+			SigBit bit_y = module->addWire(NEWER_ID);
 			log("        New $equiv for input %s: A: %s, B: %s, Y: %s\n",
 					input_names[i].c_str(), log_signal(bit_a), log_signal(bit_b), log_signal(bit_y));
-			module->addEquiv(NEW_ID, bit_a, bit_b, bit_y);
+			module->addEquiv(NEWER_ID, bit_a, bit_b, bit_y);
 			merged_map.add(bit_a, bit_y);
 			merged_map.add(bit_b, bit_y);
 		}

--- a/passes/fsm/fsm_map.cc
+++ b/passes/fsm/fsm_map.cc
@@ -71,10 +71,10 @@ static void implement_pattern_cache(RTLIL::Module *module, std::map<RTLIL::Const
 
 		if (eq_sig_a.size() > 0)
 		{
-			RTLIL::Wire *eq_wire = module->addWire(NEW_ID);
+			RTLIL::Wire *eq_wire = module->addWire(NEWER_ID);
 			and_sig.append(RTLIL::SigSpec(eq_wire));
 
-			RTLIL::Cell *eq_cell = module->addCell(NEW_ID, ID($eq));
+			RTLIL::Cell *eq_cell = module->addCell(NEWER_ID, ID($eq));
 			eq_cell->setPort(ID::A, eq_sig_a);
 			eq_cell->setPort(ID::B, eq_sig_b);
 			eq_cell->setPort(ID::Y, RTLIL::SigSpec(eq_wire));
@@ -99,10 +99,10 @@ static void implement_pattern_cache(RTLIL::Module *module, std::map<RTLIL::Const
 			}
 			else
 			{
-				RTLIL::Wire *or_wire = module->addWire(NEW_ID);
+				RTLIL::Wire *or_wire = module->addWire(NEWER_ID);
 				and_sig.append(RTLIL::SigSpec(or_wire));
 
-				RTLIL::Cell *or_cell = module->addCell(NEW_ID, ID($reduce_or));
+				RTLIL::Cell *or_cell = module->addCell(NEWER_ID, ID($reduce_or));
 				or_cell->setPort(ID::A, or_sig);
 				or_cell->setPort(ID::Y, RTLIL::SigSpec(or_wire));
 				or_cell->parameters[ID::A_SIGNED] = RTLIL::Const(false);
@@ -115,10 +115,10 @@ static void implement_pattern_cache(RTLIL::Module *module, std::map<RTLIL::Const
 		{
 		case 2:
 			{
-				RTLIL::Wire *and_wire = module->addWire(NEW_ID);
+				RTLIL::Wire *and_wire = module->addWire(NEWER_ID);
 				cases_vector.append(RTLIL::SigSpec(and_wire));
 
-				RTLIL::Cell *and_cell = module->addCell(NEW_ID, ID($and));
+				RTLIL::Cell *and_cell = module->addCell(NEWER_ID, ID($and));
 				and_cell->setPort(ID::A, and_sig.extract(0, 1));
 				and_cell->setPort(ID::B, and_sig.extract(1, 1));
 				and_cell->setPort(ID::Y, RTLIL::SigSpec(and_wire));
@@ -141,7 +141,7 @@ static void implement_pattern_cache(RTLIL::Module *module, std::map<RTLIL::Const
 	}
 
 	if (cases_vector.size() > 1) {
-		RTLIL::Cell *or_cell = module->addCell(NEW_ID, ID($reduce_or));
+		RTLIL::Cell *or_cell = module->addCell(NEWER_ID, ID($reduce_or));
 		or_cell->setPort(ID::A, cases_vector);
 		or_cell->setPort(ID::Y, output);
 		or_cell->parameters[ID::A_SIGNED] = RTLIL::Const(false);
@@ -167,9 +167,9 @@ static void map_fsm(RTLIL::Cell *fsm_cell, RTLIL::Module *module)
 	// create state register
 
 	RTLIL::Wire *state_wire = module->addWire(module->uniquify(fsm_cell->parameters[ID::NAME].decode_string()), fsm_data.state_bits);
-	RTLIL::Wire *next_state_wire = module->addWire(NEW_ID, fsm_data.state_bits);
+	RTLIL::Wire *next_state_wire = module->addWire(NEWER_ID, fsm_data.state_bits);
 
-	RTLIL::Cell *state_dff = module->addCell(NEW_ID, "");
+	RTLIL::Cell *state_dff = module->addCell(NEWER_ID, "");
 	if (fsm_cell->getPort(ID::ARST).is_fully_const()) {
 		state_dff->type = ID($dff);
 	} else {
@@ -191,7 +191,7 @@ static void map_fsm(RTLIL::Cell *fsm_cell, RTLIL::Module *module)
 
 	bool encoding_is_onehot = true;
 
-	RTLIL::Wire *state_onehot = module->addWire(NEW_ID, fsm_data.state_table.size());
+	RTLIL::Wire *state_onehot = module->addWire(NEWER_ID, fsm_data.state_table.size());
 
 	for (size_t i = 0; i < fsm_data.state_table.size(); i++)
 	{
@@ -212,7 +212,7 @@ static void map_fsm(RTLIL::Cell *fsm_cell, RTLIL::Module *module)
 		{
 			encoding_is_onehot = false;
 
-			RTLIL::Cell *eq_cell = module->addCell(NEW_ID, ID($eq));
+			RTLIL::Cell *eq_cell = module->addCell(NEWER_ID, ID($eq));
 			eq_cell->setPort(ID::A, sig_a);
 			eq_cell->setPort(ID::B, sig_b);
 			eq_cell->setPort(ID::Y, RTLIL::SigSpec(state_onehot, i));
@@ -235,7 +235,7 @@ static void map_fsm(RTLIL::Cell *fsm_cell, RTLIL::Module *module)
 	}
 	else
 	{
-		RTLIL::Wire *next_state_onehot = module->addWire(NEW_ID, fsm_data.state_table.size());
+		RTLIL::Wire *next_state_onehot = module->addWire(NEWER_ID, fsm_data.state_table.size());
 
 		for (size_t i = 0; i < fsm_data.state_table.size(); i++)
 		{
@@ -285,7 +285,7 @@ static void map_fsm(RTLIL::Cell *fsm_cell, RTLIL::Module *module)
 				}
 			}
 
-			RTLIL::Cell *mux_cell = module->addCell(NEW_ID, ID($pmux));
+			RTLIL::Cell *mux_cell = module->addCell(NEWER_ID, ID($pmux));
 			mux_cell->setPort(ID::A, sig_a);
 			mux_cell->setPort(ID::B, sig_b);
 			mux_cell->setPort(ID::S, sig_s);

--- a/passes/hierarchy/flatten.cc
+++ b/passes/hierarchy/flatten.cc
@@ -273,7 +273,7 @@ struct FlattenWorker
 		if (create_scopeinfo && cell_name.isPublic())
 		{
 			// The $scopeinfo's name will be changed below after removing the flattened cell
-			scopeinfo = module->addCell(NEW_ID, ID($scopeinfo));
+			scopeinfo = module->addCell(NEWER_ID, ID($scopeinfo));
 			scopeinfo->setParam(ID::TYPE, RTLIL::Const("module"));
 
 			for (auto const &attr : cell->attributes)

--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -1370,7 +1370,7 @@ struct HierarchyPass : public Pass {
 							continue;
 						}
 
-						Wire *t = module->addWire(NEW_ID, GetSize(c));
+						Wire *t = module->addWire(NEWER_ID, GetSize(c));
 						new_sig.append(t);
 						update_port = true;
 
@@ -1400,18 +1400,18 @@ struct HierarchyPass : public Pass {
 
 				if (GetSize(w) == 1) {
 					if (wand)
-						module->addReduceAnd(NEW_ID, sigs, w);
+						module->addReduceAnd(NEWER_ID, sigs, w);
 					else
-						module->addReduceOr(NEW_ID, sigs, w);
+						module->addReduceOr(NEWER_ID, sigs, w);
 					continue;
 				}
 
 				SigSpec s = sigs.extract(0, GetSize(w));
 				for (int i = GetSize(w); i < GetSize(sigs); i += GetSize(w)) {
 					if (wand)
-						s = module->And(NEW_ID, s, sigs.extract(i, GetSize(w)));
+						s = module->And(NEWER_ID, s, sigs.extract(i, GetSize(w)));
 					else
-						s = module->Or(NEW_ID, s, sigs.extract(i, GetSize(w)));
+						s = module->Or(NEWER_ID, s, sigs.extract(i, GetSize(w)));
 				}
 				module->connect(w, s);
 			}
@@ -1473,7 +1473,7 @@ struct HierarchyPass : public Pass {
 							if (w->port_input && !w->port_output)
 								sig.extend_u0(GetSize(w), sig.is_wire() && sig.as_wire()->is_signed);
 							else
-								sig.append(module->addWire(NEW_ID, n));
+								sig.append(module->addWire(NEWER_ID, n));
 						}
 
 						if (!conn.second.is_fully_const() || !w->port_input || w->port_output)

--- a/passes/hierarchy/submod.cc
+++ b/passes/hierarchy/submod.cc
@@ -232,10 +232,10 @@ struct SubmodWorker
 							auto &b = old_sig[i];
 							// Prevents "ERROR: Mismatch in directionality ..." when flattening
 							if (!b.wire)
-								b = module->addWire(NEW_ID);
+								b = module->addWire(NEWER_ID);
 							// Prevents "Warning: multiple conflicting drivers ..."
 							else if (!it.second.is_int_driven[i])
-								b = module->addWire(NEW_ID);
+								b = module->addWire(NEWER_ID);
 						}
 					new_cell->setPort(new_wire->name, old_sig);
 				}

--- a/passes/memory/memory_bmux2rom.cc
+++ b/passes/memory/memory_bmux2rom.cc
@@ -60,7 +60,7 @@ struct MemoryBmux2RomPass : public Pass {
 					continue;
 
 				// Ok, let's do it.
-				Mem mem(module, NEW_ID, width, 0, 1 << abits);
+				Mem mem(module, NEWER_ID, width, 0, 1 << abits);
 				mem.attributes = cell->attributes;
 
 				MemInit init;

--- a/passes/memory/memory_bram.cc
+++ b/passes/memory/memory_bram.cc
@@ -841,7 +841,7 @@ grow_read_ports:;
 
 	// Swizzle read ports.
 	for (auto &port : mem.rd_ports) {
-		SigSpec new_data = module->addWire(NEW_ID, mem.width);
+		SigSpec new_data = module->addWire(NEWER_ID, mem.width);
 		Const new_init_value = Const(State::Sx, mem.width);
 		Const new_arst_value = Const(State::Sx, mem.width);
 		Const new_srst_value = Const(State::Sx, mem.width);
@@ -920,7 +920,7 @@ grow_read_ports:;
 				if (GetSize(sig_addr) > bram.abits) {
 					SigSpec extra_addr = sig_addr.extract(bram.abits, GetSize(sig_addr) - bram.abits);
 					SigSpec extra_addr_sel = SigSpec(grid_a, GetSize(extra_addr));
-					addr_ok = module->Eq(NEW_ID, extra_addr, extra_addr_sel);
+					addr_ok = module->Eq(NEWER_ID, extra_addr, extra_addr_sel);
 				}
 
 				sig_addr.extend_u0(bram.abits);
@@ -946,7 +946,7 @@ grow_read_ports:;
 							sig_en.append(port.en[stride * i + grid_d * bram.dbits]);
 
 						if (!addr_ok.empty())
-							sig_en = module->Mux(NEW_ID, SigSpec(0, GetSize(sig_en)), sig_en, addr_ok);
+							sig_en = module->Mux(NEWER_ID, SigSpec(0, GetSize(sig_en)), sig_en, addr_ok);
 
 						c->setPort(stringf("\\%sEN", pf), sig_en);
 
@@ -961,13 +961,13 @@ grow_read_ports:;
 					auto &port = mem.rd_ports[pi.mapped_port];
 					SigSpec sig_data = port.data.extract(grid_d * bram.dbits, bram.dbits);
 
-					SigSpec bram_dout = module->addWire(NEW_ID, bram.dbits);
+					SigSpec bram_dout = module->addWire(NEWER_ID, bram.dbits);
 					c->setPort(stringf("\\%sDATA", pf), bram_dout);
 
 					SigSpec addr_ok_q = addr_ok;
 					if (port.clk_enable && !addr_ok.empty()) {
-						addr_ok_q = module->addWire(NEW_ID);
-						module->addDffe(NEW_ID, port.clk, port.en, addr_ok, addr_ok_q, port.clk_polarity);
+						addr_ok_q = module->addWire(NEWER_ID);
+						module->addDffe(NEWER_ID, port.clk, port.en, addr_ok, addr_ok_q, port.clk_polarity);
 					}
 
 					dout_cache[sig_data].first.append(addr_ok_q);
@@ -976,7 +976,7 @@ grow_read_ports:;
 					if (pi.enable) {
 						SigSpec sig_en = port.en;
 						if (!addr_ok.empty())
-							sig_en = module->And(NEW_ID, sig_en, addr_ok);
+							sig_en = module->And(NEWER_ID, sig_en, addr_ok);
 						c->setPort(stringf("\\%sEN", pf), sig_en);
 					}
 				}
@@ -994,7 +994,7 @@ grow_read_ports:;
 		else
 		{
 			log_assert(GetSize(it.first)*GetSize(it.second.first) == GetSize(it.second.second));
-			module->addPmux(NEW_ID, SigSpec(State::Sx, GetSize(it.first)), it.second.second, it.second.first, it.first);
+			module->addPmux(NEWER_ID, SigSpec(State::Sx, GetSize(it.first)), it.second.second, it.second.first, it.first);
 		}
 	}
 

--- a/passes/memory/memory_dff.cc
+++ b/passes/memory/memory_dff.cc
@@ -507,11 +507,11 @@ struct MemoryDffWorker
 
 		merger.remove_output_ff(bits);
 		if (ff.has_ce && !ff.pol_ce)
-			ff.sig_ce = module->LogicNot(NEW_ID, ff.sig_ce);
+			ff.sig_ce = module->LogicNot(NEWER_ID, ff.sig_ce);
 		if (ff.has_arst && !ff.pol_arst)
-			ff.sig_arst = module->LogicNot(NEW_ID, ff.sig_arst);
+			ff.sig_arst = module->LogicNot(NEWER_ID, ff.sig_arst);
 		if (ff.has_srst && !ff.pol_srst)
-			ff.sig_srst = module->LogicNot(NEW_ID, ff.sig_srst);
+			ff.sig_srst = module->LogicNot(NEWER_ID, ff.sig_srst);
 		port.clk = ff.sig_clk;
 		port.clk_enable = true;
 		port.clk_polarity = ff.pol_clk;

--- a/passes/memory/memory_map.cc
+++ b/passes/memory/memory_map.cc
@@ -89,12 +89,12 @@ struct MemoryMapWorker
 
 		if (decoder_cache.count(key) == 0) {
 			if (GetSize(addr_sig) < 2) {
-				decoder_cache[key] = module->Eq(NEW_ID, addr_sig, addr_val);
+				decoder_cache[key] = module->Eq(NEWER_ID, addr_sig, addr_val);
 			} else {
 				int split_at = GetSize(addr_sig) / 2;
 				RTLIL::SigBit left_eq = addr_decode(addr_sig.extract(0, split_at), addr_val.extract(0, split_at));
 				RTLIL::SigBit right_eq = addr_decode(addr_sig.extract(split_at, GetSize(addr_sig) - split_at), addr_val.extract(split_at, GetSize(addr_val) - split_at));
-				decoder_cache[key] = module->And(NEW_ID, left_eq, right_eq);
+				decoder_cache[key] = module->And(NEWER_ID, left_eq, right_eq);
 			}
 		}
 

--- a/passes/memory/memory_memx.cc
+++ b/passes/memory/memory_memx.cc
@@ -42,10 +42,10 @@ struct MemoryMemxPass : public Pass {
 
 		addr.extend_u0(32);
 
-		SigSpec res = mem.module->Nex(NEW_ID, mem.module->ReduceXor(NEW_ID, addr), mem.module->ReduceXor(NEW_ID, {addr, State::S1}));
+		SigSpec res = mem.module->Nex(NEWER_ID, mem.module->ReduceXor(NEWER_ID, addr), mem.module->ReduceXor(NEWER_ID, {addr, State::S1}));
 		if (start_addr != 0)
-			res = mem.module->LogicAnd(NEW_ID, res, mem.module->Ge(NEW_ID, addr, start_addr));
-		res = mem.module->LogicAnd(NEW_ID, res, mem.module->Lt(NEW_ID, addr, end_addr));
+			res = mem.module->LogicAnd(NEWER_ID, res, mem.module->Ge(NEWER_ID, addr, start_addr));
+		res = mem.module->LogicAnd(NEWER_ID, res, mem.module->Lt(NEWER_ID, addr, end_addr));
 		return res;
 	}
 
@@ -63,14 +63,14 @@ struct MemoryMemxPass : public Pass {
 							log_id(module), log_id(mem.memid));
 
 				SigSpec addr_ok = make_addr_check(mem, port.addr);
-				Wire *raw_rdata = module->addWire(NEW_ID, GetSize(port.data));
-				module->addMux(NEW_ID, SigSpec(State::Sx, GetSize(port.data)), raw_rdata, addr_ok, port.data);
+				Wire *raw_rdata = module->addWire(NEWER_ID, GetSize(port.data));
+				module->addMux(NEWER_ID, SigSpec(State::Sx, GetSize(port.data)), raw_rdata, addr_ok, port.data);
 				port.data = raw_rdata;
 			}
 
 			for (auto &port : mem.wr_ports) {
 				SigSpec addr_ok = make_addr_check(mem, port.addr);
-				port.en = module->And(NEW_ID, port.en, addr_ok.repeat(GetSize(port.en)));
+				port.en = module->And(NEWER_ID, port.en, addr_ok.repeat(GetSize(port.en)));
 			}
 
 			mem.emit();

--- a/passes/memory/memory_share.cc
+++ b/passes/memory/memory_share.cc
@@ -164,7 +164,7 @@ struct MemoryShareWorker
 					port2.addr = addr2;
 					mem.prepare_rd_merge(i, j, &initvals);
 					mem.widen_prep(wide_log2);
-					SigSpec new_data = module->addWire(NEW_ID, mem.width << wide_log2);
+					SigSpec new_data = module->addWire(NEWER_ID, mem.width << wide_log2);
 					module->connect(port1.data, new_data.extract(sub1 * mem.width, mem.width << port1.wide_log2));
 					module->connect(port2.data, new_data.extract(sub2 * mem.width, mem.width << port2.wide_log2));
 					for (int k = 0; k < wide_log2; k++)
@@ -271,8 +271,8 @@ struct MemoryShareWorker
 						port1.data.replace(pos, port2.data.extract(pos, width));
 						new_en = port2.en[pos];
 					} else {
-						port1.data.replace(pos, module->Mux(NEW_ID, port1.data.extract(pos, width), port2.data.extract(pos, width), port2.en[pos]));
-						new_en = module->Or(NEW_ID, port1.en[pos], port2.en[pos]);
+						port1.data.replace(pos, module->Mux(NEWER_ID, port1.data.extract(pos, width), port2.data.extract(pos, width), port2.en[pos]));
+						new_en = module->Or(NEWER_ID, port1.en[pos], port2.en[pos]);
 					}
 					for (int k = pos; k < epos; k++)
 						port1.en[k] = new_en;
@@ -424,21 +424,21 @@ struct MemoryShareWorker
 					RTLIL::SigSpec this_data = port2.data;
 					std::vector<RTLIL::SigBit> this_en = modwalker.sigmap(port2.en);
 
-					RTLIL::SigBit this_en_active = module->ReduceOr(NEW_ID, this_en);
+					RTLIL::SigBit this_en_active = module->ReduceOr(NEWER_ID, this_en);
 
 					if (GetSize(last_addr) < GetSize(this_addr))
 						last_addr.extend_u0(GetSize(this_addr));
 					else
 						this_addr.extend_u0(GetSize(last_addr));
 
-					SigSpec new_addr = module->Mux(NEW_ID, last_addr.extract_end(port1.wide_log2), this_addr.extract_end(port1.wide_log2), this_en_active);
+					SigSpec new_addr = module->Mux(NEWER_ID, last_addr.extract_end(port1.wide_log2), this_addr.extract_end(port1.wide_log2), this_en_active);
 
 					port1.addr = SigSpec({new_addr, port1.addr.extract(0, port1.wide_log2)});
-					port1.data = module->Mux(NEW_ID, last_data, this_data, this_en_active);
+					port1.data = module->Mux(NEWER_ID, last_data, this_data, this_en_active);
 
 					std::map<std::pair<RTLIL::SigBit, RTLIL::SigBit>, int> groups_en;
 					RTLIL::SigSpec grouped_last_en, grouped_this_en, en;
-					RTLIL::Wire *grouped_en = module->addWire(NEW_ID, 0);
+					RTLIL::Wire *grouped_en = module->addWire(NEWER_ID, 0);
 
 					for (int j = 0; j < int(this_en.size()); j++) {
 						std::pair<RTLIL::SigBit, RTLIL::SigBit> key(last_en[j], this_en[j]);
@@ -451,7 +451,7 @@ struct MemoryShareWorker
 						en.append(RTLIL::SigSpec(grouped_en, groups_en[key]));
 					}
 
-					module->addMux(NEW_ID, grouped_last_en, grouped_this_en, this_en_active, grouped_en);
+					module->addMux(NEWER_ID, grouped_last_en, grouped_this_en, this_en_active, grouped_en);
 					port1.en = en;
 
 					port2.removed = true;

--- a/passes/opt/muxpack.cc
+++ b/passes/opt/muxpack.cc
@@ -283,7 +283,7 @@ struct MuxpackWorker
 				else {
 					log_assert(cursor_cell->type == ID($mux));
 					b_sig.append(cursor_cell->getPort(ID::A));
-					s_sig.append(module->LogicNot(NEW_ID, cursor_cell->getPort(ID::S)));
+					s_sig.append(module->LogicNot(NEWER_ID, cursor_cell->getPort(ID::S)));
 				}
 				remove_cells.insert(cursor_cell);
 			}

--- a/passes/opt/opt_demorgan.cc
+++ b/passes/opt/opt_demorgan.cc
@@ -99,8 +99,8 @@ void demorgan_worker(
 		//We are NOT inverted! Add an inverter
 		if(!srcinv)
 		{
-			auto inverted_b = m->addWire(NEW_ID);
-			m->addNot(NEW_ID, RTLIL::SigSpec(b), RTLIL::SigSpec(inverted_b));
+			auto inverted_b = m->addWire(NEWER_ID);
+			m->addNot(NEWER_ID, RTLIL::SigSpec(b), RTLIL::SigSpec(inverted_b));
 			insig[i] = inverted_b;
 		}
 
@@ -166,8 +166,8 @@ void demorgan_worker(
 
 	//Add an inverter to the output
 	auto inverted_output = cell->getPort(ID::Y);
-	auto uninverted_output = m->addWire(NEW_ID);
-	m->addNot(NEW_ID, RTLIL::SigSpec(uninverted_output), inverted_output);
+	auto uninverted_output = m->addWire(NEWER_ID);
+	m->addNot(NEWER_ID, RTLIL::SigSpec(uninverted_output), inverted_output);
 	cell->setPort(ID::Y, uninverted_output);
 }
 

--- a/passes/opt/opt_dff.cc
+++ b/passes/opt/opt_dff.cc
@@ -244,8 +244,8 @@ struct OptDffWorker
 				s2.append(it.second);
 			}
 
-			RTLIL::SigSpec y = module->addWire(NEW_ID);
-			RTLIL::Cell *c = module->addNe(NEW_ID, s1, s2, y);
+			RTLIL::SigSpec y = module->addWire(NEWER_ID);
+			RTLIL::Cell *c = module->addNe(NEWER_ID, s1, s2, y);
 
 			if (make_gates) {
 				simplemap(module, c);
@@ -258,9 +258,9 @@ struct OptDffWorker
 			if (item.second)
 				or_input.append(item.first);
 			else if (make_gates)
-				or_input.append(module->NotGate(NEW_ID, item.first));
+				or_input.append(module->NotGate(NEWER_ID, item.first));
 			else
-				or_input.append(module->Not(NEW_ID, item.first));
+				or_input.append(module->Not(NEWER_ID, item.first));
 		}
 
 		if (GetSize(or_input) == 0)
@@ -269,8 +269,8 @@ struct OptDffWorker
 		if (GetSize(or_input) == 1)
 			return ctrl_t(or_input, true);
 
-		RTLIL::SigSpec y = module->addWire(NEW_ID);
-		RTLIL::Cell *c = module->addReduceAnd(NEW_ID, or_input, y);
+		RTLIL::SigSpec y = module->addWire(NEWER_ID);
+		RTLIL::Cell *c = module->addReduceAnd(NEWER_ID, or_input, y);
 
 		if (make_gates) {
 			simplemap(module, c);
@@ -298,13 +298,13 @@ struct OptDffWorker
 			if (item.second == final_pol)
 				or_input.append(item.first);
 			else if (make_gates)
-				or_input.append(module->NotGate(NEW_ID, item.first));
+				or_input.append(module->NotGate(NEWER_ID, item.first));
 			else
-				or_input.append(module->Not(NEW_ID, item.first));
+				or_input.append(module->Not(NEWER_ID, item.first));
 		}
 
-		RTLIL::SigSpec y = module->addWire(NEW_ID);
-		RTLIL::Cell *c = final_pol ? module->addReduceOr(NEW_ID, or_input, y) : module->addReduceAnd(NEW_ID, or_input, y);
+		RTLIL::SigSpec y = module->addWire(NEWER_ID);
+		RTLIL::Cell *c = final_pol ? module->addReduceOr(NEWER_ID, or_input, y) : module->addReduceAnd(NEWER_ID, or_input, y);
 
 		if (make_gates) {
 			simplemap(module, c);
@@ -348,9 +348,9 @@ struct OptDffWorker
 						if (!ff.pol_clr) {
 							module->connect(ff.sig_q[i], ff.sig_clr[i]);
 						} else if (ff.is_fine) {
-							module->addNotGate(NEW_ID, ff.sig_clr[i], ff.sig_q[i]);
+							module->addNotGate(NEWER_ID, ff.sig_clr[i], ff.sig_q[i]);
 						} else {
-							module->addNot(NEW_ID, ff.sig_clr[i], ff.sig_q[i]);
+							module->addNot(NEWER_ID, ff.sig_clr[i], ff.sig_q[i]);
 						}
 						log("Handling always-active SET at position %d on %s (%s) from module %s (changing to combinatorial circuit).\n",
 								i, log_id(cell), log_id(cell->type), log_id(module));
@@ -451,34 +451,34 @@ struct OptDffWorker
 						SigSpec tmp;
 						if (ff.is_fine) {
 							if (ff.pol_set)
-								tmp = module->MuxGate(NEW_ID, ff.sig_ad, State::S1, ff.sig_set);
+								tmp = module->MuxGate(NEWER_ID, ff.sig_ad, State::S1, ff.sig_set);
 							else
-								tmp = module->MuxGate(NEW_ID, State::S1, ff.sig_ad, ff.sig_set);
+								tmp = module->MuxGate(NEWER_ID, State::S1, ff.sig_ad, ff.sig_set);
 							if (ff.pol_clr)
-								module->addMuxGate(NEW_ID, tmp, State::S0, ff.sig_clr, ff.sig_q);
+								module->addMuxGate(NEWER_ID, tmp, State::S0, ff.sig_clr, ff.sig_q);
 							else
-								module->addMuxGate(NEW_ID, State::S0, tmp, ff.sig_clr, ff.sig_q);
+								module->addMuxGate(NEWER_ID, State::S0, tmp, ff.sig_clr, ff.sig_q);
 						} else {
 							if (ff.pol_set)
-								tmp = module->Or(NEW_ID, ff.sig_ad, ff.sig_set);
+								tmp = module->Or(NEWER_ID, ff.sig_ad, ff.sig_set);
 							else
-								tmp = module->Or(NEW_ID, ff.sig_ad, module->Not(NEW_ID, ff.sig_set));
+								tmp = module->Or(NEWER_ID, ff.sig_ad, module->Not(NEWER_ID, ff.sig_set));
 							if (ff.pol_clr)
-								module->addAnd(NEW_ID, tmp, module->Not(NEW_ID, ff.sig_clr), ff.sig_q);
+								module->addAnd(NEWER_ID, tmp, module->Not(NEWER_ID, ff.sig_clr), ff.sig_q);
 							else
-								module->addAnd(NEW_ID, tmp, ff.sig_clr, ff.sig_q);
+								module->addAnd(NEWER_ID, tmp, ff.sig_clr, ff.sig_q);
 						}
 					} else if (ff.has_arst) {
 						if (ff.is_fine) {
 							if (ff.pol_arst)
-								module->addMuxGate(NEW_ID, ff.sig_ad, ff.val_arst[0], ff.sig_arst, ff.sig_q);
+								module->addMuxGate(NEWER_ID, ff.sig_ad, ff.val_arst[0], ff.sig_arst, ff.sig_q);
 							else
-								module->addMuxGate(NEW_ID, ff.val_arst[0], ff.sig_ad, ff.sig_arst, ff.sig_q);
+								module->addMuxGate(NEWER_ID, ff.val_arst[0], ff.sig_ad, ff.sig_arst, ff.sig_q);
 						} else {
 							if (ff.pol_arst)
-								module->addMux(NEW_ID, ff.sig_ad, ff.val_arst, ff.sig_arst, ff.sig_q);
+								module->addMux(NEWER_ID, ff.sig_ad, ff.val_arst, ff.sig_arst, ff.sig_q);
 							else
-								module->addMux(NEW_ID, ff.val_arst, ff.sig_ad, ff.sig_arst, ff.sig_q);
+								module->addMux(NEWER_ID, ff.val_arst, ff.sig_ad, ff.sig_arst, ff.sig_q);
 						}
 					} else {
 						module->connect(ff.sig_q, ff.sig_ad);
@@ -594,20 +594,20 @@ struct OptDffWorker
 					if (ff.has_ce && ff.ce_over_srst) {
 						if (!ff.pol_ce) {
 							if (ff.is_fine)
-								ff.sig_ce = module->NotGate(NEW_ID, ff.sig_ce);
+								ff.sig_ce = module->NotGate(NEWER_ID, ff.sig_ce);
 							else
-								ff.sig_ce = module->Not(NEW_ID, ff.sig_ce);
+								ff.sig_ce = module->Not(NEWER_ID, ff.sig_ce);
 						}
 						if (!ff.pol_srst) {
 							if (ff.is_fine)
-								ff.sig_srst = module->NotGate(NEW_ID, ff.sig_srst);
+								ff.sig_srst = module->NotGate(NEWER_ID, ff.sig_srst);
 							else
-								ff.sig_srst = module->Not(NEW_ID, ff.sig_srst);
+								ff.sig_srst = module->Not(NEWER_ID, ff.sig_srst);
 						}
 						if (ff.is_fine)
-							ff.sig_ce = module->AndGate(NEW_ID, ff.sig_ce, ff.sig_srst);
+							ff.sig_ce = module->AndGate(NEWER_ID, ff.sig_ce, ff.sig_srst);
 						else
-							ff.sig_ce = module->And(NEW_ID, ff.sig_ce, ff.sig_srst);
+							ff.sig_ce = module->And(NEWER_ID, ff.sig_ce, ff.sig_srst);
 						ff.pol_ce = true;
 					} else {
 						ff.pol_ce = ff.pol_srst;

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -202,7 +202,7 @@ bool group_cell_inputs(RTLIL::Module *module, RTLIL::Cell *cell, bool commutativ
 		if (grouped_bits[i].empty())
 			continue;
 
-		RTLIL::SigSpec new_y = module->addWire(NEW_ID, GetSize(grouped_bits[i]));
+		RTLIL::SigSpec new_y = module->addWire(NEWER_ID, GetSize(grouped_bits[i]));
 		RTLIL::SigSpec new_a, new_b;
 		RTLIL::SigSig new_conn;
 
@@ -247,9 +247,9 @@ bool group_cell_inputs(RTLIL::Module *module, RTLIL::Cell *cell, bool commutativ
 				else if (new_a[i] == State::S0 || new_a[i] == State::S1) {
 					undef_a.append(new_a[i]);
 					if (cell->type == ID($xor))
-						undef_b.append(new_a[i] == State::S1 ? module->Not(NEW_ID, new_b[i]).as_bit() : new_b[i]);
+						undef_b.append(new_a[i] == State::S1 ? module->Not(NEWER_ID, new_b[i]).as_bit() : new_b[i]);
 					else if (cell->type == ID($xnor))
-						undef_b.append(new_a[i] == State::S1 ? new_b[i] : module->Not(NEW_ID, new_b[i]).as_bit());
+						undef_b.append(new_a[i] == State::S1 ? new_b[i] : module->Not(NEWER_ID, new_b[i]).as_bit());
 					else log_abort();
 					undef_y.append(new_y[i]);
 				}
@@ -273,7 +273,7 @@ bool group_cell_inputs(RTLIL::Module *module, RTLIL::Cell *cell, bool commutativ
 		}
 
 
-		RTLIL::Cell *c = module->addCell(NEW_ID, cell->type);
+		RTLIL::Cell *c = module->addCell(NEWER_ID, cell->type);
 
 		c->setPort(ID::A, new_a);
 		c->parameters[ID::A_WIDTH] = new_a.size();
@@ -612,9 +612,9 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 					cover("opt.opt_expr.xor_buffer");
 					SigSpec sig_y;
 					if (cell->type == ID($xor))
-						sig_y = (sig_b == State::S1 ? module->Not(NEW_ID, sig_a).as_bit() : sig_a);
+						sig_y = (sig_b == State::S1 ? module->Not(NEWER_ID, sig_a).as_bit() : sig_a);
 					else if (cell->type == ID($_XOR_))
-						sig_y = (sig_b == State::S1 ? module->NotGate(NEW_ID, sig_a) : sig_a);
+						sig_y = (sig_b == State::S1 ? module->NotGate(NEWER_ID, sig_a) : sig_a);
 					else log_abort();
 					replace_cell(assign_map, module, cell, "xor_buffer", ID::Y, sig_y);
 					goto next_cell;
@@ -623,12 +623,12 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 					cover("opt.opt_expr.xnor_buffer");
 					SigSpec sig_y;
 					if (cell->type == ID($xnor)) {
-						sig_y = (sig_b == State::S1 ? sig_a : module->Not(NEW_ID, sig_a).as_bit());
+						sig_y = (sig_b == State::S1 ? sig_a : module->Not(NEWER_ID, sig_a).as_bit());
 						int width = cell->getParam(ID::Y_WIDTH).as_int();
 						sig_y.append(RTLIL::Const(State::S1, width-1));
 					}
 					else if (cell->type == ID($_XNOR_))
-						sig_y = (sig_b == State::S1 ? sig_a : module->NotGate(NEW_ID, sig_a));
+						sig_y = (sig_b == State::S1 ? sig_a : module->NotGate(NEWER_ID, sig_a));
 					else log_abort();
 					replace_cell(assign_map, module, cell, "xnor_buffer", ID::Y, sig_y);
 					goto next_cell;
@@ -698,7 +698,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 					if (!y_group_1.empty()) y_new_1 = b_group_1;
 					if (!y_group_x.empty()) {
 						if (keepdc)
-							y_new_x = module->And(NEW_ID, Const(State::Sx, GetSize(y_group_x)), b_group_x);
+							y_new_x = module->And(NEWER_ID, Const(State::Sx, GetSize(y_group_x)), b_group_x);
 						else
 							y_new_x = Const(State::S0, GetSize(y_group_x));
 					}
@@ -707,16 +707,16 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 					if (!y_group_1.empty()) y_new_1 = Const(State::S1, GetSize(y_group_1));
 					if (!y_group_x.empty()) {
 						if (keepdc)
-							y_new_x = module->Or(NEW_ID, Const(State::Sx, GetSize(y_group_x)), b_group_x);
+							y_new_x = module->Or(NEWER_ID, Const(State::Sx, GetSize(y_group_x)), b_group_x);
 						else
 							y_new_x = Const(State::S1, GetSize(y_group_x));
 					}
 				} else if (cell->type.in(ID($xor), ID($xnor))) {
 					if (!y_group_0.empty()) y_new_0 = b_group_0;
-					if (!y_group_1.empty()) y_new_1 = module->Not(NEW_ID, b_group_1);
+					if (!y_group_1.empty()) y_new_1 = module->Not(NEWER_ID, b_group_1);
 					if (!y_group_x.empty()) {
 						if (keepdc)
-							y_new_x = module->Xor(NEW_ID, Const(State::Sx, GetSize(y_group_x)), b_group_x);
+							y_new_x = module->Xor(NEWER_ID, Const(State::Sx, GetSize(y_group_x)), b_group_x);
 						else // This should be fine even with keepdc, but opt_expr_xor.ys wants to keep the xor
 							y_new_x = Const(State::Sx, GetSize(y_group_x));
 					}
@@ -779,11 +779,11 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 				RTLIL::SigSpec y_new_0, y_new_1;
 
 				if (flip) {
-					if (!y_group_0.empty()) y_new_0 = module->And(NEW_ID, b_group_0, module->Not(NEW_ID, s_group_0));
-					if (!y_group_1.empty()) y_new_1 = module->Or(NEW_ID, b_group_1, s_group_1);
+					if (!y_group_0.empty()) y_new_0 = module->And(NEWER_ID, b_group_0, module->Not(NEWER_ID, s_group_0));
+					if (!y_group_1.empty()) y_new_1 = module->Or(NEWER_ID, b_group_1, s_group_1);
 				} else {
-					if (!y_group_0.empty()) y_new_0 = module->And(NEW_ID, b_group_0, s_group_0);
-					if (!y_group_1.empty()) y_new_1 = module->Or(NEW_ID, b_group_1, module->Not(NEW_ID, s_group_1));
+					if (!y_group_0.empty()) y_new_0 = module->And(NEWER_ID, b_group_0, s_group_0);
+					if (!y_group_1.empty()) y_new_1 = module->Or(NEWER_ID, b_group_1, module->Not(NEWER_ID, s_group_1));
 				}
 
 				module->connect(y_group_0, y_new_0);
@@ -996,12 +996,12 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 					RTLIL::SigBit a = sig_a[i];
 					if (b == ((bi ^ ci) ? State::S1 : State::S0)) {
 						module->connect(sig_y[i], a);
-						module->connect(sig_x[i], ci ? module->Not(NEW_ID, a).as_bit() : a);
+						module->connect(sig_x[i], ci ? module->Not(NEWER_ID, a).as_bit() : a);
 						module->connect(sig_co[i], ci ? State::S1 : State::S0);
 					}
 					else if (a == (ci ? State::S1 : State::S0)) {
-						module->connect(sig_y[i], bi ? module->Not(NEW_ID, b).as_bit() : b);
-						module->connect(sig_x[i], (bi ^ ci) ? module->Not(NEW_ID, b).as_bit() : b);
+						module->connect(sig_y[i], bi ? module->Not(NEWER_ID, b).as_bit() : b);
+						module->connect(sig_x[i], (bi ^ ci) ? module->Not(NEWER_ID, b).as_bit() : b);
 						module->connect(sig_co[i], ci ? State::S1 : State::S0);
 					}
 					else
@@ -1428,7 +1428,7 @@ skip_fine_alu:
 						/* sub, b is 0 */
 						RTLIL::SigSpec a = cell->getPort(ID::A);
 						a.extend_u0(y_width, is_signed);
-						module->connect(cell->getPort(ID::X), module->Not(NEW_ID, a));
+						module->connect(cell->getPort(ID::X), module->Not(NEWER_ID, a));
 						module->connect(cell->getPort(ID::CO), RTLIL::Const(State::S1, y_width));
 					} else {
 						/* add */
@@ -1733,10 +1733,10 @@ skip_identity:
 					cell->parameters[ID::A_SIGNED] = 0;
 					cell->setPort(ID::A, Const(bit_idx, cell->parameters[ID::A_WIDTH].as_int()));
 
-					SigSpec y_wire = module->addWire(NEW_ID, y_size);
+					SigSpec y_wire = module->addWire(NEWER_ID, y_size);
 					cell->setPort(ID::Y, y_wire);
 
-					module->addShl(NEW_ID, Const(State::S1, 1), y_wire, sig_y);
+					module->addShl(NEWER_ID, Const(State::S1, 1), y_wire, sig_y);
 				}
 				did_something = true;
 				goto next_cell;
@@ -1889,13 +1889,13 @@ skip_identity:
 						// Truncating division is the same as flooring division, except when
 						// the result is negative and there is a remainder - then trunc = floor + 1
 						if (is_truncating && a_signed && GetSize(sig_a) != 0 && exp != 0) {
-							Wire *flooring = module->addWire(NEW_ID, sig_y.size());
+							Wire *flooring = module->addWire(NEWER_ID, sig_y.size());
 							cell->setPort(ID::Y, flooring);
 
 							SigSpec a_sign = sig_a[sig_a.size()-1];
-							SigSpec rem_nonzero = module->ReduceOr(NEW_ID, sig_a.extract(0, exp));
-							SigSpec should_add = module->And(NEW_ID, a_sign, rem_nonzero);
-							module->addAdd(NEW_ID, flooring, should_add, sig_y);
+							SigSpec rem_nonzero = module->ReduceOr(NEWER_ID, sig_a.extract(0, exp));
+							SigSpec should_add = module->And(NEWER_ID, a_sign, rem_nonzero);
+							module->addAdd(NEWER_ID, flooring, should_add, sig_y);
 						}
 
 						cell->check();
@@ -1917,11 +1917,11 @@ skip_identity:
 							SigSpec truncating = sig_a.extract(0, exp);
 
 							SigSpec a_sign = sig_a[sig_a.size()-1];
-							SigSpec rem_nonzero = module->ReduceOr(NEW_ID, sig_a.extract(0, exp));
-							SigSpec extend_bit = module->And(NEW_ID, a_sign, rem_nonzero);
+							SigSpec rem_nonzero = module->ReduceOr(NEWER_ID, sig_a.extract(0, exp));
+							SigSpec extend_bit = module->And(NEWER_ID, a_sign, rem_nonzero);
 
 							truncating.append(extend_bit);
-							module->addPos(NEW_ID, truncating, sig_y, true);
+							module->addPos(NEWER_ID, truncating, sig_y, true);
 						}
 						else
 						{
@@ -2004,7 +2004,7 @@ skip_identity:
 				int sz = cur - prev;
 				bool last = cur == GetSize(sig_y);
 
-				RTLIL::Cell *c = module->addCell(NEW_ID, cell->type);
+				RTLIL::Cell *c = module->addCell(NEWER_ID, cell->type);
 				c->setPort(ID::A, sig_a.extract(prev, sz));
 				c->setPort(ID::B, sig_b.extract(prev, sz));
 				c->setPort(ID::BI, sig_bi);
@@ -2014,7 +2014,7 @@ skip_identity:
 				RTLIL::SigSpec new_co = sig_co.extract(prev, sz);
 				if (p.second != State::Sx) {
 					module->connect(new_co[sz-1], p.second);
-					RTLIL::Wire *dummy = module->addWire(NEW_ID);
+					RTLIL::Wire *dummy = module->addWire(NEWER_ID);
 					new_co[sz-1] = dummy;
 				}
 				c->setPort(ID::CO, new_co);
@@ -2181,14 +2181,14 @@ skip_alu_split:
 						{
 							condition   = stringf("unsigned X<%s", log_signal(const_sig));
 							replacement = stringf("!X[%d:%d]", var_width - 1, const_bit_hot);
-							module->addLogicNot(NEW_ID, var_high_sig, cell->getPort(ID::Y));
+							module->addLogicNot(NEWER_ID, var_high_sig, cell->getPort(ID::Y));
 							remove = true;
 						}
 						if (cmp_type == ID($ge))
 						{
 							condition   = stringf("unsigned X>=%s", log_signal(const_sig));
 							replacement = stringf("|X[%d:%d]", var_width - 1, const_bit_hot);
-							module->addReduceOr(NEW_ID, var_high_sig, cell->getPort(ID::Y));
+							module->addReduceOr(NEWER_ID, var_high_sig, cell->getPort(ID::Y));
 							remove = true;
 						}
 					}
@@ -2230,7 +2230,7 @@ skip_alu_split:
 					{
 						condition   = "signed X>=0";
 						replacement = stringf("X[%d]", var_width - 1);
-						module->addLogicNot(NEW_ID, var_sig[var_width - 1], cell->getPort(ID::Y));
+						module->addLogicNot(NEWER_ID, var_sig[var_width - 1], cell->getPort(ID::Y));
 						remove = true;
 					}
 				}

--- a/passes/opt/opt_hier.cc
+++ b/passes/opt/opt_hier.cc
@@ -137,7 +137,7 @@ struct ModuleIndex {
 					rhs.replace(constant_outputs);
 					log_assert(rhs.is_fully_const());
 					parent.module->connect(value.extract(chunk.offset, chunk.width), rhs);
-					SigSpec dummy = parent.module->addWire(NEW_ID_SUFFIX("const_output"), chunk.width);
+					SigSpec dummy = parent.module->addWire(NEWER_ID_SUFFIX("const_output"), chunk.width);
 					for (int i = 0; i < chunk.width; i++)
 						value[chunk.offset + i] = dummy[i];
 				}
@@ -182,7 +182,7 @@ struct ModuleIndex {
 		severed_port_bits.sort_and_unify();
 		for (auto chunk : severed_port_bits.chunks()) {
 			SigSpec &value = instantiation->connections_.at(chunk.wire->name);
-			SigSpec dummy = parent.module->addWire(NEW_ID_SUFFIX("tie_together"), chunk.width);
+			SigSpec dummy = parent.module->addWire(NEWER_ID_SUFFIX("tie_together"), chunk.width);
 			for (int i = 0; i < chunk.width; i++)
 				value[chunk.offset + i] = dummy[i];
 		}

--- a/passes/opt/opt_mem.cc
+++ b/passes/opt/opt_mem.cc
@@ -125,7 +125,7 @@ struct OptMemPass : public Pass {
 								module->connect(port.data[bidx], bit);
 							} else {
 								// The FF will most likely be redundant, but it's up to opt_dff to deal with this.
-								FfData ff(module, &initvals, NEW_ID);
+								FfData ff(module, &initvals, NEWER_ID);
 								ff.width = 1;
 								ff.has_clk = true;
 								ff.sig_clk = port.clk;

--- a/passes/opt/opt_mem_feedback.cc
+++ b/passes/opt/opt_mem_feedback.cc
@@ -120,7 +120,7 @@ struct OptMemFeedbackWorker
 				sig1.append(it.first);
 				sig2.append(it.second ? RTLIL::State::S1 : RTLIL::State::S0);
 			}
-			terms.append(module->Ne(NEW_ID, sig1, sig2));
+			terms.append(module->Ne(NEWER_ID, sig1, sig2));
 		}
 
 		if (olden != State::S1)
@@ -130,7 +130,7 @@ struct OptMemFeedbackWorker
 			terms = State::S1;
 
 		if (GetSize(terms) > 1)
-			terms = module->ReduceAnd(NEW_ID, terms);
+			terms = module->ReduceAnd(NEWER_ID, terms);
 
 		return conditions_logic_cache[key] = terms;
 	}

--- a/passes/opt/opt_reduce.cc
+++ b/passes/opt/opt_reduce.cc
@@ -128,13 +128,13 @@ struct OptReduceWorker
 
 			if (this_s.size() > 1)
 			{
-				RTLIL::Cell *reduce_or_cell = module->addCell(NEW_ID, ID($reduce_or));
+				RTLIL::Cell *reduce_or_cell = module->addCell(NEWER_ID, ID($reduce_or));
 				reduce_or_cell->setPort(ID::A, this_s);
 				reduce_or_cell->parameters[ID::A_SIGNED] = RTLIL::Const(0);
 				reduce_or_cell->parameters[ID::A_WIDTH] = RTLIL::Const(this_s.size());
 				reduce_or_cell->parameters[ID::Y_WIDTH] = RTLIL::Const(1);
 
-				RTLIL::Wire *reduce_or_wire = module->addWire(NEW_ID);
+				RTLIL::Wire *reduce_or_wire = module->addWire(NEWER_ID);
 				this_s = RTLIL::SigSpec(reduce_or_wire);
 				reduce_or_cell->setPort(ID::Y, this_s);
 			}

--- a/passes/opt/opt_share.cc
+++ b/passes/opt/opt_share.cc
@@ -196,7 +196,7 @@ void merge_operators(RTLIL::Module *module, RTLIL::Cell *mux, const std::vector<
 	for (auto &operand : muxed_operands) {
 		operand.sig.extend_u0(max_width, operand.is_signed);
 		if (operand.sign != muxed_operands[0].sign)
-			operand = ExtSigSpec(module->Neg(NEW_ID, operand.sig, operand.is_signed));
+			operand = ExtSigSpec(module->Neg(NEWER_ID, operand.sig, operand.is_signed));
 	}
 
 	for (const auto& p : ports) {
@@ -219,7 +219,7 @@ void merge_operators(RTLIL::Module *module, RTLIL::Cell *mux, const std::vector<
 	RTLIL::SigSpec shared_pmux_s;
 
 	// Make a new wire to avoid false equivalence with whatever the former shared output was connected to.
-	Wire *new_out = module->addWire(NEW_ID, conn_op_offset + conn_width);
+	Wire *new_out = module->addWire(NEWER_ID, conn_op_offset + conn_width);
 	SigSpec new_sig_out = SigSpec(new_out, conn_op_offset, conn_width);
 
 	for (int i = 0; i < GetSize(ports); i++) {
@@ -241,14 +241,14 @@ void merge_operators(RTLIL::Module *module, RTLIL::Cell *mux, const std::vector<
 
 	SigSpec mux_to_oper;
 	if (GetSize(shared_pmux_s) == 1) {
-		mux_to_oper = module->Mux(NEW_ID, shared_pmux_a, shared_pmux_b, shared_pmux_s);
+		mux_to_oper = module->Mux(NEWER_ID, shared_pmux_a, shared_pmux_b, shared_pmux_s);
 	} else {
-		mux_to_oper = module->Pmux(NEW_ID, shared_pmux_a, shared_pmux_b, shared_pmux_s);
+		mux_to_oper = module->Pmux(NEWER_ID, shared_pmux_a, shared_pmux_b, shared_pmux_s);
 	}
 
 	if (shared_op->type.in(ID($alu))) {
-		shared_op->setPort(ID::X, module->addWire(NEW_ID, GetSize(new_out)));
-		shared_op->setPort(ID::CO, module->addWire(NEW_ID, GetSize(new_out)));
+		shared_op->setPort(ID::X, module->addWire(NEWER_ID, GetSize(new_out)));
+		shared_op->setPort(ID::CO, module->addWire(NEWER_ID, GetSize(new_out)));
 	}
 
 	bool is_fine = shared_op->type.in(FINE_BITWISE_OPS);

--- a/passes/opt/peepopt_formal_clockgateff.pmg
+++ b/passes/opt/peepopt_formal_clockgateff.pmg
@@ -50,8 +50,8 @@ code
 	// instead of the latch. We don't delete the latch in case its output is
 	// used to drive other nodes. If it isn't, it will be trivially removed by
 	// clean
-	SigSpec flopped_en = module->addWire(NEW_ID);
-	module->addDff(NEW_ID, clk, en, flopped_en, true, latch->get_src_attribute());
+	SigSpec flopped_en = module->addWire(NEWER_ID);
+	module->addDff(NEWER_ID, clk, en, flopped_en, true, latch->get_src_attribute());
 	and_gate->setPort(latched_en_port_name, flopped_en);
 	did_something = true;
 

--- a/passes/opt/peepopt_shiftmul_left.pmg
+++ b/passes/opt/peepopt_shiftmul_left.pmg
@@ -129,7 +129,7 @@ code
 		if (bit == SigBit(State::Sm))
 			padbits++;
 
-		SigSpec padwire = module->addWire(NEW_ID, padbits);
+		SigSpec padwire = module->addWire(NEWER_ID, padbits);
 
 		for (int i = new_y.size() - 1; i >= 0; i--)
 		if (new_y[i] == SigBit(State::Sm)) {
@@ -148,8 +148,8 @@ code
 		shift->setPort(\B, new_b);
 		shift->setParam(\B_WIDTH, GetSize(new_b));
 	} else {
-		SigSpec b_neg = module->addWire(NEW_ID, GetSize(new_b) + 1);
-		module->addNeg(NEW_ID, new_b, b_neg);
+		SigSpec b_neg = module->addWire(NEWER_ID, GetSize(new_b) + 1);
+		module->addNeg(NEWER_ID, new_b, b_neg);
 		shift->setPort(\B, b_neg);
 		shift->setParam(\B_WIDTH, GetSize(b_neg));
 	}

--- a/passes/opt/pmux2shiftx.cc
+++ b/passes/opt/pmux2shiftx.cc
@@ -680,9 +680,9 @@ struct Pmux2ShiftxPass : public Pass {
 					// creat cmp signal
 					SigSpec cmp = perm_sig;
 					if (perm_xormask.as_bool())
-						cmp = module->Xor(NEW_ID, cmp, perm_xormask, false, src);
+						cmp = module->Xor(NEWER_ID, cmp, perm_xormask, false, src);
 					if (offset.as_bool())
-						cmp = module->Sub(NEW_ID, cmp, offset, false, src);
+						cmp = module->Sub(NEWER_ID, cmp, offset, false, src);
 
 					// create enable signal
 					SigBit en = State::S1;
@@ -690,8 +690,8 @@ struct Pmux2ShiftxPass : public Pass {
 						Const enable_mask(State::S0, max_choice+1);
 						for (auto &it : perm_choices)
 							enable_mask.set(it.first.as_int(), State::S1);
-						en = module->addWire(NEW_ID);
-						module->addShift(NEW_ID, enable_mask, cmp, en, false, src);
+						en = module->addWire(NEWER_ID);
+						module->addShift(NEWER_ID, enable_mask, cmp, en, false, src);
 					}
 
 					// create data signal
@@ -710,8 +710,8 @@ struct Pmux2ShiftxPass : public Pass {
 
 					// create shiftx cell
 					SigSpec shifted_cmp = {cmp, SigSpec(State::S0, width_bits)};
-					SigSpec outsig = module->addWire(NEW_ID, width);
-					Cell *c = module->addShiftx(NEW_ID, data, shifted_cmp, outsig, false, src);
+					SigSpec outsig = module->addWire(NEWER_ID, width);
+					Cell *c = module->addShiftx(NEWER_ID, data, shifted_cmp, outsig, false, src);
 					updated_S.append(en);
 					updated_B.append(outsig);
 					log("    created $shiftx cell %s.\n", log_id(c));

--- a/passes/opt/share.cc
+++ b/passes/opt/share.cc
@@ -207,13 +207,13 @@ struct ShareWorker
 			sig_b2.extend_u0(GetSize(sig_b), p2.is_signed);
 
 			if (supercell_aux && GetSize(sig_a)) {
-				sig_a = module->addWire(NEW_ID, GetSize(sig_a));
-				supercell_aux->insert(module->addMux(NEW_ID, sig_a2, sig_a1, act, sig_a));
+				sig_a = module->addWire(NEWER_ID, GetSize(sig_a));
+				supercell_aux->insert(module->addMux(NEWER_ID, sig_a2, sig_a1, act, sig_a));
 			}
 
 			if (supercell_aux && GetSize(sig_b)) {
-				sig_b = module->addWire(NEW_ID, GetSize(sig_b));
-				supercell_aux->insert(module->addMux(NEW_ID, sig_b2, sig_b1, act, sig_b));
+				sig_b = module->addWire(NEWER_ID, GetSize(sig_b));
+				supercell_aux->insert(module->addMux(NEWER_ID, sig_b2, sig_b1, act, sig_b));
 			}
 
 			Macc::term_t p;
@@ -284,13 +284,13 @@ struct ShareWorker
 			RTLIL::SigSpec sig_b = m1.terms[i].in_b;
 
 			if (supercell_aux && GetSize(sig_a)) {
-				sig_a = module->addWire(NEW_ID, GetSize(sig_a));
-				supercell_aux->insert(module->addMux(NEW_ID, RTLIL::SigSpec(0, GetSize(sig_a)), m1.terms[i].in_a, act, sig_a));
+				sig_a = module->addWire(NEWER_ID, GetSize(sig_a));
+				supercell_aux->insert(module->addMux(NEWER_ID, RTLIL::SigSpec(0, GetSize(sig_a)), m1.terms[i].in_a, act, sig_a));
 			}
 
 			if (supercell_aux && GetSize(sig_b)) {
-				sig_b = module->addWire(NEW_ID, GetSize(sig_b));
-				supercell_aux->insert(module->addMux(NEW_ID, RTLIL::SigSpec(0, GetSize(sig_b)), m1.terms[i].in_b, act, sig_b));
+				sig_b = module->addWire(NEWER_ID, GetSize(sig_b));
+				supercell_aux->insert(module->addMux(NEWER_ID, RTLIL::SigSpec(0, GetSize(sig_b)), m1.terms[i].in_b, act, sig_b));
 			}
 
 			Macc::term_t p;
@@ -307,13 +307,13 @@ struct ShareWorker
 			RTLIL::SigSpec sig_b = m2.terms[i].in_b;
 
 			if (supercell_aux && GetSize(sig_a)) {
-				sig_a = module->addWire(NEW_ID, GetSize(sig_a));
-				supercell_aux->insert(module->addMux(NEW_ID, m2.terms[i].in_a, RTLIL::SigSpec(0, GetSize(sig_a)), act, sig_a));
+				sig_a = module->addWire(NEWER_ID, GetSize(sig_a));
+				supercell_aux->insert(module->addMux(NEWER_ID, m2.terms[i].in_a, RTLIL::SigSpec(0, GetSize(sig_a)), act, sig_a));
 			}
 
 			if (supercell_aux && GetSize(sig_b)) {
-				sig_b = module->addWire(NEW_ID, GetSize(sig_b));
-				supercell_aux->insert(module->addMux(NEW_ID, m2.terms[i].in_b, RTLIL::SigSpec(0, GetSize(sig_b)), act, sig_b));
+				sig_b = module->addWire(NEWER_ID, GetSize(sig_b));
+				supercell_aux->insert(module->addMux(NEWER_ID, m2.terms[i].in_b, RTLIL::SigSpec(0, GetSize(sig_b)), act, sig_b));
 			}
 
 			Macc::term_t p;
@@ -326,10 +326,10 @@ struct ShareWorker
 
 		if (supercell)
 		{
-			RTLIL::SigSpec sig_y = module->addWire(NEW_ID, width);
+			RTLIL::SigSpec sig_y = module->addWire(NEWER_ID, width);
 
-			supercell_aux->insert(module->addPos(NEW_ID, sig_y, c1->getPort(ID::Y)));
-			supercell_aux->insert(module->addPos(NEW_ID, sig_y, c2->getPort(ID::Y)));
+			supercell_aux->insert(module->addPos(NEWER_ID, sig_y, c1->getPort(ID::Y)));
+			supercell_aux->insert(module->addPos(NEWER_ID, sig_y, c2->getPort(ID::Y)));
 
 			supercell->setParam(ID::Y_WIDTH, width);
 			supercell->setPort(ID::Y, sig_y);
@@ -541,20 +541,20 @@ struct ShareWorker
 			a1.extend_u0(a_width, a_signed);
 			a2.extend_u0(a_width, a_signed);
 
-			RTLIL::SigSpec a = module->addWire(NEW_ID, a_width);
-			supercell_aux.insert(module->addMux(NEW_ID, a2, a1, act, a));
+			RTLIL::SigSpec a = module->addWire(NEWER_ID, a_width);
+			supercell_aux.insert(module->addMux(NEWER_ID, a2, a1, act, a));
 
-			RTLIL::Wire *y = module->addWire(NEW_ID, y_width);
+			RTLIL::Wire *y = module->addWire(NEWER_ID, y_width);
 
-			RTLIL::Cell *supercell = module->addCell(NEW_ID, c1->type);
+			RTLIL::Cell *supercell = module->addCell(NEWER_ID, c1->type);
 			supercell->parameters[ID::A_SIGNED] = a_signed;
 			supercell->parameters[ID::A_WIDTH] = a_width;
 			supercell->parameters[ID::Y_WIDTH] = y_width;
 			supercell->setPort(ID::A, a);
 			supercell->setPort(ID::Y, y);
 
-			supercell_aux.insert(module->addPos(NEW_ID, y, y1));
-			supercell_aux.insert(module->addPos(NEW_ID, y, y2));
+			supercell_aux.insert(module->addPos(NEWER_ID, y, y1));
+			supercell_aux.insert(module->addPos(NEWER_ID, y, y2));
 
 			supercell_aux.insert(supercell);
 			return supercell;
@@ -656,17 +656,17 @@ struct ShareWorker
 			b1.extend_u0(b_width, b_signed);
 			b2.extend_u0(b_width, b_signed);
 
-			RTLIL::SigSpec a = module->addWire(NEW_ID, a_width);
-			RTLIL::SigSpec b = module->addWire(NEW_ID, b_width);
+			RTLIL::SigSpec a = module->addWire(NEWER_ID, a_width);
+			RTLIL::SigSpec b = module->addWire(NEWER_ID, b_width);
 
-			supercell_aux.insert(module->addMux(NEW_ID, a2, a1, act, a));
-			supercell_aux.insert(module->addMux(NEW_ID, b2, b1, act, b));
+			supercell_aux.insert(module->addMux(NEWER_ID, a2, a1, act, a));
+			supercell_aux.insert(module->addMux(NEWER_ID, b2, b1, act, b));
 
-			RTLIL::Wire *y = module->addWire(NEW_ID, y_width);
-			RTLIL::Wire *x = c1->type == ID($alu) ? module->addWire(NEW_ID, y_width) : nullptr;
-			RTLIL::Wire *co = c1->type == ID($alu) ? module->addWire(NEW_ID, y_width) : nullptr;
+			RTLIL::Wire *y = module->addWire(NEWER_ID, y_width);
+			RTLIL::Wire *x = c1->type == ID($alu) ? module->addWire(NEWER_ID, y_width) : nullptr;
+			RTLIL::Wire *co = c1->type == ID($alu) ? module->addWire(NEWER_ID, y_width) : nullptr;
 
-			RTLIL::Cell *supercell = module->addCell(NEW_ID, c1->type);
+			RTLIL::Cell *supercell = module->addCell(NEWER_ID, c1->type);
 			supercell->parameters[ID::A_SIGNED] = a_signed;
 			supercell->parameters[ID::B_SIGNED] = b_signed;
 			supercell->parameters[ID::A_WIDTH] = a_width;
@@ -676,9 +676,9 @@ struct ShareWorker
 			supercell->setPort(ID::B, b);
 			supercell->setPort(ID::Y, y);
 			if (c1->type == ID($alu)) {
-				RTLIL::Wire *ci = module->addWire(NEW_ID), *bi = module->addWire(NEW_ID);
-				supercell_aux.insert(module->addMux(NEW_ID, c2->getPort(ID::CI), c1->getPort(ID::CI), act, ci));
-				supercell_aux.insert(module->addMux(NEW_ID, c2->getPort(ID::BI), c1->getPort(ID::BI), act, bi));
+				RTLIL::Wire *ci = module->addWire(NEWER_ID), *bi = module->addWire(NEWER_ID);
+				supercell_aux.insert(module->addMux(NEWER_ID, c2->getPort(ID::CI), c1->getPort(ID::CI), act, ci));
+				supercell_aux.insert(module->addMux(NEWER_ID, c2->getPort(ID::BI), c1->getPort(ID::BI), act, bi));
 				supercell->setPort(ID::CI, ci);
 				supercell->setPort(ID::BI, bi);
 				supercell->setPort(ID::CO, co);
@@ -686,13 +686,13 @@ struct ShareWorker
 			}
 			supercell->check();
 
-			supercell_aux.insert(module->addPos(NEW_ID, y, y1));
-			supercell_aux.insert(module->addPos(NEW_ID, y, y2));
+			supercell_aux.insert(module->addPos(NEWER_ID, y, y1));
+			supercell_aux.insert(module->addPos(NEWER_ID, y, y2));
 			if (c1->type == ID($alu)) {
-				supercell_aux.insert(module->addPos(NEW_ID, co, c1->getPort(ID::CO)));
-				supercell_aux.insert(module->addPos(NEW_ID, co, c2->getPort(ID::CO)));
-				supercell_aux.insert(module->addPos(NEW_ID, x, c1->getPort(ID::X)));
-				supercell_aux.insert(module->addPos(NEW_ID, x, c2->getPort(ID::X)));
+				supercell_aux.insert(module->addPos(NEWER_ID, co, c1->getPort(ID::CO)));
+				supercell_aux.insert(module->addPos(NEWER_ID, co, c2->getPort(ID::CO)));
+				supercell_aux.insert(module->addPos(NEWER_ID, x, c1->getPort(ID::X)));
+				supercell_aux.insert(module->addPos(NEWER_ID, x, c2->getPort(ID::X)));
 			}
 
 			supercell_aux.insert(supercell);
@@ -701,7 +701,7 @@ struct ShareWorker
 
 		if (c1->type == ID($macc))
 		{
-			RTLIL::Cell *supercell = module->addCell(NEW_ID, c1->type);
+			RTLIL::Cell *supercell = module->addCell(NEWER_ID, c1->type);
 			supercell_aux.insert(supercell);
 			share_macc(c1, c2, act, supercell, &supercell_aux);
 			supercell->check();
@@ -710,16 +710,16 @@ struct ShareWorker
 
 		if (c1->type.in(ID($memrd), ID($memrd_v2)))
 		{
-			RTLIL::Cell *supercell = module->addCell(NEW_ID, c1);
+			RTLIL::Cell *supercell = module->addCell(NEWER_ID, c1);
 			RTLIL::SigSpec addr1 = c1->getPort(ID::ADDR);
 			RTLIL::SigSpec addr2 = c2->getPort(ID::ADDR);
 			if (GetSize(addr1) < GetSize(addr2))
 				addr1.extend_u0(GetSize(addr2));
 			else
 				addr2.extend_u0(GetSize(addr1));
-			supercell->setPort(ID::ADDR, addr1 != addr2 ? module->Mux(NEW_ID, addr2, addr1, act) : addr1);
+			supercell->setPort(ID::ADDR, addr1 != addr2 ? module->Mux(NEWER_ID, addr2, addr1, act) : addr1);
 			supercell->parameters[ID::ABITS] = RTLIL::Const(GetSize(addr1));
-			supercell_aux.insert(module->addPos(NEW_ID, supercell->getPort(ID::DATA), c2->getPort(ID::DATA)));
+			supercell_aux.insert(module->addPos(NEWER_ID, supercell->getPort(ID::DATA), c2->getPort(ID::DATA)));
 			supercell_aux.insert(supercell);
 			return supercell;
 		}
@@ -1065,18 +1065,18 @@ struct ShareWorker
 
 	RTLIL::SigSpec make_cell_activation_logic(const pool<ssc_pair_t> &activation_patterns, pool<RTLIL::Cell*> &supercell_aux)
 	{
-		RTLIL::Wire *all_cases_wire = module->addWire(NEW_ID, 0);
+		RTLIL::Wire *all_cases_wire = module->addWire(NEWER_ID, 0);
 
 		for (auto &p : activation_patterns) {
 			all_cases_wire->width++;
-			supercell_aux.insert(module->addEq(NEW_ID, p.first, p.second, RTLIL::SigSpec(all_cases_wire, all_cases_wire->width - 1)));
+			supercell_aux.insert(module->addEq(NEWER_ID, p.first, p.second, RTLIL::SigSpec(all_cases_wire, all_cases_wire->width - 1)));
 		}
 
 		if (all_cases_wire->width == 1)
 			return all_cases_wire;
 
-		RTLIL::Wire *result_wire = module->addWire(NEW_ID);
-		supercell_aux.insert(module->addReduceOr(NEW_ID, all_cases_wire, result_wire));
+		RTLIL::Wire *result_wire = module->addWire(NEWER_ID);
+		supercell_aux.insert(module->addReduceOr(NEWER_ID, all_cases_wire, result_wire));
 		return result_wire;
 	}
 

--- a/passes/opt/wreduce.cc
+++ b/passes/opt/wreduce.cc
@@ -511,7 +511,7 @@ struct WreduceWorker
 				continue;
 
 			log("Removed top %d bits (of %d) from wire %s.%s.\n", unused_top_bits, GetSize(w), log_id(module), log_id(w));
-			Wire *nw = module->addWire(NEW_ID, GetSize(w) - unused_top_bits);
+			Wire *nw = module->addWire(NEWER_ID, GetSize(w) - unused_top_bits);
 			module->connect(nw, SigSpec(w).extract(0, GetSize(nw)));
 			module->swap_names(w, nw);
 		}

--- a/passes/pmgen/README.md
+++ b/passes/pmgen/README.md
@@ -367,9 +367,9 @@ test-case generation. For example:
         ...
     generate 10 0
         SigSpec Y = port(ff, \D);
-        SigSpec A = module->addWire(NEW_ID, GetSize(Y) - rng(GetSize(Y)/2));
-        SigSpec B = module->addWire(NEW_ID, GetSize(Y) - rng(GetSize(Y)/2));
-        module->addMul(NEW_ID, A, B, Y, rng(2));
+        SigSpec A = module->addWire(NEWER_ID, GetSize(Y) - rng(GetSize(Y)/2));
+        SigSpec B = module->addWire(NEWER_ID, GetSize(Y) - rng(GetSize(Y)/2));
+        module->addMul(NEWER_ID, A, B, Y, rng(2));
     endmatch
 
 The expression `rng(n)` returns a non-negative integer less than `n`.

--- a/passes/pmgen/generate.h
+++ b/passes/pmgen/generate.h
@@ -78,7 +78,7 @@ void generate_pattern(std::function<void(pm&,std::function<void()>)> run, const 
 	while (modcnt < maxmodcnt)
 	{
 		int submodcnt = 0, itercnt = 0, cellcnt = 0;
-		Module *mod = design->addModule(NEW_ID);
+		Module *mod = design->addModule(NEWER_ID);
 
 		while (modcnt < maxmodcnt && submodcnt < maxsubcnt && itercnt++ < 1000)
 		{
@@ -130,7 +130,7 @@ void generate_pattern(std::function<void(pm&,std::function<void()>)> run, const 
 	for (auto mod : mods) {
 		Cell *c = m->addCell(mod->name, mod->name);
 		for (auto port : mod->ports) {
-			Wire *w = m->addWire(NEW_ID, GetSize(mod->wire(port)));
+			Wire *w = m->addWire(NEWER_ID, GetSize(mod->wire(port)));
 			c->setPort(port, w);
 		}
 	}

--- a/passes/pmgen/test_pmgen.cc
+++ b/passes/pmgen/test_pmgen.cc
@@ -58,11 +58,11 @@ void reduce_chain(test_pmgen_pm &pm)
 	Cell *c;
 
 	if (last_cell->type == ID($_AND_))
-		c = pm.module->addReduceAnd(NEW_ID, A, Y);
+		c = pm.module->addReduceAnd(NEWER_ID, A, Y);
 	else if (last_cell->type == ID($_OR_))
-		c = pm.module->addReduceOr(NEW_ID, A, Y);
+		c = pm.module->addReduceOr(NEWER_ID, A, Y);
 	else if (last_cell->type == ID($_XOR_))
-		c = pm.module->addReduceXor(NEW_ID, A, Y);
+		c = pm.module->addReduceXor(NEWER_ID, A, Y);
 	else
 		log_abort();
 
@@ -87,11 +87,11 @@ void reduce_tree(test_pmgen_pm &pm)
 	Cell *c;
 
 	if (st.first->type == ID($_AND_))
-		c = pm.module->addReduceAnd(NEW_ID, A, Y);
+		c = pm.module->addReduceAnd(NEWER_ID, A, Y);
 	else if (st.first->type == ID($_OR_))
-		c = pm.module->addReduceOr(NEW_ID, A, Y);
+		c = pm.module->addReduceOr(NEWER_ID, A, Y);
 	else if (st.first->type == ID($_XOR_))
-		c = pm.module->addReduceXor(NEW_ID, A, Y);
+		c = pm.module->addReduceXor(NEWER_ID, A, Y);
 	else
 		log_abort();
 
@@ -112,7 +112,7 @@ void opt_eqpmux(test_pmgen_pm &pm)
 			log_signal(Y), log_id(st.eq), log_id(st.ne), log_id(st.pmux));
 
 	pm.autoremove(st.pmux);
-	Cell *c = pm.module->addMux(NEW_ID, NE, EQ, st.eq->getPort(ID::Y), Y);
+	Cell *c = pm.module->addMux(NEWER_ID, NE, EQ, st.eq->getPort(ID::Y), Y);
 	log("    -> %s (%s)\n", log_id(c), log_id(c->type));
 }
 

--- a/passes/pmgen/test_pmgen.pmg
+++ b/passes/pmgen/test_pmgen.pmg
@@ -14,19 +14,19 @@ match first
 	select first->type.in($_AND_, $_OR_, $_XOR_)
 	filter !non_first_cells.count(first)
 generate
-	SigSpec A = module->addWire(NEW_ID);
-	SigSpec B = module->addWire(NEW_ID);
-	SigSpec Y = module->addWire(NEW_ID);
+	SigSpec A = module->addWire(NEWER_ID);
+	SigSpec B = module->addWire(NEWER_ID);
+	SigSpec Y = module->addWire(NEWER_ID);
 	switch (rng(3))
 	{
 	case 0:
-		module->addAndGate(NEW_ID, A, B, Y);
+		module->addAndGate(NEWER_ID, A, B, Y);
 		break;
 	case 1:
-		module->addOrGate(NEW_ID, A, B, Y);
+		module->addOrGate(NEWER_ID, A, B, Y);
 		break;
 	case 2:
-		module->addXorGate(NEW_ID, A, B, Y);
+		module->addXorGate(NEWER_ID, A, B, Y);
 		break;
 	}
 endmatch
@@ -82,10 +82,10 @@ match next
 	index <IdString> next->type === chain.back().first->type
 	index <SigSpec> port(next, \Y) === port(chain.back().first, chain.back().second)
 generate 10
-	SigSpec A = module->addWire(NEW_ID);
-	SigSpec B = module->addWire(NEW_ID);
+	SigSpec A = module->addWire(NEWER_ID);
+	SigSpec B = module->addWire(NEWER_ID);
 	SigSpec Y = port(chain.back().first, chain.back().second);
-	Cell *c = module->addAndGate(NEW_ID, A, B, Y);
+	Cell *c = module->addAndGate(NEWER_ID, A, B, Y);
 	c->type = chain.back().first->type;
 endmatch
 
@@ -121,10 +121,10 @@ match eq
 	set eq_inB port(eq, \B)
 	set eq_ne_signed param(eq, \A_SIGNED).as_bool()
 generate 100 10
-	SigSpec A = module->addWire(NEW_ID, rng(7)+1);
-	SigSpec B = module->addWire(NEW_ID, rng(7)+1);
-	SigSpec Y = module->addWire(NEW_ID);
-	module->addEq(NEW_ID, A, B, Y, rng(2));
+	SigSpec A = module->addWire(NEWER_ID, rng(7)+1);
+	SigSpec B = module->addWire(NEWER_ID, rng(7)+1);
+	SigSpec Y = module->addWire(NEWER_ID);
+	module->addEq(NEWER_ID, A, B, Y, rng(2));
 endmatch
 
 match pmux
@@ -137,16 +137,16 @@ generate 100 10
 	int numsel = rng(4) + 1;
 	int idx = rng(numsel);
 
-	SigSpec A = module->addWire(NEW_ID, width);
-	SigSpec Y = module->addWire(NEW_ID, width);
+	SigSpec A = module->addWire(NEWER_ID, width);
+	SigSpec Y = module->addWire(NEWER_ID, width);
 
 	SigSpec B, S;
 	for (int i = 0; i < numsel; i++) {
-		B.append(module->addWire(NEW_ID, width));
-		S.append(i == idx ? port(eq, \Y) : module->addWire(NEW_ID));
+		B.append(module->addWire(NEWER_ID, width));
+		S.append(i == idx ? port(eq, \Y) : module->addWire(NEWER_ID));
 	}
 
-	module->addPmux(NEW_ID, A, B, S, Y);
+	module->addPmux(NEWER_ID, A, B, S, Y);
 endmatch
 
 match ne
@@ -169,11 +169,11 @@ generate 100 10
 		if (GetSize(Y))
 			Y = Y[rng(GetSize(Y))];
 		else
-			Y = module->addWire(NEW_ID);
+			Y = module->addWire(NEWER_ID);
 	} else {
-		Y = module->addWire(NEW_ID);
+		Y = module->addWire(NEWER_ID);
 	}
-	module->addNe(NEW_ID, A, B, Y, rng(2));
+	module->addNe(NEWER_ID, A, B, Y, rng(2));
 endmatch
 
 match pmux2

--- a/passes/proc/proc_dlatch.cc
+++ b/passes/proc/proc_dlatch.cc
@@ -246,20 +246,20 @@ struct proc_dlatch_db_t
 			if (rule.match == State::S1)
 				and_bits.append(rule.signal);
 			else if (rule.match == State::S0)
-				and_bits.append(module->Not(NEW_ID, rule.signal, false, src));
+				and_bits.append(module->Not(NEWER_ID, rule.signal, false, src));
 			else
-				and_bits.append(module->Eq(NEW_ID, rule.signal, rule.match, false, src));
+				and_bits.append(module->Eq(NEWER_ID, rule.signal, rule.match, false, src));
 		}
 
 		if (!rule.children.empty()) {
 			SigSpec or_bits;
 			for (int k : rule.children)
 				or_bits.append(make_hold(k, src));
-			and_bits.append(module->ReduceOr(NEW_ID, or_bits, false, src));
+			and_bits.append(module->ReduceOr(NEWER_ID, or_bits, false, src));
 		}
 
 		if (GetSize(and_bits) == 2)
-			and_bits = module->And(NEW_ID, and_bits[0], and_bits[1], false, src);
+			and_bits = module->And(NEWER_ID, and_bits[0], and_bits[1], false, src);
 		log_assert(GetSize(and_bits) == 1);
 
 		rules_sig[n] = and_bits[0];
@@ -429,7 +429,7 @@ void proc_dlatch(proc_dlatch_db_t &db, RTLIL::Process *proc)
 			SigSpec lhs = latches_bits.first.extract(offset, width);
 			SigSpec rhs = latches_bits.second.extract(offset, width);
 
-			Cell *cell = db.module->addDlatch(NEW_ID, db.module->Not(NEW_ID, db.make_hold(n, src)), rhs, lhs);
+			Cell *cell = db.module->addDlatch(NEWER_ID, db.module->Not(NEWER_ID, db.make_hold(n, src)), rhs, lhs);
 			cell->set_src_attribute(src);
 			db.generated_dlatches.insert(cell);
 

--- a/passes/proc/proc_memwr.cc
+++ b/passes/proc/proc_memwr.cc
@@ -42,7 +42,7 @@ void proc_memwr(RTLIL::Module *mod, RTLIL::Process *proc, dict<IdString, int> &n
 					priority_mask.set(prev_port_ids[i], State::S1);
 			prev_port_ids.push_back(port_id);
 
-			RTLIL::Cell *cell = mod->addCell(NEW_ID, ID($memwr_v2));
+			RTLIL::Cell *cell = mod->addCell(NEWER_ID, ID($memwr_v2));
 			cell->attributes = memwr.attributes;
 			cell->setParam(ID::MEMID, Const(memwr.memid.str()));
 			cell->setParam(ID::ABITS, GetSize(memwr.address));
@@ -55,10 +55,10 @@ void proc_memwr(RTLIL::Module *mod, RTLIL::Process *proc, dict<IdString, int> &n
 			for (auto sr2 : proc->syncs) {
 				if (sr2->type == RTLIL::SyncType::ST0) {
 					log_assert(sr2->mem_write_actions.empty());
-					enable = mod->Mux(NEW_ID, Const(State::S0, GetSize(enable)), enable, sr2->signal);
+					enable = mod->Mux(NEWER_ID, Const(State::S0, GetSize(enable)), enable, sr2->signal);
 				} else if (sr2->type == RTLIL::SyncType::ST1) {
 					log_assert(sr2->mem_write_actions.empty());
-					enable = mod->Mux(NEW_ID, enable, Const(State::S0, GetSize(enable)), sr2->signal);
+					enable = mod->Mux(NEWER_ID, enable, Const(State::S0, GetSize(enable)), sr2->signal);
 				}
 			}
 			cell->setPort(ID::EN, enable);

--- a/passes/proc/proc_rom.cc
+++ b/passes/proc/proc_rom.cc
@@ -151,8 +151,8 @@ struct RomWorker
 		}
 
 		// Ok, let's do it.
-		SigSpec rdata = module->addWire(NEW_ID, GetSize(lhs));
-		Mem mem(module, NEW_ID, GetSize(lhs), 0, 1 << abits);
+		SigSpec rdata = module->addWire(NEWER_ID, GetSize(lhs));
+		Mem mem(module, NEWER_ID, GetSize(lhs), 0, 1 << abits);
 		mem.attributes = sw->attributes;
 
 		Const::Builder builder(mem.size * GetSize(lhs));

--- a/passes/sat/assertpmux.cc
+++ b/passes/sat/assertpmux.cc
@@ -100,12 +100,12 @@ struct AssertpmuxWorker
 
 				if (muxport_actsignal.count(muxport) == 0) {
 					if (portidx == 0)
-						muxport_actsignal[muxport] = module->LogicNot(NEW_ID, cell->getPort(ID::S));
+						muxport_actsignal[muxport] = module->LogicNot(NEWER_ID, cell->getPort(ID::S));
 					else
 						muxport_actsignal[muxport] = cell->getPort(ID::S)[portidx-1];
 				}
 
-				output.append(module->LogicAnd(NEW_ID, muxport_actsignal.at(muxport), get_bit_activation(cell->getPort(ID::Y)[bitidx])));
+				output.append(module->LogicAnd(NEWER_ID, muxport_actsignal.at(muxport), get_bit_activation(cell->getPort(ID::Y)[bitidx])));
 			}
 
 			output.sort_and_unify();
@@ -113,7 +113,7 @@ struct AssertpmuxWorker
 			if (GetSize(output) == 0)
 				output = State::S0;
 			else if (GetSize(output) > 1)
-				output = module->ReduceOr(NEW_ID, output);
+				output = module->ReduceOr(NEWER_ID, output);
 
 			sigbit_actsignals[bit] = output.as_bit();
 		}
@@ -138,7 +138,7 @@ struct AssertpmuxWorker
 			if (GetSize(output) == 0)
 				output = State::S0;
 			else if (GetSize(output) > 1)
-				output = module->ReduceOr(NEW_ID, output);
+				output = module->ReduceOr(NEWER_ID, output);
 
 			sigspec_actsignals[sig] = output.as_bit();
 		}
@@ -157,13 +157,13 @@ struct AssertpmuxWorker
 		SigSpec cnt(State::S0, cntbits);
 
 		for (int i = 0; i < swidth; i++)
-			cnt = module->Add(NEW_ID, cnt, sel[i]);
+			cnt = module->Add(NEWER_ID, cnt, sel[i]);
 
-		SigSpec assert_a = module->Le(NEW_ID, cnt, SigSpec(1, cntbits));
+		SigSpec assert_a = module->Le(NEWER_ID, cnt, SigSpec(1, cntbits));
 		SigSpec assert_en;
 
 		if (flag_noinit)
-			assert_en.append(module->LogicNot(NEW_ID, module->Initstate(NEW_ID)));
+			assert_en.append(module->LogicNot(NEWER_ID, module->Initstate(NEWER_ID)));
 
 		if (!flag_always)
 			assert_en.append(get_activation(pmux->getPort(ID::Y)));
@@ -172,9 +172,9 @@ struct AssertpmuxWorker
 			assert_en = State::S1;
 
 		if (GetSize(assert_en) == 2)
-			assert_en = module->LogicAnd(NEW_ID, assert_en[0], assert_en[1]);
+			assert_en = module->LogicAnd(NEWER_ID, assert_en[0], assert_en[1]);
 
-		Cell *assert_cell = module->addAssert(NEW_ID, assert_a, assert_en);
+		Cell *assert_cell = module->addAssert(NEWER_ID, assert_a, assert_en);
 
 		if (pmux->attributes.count(ID::src) != 0)
 			assert_cell->attributes[ID::src] = pmux->attributes.at(ID::src);

--- a/passes/sat/async2sync.cc
+++ b/passes/sat/async2sync.cc
@@ -95,27 +95,27 @@ struct Async2syncPass : public Pass {
 
 					if (trg_width == 0) {
 						if (initstate == State::S0)
-							initstate = module->Initstate(NEW_ID);
+							initstate = module->Initstate(NEWER_ID);
 
 						SigBit sig_en = cell->getPort(ID::EN);
-						cell->setPort(ID::EN, module->And(NEW_ID, sig_en, initstate));
+						cell->setPort(ID::EN, module->And(NEWER_ID, sig_en, initstate));
 					} else {
 						SigBit sig_en = cell->getPort(ID::EN);
 						SigSpec sig_args = cell->getPort(ID::ARGS);
 						bool trg_polarity = cell->getParam(ID(TRG_POLARITY)).as_bool();
 						SigBit sig_trg = cell->getPort(ID::TRG);
-						Wire *sig_en_q = module->addWire(NEW_ID);
-						Wire *sig_args_q = module->addWire(NEW_ID, GetSize(sig_args));
+						Wire *sig_en_q = module->addWire(NEWER_ID);
+						Wire *sig_args_q = module->addWire(NEWER_ID, GetSize(sig_args));
 						sig_en_q->attributes.emplace(ID::init, State::S0);
-						module->addDff(NEW_ID, sig_trg, sig_en, sig_en_q, trg_polarity, cell->get_src_attribute());
-						module->addDff(NEW_ID, sig_trg, sig_args, sig_args_q, trg_polarity, cell->get_src_attribute());
+						module->addDff(NEWER_ID, sig_trg, sig_en, sig_en_q, trg_polarity, cell->get_src_attribute());
+						module->addDff(NEWER_ID, sig_trg, sig_args, sig_args_q, trg_polarity, cell->get_src_attribute());
 						cell->setPort(ID::EN, sig_en_q);
 						cell->setPort(ID::ARGS, sig_args_q);
 						if (cell->type == ID($check)) {
 							SigBit sig_a = cell->getPort(ID::A);
-							Wire *sig_a_q = module->addWire(NEW_ID);
+							Wire *sig_a_q = module->addWire(NEWER_ID);
 							sig_a_q->attributes.emplace(ID::init, State::S1);
-							module->addDff(NEW_ID, sig_trg, sig_a, sig_a_q, trg_polarity, cell->get_src_attribute());
+							module->addDff(NEWER_ID, sig_trg, sig_a, sig_a_q, trg_polarity, cell->get_src_attribute());
 							cell->setPort(ID::A, sig_a_q);
 						}
 					}
@@ -152,38 +152,38 @@ struct Async2syncPass : public Pass {
 
 						initvals.remove_init(ff.sig_q);
 
-						Wire *new_d = module->addWire(NEW_ID, ff.width);
-						Wire *new_q = module->addWire(NEW_ID, ff.width);
+						Wire *new_d = module->addWire(NEWER_ID, ff.width);
+						Wire *new_q = module->addWire(NEWER_ID, ff.width);
 
 						SigSpec sig_set = ff.sig_set;
 						SigSpec sig_clr = ff.sig_clr;
 
 						if (!ff.pol_set) {
 							if (!ff.is_fine)
-								sig_set = module->Not(NEW_ID, sig_set);
+								sig_set = module->Not(NEWER_ID, sig_set);
 							else
-								sig_set = module->NotGate(NEW_ID, sig_set);
+								sig_set = module->NotGate(NEWER_ID, sig_set);
 						}
 
 						if (ff.pol_clr) {
 							if (!ff.is_fine)
-								sig_clr = module->Not(NEW_ID, sig_clr);
+								sig_clr = module->Not(NEWER_ID, sig_clr);
 							else
-								sig_clr = module->NotGate(NEW_ID, sig_clr);
+								sig_clr = module->NotGate(NEWER_ID, sig_clr);
 						}
 
 						if (!ff.is_fine) {
-							SigSpec tmp = module->Or(NEW_ID, ff.sig_d, sig_set);
-							module->addAnd(NEW_ID, tmp, sig_clr, new_d);
+							SigSpec tmp = module->Or(NEWER_ID, ff.sig_d, sig_set);
+							module->addAnd(NEWER_ID, tmp, sig_clr, new_d);
 
-							tmp = module->Or(NEW_ID, new_q, sig_set);
-							module->addAnd(NEW_ID, tmp, sig_clr, ff.sig_q);
+							tmp = module->Or(NEWER_ID, new_q, sig_set);
+							module->addAnd(NEWER_ID, tmp, sig_clr, ff.sig_q);
 						} else {
-							SigSpec tmp = module->OrGate(NEW_ID, ff.sig_d, sig_set);
-							module->addAndGate(NEW_ID, tmp, sig_clr, new_d);
+							SigSpec tmp = module->OrGate(NEWER_ID, ff.sig_d, sig_set);
+							module->addAndGate(NEWER_ID, tmp, sig_clr, new_d);
 
-							tmp = module->OrGate(NEW_ID, new_q, sig_set);
-							module->addAndGate(NEW_ID, tmp, sig_clr, ff.sig_q);
+							tmp = module->OrGate(NEWER_ID, new_q, sig_set);
+							module->addAndGate(NEWER_ID, tmp, sig_clr, ff.sig_q);
 						}
 
 						ff.sig_d = new_d;
@@ -198,24 +198,24 @@ struct Async2syncPass : public Pass {
 
 						initvals.remove_init(ff.sig_q);
 
-						Wire *new_d = module->addWire(NEW_ID, ff.width);
-						Wire *new_q = module->addWire(NEW_ID, ff.width);
+						Wire *new_d = module->addWire(NEWER_ID, ff.width);
+						Wire *new_q = module->addWire(NEWER_ID, ff.width);
 
 						if (ff.pol_aload) {
 							if (!ff.is_fine) {
-								module->addMux(NEW_ID, new_q, ff.sig_ad, ff.sig_aload, ff.sig_q);
-								module->addMux(NEW_ID, ff.sig_d, ff.sig_ad, ff.sig_aload, new_d);
+								module->addMux(NEWER_ID, new_q, ff.sig_ad, ff.sig_aload, ff.sig_q);
+								module->addMux(NEWER_ID, ff.sig_d, ff.sig_ad, ff.sig_aload, new_d);
 							} else {
-								module->addMuxGate(NEW_ID, new_q, ff.sig_ad, ff.sig_aload, ff.sig_q);
-								module->addMuxGate(NEW_ID, ff.sig_d, ff.sig_ad, ff.sig_aload, new_d);
+								module->addMuxGate(NEWER_ID, new_q, ff.sig_ad, ff.sig_aload, ff.sig_q);
+								module->addMuxGate(NEWER_ID, ff.sig_d, ff.sig_ad, ff.sig_aload, new_d);
 							}
 						} else {
 							if (!ff.is_fine) {
-								module->addMux(NEW_ID, ff.sig_ad, new_q, ff.sig_aload, ff.sig_q);
-								module->addMux(NEW_ID, ff.sig_ad, ff.sig_d, ff.sig_aload, new_d);
+								module->addMux(NEWER_ID, ff.sig_ad, new_q, ff.sig_aload, ff.sig_q);
+								module->addMux(NEWER_ID, ff.sig_ad, ff.sig_d, ff.sig_aload, new_d);
 							} else {
-								module->addMuxGate(NEW_ID, ff.sig_ad, new_q, ff.sig_aload, ff.sig_q);
-								module->addMuxGate(NEW_ID, ff.sig_ad, ff.sig_d, ff.sig_aload, new_d);
+								module->addMuxGate(NEWER_ID, ff.sig_ad, new_q, ff.sig_aload, ff.sig_q);
+								module->addMuxGate(NEWER_ID, ff.sig_ad, ff.sig_d, ff.sig_aload, new_d);
 							}
 						}
 
@@ -231,18 +231,18 @@ struct Async2syncPass : public Pass {
 
 						initvals.remove_init(ff.sig_q);
 
-						Wire *new_q = module->addWire(NEW_ID, ff.width);
+						Wire *new_q = module->addWire(NEWER_ID, ff.width);
 
 						if (ff.pol_arst) {
 							if (!ff.is_fine)
-								module->addMux(NEW_ID, new_q, ff.val_arst, ff.sig_arst, ff.sig_q);
+								module->addMux(NEWER_ID, new_q, ff.val_arst, ff.sig_arst, ff.sig_q);
 							else
-								module->addMuxGate(NEW_ID, new_q, ff.val_arst[0], ff.sig_arst, ff.sig_q);
+								module->addMuxGate(NEWER_ID, new_q, ff.val_arst[0], ff.sig_arst, ff.sig_q);
 						} else {
 							if (!ff.is_fine)
-								module->addMux(NEW_ID, ff.val_arst, new_q, ff.sig_arst, ff.sig_q);
+								module->addMux(NEWER_ID, ff.val_arst, new_q, ff.sig_arst, ff.sig_q);
 							else
-								module->addMuxGate(NEW_ID, ff.val_arst[0], new_q, ff.sig_arst, ff.sig_q);
+								module->addMuxGate(NEWER_ID, ff.val_arst[0], new_q, ff.sig_arst, ff.sig_q);
 						}
 
 						ff.sig_q = new_q;
@@ -265,21 +265,21 @@ struct Async2syncPass : public Pass {
 
 					initvals.remove_init(ff.sig_q);
 
-					Wire *new_q = module->addWire(NEW_ID, ff.width);
+					Wire *new_q = module->addWire(NEWER_ID, ff.width);
 					Wire *new_d;
 
 					if (ff.has_aload) {
-						new_d = module->addWire(NEW_ID, ff.width);
+						new_d = module->addWire(NEWER_ID, ff.width);
 						if (ff.pol_aload) {
 							if (!ff.is_fine)
-								module->addMux(NEW_ID, new_q, ff.sig_ad, ff.sig_aload, new_d);
+								module->addMux(NEWER_ID, new_q, ff.sig_ad, ff.sig_aload, new_d);
 							else
-								module->addMuxGate(NEW_ID, new_q, ff.sig_ad, ff.sig_aload, new_d);
+								module->addMuxGate(NEWER_ID, new_q, ff.sig_ad, ff.sig_aload, new_d);
 						} else {
 							if (!ff.is_fine)
-								module->addMux(NEW_ID, ff.sig_ad, new_q, ff.sig_aload, new_d);
+								module->addMux(NEWER_ID, ff.sig_ad, new_q, ff.sig_aload, new_d);
 							else
-								module->addMuxGate(NEW_ID, ff.sig_ad, new_q, ff.sig_aload, new_d);
+								module->addMuxGate(NEWER_ID, ff.sig_ad, new_q, ff.sig_aload, new_d);
 						}
 					} else {
 						new_d = new_q;
@@ -291,36 +291,36 @@ struct Async2syncPass : public Pass {
 
 						if (!ff.pol_set) {
 							if (!ff.is_fine)
-								sig_set = module->Not(NEW_ID, sig_set);
+								sig_set = module->Not(NEWER_ID, sig_set);
 							else
-								sig_set = module->NotGate(NEW_ID, sig_set);
+								sig_set = module->NotGate(NEWER_ID, sig_set);
 						}
 
 						if (ff.pol_clr) {
 							if (!ff.is_fine)
-								sig_clr = module->Not(NEW_ID, sig_clr);
+								sig_clr = module->Not(NEWER_ID, sig_clr);
 							else
-								sig_clr = module->NotGate(NEW_ID, sig_clr);
+								sig_clr = module->NotGate(NEWER_ID, sig_clr);
 						}
 
 						if (!ff.is_fine) {
-							SigSpec tmp = module->Or(NEW_ID, new_d, sig_set);
-							module->addAnd(NEW_ID, tmp, sig_clr, ff.sig_q);
+							SigSpec tmp = module->Or(NEWER_ID, new_d, sig_set);
+							module->addAnd(NEWER_ID, tmp, sig_clr, ff.sig_q);
 						} else {
-							SigSpec tmp = module->OrGate(NEW_ID, new_d, sig_set);
-							module->addAndGate(NEW_ID, tmp, sig_clr, ff.sig_q);
+							SigSpec tmp = module->OrGate(NEWER_ID, new_d, sig_set);
+							module->addAndGate(NEWER_ID, tmp, sig_clr, ff.sig_q);
 						}
 					} else if (ff.has_arst) {
 						if (ff.pol_arst) {
 							if (!ff.is_fine)
-								module->addMux(NEW_ID, new_d, ff.val_arst, ff.sig_arst, ff.sig_q);
+								module->addMux(NEWER_ID, new_d, ff.val_arst, ff.sig_arst, ff.sig_q);
 							else
-								module->addMuxGate(NEW_ID, new_d, ff.val_arst[0], ff.sig_arst, ff.sig_q);
+								module->addMuxGate(NEWER_ID, new_d, ff.val_arst[0], ff.sig_arst, ff.sig_q);
 						} else {
 							if (!ff.is_fine)
-								module->addMux(NEW_ID, ff.val_arst, new_d, ff.sig_arst, ff.sig_q);
+								module->addMux(NEWER_ID, ff.val_arst, new_d, ff.sig_arst, ff.sig_q);
 							else
-								module->addMuxGate(NEW_ID, ff.val_arst[0], new_d, ff.sig_arst, ff.sig_q);
+								module->addMuxGate(NEWER_ID, ff.val_arst[0], new_d, ff.sig_arst, ff.sig_q);
 						}
 					} else {
 						module->connect(ff.sig_q, new_d);

--- a/passes/sat/cutpoint.cc
+++ b/passes/sat/cutpoint.cc
@@ -102,7 +102,7 @@ struct CutpointPass : public Pass {
 					if (wire->port_output)
 						output_wires.push_back(wire);
 				for (auto wire : output_wires)
-					module->connect(wire, flag_undef ? Const(State::Sx, GetSize(wire)) : module->Anyseq(NEW_ID, GetSize(wire)));
+					module->connect(wire, flag_undef ? Const(State::Sx, GetSize(wire)) : module->Anyseq(NEWER_ID, GetSize(wire)));
 				continue;
 			}
 
@@ -115,13 +115,13 @@ struct CutpointPass : public Pass {
 				log("Removing cell %s.%s, making all cell outputs cutpoints.\n", log_id(module), log_id(cell));
 				for (auto &conn : cell->connections()) {
 					if (cell->output(conn.first))
-						module->connect(conn.second, flag_undef ? Const(State::Sx, GetSize(conn.second)) : module->Anyseq(NEW_ID, GetSize(conn.second)));
+						module->connect(conn.second, flag_undef ? Const(State::Sx, GetSize(conn.second)) : module->Anyseq(NEWER_ID, GetSize(conn.second)));
 				}
 
 				RTLIL::Cell *scopeinfo = nullptr;
 				auto cell_name = cell->name;
 				if (flag_scopeinfo && cell_name.isPublic()) {
-					auto scopeinfo = module->addCell(NEW_ID, ID($scopeinfo));
+					auto scopeinfo = module->addCell(NEWER_ID, ID($scopeinfo));
 					scopeinfo->setParam(ID::TYPE, RTLIL::Const("blackbox"));
 
 					for (auto const &attr : cell->attributes)
@@ -142,9 +142,9 @@ struct CutpointPass : public Pass {
 			for (auto wire : module->selected_wires()) {
 				if (wire->port_output) {
 					log("Making output wire %s.%s a cutpoint.\n", log_id(module), log_id(wire));
-					Wire *new_wire = module->addWire(NEW_ID, wire);
+					Wire *new_wire = module->addWire(NEWER_ID, wire);
 					module->swap_names(wire, new_wire);
-					module->connect(new_wire, flag_undef ? Const(State::Sx, GetSize(new_wire)) : module->Anyseq(NEW_ID, GetSize(new_wire)));
+					module->connect(new_wire, flag_undef ? Const(State::Sx, GetSize(new_wire)) : module->Anyseq(NEWER_ID, GetSize(new_wire)));
 					wire->port_id = 0;
 					wire->port_input = false;
 					wire->port_output = false;
@@ -169,7 +169,7 @@ struct CutpointPass : public Pass {
 						}
 						if (bit_count == 0)
 							continue;
-						SigSpec dummy = module->addWire(NEW_ID, bit_count);
+						SigSpec dummy = module->addWire(NEWER_ID, bit_count);
 						bit_count = 0;
 						for (auto &bit : sig) {
 							if (cutpoint_bits.count(bit))
@@ -193,7 +193,7 @@ struct CutpointPass : public Pass {
 				}
 
 				for (auto wire : rewrite_wires) {
-					Wire *new_wire = module->addWire(NEW_ID, wire);
+					Wire *new_wire = module->addWire(NEWER_ID, wire);
 					SigSpec lhs, rhs, sig = sigmap(wire);
 					for (int i = 0; i < GetSize(sig); i++)
 						if (!cutpoint_bits.count(sig[i])) {
@@ -213,7 +213,7 @@ struct CutpointPass : public Pass {
 
 				for (auto chunk : sig.chunks()) {
 					SigSpec s(chunk);
-					module->connect(s, flag_undef ? Const(State::Sx, GetSize(s)) : module->Anyseq(NEW_ID, GetSize(s)));
+					module->connect(s, flag_undef ? Const(State::Sx, GetSize(s)) : module->Anyseq(NEWER_ID, GetSize(s)));
 				}
 			}
 		}

--- a/passes/sat/expose.cc
+++ b/passes/sat/expose.cc
@@ -472,7 +472,7 @@ struct ExposePass : public Pass {
 					if (!w->port_input) {
 						w->port_input = true;
 						log("New module port: %s/%s\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(w->name));
-						wire_map[w] = NEW_ID;
+						wire_map[w] = NEWER_ID;
 					}
 				}
 				else
@@ -542,7 +542,7 @@ struct ExposePass : public Pass {
 
 				dff_map_info_t &info = dq.second;
 
-				RTLIL::Wire *wire_dummy_q = add_new_wire(module, NEW_ID, 0);
+				RTLIL::Wire *wire_dummy_q = add_new_wire(module, NEWER_ID, 0);
 
 				for (auto &cell_name : info.cells) {
 					RTLIL::Cell *cell = module->cell(cell_name);
@@ -578,7 +578,7 @@ struct ExposePass : public Pass {
 				if (info.clk_polarity) {
 					module->connect(RTLIL::SigSig(wire_c, info.sig_clk));
 				} else {
-					RTLIL::Cell *c = module->addCell(NEW_ID, ID($not));
+					RTLIL::Cell *c = module->addCell(NEWER_ID, ID($not));
 					c->parameters[ID::A_SIGNED] = 0;
 					c->parameters[ID::A_WIDTH] = 1;
 					c->parameters[ID::Y_WIDTH] = 1;
@@ -594,7 +594,7 @@ struct ExposePass : public Pass {
 					if (info.arst_polarity) {
 						module->connect(RTLIL::SigSig(wire_r, info.sig_arst));
 					} else {
-						RTLIL::Cell *c = module->addCell(NEW_ID, ID($not));
+						RTLIL::Cell *c = module->addCell(NEWER_ID, ID($not));
 						c->parameters[ID::A_SIGNED] = 0;
 						c->parameters[ID::A_WIDTH] = 1;
 						c->parameters[ID::Y_WIDTH] = 1;

--- a/passes/sat/fmcombine.cc
+++ b/passes/sat/fmcombine.cc
@@ -121,9 +121,9 @@ struct FmcombineWorker
 						if (RTLIL::builtin_ff_cell_types().count(cell->type)) {
 							SigSpec gold_q = gold->getPort(ID::Q);
 							SigSpec gate_q = gate->getPort(ID::Q);
-							SigSpec en = module->Initstate(NEW_ID);
-							SigSpec eq = module->Eq(NEW_ID, gold_q, gate_q);
-							module->addAssume(NEW_ID, eq, en);
+							SigSpec en = module->Initstate(NEWER_ID);
+							SigSpec eq = module->Eq(NEWER_ID, gold_q, gate_q);
+							module->addAssume(NEWER_ID, eq, en);
 						}
 					}
 				}
@@ -163,7 +163,7 @@ struct FmcombineWorker
 
 				SigSpec A = import_sig(conn.second, "_gold");
 				SigSpec B = import_sig(conn.second, "_gate");
-				SigBit EQ = module->Eq(NEW_ID, A, B);
+				SigBit EQ = module->Eq(NEWER_ID, A, B);
 
 				for (auto bit : sigmap({A, B}))
 					data_bit_to_eq_net[bit] = EQ;
@@ -205,7 +205,7 @@ struct FmcombineWorker
 
 				if (GetSize(antecedent) > 1) {
 					if (reduce_db.count(antecedent) == 0)
-						reduce_db[antecedent] = module->ReduceAnd(NEW_ID, antecedent);
+						reduce_db[antecedent] = module->ReduceAnd(NEWER_ID, antecedent);
 					antecedent = reduce_db.at(antecedent);
 				}
 
@@ -214,22 +214,22 @@ struct FmcombineWorker
 
 				if (GetSize(consequent) > 1) {
 					if (reduce_db.count(consequent) == 0)
-						reduce_db[consequent] = module->ReduceAnd(NEW_ID, consequent);
+						reduce_db[consequent] = module->ReduceAnd(NEWER_ID, consequent);
 					consequent = reduce_db.at(consequent);
 				}
 
 				if (opts.fwd)
-					module->addAssume(NEW_ID, consequent, antecedent);
+					module->addAssume(NEWER_ID, consequent, antecedent);
 
 				if (opts.bwd)
 				{
 					if (invert_db.count(antecedent) == 0)
-						invert_db[antecedent] = module->Not(NEW_ID, antecedent);
+						invert_db[antecedent] = module->Not(NEWER_ID, antecedent);
 
 					if (invert_db.count(consequent) == 0)
-						invert_db[consequent] = module->Not(NEW_ID, consequent);
+						invert_db[consequent] = module->Not(NEWER_ID, consequent);
 
-					module->addAssume(NEW_ID, invert_db.at(antecedent), invert_db.at(consequent));
+					module->addAssume(NEWER_ID, invert_db.at(antecedent), invert_db.at(consequent));
 				}
 			}
 		}

--- a/passes/sat/fminit.cc
+++ b/passes/sat/fminit.cc
@@ -131,8 +131,8 @@ struct FminitPass : public Pass {
 				}
 
 			if (!final_lhs.empty()) {
-				SigSpec eq = module->Eq(NEW_ID, final_lhs, final_rhs);
-				module->addAssume(NEW_ID, eq, State::S1);
+				SigSpec eq = module->Eq(NEWER_ID, final_lhs, final_rhs);
+				module->addAssume(NEWER_ID, eq, State::S1);
 			}
 		}
 
@@ -152,13 +152,13 @@ struct FminitPass : public Pass {
 				{
 					SigSpec insig = i > 0 ? ctrlsig.at(i-1) : State::S0;
 
-					Wire *outwire = module->addWire(NEW_ID);
+					Wire *outwire = module->addWire(NEWER_ID);
 					outwire->attributes[ID::init] = i > 0 ? State::S0 : State::S1;
 
 					if (clksig.empty())
-						module->addFf(NEW_ID, insig, outwire);
+						module->addFf(NEWER_ID, insig, outwire);
 					else
-						module->addDff(NEW_ID, clksig, insig, outwire, clockedge);
+						module->addDff(NEWER_ID, clksig, insig, outwire, clockedge);
 
 					ctrlsig.push_back(outwire);
 					ctrlsig_latched.push_back(SigSpec());
@@ -166,14 +166,14 @@ struct FminitPass : public Pass {
 
 				if (i+1 == GetSize(it.second) && ctrlsig_latched[i].empty())
 				{
-					Wire *ffwire = module->addWire(NEW_ID);
+					Wire *ffwire = module->addWire(NEWER_ID);
 					ffwire->attributes[ID::init] = State::S0;
-					SigSpec outsig = module->Or(NEW_ID, ffwire, ctrlsig[i]);
+					SigSpec outsig = module->Or(NEWER_ID, ffwire, ctrlsig[i]);
 
 					if (clksig.empty())
-						module->addFf(NEW_ID, outsig, ffwire);
+						module->addFf(NEWER_ID, outsig, ffwire);
 					else
-						module->addDff(NEW_ID, clksig, outsig, ffwire, clockedge);
+						module->addDff(NEWER_ID, clksig, outsig, ffwire, clockedge);
 
 					ctrlsig_latched[i] = outsig;
 				}
@@ -192,8 +192,8 @@ struct FminitPass : public Pass {
 					}
 
 				if (!final_lhs.empty()) {
-					SigSpec eq = module->Eq(NEW_ID, final_lhs, final_rhs);
-					module->addAssume(NEW_ID, eq, ctrl);
+					SigSpec eq = module->Eq(NEWER_ID, final_lhs, final_rhs);
+					module->addAssume(NEWER_ID, eq, ctrl);
 				}
 			}
 		}

--- a/passes/sat/formalff.cc
+++ b/passes/sat/formalff.cc
@@ -420,7 +420,7 @@ struct PropagateWorker
 				replaced_clk_inputs.emplace_back(ReplacedPort {port, i, it->second});
 
 				if (it->second) {
-					bit = module->Not(NEW_ID, bit);
+					bit = module->Not(NEWER_ID, bit);
 				}
 			}
 		}
@@ -445,7 +445,7 @@ struct PropagateWorker
 		if (add_attribute) {
 			Wire *clk_wire = bit.wire;
 			if (bit.offset != 0 || GetSize(bit.wire) != 1) {
-				clk_wire = module->addWire(NEW_ID);
+				clk_wire = module->addWire(NEWER_ID);
 				module->connect(RTLIL::SigBit(clk_wire), bit);
 			}
 			clk_wire->attributes[ID::replaced_by_gclk] = polarity ? State::S1 : State::S0;
@@ -802,9 +802,9 @@ struct FormalFfPass : public Pass {
 										log_debug("patching rd port\n");
 										changed = true;
 										rd_port.clk = gate_clock;
-										SigBit en_bit = pol_clk ? sig_gate : SigBit(module->Not(NEW_ID, sig_gate));
+										SigBit en_bit = pol_clk ? sig_gate : SigBit(module->Not(NEWER_ID, sig_gate));
 										SigSpec en_mask = SigSpec(en_bit, GetSize(rd_port.en));
-										rd_port.en = module->And(NEW_ID, rd_port.en, en_mask);
+										rd_port.en = module->And(NEWER_ID, rd_port.en, en_mask);
 									}
 								}
 								for (auto &wr_port : mem.wr_ports) {
@@ -812,9 +812,9 @@ struct FormalFfPass : public Pass {
 										log_debug("patching wr port\n");
 										changed = true;
 										wr_port.clk = gate_clock;
-										SigBit en_bit = pol_clk ? sig_gate : SigBit(module->Not(NEW_ID, sig_gate));
+										SigBit en_bit = pol_clk ? sig_gate : SigBit(module->Not(NEWER_ID, sig_gate));
 										SigSpec en_mask = SigSpec(en_bit, GetSize(wr_port.en));
-										wr_port.en = module->And(NEW_ID, wr_port.en, en_mask);
+										wr_port.en = module->And(NEWER_ID, wr_port.en, en_mask);
 									}
 								}
 								if (changed)
@@ -900,7 +900,7 @@ struct FormalFfPass : public Pass {
 					auto clk_wire = ff.sig_clk.is_wire() ? ff.sig_clk.as_wire() : nullptr;
 
 					if (clk_wire == nullptr) {
-						clk_wire = module->addWire(NEW_ID);
+						clk_wire = module->addWire(NEWER_ID);
 						module->connect(RTLIL::SigBit(clk_wire), ff.sig_clk);
 					}
 
@@ -982,9 +982,9 @@ struct FormalFfPass : public Pass {
 					SigBit clk = pair.first;
 
 					if (pair.second)
-						clk = module->Not(NEW_ID, clk);
+						clk = module->Not(NEWER_ID, clk);
 
-					module->addAssume(NEW_ID, clk, State::S1);
+					module->addAssume(NEWER_ID, clk, State::S1);
 
 				}
 			}

--- a/passes/sat/freduce.cc
+++ b/passes/sat/freduce.cc
@@ -716,7 +716,7 @@ struct FreduceWorker
 				log("      Connect slave%s: %s\n", grp[i].inverted ? " using inverter" : "", log_signal(grp[i].bit));
 
 				RTLIL::Cell *drv = drivers.at(grp[i].bit).first;
-				RTLIL::Wire *dummy_wire = module->addWire(NEW_ID);
+				RTLIL::Wire *dummy_wire = module->addWire(NEWER_ID);
 				for (auto &port : drv->connections_)
 					if (ct.cell_output(drv->type, port.first))
 						sigmap(port.second).replace(grp[i].bit, dummy_wire, &port.second);
@@ -725,9 +725,9 @@ struct FreduceWorker
 				{
 					if (inv_sig.size() == 0)
 					{
-						inv_sig = module->addWire(NEW_ID);
+						inv_sig = module->addWire(NEWER_ID);
 
-						RTLIL::Cell *inv_cell = module->addCell(NEW_ID, ID($_NOT_));
+						RTLIL::Cell *inv_cell = module->addCell(NEWER_ID, ID($_NOT_));
 						inv_cell->setPort(ID::A, grp[0].bit);
 						inv_cell->setPort(ID::Y, inv_sig);
 					}

--- a/passes/sat/miter.cc
+++ b/passes/sat/miter.cc
@@ -146,12 +146,12 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 			SigSpec w = miter_module->addWire("\\cross_" + RTLIL::unescape_id(gold_wire->name), gold_wire->width);
 			gold_cell->setPort(gold_wire->name, w);
 			if (flag_ignore_gold_x) {
-				RTLIL::SigSpec w_x = miter_module->addWire(NEW_ID, GetSize(w));
+				RTLIL::SigSpec w_x = miter_module->addWire(NEWER_ID, GetSize(w));
 				for (int i = 0; i < GetSize(w); i++)
-					miter_module->addEqx(NEW_ID, w[i], State::Sx, w_x[i]);
-				RTLIL::SigSpec w_any = miter_module->And(NEW_ID, miter_module->Anyseq(NEW_ID, GetSize(w)), w_x);
-				RTLIL::SigSpec w_masked = miter_module->And(NEW_ID, w, miter_module->Not(NEW_ID, w_x));
-				w = miter_module->And(NEW_ID, w_any, w_masked);
+					miter_module->addEqx(NEWER_ID, w[i], State::Sx, w_x[i]);
+				RTLIL::SigSpec w_any = miter_module->And(NEWER_ID, miter_module->Anyseq(NEWER_ID, GetSize(w)), w_x);
+				RTLIL::SigSpec w_masked = miter_module->And(NEWER_ID, w, miter_module->Not(NEWER_ID, w_x));
+				w = miter_module->And(NEWER_ID, w_any, w_masked);
 			}
 			gate_cell->setPort(gold_wire->name, w);
 			continue;
@@ -181,9 +181,9 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 
 			if (flag_ignore_gold_x)
 			{
-				RTLIL::SigSpec gold_x = miter_module->addWire(NEW_ID, w_gold->width);
+				RTLIL::SigSpec gold_x = miter_module->addWire(NEWER_ID, w_gold->width);
 				for (int i = 0; i < w_gold->width; i++) {
-					RTLIL::Cell *eqx_cell = miter_module->addCell(NEW_ID, ID($eqx));
+					RTLIL::Cell *eqx_cell = miter_module->addCell(NEWER_ID, ID($eqx));
 					eqx_cell->parameters[ID::A_WIDTH] = 1;
 					eqx_cell->parameters[ID::B_WIDTH] = 1;
 					eqx_cell->parameters[ID::Y_WIDTH] = 1;
@@ -194,10 +194,10 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 					eqx_cell->setPort(ID::Y, gold_x.extract(i, 1));
 				}
 
-				RTLIL::SigSpec gold_masked = miter_module->addWire(NEW_ID, w_gold->width);
-				RTLIL::SigSpec gate_masked = miter_module->addWire(NEW_ID, w_gate->width);
+				RTLIL::SigSpec gold_masked = miter_module->addWire(NEWER_ID, w_gold->width);
+				RTLIL::SigSpec gate_masked = miter_module->addWire(NEWER_ID, w_gate->width);
 
-				RTLIL::Cell *or_gold_cell = miter_module->addCell(NEW_ID, ID($or));
+				RTLIL::Cell *or_gold_cell = miter_module->addCell(NEWER_ID, ID($or));
 				or_gold_cell->parameters[ID::A_WIDTH] = w_gold->width;
 				or_gold_cell->parameters[ID::B_WIDTH] = w_gold->width;
 				or_gold_cell->parameters[ID::Y_WIDTH] = w_gold->width;
@@ -207,7 +207,7 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 				or_gold_cell->setPort(ID::B, gold_x);
 				or_gold_cell->setPort(ID::Y, gold_masked);
 
-				RTLIL::Cell *or_gate_cell = miter_module->addCell(NEW_ID, ID($or));
+				RTLIL::Cell *or_gate_cell = miter_module->addCell(NEWER_ID, ID($or));
 				or_gate_cell->parameters[ID::A_WIDTH] = w_gate->width;
 				or_gate_cell->parameters[ID::B_WIDTH] = w_gate->width;
 				or_gate_cell->parameters[ID::Y_WIDTH] = w_gate->width;
@@ -217,7 +217,7 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 				or_gate_cell->setPort(ID::B, gold_x);
 				or_gate_cell->setPort(ID::Y, gate_masked);
 
-				RTLIL::Cell *eq_cell = miter_module->addCell(NEW_ID, ID($eqx));
+				RTLIL::Cell *eq_cell = miter_module->addCell(NEWER_ID, ID($eqx));
 				eq_cell->parameters[ID::A_WIDTH] = w_gold->width;
 				eq_cell->parameters[ID::B_WIDTH] = w_gate->width;
 				eq_cell->parameters[ID::Y_WIDTH] = 1;
@@ -225,12 +225,12 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 				eq_cell->parameters[ID::B_SIGNED] = 0;
 				eq_cell->setPort(ID::A, gold_masked);
 				eq_cell->setPort(ID::B, gate_masked);
-				eq_cell->setPort(ID::Y, miter_module->addWire(NEW_ID));
+				eq_cell->setPort(ID::Y, miter_module->addWire(NEWER_ID));
 				this_condition = eq_cell->getPort(ID::Y);
 			}
 			else
 			{
-				RTLIL::Cell *eq_cell = miter_module->addCell(NEW_ID, ID($eqx));
+				RTLIL::Cell *eq_cell = miter_module->addCell(NEWER_ID, ID($eqx));
 				eq_cell->parameters[ID::A_WIDTH] = w_gold->width;
 				eq_cell->parameters[ID::B_WIDTH] = w_gate->width;
 				eq_cell->parameters[ID::Y_WIDTH] = 1;
@@ -238,7 +238,7 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 				eq_cell->parameters[ID::B_SIGNED] = 0;
 				eq_cell->setPort(ID::A, w_gold);
 				eq_cell->setPort(ID::B, w_gate);
-				eq_cell->setPort(ID::Y, miter_module->addWire(NEW_ID));
+				eq_cell->setPort(ID::Y, miter_module->addWire(NEWER_ID));
 				this_condition = eq_cell->getPort(ID::Y);
 			}
 
@@ -251,7 +251,7 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 
 			if (flag_make_cover)
 			{
-				auto cover_condition = miter_module->Not(NEW_ID, this_condition);
+				auto cover_condition = miter_module->Not(NEWER_ID, this_condition);
 				miter_module->addCover("\\cover_" + RTLIL::unescape_id(gold_wire->name), cover_condition, State::S1);
 			}
 
@@ -260,17 +260,17 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 	}
 
 	if (all_conditions.size() != 1) {
-		RTLIL::Cell *reduce_cell = miter_module->addCell(NEW_ID, ID($reduce_and));
+		RTLIL::Cell *reduce_cell = miter_module->addCell(NEWER_ID, ID($reduce_and));
 		reduce_cell->parameters[ID::A_WIDTH] = all_conditions.size();
 		reduce_cell->parameters[ID::Y_WIDTH] = 1;
 		reduce_cell->parameters[ID::A_SIGNED] = 0;
 		reduce_cell->setPort(ID::A, all_conditions);
-		reduce_cell->setPort(ID::Y, miter_module->addWire(NEW_ID));
+		reduce_cell->setPort(ID::Y, miter_module->addWire(NEWER_ID));
 		all_conditions = reduce_cell->getPort(ID::Y);
 	}
 
 	if (flag_make_assert) {
-		RTLIL::Cell *assert_cell = miter_module->addCell(NEW_ID, ID($assert));
+		RTLIL::Cell *assert_cell = miter_module->addCell(NEWER_ID, ID($assert));
 		assert_cell->setPort(ID::A, all_conditions);
 		assert_cell->setPort(ID::EN, State::S1);
 	}
@@ -278,7 +278,7 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 	RTLIL::Wire *w_trigger = miter_module->addWire(ID(trigger));
 	w_trigger->port_output = true;
 
-	RTLIL::Cell *not_cell = miter_module->addCell(NEW_ID, ID($not));
+	RTLIL::Cell *not_cell = miter_module->addCell(NEWER_ID, ID($not));
 	not_cell->parameters[ID::A_WIDTH] = all_conditions.size();
 	not_cell->parameters[ID::A_WIDTH] = all_conditions.size();
 	not_cell->parameters[ID::Y_WIDTH] = w_trigger->width;
@@ -355,13 +355,13 @@ void create_miter_assert(struct Pass *that, std::vector<std::string> args, RTLIL
 		if (!cell->type.in(ID($assert), ID($assume)))
 			continue;
 
-		SigBit is_active = module->Nex(NEW_ID, cell->getPort(ID::A), State::S1);
-		SigBit is_enabled = module->Eqx(NEW_ID, cell->getPort(ID::EN), State::S1);
+		SigBit is_active = module->Nex(NEWER_ID, cell->getPort(ID::A), State::S1);
+		SigBit is_enabled = module->Eqx(NEWER_ID, cell->getPort(ID::EN), State::S1);
 
 		if (cell->type == ID($assert)) {
-			assert_signals.append(module->And(NEW_ID, is_active, is_enabled));
+			assert_signals.append(module->And(NEWER_ID, is_active, is_enabled));
 		} else {
-			assume_signals.append(module->And(NEW_ID, is_active, is_enabled));
+			assume_signals.append(module->And(NEWER_ID, is_active, is_enabled));
 		}
 
 		module->remove(cell);
@@ -369,20 +369,20 @@ void create_miter_assert(struct Pass *that, std::vector<std::string> args, RTLIL
 
 	if (assume_signals.empty())
 	{
-		module->addReduceOr(NEW_ID, assert_signals, trigger);
+		module->addReduceOr(NEWER_ID, assert_signals, trigger);
 	}
 	else
 	{
-		Wire *assume_q = module->addWire(NEW_ID);
+		Wire *assume_q = module->addWire(NEWER_ID);
 		assume_q->attributes[ID::init] = State::S0;
 		assume_signals.append(assume_q);
 
-		SigSpec assume_nok = module->ReduceOr(NEW_ID, assume_signals);
-		SigSpec assume_ok = module->Not(NEW_ID, assume_nok);
-		module->addFf(NEW_ID, assume_nok, assume_q);
+		SigSpec assume_nok = module->ReduceOr(NEWER_ID, assume_signals);
+		SigSpec assume_ok = module->Not(NEWER_ID, assume_nok);
+		module->addFf(NEWER_ID, assume_nok, assume_q);
 
-		SigSpec assert_fail = module->ReduceOr(NEW_ID, assert_signals);
-		module->addAnd(NEW_ID, assert_fail, assume_ok, trigger);
+		SigSpec assert_fail = module->ReduceOr(NEWER_ID, assert_signals);
+		module->addAnd(NEWER_ID, assert_fail, assume_ok, trigger);
 	}
 
 	if (flag_flatten) {

--- a/passes/sat/mutate.cc
+++ b/passes/sat/mutate.cc
@@ -629,7 +629,7 @@ SigBit mutate_ctrl(Module *module, const mutate_opts_t &opts)
 		return State::S1;
 
 	SigSpec sig = mutate_ctrl_sig(module, opts.ctrl_name, opts.ctrl_width);
-	return module->Eq(NEW_ID, sig, Const(opts.ctrl_value, GetSize(sig)));
+	return module->Eq(NEWER_ID, sig, Const(opts.ctrl_value, GetSize(sig)));
 }
 
 SigSpec mutate_ctrl_mux(Module *module, const mutate_opts_t &opts, SigSpec unchanged_sig, SigSpec changed_sig)
@@ -639,7 +639,7 @@ SigSpec mutate_ctrl_mux(Module *module, const mutate_opts_t &opts, SigSpec uncha
 		return unchanged_sig;
 	if (ctrl_bit == State::S1)
 		return changed_sig;
-	return module->Mux(NEW_ID, unchanged_sig, changed_sig, ctrl_bit);
+	return module->Mux(NEWER_ID, unchanged_sig, changed_sig, ctrl_bit);
 }
 
 void mutate_inv(Design *design, const mutate_opts_t &opts)
@@ -653,14 +653,14 @@ void mutate_inv(Design *design, const mutate_opts_t &opts)
 	if (cell->input(opts.port))
 	{
 		log("Add input inverter at %s.%s.%s[%d].\n", log_id(module), log_id(cell), log_id(opts.port), opts.portbit);
-		SigBit outbit = module->Not(NEW_ID, bit);
+		SigBit outbit = module->Not(NEWER_ID, bit);
 		bit = mutate_ctrl_mux(module, opts, bit, outbit);
 	}
 	else
 	{
 		log("Add output inverter at %s.%s.%s[%d].\n", log_id(module), log_id(cell), log_id(opts.port), opts.portbit);
-		SigBit inbit = module->addWire(NEW_ID);
-		SigBit outbit = module->Not(NEW_ID, inbit);
+		SigBit inbit = module->addWire(NEWER_ID);
+		SigBit outbit = module->Not(NEWER_ID, inbit);
 		module->connect(bit, mutate_ctrl_mux(module, opts, inbit, outbit));
 		bit = inbit;
 	}
@@ -687,7 +687,7 @@ void mutate_const(Design *design, const mutate_opts_t &opts, bool one)
 	else
 	{
 		log("Add output constant %d at %s.%s.%s[%d].\n", one ? 1 : 0, log_id(module), log_id(cell), log_id(opts.port), opts.portbit);
-		SigBit inbit = module->addWire(NEW_ID);
+		SigBit inbit = module->addWire(NEWER_ID);
 		SigBit outbit = one ? State::S1 : State::S0;
 		module->connect(bit, mutate_ctrl_mux(module, opts, inbit, outbit));
 		bit = inbit;
@@ -710,14 +710,14 @@ void mutate_cnot(Design *design, const mutate_opts_t &opts, bool one)
 	if (cell->input(opts.port))
 	{
 		log("Add input cnot%d at %s.%s.%s[%d,%d].\n", one ? 1 : 0, log_id(module), log_id(cell), log_id(opts.port), opts.portbit, opts.ctrlbit);
-		SigBit outbit = one ? module->Xor(NEW_ID, bit, ctrl) : module->Xnor(NEW_ID, bit, ctrl);
+		SigBit outbit = one ? module->Xor(NEWER_ID, bit, ctrl) : module->Xnor(NEWER_ID, bit, ctrl);
 		bit = mutate_ctrl_mux(module, opts, bit, outbit);
 	}
 	else
 	{
 		log("Add output cnot%d at %s.%s.%s[%d,%d].\n", one ? 1 : 0, log_id(module), log_id(cell), log_id(opts.port), opts.portbit, opts.ctrlbit);
-		SigBit inbit = module->addWire(NEW_ID);
-		SigBit outbit = one ? module->Xor(NEW_ID, inbit, ctrl) : module->Xnor(NEW_ID, inbit, ctrl);
+		SigBit inbit = module->addWire(NEWER_ID);
+		SigBit outbit = one ? module->Xor(NEWER_ID, inbit, ctrl) : module->Xnor(NEWER_ID, inbit, ctrl);
 		module->connect(bit, mutate_ctrl_mux(module, opts, inbit, outbit));
 		bit = inbit;
 	}

--- a/passes/sat/qbfsat.cc
+++ b/passes/sat/qbfsat.cc
@@ -312,8 +312,8 @@ QbfSolutionType qbf_solve(RTLIL::Module *mod, const QbfSolveOptions &opt) {
 
 			if (cur_thresh != 0) {
 				//Add thresholding logic (but not on the initial run when we don't have a sense of where to start):
-				RTLIL::SigSpec comparator = maximize? module->Ge(NEW_ID, module->wire(wire_to_optimize_name), RTLIL::Const(cur_thresh), false)
-				                                    : module->Le(NEW_ID, module->wire(wire_to_optimize_name), RTLIL::Const(cur_thresh), false);
+				RTLIL::SigSpec comparator = maximize? module->Ge(NEWER_ID, module->wire(wire_to_optimize_name), RTLIL::Const(cur_thresh), false)
+				                                    : module->Le(NEWER_ID, module->wire(wire_to_optimize_name), RTLIL::Const(cur_thresh), false);
 
 				module->addAssume(wire_to_optimize_name.str() + "__threshold", comparator, RTLIL::Const(1, 1));
 				log("Trying to solve with %s %s %d.\n", wire_to_optimize_name, (maximize? ">=" : "<="), cur_thresh);

--- a/passes/sat/recover_names.cc
+++ b/passes/sat/recover_names.cc
@@ -95,7 +95,7 @@ struct RecoverModuleWorker {
     {
         // Create a derivative of the module with whiteboxes flattened so we can
         // run eval and sat on it
-        flat = design->addModule(NEW_ID);
+        flat = design->addModule(NEWER_ID);
         mod->cloneInto(flat);
         Pass::call_on_module(design, flat, "flatten -wb");
         ce = new ConstEval(flat);

--- a/passes/sat/supercover.cc
+++ b/passes/sat/supercover.cc
@@ -78,9 +78,9 @@ struct SupercoverPass : public Pass {
 					if (handled_bits.count(bit))
 						continue;
 
-					SigSpec inv = module->Not(NEW_ID, bit);
-					module->addCover(NEW_ID, bit, State::S1, src);
-					module->addCover(NEW_ID, inv, State::S1, src);
+					SigSpec inv = module->Not(NEWER_ID, bit);
+					module->addCover(NEWER_ID, bit, State::S1, src);
+					module->addCover(NEWER_ID, inv, State::S1, src);
 
 					handled_bits.insert(bit);
 					if (!counted_wire) {

--- a/passes/sat/synthprop.cc
+++ b/passes/sat/synthprop.cc
@@ -107,16 +107,16 @@ void SynthPropWorker::run()
 		int num = 0;
 		RTLIL::Wire *port_wire = data.first->wire(port_name);
 		if (!reset_name.empty() && data.first == module) {
-			port_wire = data.first->addWire(NEW_ID, data.second.names.size());
+			port_wire = data.first->addWire(NEWER_ID, data.second.names.size());
 			output = port_wire;
 		}
 		pool<Wire*> connected;
 		for (auto cell : data.second.assertion_cells) {
 			if (cell->type == ID($assert)) {
-				RTLIL::Wire *neg_wire = data.first->addWire(NEW_ID);
-				RTLIL::Wire *result_wire = data.first->addWire(NEW_ID);
-				data.first->addNot(NEW_ID, cell->getPort(ID::A), neg_wire);
-				data.first->addAnd(NEW_ID, cell->getPort(ID::EN), neg_wire, result_wire);
+				RTLIL::Wire *neg_wire = data.first->addWire(NEWER_ID);
+				RTLIL::Wire *result_wire = data.first->addWire(NEWER_ID);
+				data.first->addNot(NEWER_ID, cell->getPort(ID::A), neg_wire);
+				data.first->addAnd(NEWER_ID, cell->getPort(ID::EN), neg_wire, result_wire);
 				if (!or_outputs) {
 					data.first->connect(SigBit(port_wire,num), result_wire);
 				} else {
@@ -132,7 +132,7 @@ void SynthPropWorker::run()
 					if (!or_outputs) {
 						cell->setPort(port_name, SigChunk(port_wire, num, tracing_data[submod].names.size()));
 					} else {
-						RTLIL::Wire *result_wire = data.first->addWire(NEW_ID);
+						RTLIL::Wire *result_wire = data.first->addWire(NEWER_ID);
 						cell->setPort(port_name, result_wire);
 						connected.emplace(result_wire);
 					}
@@ -146,8 +146,8 @@ void SynthPropWorker::run()
 				if (!prev_wire) {
 					prev_wire = wire;
 				} else {
-					RTLIL::Wire *result = data.first->addWire(NEW_ID);
-					data.first->addOr(NEW_ID, prev_wire, wire, result);
+					RTLIL::Wire *result = data.first->addWire(NEWER_ID);
+					data.first->addOr(NEWER_ID, prev_wire, wire, result);
 					prev_wire = result;
 				}
 			}
@@ -163,7 +163,7 @@ void SynthPropWorker::run()
 		SigSpec reset = module->wire(reset_name);
 		reset.extend_u0(width, true);
 
-		module->addDlatchsr(NEW_ID, State::S1, Const(State::S0,width), reset, output, module->wire(port_name), true, true, reset_pol);
+		module->addDlatchsr(NEWER_ID, State::S1, Const(State::S0,width), reset, output, module->wire(port_name), true, true, reset_pol);
 	}
 
 	if (!map_file.empty()) {

--- a/passes/techmap/aigmap.cc
+++ b/passes/techmap/aigmap.cc
@@ -108,8 +108,8 @@ struct AigmapPass : public Pass {
 						SigBit A = sigs.at(node.left_parent);
 						SigBit B = sigs.at(node.right_parent);
 						if (nand_mode && node.inverter) {
-							bit = module->addWire(NEW_ID);
-							auto gate = module->addNandGate(NEW_ID, A, B, bit);
+							bit = module->addWire(NEWER_ID);
+							auto gate = module->addNandGate(NEWER_ID, A, B, bit);
 							if (select_mode)
 								new_sel.insert(gate->name);
 
@@ -119,8 +119,8 @@ struct AigmapPass : public Pass {
 							if (and_cache.count(key))
 								bit = and_cache.at(key);
 							else {
-								bit = module->addWire(NEW_ID);
-								auto gate = module->addAndGate(NEW_ID, A, B, bit);
+								bit = module->addWire(NEWER_ID);
+								auto gate = module->addAndGate(NEWER_ID, A, B, bit);
 								if (select_mode)
 									new_sel.insert(gate->name);
 							}
@@ -128,8 +128,8 @@ struct AigmapPass : public Pass {
 					}
 
 					if (node.inverter) {
-						SigBit new_bit = module->addWire(NEW_ID);
-						auto gate = module->addNotGate(NEW_ID, bit, new_bit);
+						SigBit new_bit = module->addWire(NEWER_ID);
+						auto gate = module->addNotGate(NEWER_ID, bit, new_bit);
 						bit = new_bit;
 						if (select_mode)
 							new_sel.insert(gate->name);

--- a/passes/techmap/alumacc.cc
+++ b/passes/techmap/alumacc.cc
@@ -52,7 +52,7 @@ struct AlumaccWorker
 				if (is_signed) {
 					get_of();
 					get_sf();
-					cached_lt = alu_cell->module->Xor(NEW_ID, cached_of, cached_sf);
+					cached_lt = alu_cell->module->Xor(NEWER_ID, cached_of, cached_sf);
 				}
 				else
 					cached_lt = get_cf();
@@ -64,21 +64,21 @@ struct AlumaccWorker
 			if (GetSize(cached_gt) == 0) {
 				get_lt();
 				get_eq();
-				SigSpec Or = alu_cell->module->Or(NEW_ID, cached_lt, cached_eq);
-				cached_gt = alu_cell->module->Not(NEW_ID, Or, false, alu_cell->get_src_attribute());
+				SigSpec Or = alu_cell->module->Or(NEWER_ID, cached_lt, cached_eq);
+				cached_gt = alu_cell->module->Not(NEWER_ID, Or, false, alu_cell->get_src_attribute());
 			}
 			return cached_gt;
 		}
 
 		RTLIL::SigSpec get_eq() {
 			if (GetSize(cached_eq) == 0)
-				cached_eq = alu_cell->module->ReduceAnd(NEW_ID, alu_cell->getPort(ID::X), false, alu_cell->get_src_attribute());
+				cached_eq = alu_cell->module->ReduceAnd(NEWER_ID, alu_cell->getPort(ID::X), false, alu_cell->get_src_attribute());
 			return cached_eq;
 		}
 
 		RTLIL::SigSpec get_ne() {
 			if (GetSize(cached_ne) == 0)
-				cached_ne = alu_cell->module->Not(NEW_ID, get_eq(), false, alu_cell->get_src_attribute());
+				cached_ne = alu_cell->module->Not(NEWER_ID, get_eq(), false, alu_cell->get_src_attribute());
 			return cached_ne;
 		}
 
@@ -86,7 +86,7 @@ struct AlumaccWorker
 			if (GetSize(cached_cf) == 0) {
 				cached_cf = alu_cell->getPort(ID::CO);
 				log_assert(GetSize(cached_cf) >= 1);
-				cached_cf = alu_cell->module->Not(NEW_ID, cached_cf[GetSize(cached_cf)-1], false, alu_cell->get_src_attribute());
+				cached_cf = alu_cell->module->Not(NEWER_ID, cached_cf[GetSize(cached_cf)-1], false, alu_cell->get_src_attribute());
 			}
 			return cached_cf;
 		}
@@ -95,7 +95,7 @@ struct AlumaccWorker
 			if (GetSize(cached_of) == 0) {
 				cached_of = {alu_cell->getPort(ID::CO), alu_cell->getPort(ID::CI)};
 				log_assert(GetSize(cached_of) >= 2);
-				cached_of = alu_cell->module->Xor(NEW_ID, cached_of[GetSize(cached_of)-1], cached_of[GetSize(cached_of)-2]);
+				cached_of = alu_cell->module->Xor(NEWER_ID, cached_of[GetSize(cached_of)-1], cached_of[GetSize(cached_of)-2]);
 			}
 			return cached_of;
 		}
@@ -362,7 +362,7 @@ struct AlumaccWorker
 		for (auto &it : sig_macc)
 		{
 			auto n = it.second;
-			auto cell = module->addCell(NEW_ID, ID($macc));
+			auto cell = module->addCell(NEWER_ID, ID($macc));
 
 			macc_counter++;
 
@@ -428,7 +428,7 @@ struct AlumaccWorker
 				n->a = A;
 				n->b = B;
 				n->c = State::S1;
-				n->y = module->addWire(NEW_ID, max(GetSize(A), GetSize(B)));
+				n->y = module->addWire(NEWER_ID, max(GetSize(A), GetSize(B)));
 				n->is_signed = is_signed;
 				n->invert_b = true;
 				sig_alu[RTLIL::SigSig(A, B)].insert(n);
@@ -482,7 +482,7 @@ struct AlumaccWorker
 		{
 			if (GetSize(n->b) == 0 && GetSize(n->c) == 0 && GetSize(n->cmp) == 0)
 			{
-				n->alu_cell = module->addPos(NEW_ID, n->a, n->y, n->is_signed);
+				n->alu_cell = module->addPos(NEWER_ID, n->a, n->y, n->is_signed);
 
 				log("  creating $pos cell for ");
 				for (int i = 0; i < GetSize(n->cells); i++)
@@ -492,7 +492,7 @@ struct AlumaccWorker
 				goto delete_node;
 			}
 
-			n->alu_cell = module->addCell(NEW_ID, ID($alu));
+			n->alu_cell = module->addCell(NEWER_ID, ID($alu));
 			alu_counter++;
 
 			log("  creating $alu cell for ");
@@ -508,8 +508,8 @@ struct AlumaccWorker
 			n->alu_cell->setPort(ID::CI, GetSize(n->c) ? n->c : State::S0);
 			n->alu_cell->setPort(ID::BI, n->invert_b ? State::S1 : State::S0);
 			n->alu_cell->setPort(ID::Y, n->y);
-			n->alu_cell->setPort(ID::X, module->addWire(NEW_ID, GetSize(n->y)));
-			n->alu_cell->setPort(ID::CO, module->addWire(NEW_ID, GetSize(n->y)));
+			n->alu_cell->setPort(ID::X, module->addWire(NEWER_ID, GetSize(n->y)));
+			n->alu_cell->setPort(ID::CO, module->addWire(NEWER_ID, GetSize(n->y)));
 			n->alu_cell->fixup_parameters(n->is_signed, n->is_signed);
 
 			for (auto &it : n->cmp)
@@ -527,7 +527,7 @@ struct AlumaccWorker
 				if (cmp_ne) sig.append(n->get_ne());
 
 				if (GetSize(sig) > 1)
-					sig = module->ReduceOr(NEW_ID, sig);
+					sig = module->ReduceOr(NEWER_ID, sig);
 
 				sig.extend_u0(GetSize(cmp_y));
 				module->connect(cmp_y, sig);

--- a/passes/techmap/bmuxmap.cc
+++ b/passes/techmap/bmuxmap.cc
@@ -68,22 +68,22 @@ struct BmuxmapPass : public Pass {
 			{
 				int num_cases = 1 << s_width;
 				SigSpec new_a = SigSpec(State::Sx, width);
-				SigSpec new_s = module->addWire(NEW_ID, num_cases);
-				SigSpec new_data = module->addWire(NEW_ID, width);
+				SigSpec new_s = module->addWire(NEWER_ID, num_cases);
+				SigSpec new_data = module->addWire(NEWER_ID, width);
 				for (int val = 0; val < num_cases; val++)
 				{
-					module->addEq(NEW_ID, sel, SigSpec(val, GetSize(sel)), new_s[val]);
+					module->addEq(NEWER_ID, sel, SigSpec(val, GetSize(sel)), new_s[val]);
 				}
-				RTLIL::Cell *pmux = module->addPmux(NEW_ID, new_a, data, new_s, new_data);
+				RTLIL::Cell *pmux = module->addPmux(NEWER_ID, new_a, data, new_s, new_data);
 				pmux->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
 				data = new_data;
 			}
 			else
 			{
 				for (int idx = 0; idx < GetSize(sel); idx++) {
-					SigSpec new_data = module->addWire(NEW_ID, GetSize(data)/2);
+					SigSpec new_data = module->addWire(NEWER_ID, GetSize(data)/2);
 					for (int i = 0; i < GetSize(new_data); i += width) {
-						RTLIL::Cell *mux = module->addMux(NEW_ID,
+						RTLIL::Cell *mux = module->addMux(NEWER_ID,
 							data.extract(i*2, width),
 							data.extract(i*2+width, width),
 							sel[idx],

--- a/passes/techmap/booth.cc
+++ b/passes/techmap/booth.cc
@@ -75,44 +75,44 @@ struct BoothPassWorker {
 	// Booth unsigned decoder lsb
 	SigBit Bur4d_lsb(std::string name, SigBit lsb_i, SigBit one_i, SigBit s_i)
 	{
-		SigBit and_op = module->AndGate(NEW_ID_SUFFIX(name), lsb_i, one_i);
-		return module->XorGate(NEW_ID_SUFFIX(name), and_op, s_i);
+		SigBit and_op = module->AndGate(NEWER_ID_SUFFIX(name), lsb_i, one_i);
+		return module->XorGate(NEWER_ID_SUFFIX(name), and_op, s_i);
 	}
 
 	// Booth unsigned radix4 decoder
 	SigBit Bur4d_n(std::string name, SigBit yn_i, SigBit ynm1_i, SigBit one_i, SigBit two_i, SigBit s_i)
 	{
 		// ppij = ((yn & one)   | (ynm1 & two)) ^ s;
-		SigBit an1 = module->AndGate(NEW_ID_SUFFIX(name), yn_i, one_i);
-		SigBit an2 = module->AndGate(NEW_ID_SUFFIX(name), ynm1_i, two_i);
-		SigBit or1 = module->OrGate(NEW_ID_SUFFIX(name), an1, an2);
-		return module->XorGate(NEW_ID_SUFFIX(name), s_i, or1);
+		SigBit an1 = module->AndGate(NEWER_ID_SUFFIX(name), yn_i, one_i);
+		SigBit an2 = module->AndGate(NEWER_ID_SUFFIX(name), ynm1_i, two_i);
+		SigBit or1 = module->OrGate(NEWER_ID_SUFFIX(name), an1, an2);
+		return module->XorGate(NEWER_ID_SUFFIX(name), s_i, or1);
 	}
 
 	// Booth unsigned radix4 decoder
 	SigBit Bur4d_msb(std::string name, SigBit msb_i, SigBit two_i, SigBit s_i)
 	{
 		// ppij = (msb & two)  ^ s;
-		SigBit an1 = module->AndGate(NEW_ID_SUFFIX(name), msb_i, two_i);
-		return module->XorGate(NEW_ID_SUFFIX(name), s_i, an1);
+		SigBit an1 = module->AndGate(NEWER_ID_SUFFIX(name), msb_i, two_i);
+		return module->XorGate(NEWER_ID_SUFFIX(name), s_i, an1);
 	}
 
 	// half adder, used in CPA
 	void BuildHa(std::string name, SigBit a_i, SigBit b_i, SigBit &s_o, SigBit &c_o)
 	{
-		s_o = module->XorGate(NEW_ID_SUFFIX(name), a_i, b_i);
-		c_o = module->AndGate(NEW_ID_SUFFIX(name), a_i, b_i);
+		s_o = module->XorGate(NEWER_ID_SUFFIX(name), a_i, b_i);
+		c_o = module->AndGate(NEWER_ID_SUFFIX(name), a_i, b_i);
 	}
 
 	// Booth unsigned radix 4 encoder
 	void BuildBur4e(std::string name, SigBit y0_i, SigBit y1_i, SigBit y2_i,
 			SigBit &one_o, SigBit &two_o, SigBit &s_o, SigBit &sb_o)
 	{
-		one_o = module->XorGate(NEW_ID_SUFFIX(name), y0_i, y1_i);
+		one_o = module->XorGate(NEWER_ID_SUFFIX(name), y0_i, y1_i);
 		s_o = y2_i;
-		sb_o = module->NotGate(NEW_ID_SUFFIX(name), y2_i);
-		SigBit y1_xnor_y2 = module->XnorGate(NEW_ID_SUFFIX(name), y1_i, y2_i);
-		two_o = module->NorGate(NEW_ID_SUFFIX(name), y1_xnor_y2, one_o);
+		sb_o = module->NotGate(NEWER_ID_SUFFIX(name), y2_i);
+		SigBit y1_xnor_y2 = module->XnorGate(NEWER_ID_SUFFIX(name), y1_i, y2_i);
+		two_o = module->NorGate(NEWER_ID_SUFFIX(name), y1_xnor_y2, one_o);
 	}
 
 	void BuildBr4e(std::string name, SigBit y2_m1_i,
@@ -120,9 +120,9 @@ struct BoothPassWorker {
 		       SigBit y2_p1_i,
 		       SigBit &negi_o, SigBit &twoi_n_o, SigBit &onei_n_o, SigBit &cori_o)
 	{
-		auto y2_p1_n = module->NotGate(NEW_ID_SUFFIX(name), y2_p1_i);
-		auto y2_n = module->NotGate(NEW_ID_SUFFIX(name), y2_i);
-		auto y2_m1_n = module->NotGate(NEW_ID_SUFFIX(name), y2_m1_i);
+		auto y2_p1_n = module->NotGate(NEWER_ID_SUFFIX(name), y2_p1_i);
+		auto y2_n = module->NotGate(NEWER_ID_SUFFIX(name), y2_i);
+		auto y2_m1_n = module->NotGate(NEWER_ID_SUFFIX(name), y2_m1_i);
 
 		negi_o = y2_p1_i;
 
@@ -130,15 +130,15 @@ struct BoothPassWorker {
 		//    (y2_p1_n & y2_i & y2_m1_i) |
 		//    (y2_p1 & y2_n & y2_m1_n)
 		// )
-		twoi_n_o = module->NorGate(NEW_ID_SUFFIX(name),
-			module->AndGate(NEW_ID_SUFFIX(name), y2_p1_n, module->AndGate(NEW_ID_SUFFIX(name), y2_i, y2_m1_i)),
-			module->AndGate(NEW_ID_SUFFIX(name), y2_p1_i, module->AndGate(NEW_ID_SUFFIX(name), y2_n, y2_m1_n))
+		twoi_n_o = module->NorGate(NEWER_ID_SUFFIX(name),
+			module->AndGate(NEWER_ID_SUFFIX(name), y2_p1_n, module->AndGate(NEWER_ID_SUFFIX(name), y2_i, y2_m1_i)),
+			module->AndGate(NEWER_ID_SUFFIX(name), y2_p1_i, module->AndGate(NEWER_ID_SUFFIX(name), y2_n, y2_m1_n))
 		);
 
 		// onei_n = ~(y2_m1_i ^ y2_i);
-		onei_n_o = module->XnorGate(NEW_ID_SUFFIX(name), y2_m1_i, y2_i);
+		onei_n_o = module->XnorGate(NEWER_ID_SUFFIX(name), y2_m1_i, y2_i);
 		// cori = (y2_m1_n | y2_n) & y2_p1_i;
-		cori_o = module->AndGate(NEW_ID_SUFFIX(name), module->OrGate(NEW_ID_SUFFIX(name), y2_m1_n, y2_n), y2_p1_i);
+		cori_o = module->AndGate(NEWER_ID_SUFFIX(name), module->OrGate(NEWER_ID_SUFFIX(name), y2_m1_n, y2_n), y2_p1_i);
 	}
 
 	//
@@ -150,10 +150,10 @@ struct BoothPassWorker {
 		// nxj_in = xnor(xj,negi)
 		// nxj_o = xnj_in,
 		// ppij = ~( (nxj_m1_i | twoi_n_i) & (nxj_int | onei_n_i));
-		nxj_o = module->XnorGate(NEW_ID_SUFFIX(name), xj_i, negi_i);
-		ppij_o = module->NandGate(NEW_ID_SUFFIX(name),
-			module->OrGate(NEW_ID_SUFFIX(name), nxj_m1_i, twoi_n_i),
-			module->OrGate(NEW_ID_SUFFIX(name), nxj_o, onei_n_i)
+		nxj_o = module->XnorGate(NEWER_ID_SUFFIX(name), xj_i, negi_i);
+		ppij_o = module->NandGate(NEWER_ID_SUFFIX(name),
+			module->OrGate(NEWER_ID_SUFFIX(name), nxj_m1_i, twoi_n_i),
+			module->OrGate(NEWER_ID_SUFFIX(name), nxj_o, onei_n_i)
 		);
 	}
 
@@ -177,14 +177,14 @@ struct BoothPassWorker {
 		  //correction propagation
 		  assign CORO = (~PP1 & ~PP0)? CORI : 1'b0;
 		*/
-		nxj_o = module->XnorGate(NEW_ID_SUFFIX(name), x1_i, negi_i);
-		pp0_o = module->AndGate(NEW_ID_SUFFIX(name), x0_i, y0_i);
-		SigBit pp1_1_int = module->AndGate(NEW_ID_SUFFIX(name), x1_i, y0_i);
-		SigBit pp1_2_int = module->AndGate(NEW_ID_SUFFIX(name), x0_i, y1_i);
-		pp1_o = module->XorGate(NEW_ID_SUFFIX(name), pp1_1_int, pp1_2_int);
+		nxj_o = module->XnorGate(NEWER_ID_SUFFIX(name), x1_i, negi_i);
+		pp0_o = module->AndGate(NEWER_ID_SUFFIX(name), x0_i, y0_i);
+		SigBit pp1_1_int = module->AndGate(NEWER_ID_SUFFIX(name), x1_i, y0_i);
+		SigBit pp1_2_int = module->AndGate(NEWER_ID_SUFFIX(name), x0_i, y1_i);
+		pp1_o = module->XorGate(NEWER_ID_SUFFIX(name), pp1_1_int, pp1_2_int);
 
-		SigBit pp1_nor_pp0 = module->NorGate(NEW_ID_SUFFIX(name), pp1_o, pp0_o);
-		cor_o = module->AndGate(NEW_ID_SUFFIX(name), pp1_nor_pp0, cori_i);
+		SigBit pp1_nor_pp0 = module->NorGate(NEWER_ID_SUFFIX(name), pp1_o, pp0_o);
+		cor_o = module->AndGate(NEWER_ID_SUFFIX(name), pp1_nor_pp0, cori_i);
 	}
 
 	void BuildBitwiseFa(Module *mod, std::string name, const SigSpec &sig_a, const SigSpec &sig_b,
@@ -289,7 +289,7 @@ struct BoothPassWorker {
 			int required_op_size = x_sz_revised + y_sz_revised;
 
 			if (required_op_size != z_sz) {
-				SigSpec expanded_Y = module->addWire(NEW_ID, required_op_size);
+				SigSpec expanded_Y = module->addWire(NEWER_ID, required_op_size);
 				SigSpec Y_driver = expanded_Y;
 				Y_driver.extend_u0(Y.size(), is_signed);
 				module->connect(Y, Y_driver);
@@ -326,9 +326,9 @@ struct BoothPassWorker {
 			std::vector<SigSpec> new_summands;
 			int i;
 			for (i = 0; i < (int) summands.size() - 2; i += 3) {
-				SigSpec x = module->addWire(NEW_ID, width);
-				SigSpec y = module->addWire(NEW_ID, width);
-				BuildBitwiseFa(module, NEW_ID.str(), summands[i], summands[i + 1],
+				SigSpec x = module->addWire(NEWER_ID, width);
+				SigSpec y = module->addWire(NEWER_ID, width);
+				BuildBitwiseFa(module, NEWER_ID.str(), summands[i], summands[i + 1],
 					       summands[i + 2], x, y);
 				new_summands.push_back(y);
 				new_summands.push_back({x.extract(0, width - 1), State::S0});
@@ -424,7 +424,7 @@ struct BoothPassWorker {
 		if (mapped_cpa)
 			BuildCPA(module, wtree_sum.first, {State::S0, wtree_sum.second.extract_end(1)}, Z);
 		else
-			module->addAdd(NEW_ID, wtree_sum.first, {wtree_sum.second.extract_end(1), State::S0}, Z);
+			module->addAdd(NEWER_ID, wtree_sum.first, {wtree_sum.second.extract_end(1), State::S0}, Z);
 	}
 
 	/*
@@ -460,11 +460,11 @@ struct BoothPassWorker {
 
 		// append the sign bits
 		if (is_signed) {
-			SigBit e = module->XorGate(NEW_ID, s_int[0], module->AndGate(NEW_ID, X.msb(), module->OrGate(NEW_ID, two_int[0], one_int[0])));
-			ppij_vec.append({module->NotGate(NEW_ID, e), e, e});
+			SigBit e = module->XorGate(NEWER_ID, s_int[0], module->AndGate(NEWER_ID, X.msb(), module->OrGate(NEWER_ID, two_int[0], one_int[0])));
+			ppij_vec.append({module->NotGate(NEWER_ID, e), e, e});
 		} else {
 			// append the sign bits
-			ppij_vec.append({module->NotGate(NEW_ID, s_int[0]), s_int[0], s_int[0]});
+			ppij_vec.append({module->NotGate(NEWER_ID, s_int[0]), s_int[0], s_int[0]});
 		}
 	}
 
@@ -494,7 +494,7 @@ struct BoothPassWorker {
 				     					one_int, two_int, s_int));
 		}
 
-		ppij_vec.append(!is_signed ? sb_int[0] : module->XorGate(NEW_ID, sb_int, module->AndGate(NEW_ID, X.msb(), module->OrGate(NEW_ID, two_int, one_int))));
+		ppij_vec.append(!is_signed ? sb_int[0] : module->XorGate(NEWER_ID, sb_int, module->AndGate(NEWER_ID, X.msb(), module->OrGate(NEWER_ID, two_int, one_int))));
 		ppij_vec.append(State::S1);
 	}
 
@@ -721,7 +721,7 @@ struct BoothPassWorker {
 
 			// Base Case: Bit 0 is sum 0
 			if (n == 0) {
-				module->addBufGate(NEW_ID_SUFFIX(stringf("base_buf_%d_%d", cpa_id, n)), s_vec[0], result[0]);
+				module->addBufGate(NEWER_ID_SUFFIX(stringf("base_buf_%d_%d", cpa_id, n)), s_vec[0], result[0]);
 
 #ifdef DEBUG_CPA
 				printf("CPA bit [%d] Cell %s IP 0 %s \n", n, buf->name.c_str(), s_vec[0]->name.c_str());
@@ -747,8 +747,8 @@ struct BoothPassWorker {
 			// End Case
 			else if (n == s_vec.size() - 1) {
 				// Make the carry results.. Two extra bits after fa.
-				SigBit carry_out = module->addWire(NEW_ID, 1);
-				module->addFa(NEW_ID_SUFFIX(stringf("cpa_%d_fa_%d", cpa_id, n)),
+				SigBit carry_out = module->addWire(NEWER_ID, 1);
+				module->addFa(NEWER_ID_SUFFIX(stringf("cpa_%d_fa_%d", cpa_id, n)),
 					/* A */ s_vec[n],
 					/* B */ c_vec[n - 1],
 					/* C */ carry,
@@ -775,8 +775,8 @@ struct BoothPassWorker {
 			}
 			// Step case
 			else {
-				SigBit carry_out = module->addWire(NEW_ID_SUFFIX(stringf("cpa_%d_carry_%d", cpa_id, n)), 1);
-				module->addFa(NEW_ID_SUFFIX(stringf("cpa_%d_fa_%d", cpa_id, n)),
+				SigBit carry_out = module->addWire(NEWER_ID_SUFFIX(stringf("cpa_%d_carry_%d", cpa_id, n)), 1);
+				module->addFa(NEWER_ID_SUFFIX(stringf("cpa_%d_fa_%d", cpa_id, n)),
 					/* A */ s_vec[n],
 					/* B */ c_vec[n - 1],
 					/* C */ carry,
@@ -814,10 +814,10 @@ struct BoothPassWorker {
 
 			if (first_csa_ips.size() > 0) {
 				// build the first csa
-				auto s_wire = module->addWire(NEW_ID_SUFFIX(stringf("csa_%d_%d_s", column_ix, csa_ix + 1)), 1);
-				auto c_wire = module->addWire(NEW_ID_SUFFIX(stringf("csa_%d_%d_c", column_ix, csa_ix + 1)), 1);
+				auto s_wire = module->addWire(NEWER_ID_SUFFIX(stringf("csa_%d_%d_s", column_ix, csa_ix + 1)), 1);
+				auto c_wire = module->addWire(NEWER_ID_SUFFIX(stringf("csa_%d_%d_c", column_ix, csa_ix + 1)), 1);
 
-				auto csa = module->addFa(NEW_ID_SUFFIX(stringf("csa_%d_%d", column_ix, csa_ix)),
+				auto csa = module->addFa(NEWER_ID_SUFFIX(stringf("csa_%d_%d", column_ix, csa_ix)),
 					/* A */ first_csa_ips[0],
 					/* B */ first_csa_ips.size() > 1 ? first_csa_ips[1] : State::S0,
 					/* C */ first_csa_ips.size() > 2 ? first_csa_ips[2] : State::S0,
@@ -846,10 +846,10 @@ struct BoothPassWorker {
 					}
 
 					if (csa_ips.size() > 0) {
-						auto c_wire = module->addWire(NEW_ID_SUFFIX(stringf("csa_%d_%d_c", column_ix, csa_ix + 1)), 1);
-						auto s_wire = module->addWire(NEW_ID_SUFFIX(stringf("csa_%d_%d_s", column_ix, csa_ix + 1)), 1);
+						auto c_wire = module->addWire(NEWER_ID_SUFFIX(stringf("csa_%d_%d_c", column_ix, csa_ix + 1)), 1);
+						auto s_wire = module->addWire(NEWER_ID_SUFFIX(stringf("csa_%d_%d_s", column_ix, csa_ix + 1)), 1);
 
-						auto csa = module->addFa(NEW_ID_SUFFIX(stringf("csa_%d_%d", column_ix, csa_ix)),
+						auto csa = module->addFa(NEWER_ID_SUFFIX(stringf("csa_%d_%d", column_ix, csa_ix)),
 							/* A */ s_result,
 							/* B */ csa_ips[0],
 							/* C */ csa_ips.size() > 1 ? csa_ips[1] : State::S0,
@@ -879,10 +879,10 @@ struct BoothPassWorker {
 		for (int y_ix = 0; y_ix < (!is_signed ? y_sz : y_sz - 1);) {
 			std::string enc_name = stringf("bur_enc_%d", encoder_ix);
 
-			two_int.append(module->addWire(NEW_ID_SUFFIX(stringf("two_int_%d", encoder_ix)), 1));
-			one_int.append(module->addWire(NEW_ID_SUFFIX(stringf("one_int_%d", encoder_ix)), 1));
-			s_int.append(module->addWire(NEW_ID_SUFFIX(stringf("s_int_%d", encoder_ix)), 1));
-			sb_int.append(module->addWire(NEW_ID_SUFFIX(stringf("sb_int_%d", encoder_ix)), 1));
+			two_int.append(module->addWire(NEWER_ID_SUFFIX(stringf("two_int_%d", encoder_ix)), 1));
+			one_int.append(module->addWire(NEWER_ID_SUFFIX(stringf("one_int_%d", encoder_ix)), 1));
+			s_int.append(module->addWire(NEWER_ID_SUFFIX(stringf("s_int_%d", encoder_ix)), 1));
+			sb_int.append(module->addWire(NEWER_ID_SUFFIX(stringf("sb_int_%d", encoder_ix)), 1));
 
 			if (y_ix == 0) {
 				BuildBur4e(enc_name, State::S0, Y[y_ix],
@@ -939,10 +939,10 @@ struct BoothPassWorker {
 
 					std::string enc_name = stringf("br_enc_pad_%d", encoder_ix);
 
-					two_int.append(module->addWire(NEW_ID_SUFFIX(stringf("two_int_%d", encoder_ix)), 1));
-					one_int.append(module->addWire(NEW_ID_SUFFIX(stringf("one_int_%d", encoder_ix)), 1));
-					s_int.append(module->addWire(NEW_ID_SUFFIX(stringf("s_int_%d", encoder_ix)), 1));
-					sb_int.append(module->addWire(NEW_ID_SUFFIX(stringf("sb_int_%d", encoder_ix)), 1));
+					two_int.append(module->addWire(NEWER_ID_SUFFIX(stringf("two_int_%d", encoder_ix)), 1));
+					one_int.append(module->addWire(NEWER_ID_SUFFIX(stringf("one_int_%d", encoder_ix)), 1));
+					s_int.append(module->addWire(NEWER_ID_SUFFIX(stringf("s_int_%d", encoder_ix)), 1));
+					sb_int.append(module->addWire(NEWER_ID_SUFFIX(stringf("sb_int_%d", encoder_ix)), 1));
 
 					SigBit one_o_int, two_o_int, s_o_int, sb_o_int;
 					BuildBur4e(enc_name, Y[y_ix], State::S0,
@@ -986,10 +986,10 @@ struct BoothPassWorker {
 
 		for (unsigned encoder_ix = 1; encoder_ix <= enc_count; encoder_ix++) {
 			std::string enc_name = stringf("enc_%d", encoder_ix);
-			negi_n_int[encoder_ix - 1] = module->addWire(NEW_ID_SUFFIX(stringf("negi_n_int_%d", encoder_ix)), 1);
-			twoi_n_int[encoder_ix - 1] = module->addWire(NEW_ID_SUFFIX(stringf("twoi_n_int_%d", encoder_ix)), 1);
-			onei_n_int[encoder_ix - 1] = module->addWire(NEW_ID_SUFFIX(stringf("onei_n_int_%d", encoder_ix)), 1);
-			cori_n_int[encoder_ix - 1] = module->addWire(NEW_ID_SUFFIX(stringf("cori_n_int_%d", encoder_ix)), 1);
+			negi_n_int[encoder_ix - 1] = module->addWire(NEWER_ID_SUFFIX(stringf("negi_n_int_%d", encoder_ix)), 1);
+			twoi_n_int[encoder_ix - 1] = module->addWire(NEWER_ID_SUFFIX(stringf("twoi_n_int_%d", encoder_ix)), 1);
+			onei_n_int[encoder_ix - 1] = module->addWire(NEWER_ID_SUFFIX(stringf("onei_n_int_%d", encoder_ix)), 1);
+			cori_n_int[encoder_ix - 1] = module->addWire(NEWER_ID_SUFFIX(stringf("cori_n_int_%d", encoder_ix)), 1);
 
 			if (encoder_ix == 1) {
 				BuildBr4e(enc_name, State::S0, Y[0], Y[1],
@@ -1024,10 +1024,10 @@ struct BoothPassWorker {
 		for (int encoder_ix = 1; encoder_ix <= (int)enc_count; encoder_ix++) {
 			for (int decoder_ix = 1; decoder_ix <= dec_count; decoder_ix++) {
 				PPij[((encoder_ix - 1) * dec_count) + decoder_ix - 1] =
-					module->addWire(NEW_ID_SUFFIX(stringf("ppij_%d_%d", encoder_ix, decoder_ix)), 1);
+					module->addWire(NEWER_ID_SUFFIX(stringf("ppij_%d_%d", encoder_ix, decoder_ix)), 1);
 
 				nxj[((encoder_ix - 1) * dec_count) + decoder_ix - 1] =
-					module->addWire(NEW_ID_SUFFIX(stringf("nxj_%s%d_%d", decoder_ix == 1 ? "pre_dec_" : "",
+					module->addWire(NEWER_ID_SUFFIX(stringf("nxj_%s%d_%d", decoder_ix == 1 ? "pre_dec_" : "",
 									      encoder_ix, decoder_ix)), 1);
 			}
 		}
@@ -1042,7 +1042,7 @@ struct BoothPassWorker {
 			if (encoder_ix == 1) {
 				// quadrant 1 optimization
 			} else {
-				module->addNotGate(NEW_ID_SUFFIX(stringf("pre_dec_%d", encoder_ix)),
+				module->addNotGate(NEWER_ID_SUFFIX(stringf("pre_dec_%d", encoder_ix)),
 					negi_n_int[encoder_ix - 1],
 					nxj[(encoder_ix - 1) * dec_count]
 				);
@@ -1094,16 +1094,16 @@ struct BoothPassWorker {
 		std::vector<SigSpec> fa_carry;
 
 		for (fa_row_ix = 0; fa_row_ix < fa_row_count; fa_row_ix++) {
-			fa_sum.push_back(module->addWire(NEW_ID_SUFFIX(stringf("fa_sum_%d", fa_row_ix)), fa_count));
-			fa_carry.push_back(module->addWire(NEW_ID_SUFFIX(stringf("fa_carry_%d", fa_row_ix)), fa_count));
+			fa_sum.push_back(module->addWire(NEWER_ID_SUFFIX(stringf("fa_sum_%d", fa_row_ix)), fa_count));
+			fa_carry.push_back(module->addWire(NEWER_ID_SUFFIX(stringf("fa_carry_%d", fa_row_ix)), fa_count));
 		}
 
 		// full adder creation
 		// base case: 1st row: Inputs from decoders
 		// 1st row exception: two localized inverters due to sign extension structure
-		SigBit d08_inv = module->NotGate(NEW_ID_SUFFIX("bfa_0_exc_inv1"), PPij[(0 * dec_count) + dec_count - 1]);
-		SigBit d18_inv = module->NotGate(NEW_ID_SUFFIX("bfa_0_exc_inv2"), PPij[(1 * dec_count) + dec_count - 1]);
-		BuildBitwiseFa(module, NEW_ID_SUFFIX("fa_row_0").str(),
+		SigBit d08_inv = module->NotGate(NEWER_ID_SUFFIX("bfa_0_exc_inv1"), PPij[(0 * dec_count) + dec_count - 1]);
+		SigBit d18_inv = module->NotGate(NEWER_ID_SUFFIX("bfa_0_exc_inv2"), PPij[(1 * dec_count) + dec_count - 1]);
+		BuildBitwiseFa(module, NEWER_ID_SUFFIX("fa_row_0").str(),
 			/* A */ {State::S0, d08_inv, PPij[(0 * dec_count) + x_sz], PPij.extract((0 * dec_count) + 2, x_sz - 1)},
 			/* B */ {State::S1, d18_inv, PPij.extract((1 * dec_count), x_sz)},
 			/* C */ fa_carry[0].extract(1, x_sz + 2),
@@ -1116,10 +1116,10 @@ struct BoothPassWorker {
 		// special because these are driven by a decoder and prior fa.
 		for (fa_row_ix = 1; fa_row_ix < fa_row_count; fa_row_ix++) {
 			// end two bits: sign extension
-			SigBit d_inv = module->NotGate(NEW_ID_SUFFIX(stringf("bfa_se_inv_%d_L", fa_row_ix)),
+			SigBit d_inv = module->NotGate(NEWER_ID_SUFFIX(stringf("bfa_se_inv_%d_L", fa_row_ix)),
 						       PPij[((fa_row_ix + 1) * dec_count) + dec_count - 1]);
 
-			BuildBitwiseFa(module, NEW_ID_SUFFIX(stringf("fa_row_%d", fa_row_ix)).str(),
+			BuildBitwiseFa(module, NEWER_ID_SUFFIX(stringf("fa_row_%d", fa_row_ix)).str(),
 				/* A */	{State::S0, fa_carry[fa_row_ix - 1][fa_count - 1], fa_sum[fa_row_ix - 1].extract(2, x_sz + 2)},
 				/* B */ {State::S1, d_inv, PPij.extract((fa_row_ix + 1) * dec_count, x_sz), State::S0, State::S0},
 
@@ -1132,7 +1132,7 @@ struct BoothPassWorker {
 		// instantiate the cpa
 		SigSpec cpa_carry;
 		if (z_sz > fa_row_count * 2)
-			cpa_carry = module->addWire(NEW_ID_SUFFIX("cpa_carry"), z_sz - fa_row_count * 2);
+			cpa_carry = module->addWire(NEWER_ID_SUFFIX("cpa_carry"), z_sz - fa_row_count * 2);
 
 		// The end case where we pass the last two summands
 		// from prior row directly to product output

--- a/passes/techmap/bufnorm.cc
+++ b/passes/techmap/bufnorm.cc
@@ -384,7 +384,7 @@ struct BufnormPass : public Pass {
 							it->second.sort(compare_wires_f);
 							w = *(it->second.begin());
 						} else {
-							w = module->addWire(NEW_ID, GetSize(conn.second));
+							w = module->addWire(NEWER_ID, GetSize(conn.second));
 							for (int i = 0; i < GetSize(w); i++)
 								sigmap.add(SigBit(w, i), keysig[i]);
 						}
@@ -434,7 +434,7 @@ struct BufnormPass : public Pass {
 					return;
 				}
 
-				Cell *cell = module->addCell(NEW_ID, type);
+				Cell *cell = module->addCell(NEWER_ID, type);
 				added_buffers.insert(cell);
 
 				cell->setPort(ID::A, src);

--- a/passes/techmap/bwmuxmap.cc
+++ b/passes/techmap/bwmuxmap.cc
@@ -57,10 +57,10 @@ struct BwmuxmapPass : public Pass {
 			auto &sig_b = cell->getPort(ID::B);
 			auto &sig_s = cell->getPort(ID::S);
 
-			auto not_s = module->Not(NEW_ID, sig_s);
-			auto masked_b = module->And(NEW_ID, sig_s, sig_b);
-			auto masked_a = module->And(NEW_ID, not_s, sig_a);
-			module->addOr(NEW_ID, masked_a, masked_b, sig_y);
+			auto not_s = module->Not(NEWER_ID, sig_s);
+			auto masked_b = module->And(NEWER_ID, sig_s, sig_b);
+			auto masked_a = module->And(NEWER_ID, not_s, sig_a);
+			module->addOr(NEWER_ID, masked_a, masked_b, sig_y);
 
 			module->remove(cell);
 		}

--- a/passes/techmap/clkbufmap.cc
+++ b/passes/techmap/clkbufmap.cc
@@ -258,21 +258,21 @@ struct ClkbufmapPass : public Pass {
 						bool is_input = wire->port_input && !inpad_celltype.empty() && module->get_bool_attribute(ID::top);
 						if (!buf_celltype.empty() && (!is_input || buffer_inputs)) {
 							log("Inserting %s on %s.%s[%d].\n", buf_celltype, log_id(module), log_id(wire), i);
-							cell = module->addCell(NEW_ID, RTLIL::escape_id(buf_celltype));
-							iwire = module->addWire(NEW_ID);
+							cell = module->addCell(NEWER_ID, RTLIL::escape_id(buf_celltype));
+							iwire = module->addWire(NEWER_ID);
 							cell->setPort(RTLIL::escape_id(buf_portname), mapped_wire_bit);
 							cell->setPort(RTLIL::escape_id(buf_portname2), iwire);
 						}
 						if (is_input) {
 							log("Inserting %s on %s.%s[%d].\n", inpad_celltype, log_id(module), log_id(wire), i);
-							RTLIL::Cell *cell2 = module->addCell(NEW_ID, RTLIL::escape_id(inpad_celltype));
+							RTLIL::Cell *cell2 = module->addCell(NEWER_ID, RTLIL::escape_id(inpad_celltype));
 							if (iwire) {
 								cell2->setPort(RTLIL::escape_id(inpad_portname), iwire);
 							} else {
 								cell2->setPort(RTLIL::escape_id(inpad_portname), mapped_wire_bit);
 								cell = cell2;
 							}
-							iwire = module->addWire(NEW_ID);
+							iwire = module->addWire(NEWER_ID);
 							cell2->setPort(RTLIL::escape_id(inpad_portname2), iwire);
 						}
 						if (iwire)
@@ -291,7 +291,7 @@ struct ClkbufmapPass : public Pass {
 				if (!input_bits.empty()) {
 					// This is an input port and some buffers were inserted -- we need
 					// to create a new input wire and transfer attributes.
-					Wire *new_wire = module->addWire(NEW_ID, wire);
+					Wire *new_wire = module->addWire(NEWER_ID, wire);
 
 					for (int i = 0; i < wire->width; i++) {
 						SigBit wire_bit(wire, i);

--- a/passes/techmap/clockgate.cc
+++ b/passes/techmap/clockgate.cc
@@ -371,17 +371,17 @@ struct ClockgatePass : public Pass {
 				if (!matching_icg_desc)
 					continue;
 
-				Cell* icg = module->addCell(NEW_ID, matching_icg_desc->name);
+				Cell* icg = module->addCell(NEWER_ID, matching_icg_desc->name);
 				icg->setPort(matching_icg_desc->ce_pin, clk.ce_bit);
 				icg->setPort(matching_icg_desc->clk_in_pin, clk.clk_bit);
-				gclk.new_net = module->addWire(NEW_ID);
+				gclk.new_net = module->addWire(NEWER_ID);
 				icg->setPort(matching_icg_desc->clk_out_pin, gclk.new_net);
 				// Tie low DFT ports like scan chain enable
 				for (auto port : matching_icg_desc->tie_lo_pins)
 					icg->setPort(port, Const(0, 1));
 				// Fix CE polarity if needed
 				if (!clk.pol_ce) {
-					SigBit ce_fixed_pol = module->NotGate(NEW_ID, clk.ce_bit);
+					SigBit ce_fixed_pol = module->NotGate(NEWER_ID, clk.ce_bit);
 					icg->setPort(matching_icg_desc->ce_pin, ce_fixed_pol);
 				}
 			}

--- a/passes/techmap/constmap.cc
+++ b/passes/techmap/constmap.cc
@@ -32,8 +32,8 @@ static RTLIL::SigChunk value;
 void constmap_worker(RTLIL::SigSpec &sig)
 {
 	if (sig.is_fully_const()){
-		value = module->addWire(NEW_ID, sig.size());
-		RTLIL::Cell *cell = module->addCell(NEW_ID, celltype);
+		value = module->addWire(NEWER_ID, sig.size());
+		RTLIL::Cell *cell = module->addCell(NEWER_ID, celltype);
 		cell->setParam(cell_paramname, sig.as_const());
 		cell->setPort(cell_portname, value);
 		sig = value;

--- a/passes/techmap/demuxmap.cc
+++ b/passes/techmap/demuxmap.cc
@@ -57,13 +57,13 @@ struct DemuxmapPass : public Pass {
 
 			for (int i = 0; i < 1 << GetSize(sel); i++) {
 				if (width == 1 && data == State::S1) {
-					RTLIL::Cell *eq_cell = module->addEq(NEW_ID, sel, Const(i, GetSize(sel)), out[i]);
+					RTLIL::Cell *eq_cell = module->addEq(NEWER_ID, sel, Const(i, GetSize(sel)), out[i]);
 					eq_cell->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
 				} else {
-					Wire *eq = module->addWire(NEW_ID);
-					RTLIL::Cell *eq_cell = module->addEq(NEW_ID, sel, Const(i, GetSize(sel)), eq);
+					Wire *eq = module->addWire(NEWER_ID);
+					RTLIL::Cell *eq_cell = module->addEq(NEWER_ID, sel, Const(i, GetSize(sel)), eq);
 					eq_cell->add_strpool_attribute(ID::src, cell->get_strpool_attribute(ID::src));
-					RTLIL::Cell *mux = module->addMux(NEW_ID,
+					RTLIL::Cell *mux = module->addMux(NEWER_ID,
 							Const(State::S0, width),
 							data,
 							eq,

--- a/passes/techmap/dfflegalize.cc
+++ b/passes/techmap/dfflegalize.cc
@@ -280,7 +280,7 @@ struct DffLegalizePass : public Pass {
 	void emulate_split_init_arst(FfData &ff) {
 		ff.remove();
 
-		FfData ff_dff(ff.module, &initvals, NEW_ID);
+		FfData ff_dff(ff.module, &initvals, NEWER_ID);
 		ff_dff.width = ff.width;
 		ff_dff.has_aload = ff.has_aload;
 		ff_dff.sig_aload = ff.sig_aload;
@@ -293,11 +293,11 @@ struct DffLegalizePass : public Pass {
 		ff_dff.has_ce = ff.has_ce;
 		ff_dff.sig_ce = ff.sig_ce;
 		ff_dff.pol_ce = ff.pol_ce;
-		ff_dff.sig_q = ff.module->addWire(NEW_ID, ff.width);
+		ff_dff.sig_q = ff.module->addWire(NEWER_ID, ff.width);
 		ff_dff.val_init = ff.val_init;
 		ff_dff.is_fine = ff.is_fine;
 
-		FfData ff_adff(ff.module, &initvals, NEW_ID);
+		FfData ff_adff(ff.module, &initvals, NEWER_ID);
 		ff_adff.width = ff.width;
 		ff_adff.has_aload = ff.has_aload;
 		ff_adff.sig_aload = ff.sig_aload;
@@ -310,7 +310,7 @@ struct DffLegalizePass : public Pass {
 		ff_adff.has_ce = ff.has_ce;
 		ff_adff.sig_ce = ff.sig_ce;
 		ff_adff.pol_ce = ff.pol_ce;
-		ff_adff.sig_q = ff.module->addWire(NEW_ID, ff.width);
+		ff_adff.sig_q = ff.module->addWire(NEWER_ID, ff.width);
 		ff_adff.val_init = Const(State::Sx, ff.width);
 		ff_adff.has_arst = true;
 		ff_adff.sig_arst = ff.sig_arst;
@@ -318,9 +318,9 @@ struct DffLegalizePass : public Pass {
 		ff_adff.val_arst = ff.val_arst;
 		ff_adff.is_fine = ff.is_fine;
 
-		FfData ff_sel(ff.module, &initvals, NEW_ID);
+		FfData ff_sel(ff.module, &initvals, NEWER_ID);
 		ff_sel.width = 1;
-		ff_sel.sig_q = ff.module->addWire(NEW_ID);
+		ff_sel.sig_q = ff.module->addWire(NEWER_ID);
 		ff_sel.has_arst = true;
 		ff_sel.sig_arst = ff.sig_arst;
 		ff_sel.pol_arst = ff.pol_arst;
@@ -329,9 +329,9 @@ struct DffLegalizePass : public Pass {
 		ff_sel.is_fine = ff.is_fine;
 
 		if (ff.is_fine)
-			ff.module->addMuxGate(NEW_ID, ff_dff.sig_q, ff_adff.sig_q, ff_sel.sig_q, ff.sig_q);
+			ff.module->addMuxGate(NEWER_ID, ff_dff.sig_q, ff_adff.sig_q, ff_sel.sig_q, ff.sig_q);
 		else
-			ff.module->addMux(NEW_ID, ff_dff.sig_q, ff_adff.sig_q, ff_sel.sig_q, ff.sig_q);
+			ff.module->addMux(NEWER_ID, ff_dff.sig_q, ff_adff.sig_q, ff_sel.sig_q, ff.sig_q);
 
 		legalize_ff(ff_dff);
 		legalize_ff(ff_adff);
@@ -386,7 +386,7 @@ struct DffLegalizePass : public Pass {
 		log_assert(ff.width == 1);
 		ff.remove();
 
-		FfData ff_clr(ff.module, &initvals, NEW_ID);
+		FfData ff_clr(ff.module, &initvals, NEWER_ID);
 		ff_clr.width = ff.width;
 		ff_clr.has_aload = ff.has_aload;
 		ff_clr.sig_aload = ff.sig_aload;
@@ -403,11 +403,11 @@ struct DffLegalizePass : public Pass {
 		ff_clr.sig_arst = ff.sig_clr;
 		ff_clr.pol_arst = ff.pol_clr;
 		ff_clr.val_arst = Const(State::S0, ff.width);
-		ff_clr.sig_q = ff.module->addWire(NEW_ID, ff.width);
+		ff_clr.sig_q = ff.module->addWire(NEWER_ID, ff.width);
 		ff_clr.val_init = init_clr ? ff.val_init : Const(State::Sx, ff.width);
 		ff_clr.is_fine = ff.is_fine;
 
-		FfData ff_set(ff.module, &initvals, NEW_ID);
+		FfData ff_set(ff.module, &initvals, NEWER_ID);
 		ff_set.width = ff.width;
 		ff_set.has_aload = ff.has_aload;
 		ff_set.sig_aload = ff.sig_aload;
@@ -424,25 +424,25 @@ struct DffLegalizePass : public Pass {
 		ff_set.sig_arst = ff.sig_set;
 		ff_set.pol_arst = ff.pol_set;
 		ff_set.val_arst = Const(State::S1, ff.width);
-		ff_set.sig_q = ff.module->addWire(NEW_ID, ff.width);
+		ff_set.sig_q = ff.module->addWire(NEWER_ID, ff.width);
 		ff_set.val_init = init_set ? ff.val_init : Const(State::Sx, ff.width);
 		ff_set.is_fine = ff.is_fine;
 
-		FfData ff_sel(ff.module, &initvals, NEW_ID);
+		FfData ff_sel(ff.module, &initvals, NEWER_ID);
 		ff_sel.width = ff.width;
 		ff_sel.has_sr = true;
 		ff_sel.pol_clr = ff.pol_clr;
 		ff_sel.pol_set = ff.pol_set;
 		ff_sel.sig_clr = ff.sig_clr;
 		ff_sel.sig_set = ff.sig_set;
-		ff_sel.sig_q = ff.module->addWire(NEW_ID, ff.width);
+		ff_sel.sig_q = ff.module->addWire(NEWER_ID, ff.width);
 		ff_sel.val_init = Const(initsel, ff.width);
 		ff_sel.is_fine = ff.is_fine;
 
 		if (!ff.is_fine)
-			ff.module->addMux(NEW_ID, ff_clr.sig_q, ff_set.sig_q, ff_sel.sig_q, ff.sig_q);
+			ff.module->addMux(NEWER_ID, ff_clr.sig_q, ff_set.sig_q, ff_sel.sig_q, ff.sig_q);
 		else
-			ff.module->addMuxGate(NEW_ID, ff_clr.sig_q, ff_set.sig_q, ff_sel.sig_q, ff.sig_q);
+			ff.module->addMuxGate(NEWER_ID, ff_clr.sig_q, ff_set.sig_q, ff_sel.sig_q, ff.sig_q);
 
 		legalize_ff(ff_clr);
 		legalize_ff(ff_set);
@@ -841,11 +841,11 @@ struct DffLegalizePass : public Pass {
 			ff.sig_ad = State::S0;
 			ff.val_arst = State::S1;
 			ff.remove_init();
-			Wire *new_q = ff.module->addWire(NEW_ID);
+			Wire *new_q = ff.module->addWire(NEWER_ID);
 			if (ff.is_fine)
-				ff.module->addNotGate(NEW_ID, new_q, ff.sig_q);
+				ff.module->addNotGate(NEWER_ID, new_q, ff.sig_q);
 			else
-				ff.module->addNot(NEW_ID, new_q, ff.sig_q);
+				ff.module->addNot(NEWER_ID, new_q, ff.sig_q);
 			ff.sig_q = new_q;
 			if (ff.val_init == State::S0)
 				ff.val_init = State::S1;
@@ -938,9 +938,9 @@ struct DffLegalizePass : public Pass {
 		} else if (sig == State::S1) {
 			sig = State::S0;
 		} else if (ff.is_fine) {
-			sig = ff.module->NotGate(NEW_ID, sig);
+			sig = ff.module->NotGate(NEWER_ID, sig);
 		} else {
-			sig = ff.module->Not(NEW_ID, sig);
+			sig = ff.module->Not(NEWER_ID, sig);
 		}
 		pol = !pol;
 	}

--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -529,25 +529,25 @@ static void dfflibmap(RTLIL::Design *design, RTLIL::Module *module)
 			} else
 			if (port.second == 'q') {
 				RTLIL::SigSpec old_sig = cell_connections[std::string("\\") + char(port.second - ('a' - 'A'))];
-				sig = module->addWire(NEW_ID, GetSize(old_sig));
+				sig = module->addWire(NEWER_ID, GetSize(old_sig));
 				if (has_q && has_qn) {
 					for (auto &it : notmap[sigmap(old_sig)]) {
 						module->connect(it->getPort(ID::Y), sig);
-						it->setPort(ID::Y, module->addWire(NEW_ID, GetSize(old_sig)));
+						it->setPort(ID::Y, module->addWire(NEWER_ID, GetSize(old_sig)));
 					}
 				} else {
-					module->addNotGate(NEW_ID, sig, old_sig);
+					module->addNotGate(NEWER_ID, sig, old_sig);
 				}
 			} else
 			if ('a' <= port.second && port.second <= 'z') {
 				sig = cell_connections[std::string("\\") + char(port.second - ('a' - 'A'))];
-				sig = module->NotGate(NEW_ID, sig);
+				sig = module->NotGate(NEWER_ID, sig);
 			} else
 			if (port.second == '0' || port.second == '1') {
 				sig = RTLIL::SigSpec(port.second == '0' ? 0 : 1, 1);
 			} else
 			if (port.second == 0) {
-				sig = module->addWire(NEW_ID);
+				sig = module->addWire(NEWER_ID);
 			} else
 				log_abort();
 			new_cell->setPort("\\" + port.first, sig);

--- a/passes/techmap/extract_counter.cc
+++ b/passes/techmap/extract_counter.cc
@@ -639,8 +639,8 @@ void counter_worker(
 		//If the reset is active low, infer an inverter ($__COUNT_ cells always have active high reset)
 		if(extract.rst_inverted)
 		{
-			auto realreset = cell->module->addWire(NEW_ID);
-			cell->module->addNot(NEW_ID, extract.rst, RTLIL::SigSpec(realreset));
+			auto realreset = cell->module->addWire(NEWER_ID);
+			cell->module->addNot(NEWER_ID, extract.rst, RTLIL::SigSpec(realreset));
 			cell->setPort(ID(RST), realreset);
 		}
 		else
@@ -665,8 +665,8 @@ void counter_worker(
 		cell->setParam(ID(HAS_CE), RTLIL::Const(1));
 		if(extract.ce_inverted)
 		{
-			auto realce = cell->module->addWire(NEW_ID);
-			cell->module->addNot(NEW_ID, extract.ce, RTLIL::SigSpec(realce));
+			auto realce = cell->module->addWire(NEWER_ID);
+			cell->module->addNot(NEWER_ID, extract.ce, RTLIL::SigSpec(realce));
 			cell->setPort(ID(CE), realce);
 		}
 		else

--- a/passes/techmap/extract_fa.cc
+++ b/passes/techmap/extract_fa.cc
@@ -282,7 +282,7 @@ struct ExtractFaWorker
 	{
 		Cell *cell = driver.at(bit);
 		if (sigmap(cell->getPort(ID::Y)) == SigSpec(bit)) {
-			cell->setPort(ID::Y, module->addWire(NEW_ID));
+			cell->setPort(ID::Y, module->addWire(NEWER_ID));
 			module->connect(bit, new_driver);
 		}
 	}
@@ -394,17 +394,17 @@ struct ExtractFaWorker
 				}
 				else
 				{
-					Cell *cell = module->addCell(NEW_ID, ID($fa));
+					Cell *cell = module->addCell(NEWER_ID, ID($fa));
 					cell->setParam(ID::WIDTH, 1);
 
 					log("      Created $fa cell %s.\n", log_id(cell));
 
-					cell->setPort(ID::A, f3i.inv_a ? module->NotGate(NEW_ID, A) : A);
-					cell->setPort(ID::B, f3i.inv_b ? module->NotGate(NEW_ID, B) : B);
-					cell->setPort(ID::C, f3i.inv_c ? module->NotGate(NEW_ID, C) : C);
+					cell->setPort(ID::A, f3i.inv_a ? module->NotGate(NEWER_ID, A) : A);
+					cell->setPort(ID::B, f3i.inv_b ? module->NotGate(NEWER_ID, B) : B);
+					cell->setPort(ID::C, f3i.inv_c ? module->NotGate(NEWER_ID, C) : C);
 
-					X = module->addWire(NEW_ID);
-					Y = module->addWire(NEW_ID);
+					X = module->addWire(NEWER_ID);
+					Y = module->addWire(NEWER_ID);
 
 					cell->setPort(ID::X, X);
 					cell->setPort(ID::Y, Y);
@@ -414,18 +414,18 @@ struct ExtractFaWorker
 
 				bool invert_y = f3i.inv_a ^ f3i.inv_b ^ f3i.inv_c;
 				if (func3.at(key).count(xor3_func)) {
-					SigBit YY = invert_xy ^ invert_y ? module->NotGate(NEW_ID, Y) : Y;
+					SigBit YY = invert_xy ^ invert_y ? module->NotGate(NEWER_ID, Y) : Y;
 					for (auto bit : func3.at(key).at(xor3_func))
 						assign_new_driver(bit, YY);
 				}
 
 				if (func3.at(key).count(xnor3_func)) {
-					SigBit YY = invert_xy ^ invert_y ? Y : module->NotGate(NEW_ID, Y);
+					SigBit YY = invert_xy ^ invert_y ? Y : module->NotGate(NEWER_ID, Y);
 					for (auto bit : func3.at(key).at(xnor3_func))
 						assign_new_driver(bit, YY);
 				}
 
-				SigBit XX = invert_xy != f3i.inv_y ? module->NotGate(NEW_ID, X) : X;
+				SigBit XX = invert_xy != f3i.inv_y ? module->NotGate(NEWER_ID, X) : X;
 
 				for (auto bit : func3.at(key).at(func))
 					assign_new_driver(bit, XX);
@@ -501,35 +501,35 @@ struct ExtractFaWorker
 				}
 				else
 				{
-					Cell *cell = module->addCell(NEW_ID, ID($fa));
+					Cell *cell = module->addCell(NEWER_ID, ID($fa));
 					cell->setParam(ID::WIDTH, 1);
 
 					log("      Created $fa cell %s.\n", log_id(cell));
 
-					cell->setPort(ID::A, f2i.inv_a ? module->NotGate(NEW_ID, A) : A);
-					cell->setPort(ID::B, f2i.inv_b ? module->NotGate(NEW_ID, B) : B);
+					cell->setPort(ID::A, f2i.inv_a ? module->NotGate(NEWER_ID, A) : A);
+					cell->setPort(ID::B, f2i.inv_b ? module->NotGate(NEWER_ID, B) : B);
 					cell->setPort(ID::C, State::S0);
 
-					X = module->addWire(NEW_ID);
-					Y = module->addWire(NEW_ID);
+					X = module->addWire(NEWER_ID);
+					Y = module->addWire(NEWER_ID);
 
 					cell->setPort(ID::X, X);
 					cell->setPort(ID::Y, Y);
 				}
 
 				if (func2.at(key).count(xor2_func)) {
-					SigBit YY = invert_xy || (f2i.inv_a && !f2i.inv_b) || (!f2i.inv_a && f2i.inv_b) ? module->NotGate(NEW_ID, Y) : Y;
+					SigBit YY = invert_xy || (f2i.inv_a && !f2i.inv_b) || (!f2i.inv_a && f2i.inv_b) ? module->NotGate(NEWER_ID, Y) : Y;
 					for (auto bit : func2.at(key).at(xor2_func))
 						assign_new_driver(bit, YY);
 				}
 
 				if (func2.at(key).count(xnor2_func)) {
-					SigBit YY = invert_xy || (f2i.inv_a && !f2i.inv_b) || (!f2i.inv_a && f2i.inv_b) ? Y : module->NotGate(NEW_ID, Y);
+					SigBit YY = invert_xy || (f2i.inv_a && !f2i.inv_b) || (!f2i.inv_a && f2i.inv_b) ? Y : module->NotGate(NEWER_ID, Y);
 					for (auto bit : func2.at(key).at(xnor2_func))
 						assign_new_driver(bit, YY);
 				}
 
-				SigBit XX = invert_xy != f2i.inv_y ? module->NotGate(NEW_ID, X) : X;
+				SigBit XX = invert_xy != f2i.inv_y ? module->NotGate(NEWER_ID, X) : X;
 
 				for (auto bit : func2.at(key).at(func))
 					assign_new_driver(bit, XX);

--- a/passes/techmap/extract_reduce.cc
+++ b/passes/techmap/extract_reduce.cc
@@ -270,11 +270,11 @@ struct ExtractReducePass : public Pass
 						}
 
 						if (head_cell->type == ID($_AND_)) {
-							module->addReduceAnd(NEW_ID, input, output);
+							module->addReduceAnd(NEWER_ID, input, output);
 						} else if (head_cell->type == ID($_OR_)) {
-							module->addReduceOr(NEW_ID, input, output);
+							module->addReduceOr(NEWER_ID, input, output);
 						} else if (head_cell->type == ID($_XOR_)) {
-							module->addReduceXor(NEW_ID, input, output);
+							module->addReduceXor(NEWER_ID, input, output);
 						} else {
 							log_assert(false);
 						}

--- a/passes/techmap/extractinv.cc
+++ b/passes/techmap/extractinv.cc
@@ -105,10 +105,10 @@ struct ExtractinvPass : public Pass {
 				cell->parameters.erase(param_name);
 				if (invmask.is_fully_zero())
 					continue;
-				Wire *iwire = module->addWire(NEW_ID, sig.size());
+				Wire *iwire = module->addWire(NEWER_ID, sig.size());
 				for (int i = 0; i < sig.size(); i++)
 					if (invmask[i] == State::S1) {
-						RTLIL::Cell *icell = module->addCell(NEW_ID, RTLIL::escape_id(inv_celltype));
+						RTLIL::Cell *icell = module->addCell(NEWER_ID, RTLIL::escape_id(inv_celltype));
 						icell->setPort(RTLIL::escape_id(inv_portname), SigSpec(iwire, i));
 						icell->setPort(RTLIL::escape_id(inv_portname2), sig[i]);
 						log("Inserting %s on %s.%s.%s[%d].\n", inv_celltype, log_id(module), log_id(cell->type), log_id(port.first), i);

--- a/passes/techmap/flowmap.cc
+++ b/passes/techmap/flowmap.cc
@@ -1411,7 +1411,7 @@ struct FlowmapWorker
 			if ((int)input_nodes.size() < minlut)
 				lut_a.append(RTLIL::Const(State::Sx, minlut - input_nodes.size()));
 
-			RTLIL::Cell *lut = module->addLut(NEW_ID, lut_a, lut_y, lut_table);
+			RTLIL::Cell *lut = module->addLut(NEWER_ID, lut_a, lut_y, lut_table);
 			mapped_nodes.insert(node);
 			for (auto gate_node : lut_gates[node])
 			{
@@ -1432,7 +1432,7 @@ struct FlowmapWorker
 		{
 			auto origin = node_origins[node];
 			RTLIL::SigSpec driver = origin.cell->getPort(origin.port);
-			driver[origin.offset] = module->addWire(NEW_ID);
+			driver[origin.offset] = module->addWire(NEWER_ID);
 			origin.cell->setPort(origin.port, driver);
 		}
 	}

--- a/passes/techmap/hilomap.cc
+++ b/passes/techmap/hilomap.cc
@@ -36,16 +36,16 @@ void hilomap_worker(RTLIL::SigSpec &sig)
 	for (auto &bit : sig) {
 		if (bit == RTLIL::State::S1 && !hicell_celltype.empty()) {
 			if (!singleton_mode || last_hi == RTLIL::State::Sm) {
-				last_hi = module->addWire(NEW_ID);
-				RTLIL::Cell *cell = module->addCell(NEW_ID, RTLIL::escape_id(hicell_celltype));
+				last_hi = module->addWire(NEWER_ID);
+				RTLIL::Cell *cell = module->addCell(NEWER_ID, RTLIL::escape_id(hicell_celltype));
 				cell->setPort(RTLIL::escape_id(hicell_portname), last_hi);
 			}
 			bit = last_hi;
 		}
 		if (bit == RTLIL::State::S0 && !locell_celltype.empty()) {
 			if (!singleton_mode || last_lo == RTLIL::State::Sm) {
-				last_lo = module->addWire(NEW_ID);
-				RTLIL::Cell *cell = module->addCell(NEW_ID, RTLIL::escape_id(locell_celltype));
+				last_lo = module->addWire(NEWER_ID);
+				RTLIL::Cell *cell = module->addCell(NEWER_ID, RTLIL::escape_id(locell_celltype));
 				cell->setPort(RTLIL::escape_id(locell_portname), last_lo);
 			}
 			bit = last_lo;

--- a/passes/techmap/insbuf.cc
+++ b/passes/techmap/insbuf.cc
@@ -94,7 +94,7 @@ struct InsbufPass : public Pass {
 						sigmap.add(outbit);
 					}
 
-					Cell *cell = module->addCell(NEW_ID, celltype);
+					Cell *cell = module->addCell(NEWER_ID, celltype);
 					cell->setPort(in_portname, rhs);
 					cell->setPort(out_portname, lhs);
 

--- a/passes/techmap/iopadmap.cc
+++ b/passes/techmap/iopadmap.cc
@@ -331,7 +331,7 @@ struct IopadmapPass : public Pass {
 								RTLIL::escape_id(tinoutpad_celltype));
 
 							if (tinoutpad_neg_oe)
-								en_sig = module->NotGate(NEW_ID, en_sig);
+								en_sig = module->NotGate(NEWER_ID, en_sig);
 							cell->setPort(RTLIL::escape_id(tinoutpad_portname_oe), en_sig);
 							cell->attributes[ID::keep] = RTLIL::Const(1);
 
@@ -355,7 +355,7 @@ struct IopadmapPass : public Pass {
 								RTLIL::escape_id(toutpad_celltype));
 
 							if (toutpad_neg_oe)
-								en_sig = module->NotGate(NEW_ID, en_sig);
+								en_sig = module->NotGate(NEWER_ID, en_sig);
 							cell->setPort(RTLIL::escape_id(toutpad_portname_oe), en_sig);
 							cell->setPort(RTLIL::escape_id(toutpad_portname_i), data_sig);
 							cell->attributes[ID::keep] = RTLIL::Const(1);

--- a/passes/techmap/lut2mux.cc
+++ b/passes/techmap/lut2mux.cc
@@ -32,22 +32,22 @@ int lut2mux(Cell *cell)
 
 	if (GetSize(sig_a) == 1)
 	{
-		cell->module->addMuxGate(NEW_ID, lut.extract(0)[0], lut.extract(1)[0], sig_a, sig_y);
+		cell->module->addMuxGate(NEWER_ID, lut.extract(0)[0], lut.extract(1)[0], sig_a, sig_y);
 	}
 	else
 	{
 		SigSpec sig_a_hi = sig_a[GetSize(sig_a)-1];
 		SigSpec sig_a_lo = sig_a.extract(0, GetSize(sig_a)-1);
-		SigSpec sig_y1 = cell->module->addWire(NEW_ID);
-		SigSpec sig_y2 = cell->module->addWire(NEW_ID);
+		SigSpec sig_y1 = cell->module->addWire(NEWER_ID);
+		SigSpec sig_y2 = cell->module->addWire(NEWER_ID);
 
 		Const lut1 = lut.extract(0, GetSize(lut)/2);
 		Const lut2 = lut.extract(GetSize(lut)/2, GetSize(lut)/2);
 
-		count += lut2mux(cell->module->addLut(NEW_ID, sig_a_lo, sig_y1, lut1));
-		count += lut2mux(cell->module->addLut(NEW_ID, sig_a_lo, sig_y2, lut2));
+		count += lut2mux(cell->module->addLut(NEWER_ID, sig_a_lo, sig_y1, lut1));
+		count += lut2mux(cell->module->addLut(NEWER_ID, sig_a_lo, sig_y2, lut2));
 
-		cell->module->addMuxGate(NEW_ID, sig_y1, sig_y2, sig_a_hi, sig_y);
+		cell->module->addMuxGate(NEWER_ID, sig_y1, sig_y2, sig_a_hi, sig_y);
 	}
 
 	cell->module->remove(cell);

--- a/passes/techmap/muxcover.cc
+++ b/passes/techmap/muxcover.cc
@@ -185,7 +185,7 @@ struct MuxcoverWorker
 		tuple<SigBit, SigBit, SigBit> key(A, B, sel);
 		if (decode_mux_cache.count(key) == 0) {
 			auto &entry = decode_mux_cache[key];
-			std::get<0>(entry) = module->addWire(NEW_ID);
+			std::get<0>(entry) = module->addWire(NEWER_ID);
 			std::get<2>(entry) = false;
 			decode_mux_reverse_cache[std::get<0>(entry)] = key;
 		}
@@ -215,11 +215,11 @@ struct MuxcoverWorker
 		implement_decode_mux(std::get<1>(key));
 
 		if (std::get<0>(key) == State::Sx) {
-			module->addBufGate(NEW_ID, std::get<1>(key), ctrl_bit);
+			module->addBufGate(NEWER_ID, std::get<1>(key), ctrl_bit);
 		} else if (std::get<1>(key) == State::Sx) {
-			module->addBufGate(NEW_ID, std::get<0>(key), ctrl_bit);
+			module->addBufGate(NEWER_ID, std::get<0>(key), ctrl_bit);
 		} else {
-			module->addMuxGate(NEW_ID, std::get<0>(key), std::get<1>(key), std::get<2>(key), ctrl_bit);
+			module->addMuxGate(NEWER_ID, std::get<0>(key), std::get<1>(key), std::get<2>(key), ctrl_bit);
 			decode_mux_counter++;
 		}
 		std::get<2>(entry) = true;
@@ -513,7 +513,7 @@ struct MuxcoverWorker
 
 		if (GetSize(mux.inputs) == 2) {
 			count_muxes_by_type[0]++;
-			Cell *cell = module->addCell(NEW_ID, ID($_MUX_));
+			Cell *cell = module->addCell(NEWER_ID, ID($_MUX_));
 			cell->setPort(ID::A, mux.inputs[0]);
 			cell->setPort(ID::B, mux.inputs[1]);
 			cell->setPort(ID::S, mux.selects[0]);
@@ -523,7 +523,7 @@ struct MuxcoverWorker
 
 		if (GetSize(mux.inputs) == 4) {
 			count_muxes_by_type[1]++;
-			Cell *cell = module->addCell(NEW_ID, ID($_MUX4_));
+			Cell *cell = module->addCell(NEWER_ID, ID($_MUX4_));
 			cell->setPort(ID::A, mux.inputs[0]);
 			cell->setPort(ID::B, mux.inputs[1]);
 			cell->setPort(ID::C, mux.inputs[2]);
@@ -536,7 +536,7 @@ struct MuxcoverWorker
 
 		if (GetSize(mux.inputs) == 8) {
 			count_muxes_by_type[2]++;
-			Cell *cell = module->addCell(NEW_ID, ID($_MUX8_));
+			Cell *cell = module->addCell(NEWER_ID, ID($_MUX8_));
 			cell->setPort(ID::A, mux.inputs[0]);
 			cell->setPort(ID::B, mux.inputs[1]);
 			cell->setPort(ID::C, mux.inputs[2]);
@@ -554,7 +554,7 @@ struct MuxcoverWorker
 
 		if (GetSize(mux.inputs) == 16) {
 			count_muxes_by_type[3]++;
-			Cell *cell = module->addCell(NEW_ID, ID($_MUX16_));
+			Cell *cell = module->addCell(NEWER_ID, ID($_MUX16_));
 			cell->setPort(ID::A, mux.inputs[0]);
 			cell->setPort(ID::B, mux.inputs[1]);
 			cell->setPort(ID::C, mux.inputs[2]);

--- a/passes/techmap/pmuxtree.cc
+++ b/passes/techmap/pmuxtree.cc
@@ -32,9 +32,9 @@ static SigSpec or_generator(Module *module, const SigSpec &sig)
 	case 1:
 		return sig;
 	case 2:
-		return module->Or(NEW_ID, sig[0], sig[1]);
+		return module->Or(NEWER_ID, sig[0], sig[1]);
 	default:
-		return module->ReduceOr(NEW_ID, sig);
+		return module->ReduceOr(NEWER_ID, sig);
 	}
 }
 
@@ -62,7 +62,7 @@ static SigSpec recursive_mux_generator(Module *module, const SigSpec &sig_data, 
 	left_or = or_generator(module, left_or);
 	sig_or.append(left_or);
 
-	return module->Mux(NEW_ID, right_result, left_result, left_or);
+	return module->Mux(NEWER_ID, right_result, left_result, left_or);
 }
 
 struct PmuxtreePass : public Pass {
@@ -97,8 +97,8 @@ struct PmuxtreePass : public Pass {
 
 			if (!cell->getPort(ID::A).is_fully_undef()) {
 				sig_data.append(cell->getPort(ID::A));
-				SigSpec sig_sel_or = module->ReduceOr(NEW_ID, sig_sel);
-				sig_sel.append(module->Not(NEW_ID, sig_sel_or));
+				SigSpec sig_sel_or = module->ReduceOr(NEWER_ID, sig_sel);
+				sig_sel.append(module->Not(NEWER_ID, sig_sel_or));
 			}
 
 			SigSpec result, result_or;

--- a/passes/techmap/shregmap.cc
+++ b/passes/techmap/shregmap.cc
@@ -75,7 +75,7 @@ struct ShregmapTechGreenpak4 : ShregmapTech
 		auto D = cell->getPort(ID::D);
 		auto C = cell->getPort(ID::C);
 
-		auto newcell = cell->module->addCell(NEW_ID, ID(GP_SHREG));
+		auto newcell = cell->module->addCell(NEWER_ID, ID(GP_SHREG));
 		newcell->setPort(ID(nRST), State::S1);
 		newcell->setPort(ID::CLK, C);
 		newcell->setPort(ID(IN), D);
@@ -142,7 +142,7 @@ struct ShregmapWorker
 						// so that it can be identified as another chain
 						// (omitting this common flop)
 						// Link: https://github.com/YosysHQ/yosys/pull/1085
-						Wire *wire = module->addWire(NEW_ID);
+						Wire *wire = module->addWire(NEWER_ID);
 						module->connect(wire, d_bit);
 						sigmap.add(wire, d_bit);
 						sigbit_chain_next.insert(std::make_pair(wire, cell));

--- a/passes/techmap/simplemap.cc
+++ b/passes/techmap/simplemap.cc
@@ -35,7 +35,7 @@ void simplemap_not(RTLIL::Module *module, RTLIL::Cell *cell)
 	sig_a.extend_u0(GetSize(sig_y), cell->parameters.at(ID::A_SIGNED).as_bool());
 
 	for (int i = 0; i < GetSize(sig_y); i++) {
-		RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_NOT_));
+		RTLIL::Cell *gate = module->addCell(NEWER_ID, ID($_NOT_));
 		gate->attributes[ID::src] = cell->attributes[ID::src];
 		gate->setPort(ID::A, sig_a[i]);
 		gate->setPort(ID::Y, sig_y[i]);
@@ -80,7 +80,7 @@ void simplemap_bitop(RTLIL::Module *module, RTLIL::Cell *cell)
 	log_assert(!gate_type.empty());
 
 	for (int i = 0; i < GetSize(sig_y); i++) {
-		RTLIL::Cell *gate = module->addCell(NEW_ID, gate_type);
+		RTLIL::Cell *gate = module->addCell(NEWER_ID, gate_type);
 		gate->attributes[ID::src] = cell->attributes[ID::src];
 		gate->setPort(ID::A, sig_a[i]);
 		gate->setPort(ID::B, sig_b[i]);
@@ -122,7 +122,7 @@ void simplemap_reduce(RTLIL::Module *module, RTLIL::Cell *cell)
 
 	while (sig_a.size() > 1)
 	{
-		RTLIL::SigSpec sig_t = module->addWire(NEW_ID, sig_a.size() / 2);
+		RTLIL::SigSpec sig_t = module->addWire(NEWER_ID, sig_a.size() / 2);
 
 		for (int i = 0; i < sig_a.size(); i += 2)
 		{
@@ -131,7 +131,7 @@ void simplemap_reduce(RTLIL::Module *module, RTLIL::Cell *cell)
 				continue;
 			}
 
-			RTLIL::Cell *gate = module->addCell(NEW_ID, gate_type);
+			RTLIL::Cell *gate = module->addCell(NEWER_ID, gate_type);
 			gate->attributes[ID::src] = cell->attributes[ID::src];
 			gate->setPort(ID::A, sig_a[i]);
 			gate->setPort(ID::B, sig_a[i+1]);
@@ -143,8 +143,8 @@ void simplemap_reduce(RTLIL::Module *module, RTLIL::Cell *cell)
 	}
 
 	if (cell->type == ID($reduce_xnor)) {
-		RTLIL::SigSpec sig_t = module->addWire(NEW_ID);
-		RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_NOT_));
+		RTLIL::SigSpec sig_t = module->addWire(NEWER_ID);
+		RTLIL::Cell *gate = module->addCell(NEWER_ID, ID($_NOT_));
 		gate->attributes[ID::src] = cell->attributes[ID::src];
 		gate->setPort(ID::A, sig_a);
 		gate->setPort(ID::Y, sig_t);
@@ -163,7 +163,7 @@ static void logic_reduce(RTLIL::Module *module, RTLIL::SigSpec &sig, RTLIL::Cell
 {
 	while (sig.size() > 1)
 	{
-		RTLIL::SigSpec sig_t = module->addWire(NEW_ID, sig.size() / 2);
+		RTLIL::SigSpec sig_t = module->addWire(NEWER_ID, sig.size() / 2);
 
 		for (int i = 0; i < sig.size(); i += 2)
 		{
@@ -172,7 +172,7 @@ static void logic_reduce(RTLIL::Module *module, RTLIL::SigSpec &sig, RTLIL::Cell
 				continue;
 			}
 
-			RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_OR_));
+			RTLIL::Cell *gate = module->addCell(NEWER_ID, ID($_OR_));
 			gate->attributes[ID::src] = cell->attributes[ID::src];
 			gate->setPort(ID::A, sig[i]);
 			gate->setPort(ID::B, sig[i+1]);
@@ -201,7 +201,7 @@ void simplemap_lognot(RTLIL::Module *module, RTLIL::Cell *cell)
 		sig_y = sig_y.extract(0, 1);
 	}
 
-	RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_NOT_));
+	RTLIL::Cell *gate = module->addCell(NEWER_ID, ID($_NOT_));
 	gate->attributes[ID::src] = cell->attributes[ID::src];
 	gate->setPort(ID::A, sig_a);
 	gate->setPort(ID::Y, sig_y);
@@ -230,7 +230,7 @@ void simplemap_logbin(RTLIL::Module *module, RTLIL::Cell *cell)
 	if (cell->type == ID($logic_or))  gate_type = ID($_OR_);
 	log_assert(!gate_type.empty());
 
-	RTLIL::Cell *gate = module->addCell(NEW_ID, gate_type);
+	RTLIL::Cell *gate = module->addCell(NEWER_ID, gate_type);
 	gate->attributes[ID::src] = cell->attributes[ID::src];
 	gate->setPort(ID::A, sig_a);
 	gate->setPort(ID::B, sig_b);
@@ -245,20 +245,20 @@ void simplemap_eqne(RTLIL::Module *module, RTLIL::Cell *cell)
 	bool is_signed = cell->parameters.at(ID::A_SIGNED).as_bool();
 	bool is_ne = cell->type.in(ID($ne), ID($nex));
 
-	RTLIL::SigSpec xor_out = module->addWire(NEW_ID, max(GetSize(sig_a), GetSize(sig_b)));
-	RTLIL::Cell *xor_cell = module->addXor(NEW_ID, sig_a, sig_b, xor_out, is_signed);
+	RTLIL::SigSpec xor_out = module->addWire(NEWER_ID, max(GetSize(sig_a), GetSize(sig_b)));
+	RTLIL::Cell *xor_cell = module->addXor(NEWER_ID, sig_a, sig_b, xor_out, is_signed);
 	xor_cell->attributes[ID::src] = cell->attributes[ID::src];
 	simplemap_bitop(module, xor_cell);
 	module->remove(xor_cell);
 
-	RTLIL::SigSpec reduce_out = is_ne ? sig_y : module->addWire(NEW_ID);
-	RTLIL::Cell *reduce_cell = module->addReduceOr(NEW_ID, xor_out, reduce_out);
+	RTLIL::SigSpec reduce_out = is_ne ? sig_y : module->addWire(NEWER_ID);
+	RTLIL::Cell *reduce_cell = module->addReduceOr(NEWER_ID, xor_out, reduce_out);
 	reduce_cell->attributes[ID::src] = cell->attributes[ID::src];
 	simplemap_reduce(module, reduce_cell);
 	module->remove(reduce_cell);
 
 	if (!is_ne) {
-		RTLIL::Cell *not_cell = module->addLogicNot(NEW_ID, reduce_out, sig_y);
+		RTLIL::Cell *not_cell = module->addLogicNot(NEWER_ID, reduce_out, sig_y);
 		not_cell->attributes[ID::src] = cell->attributes[ID::src];
                 simplemap_lognot(module, not_cell);
 		module->remove(not_cell);
@@ -272,7 +272,7 @@ void simplemap_mux(RTLIL::Module *module, RTLIL::Cell *cell)
 	RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 
 	for (int i = 0; i < GetSize(sig_y); i++) {
-		RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_MUX_));
+		RTLIL::Cell *gate = module->addCell(NEWER_ID, ID($_MUX_));
 		gate->attributes[ID::src] = cell->attributes[ID::src];
 		gate->setPort(ID::A, sig_a[i]);
 		gate->setPort(ID::B, sig_b[i]);
@@ -289,7 +289,7 @@ void simplemap_bwmux(RTLIL::Module *module, RTLIL::Cell *cell)
 	RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 
 	for (int i = 0; i < GetSize(sig_y); i++) {
-		RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_MUX_));
+		RTLIL::Cell *gate = module->addCell(NEWER_ID, ID($_MUX_));
 		gate->attributes[ID::src] = cell->attributes[ID::src];
 		gate->setPort(ID::A, sig_a[i]);
 		gate->setPort(ID::B, sig_b[i]);
@@ -305,7 +305,7 @@ void simplemap_tribuf(RTLIL::Module *module, RTLIL::Cell *cell)
 	RTLIL::SigSpec sig_y = cell->getPort(ID::Y);
 
 	for (int i = 0; i < GetSize(sig_y); i++) {
-		RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_TBUF_));
+		RTLIL::Cell *gate = module->addCell(NEWER_ID, ID($_TBUF_));
 		gate->attributes[ID::src] = cell->attributes[ID::src];
 		gate->setPort(ID::A, sig_a[i]);
 		gate->setPort(ID::E, sig_e);
@@ -320,10 +320,10 @@ void simplemap_bmux(RTLIL::Module *module, RTLIL::Cell *cell)
 	int width = GetSize(cell->getPort(ID::Y));
 
 	for (int idx = 0; idx < GetSize(sel); idx++) {
-		SigSpec new_data = module->addWire(NEW_ID, GetSize(data)/2);
+		SigSpec new_data = module->addWire(NEWER_ID, GetSize(data)/2);
 		for (int i = 0; i < GetSize(new_data); i += width) {
 			for (int k = 0; k < width; k++) {
-				RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_MUX_));
+				RTLIL::Cell *gate = module->addCell(NEWER_ID, ID($_MUX_));
 				gate->attributes[ID::src] = cell->attributes[ID::src];
 				gate->setPort(ID::A, data[i*2+k]);
 				gate->setPort(ID::B, data[i*2+width+k]);
@@ -344,9 +344,9 @@ void simplemap_lut(RTLIL::Module *module, RTLIL::Cell *cell)
 	lut_data.extend_u0(1 << cell->getParam(ID::WIDTH).as_int());
 
 	for (int idx = 0; GetSize(lut_data) > 1; idx++) {
-		SigSpec new_lut_data = module->addWire(NEW_ID, GetSize(lut_data)/2);
+		SigSpec new_lut_data = module->addWire(NEWER_ID, GetSize(lut_data)/2);
 		for (int i = 0; i < GetSize(lut_data); i += 2) {
-			RTLIL::Cell *gate = module->addCell(NEW_ID, ID($_MUX_));
+			RTLIL::Cell *gate = module->addCell(NEWER_ID, ID($_MUX_));
 			gate->attributes[ID::src] = cell->attributes[ID::src];
 			gate->setPort(ID::A, lut_data[i]);
 			gate->setPort(ID::B, lut_data[i+1]);
@@ -383,10 +383,10 @@ void simplemap_sop(RTLIL::Module *module, RTLIL::Cell *cell)
 			}
 		}
 
-		products.append(GetSize(in) > 0 ? module->Eq(NEW_ID, in, pat) : State::S1);
+		products.append(GetSize(in) > 0 ? module->Eq(NEWER_ID, in, pat) : State::S1);
 	}
 
-	module->connect(cell->getPort(ID::Y), module->ReduceOr(NEW_ID, products));
+	module->connect(cell->getPort(ID::Y), module->ReduceOr(NEWER_ID, products));
 }
 
 void simplemap_slice(RTLIL::Module *module, RTLIL::Cell *cell)

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -205,7 +205,7 @@ struct TechmapWorker
 			RTLIL::Wire *w = module->wire(w_name);
 			if (w != nullptr) {
 				temp_renamed_wires[w] = w->name;
-				module->rename(w, NEW_ID);
+				module->rename(w, NEWER_ID);
 				w = nullptr;
 			}
 			if (w == nullptr) {
@@ -792,7 +792,7 @@ struct TechmapWorker
 										continue;
 
 									IdString port_name = wire->name;
-									tpl->rename(wire, NEW_ID);
+									tpl->rename(wire, NEWER_ID);
 
 									RTLIL::Wire *new_wire = tpl->addWire(port_name, wire);
 									wire->port_input = false;

--- a/passes/techmap/tribuf.cc
+++ b/passes/techmap/tribuf.cc
@@ -93,7 +93,7 @@ struct TribufWorker {
 				}
 
 				if (is_all_z(cell->getPort(ID::B))) {
-					cell->setPort(en_port, module->Not(NEW_ID, cell->getPort(ID::S)));
+					cell->setPort(en_port, module->Not(NEWER_ID, cell->getPort(ID::S)));
 					cell->unsetPort(ID::B);
 					cell->unsetPort(ID::S);
 					cell->type = tri_type;
@@ -138,12 +138,12 @@ struct TribufWorker {
 
 						auto cell_s = cell->type == ID($tribuf) ? cell->getPort(ID::EN) : cell->getPort(ID::E);
 
-						auto other_s = module->ReduceOr(NEW_ID, others_s);
+						auto other_s = module->ReduceOr(NEWER_ID, others_s);
 
-						auto conflict = module->And(NEW_ID, cell_s, other_s);
+						auto conflict = module->And(NEWER_ID, cell_s, other_s);
 
 						std::string name = stringf("$tribuf_conflict$%s", log_id(cell->name));
-						auto assert_cell = module->addAssert(name, module->Not(NEW_ID, conflict), SigSpec(true));
+						auto assert_cell = module->addAssert(name, module->Not(NEWER_ID, conflict), SigSpec(true));
 
 						assert_cell->set_src_attribute(cell->get_src_attribute());
 						assert_cell->set_bool_attribute(ID::keep);
@@ -162,12 +162,12 @@ struct TribufWorker {
 					module->remove(cell);
 				}
 
-				SigSpec muxout = GetSize(pmux_s) > 1 ? module->Pmux(NEW_ID, SigSpec(State::Sx, GetSize(it.first)), pmux_b, pmux_s) : pmux_b;
+				SigSpec muxout = GetSize(pmux_s) > 1 ? module->Pmux(NEWER_ID, SigSpec(State::Sx, GetSize(it.first)), pmux_b, pmux_s) : pmux_b;
 
 				if (no_tribuf)
 					module->connect(it.first, muxout);
 				else {
-					module->addTribuf(NEW_ID, muxout, module->ReduceOr(NEW_ID, pmux_s), it.first);
+					module->addTribuf(NEWER_ID, muxout, module->ReduceOr(NEWER_ID, pmux_s), it.first);
 					module->design->scratchpad_set_bool("tribuf.added_something", true);
 				}
 			}

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -364,9 +364,9 @@ static RTLIL::Cell* create_gold_module(RTLIL::Design *design, RTLIL::IdString ce
 	}
 
 	if (muxdiv && cell_type.in(ID($div), ID($mod), ID($divfloor), ID($modfloor))) {
-		auto b_not_zero = module->ReduceBool(NEW_ID, cell->getPort(ID::B));
-		auto div_out = module->addWire(NEW_ID, GetSize(cell->getPort(ID::Y)));
-		module->addMux(NEW_ID, RTLIL::SigSpec(0, GetSize(div_out)), div_out, b_not_zero, cell->getPort(ID::Y));
+		auto b_not_zero = module->ReduceBool(NEWER_ID, cell->getPort(ID::B));
+		auto div_out = module->addWire(NEWER_ID, GetSize(cell->getPort(ID::Y)));
+		module->addMux(NEWER_ID, RTLIL::SigSpec(0, GetSize(div_out)), div_out, b_not_zero, cell->getPort(ID::Y));
 		cell->setPort(ID::Y, div_out);
 	}
 

--- a/techlibs/anlogic/anlogic_fixcarry.cc
+++ b/techlibs/anlogic/anlogic_fixcarry.cc
@@ -79,9 +79,9 @@ static void fix_carry_chain(Module *module)
 		SigBit canonical_bit = sigmap(bit_ci);
 		auto bit = mapping_bits.at(canonical_bit);
 		log("Fixing %s cell named %s breaking carry chain.\n", log_id(cell->type), log_id(cell));
-		Cell *c = module->addCell(NEW_ID, ID(AL_MAP_ADDER));
-		SigBit new_bit = module->addWire(NEW_ID);
-		SigBit dummy_bit = module->addWire(NEW_ID);
+		Cell *c = module->addCell(NEWER_ID, ID(AL_MAP_ADDER));
+		SigBit new_bit = module->addWire(NEWER_ID);
+		SigBit dummy_bit = module->addWire(NEWER_ID);
 		SigSpec bits;
 		bits.append(dummy_bit);
 		bits.append(new_bit);

--- a/techlibs/efinix/efinix_fixcarry.cc
+++ b/techlibs/efinix/efinix_fixcarry.cc
@@ -75,8 +75,8 @@ static void fix_carry_chain(Module *module)
 		SigBit canonical_bit = sigmap(bit_ci);
 		auto bit = mapping_bits.at(canonical_bit);
 		log("Fixing %s cell named %s breaking carry chain.\n", log_id(cell->type), log_id(cell));
-		Cell *c = module->addCell(NEW_ID, ID(EFX_ADD));
-		SigBit new_bit = module->addWire(NEW_ID);
+		Cell *c = module->addCell(NEWER_ID, ID(EFX_ADD));
+		SigBit new_bit = module->addWire(NEWER_ID);
 		c->setParam(ID(I0_POLARITY), State::S1);
 		c->setParam(ID(I1_POLARITY), State::S1);
 		c->setPort(ID(I0), bit);

--- a/techlibs/gatemate/gatemate_foldinv.cc
+++ b/techlibs/gatemate/gatemate_foldinv.cc
@@ -162,7 +162,7 @@ struct FoldInvWorker {
                 continue;
             // Create a duplicate of the LUT with an inverted output
             // (if the uninverted version becomes unused it will be swept away)
-            Cell *dup_lut = module->addCell(NEW_ID, orig_lut->type);
+            Cell *dup_lut = module->addCell(NEWER_ID, orig_lut->type);
             inv->unsetPort(ID::Y);
             dup_lut->setPort(ID::O, inv_y);
             for (auto conn : orig_lut->connections()) {

--- a/techlibs/ice40/ice40_dsp.cc
+++ b/techlibs/ice40/ice40_dsp.cc
@@ -66,7 +66,7 @@ void create_ice40_dsp(ice40_dsp_pm &pm)
 	if (cell->type == ID($mul)) {
 		log("  replacing %s with SB_MAC16 cell.\n", log_id(st.mul->type));
 
-		cell = pm.module->addCell(NEW_ID, ID(SB_MAC16));
+		cell = pm.module->addCell(NEWER_ID, ID(SB_MAC16));
 		pm.module->swap_names(cell, st.mul);
 	}
 	else log_assert(cell->type == ID(SB_MAC16));
@@ -98,15 +98,15 @@ void create_ice40_dsp(ice40_dsp_pm &pm)
 
 	SigSpec AHOLD, BHOLD, CDHOLD;
 	if (st.ffA && st.ffA->hasPort(ID::EN))
-		AHOLD = st.ffA->getParam(ID::EN_POLARITY).as_bool() ? pm.module->Not(NEW_ID, st.ffA->getPort(ID::EN)) : st.ffA->getPort(ID::EN);
+		AHOLD = st.ffA->getParam(ID::EN_POLARITY).as_bool() ? pm.module->Not(NEWER_ID, st.ffA->getPort(ID::EN)) : st.ffA->getPort(ID::EN);
 	else
 		AHOLD = State::S0;
 	if (st.ffB && st.ffB->hasPort(ID::EN))
-		BHOLD = st.ffB->getParam(ID::EN_POLARITY).as_bool() ? pm.module->Not(NEW_ID, st.ffB->getPort(ID::EN)) : st.ffB->getPort(ID::EN);
+		BHOLD = st.ffB->getParam(ID::EN_POLARITY).as_bool() ? pm.module->Not(NEWER_ID, st.ffB->getPort(ID::EN)) : st.ffB->getPort(ID::EN);
 	else
 		BHOLD = State::S0;
 	if (st.ffCD && st.ffCD->hasPort(ID::EN))
-		CDHOLD = st.ffCD->getParam(ID::EN_POLARITY).as_bool() ? pm.module->Not(NEW_ID, st.ffCD->getPort(ID::EN)) : st.ffCD->getPort(ID::EN);
+		CDHOLD = st.ffCD->getParam(ID::EN_POLARITY).as_bool() ? pm.module->Not(NEWER_ID, st.ffCD->getPort(ID::EN)) : st.ffCD->getPort(ID::EN);
 	else
 		CDHOLD = State::S0;
 	cell->setPort(ID(AHOLD), AHOLD);
@@ -116,11 +116,11 @@ void create_ice40_dsp(ice40_dsp_pm &pm)
 
 	SigSpec IRSTTOP, IRSTBOT;
 	if (st.ffA && st.ffA->hasPort(ID::ARST))
-		IRSTTOP = st.ffA->getParam(ID::ARST_POLARITY).as_bool() ? st.ffA->getPort(ID::ARST) : pm.module->Not(NEW_ID, st.ffA->getPort(ID::ARST));
+		IRSTTOP = st.ffA->getParam(ID::ARST_POLARITY).as_bool() ? st.ffA->getPort(ID::ARST) : pm.module->Not(NEWER_ID, st.ffA->getPort(ID::ARST));
 	else
 		IRSTTOP = State::S0;
 	if (st.ffB && st.ffB->hasPort(ID::ARST))
-		IRSTBOT = st.ffB->getParam(ID::ARST_POLARITY).as_bool() ? st.ffB->getPort(ID::ARST) : pm.module->Not(NEW_ID, st.ffB->getPort(ID::ARST));
+		IRSTBOT = st.ffB->getParam(ID::ARST_POLARITY).as_bool() ? st.ffB->getPort(ID::ARST) : pm.module->Not(NEWER_ID, st.ffB->getPort(ID::ARST));
 	else
 		IRSTBOT = State::S0;
 	cell->setPort(ID(IRSTTOP), IRSTTOP);
@@ -164,12 +164,12 @@ void create_ice40_dsp(ice40_dsp_pm &pm)
 	// SB_MAC16 Cascade Interface
 
 	cell->setPort(ID(SIGNEXTIN), State::Sx);
-	cell->setPort(ID(SIGNEXTOUT), pm.module->addWire(NEW_ID));
+	cell->setPort(ID(SIGNEXTOUT), pm.module->addWire(NEWER_ID));
 
 	cell->setPort(ID::CI, State::Sx);
 
 	cell->setPort(ID(ACCUMCI), State::Sx);
-	cell->setPort(ID(ACCUMCO), pm.module->addWire(NEW_ID));
+	cell->setPort(ID(ACCUMCO), pm.module->addWire(NEWER_ID));
 
 	// SB_MAC16 Output Interface
 
@@ -185,10 +185,10 @@ void create_ice40_dsp(ice40_dsp_pm &pm)
 		O.remove(O_width-1);
 	}
 	else
-		cell->setPort(ID::CO, pm.module->addWire(NEW_ID));
+		cell->setPort(ID::CO, pm.module->addWire(NEWER_ID));
 	log_assert(GetSize(O) <= 32);
 	if (GetSize(O) < 32)
-		O.append(pm.module->addWire(NEW_ID, 32-GetSize(O)));
+		O.append(pm.module->addWire(NEWER_ID, 32-GetSize(O)));
 
 	cell->setPort(ID::O, O);
 
@@ -208,7 +208,7 @@ void create_ice40_dsp(ice40_dsp_pm &pm)
 
 	SigSpec OHOLD;
 	if (st.ffO && st.ffO->hasPort(ID::EN))
-		OHOLD = st.ffO->getParam(ID::EN_POLARITY).as_bool() ? pm.module->Not(NEW_ID, st.ffO->getPort(ID::EN)) : st.ffO->getPort(ID::EN);
+		OHOLD = st.ffO->getParam(ID::EN_POLARITY).as_bool() ? pm.module->Not(NEWER_ID, st.ffO->getPort(ID::EN)) : st.ffO->getPort(ID::EN);
 	else
 		OHOLD = State::S0;
 	cell->setPort(ID(OHOLDTOP), OHOLD);
@@ -216,7 +216,7 @@ void create_ice40_dsp(ice40_dsp_pm &pm)
 
 	SigSpec ORST;
 	if (st.ffO && st.ffO->hasPort(ID::ARST))
-		ORST = st.ffO->getParam(ID::ARST_POLARITY).as_bool() ? st.ffO->getPort(ID::ARST) : pm.module->Not(NEW_ID, st.ffO->getPort(ID::ARST));
+		ORST = st.ffO->getParam(ID::ARST_POLARITY).as_bool() ? st.ffO->getPort(ID::ARST) : pm.module->Not(NEWER_ID, st.ffO->getPort(ID::ARST));
 	else
 		ORST = State::S0;
 	cell->setPort(ID(ORSTTOP), ORST);
@@ -227,9 +227,9 @@ void create_ice40_dsp(ice40_dsp_pm &pm)
 		if (st.muxAB == ID::A)
 			acc_reset = st.mux->getPort(ID::S);
 		else
-			acc_reset = pm.module->Not(NEW_ID, st.mux->getPort(ID::S));
+			acc_reset = pm.module->Not(NEWER_ID, st.mux->getPort(ID::S));
 	} else if (st.ffO && st.ffO->hasPort(ID::SRST)) {
-		acc_reset = st.ffO->getParam(ID::SRST_POLARITY).as_bool() ? st.ffO->getPort(ID::SRST) : pm.module->Not(NEW_ID, st.ffO->getPort(ID::SRST));
+		acc_reset = st.ffO->getParam(ID::SRST_POLARITY).as_bool() ? st.ffO->getPort(ID::SRST) : pm.module->Not(NEWER_ID, st.ffO->getPort(ID::SRST));
 	}
 	cell->setPort(ID(OLOADTOP), acc_reset);
 	cell->setPort(ID(OLOADBOT), acc_reset);
@@ -259,7 +259,7 @@ void create_ice40_dsp(ice40_dsp_pm &pm)
 		else
 			cell->setParam(ID(TOPOUTPUT_SELECT), Const(1, 2));
 
-		st.ffO->connections_.at(ID::Q).replace(O, pm.module->addWire(NEW_ID, GetSize(O)));
+		st.ffO->connections_.at(ID::Q).replace(O, pm.module->addWire(NEWER_ID, GetSize(O)));
 		cell->setParam(ID(BOTOUTPUT_SELECT), Const(1, 2));
 	}
 	else {

--- a/techlibs/ice40/ice40_dsp.pmg
+++ b/techlibs/ice40/ice40_dsp.pmg
@@ -66,7 +66,7 @@ code sigA sigB sigH
 			wire_width++;
 		else {
 			if (wire_width) { // add empty wires for bit offset if needed
-				sigH.append(module->addWire(NEW_ID, wire_width));
+				sigH.append(module->addWire(NEWER_ID, wire_width));
 				wire_width = 0;
 			}
 			sigH.append(O[j]);

--- a/techlibs/ice40/ice40_wrapcarry.cc
+++ b/techlibs/ice40/ice40_wrapcarry.cc
@@ -37,7 +37,7 @@ void create_ice40_wrapcarry(ice40_wrapcarry_pm &pm)
 
 	log("  replacing SB_LUT + SB_CARRY with $__ICE40_CARRY_WRAPPER cell.\n");
 
-	Cell *cell = pm.module->addCell(NEW_ID, ID($__ICE40_CARRY_WRAPPER));
+	Cell *cell = pm.module->addCell(NEWER_ID, ID($__ICE40_CARRY_WRAPPER));
 	pm.module->swap_names(cell, st.carry);
 
 	cell->setPort(ID::A, st.carry->getPort(ID(I0)));
@@ -116,13 +116,13 @@ struct Ice40WrapCarryPass : public Pass {
 					if (cell->type != ID($__ICE40_CARRY_WRAPPER))
 						continue;
 
-					auto carry = module->addCell(NEW_ID, ID(SB_CARRY));
+					auto carry = module->addCell(NEWER_ID, ID(SB_CARRY));
 					carry->setPort(ID(I0), cell->getPort(ID::A));
 					carry->setPort(ID(I1), cell->getPort(ID::B));
 					carry->setPort(ID::CI, cell->getPort(ID::CI));
 					carry->setPort(ID::CO, cell->getPort(ID::CO));
 					module->swap_names(carry, cell);
-					auto lut_name = cell->attributes.at(ID(SB_LUT4.name), Const(NEW_ID.str())).decode_string();
+					auto lut_name = cell->attributes.at(ID(SB_LUT4.name), Const(NEWER_ID.str())).decode_string();
 					auto lut = module->addCell(lut_name, ID($lut));
 					lut->setParam(ID::WIDTH, 4);
 					lut->setParam(ID::LUT, cell->getParam(ID::LUT));

--- a/techlibs/microchip/microchip_dffopt.cc
+++ b/techlibs/microchip/microchip_dffopt.cc
@@ -309,22 +309,22 @@ struct MicrochipDffOptPass : public Pass {
 				Cell *lut_cell = nullptr;
 				switch (GetSize(final_lut.second)) {
 				case 1:
-					lut_cell = module->addCell(NEW_ID, ID(CFG1));
+					lut_cell = module->addCell(NEWER_ID, ID(CFG1));
 					break;
 				case 2:
-					lut_cell = module->addCell(NEW_ID, ID(CFG2));
+					lut_cell = module->addCell(NEWER_ID, ID(CFG2));
 					break;
 				case 3:
-					lut_cell = module->addCell(NEW_ID, ID(CFG3));
+					lut_cell = module->addCell(NEWER_ID, ID(CFG3));
 					break;
 				case 4:
-					lut_cell = module->addCell(NEW_ID, ID(CFG4));
+					lut_cell = module->addCell(NEWER_ID, ID(CFG4));
 					break;
 				default:
 					log_assert(!"unknown lut size");
 				}
 				lut_cell->attributes = cell_d->attributes;
-				Wire *lut_out = module->addWire(NEW_ID);
+				Wire *lut_out = module->addWire(NEWER_ID);
 				lut_cell->setParam(ID::INIT, final_lut.first);
 				cell->setPort(ID::D, lut_out);
 				lut_cell->setPort(ID::Y, lut_out);

--- a/techlibs/microchip/microchip_dsp.cc
+++ b/techlibs/microchip/microchip_dsp.cc
@@ -98,12 +98,12 @@ void microchip_dsp_pack(microchip_dsp_pm &pm)
 					SigSpec srst = ff->getPort(ID::SRST);
 					bool rstpol_n = !ff->getParam(ID::SRST_POLARITY).as_bool();
 					// active low sync rst
-					cell->setPort(rstport, rstpol_n ? srst : pm.module->Not(NEW_ID, srst));
+					cell->setPort(rstport, rstpol_n ? srst : pm.module->Not(NEWER_ID, srst));
 				} else if (ff->type.in(ID($adff), ID($adffe))) {
 					SigSpec arst = ff->getPort(ID::ARST);
 					bool rstpol_n = !ff->getParam(ID::ARST_POLARITY).as_bool();
 					// active low async rst
-					cell->setPort(rstport, rstpol_n ? arst : pm.module->Not(NEW_ID, arst));
+					cell->setPort(rstport, rstpol_n ? arst : pm.module->Not(NEWER_ID, arst));
 				} else {
 					// active low async/sync rst
 					cell->setPort(rstport, State::S1);
@@ -113,7 +113,7 @@ void microchip_dsp_pack(microchip_dsp_pm &pm)
 				SigSpec ce = ff->getPort(ID::EN);
 				bool cepol = ff->getParam(ID::EN_POLARITY).as_bool();
 				// enables are all active high
-				cell->setPort(ceport, cepol ? ce : pm.module->Not(NEW_ID, ce));
+				cell->setPort(ceport, cepol ? ce : pm.module->Not(NEWER_ID, ce));
 			} else {
 				// enables are all active high
 				cell->setPort(ceport, State::S1);
@@ -165,7 +165,7 @@ void microchip_dsp_pack(microchip_dsp_pm &pm)
 		if (st.ffP) {
 			SigSpec P; // unused
 			f(P, st.ffP, ID(P_EN), ID(P_SRST_N), ID(P_BYPASS));
-			st.ffP->connections_.at(ID::Q).replace(st.sigP, pm.module->addWire(NEW_ID, GetSize(st.sigP)));
+			st.ffP->connections_.at(ID::Q).replace(st.sigP, pm.module->addWire(NEWER_ID, GetSize(st.sigP)));
 		}
 
 		log("  clock: %s (%s)\n", log_signal(st.clock), "posedge");
@@ -183,7 +183,7 @@ void microchip_dsp_pack(microchip_dsp_pm &pm)
 
 	SigSpec P = st.sigP;
 	if (GetSize(P) < 48)
-		P.append(pm.module->addWire(NEW_ID, 48 - GetSize(P)));
+		P.append(pm.module->addWire(NEWER_ID, 48 - GetSize(P)));
 	cell->setPort(ID::P, P);
 
 	pm.blacklist(cell);
@@ -214,12 +214,12 @@ void microchip_dsp_packC(microchip_dsp_CREG_pm &pm)
 					SigSpec srst = ff->getPort(ID::SRST);
 					bool rstpol_n = !ff->getParam(ID::SRST_POLARITY).as_bool();
 					// active low sync rst
-					cell->setPort(rstport, rstpol_n ? srst : pm.module->Not(NEW_ID, srst));
+					cell->setPort(rstport, rstpol_n ? srst : pm.module->Not(NEWER_ID, srst));
 				} else if (ff->type.in(ID($adff), ID($adffe))) {
 					SigSpec arst = ff->getPort(ID::ARST);
 					bool rstpol_n = !ff->getParam(ID::ARST_POLARITY).as_bool();
 					// active low async rst
-					cell->setPort(rstport, rstpol_n ? arst : pm.module->Not(NEW_ID, arst));
+					cell->setPort(rstport, rstpol_n ? arst : pm.module->Not(NEWER_ID, arst));
 				} else {
 					// active low async/sync rst
 					cell->setPort(rstport, State::S1);
@@ -229,7 +229,7 @@ void microchip_dsp_packC(microchip_dsp_CREG_pm &pm)
 				SigSpec ce = ff->getPort(ID::EN);
 				bool cepol = ff->getParam(ID::EN_POLARITY).as_bool();
 				// enables are all active high
-				cell->setPort(ceport, cepol ? ce : pm.module->Not(NEW_ID, ce));
+				cell->setPort(ceport, cepol ? ce : pm.module->Not(NEWER_ID, ce));
 			} else {
 				// enables are all active high
 				cell->setPort(ceport, State::S1);

--- a/techlibs/microchip/microchip_dsp_cascade.pmg
+++ b/techlibs/microchip/microchip_dsp_cascade.pmg
@@ -112,7 +112,7 @@ finally
 
 			// Chain length exceeds the maximum cascade length, must split it up
 			if (i % MAX_DSP_CASCADE > 0) {
-				Wire *cascade = module->addWire(NEW_ID, 48);
+				Wire *cascade = module->addWire(NEWER_ID, 48);
 
 				// zero port C and move wire to cascade
 				dsp_pcin->setPort(ID(C), Const(0, 48));

--- a/techlibs/nanoxplore/nx_carry.cc
+++ b/techlibs/nanoxplore/nx_carry.cc
@@ -81,7 +81,7 @@ static void nx_carry_chain(Module *module)
 		IdString names_B[] = { ID(B1), ID(B2), ID(B3), ID(B4) };
 		IdString names_S[] = { ID(S1), ID(S2), ID(S3), ID(S4) };
 		if (!c.second.at(0)->getPort(ID(CI)).is_fully_const()) {
-			cell = module->addCell(NEW_ID, ID(NX_CY));
+			cell = module->addCell(NEWER_ID, ID(NX_CY));
 			cell->setParam(ID(add_carry), Const(1,2));
 			cell->setPort(ID(CI), State::S1);
 
@@ -92,7 +92,7 @@ static void nx_carry_chain(Module *module)
 
 		for (size_t i=0 ; i<c.second.size(); i++) {
 			if (j==0) {
-				cell = module->addCell(NEW_ID, ID(NX_CY));
+				cell = module->addCell(NEWER_ID, ID(NX_CY));
 				SigBit ci = c.second.at(i)->getPort(ID(CI)).as_bit();
 				cell->setPort(ID(CI), ci);
 				if (ci.is_wire()) {
@@ -106,11 +106,11 @@ static void nx_carry_chain(Module *module)
 			}
 			if (j==3) {
 				if (cnt !=0 && (cnt % 24 == 0)) {
-					SigBit new_co = module->addWire(NEW_ID);
+					SigBit new_co = module->addWire(NEWER_ID);
 					cell->setPort(ID(A4), State::S0);
 					cell->setPort(ID(B4), State::S0);
 					cell->setPort(ID(S4), new_co);
-					cell = module->addCell(NEW_ID, ID(NX_CY));
+					cell = module->addCell(NEWER_ID, ID(NX_CY));
 					cell->setParam(ID(add_carry), Const(1,2));
 					cell->setPort(ID(CI), State::S1);
 					cell->setPort(ID(A1), new_co);

--- a/techlibs/quicklogic/ql_bram_merge.cc
+++ b/techlibs/quicklogic/ql_bram_merge.cc
@@ -127,7 +127,7 @@ struct QlBramMergeWorker {
 		const RTLIL::IdString merged_cell_type = ID($__QLF_TDP36K_MERGED);
 
 		// Create the new cell
-		RTLIL::Cell* merged = module->addCell(NEW_ID, merged_cell_type);
+		RTLIL::Cell* merged = module->addCell(NEWER_ID, merged_cell_type);
 		log_debug("Merging split BRAM cells %s and %s -> %s\n", log_id(bram1->name), log_id(bram2->name), log_id(merged->name));
 
 		for (auto &it : param_map(false))

--- a/techlibs/quicklogic/ql_dsp_macc.cc
+++ b/techlibs/quicklogic/ql_dsp_macc.cc
@@ -80,7 +80,7 @@ static void create_ql_macc_dsp(ql_dsp_macc_pm &pm)
         log("  %s (%s)\n", log_id(cell), log_id(cell->type));
 
     // Add the DSP cell
-    RTLIL::Cell *cell = pm.module->addCell(NEW_ID, type);
+    RTLIL::Cell *cell = pm.module->addCell(NEWER_ID, type);
 
     // Set attributes
     cell->set_bool_attribute(ID(is_inferred), true);
@@ -102,7 +102,7 @@ static void create_ql_macc_dsp(ql_dsp_macc_pm &pm)
 
     // Connect output data port, pad if needed
     if ((size_t) GetSize(sig_z) < tgt_z_width) {
-        auto *wire = pm.module->addWire(NEW_ID, tgt_z_width - GetSize(sig_z));
+        auto *wire = pm.module->addWire(NEWER_ID, tgt_z_width - GetSize(sig_z));
         sig_z.append(wire);
     }
     cell->setPort(ID(z_o), sig_z);
@@ -115,7 +115,7 @@ static void create_ql_macc_dsp(ql_dsp_macc_pm &pm)
 
     if (st.ff->hasPort(ID(ARST))) {
         if (st.ff->getParam(ID(ARST_POLARITY)).as_int() != 1) {
-            rst = pm.module->Not(NEW_ID, st.ff->getPort(ID(ARST)));
+            rst = pm.module->Not(NEWER_ID, st.ff->getPort(ID(ARST)));
         } else {
             rst = st.ff->getPort(ID(ARST));
         }
@@ -125,7 +125,7 @@ static void create_ql_macc_dsp(ql_dsp_macc_pm &pm)
 
     if (st.ff->hasPort(ID(EN))) {
         if (st.ff->getParam(ID(EN_POLARITY)).as_int() != 1) {
-            ena = pm.module->Not(NEW_ID, st.ff->getPort(ID(EN)));
+            ena = pm.module->Not(NEWER_ID, st.ff->getPort(ID(EN)));
         } else {
             ena = st.ff->getPort(ID(EN));
         }
@@ -143,7 +143,7 @@ static void create_ql_macc_dsp(ql_dsp_macc_pm &pm)
         // Depending on the mux port ordering insert inverter if needed
         log_assert(st.mux_ab.in(ID(A), ID(B)));
         if (st.mux_ab == ID(A))
-            sig_s = pm.module->Not(NEW_ID, sig_s);
+            sig_s = pm.module->Not(NEWER_ID, sig_s);
 
         // Assemble the full control signal for the feedback_i port
         RTLIL::SigSpec sig_f;

--- a/techlibs/quicklogic/ql_dsp_simd.cc
+++ b/techlibs/quicklogic/ql_dsp_simd.cc
@@ -148,7 +148,7 @@ struct QlDspSimdPass : public Pass {
 					Cell *dsp_b = group[i + 1];
 
 					// Create the new cell
-					Cell *simd = module->addCell(NEW_ID, m_SimdDspType);
+					Cell *simd = module->addCell(NEWER_ID, m_SimdDspType);
 
 					log(" SIMD: %s (%s) + %s (%s) => %s (%s)\n", log_id(dsp_a), log_id(dsp_a->type),
 						log_id(dsp_b), log_id(dsp_b->type), log_id(simd), log_id(simd->type));
@@ -182,7 +182,7 @@ struct QlDspSimdPass : public Pass {
 								if (!isOutput)
 									sigspec.append(RTLIL::SigSpec(RTLIL::Sx, padding));
 								else
-									sigspec.append(module->addWire(NEW_ID, padding));
+									sigspec.append(module->addWire(NEWER_ID, padding));
 							}
 							return sigspec;
 						};

--- a/techlibs/quicklogic/ql_ioff.cc
+++ b/techlibs/quicklogic/ql_ioff.cc
@@ -91,7 +91,7 @@ struct QlIoffPass : public Pass {
 			if (std::any_of(ioff_cells.begin(), ioff_cells.end(), [](Cell * c) { return c != nullptr; }))
 			{
 				// create replacement output wire
-				RTLIL::Wire* new_port_output = module->addWire(NEW_ID, old_port_output->width);
+				RTLIL::Wire* new_port_output = module->addWire(NEWER_ID, old_port_output->width);
 				new_port_output->start_offset = old_port_output->start_offset;
 				module->swap_names(old_port_output, new_port_output);
 				std::swap(old_port_output->port_id, new_port_output->port_id);
@@ -108,7 +108,7 @@ struct QlIoffPass : public Pass {
 					if (ioff_cells[i]) {
 						log("Promoting %s to output IOFF.\n", log_signal(sig_n[i]));
 
-						RTLIL::Cell *new_cell = module->addCell(NEW_ID, ID(dff));
+						RTLIL::Cell *new_cell = module->addCell(NEWER_ID, ID(dff));
 						new_cell->setPort(ID::C, ioff_cells[i]->getPort(ID::C));
 						new_cell->setPort(ID::D, ioff_cells[i]->getPort(ID::D));
 						new_cell->setPort(ID::Q, sig_n[i]);

--- a/techlibs/xilinx/xilinx_dffopt.cc
+++ b/techlibs/xilinx/xilinx_dffopt.cc
@@ -323,28 +323,28 @@ unmap:
 				Cell *lut_cell = 0;
 				switch (GetSize(final_lut.second)) {
 					case 1:
-						lut_cell = module->addCell(NEW_ID, ID(LUT1));
+						lut_cell = module->addCell(NEWER_ID, ID(LUT1));
 						break;
 					case 2:
-						lut_cell = module->addCell(NEW_ID, ID(LUT2));
+						lut_cell = module->addCell(NEWER_ID, ID(LUT2));
 						break;
 					case 3:
-						lut_cell = module->addCell(NEW_ID, ID(LUT3));
+						lut_cell = module->addCell(NEWER_ID, ID(LUT3));
 						break;
 					case 4:
-						lut_cell = module->addCell(NEW_ID, ID(LUT4));
+						lut_cell = module->addCell(NEWER_ID, ID(LUT4));
 						break;
 					case 5:
-						lut_cell = module->addCell(NEW_ID, ID(LUT5));
+						lut_cell = module->addCell(NEWER_ID, ID(LUT5));
 						break;
 					case 6:
-						lut_cell = module->addCell(NEW_ID, ID(LUT6));
+						lut_cell = module->addCell(NEWER_ID, ID(LUT6));
 						break;
 					default:
 						log_assert(!"unknown lut size");
 				}
 				lut_cell->attributes = cell_d->attributes;
-				Wire *lut_out = module->addWire(NEW_ID);
+				Wire *lut_out = module->addWire(NEWER_ID);
 				lut_cell->setParam(ID::INIT, final_lut.first);
 				cell->setPort(ID::D, lut_out);
 				lut_cell->setPort(ID::O, lut_out);

--- a/techlibs/xilinx/xilinx_dsp.cc
+++ b/techlibs/xilinx/xilinx_dsp.cc
@@ -31,7 +31,7 @@ PRIVATE_NAMESPACE_BEGIN
 #include "techlibs/xilinx/xilinx_dsp_cascade_pm.h"
 
 static Cell* addDsp(Module *module) {
-	Cell *cell = module->addCell(NEW_ID, ID(DSP48E1));
+	Cell *cell = module->addCell(NEWER_ID, ID(DSP48E1));
 	cell->setParam(ID(ACASCREG), 0);
 	cell->setParam(ID(ADREG), 0);
 	cell->setParam(ID(A_INPUT), Const("DIRECT"));
@@ -114,7 +114,7 @@ void xilinx_simd_pack(Module *module, const std::vector<Cell*> &selected_cells)
 		AB.append(A);
 		C.append(B);
 		if (GetSize(Y) < 13)
-			Y.append(module->addWire(NEW_ID, 13-GetSize(Y)));
+			Y.append(module->addWire(NEWER_ID, 13-GetSize(Y)));
 		else
 			log_assert(GetSize(Y) == 13);
 		P.append(Y.extract(0, 12));
@@ -160,15 +160,15 @@ void xilinx_simd_pack(Module *module, const std::vector<Cell*> &selected_cells)
 				else {
 					AB.append(Const(0, 12));
 					C.append(Const(0, 12));
-					P.append(module->addWire(NEW_ID, 12));
-					CARRYOUT.append(module->addWire(NEW_ID, 1));
+					P.append(module->addWire(NEWER_ID, 12));
+					CARRYOUT.append(module->addWire(NEWER_ID, 1));
 				}
 			}
 			else {
 				AB.append(Const(0, 24));
 				C.append(Const(0, 24));
-				P.append(module->addWire(NEW_ID, 24));
-				CARRYOUT.append(module->addWire(NEW_ID, 2));
+				P.append(module->addWire(NEWER_ID, 24));
+				CARRYOUT.append(module->addWire(NEWER_ID, 2));
 			}
 			log_assert(GetSize(AB) == 48);
 			log_assert(GetSize(C) == 48);
@@ -202,11 +202,11 @@ void xilinx_simd_pack(Module *module, const std::vector<Cell*> &selected_cells)
 		C.append(A);
 		AB.append(B);
 		if (GetSize(Y) < 25)
-			Y.append(module->addWire(NEW_ID, 25-GetSize(Y)));
+			Y.append(module->addWire(NEWER_ID, 25-GetSize(Y)));
 		else
 			log_assert(GetSize(Y) == 25);
 		P.append(Y.extract(0, 24));
-		CARRYOUT.append(module->addWire(NEW_ID)); // TWO24 uses every other bit
+		CARRYOUT.append(module->addWire(NEWER_ID)); // TWO24 uses every other bit
 		CARRYOUT.append(Y[24]);
 	};
 	auto g24 = [&f24,module](std::deque<Cell*> &simd24) {
@@ -294,7 +294,7 @@ void xilinx_dsp_pack(xilinx_dsp_pm &pm)
 			if (st.ffAD->type.in(ID($dffe), ID($sdffe))) {
 				bool pol = st.ffAD->getParam(ID::EN_POLARITY).as_bool();
 				SigSpec S = st.ffAD->getPort(ID::EN);
-				cell->setPort(ID(CEAD), pol ? S : pm.module->Not(NEW_ID, S));
+				cell->setPort(ID(CEAD), pol ? S : pm.module->Not(NEWER_ID, S));
 			}
 			else
 				cell->setPort(ID(CEAD), State::S1);
@@ -373,7 +373,7 @@ void xilinx_dsp_pack(xilinx_dsp_pm &pm)
 				if (ff->type.in(ID($sdff), ID($sdffe))) {
 					SigSpec srst = ff->getPort(ID::SRST);
 					bool rstpol = ff->getParam(ID::SRST_POLARITY).as_bool();
-					cell->setPort(rstport, rstpol ? srst : pm.module->Not(NEW_ID, srst));
+					cell->setPort(rstport, rstpol ? srst : pm.module->Not(NEWER_ID, srst));
 				} else {
 					cell->setPort(rstport, State::S0);
 				}
@@ -381,7 +381,7 @@ void xilinx_dsp_pack(xilinx_dsp_pm &pm)
 			if (ff->type.in(ID($dffe), ID($sdffe))) {
 				SigSpec ce = ff->getPort(ID::EN);
 				bool cepol = ff->getParam(ID::EN_POLARITY).as_bool();
-				cell->setPort(ceport, cepol ? ce : pm.module->Not(NEW_ID, ce));
+				cell->setPort(ceport, cepol ? ce : pm.module->Not(NEWER_ID, ce));
 			}
 			else
 				cell->setPort(ceport, State::S1);
@@ -437,13 +437,13 @@ void xilinx_dsp_pack(xilinx_dsp_pm &pm)
 		if (st.ffM) {
 			SigSpec M; // unused
 			f(M, st.ffM, ID(CEM), ID(RSTM));
-			st.ffM->connections_.at(ID::Q).replace(st.sigM, pm.module->addWire(NEW_ID, GetSize(st.sigM)));
+			st.ffM->connections_.at(ID::Q).replace(st.sigM, pm.module->addWire(NEWER_ID, GetSize(st.sigM)));
 			cell->setParam(ID(MREG), State::S1);
 		}
 		if (st.ffP) {
 			SigSpec P; // unused
 			f(P, st.ffP, ID(CEP), ID(RSTP));
-			st.ffP->connections_.at(ID::Q).replace(st.sigP, pm.module->addWire(NEW_ID, GetSize(st.sigP)));
+			st.ffP->connections_.at(ID::Q).replace(st.sigP, pm.module->addWire(NEWER_ID, GetSize(st.sigP)));
 			cell->setParam(ID(PREG), State::S1);
 		}
 
@@ -477,7 +477,7 @@ void xilinx_dsp_pack(xilinx_dsp_pm &pm)
 
 	SigSpec P = st.sigP;
 	if (GetSize(P) < 48)
-		P.append(pm.module->addWire(NEW_ID, 48-GetSize(P)));
+		P.append(pm.module->addWire(NEWER_ID, 48-GetSize(P)));
 	cell->setPort(ID::P, P);
 
 	pm.blacklist(cell);
@@ -560,7 +560,7 @@ void xilinx_dsp48a_pack(xilinx_dsp48a_pm &pm)
 				if (ff->type.in(ID($sdff), ID($sdffe))) {
 					SigSpec srst = ff->getPort(ID::SRST);
 					bool rstpol = ff->getParam(ID::SRST_POLARITY).as_bool();
-					cell->setPort(rstport, rstpol ? srst : pm.module->Not(NEW_ID, srst));
+					cell->setPort(rstport, rstpol ? srst : pm.module->Not(NEWER_ID, srst));
 				} else {
 					cell->setPort(rstport, State::S0);
 				}
@@ -568,7 +568,7 @@ void xilinx_dsp48a_pack(xilinx_dsp48a_pm &pm)
 			if (ff->type.in(ID($dffe), ID($sdffe))) {
 				SigSpec ce = ff->getPort(ID::EN);
 				bool cepol = ff->getParam(ID::EN_POLARITY).as_bool();
-				cell->setPort(ceport, cepol ? ce : pm.module->Not(NEW_ID, ce));
+				cell->setPort(ceport, cepol ? ce : pm.module->Not(NEWER_ID, ce));
 			}
 			else
 				cell->setPort(ceport, State::S1);
@@ -620,13 +620,13 @@ void xilinx_dsp48a_pack(xilinx_dsp48a_pm &pm)
 		if (st.ffM) {
 			SigSpec M; // unused
 			f(M, st.ffM, ID(CEM), ID(RSTM));
-			st.ffM->connections_.at(ID::Q).replace(st.sigM, pm.module->addWire(NEW_ID, GetSize(st.sigM)));
+			st.ffM->connections_.at(ID::Q).replace(st.sigM, pm.module->addWire(NEWER_ID, GetSize(st.sigM)));
 			cell->setParam(ID(MREG), State::S1);
 		}
 		if (st.ffP) {
 			SigSpec P; // unused
 			f(P, st.ffP, ID(CEP), ID(RSTP));
-			st.ffP->connections_.at(ID::Q).replace(st.sigP, pm.module->addWire(NEW_ID, GetSize(st.sigP)));
+			st.ffP->connections_.at(ID::Q).replace(st.sigP, pm.module->addWire(NEWER_ID, GetSize(st.sigP)));
 			cell->setParam(ID(PREG), State::S1);
 		}
 
@@ -655,7 +655,7 @@ void xilinx_dsp48a_pack(xilinx_dsp48a_pm &pm)
 
 	SigSpec P = st.sigP;
 	if (GetSize(P) < 48)
-		P.append(pm.module->addWire(NEW_ID, 48-GetSize(P)));
+		P.append(pm.module->addWire(NEWER_ID, 48-GetSize(P)));
 	cell->setPort(ID::P, P);
 
 	pm.blacklist(cell);
@@ -683,7 +683,7 @@ void xilinx_dsp_packC(xilinx_dsp_CREG_pm &pm)
 				if (ff->type.in(ID($sdff), ID($sdffe))) {
 					SigSpec srst = ff->getPort(ID::SRST);
 					bool rstpol = ff->getParam(ID::SRST_POLARITY).as_bool();
-					cell->setPort(rstport, rstpol ? srst : pm.module->Not(NEW_ID, srst));
+					cell->setPort(rstport, rstpol ? srst : pm.module->Not(NEWER_ID, srst));
 				} else {
 					cell->setPort(rstport, State::S0);
 				}
@@ -691,7 +691,7 @@ void xilinx_dsp_packC(xilinx_dsp_CREG_pm &pm)
 			if (ff->type.in(ID($dffe), ID($sdffe))) {
 				SigSpec ce = ff->getPort(ID::EN);
 				bool cepol = ff->getParam(ID::EN_POLARITY).as_bool();
-				cell->setPort(ceport, cepol ? ce : pm.module->Not(NEW_ID, ce));
+				cell->setPort(ceport, cepol ? ce : pm.module->Not(NEWER_ID, ce));
 			}
 			else
 				cell->setPort(ceport, State::S1);

--- a/techlibs/xilinx/xilinx_dsp_cascade.pmg
+++ b/techlibs/xilinx/xilinx_dsp_cascade.pmg
@@ -89,7 +89,7 @@ finally
 
 			if (i % MAX_DSP_CASCADE > 0) {
 				if (P >= 0) {
-					Wire *cascade = module->addWire(NEW_ID, 48);
+					Wire *cascade = module->addWire(NEWER_ID, 48);
 					dsp_pcin->setPort(ID(C), Const(0, 48));
 					dsp_pcin->setPort(ID(PCIN), cascade);
 					dsp->setPort(ID(PCOUT), cascade);
@@ -117,7 +117,7 @@ finally
 					log_debug("PCOUT -> PCIN cascade for %s -> %s\n", log_id(dsp), log_id(dsp_pcin));
 				}
 				if (AREG >= 0) {
-					Wire *cascade = module->addWire(NEW_ID, 30);
+					Wire *cascade = module->addWire(NEWER_ID, 30);
 					dsp_pcin->setPort(ID(A), Const(0, 30));
 					dsp_pcin->setPort(ID(ACIN), cascade);
 					dsp->setPort(ID(ACOUT), cascade);
@@ -131,7 +131,7 @@ finally
 					log_debug("ACOUT -> ACIN cascade for %s -> %s\n", log_id(dsp), log_id(dsp_pcin));
 				}
 				if (BREG >= 0) {
-					Wire *cascade = module->addWire(NEW_ID, 18);
+					Wire *cascade = module->addWire(NEWER_ID, 18);
 					if (dsp->type.in(\DSP48A, \DSP48A1)) {
 						// According to UG389 p9 [https://www.xilinx.com/support/documentation/user_guides/ug389.pdf]
 						// "The DSP48A1 component uses this input when cascading

--- a/techlibs/xilinx/xilinx_srl.cc
+++ b/techlibs/xilinx/xilinx_srl.cc
@@ -59,7 +59,7 @@ void run_fixed(xilinx_srl_pm &pm)
 
 	auto first_cell = ud.longest_chain.back();
 	auto last_cell = ud.longest_chain.front();
-	Cell *c = pm.module->addCell(NEW_ID, ID($__XILINX_SHREG_));
+	Cell *c = pm.module->addCell(NEWER_ID, ID($__XILINX_SHREG_));
 	pm.module->swap_names(c, first_cell);
 
 	if (first_cell->type.in(ID($_DFF_N_), ID($_DFF_P_), ID($_DFFE_NN_), ID($_DFFE_NP_), ID($_DFFE_PN_), ID($_DFFE_PP_), ID(FDRE), ID(FDRE_1))) {
@@ -134,7 +134,7 @@ void run_variable(xilinx_srl_pm &pm)
 	auto first_cell = ud.chain.back().first;
 	auto first_slice = ud.chain.back().second;
 
-	Cell *c = pm.module->addCell(NEW_ID, ID($__XILINX_SHREG_));
+	Cell *c = pm.module->addCell(NEWER_ID, ID($__XILINX_SHREG_));
 	pm.module->swap_names(c, first_cell);
 
 	if (first_cell->type.in(ID($_DFF_N_), ID($_DFF_P_), ID($_DFFE_NN_), ID($_DFFE_NP_), ID($_DFFE_PN_), ID($_DFFE_PP_), ID($dff), ID($dffe))) {

--- a/techlibs/xilinx/xilinx_srl.pmg
+++ b/techlibs/xilinx/xilinx_srl.pmg
@@ -18,22 +18,22 @@ match first
 	select !first->type.in(\FDRE, \FDRE_1) || port(first, \R, State::S0).is_fully_zero()
 	filter !non_first_cells.count(first)
 generate
-	SigSpec C = module->addWire(NEW_ID);
-	SigSpec D = module->addWire(NEW_ID);
-	SigSpec Q = module->addWire(NEW_ID);
+	SigSpec C = module->addWire(NEWER_ID);
+	SigSpec D = module->addWire(NEWER_ID);
+	SigSpec Q = module->addWire(NEWER_ID);
 	auto r = rng(8);
 	Cell* cell;
 	switch (r)
 	{
 	case 0:
 	case 1:
-		cell = module->addCell(NEW_ID, \FDRE);
+		cell = module->addCell(NEWER_ID, \FDRE);
 		cell->setPort(\C, C);
 		cell->setPort(\D, D);
 		cell->setPort(\Q, Q);
-		cell->setPort(\CE, module->addWire(NEW_ID));
+		cell->setPort(\CE, module->addWire(NEWER_ID));
 		if (r & 1)
-			cell->setPort(\R, module->addWire(NEW_ID));
+			cell->setPort(\R, module->addWire(NEWER_ID));
 		else {
 			if (rng(2) == 0)
 				cell->setPort(\R, State::S0);
@@ -41,13 +41,13 @@ generate
 		break;
 	case 2:
 	case 3:
-		cell = module->addDffGate(NEW_ID, C, D, Q, r & 1);
+		cell = module->addDffGate(NEWER_ID, C, D, Q, r & 1);
 		break;
 	case 4:
 	case 5:
 	case 6:
 	case 7:
-		cell = module->addDffeGate(NEW_ID, C, module->addWire(NEW_ID), D, Q, r & 1, r & 2);
+		cell = module->addDffeGate(NEWER_ID, C, module->addWire(NEWER_ID), D, Q, r & 1, r & 2);
 		break;
 	default: log_abort();
 	}
@@ -143,9 +143,9 @@ match next
 	filter !first->type.in(\FDRE) || param(next, \IS_R_INVERTED).as_bool() == param(first, \IS_R_INVERTED).as_bool()
 	filter !first->type.in(\FDRE, \FDRE_1) || port(next, \R, State::S0).is_fully_zero()
 generate
-	Cell *cell = module->addCell(NEW_ID, chain.back()->type);
+	Cell *cell = module->addCell(NEWER_ID, chain.back()->type);
 	cell->setPort(\C, chain.back()->getPort(\C));
-	cell->setPort(\D, module->addWire(NEW_ID));
+	cell->setPort(\D, module->addWire(NEWER_ID));
 	cell->setPort(\Q, chain.back()->getPort(\D));
 	if (cell->type == \FDRE) {
 		if (rng(2) == 0)
@@ -191,7 +191,7 @@ match shiftx
 	filter param(shiftx, \A_WIDTH).as_int() >= minlen
 generate
 	minlen = 3;
-	module->addShiftx(NEW_ID, module->addWire(NEW_ID, rng(6)+minlen), module->addWire(NEW_ID, 3), module->addWire(NEW_ID));
+	module->addShiftx(NEWER_ID, module->addWire(NEWER_ID, rng(6)+minlen), module->addWire(NEWER_ID, 3), module->addWire(NEWER_ID));
 endmatch
 
 code shiftx_width
@@ -207,28 +207,28 @@ match first
 	index <SigBit> port(first, \Q)[idx] === port(shiftx, \A)[shiftx_width-1]
 	set slice idx
 generate
-	SigSpec C = module->addWire(NEW_ID);
+	SigSpec C = module->addWire(NEWER_ID);
 	auto WIDTH = rng(3)+1;
-	SigSpec D = module->addWire(NEW_ID, WIDTH);
-	SigSpec Q = module->addWire(NEW_ID, WIDTH);
+	SigSpec D = module->addWire(NEWER_ID, WIDTH);
+	SigSpec Q = module->addWire(NEWER_ID, WIDTH);
 	auto r = rng(8);
 	Cell *cell = nullptr;
 	switch (r)
 	{
 	case 0:
 	case 1:
-		cell = module->addDff(NEW_ID, C, D, Q, r & 1);
+		cell = module->addDff(NEWER_ID, C, D, Q, r & 1);
 		break;
 	case 2:
 	case 3:
 	case 4:
 	case 5:
-		//cell = module->addDffe(NEW_ID, C, module->addWire(NEW_ID), D, Q, r & 1, r & 4);
+		//cell = module->addDffe(NEWER_ID, C, module->addWire(NEWER_ID), D, Q, r & 1, r & 4);
 		//break;
 	case 6:
 	case 7:
 		WIDTH = 1;
-		cell = module->addDffGate(NEW_ID, C, D[0], Q[0], r & 1);
+		cell = module->addDffGate(NEWER_ID, C, D[0], Q[0], r & 1);
 		break;
 	default: log_abort();
 	}
@@ -295,19 +295,19 @@ generate
 				back->connections_.at(\D)[slice] = port(back, \Q)[new_slice];
 			}
 			else {
-				auto D = module->addWire(NEW_ID, WIDTH);
+				auto D = module->addWire(NEWER_ID, WIDTH);
 				if (back->type == $dff)
-					module->addDff(NEW_ID, port(back, \CLK), D, port(back, \D), param(back, \CLK_POLARITY).as_bool());
+					module->addDff(NEWER_ID, port(back, \CLK), D, port(back, \D), param(back, \CLK_POLARITY).as_bool());
 				else if (back->type == $dffe)
-					module->addDffe(NEW_ID, port(back, \CLK), port(back, \EN), D, port(back, \D), param(back, \CLK_POLARITY).as_bool(), param(back, \EN_POLARITY).as_bool());
+					module->addDffe(NEWER_ID, port(back, \CLK), port(back, \EN), D, port(back, \D), param(back, \CLK_POLARITY).as_bool(), param(back, \EN_POLARITY).as_bool());
 				else
 					log_abort();
 			}
 		}
 		else if (back->type.begins_with("$_DFF_")) {
-			Cell *cell = module->addCell(NEW_ID, back->type);
+			Cell *cell = module->addCell(NEWER_ID, back->type);
 			cell->setPort(\C, back->getPort(\C));
-			cell->setPort(\D, module->addWire(NEW_ID));
+			cell->setPort(\D, module->addWire(NEWER_ID));
 			cell->setPort(\Q, back->getPort(\D));
 		}
 		else


### PR DESCRIPTION
This PR adds a new option named `--no-private-id-locs` that prevents users of the new version of `NEW_ID` and `NEW_ID_SUFFIX` from adding Yosys C++ source file locations to automatic design object names.

```
$ yosys -p "read_verilog add.v; synth; dump" | grep auto | tail -n1
  cell $_XOR_ $abc$192$auto$blifparse.cc:397:parse_blif$232
$ yosys --no-private-id-locs -p "read_verilog add.v; synth; dump" | grep auto | tail -n1
  cell $_XOR_ $abc$192$auto$?:0:?$232
```

The old macros still work the same way as before and now give a deprecation warning. The new macros are named `NEWER_ID` and `NEWER_ID_SUFFIX`, `NEW_ID2` and `NEW_ID_SUFFIX2` are an option as well. #5315 benefits from this feature, reducing the proportion of PRs that require an update of the reference RTLIL dump for its `synth -noabc` result stability test. Sorry for the reviewer spam.

- [ ] Add test