### PR TITLE
Remove more `.c_str()` calls

### DIFF
--- a/backends/aiger2/aiger.cc
+++ b/backends/aiger2/aiger.cc
@@ -1446,7 +1446,7 @@ struct XAiger2Backend : Backend {
 		if (!map_filename.empty()) {
 			writer.map_file.open(map_filename);
 			if (!writer.map_file)
-				log_cmd_error("Failed to open '%s' for writing\n", map_filename.c_str());
+				log_cmd_error("Failed to open '%s' for writing\n", map_filename);
 		}
 
 		design->bufNormalize(true);

--- a/backends/aiger2/aiger.cc
+++ b/backends/aiger2/aiger.cc
@@ -1012,7 +1012,7 @@ struct XAigerWriter : AigerWriter {
 
 			for (auto box : minfo.found_blackboxes) {
 				log_debug(" - %s.%s (type %s): ", cursor.path().c_str(),
-						  RTLIL::unescape_id(box->name).c_str(),
+						  RTLIL::unescape_id(box->name),
 						  log_id(box->type));
 
 				Module *box_module = design->module(box->type), *box_derived;

--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -1533,7 +1533,7 @@ struct CxxrtlWorker {
 			}
 		// Internal cells
 		} else if (is_internal_cell(cell->type)) {
-			log_cmd_error("Unsupported internal cell `%s'.\n", cell->type.c_str());
+			log_cmd_error("Unsupported internal cell `%s'.\n", cell->type);
 		// User cells
 		} else if (for_debug) {
 			// Outlines are called on demand when computing the value of a debug item. Nothing to do here.
@@ -3803,7 +3803,7 @@ struct CxxrtlBackend : public Backend {
 			if (args[argidx] == "-print-output" && argidx+1 < args.size()) {
 				worker.print_output = args[++argidx];
 				if (!(worker.print_output == "std::cout" || worker.print_output == "std::cerr")) {
-					log_cmd_error("Invalid output stream \"%s\".\n", worker.print_output.c_str());
+					log_cmd_error("Invalid output stream \"%s\".\n", worker.print_output);
 					worker.print_output = "std::cout";
 				}
 				continue;

--- a/backends/edif/edif.cc
+++ b/backends/edif/edif.cc
@@ -513,7 +513,7 @@ struct EdifBackend : public Backend {
 				if (sig.wire == NULL && sig != RTLIL::State::S0 && sig != RTLIL::State::S1) {
 					if (sig == RTLIL::State::Sx) {
 						for (auto &ref : it.second)
-							log_warning("Exporting x-bit on %s as zero bit.\n", ref.first.c_str());
+							log_warning("Exporting x-bit on %s as zero bit.\n", ref.first);
 						sig = RTLIL::State::S0;
 					} else if (sig == RTLIL::State::Sz) {
 						continue;

--- a/backends/edif/edif.cc
+++ b/backends/edif/edif.cc
@@ -30,9 +30,9 @@
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
-#define EDIF_DEF(_id) edif_names(RTLIL::unescape_id(_id), true).c_str()
-#define EDIF_DEFR(_id, _ren, _bl, _br) edif_names(RTLIL::unescape_id(_id), true, _ren, _bl, _br).c_str()
-#define EDIF_REF(_id) edif_names(RTLIL::unescape_id(_id), false).c_str()
+#define EDIF_DEF(_id) edif_names(RTLIL::unescape_id(_id), true)
+#define EDIF_DEFR(_id, _ren, _bl, _br) edif_names(RTLIL::unescape_id(_id), true, _ren, _bl, _br)
+#define EDIF_REF(_id) edif_names(RTLIL::unescape_id(_id), false)
 
 struct EdifNames
 {

--- a/backends/firrtl/firrtl.cc
+++ b/backends/firrtl/firrtl.cc
@@ -465,7 +465,7 @@ struct FirrtlWorker
 		// If there is no instance for this, just return.
 		if (instModule == NULL)
 		{
-			log_warning("No instance for %s.%s\n", cell_type.c_str(), cell_name.c_str());
+			log_warning("No instance for %s.%s\n", cell_type, cell_name);
 			return;
 		}
 
@@ -490,7 +490,7 @@ struct FirrtlWorker
 				const SigSpec *sinkSig = nullptr;
 				switch (dir) {
 					case FD_INOUT:
-						log_warning("Instance port connection %s.%s is INOUT; treating as OUT\n", cell_type.c_str(), log_signal(it->second));
+						log_warning("Instance port connection %s.%s is INOUT; treating as OUT\n", cell_type, log_signal(it->second));
 						YS_FALLTHROUGH
 					case FD_OUT:
 						sourceExpr = firstName;
@@ -498,7 +498,7 @@ struct FirrtlWorker
 						sinkSig = &secondSig;
 						break;
 					case FD_NODIRECTION:
-						log_warning("Instance port connection %s.%s is NODIRECTION; treating as IN\n", cell_type.c_str(), log_signal(it->second));
+						log_warning("Instance port connection %s.%s is NODIRECTION; treating as IN\n", cell_type, log_signal(it->second));
 						YS_FALLTHROUGH
 					case FD_IN:
 						sourceExpr = secondExpr;

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -1822,7 +1822,7 @@ std::string AstModule::derive_common(RTLIL::Design *design, const dict<RTLIL::Id
 		return modname;
 
 	if (!quiet)
-		log_header(design, "Executing AST frontend in derive mode using pre-parsed AST for module `%s'.\n", stripped_name.c_str());
+		log_header(design, "Executing AST frontend in derive mode using pre-parsed AST for module `%s'.\n", stripped_name);
 	loadconfig();
 
 	pool<IdString> rewritten;

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -1446,7 +1446,7 @@ void AST::process(RTLIL::Design *design, AstNode *ast, bool nodisplay, bool dump
 			if (design->has(child->str)) {
 				RTLIL::Module *existing_mod = design->module(child->str);
 				if (!nooverwrite && !overwrite && !existing_mod->get_blackbox_attribute()) {
-					log_file_error(*child->location.begin.filename, child->location.begin.line, "Re-definition of module `%s'!\n", child->str.c_str());
+					log_file_error(*child->location.begin.filename, child->location.begin.line, "Re-definition of module `%s'!\n", child->str);
 				} else if (nooverwrite) {
 					log("Ignoring re-definition of module `%s' at %s.\n",
 							child->str.c_str(), child->loc_string().c_str());

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -1539,7 +1539,7 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 				if (dynamic_cast<RTLIL::Binding*>(current_module)) {
 					/* nothing to do here */
 				} else if (flag_autowire)
-					log_file_warning(*location.begin.filename, location.begin.line, "Identifier `%s' is implicitly declared.\n", str.c_str());
+					log_file_warning(*location.begin.filename, location.begin.line, "Identifier `%s' is implicitly declared.\n", str);
 				else
 					input_error("Identifier `%s' is implicitly declared and `default_nettype is set to none.\n", str);
 			}
@@ -2200,7 +2200,7 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 					log_file_info(*location.begin.filename, location.begin.line, "\n");
 			} else if (str == "$warning") {
 				if (sz > 0)
-					log_file_warning(*location.begin.filename, location.begin.line, "%s.\n", children[0]->str.c_str());
+					log_file_warning(*location.begin.filename, location.begin.line, "%s.\n", children[0]->str);
 				else
 					log_file_warning(*location.begin.filename, location.begin.line, "\n");
 			} else if (str == "$error") {

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -1241,7 +1241,7 @@ void AstNode::detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *foun
 				while (children[0]->simplify(true, 1, -1, false) == true) { }
 				if (children[0]->type != AST_CONSTANT)
 					input_error("System function %s called with non-const argument!\n",
-							RTLIL::unescape_id(str).c_str());
+							RTLIL::unescape_id(str));
 				width_hint = max(width_hint, int(children[0]->asInt(true)));
 			}
 			break;
@@ -1291,7 +1291,7 @@ void AstNode::detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *foun
 				while (right->simplify(true, 1, -1, false)) { }
 				if (left->type != AST_CONSTANT || right->type != AST_CONSTANT)
 					input_error("Function %s has non-constant width!",
-							RTLIL::unescape_id(str).c_str());
+							RTLIL::unescape_id(str));
 				result_width = abs(int(left->asInt(true) - right->asInt(true)));
 			}
 			width_hint = max(width_hint, result_width);
@@ -2237,12 +2237,12 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 
 				if (GetSize(children) > 1)
 					input_error("System function %s got %d arguments, expected 1 or 0.\n",
-							RTLIL::unescape_id(str).c_str(), GetSize(children));
+							RTLIL::unescape_id(str), GetSize(children));
 
 				if (GetSize(children) == 1) {
 					if (children[0]->type != AST_CONSTANT)
 						input_error("System function %s called with non-const argument!\n",
-								RTLIL::unescape_id(str).c_str());
+								RTLIL::unescape_id(str));
 					width = children[0]->asInt(true);
 				}
 

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -2195,7 +2195,7 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 			int sz = children.size();
 			if (str == "$info") {
 				if (sz > 0)
-					log_file_info(*location.begin.filename, location.begin.line, "%s.\n", children[0]->str.c_str());
+					log_file_info(*location.begin.filename, location.begin.line, "%s.\n", children[0]->str);
 				else
 					log_file_info(*location.begin.filename, location.begin.line, "\n");
 			} else if (str == "$warning") {

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -795,7 +795,7 @@ struct AST_INTERNAL::ProcessGenerator
 					fmt.append_literal("\n");
 				fmt.emit_rtlil(cell);
 			} else if (!ast->str.empty()) {
-				log_file_error(*ast->location.begin.filename, ast->location.begin.line, "Found unsupported invocation of system task `%s'!\n", ast->str.c_str());
+				log_file_error(*ast->location.begin.filename, ast->location.begin.line, "Found unsupported invocation of system task `%s'!\n", ast->str);
 			}
 			break;
 
@@ -846,7 +846,7 @@ struct AST_INTERNAL::ProcessGenerator
 				set_src_attr(cell, ast);
 				for (auto &attr : ast->attributes) {
 					if (attr.second->type != AST_CONSTANT)
-						log_file_error(*ast->location.begin.filename, ast->location.begin.line, "Attribute `%s' with non-constant value!\n", attr.first.c_str());
+						log_file_error(*ast->location.begin.filename, ast->location.begin.line, "Attribute `%s' with non-constant value!\n", attr.first);
 					cell->attributes[attr.first] = attr.second->asAttrConst();
 				}
 				cell->setParam(ID::FLAVOR, flavor);

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -161,7 +161,7 @@ Fmt AstNode::processFormat(int stage, bool sformat_like, int default_base, size_
 			arg.sig = node_arg->bitsAsConst();
 			arg.signed_ = node_arg->is_signed;
 		} else if (may_fail) {
-			log_file_info(*location.begin.filename, location.begin.line, "Skipping system task `%s' with non-constant argument at position %zu.\n", str.c_str(), index + 1);
+			log_file_info(*location.begin.filename, location.begin.line, "Skipping system task `%s' with non-constant argument at position %zu.\n", str, index + 1);
 			return Fmt();
 		} else {
 			log_file_error(*location.begin.filename, location.begin.line, "Failed to evaluate system task `%s' with non-constant argument at position %zu.\n", str, index + 1);

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1032,7 +1032,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 	// note that $display, $finish, and $stop are used for synthesis-time DRC so they're not in this list
 	if ((type == AST_FCALL || type == AST_TCALL) && (str == "$strobe" || str == "$monitor" || str == "$time" ||
 			str == "$dumpfile" || str == "$dumpvars" || str == "$dumpon" || str == "$dumpoff" || str == "$dumpall")) {
-		log_file_warning(*location.begin.filename, location.begin.line, "Ignoring call to system %s %s.\n", type == AST_FCALL ? "function" : "task", str.c_str());
+		log_file_warning(*location.begin.filename, location.begin.line, "Ignoring call to system %s %s.\n", type == AST_FCALL ? "function" : "task", str);
 		delete_children();
 		str = std::string();
 	}
@@ -1042,7 +1042,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 		 str == "$write"   || str == "$writeb"   || str == "$writeh"   || str == "$writeo"))
 	{
 		if (!current_always) {
-			log_file_warning(*location.begin.filename, location.begin.line, "System task `%s' outside initial or always block is unsupported.\n", str.c_str());
+			log_file_warning(*location.begin.filename, location.begin.line, "System task `%s' outside initial or always block is unsupported.\n", str);
 			delete_children();
 			str = std::string();
 		} else {

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -974,7 +974,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 						message += stringf("%s%s", first_element ? " See " : ", ", place);
 						first_element = false;
 					}
-					log_warning("%s\n", message.c_str());
+					log_warning("%s\n", message);
 				}
 
 			silent_activate:
@@ -1144,7 +1144,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 					i--; // Adjust index since we removed an element
 				} else {
 					// If we can't find the package, just remove the import node to avoid errors later
-					log_warning("Package `%s' not found for import, removing import statement\n", child->str.c_str());
+					log_warning("Package `%s' not found for import, removing import statement\n", child->str);
 					children.erase(children.begin() + i);
 					i--; // Adjust index since we removed an element
 				}
@@ -1438,7 +1438,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 			if ((type == AST_ASSIGN_LE || type == AST_ASSIGN_EQ) && children[0]->id2ast->is_logic)
 				children[0]->id2ast->is_reg = true; // if logic type is used in a block asignment
 			if ((type == AST_ASSIGN_LE || type == AST_ASSIGN_EQ) && !children[0]->id2ast->is_reg)
-				log_warning("wire '%s' is assigned in a block at %s.\n", children[0]->str.c_str(), loc_string().c_str());
+				log_warning("wire '%s' is assigned in a block at %s.\n", children[0]->str, loc_string());
 			if (type == AST_ASSIGN && children[0]->id2ast->is_reg) {
 				bool is_rand_reg = false;
 				if (children[1]->type == AST_FCALL) {
@@ -1452,7 +1452,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 						is_rand_reg = true;
 				}
 				if (!is_rand_reg)
-					log_warning("reg '%s' is assigned in a continuous assignment at %s.\n", children[0]->str.c_str(), loc_string().c_str());
+					log_warning("reg '%s' is assigned in a continuous assignment at %s.\n", children[0]->str, loc_string());
 			}
 			children[0]->was_checked = true;
 		}

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1915,7 +1915,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 
 		if (current_scope.at(modname)->type != AST_CELL)
 			input_error("Defparam argument `%s . %s` does not match a cell!\n",
-					RTLIL::unescape_id(modname).c_str(), RTLIL::unescape_id(paramname).c_str());
+					RTLIL::unescape_id(modname), RTLIL::unescape_id(paramname));
 
 		auto paraset = std::make_unique<AstNode>(location, AST_PARASET, children[1]->clone(), GetSize(children) > 2 ? children[2]->clone() : nullptr);
 		paraset->str = paramname;
@@ -3394,11 +3394,11 @@ skip_dynamic_range_lvalue_expansion:;
 
 				if (GetSize(children) != 1 && GetSize(children) != 2)
 					input_error("System function %s got %d arguments, expected 1 or 2.\n",
-							RTLIL::unescape_id(str).c_str(), int(children.size()));
+							RTLIL::unescape_id(str), int(children.size()));
 
 				if (!current_always_clocked)
 					input_error("System function %s is only allowed in clocked blocks.\n",
-							RTLIL::unescape_id(str).c_str());
+							RTLIL::unescape_id(str));
 
 				if (GetSize(children) == 2)
 				{
@@ -3469,11 +3469,11 @@ skip_dynamic_range_lvalue_expansion:;
 			{
 				if (GetSize(children) != 1)
 					input_error("System function %s got %d arguments, expected 1.\n",
-							RTLIL::unescape_id(str).c_str(), int(children.size()));
+							RTLIL::unescape_id(str), int(children.size()));
 
 				if (!current_always_clocked)
 					input_error("System function %s is only allowed in clocked blocks.\n",
-							RTLIL::unescape_id(str).c_str());
+							RTLIL::unescape_id(str));
 
 				auto present = children.at(0)->clone();
 				auto past = clone();
@@ -3511,7 +3511,7 @@ skip_dynamic_range_lvalue_expansion:;
 			{
 				if (children.size() != 1)
 					input_error("System function %s got %d arguments, expected 1.\n",
-							RTLIL::unescape_id(str).c_str(), int(children.size()));
+							RTLIL::unescape_id(str), int(children.size()));
 
 				auto buf = children[0]->clone();
 				while (buf->simplify(true, stage, width_hint, sign_hint)) { }
@@ -3538,11 +3538,11 @@ skip_dynamic_range_lvalue_expansion:;
 				if (str == "\\$dimensions" || str == "\\$unpacked_dimensions" || str == "\\$bits") {
 					if (children.size() != 1)
 						input_error("System function %s got %d arguments, expected 1.\n",
-								RTLIL::unescape_id(str).c_str(), int(children.size()));
+								RTLIL::unescape_id(str), int(children.size()));
 				} else {
 					if (children.size() != 1 && children.size() != 2)
 						input_error("System function %s got %d arguments, expected 1 or 2.\n",
-							RTLIL::unescape_id(str).c_str(), int(children.size()));
+							RTLIL::unescape_id(str), int(children.size()));
 					if (children.size() == 2) {
 						auto buf = children[1]->clone();
 						// Evaluate constant expression
@@ -3634,18 +3634,18 @@ skip_dynamic_range_lvalue_expansion:;
 				if (func_with_two_arguments) {
 					if (children.size() != 2)
 						input_error("System function %s got %d arguments, expected 2.\n",
-								RTLIL::unescape_id(str).c_str(), int(children.size()));
+								RTLIL::unescape_id(str), int(children.size()));
 				} else {
 					if (children.size() != 1)
 						input_error("System function %s got %d arguments, expected 1.\n",
-								RTLIL::unescape_id(str).c_str(), int(children.size()));
+								RTLIL::unescape_id(str), int(children.size()));
 				}
 
 				if (children.size() >= 1) {
 					while (children[0]->simplify(true, stage, width_hint, sign_hint)) { }
 					if (!children[0]->isConst())
 						input_error("Failed to evaluate system function `%s' with non-constant argument.\n",
-								RTLIL::unescape_id(str).c_str());
+								RTLIL::unescape_id(str));
 					int child_width_hint = width_hint;
 					bool child_sign_hint = sign_hint;
 					children[0]->detectSignWidth(child_width_hint, child_sign_hint);
@@ -3656,7 +3656,7 @@ skip_dynamic_range_lvalue_expansion:;
 					while (children[1]->simplify(true, stage, width_hint, sign_hint)) { }
 					if (!children[1]->isConst())
 						input_error("Failed to evaluate system function `%s' with non-constant argument.\n",
-								RTLIL::unescape_id(str).c_str());
+								RTLIL::unescape_id(str));
 					int child_width_hint = width_hint;
 					bool child_sign_hint = sign_hint;
 					children[1]->detectSignWidth(child_width_hint, child_sign_hint);
@@ -3703,7 +3703,7 @@ skip_dynamic_range_lvalue_expansion:;
 			if (str == "\\$countbits") {
 				if (children.size() < 2)
 					input_error("System function %s got %d arguments, expected at least 2.\n",
-							RTLIL::unescape_id(str).c_str(), int(children.size()));
+							RTLIL::unescape_id(str), int(children.size()));
 
 				std::vector<RTLIL::State> control_bits;
 
@@ -3760,7 +3760,7 @@ skip_dynamic_range_lvalue_expansion:;
 			if (str == "\\$countones" || str == "\\$isunknown" || str == "\\$onehot" || str == "\\$onehot0") {
 				if (children.size() != 1)
 					input_error("System function %s got %d arguments, expected 1.\n",
-							RTLIL::unescape_id(str).c_str(), int(children.size()));
+							RTLIL::unescape_id(str), int(children.size()));
 
 				auto countbits = clone();
 				countbits->str = "\\$countbits";
@@ -3834,7 +3834,7 @@ skip_dynamic_range_lvalue_expansion:;
 			{
 				if (GetSize(children) < 2 || GetSize(children) > 4)
 					input_error("System function %s got %d arguments, expected 2-4.\n",
-							RTLIL::unescape_id(str).c_str(), int(children.size()));
+							RTLIL::unescape_id(str), int(children.size()));
 
 				auto node_filename = children[0]->clone();
 				while (node_filename->simplify(true, stage, width_hint, sign_hint)) { }

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -164,7 +164,7 @@ Fmt AstNode::processFormat(int stage, bool sformat_like, int default_base, size_
 			log_file_info(*location.begin.filename, location.begin.line, "Skipping system task `%s' with non-constant argument at position %zu.\n", str.c_str(), index + 1);
 			return Fmt();
 		} else {
-			log_file_error(*location.begin.filename, location.begin.line, "Failed to evaluate system task `%s' with non-constant argument at position %zu.\n", str.c_str(), index + 1);
+			log_file_error(*location.begin.filename, location.begin.line, "Failed to evaluate system task `%s' with non-constant argument at position %zu.\n", str, index + 1);
 		}
 		args.push_back(arg);
 	}

--- a/frontends/liberty/liberty.cc
+++ b/frontends/liberty/liberty.cc
@@ -537,7 +537,7 @@ struct LibertyFrontend : public Frontend {
 		if (flag_wb && flag_lib)
 			log_error("-wb and -lib cannot be specified together!\n");
 
-		log_header(design, "Executing Liberty frontend: %s\n", filename.c_str());
+		log_header(design, "Executing Liberty frontend: %s\n", filename);
 
 		LibertyParser parser(*f, filename);
 		int cell_count = 0;

--- a/frontends/rpc/rpc_frontend.cc
+++ b/frontends/rpc/rpc_frontend.cc
@@ -163,7 +163,7 @@ struct RpcModule : RTLIL::Module {
 			stripped_name = stripped_name.substr(9);
 		log_assert(stripped_name[0] == '\\');
 
-		log_header(design, "Executing RPC frontend `%s' for module `%s'.\n", server->name.c_str(), stripped_name.c_str());
+		log_header(design, "Executing RPC frontend `%s' for module `%s'.\n", server->name, stripped_name);
 
 		std::string parameter_info;
 		for (auto &param : parameters) {

--- a/frontends/rpc/rpc_frontend.cc
+++ b/frontends/rpc/rpc_frontend.cc
@@ -91,9 +91,9 @@ struct RpcServer {
 		std::string error;
 		Json json_response = Json::parse(response, error);
 		if (json_response.is_null())
-			log_cmd_error("parsing JSON failed: %s\n", error.c_str());
+			log_cmd_error("parsing JSON failed: %s\n", error);
 		if (json_response["error"].is_string())
-			log_cmd_error("RPC frontend returned an error: %s\n", json_response["error"].string_value().c_str());
+			log_cmd_error("RPC frontend returned an error: %s\n", json_response["error"].string_value());
 		return json_response;
 	}
 
@@ -111,7 +111,7 @@ struct RpcServer {
 			}
 		} else is_valid = false;
 		if (!is_valid)
-			log_cmd_error("RPC frontend returned malformed response: %s\n", response.dump().c_str());
+			log_cmd_error("RPC frontend returned malformed response: %s\n", response.dump());
 		return modules;
 	}
 
@@ -149,7 +149,7 @@ struct RpcServer {
 			source = response["source"].string_value();
 		else is_valid = false;
 		if (!is_valid)
-			log_cmd_error("RPC frontend returned malformed response: %s\n", response.dump().c_str());
+			log_cmd_error("RPC frontend returned malformed response: %s\n", response.dump());
 		return std::make_pair(frontend, source);
 	}
 };
@@ -202,7 +202,7 @@ struct RpcModule : RTLIL::Module {
 				}
 			}
 			if (!found_derived_top)
-				log_cmd_error("RPC frontend did not return requested module `%s`!\n", stripped_name.c_str());
+				log_cmd_error("RPC frontend did not return requested module `%s`!\n", stripped_name);
 
 			for (auto module : derived_design->modules())
 				for (auto cell : module->cells())
@@ -256,7 +256,7 @@ struct HandleRpcServer : RpcServer {
 		do {
 			DWORD data_written;
 			if (!WriteFile(hsend, &data[offset], data.length() - offset, &data_written, /*lpOverlapped=*/NULL))
-				log_cmd_error("WriteFile failed: %s\n", get_last_error_str().c_str());
+				log_cmd_error("WriteFile failed: %s\n", get_last_error_str());
 			offset += data_written;
 		} while(offset < (ssize_t)data.length());
 	}
@@ -268,7 +268,7 @@ struct HandleRpcServer : RpcServer {
 			data.resize(data.length() + 1024);
 			DWORD data_read;
 			if (!ReadFile(hrecv, &data[offset], data.length() - offset, &data_read, /*lpOverlapped=*/NULL))
-				log_cmd_error("ReadFile failed: %s\n", get_last_error_str().c_str());
+				log_cmd_error("ReadFile failed: %s\n", get_last_error_str());
 			offset += data_read;
 			data.resize(offset);
 			size_t term_pos = data.find('\n', offset);

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -141,7 +141,7 @@ void msg_func(msg_type_t msg_type, const char *message_id, linefile_type linefil
 #endif
 	} else {
 		if (msg_type == VERIFIC_ERROR || msg_type == VERIFIC_WARNING || msg_type == VERIFIC_PROGRAM_ERROR)
-			log_warning_noprefix("%s%s\n", message_prefix.c_str(), message.c_str());
+			log_warning_noprefix("%s%s\n", message_prefix, message);
 		else
 			log("%s%s\n", message_prefix, message);
 	}
@@ -4098,7 +4098,7 @@ struct VerificPass : public Pass {
 					unsigned new_insertion = parameters.Insert(key.c_str(), value.c_str(),
 											   1 /* force_overwrite */);
 					if (!new_insertion)
-						log_warning_noprefix("-chparam %s already specified: overwriting.\n", key.c_str());
+						log_warning_noprefix("-chparam %s already specified: overwriting.\n", key);
 					continue;
 				}
 				if (args[argidx] == "-V") {

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -1469,7 +1469,7 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 
 	if (design->has(module_name)) {
 		if (!nl->IsOperator() && !is_blackbox(nl))
-			log_cmd_error("Re-definition of module `%s'.\n", netlist_name.c_str());
+			log_cmd_error("Re-definition of module `%s'.\n", netlist_name);
 		return;
 	}
 
@@ -3824,7 +3824,7 @@ struct VerificPass : public Pass {
 				add_units_to_map(map, work, flag_lib);
 				std::string filename = frontent_rewrite(args, argidx, tmp_files);
 				if (!vhdl_file::Analyze(filename.c_str(), work.c_str(), vhdl_file::VHDL_87))
-					log_cmd_error("Reading `%s' in VHDL_87 mode failed.\n", filename.c_str());
+					log_cmd_error("Reading `%s' in VHDL_87 mode failed.\n", filename);
 				set_units_to_blackbox(map, work, flag_lib);
 			}
 			verific_import_pending = true;
@@ -3849,7 +3849,7 @@ struct VerificPass : public Pass {
 				add_units_to_map(map, work, flag_lib);
 				std::string filename = frontent_rewrite(args, argidx, tmp_files);
 				if (!vhdl_file::Analyze(filename.c_str(), work.c_str(), vhdl_file::VHDL_93))
-					log_cmd_error("Reading `%s' in VHDL_93 mode failed.\n", filename.c_str());
+					log_cmd_error("Reading `%s' in VHDL_93 mode failed.\n", filename);
 				set_units_to_blackbox(map, work, flag_lib);
 			}
 			verific_import_pending = true;
@@ -3874,7 +3874,7 @@ struct VerificPass : public Pass {
 				add_units_to_map(map, work, flag_lib);
 				std::string filename = frontent_rewrite(args, argidx, tmp_files);
 				if (!vhdl_file::Analyze(filename.c_str(), work.c_str(), vhdl_file::VHDL_2K))
-					log_cmd_error("Reading `%s' in VHDL_2K mode failed.\n", filename.c_str());
+					log_cmd_error("Reading `%s' in VHDL_2K mode failed.\n", filename);
 				set_units_to_blackbox(map, work, flag_lib);
 			}
 			verific_import_pending = true;
@@ -3899,7 +3899,7 @@ struct VerificPass : public Pass {
 				add_units_to_map(map, work, flag_lib);
 				std::string filename = frontent_rewrite(args, argidx, tmp_files);
 				if (!vhdl_file::Analyze(filename.c_str(), work.c_str(), vhdl_file::VHDL_2019))
-					log_cmd_error("Reading `%s' in VHDL_2019 mode failed.\n", filename.c_str());
+					log_cmd_error("Reading `%s' in VHDL_2019 mode failed.\n", filename);
 				set_units_to_blackbox(map, work, flag_lib);
 			}
 			verific_import_pending = true;
@@ -3924,7 +3924,7 @@ struct VerificPass : public Pass {
 				add_units_to_map(map, work, flag_lib);
 				std::string filename = frontent_rewrite(args, argidx, tmp_files);
 				if (!vhdl_file::Analyze(filename.c_str(), work.c_str(), vhdl_file::VHDL_2008))
-					log_cmd_error("Reading `%s' in VHDL_2008 mode failed.\n", filename.c_str());
+					log_cmd_error("Reading `%s' in VHDL_2008 mode failed.\n", filename);
 				set_units_to_blackbox(map, work, flag_lib);
 			}
 			verific_import_pending = true;
@@ -3938,7 +3938,7 @@ struct VerificPass : public Pass {
 			while (argidx < GetSize(args)) {
 				std::string filename = frontent_rewrite(args, argidx, tmp_files);
 				if (!edif.Read(filename.c_str()))
-					log_cmd_error("Reading `%s' in EDIF mode failed.\n", filename.c_str());
+					log_cmd_error("Reading `%s' in EDIF mode failed.\n", filename);
 			}
 			goto check_error;
 		}
@@ -3961,7 +3961,7 @@ struct VerificPass : public Pass {
 			while (argidx < GetSize(args)) {
 				std::string filename = frontent_rewrite(args, argidx, tmp_files);
 				if (!synlib_file::Read(filename.c_str(), is_work_set ? work.c_str() : nullptr))
-					log_cmd_error("Reading `%s' in LIBERTY mode failed.\n", filename.c_str());
+					log_cmd_error("Reading `%s' in LIBERTY mode failed.\n", filename);
 				SynlibLibrary *lib = synlib_file::GetLastLibraryAnalyzed();
 				if (lib && flag_lib) {
 					MapIter mi ;

--- a/frontends/verific/verificsva.cc
+++ b/frontends/verific/verificsva.cc
@@ -1025,7 +1025,7 @@ struct VerificSvaImporter
 	{
 		if (!importer->mode_keep)
 			log_error("%s", errmsg);
-		log_warning("%s", errmsg.c_str());
+		log_warning("%s", errmsg);
 		throw ParserErrorException();
 	}
 

--- a/frontends/verilog/const2ast.cc
+++ b/frontends/verilog/const2ast.cc
@@ -45,7 +45,7 @@ using namespace AST;
 using namespace VERILOG_FRONTEND;
 
 void ConstParser::log_maybe_loc_error(std::string msg) {
-	log_file_error(*loc.begin.filename, loc.begin.line, "%s", msg.c_str());
+	log_file_error(*loc.begin.filename, loc.begin.line, "%s", msg);
 }
 
 void ConstParser::log_maybe_loc_warn(std::string msg) {

--- a/frontends/verilog/const2ast.cc
+++ b/frontends/verilog/const2ast.cc
@@ -49,7 +49,7 @@ void ConstParser::log_maybe_loc_error(std::string msg) {
 }
 
 void ConstParser::log_maybe_loc_warn(std::string msg) {
-	log_file_warning(*loc.begin.filename, loc.begin.line, "%s", msg.c_str());
+	log_file_warning(*loc.begin.filename, loc.begin.line, "%s", msg);
 }
 
 // divide an arbitrary length decimal number by two and return the rest

--- a/frontends/verilog/preproc.cc
+++ b/frontends/verilog/preproc.cc
@@ -741,7 +741,7 @@ read_define(const std::string &filename,
 		defines_map.add(name, value, (state == 2) ? &args : nullptr);
 		global_defines_cache.add(name, value, (state == 2) ? &args : nullptr);
 	} else {
-		log_file_error(filename, 0, "Invalid name for macro definition: >>%s<<.\n", name.c_str());
+		log_file_error(filename, 0, "Invalid name for macro definition: >>%s<<.\n", name);
 	}
 }
 

--- a/frontends/verilog/verilog_frontend.cc
+++ b/frontends/verilog/verilog_frontend.cc
@@ -485,7 +485,7 @@ struct VerilogFrontend : public Frontend {
 
 		extra_args(f, filename, args, argidx);
 
-		log_header(design, "Executing Verilog-2005 frontend: %s\n", filename.c_str());
+		log_header(design, "Executing Verilog-2005 frontend: %s\n", filename);
 
 		log("Parsing %s%s input from `%s' to AST representation.\n",
 				parse_mode.formal ? "formal " : "", parse_mode.sv ? "SystemVerilog" : "Verilog", filename.c_str());

--- a/kernel/fmt.cc
+++ b/kernel/fmt.cc
@@ -401,11 +401,11 @@ void Fmt::parse_verilog(const std::vector<VerilogFmtArg> &args, bool sformat_lik
 								part = {};
 							}
 							if (++i == fmt.size()) {
-								log_file_error(fmtarg->filename, fmtarg->first_line, "System task `%s' called with incomplete format specifier in argument %zu.\n", task_name.c_str(), fmtarg - args.begin() + 1);
+								log_file_error(fmtarg->filename, fmtarg->first_line, "System task `%s' called with incomplete format specifier in argument %zu.\n", task_name, fmtarg - args.begin() + 1);
 							}
 
 							if (++arg == args.end()) {
-								log_file_error(fmtarg->filename, fmtarg->first_line, "System task `%s' called with fewer arguments than the format specifiers in argument %zu require.\n", task_name.c_str(), fmtarg - args.begin() + 1);
+								log_file_error(fmtarg->filename, fmtarg->first_line, "System task `%s' called with fewer arguments than the format specifiers in argument %zu require.\n", task_name, fmtarg - args.begin() + 1);
 							}
 							part.sig = arg->sig;
 							part.signed_ = arg->signed_;
@@ -420,7 +420,7 @@ void Fmt::parse_verilog(const std::vector<VerilogFmtArg> &args, bool sformat_lik
 								} else break;
 							}
 							if (i == fmt.size()) {
-								log_file_error(fmtarg->filename, fmtarg->first_line, "System task `%s' called with incomplete format specifier in argument %zu.\n", task_name.c_str(), fmtarg - args.begin() + 1);
+								log_file_error(fmtarg->filename, fmtarg->first_line, "System task `%s' called with incomplete format specifier in argument %zu.\n", task_name, fmtarg - args.begin() + 1);
 							}
 
 							bool has_leading_zero = false, has_width = false;
@@ -465,15 +465,15 @@ void Fmt::parse_verilog(const std::vector<VerilogFmtArg> &args, bool sformat_lik
 										if (!has_width && !has_leading_zero)
 											part.width = 20;
 									} else {
-										log_file_error(fmtarg->filename, fmtarg->first_line, "System task `%s' called with format character `%c' in argument %zu, but the argument is not $time or $realtime.\n", task_name.c_str(), fmt[i], fmtarg - args.begin() + 1);
+										log_file_error(fmtarg->filename, fmtarg->first_line, "System task `%s' called with format character `%c' in argument %zu, but the argument is not $time or $realtime.\n", task_name, fmt[i], fmtarg - args.begin() + 1);
 									}
 								} else {
-									log_file_error(fmtarg->filename, fmtarg->first_line, "System task `%s' called with unrecognized format character `%c' in argument %zu.\n", task_name.c_str(), fmt[i], fmtarg - args.begin() + 1);
+									log_file_error(fmtarg->filename, fmtarg->first_line, "System task `%s' called with unrecognized format character `%c' in argument %zu.\n", task_name, fmt[i], fmtarg - args.begin() + 1);
 								}
 								break;
 							}
 							if (i == fmt.size()) {
-								log_file_error(fmtarg->filename, fmtarg->first_line, "System task `%s' called with incomplete format specifier in argument %zu.\n", task_name.c_str(), fmtarg - args.begin() + 1);
+								log_file_error(fmtarg->filename, fmtarg->first_line, "System task `%s' called with incomplete format specifier in argument %zu.\n", task_name, fmtarg - args.begin() + 1);
 							}
 
 							if (part.padding == '\0') {
@@ -486,7 +486,7 @@ void Fmt::parse_verilog(const std::vector<VerilogFmtArg> &args, bool sformat_lik
 							}
 
 							if (part.type == FmtPart::INTEGER && part.base != 10 && part.sign != FmtPart::MINUS)
-								log_file_error(fmtarg->filename, fmtarg->first_line, "System task `%s' called with invalid format specifier in argument %zu.\n", task_name.c_str(), fmtarg - args.begin() + 1);
+								log_file_error(fmtarg->filename, fmtarg->first_line, "System task `%s' called with invalid format specifier in argument %zu.\n", task_name, fmtarg - args.begin() + 1);
 
 							if (part.base != 10)
 								part.signed_ = false;

--- a/kernel/gzip.cc
+++ b/kernel/gzip.cc
@@ -103,11 +103,11 @@ gzip_istream::ibuf::~ibuf() {
 // Never returns nullptr or failed state istream*
 std::istream* uncompressed(const std::string filename, std::ios_base::openmode mode) {
 	if (!check_file_exists(filename))
-		log_cmd_error("File `%s' not found or is a directory\n", filename.c_str());
+		log_cmd_error("File `%s' not found or is a directory\n", filename);
 	std::ifstream* f = new std::ifstream();
 	f->open(filename, mode);
 	if (f->fail())
-		log_cmd_error("Can't open input file `%s' for reading: %s\n", filename.c_str(), strerror(errno));
+		log_cmd_error("Can't open input file `%s' for reading: %s\n", filename, strerror(errno));
 	// Check for gzip magic
 	unsigned char magic[3];
 	int n = 0;
@@ -131,7 +131,7 @@ std::istream* uncompressed(const std::string filename, std::ios_base::openmode m
 		log_assert(ok && "Failed to open gzipped file.\n");
 		return s;
 #else
-		log_cmd_error("File `%s' is a gzip file, but Yosys is compiled without zlib.\n", filename.c_str());
+		log_cmd_error("File `%s' is a gzip file, but Yosys is compiled without zlib.\n", filename);
 #endif // YOSYS_ENABLE_ZLIB
 	} else {
 		f->clear();

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -187,7 +187,7 @@ static void logv_string(std::string_view format, std::string str) {
 			if (!linebuffer.empty() && linebuffer.back() == '\n') {
 				for (auto &re : log_warn_regexes)
 					if (std::regex_search(linebuffer, re))
-						log_warning("Found log message matching -W regex:\n%s", str.c_str());
+						log_warning("Found log message matching -W regex:\n%s", str);
 
 				for (auto &[_, item] : log_expect_log)
 					if (std::regex_search(linebuffer, item.pattern))
@@ -704,7 +704,7 @@ dict<std::string, std::pair<std::string, int>> get_coverage_data()
 
 	for (auto &it : extra_coverage_data) {
 		if (coverage_data.count(it.first))
-			log_warning("found duplicate coverage id \"%s\".\n", it.first.c_str());
+			log_warning("found duplicate coverage id \"%s\".\n", it.first);
 		coverage_data[it.first].first = it.second.first;
 		coverage_data[it.first].second += it.second.second;
 	}

--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -972,7 +972,7 @@ struct HelpPass : public Pass {
 		}
 		for (auto &it : cell_help_messages.cell_help) {
 			if (cells.count(it.first) == 0) {
-				log_warning("Found cell model '%s' without matching cell type.\n", it.first.c_str());
+				log_warning("Found cell model '%s' without matching cell type.\n", it.first);
 			}
 		}
 

--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -262,7 +262,7 @@ void Pass::call(RTLIL::Design *design, std::vector<std::string> args)
 	}
 
 	if (pass_register.count(args[0]) == 0)
-		log_cmd_error("No such command: %s (type 'help' for a command overview)\n", args[0].c_str());
+		log_cmd_error("No such command: %s (type 'help' for a command overview)\n", args[0]);
 
 	if (pass_register[args[0]]->experimental_flag)
 		log_experimental(args[0]);
@@ -521,7 +521,7 @@ void Frontend::frontend_call(RTLIL::Design *design, std::istream *f, std::string
 	if (args.size() == 0)
 		return;
 	if (frontend_register.count(args[0]) == 0)
-		log_cmd_error("No such frontend: %s\n", args[0].c_str());
+		log_cmd_error("No such frontend: %s\n", args[0]);
 
 	if (f != NULL) {
 		auto state = frontend_register[args[0]]->pre_execute();
@@ -596,7 +596,7 @@ void Backend::extra_args(std::ostream *&f, std::string &filename, std::vector<st
 			gzip_ostream *gf = new gzip_ostream;
 			if (!gf->open(filename)) {
 				delete gf;
-				log_cmd_error("Can't open output file `%s' for writing: %s\n", filename.c_str(), strerror(errno));
+				log_cmd_error("Can't open output file `%s' for writing: %s\n", filename, strerror(errno));
 			}
 			yosys_output_files.insert(filename);
 			f = gf;
@@ -609,7 +609,7 @@ void Backend::extra_args(std::ostream *&f, std::string &filename, std::vector<st
 			yosys_output_files.insert(filename);
 			if (ff->fail()) {
 				delete ff;
-				log_cmd_error("Can't open output file `%s' for writing: %s\n", filename.c_str(), strerror(errno));
+				log_cmd_error("Can't open output file `%s' for writing: %s\n", filename, strerror(errno));
 			}
 			f = ff;
 		}
@@ -641,7 +641,7 @@ void Backend::backend_call(RTLIL::Design *design, std::ostream *f, std::string f
 	if (args.size() == 0)
 		return;
 	if (backend_register.count(args[0]) == 0)
-		log_cmd_error("No such backend: %s\n", args[0].c_str());
+		log_cmd_error("No such backend: %s\n", args[0]);
 
 	size_t orig_sel_stack_pos = design->selection_stack.size();
 

--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -199,7 +199,7 @@ void Pass::call(RTLIL::Design *design, std::string command)
 		while (!cmd_buf.empty() && (cmd_buf.back() == ' ' || cmd_buf.back() == '\t' ||
 				cmd_buf.back() == '\r' || cmd_buf.back() == '\n'))
 			cmd_buf.resize(cmd_buf.size()-1);
-		log_header(design, "Shell command: %s\n", cmd_buf.c_str());
+		log_header(design, "Shell command: %s\n", cmd_buf);
 		int retCode = run_command(cmd_buf);
 		if (retCode != 0)
 			log_cmd_error("Shell command returned error code %d.\n", retCode);

--- a/kernel/tclapi.cc
+++ b/kernel/tclapi.cc
@@ -137,7 +137,7 @@ static int tcl_yosys_cmd(ClientData, Tcl_Interp *interp, int argc, const char *a
 		if (err.empty()) {
 			Tcl_SetObjResult(interp, json_to_tcl(interp, json));
 		} else
-			log_warning("Ignoring result.json scratchpad value due to parse error: %s\n", err.c_str());
+			log_warning("Ignoring result.json scratchpad value due to parse error: %s\n", err);
 	} else if ((result = scratchpad.find("result.string")) != scratchpad.end()) {
 		Tcl_SetObjResult(interp, Tcl_NewStringObj(result->second.data(), result->second.size()));
 	}

--- a/passes/cmds/abstract.cc
+++ b/passes/cmds/abstract.cc
@@ -53,7 +53,7 @@ struct Slice {
 	}
 
 	static void syntax_error(const std::string &slice) {
-		log_cmd_error("Invalid slice '%s', expected '<first>:<last>' or '<single>'", slice.c_str());
+		log_cmd_error("Invalid slice '%s', expected '<first>:<last>' or '<single>'", slice);
 	}
 
 	std::string to_string() const {
@@ -494,7 +494,7 @@ struct AbstractPass : public Pass {
 					case Enable::ActiveHigh: {
 						Wire *enable_wire = mod->wire("\\" + enable_name);
 						if (!enable_wire)
-							log_cmd_error("Enable wire %s not found in module %s\n", enable_name.c_str(), mod->name.c_str());
+							log_cmd_error("Enable wire %s not found in module %s\n", enable_name, mod->name);
 						if (GetSize(enable_wire) != 1)
 							log_cmd_error("Enable wire %s must have width 1 but has width %d in module %s\n",
 									enable_name.c_str(), GetSize(enable_wire), mod->name.c_str());

--- a/passes/cmds/add.cc
+++ b/passes/cmds/add.cc
@@ -77,7 +77,7 @@ static void add_wire(RTLIL::Design *design, RTLIL::Module *module, std::string n
 			wire = nullptr;
 
 		if (wire == nullptr)
-			log_cmd_error("Found incompatible object with same name in module %s!\n", module->name.c_str());
+			log_cmd_error("Found incompatible object with same name in module %s!\n", module->name);
 
 		log("Module %s already has such an object.\n", module->name);
 	}

--- a/passes/cmds/check.cc
+++ b/passes/cmds/check.cc
@@ -323,7 +323,7 @@ struct CheckPass : public Pass {
 					string message = stringf("Drivers conflicting with a constant %s driver:\n", log_signal(state));
 					for (auto str : wire_drivers[state])
 						message += stringf("    %s\n", str);
-					log_warning("%s", message.c_str());
+					log_warning("%s", message);
 					counter++;
 				}
 
@@ -332,7 +332,7 @@ struct CheckPass : public Pass {
 					string message = stringf("multiple conflicting drivers for %s.%s:\n", log_id(module), log_signal(it.first));
 					for (auto str : it.second)
 						message += stringf("    %s\n", str);
-					log_warning("%s", message.c_str());
+					log_warning("%s", message);
 					counter++;
 				}
 
@@ -418,7 +418,7 @@ struct CheckPass : public Pass {
 
 					prev = bit;
 				}
-				log_warning("%s", message.c_str());
+				log_warning("%s", message);
 				counter++;
 			}
 

--- a/passes/cmds/connect.cc
+++ b/passes/cmds/connect.cc
@@ -150,9 +150,9 @@ struct ConnectPass : public Pass {
 
 			RTLIL::SigSpec sig_lhs, sig_rhs;
 			if (!RTLIL::SigSpec::parse_sel(sig_lhs, design, module, set_lhs))
-				log_cmd_error("Failed to parse set lhs expression `%s'.\n", set_lhs.c_str());
+				log_cmd_error("Failed to parse set lhs expression `%s'.\n", set_lhs);
 			if (!RTLIL::SigSpec::parse_rhs(sig_lhs, sig_rhs, module, set_rhs))
-				log_cmd_error("Failed to parse set rhs expression `%s'.\n", set_rhs.c_str());
+				log_cmd_error("Failed to parse set rhs expression `%s'.\n", set_rhs);
 
 			sigmap.apply(sig_lhs);
 			sigmap.apply(sig_rhs);
@@ -173,7 +173,7 @@ struct ConnectPass : public Pass {
 
 			RTLIL::SigSpec sig;
 			if (!RTLIL::SigSpec::parse_sel(sig, design, module, unset_expr))
-				log_cmd_error("Failed to parse unset expression `%s'.\n", unset_expr.c_str());
+				log_cmd_error("Failed to parse unset expression `%s'.\n", unset_expr);
 
 			sigmap.apply(sig);
 			unset_drivers(design, module, sigmap, sig);
@@ -185,11 +185,11 @@ struct ConnectPass : public Pass {
 				log_cmd_error("Can't use -port together with -nounset.\n");
 
 			if (module->cell(RTLIL::escape_id(port_cell)) == nullptr)
-				log_cmd_error("Can't find cell %s.\n", port_cell.c_str());
+				log_cmd_error("Can't find cell %s.\n", port_cell);
 
 			RTLIL::SigSpec sig;
 			if (!RTLIL::SigSpec::parse_sel(sig, design, module, port_expr))
-				log_cmd_error("Failed to parse port expression `%s'.\n", port_expr.c_str());
+				log_cmd_error("Failed to parse port expression `%s'.\n", port_expr);
 
 			if (!flag_assert) {
 				module->cell(RTLIL::escape_id(port_cell))->setPort(RTLIL::escape_id(port_port), sigmap(sig));

--- a/passes/cmds/connwrappers.cc
+++ b/passes/cmds/connwrappers.cc
@@ -42,7 +42,7 @@ struct ConnwrappersWorker
 		decl_celltypes.insert(key.first);
 
 		if (decls.count(key))
-			log_cmd_error("Duplicate port decl: %s %s\n", celltype.c_str(), portname.c_str());
+			log_cmd_error("Duplicate port decl: %s %s\n", celltype, portname);
 
 		portdecl_t decl;
 		decl.widthparam = RTLIL::escape_id(widthparam);
@@ -57,7 +57,7 @@ struct ConnwrappersWorker
 		decl_celltypes.insert(key.first);
 
 		if (decls.count(key))
-			log_cmd_error("Duplicate port decl: %s %s\n", celltype.c_str(), portname.c_str());
+			log_cmd_error("Duplicate port decl: %s %s\n", celltype, portname);
 
 		portdecl_t decl;
 		decl.widthparam = RTLIL::escape_id(widthparam);

--- a/passes/cmds/copy.cc
+++ b/passes/cmds/copy.cc
@@ -45,10 +45,10 @@ struct CopyPass : public Pass {
 		std::string trg_name = RTLIL::escape_id(args[2]);
 
 		if (design->module(src_name) == nullptr)
-			log_cmd_error("Can't find source module %s.\n", src_name.c_str());
+			log_cmd_error("Can't find source module %s.\n", src_name);
 
 		if (design->module(trg_name) != nullptr)
-			log_cmd_error("Target module name %s already exists.\n", trg_name.c_str());
+			log_cmd_error("Target module name %s already exists.\n", trg_name);
 
 		RTLIL::Module *new_mod = design->module(src_name)->clone();
 		new_mod->name = trg_name;

--- a/passes/cmds/cover.cc
+++ b/passes/cmds/cover.cc
@@ -118,7 +118,7 @@ struct CoverPass : public Pass {
 				if (f == NULL) {
 					for (auto f : out_files)
 						fclose(f);
-					log_cmd_error("Can't create file %s%s.\n", args[argidx-1] == "-d" ? "in directory " : "", args[argidx].c_str());
+					log_cmd_error("Can't create file %s%s.\n", args[argidx-1] == "-d" ? "in directory " : "", args[argidx]);
 				}
 				out_files.push_back(f);
 				continue;

--- a/passes/cmds/design.cc
+++ b/passes/cmds/design.cc
@@ -165,13 +165,13 @@ struct DesignPass : public Pass {
 				got_mode = true;
 				load_name = args[++argidx];
 				if (saved_designs.count(load_name) == 0)
-					log_cmd_error("No saved design '%s' found!\n", load_name.c_str());
+					log_cmd_error("No saved design '%s' found!\n", load_name);
 				continue;
 			}
 			if (!got_mode && args[argidx] == "-copy-from" && argidx+1 < args.size()) {
 				got_mode = true;
 				if (saved_designs.count(args[++argidx]) == 0)
-					log_cmd_error("No saved design '%s' found!\n", args[argidx].c_str());
+					log_cmd_error("No saved design '%s' found!\n", args[argidx]);
 				copy_from_design = saved_designs.at(args[argidx]);
 				copy_to_design = design;
 				continue;
@@ -188,7 +188,7 @@ struct DesignPass : public Pass {
 				got_mode = true;
 				import_mode = true;
 				if (saved_designs.count(args[++argidx]) == 0)
-					log_cmd_error("No saved design '%s' found!\n", args[argidx].c_str());
+					log_cmd_error("No saved design '%s' found!\n", args[argidx]);
 				copy_from_design = saved_designs.at(args[argidx]);
 				copy_to_design = design;
 				as_name = args[argidx];
@@ -202,7 +202,7 @@ struct DesignPass : public Pass {
 				got_mode = true;
 				delete_name = args[++argidx];
 				if (saved_designs.count(delete_name) == 0)
-					log_cmd_error("No saved design '%s' found!\n", delete_name.c_str());
+					log_cmd_error("No saved design '%s' found!\n", delete_name);
 				continue;
 			}
 			break;

--- a/passes/cmds/exec.cc
+++ b/passes/cmds/exec.cc
@@ -127,7 +127,7 @@ struct ExecPass : public Pass {
 						x.re = YS_REGEX_COMPILE(args[argidx]);
 						expect_stdout.push_back(x);
 					} catch (const std::regex_error& e) {
-						log_cmd_error("Error in regex expression '%s' !\n", args[argidx].c_str());
+						log_cmd_error("Error in regex expression '%s' !\n", args[argidx]);
 					}
 				} else if (args[argidx] == "-not-expect-stdout") {
 					flag_expect_stdout = true;
@@ -142,11 +142,11 @@ struct ExecPass : public Pass {
 						x.polarity = false;
 						expect_stdout.push_back(x);
 					} catch (const std::regex_error& e) {
-						log_cmd_error("Error in regex expression '%s' !\n", args[argidx].c_str());
+						log_cmd_error("Error in regex expression '%s' !\n", args[argidx]);
 					}
 
 				} else
-					log_cmd_error("Unknown option \"%s\" or \"--\" doesn\'t precede command.\n", args[argidx].c_str());
+					log_cmd_error("Unknown option \"%s\" or \"--\" doesn\'t precede command.\n", args[argidx]);
 			}
 		}
 
@@ -201,7 +201,7 @@ struct ExecPass : public Pass {
 		if (flag_expect_stdout)
 			for (auto &x : expect_stdout)
 				if (x.polarity ^ x.matched)
-					log_cmd_error("Command stdout did%s have a line matching given regex \"%s\".\n", (x.polarity? " not" : ""), x.str.c_str());
+					log_cmd_error("Command stdout did%s have a line matching given regex \"%s\".\n", (x.polarity? " not" : ""), x.str);
 
 		log_pop();
 	}

--- a/passes/cmds/exec.cc
+++ b/passes/cmds/exec.cc
@@ -150,7 +150,7 @@ struct ExecPass : public Pass {
 			}
 		}
 
-		log_header(design, "Executing command \"%s\".\n", cmd.c_str());
+		log_header(design, "Executing command \"%s\".\n", cmd);
 		log_push();
 
 		fflush(stdout);

--- a/passes/cmds/glift.cc
+++ b/passes/cmds/glift.cc
@@ -184,7 +184,7 @@ private:
 
 		for(auto &cell : module->cells().to_vector()) {
 			if (!cell->type.in(ID($_AND_), ID($_NAND_), ID($_OR_), ID($_NOR_), ID($_XOR_), ID($_XNOR_), ID($_MUX_), ID($_NMUX_), ID($_NOT_), ID($anyconst), ID($allconst), ID($assume), ID($assert)) && module->design->module(cell->type) == nullptr) {
-				log_cmd_error("Unsupported cell type \"%s\" found.  Run `techmap` first.\n", cell->type.c_str());
+				log_cmd_error("Unsupported cell type \"%s\" found.  Run `techmap` first.\n", cell->type);
 			}
 			if (cell->type.in(ID($_AND_), ID($_NAND_), ID($_OR_), ID($_NOR_))) {
 				const unsigned int A = 0, B = 1, Y = 2;

--- a/passes/cmds/logcmd.cc
+++ b/passes/cmds/logcmd.cc
@@ -107,7 +107,7 @@ struct LogPass : public Pass {
 		if (to_stderr) fprintf(stderr, "%s%s", text.c_str(), line_end);
 		if (to_log) {
 			if (!header) log("%s%s", text, line_end);
-			else log_header(design, "%s%s", text.c_str(), line_end);
+			else log_header(design, "%s%s", text, line_end);
 		}
 	}
 } LogPass;

--- a/passes/cmds/logger.cc
+++ b/passes/cmds/logger.cc
@@ -112,7 +112,7 @@ struct LoggerPass : public Pass {
 					log_warn_regexes.push_back(YS_REGEX_COMPILE(pattern));
 				}
 				catch (const std::regex_error& e) {
-					log_cmd_error("Error in regex expression '%s' !\n", pattern.c_str());
+					log_cmd_error("Error in regex expression '%s' !\n", pattern);
 				}
 				continue;
 			}
@@ -124,7 +124,7 @@ struct LoggerPass : public Pass {
 					log_nowarn_regexes.push_back(YS_REGEX_COMPILE(pattern));
 				}
 				catch (const std::regex_error& e) {
-					log_cmd_error("Error in regex expression '%s' !\n", pattern.c_str());
+					log_cmd_error("Error in regex expression '%s' !\n", pattern);
 				}
 				continue;
 			}
@@ -136,7 +136,7 @@ struct LoggerPass : public Pass {
 					log_werror_regexes.push_back(YS_REGEX_COMPILE(pattern));
 				}
 				catch (const std::regex_error& e) {
-					log_cmd_error("Error in regex expression '%s' !\n", pattern.c_str());
+					log_cmd_error("Error in regex expression '%s' !\n", pattern);
 				}
 				continue;
 			}
@@ -188,7 +188,7 @@ struct LoggerPass : public Pass {
 					else log_abort();
 				}
 				catch (const std::regex_error& e) {
-					log_cmd_error("Error in regex expression '%s' !\n", pattern.c_str());
+					log_cmd_error("Error in regex expression '%s' !\n", pattern);
 				}
 				continue;
 			}

--- a/passes/cmds/plugin.cc
+++ b/passes/cmds/plugin.cc
@@ -70,7 +70,7 @@ void load_plugin(std::string filename, std::vector<std::string> aliases)
 				if(module_p == NULL)
 				{
 					PyErr_Print();
-					log_cmd_error("Can't load python module `%s'\n", full_path.filename().c_str());
+					log_cmd_error("Can't load python module `%s'\n", full_path.filename());
 					return;
 				}
 				loaded_python_plugins[orig_filename] = module_p;
@@ -100,7 +100,7 @@ void load_plugin(std::string filename, std::vector<std::string> aliases)
 			}
 
 			if (hdl == NULL)
-				log_cmd_error("Can't load module `%s': %s\n", filename.c_str(), dlerror());
+				log_cmd_error("Can't load module `%s': %s\n", filename, dlerror());
 
 			loaded_plugins[orig_filename] = hdl;
 			Pass::init_register();

--- a/passes/cmds/rename.cc
+++ b/passes/cmds/rename.cc
@@ -31,7 +31,7 @@ static void rename_in_module(RTLIL::Module *module, std::string from_name, std::
 	to_name = RTLIL::escape_id(to_name);
 
 	if (module->count_id(to_name))
-		log_cmd_error("There is already an object `%s' in module `%s'.\n", to_name.c_str(), module->name.c_str());
+		log_cmd_error("There is already an object `%s' in module `%s'.\n", to_name, module->name);
 
 	RTLIL::Wire *wire_to_rename = module->wire(from_name);
 	RTLIL::Cell *cell_to_rename = module->cell(from_name);
@@ -55,7 +55,7 @@ static void rename_in_module(RTLIL::Module *module, std::string from_name, std::
 		return;
 	}
 
-	log_cmd_error("Object `%s' not found!\n", from_name.c_str());
+	log_cmd_error("Object `%s' not found!\n", from_name);
 }
 
 static std::string derive_name_from_src(const std::string &src, int counter)
@@ -632,7 +632,7 @@ struct RenamePass : public Pass {
 					log("Renaming module %s to %s.\n", module_to_rename->name, to_name);
 					design->rename(module_to_rename, to_name);
 				} else
-					log_cmd_error("Object `%s' not found!\n", from_name.c_str());
+					log_cmd_error("Object `%s' not found!\n", from_name);
 			}
 		}
 	}

--- a/passes/cmds/select.cc
+++ b/passes/cmds/select.cc
@@ -658,7 +658,7 @@ static void select_op_expand(RTLIL::Design *design, const std::string &arg, char
 	}
 
 	if (rem_objects == 0)
-		log_warning("reached configured limit at `%s'.\n", arg.c_str());
+		log_warning("reached configured limit at `%s'.\n", arg);
 }
 
 static void select_filter_active_mod(RTLIL::Design *design, RTLIL::Selection &sel)
@@ -1002,14 +1002,14 @@ static void select_stmt(RTLIL::Design *design, std::string arg, bool disable_emp
 		if (it.second == false && !disable_empty_warning) {
 			std::string selection_str = select_blackboxes ? "=" : "";
 			selection_str += it.first;
-			log_warning("Selection \"%s\" did not match any module.\n", selection_str.c_str());
+			log_warning("Selection \"%s\" did not match any module.\n", selection_str);
 		}
 	}
 	for (auto &it : arg_memb_found) {
 		if (it.second == false && !disable_empty_warning) {
 			std::string selection_str = select_blackboxes ? "=" : "";
 			selection_str += it.first;
-			log_warning("Selection \"%s\" did not match any object.\n", selection_str.c_str());
+			log_warning("Selection \"%s\" did not match any object.\n", selection_str);
 		}
 	}
 }
@@ -1451,7 +1451,7 @@ struct SelectPass : public Pass {
 			while (std::getline(f, line)) {
 				size_t slash_pos = line.find('/');
 				if (slash_pos == string::npos) {
-					log_warning("Ignoring line without slash in 'select -read': %s\n", line.c_str());
+					log_warning("Ignoring line without slash in 'select -read': %s\n", line);
 					continue;
 				}
 				IdString mod_name = RTLIL::escape_id(line.substr(0, slash_pos));

--- a/passes/cmds/select.cc
+++ b/passes/cmds/select.cc
@@ -592,7 +592,7 @@ static void select_op_expand(RTLIL::Design *design, const std::string &arg, char
 
 	while (pos < int(arg.size())) {
 		if (arg[pos] != ':' || pos+1 == int(arg.size()))
-			log_cmd_error("Syntax error in expand operator '%s'.\n", arg.c_str());
+			log_cmd_error("Syntax error in expand operator '%s'.\n", arg);
 		pos++;
 		if (arg[pos] == '+' || arg[pos] == '-') {
 			expand_rule_t rule;
@@ -617,7 +617,7 @@ static void select_op_expand(RTLIL::Design *design, const std::string &arg, char
 						for (auto i2 : i1.second)
 							limits.insert(i2);
 					} else
-						log_cmd_error("Selection %s is not defined!\n", RTLIL::unescape_id(str).c_str());
+						log_cmd_error("Selection %s is not defined!\n", RTLIL::unescape_id(str));
 				} else
 					limits.insert(RTLIL::escape_id(str));
 			}
@@ -804,7 +804,7 @@ static void select_stmt(RTLIL::Design *design, std::string arg, bool disable_emp
 				log_cmd_error("Must have at least one element on the stack for operator %%coe.\n");
 			select_op_expand(design, arg, 'o', true);
 		} else
-			log_cmd_error("Unknown selection operator '%s'.\n", arg.c_str());
+			log_cmd_error("Unknown selection operator '%s'.\n", arg);
 		if (work_stack.size() >= 1)
 			select_filter_active_mod(design, work_stack.back());
 		return;
@@ -815,7 +815,7 @@ static void select_stmt(RTLIL::Design *design, std::string arg, bool disable_emp
 		if (design->selection_vars.count(set_name) > 0)
 			work_stack.push_back(design->selection_vars[set_name]);
 		else
-			log_cmd_error("Selection @%s is not defined!\n", RTLIL::unescape_id(set_name).c_str());
+			log_cmd_error("Selection @%s is not defined!\n", RTLIL::unescape_id(set_name));
 		select_filter_active_mod(design, work_stack.back());
 		return;
 	}
@@ -934,7 +934,7 @@ static void select_stmt(RTLIL::Design *design, std::string arg, bool disable_emp
 			if (arg_memb.compare(2, 1, "@") == 0) {
 				std::string set_name = RTLIL::escape_id(arg_memb.substr(3));
 				if (!design->selection_vars.count(set_name))
-					log_cmd_error("Selection @%s is not defined!\n", RTLIL::unescape_id(set_name).c_str());
+					log_cmd_error("Selection @%s is not defined!\n", RTLIL::unescape_id(set_name));
 
 				auto &muster = design->selection_vars[set_name];
 				for (auto cell : mod->cells())
@@ -1428,7 +1428,7 @@ struct SelectPass : public Pass {
 				continue;
 			}
 			if (arg.size() > 0 && arg[0] == '-')
-				log_cmd_error("Unknown option %s.\n", arg.c_str());
+				log_cmd_error("Unknown option %s.\n", arg);
 			bool disable_empty_warning = count_mode || assert_none || assert_any || (assert_modcount != -1) ||
 											(assert_count != -1) || (assert_max != -1) || (assert_min != -1);
 			select_stmt(design, arg, disable_empty_warning);
@@ -1762,7 +1762,7 @@ struct CdPass : public Pass {
 			return;
 		}
 
-		log_cmd_error("No such module `%s' found!\n", RTLIL::unescape_id(modname).c_str());
+		log_cmd_error("No such module `%s' found!\n", RTLIL::unescape_id(modname));
 	}
 } CdPass;
 

--- a/passes/cmds/setattr.cc
+++ b/passes/cmds/setattr.cc
@@ -39,7 +39,7 @@ struct setunset_t
 		} else {
 			RTLIL::SigSpec sig_value;
 			if (!RTLIL::SigSpec::parse(sig_value, nullptr, set_value))
-				log_cmd_error("Can't decode value '%s'!\n", set_value.c_str());
+				log_cmd_error("Can't decode value '%s'!\n", set_value);
 			value = sig_value.as_const();
 		}
 	}

--- a/passes/cmds/setenv.cc
+++ b/passes/cmds/setenv.cc
@@ -52,7 +52,7 @@ struct SetenvPass : public Pass {
 		_putenv_s(name.c_str(), value.c_str());
 #else
 		if (setenv(name.c_str(), value.c_str(), 1))
-			log_cmd_error("Invalid name \"%s\".\n", name.c_str());
+			log_cmd_error("Invalid name \"%s\".\n", name);
 #endif
 		
 	}

--- a/passes/cmds/show.cc
+++ b/passes/cmds/show.cc
@@ -926,7 +926,7 @@ struct ShowPass : public Pass {
 		if (f == nullptr) {
 			for (auto lib : libs)
 				delete lib;
-			log_cmd_error("Can't open dot file `%s' for writing.\n", dot_file.c_str());
+			log_cmd_error("Can't open dot file `%s' for writing.\n", dot_file);
 		}
 		ShowWorker worker(f, design, libs, colorSeed, flag_width, flag_wireshape, flag_signed, flag_stretch, flag_enum, flag_abbreviate, flag_notitle, flag_href, color_selections, label_selections, colorattr);
 		fclose(f);

--- a/passes/cmds/stat.cc
+++ b/passes/cmds/stat.cc
@@ -228,7 +228,7 @@ struct statdata_t {
 							cell_area.at(cell_type).is_sequential = cell_data.is_sequential;
 
 						} else {
-							log_warning("too small single_parameter_area %s width: %d size: %d\n", cell_type.c_str(), max_width,
+							log_warning("too small single_parameter_area %s width: %d size: %d\n", cell_type, max_width,
 							       (int)cell_data.single_parameter_area.size());
 							cell_area.at(cell_type).area = cell_data.single_parameter_area.back();
 							cell_area.at(cell_type).is_sequential = cell_data.is_sequential;
@@ -274,7 +274,7 @@ struct statdata_t {
 									  cell_data.double_parameter_area.at(width_a - 1).at(width_b - 1);
 									cell_area.at(cell_type).is_sequential = cell_data.is_sequential;
 								} else {
-									log_warning("too small double_parameter_area %s, width_a: %d, width_b: %d, size_a: %d, size_b: %d\n", cell_type.c_str(),
+									log_warning("too small double_parameter_area %s, width_a: %d, width_b: %d, size_a: %d, size_b: %d\n", cell_type,
 									       width_a, width_b, (int)cell_data.double_parameter_area.size(),
 									       (int)cell_data.double_parameter_area.at(width_a - 1).size());
 									cell_area.at(cell_type).area = cell_data.double_parameter_area.back().back();

--- a/passes/cmds/stat.cc
+++ b/passes/cmds/stat.cc
@@ -949,7 +949,7 @@ struct StatPass : public Pass {
 			}
 			if (args[argidx] == "-top" && argidx + 1 < args.size()) {
 				if (design->module(RTLIL::escape_id(args[argidx + 1])) == nullptr)
-					log_cmd_error("Can't find module %s.\n", args[argidx + 1].c_str());
+					log_cmd_error("Can't find module %s.\n", args[argidx + 1]);
 				top_mod = design->module(RTLIL::escape_id(args[++argidx]));
 				continue;
 			}
@@ -969,7 +969,7 @@ struct StatPass : public Pass {
 			log_header(design, "Printing statistics.\n");
 
 		if (techname != "" && techname != "xilinx" && techname != "cmos" && !json_mode)
-			log_cmd_error("Unsupported technology: '%s'\n", techname.c_str());
+			log_cmd_error("Unsupported technology: '%s'\n", techname);
 
 		if (json_mode) {
 			log("{\n");

--- a/passes/cmds/tee.cc
+++ b/passes/cmds/tee.cc
@@ -83,7 +83,7 @@ struct TeePass : public Pass {
 				if (f == NULL) {
 					for (auto cf : files_to_close)
 						fclose(cf);
-					log_cmd_error("Can't create file %s.\n", args[argidx].c_str());
+					log_cmd_error("Can't create file %s.\n", args[argidx]);
 				}
 				log_files.push_back(f);
 				files_to_close.push_back(f);

--- a/passes/cmds/timeest.cc
+++ b/passes/cmds/timeest.cc
@@ -403,7 +403,7 @@ struct TimeestPass : Pass {
 
 		for (auto m : d->selected_modules()) {
 			if (!m->wire(RTLIL::escape_id(clk))) {
-				log_warning("No domain '%s' in module %s\n", clk.c_str(), log_id(m));
+				log_warning("No domain '%s' in module %s\n", clk, log_id(m));
 				continue;
 			}
 

--- a/passes/cmds/viz.cc
+++ b/passes/cmds/viz.cc
@@ -994,7 +994,7 @@ struct VizPass : public Pass {
 			if (f != nullptr) return;
 			f = fopen(dot_file.c_str(), "w");
 			if (f == nullptr)
-				log_cmd_error("Can't open dot file `%s' for writing.\n", dot_file.c_str());
+				log_cmd_error("Can't open dot file `%s' for writing.\n", dot_file);
 		};
 		for (auto module : modlist) {
 			VizWorker worker(module, config);

--- a/passes/equiv/equiv_add.cc
+++ b/passes/equiv/equiv_add.cc
@@ -64,7 +64,7 @@ struct EquivAddPass : public Pass {
 					log_warning("Can't find gold cell '%s'.\n", args[2].c_str());
 					return;
 				}
-				log_cmd_error("Can't find gold cell '%s'.\n", args[2].c_str());
+				log_cmd_error("Can't find gold cell '%s'.\n", args[2]);
 			}
 
 			if (gate_cell == nullptr) {
@@ -72,7 +72,7 @@ struct EquivAddPass : public Pass {
 					log_warning("Can't find gate cell '%s'.\n", args[3].c_str());
 					return;
 				}
-				log_cmd_error("Can't find gate cell '%s'.\n", args[3].c_str());
+				log_cmd_error("Can't find gate cell '%s'.\n", args[3]);
 			}
 
 			for (auto conn : gold_cell->connections())
@@ -129,7 +129,7 @@ struct EquivAddPass : public Pass {
 					log_warning("Error in gate signal: %s\n", args[2].c_str());
 					return;
 				}
-				log_cmd_error("Error in gate signal: %s\n", args[2].c_str());
+				log_cmd_error("Error in gate signal: %s\n", args[2]);
 			}
 
 			if (!SigSpec::parse_rhs(gate_signal, gold_signal, module, args[1])) {
@@ -137,7 +137,7 @@ struct EquivAddPass : public Pass {
 					log_warning("Error in gold signal: %s\n", args[1].c_str());
 					return;
 				}
-				log_cmd_error("Error in gold signal: %s\n", args[1].c_str());
+				log_cmd_error("Error in gold signal: %s\n", args[1]);
 			}
 
 			log_assert(GetSize(gold_signal) == GetSize(gate_signal));

--- a/passes/equiv/equiv_add.cc
+++ b/passes/equiv/equiv_add.cc
@@ -61,7 +61,7 @@ struct EquivAddPass : public Pass {
 
 			if (gold_cell == nullptr) {
 				if (try_mode) {
-					log_warning("Can't find gold cell '%s'.\n", args[2].c_str());
+					log_warning("Can't find gold cell '%s'.\n", args[2]);
 					return;
 				}
 				log_cmd_error("Can't find gold cell '%s'.\n", args[2]);
@@ -69,7 +69,7 @@ struct EquivAddPass : public Pass {
 
 			if (gate_cell == nullptr) {
 				if (try_mode) {
-					log_warning("Can't find gate cell '%s'.\n", args[3].c_str());
+					log_warning("Can't find gate cell '%s'.\n", args[3]);
 					return;
 				}
 				log_cmd_error("Can't find gate cell '%s'.\n", args[3]);
@@ -126,7 +126,7 @@ struct EquivAddPass : public Pass {
 
 			if (!SigSpec::parse(gate_signal, module, args[2])) {
 				if (try_mode) {
-					log_warning("Error in gate signal: %s\n", args[2].c_str());
+					log_warning("Error in gate signal: %s\n", args[2]);
 					return;
 				}
 				log_cmd_error("Error in gate signal: %s\n", args[2]);
@@ -134,7 +134,7 @@ struct EquivAddPass : public Pass {
 
 			if (!SigSpec::parse_rhs(gate_signal, gold_signal, module, args[1])) {
 				if (try_mode) {
-					log_warning("Error in gold signal: %s\n", args[1].c_str());
+					log_warning("Error in gold signal: %s\n", args[1]);
 					return;
 				}
 				log_cmd_error("Error in gold signal: %s\n", args[1]);

--- a/passes/equiv/equiv_make.cc
+++ b/passes/equiv/equiv_make.cc
@@ -47,7 +47,7 @@ struct EquivMakeWorker
 		{
 			std::ifstream f(fn);
 			if (f.fail())
-				log_cmd_error("Can't open blacklist file '%s'!\n", fn.c_str());
+				log_cmd_error("Can't open blacklist file '%s'!\n", fn);
 
 			string line, token;
 			while (std::getline(f, line)) {
@@ -67,7 +67,7 @@ struct EquivMakeWorker
 		{
 			std::ifstream f(fn);
 			if (f.fail())
-				log_cmd_error("Can't open encfile '%s'!\n", fn.c_str());
+				log_cmd_error("Can't open encfile '%s'!\n", fn);
 
 			dict<Const, Const> *ed = nullptr;
 			string line, token;
@@ -81,7 +81,7 @@ struct EquivMakeWorker
 					IdString modname = RTLIL::escape_id(next_token(line));
 					IdString signame = RTLIL::escape_id(next_token(line));
 					if (encdata.count(signame))
-						log_cmd_error("Re-definition of signal '%s' in encfile '%s'!\n", signame.c_str(), fn.c_str());
+						log_cmd_error("Re-definition of signal '%s' in encfile '%s'!\n", signame, fn);
 					encdata[signame] = dict<Const, Const>();
 					ed = &encdata[signame];
 					continue;
@@ -94,7 +94,7 @@ struct EquivMakeWorker
 					continue;
 				}
 
-				log_cmd_error("Syntax error in encfile '%s'!\n", fn.c_str());
+				log_cmd_error("Syntax error in encfile '%s'!\n", fn);
 			}
 		}
 	}
@@ -492,13 +492,13 @@ struct EquivMakePass : public Pass {
 		worker.equiv_mod = design->module(RTLIL::escape_id(args[argidx+2]));
 
 		if (worker.gold_mod == nullptr)
-			log_cmd_error("Can't find gold module %s.\n", args[argidx].c_str());
+			log_cmd_error("Can't find gold module %s.\n", args[argidx]);
 
 		if (worker.gate_mod == nullptr)
-			log_cmd_error("Can't find gate module %s.\n", args[argidx+1].c_str());
+			log_cmd_error("Can't find gate module %s.\n", args[argidx+1]);
 
 		if (worker.equiv_mod != nullptr)
-			log_cmd_error("Equiv module %s already exists.\n", args[argidx+2].c_str());
+			log_cmd_error("Equiv module %s already exists.\n", args[argidx+2]);
 
 		if (worker.gold_mod->has_memories() || worker.gold_mod->has_processes())
 			log_cmd_error("Gold module contains memories or processes. Run 'memory' or 'proc' respectively.\n");

--- a/passes/fsm/fsm_detect.cc
+++ b/passes/fsm/fsm_detect.cc
@@ -225,7 +225,7 @@ static void detect_fsm(RTLIL::Wire *wire, bool ignore_self_reset=false)
 		if (!warnings.empty()) {
 			string warnmsg = stringf("Regarding the user-specified fsm_encoding attribute on %s.%s:\n", log_id(wire->module), log_id(wire));
 			for (auto w : warnings) warnmsg += "    " + w;
-			log_warning("%s", warnmsg.c_str());
+			log_warning("%s", warnmsg);
 		} else {
 			log("FSM state register %s.%s already has fsm_encoding attribute.\n", log_id(wire->module), log_id(wire));
 		}

--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -937,7 +937,7 @@ struct HierarchyPass : public Pass {
 				const std::string &value = args[++argidx];
 				auto r = parameters.emplace(key, value);
 				if (!r.second) {
-					log_warning("-chparam %s already specified: overwriting.\n", key.c_str());
+					log_warning("-chparam %s already specified: overwriting.\n", key);
 					r.first->second = value;
 				}
 				continue;

--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -957,7 +957,7 @@ struct HierarchyPass : public Pass {
 				for (auto &para : parameters) {
 					SigSpec sig_value;
 					if (!RTLIL::SigSpec::parse(sig_value, NULL, para.second))
-						log_cmd_error("Can't decode value '%s'!\n", para.second.c_str());
+						log_cmd_error("Can't decode value '%s'!\n", para.second);
 					top_parameters[RTLIL::escape_id(para.first)] = sig_value.as_const();
 				}
 			}
@@ -991,7 +991,7 @@ struct HierarchyPass : public Pass {
 			}
 #endif
 			if (top_mod == NULL)
-				log_cmd_error("Module `%s' not found!\n", load_top_mod.c_str());
+				log_cmd_error("Module `%s' not found!\n", load_top_mod);
 		} else {
 #ifdef YOSYS_ENABLE_VERIFIC
 			if (verific_import_pending)
@@ -1045,7 +1045,7 @@ struct HierarchyPass : public Pass {
 			for (auto &para : parameters) {
 				SigSpec sig_value;
 				if (!RTLIL::SigSpec::parse(sig_value, NULL, para.second))
-					log_cmd_error("Can't decode value '%s'!\n", para.second.c_str());
+					log_cmd_error("Can't decode value '%s'!\n", para.second);
 				top_parameters[RTLIL::escape_id(para.first)] = sig_value.as_const();
 			}
 

--- a/passes/hierarchy/submod.cc
+++ b/passes/hierarchy/submod.cc
@@ -408,7 +408,7 @@ struct SubmodPass : public Pass {
 			RTLIL::Module *module = nullptr;
 			for (auto mod : design->selected_modules()) {
 				if (module != nullptr)
-					log_cmd_error("More than one module selected: %s %s\n", module->name.c_str(), mod->name.c_str());
+					log_cmd_error("More than one module selected: %s %s\n", module->name, mod->name);
 				module = mod;
 			}
 			if (module == nullptr)

--- a/passes/hierarchy/submod.cc
+++ b/passes/hierarchy/submod.cc
@@ -95,7 +95,7 @@ struct SubmodWorker
 				for (auto &conn : cell->connections())
 					flag_signal(conn.second, true, ct.cell_output(cell->type, conn.first), ct.cell_input(cell->type, conn.first), false, false);
 			} else {
-				log_warning("Port directions for cell %s (%s) are unknown. Assuming inout for all ports.\n", cell->name.c_str(), cell->type.c_str());
+				log_warning("Port directions for cell %s (%s) are unknown. Assuming inout for all ports.\n", cell->name, cell->type);
 				for (auto &conn : cell->connections())
 					flag_signal(conn.second, true, true, true, false, false);
 			}
@@ -111,7 +111,7 @@ struct SubmodWorker
 				for (auto &conn : cell->connections())
 					flag_signal(conn.second, false, false, false, true, true);
 				if (flag_found_something)
-					log_warning("Port directions for cell %s (%s) are unknown. Assuming inout for all ports.\n", cell->name.c_str(), cell->type.c_str());
+					log_warning("Port directions for cell %s (%s) are unknown. Assuming inout for all ports.\n", cell->name, cell->type);
 			}
 		}
 

--- a/passes/memory/memlib.cc
+++ b/passes/memory/memlib.cc
@@ -1097,7 +1097,7 @@ Library MemLibrary::parse_library(const std::vector<std::string> &filenames, con
 		Parser(file, res, defines, defines_unused);
 	}
 	for (auto def: defines_unused) {
-		log_warning("define %s not used in the library.\n", def.c_str());
+		log_warning("define %s not used in the library.\n", def);
 	}
 	return res;
 }

--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -233,7 +233,7 @@ void rmunused_module_cells(Module *module, bool verbose)
 	for (auto it : driver_driver_logs) {
 		if (used_raw_bits.count(it.first))
 			for (auto msg : it.second)
-				log_warning("%s\n", msg.c_str());
+				log_warning("%s\n", msg);
 	}
 }
 

--- a/passes/opt/opt_lut.cc
+++ b/passes/opt/opt_lut.cc
@@ -555,7 +555,7 @@ struct OptLutPass : public Pass {
 			{
 				std::string tech = args[++argidx];
 				if (tech != "ice40")
-					log_cmd_error("Unsupported -tech argument: %s\n", tech.c_str());
+					log_cmd_error("Unsupported -tech argument: %s\n", tech);
 
 				dlogic = {{
 					ID(SB_CARRY),

--- a/passes/opt/opt_lut_ins.cc
+++ b/passes/opt/opt_lut_ins.cc
@@ -59,7 +59,7 @@ struct OptLutInsPass : public Pass {
 		extra_args(args, argidx, design);
 
 		if (techname != "" && techname != "xilinx" && techname != "lattice" && techname != "ecp5" && techname != "gowin")
-			log_cmd_error("Unsupported technology: '%s'\n", techname.c_str());
+			log_cmd_error("Unsupported technology: '%s'\n", techname);
 
 		for (auto module : design->selected_modules())
 		{

--- a/passes/pmgen/test_pmgen.cc
+++ b/passes/pmgen/test_pmgen.cc
@@ -238,7 +238,7 @@ struct TestPmgenPass : public Pass {
 		if (pattern == "xilinx_srl.variable")
 			return GENERATE_PATTERN(xilinx_srl_pm, variable);
 
-		log_cmd_error("Unknown pattern: %s\n", pattern.c_str());
+		log_cmd_error("Unknown pattern: %s\n", pattern);
 	}
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override

--- a/passes/sat/eval.cc
+++ b/passes/sat/eval.cc
@@ -94,11 +94,11 @@ struct BruteForceEquivChecker
 				continue;
 
 			if (mod2->wire(w->name) == nullptr)
-				log_cmd_error("Port %s in module 1 has no counterpart in module 2!\n", w->name.c_str());
+				log_cmd_error("Port %s in module 1 has no counterpart in module 2!\n", w->name);
 
 			RTLIL::Wire *w2 = mod2->wire(w->name);
 			if (w->width != w2->width || w->port_input != w2->port_input || w->port_output != w2->port_output)
-				log_cmd_error("Port %s in module 1 does not match its counterpart in module 2!\n", w->name.c_str());
+				log_cmd_error("Port %s in module 1 does not match its counterpart in module 2!\n", w->name);
 
 			if (w->port_input) {
 				mod1_inputs.append(w);
@@ -454,11 +454,11 @@ struct EvalPass : public Pass {
 		for (auto &it : sets) {
 			RTLIL::SigSpec lhs, rhs;
 			if (!RTLIL::SigSpec::parse_sel(lhs, design, module, it.first))
-				log_cmd_error("Failed to parse lhs set expression `%s'.\n", it.first.c_str());
+				log_cmd_error("Failed to parse lhs set expression `%s'.\n", it.first);
 			if (!RTLIL::SigSpec::parse_rhs(lhs, rhs, module, it.second))
-				log_cmd_error("Failed to parse rhs set expression `%s'.\n", it.second.c_str());
+				log_cmd_error("Failed to parse rhs set expression `%s'.\n", it.second);
 			if (!rhs.is_fully_const())
-				log_cmd_error("Right-hand-side set expression `%s' is not constant.\n", it.second.c_str());
+				log_cmd_error("Right-hand-side set expression `%s' is not constant.\n", it.second);
 			if (lhs.size() != rhs.size())
 				log_cmd_error("Set expression with different lhs and rhs sizes: %s (%s, %d bits) vs. %s (%s, %d bits)\n",
 						it.first.c_str(), log_signal(lhs), lhs.size(), it.second.c_str(), log_signal(rhs), rhs.size());
@@ -476,7 +476,7 @@ struct EvalPass : public Pass {
 			for (auto &it : shows) {
 				RTLIL::SigSpec signal, value, undef;
 				if (!RTLIL::SigSpec::parse_sel(signal, design, module, it))
-					log_cmd_error("Failed to parse show expression `%s'.\n", it.c_str());
+					log_cmd_error("Failed to parse show expression `%s'.\n", it);
 				value = signal;
 				if (set_undef) {
 					while (!ce.eval(value, undef)) {
@@ -502,14 +502,14 @@ struct EvalPass : public Pass {
 			for (auto &it : shows) {
 				RTLIL::SigSpec sig;
 				if (!RTLIL::SigSpec::parse_sel(sig, design, module, it))
-					log_cmd_error("Failed to parse show expression `%s'.\n", it.c_str());
+					log_cmd_error("Failed to parse show expression `%s'.\n", it);
 				signal.append(sig);
 			}
 
 			for (auto &it : tables) {
 				RTLIL::SigSpec sig;
 				if (!RTLIL::SigSpec::parse_sel(sig, design, module, it))
-					log_cmd_error("Failed to parse table expression `%s'.\n", it.c_str());
+					log_cmd_error("Failed to parse table expression `%s'.\n", it);
 				tabsigs.append(sig);
 			}
 

--- a/passes/sat/miter.cc
+++ b/passes/sat/miter.cc
@@ -76,11 +76,11 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 	RTLIL::IdString miter_name = RTLIL::escape_id(args[argidx++]);
 
 	if (design->module(gold_name) == nullptr)
-		log_cmd_error("Can't find gold module %s!\n", gold_name.c_str());
+		log_cmd_error("Can't find gold module %s!\n", gold_name);
 	if (design->module(gate_name) == nullptr)
-		log_cmd_error("Can't find gate module %s!\n", gate_name.c_str());
+		log_cmd_error("Can't find gate module %s!\n", gate_name);
 	if (design->module(miter_name) != nullptr)
-		log_cmd_error("There is already a module %s!\n", miter_name.c_str());
+		log_cmd_error("There is already a module %s!\n", miter_name);
 
 	RTLIL::Module *gold_module = design->module(gold_name);
 	RTLIL::Module *gate_module = design->module(gate_name);
@@ -105,7 +105,7 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 			goto match_gold_port_error;
 		continue;
 	match_gold_port_error:
-		log_cmd_error("No matching port in gate module was found for %s!\n", gold_wire->name.c_str());
+		log_cmd_error("No matching port in gate module was found for %s!\n", gold_wire->name);
 	}
 
 	for (auto gate_wire : gate_module->wires()) {
@@ -125,7 +125,7 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 			goto match_gate_port_error;
 		continue;
 	match_gate_port_error:
-		log_cmd_error("No matching port in gold module was found for %s!\n", gate_wire->name.c_str());
+		log_cmd_error("No matching port in gold module was found for %s!\n", gate_wire->name);
 	}
 
 	log("Creating miter cell \"%s\" with gold cell \"%s\" and gate cell \"%s\".\n", RTLIL::id2cstr(miter_name), RTLIL::id2cstr(gold_name), RTLIL::id2cstr(gate_name));
@@ -322,9 +322,9 @@ void create_miter_assert(struct Pass *that, std::vector<std::string> args, RTLIL
 	IdString miter_name = argidx < args.size() ? RTLIL::escape_id(args[argidx++]) : "";
 
 	if (design->module(module_name) == nullptr)
-		log_cmd_error("Can't find module %s!\n", module_name.c_str());
+		log_cmd_error("Can't find module %s!\n", module_name);
 	if (!miter_name.empty() && design->module(miter_name) != nullptr)
-		log_cmd_error("There is already a module %s!\n", miter_name.c_str());
+		log_cmd_error("There is already a module %s!\n", miter_name);
 
 	Module *module = design->module(module_name);
 

--- a/passes/sat/mutate.cc
+++ b/passes/sat/mutate.cc
@@ -989,7 +989,7 @@ struct MutatePass : public Pass {
 			return;
 		}
 
-		log_cmd_error("Invalid mode: %s\n", opts.mode.c_str());
+		log_cmd_error("Invalid mode: %s\n", opts.mode);
 	}
 } MutatePass;
 

--- a/passes/sat/qbfsat.cc
+++ b/passes/sat/qbfsat.cc
@@ -233,7 +233,7 @@ QbfSolutionType call_qbf_solver(RTLIL::Module *mod, const QbfSolveOptions &opt, 
 		ret.stdout_lines.push_back(line.substr(0, line.size()-1)); //don't include trailing newline
 		auto warning_pos = line.find(smtbmc_warning);
 		if (warning_pos != std::string::npos)
-			log_warning("%s", line.substr(warning_pos + smtbmc_warning.size() + 1).c_str());
+			log_warning("%s", line.substr(warning_pos + smtbmc_warning.size() + 1));
 		else
 			if (opt.show_smtbmc && !quiet)
 				log("smtbmc output: %s", line);

--- a/passes/sat/qbfsat.cc
+++ b/passes/sat/qbfsat.cc
@@ -87,7 +87,7 @@ void specialize_from_file(RTLIL::Module *module, const std::string &file) {
 		if (!std::regex_search(buf, bit_m, hole_bit_assn_regex)) {
 			bit_assn = false;
 			if (!std::regex_search(buf, m, hole_assn_regex))
-				log_cmd_error("solution file is not formatted correctly: \"%s\"\n", buf.c_str());
+				log_cmd_error("solution file is not formatted correctly: \"%s\"\n", buf);
 		}
 
 		std::string hole_loc = bit_assn? bit_m[1].str() : m[1].str();
@@ -108,7 +108,7 @@ void specialize_from_file(RTLIL::Module *module, const std::string &file) {
 			pool<std::string> hole_loc_pool(locs.begin(), locs.end());
 			auto hole_cell_it = anyconst_loc_to_cell.find(hole_loc_pool);
 			if (hole_cell_it == anyconst_loc_to_cell.end())
-				log_cmd_error("cannot find matching wire name or $anyconst cell location for hole spec \"%s\"\n", buf.c_str());
+				log_cmd_error("cannot find matching wire name or $anyconst cell location for hole spec \"%s\"\n", buf);
 
 			RTLIL::Cell *hole_cell = hole_cell_it->second;
 			hole_sigbit = hole_cell->getPort(ID::Y)[hole_bit];
@@ -420,7 +420,7 @@ QbfSolveOptions parse_args(const std::vector<std::string> &args) {
 				else if (args[opt.argidx+1] == "cvc5")
 					opt.solver = opt.Solver::CVC5;
 				else
-					log_cmd_error("Unknown solver \"%s\".\n", args[opt.argidx+1].c_str());
+					log_cmd_error("Unknown solver \"%s\".\n", args[opt.argidx+1]);
 				opt.argidx++;
 			}
 			continue;
@@ -457,7 +457,7 @@ QbfSolveOptions parse_args(const std::vector<std::string> &args) {
 					opt.oflag = opt.OptimizationLevel::O2;
 				break;
 				default:
-					log_cmd_error("unknown argument %s\n", args[opt.argidx].c_str());
+					log_cmd_error("unknown argument %s\n", args[opt.argidx]);
 			}
 			continue;
 		}

--- a/passes/sat/sat.cc
+++ b/passes/sat/sat.cc
@@ -106,9 +106,9 @@ struct SatHelper
 			RTLIL::SigSpec lhs, rhs;
 
 			if (!RTLIL::SigSpec::parse_sel(lhs, design, module, s.first))
-				log_cmd_error("Failed to parse lhs set expression `%s'.\n", s.first.c_str());
+				log_cmd_error("Failed to parse lhs set expression `%s'.\n", s.first);
 			if (!RTLIL::SigSpec::parse_rhs(lhs, rhs, module, s.second))
-				log_cmd_error("Failed to parse rhs set expression `%s'.\n", s.second.c_str());
+				log_cmd_error("Failed to parse rhs set expression `%s'.\n", s.second);
 			show_signal_pool.add(sigmap(lhs));
 			show_signal_pool.add(sigmap(rhs));
 
@@ -127,9 +127,9 @@ struct SatHelper
 			RTLIL::SigSpec lhs, rhs;
 
 			if (!RTLIL::SigSpec::parse_sel(lhs, design, module, s.first))
-				log_cmd_error("Failed to parse lhs set expression `%s'.\n", s.first.c_str());
+				log_cmd_error("Failed to parse lhs set expression `%s'.\n", s.first);
 			if (!RTLIL::SigSpec::parse_rhs(lhs, rhs, module, s.second))
-				log_cmd_error("Failed to parse rhs set expression `%s'.\n", s.second.c_str());
+				log_cmd_error("Failed to parse rhs set expression `%s'.\n", s.second);
 			show_signal_pool.add(sigmap(lhs));
 			show_signal_pool.add(sigmap(rhs));
 
@@ -148,7 +148,7 @@ struct SatHelper
 			RTLIL::SigSpec lhs;
 
 			if (!RTLIL::SigSpec::parse_sel(lhs, design, module, s))
-				log_cmd_error("Failed to parse lhs set expression `%s'.\n", s.c_str());
+				log_cmd_error("Failed to parse lhs set expression `%s'.\n", s);
 			show_signal_pool.add(sigmap(lhs));
 
 			log("Import unset-constraint for this timestep: %s\n", log_signal(lhs));
@@ -167,28 +167,28 @@ struct SatHelper
 		for (auto &s : sets_def) {
 			RTLIL::SigSpec sig;
 			if (!RTLIL::SigSpec::parse_sel(sig, design, module, s))
-				log_cmd_error("Failed to parse set-def expression `%s'.\n", s.c_str());
+				log_cmd_error("Failed to parse set-def expression `%s'.\n", s);
 			sets_def_undef[0].insert(sig);
 		}
 
 		for (auto &s : sets_any_undef) {
 			RTLIL::SigSpec sig;
 			if (!RTLIL::SigSpec::parse_sel(sig, design, module, s))
-				log_cmd_error("Failed to parse set-def expression `%s'.\n", s.c_str());
+				log_cmd_error("Failed to parse set-def expression `%s'.\n", s);
 			sets_def_undef[1].insert(sig);
 		}
 
 		for (auto &s : sets_all_undef) {
 			RTLIL::SigSpec sig;
 			if (!RTLIL::SigSpec::parse_sel(sig, design, module, s))
-				log_cmd_error("Failed to parse set-def expression `%s'.\n", s.c_str());
+				log_cmd_error("Failed to parse set-def expression `%s'.\n", s);
 			sets_def_undef[2].insert(sig);
 		}
 
 		for (auto &s : sets_def_at[timestep]) {
 			RTLIL::SigSpec sig;
 			if (!RTLIL::SigSpec::parse_sel(sig, design, module, s))
-				log_cmd_error("Failed to parse set-def expression `%s'.\n", s.c_str());
+				log_cmd_error("Failed to parse set-def expression `%s'.\n", s);
 			sets_def_undef[0].insert(sig);
 			sets_def_undef[1].erase(sig);
 			sets_def_undef[2].erase(sig);
@@ -197,7 +197,7 @@ struct SatHelper
 		for (auto &s : sets_any_undef_at[timestep]) {
 			RTLIL::SigSpec sig;
 			if (!RTLIL::SigSpec::parse_sel(sig, design, module, s))
-				log_cmd_error("Failed to parse set-def expression `%s'.\n", s.c_str());
+				log_cmd_error("Failed to parse set-def expression `%s'.\n", s);
 			sets_def_undef[0].erase(sig);
 			sets_def_undef[1].insert(sig);
 			sets_def_undef[2].erase(sig);
@@ -206,7 +206,7 @@ struct SatHelper
 		for (auto &s : sets_all_undef_at[timestep]) {
 			RTLIL::SigSpec sig;
 			if (!RTLIL::SigSpec::parse_sel(sig, design, module, s))
-				log_cmd_error("Failed to parse set-def expression `%s'.\n", s.c_str());
+				log_cmd_error("Failed to parse set-def expression `%s'.\n", s);
 			sets_def_undef[0].erase(sig);
 			sets_def_undef[1].erase(sig);
 			sets_def_undef[2].insert(sig);
@@ -295,9 +295,9 @@ struct SatHelper
 				RTLIL::SigSpec lhs, rhs;
 
 				if (!RTLIL::SigSpec::parse_sel(lhs, design, module, s.first))
-					log_cmd_error("Failed to parse lhs set expression `%s'.\n", s.first.c_str());
+					log_cmd_error("Failed to parse lhs set expression `%s'.\n", s.first);
 				if (!RTLIL::SigSpec::parse_rhs(lhs, rhs, module, s.second))
-					log_cmd_error("Failed to parse rhs set expression `%s'.\n", s.second.c_str());
+					log_cmd_error("Failed to parse rhs set expression `%s'.\n", s.second);
 				show_signal_pool.add(sigmap(lhs));
 				show_signal_pool.add(sigmap(rhs));
 
@@ -362,9 +362,9 @@ struct SatHelper
 				RTLIL::SigSpec lhs, rhs;
 
 				if (!RTLIL::SigSpec::parse_sel(lhs, design, module, s.first))
-					log_cmd_error("Failed to parse lhs proof expression `%s'.\n", s.first.c_str());
+					log_cmd_error("Failed to parse lhs proof expression `%s'.\n", s.first);
 				if (!RTLIL::SigSpec::parse_rhs(lhs, rhs, module, s.second))
-					log_cmd_error("Failed to parse rhs proof expression `%s'.\n", s.second.c_str());
+					log_cmd_error("Failed to parse rhs proof expression `%s'.\n", s.second);
 				show_signal_pool.add(sigmap(lhs));
 				show_signal_pool.add(sigmap(rhs));
 
@@ -390,9 +390,9 @@ struct SatHelper
 				RTLIL::SigSpec lhs, rhs;
 
 				if (!RTLIL::SigSpec::parse_sel(lhs, design, module, s.first))
-					log_cmd_error("Failed to parse lhs proof-x expression `%s'.\n", s.first.c_str());
+					log_cmd_error("Failed to parse lhs proof-x expression `%s'.\n", s.first);
 				if (!RTLIL::SigSpec::parse_rhs(lhs, rhs, module, s.second))
-					log_cmd_error("Failed to parse rhs proof-x expression `%s'.\n", s.second.c_str());
+					log_cmd_error("Failed to parse rhs proof-x expression `%s'.\n", s.second);
 				show_signal_pool.add(sigmap(lhs));
 				show_signal_pool.add(sigmap(rhs));
 
@@ -540,7 +540,7 @@ struct SatHelper
 			for (auto &s : shows) {
 				RTLIL::SigSpec sig;
 				if (!RTLIL::SigSpec::parse_sel(sig, design, module, s))
-					log_cmd_error("Failed to parse show expression `%s'.\n", s.c_str());
+					log_cmd_error("Failed to parse show expression `%s'.\n", s);
 				log("Import show expression: %s\n", log_signal(sig));
 				modelSig.append(sig);
 			}
@@ -670,7 +670,7 @@ struct SatHelper
 		rewrite_filename(vcd_file_name);
 		FILE *f = fopen(vcd_file_name.c_str(), "w");
 		if (!f)
-			log_cmd_error("Can't open output file `%s' for writing: %s\n", vcd_file_name.c_str(), strerror(errno));
+			log_cmd_error("Can't open output file `%s' for writing: %s\n", vcd_file_name, strerror(errno));
 
 		log("Dumping SAT model to VCD file %s\n", vcd_file_name);
 
@@ -775,7 +775,7 @@ struct SatHelper
 		rewrite_filename(json_file_name);
 		FILE *f = fopen(json_file_name.c_str(), "w");
 		if (!f)
-			log_cmd_error("Can't open output file `%s' for writing: %s\n", json_file_name.c_str(), strerror(errno));
+			log_cmd_error("Can't open output file `%s' for writing: %s\n", json_file_name, strerror(errno));
 
 		log("Dumping SAT model to WaveJSON file '%s'.\n", json_file_name);
 
@@ -1535,7 +1535,7 @@ struct SatPass : public Pass {
 							rewrite_filename(cnf_file_name);
 							FILE *f = fopen(cnf_file_name.c_str(), "w");
 							if (!f)
-								log_cmd_error("Can't open output file `%s' for writing: %s\n", cnf_file_name.c_str(), strerror(errno));
+								log_cmd_error("Can't open output file `%s' for writing: %s\n", cnf_file_name, strerror(errno));
 
 							log("Dumping CNF to file `%s'.\n", cnf_file_name);
 							cnf_file_name.clear();
@@ -1639,7 +1639,7 @@ struct SatPass : public Pass {
 				rewrite_filename(cnf_file_name);
 				FILE *f = fopen(cnf_file_name.c_str(), "w");
 				if (!f)
-					log_cmd_error("Can't open output file `%s' for writing: %s\n", cnf_file_name.c_str(), strerror(errno));
+					log_cmd_error("Can't open output file `%s' for writing: %s\n", cnf_file_name, strerror(errno));
 
 				log("Dumping CNF to file `%s'.\n", cnf_file_name);
 				cnf_file_name.clear();

--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -256,7 +256,7 @@ struct SimInstance
 			if ((shared->fst) && !(shared->hide_internal && wire->name[0] == '$')) {
 				fstHandle id = shared->fst->getHandle(scope + "." + RTLIL::unescape_id(wire->name));
 				if (id==0 && wire->name.isPublic())
-					log_warning("Unable to find wire %s in input file.\n", (scope + "." + RTLIL::unescape_id(wire->name)).c_str());
+					log_warning("Unable to find wire %s in input file.\n", (scope + "." + RTLIL::unescape_id(wire->name)));
 				fst_handles[wire] = id;
 			}
 
@@ -927,7 +927,7 @@ struct SimInstance
 					if (shared->serious_asserts)
 						log_error("Assertion %s.%s (%s) failed.\n", hiername(), log_id(cell), label);
 					else
-						log_warning("Assertion %s.%s (%s) failed.\n", hiername().c_str(), log_id(cell), label.c_str());
+						log_warning("Assertion %s.%s (%s) failed.\n", hiername(), log_id(cell), label);
 				}
 			}
 		}
@@ -1244,7 +1244,7 @@ struct SimInstance
 			Const fst_val = Const::from_string(shared->fst->valueOf(item.second));
 			Const sim_val = get_state(item.first);
 			if (sim_val.size()!=fst_val.size()) {
-				log_warning("Signal '%s.%s' size is different in gold and gate.\n", scope.c_str(), log_id(item.first));
+				log_warning("Signal '%s.%s' size is different in gold and gate.\n", scope, log_id(item.first));
 				continue;
 			}
 			if (shared->sim_mode == SimulationMode::sim) {
@@ -1252,7 +1252,7 @@ struct SimInstance
 			} else if (shared->sim_mode == SimulationMode::gate && !fst_val.is_fully_def()) { // FST data contains X
 				for(int i=0;i<fst_val.size();i++) {
 					if (fst_val[i]!=State::Sx && fst_val[i]!=sim_val[i]) {
-						log_warning("Signal '%s.%s' in file %s in simulation %s\n", scope.c_str(), log_id(item.first), log_signal(fst_val), log_signal(sim_val));
+						log_warning("Signal '%s.%s' in file %s in simulation %s\n", scope, log_id(item.first), log_signal(fst_val), log_signal(sim_val));
 						retVal = true;
 						break;
 					}
@@ -1260,14 +1260,14 @@ struct SimInstance
 			} else if (shared->sim_mode == SimulationMode::gold && !sim_val.is_fully_def()) { // sim data contains X
 				for(int i=0;i<sim_val.size();i++) {
 					if (sim_val[i]!=State::Sx && fst_val[i]!=sim_val[i]) {
-						log_warning("Signal '%s.%s' in file %s in simulation %s\n", scope.c_str(), log_id(item.first), log_signal(fst_val), log_signal(sim_val));
+						log_warning("Signal '%s.%s' in file %s in simulation %s\n", scope, log_id(item.first), log_signal(fst_val), log_signal(sim_val));
 						retVal = true;
 						break;
 					}
 				}
 			} else {
 				if (fst_val!=sim_val) {
-					log_warning("Signal '%s.%s' in file %s in simulation '%s'\n", scope.c_str(), log_id(item.first), log_signal(fst_val), log_signal(sim_val));
+					log_warning("Signal '%s.%s' in file %s in simulation '%s'\n", scope, log_id(item.first), log_signal(fst_val), log_signal(sim_val));
 					retVal = true;
 				}
 			}
@@ -1607,7 +1607,7 @@ struct SimWorker : SimShared
 				escaped_s = RTLIL::escape_id(cell_name(symbol));
 				Cell *c = topmod->cell(escaped_s);
 				if (!c)
-					log_warning("Wire/cell %s not present in module %s\n",symbol.c_str(),log_id(topmod));
+					log_warning("Wire/cell %s not present in module %s\n",symbol,log_id(topmod));
 
 				if (c->is_mem_cell()) {
 					std::string memid = c->parameters.at(ID::MEMID).decode_string();
@@ -1873,7 +1873,7 @@ struct SimWorker : SimShared
 						log("witness hierarchy: found wire %s\n", path.str());
 					bool inserted = hierarchy.paths.emplace(path, {instance, item.wire, {}, INT_MIN}).second;
 					if (!inserted)
-						log_warning("Yosys witness path `%s` is ambiguous in this design\n", path.str().c_str());
+						log_warning("Yosys witness path `%s` is ambiguous in this design\n", path.str());
 				}
 			} else if (item.mem) {
 				auto it = mem_paths.find(path);
@@ -1890,7 +1890,7 @@ struct SimWorker : SimShared
 							continue;
 						bool inserted = hierarchy.paths.emplace(word_path, {instance, nullptr, item.mem->memid, addr}).second;
 						if (!inserted)
-							log_warning("Yosys witness path `%s` is ambiguous in this design\n", path.str().c_str());
+							log_warning("Yosys witness path `%s` is ambiguous in this design\n", path.str());
 					}
 				}
 			}
@@ -1899,7 +1899,7 @@ struct SimWorker : SimShared
 
 		for (auto &path : paths)
 			if (!hierarchy.paths.count(path))
-				log_warning("Yosys witness path `%s` was not found in this design, ignoring\n", path.str().c_str());
+				log_warning("Yosys witness path `%s` was not found in this design, ignoring\n", path.str());
 
 		dict<IdPath, dict<int, bool>> clock_inputs;
 
@@ -1922,7 +1922,7 @@ struct SimWorker : SimShared
 
 					for (int t = 0; t < GetSize(yw.steps); t++) {
 						if (yw.get_bits(t, clock_bits_offset, 1) != expected)
-							log_warning("Yosys witness trace has an unexpected value for the clock input `%s` in step %d.\n", signal.path.str().c_str(), t);
+							log_warning("Yosys witness trace has an unexpected value for the clock input `%s` in step %d.\n", signal.path.str(), t);
 					}
 				}
 			}
@@ -2000,7 +2000,7 @@ struct SimWorker : SimShared
 		YwHierarchy hierarchy = prepare_yw_hierarchy(yw);
 
 		if (yw.steps.empty()) {
-			log_warning("Yosys witness file `%s` contains no time steps\n", yw.filename.c_str());
+			log_warning("Yosys witness file `%s` contains no time steps\n", yw.filename);
 		} else {
 			top->set_initstate_outputs(initstate ? State::S1 : State::S0);
 			set_yw_state(yw, hierarchy, 0);

--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -2887,7 +2887,7 @@ struct SimPass : public Pass {
 			} else if (filename_trim.size() > 3 && filename_trim.compare(filename_trim.size()-3, std::string::npos, ".yw") == 0) {
 				worker.run_cosim_yw_witness(top_mod, append);
 			} else {
-				log_cmd_error("Unhandled extension for simulation input file `%s`.\n", worker.sim_filename.c_str());
+				log_cmd_error("Unhandled extension for simulation input file `%s`.\n", worker.sim_filename);
 			}
 		}
 

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -988,7 +988,7 @@ void AbcModuleState::prepare_module(RTLIL::Design *design, RTLIL::Module *module
 	}
 
 	if (dff_mode && clk_sig.empty())
-		log_cmd_error("Clock domain %s not found.\n", clk_str.c_str());
+		log_cmd_error("Clock domain %s not found.\n", clk_str);
 
 	const AbcConfig &config = run_abc.config;
 	if (config.cleanup)
@@ -2322,7 +2322,7 @@ struct AbcPass : public Pass {
 				if (g_arg_from_cmd)
 					cmd_error(args, g_argidx, stringf("Unsupported gate type: %s", g));
 				else
-					log_cmd_error("Unsupported gate type: %s", g.c_str());
+					log_cmd_error("Unsupported gate type: %s", g);
 			ok_gate:
 				gate_list.push_back(g);
 			ok_alias:

--- a/passes/techmap/abc9_exe.cc
+++ b/passes/techmap/abc9_exe.cc
@@ -329,7 +329,7 @@ void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe
 #endif
 	if (ret != 0) {
 		if (check_file_exists(stringf("%s/output.aig", tempdir_name)))
-			log_warning("ABC: execution of command \"%s\" failed: return code %d.\n", buffer.c_str(), ret);
+			log_warning("ABC: execution of command \"%s\" failed: return code %d.\n", buffer, ret);
 		else
 			log_error("ABC: execution of command \"%s\" failed: return code %d.\n", buffer, ret);
 	}

--- a/passes/techmap/cellmatch.cc
+++ b/passes/techmap/cellmatch.cc
@@ -173,7 +173,7 @@ struct CellmatchPass : Pass {
 				derive_luts = true;
 			} else if (args[argidx] == "-lib" && argidx + 1 < args.size()) {
 				if (!saved_designs.count(args[++argidx]))
-					log_cmd_error("No design '%s' found!\n", args[argidx].c_str());
+					log_cmd_error("No design '%s' found!\n", args[argidx]);
 				lib = saved_designs.at(args[argidx]);
 			} else {
 				break;

--- a/passes/techmap/constmap.cc
+++ b/passes/techmap/constmap.cc
@@ -82,7 +82,7 @@ struct ConstmapPass : public Pass {
 				}
 			}
 			if (!has_port)
-				log_cmd_error("Cell type '%s' does not have port '%s'.\n", celltype.c_str(), cell_portname.c_str());
+				log_cmd_error("Cell type '%s' does not have port '%s'.\n", celltype, cell_portname);
 
 			bool has_param = false;
 			for (auto &p : existing->avail_parameters){
@@ -91,7 +91,7 @@ struct ConstmapPass : public Pass {
 			}
 
 			if (!has_param)
-				log_cmd_error("Cell type '%s' does not have parameter '%s'.\n", celltype.c_str(), cell_paramname.c_str());
+				log_cmd_error("Cell type '%s' does not have parameter '%s'.\n", celltype, cell_paramname);
 		}
 
 

--- a/passes/techmap/extract.cc
+++ b/passes/techmap/extract.cc
@@ -605,7 +605,7 @@ struct ExtractPass : public Pass {
 					f.open(filename.c_str());
 					if (f.fail()) {
 						delete map;
-						log_cmd_error("Can't open map file `%s'.\n", filename.c_str());
+						log_cmd_error("Can't open map file `%s'.\n", filename);
 					}
 					Frontend::frontend_call(map, &f, filename, (filename.size() > 3 && filename.compare(filename.size()-3, std::string::npos, ".il") == 0 ? "rtlil" : "verilog"));
 					f.close();

--- a/passes/techmap/libparse.cc
+++ b/passes/techmap/libparse.cc
@@ -191,7 +191,7 @@ LibertyExpression LibertyExpression::parse(Lexer &s, int min_prio) {
 		s.next();
 		lhs = parse(s);
 		if (s.peek() != ')') {
-			log_warning("expected ')' instead of '%c' while parsing Liberty expression '%s'\n", s.peek(), s.full_expr().c_str());
+			log_warning("expected ')' instead of '%c' while parsing Liberty expression '%s'\n", s.peek(), s.full_expr());
 			return lhs;
 		}
 		s.next();
@@ -200,7 +200,7 @@ LibertyExpression LibertyExpression::parse(Lexer &s, int min_prio) {
 		lhs.kind = Kind::NOT;
 		lhs.children.push_back(parse(s, 7));
 	} else {
-		log_warning("unrecognised character '%c' while parsing Liberty expression '%s'\n", c, s.full_expr().c_str());
+		log_warning("unrecognised character '%c' while parsing Liberty expression '%s'\n", c, s.full_expr());
 		return lhs;
 	}
 

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -958,7 +958,7 @@ struct TestCellPass : public Pass {
 			if (args[argidx] == "-vlog" && argidx+1 < GetSize(args)) {
 				vlog_file.open(args[++argidx], std::ios_base::trunc);
 				if (!vlog_file.is_open())
-					log_cmd_error("Failed to open output file `%s'.\n", args[argidx].c_str());
+					log_cmd_error("Failed to open output file `%s'.\n", args[argidx]);
 				continue;
 			}
 			if (args[argidx] == "-bloat" && argidx+1 < GetSize(args)) {
@@ -1079,7 +1079,7 @@ struct TestCellPass : public Pass {
 		for (; argidx < GetSize(args); argidx++)
 		{
 			if (args[argidx].rfind("-", 0) == 0)
-				log_cmd_error("Unexpected option: %s\n", args[argidx].c_str());
+				log_cmd_error("Unexpected option: %s\n", args[argidx]);
 
 			if (args[argidx] == "all") {
 				for (auto &it : cell_types)

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -1192,7 +1192,7 @@ struct TestCellPass : public Pass {
 									worst_abs = num_cells - num_cells_estimate;
 									worst_rel = (float)(num_cells - num_cells_estimate) / (float)num_cells_estimate;
 								}
-								log_warning("Upper bound violated for %s: %d > %d\n", cell_type.c_str(), num_cells, num_cells_estimate);
+								log_warning("Upper bound violated for %s: %d > %d\n", cell_type, num_cells, num_cells_estimate);
 							}
 						}
 					}

--- a/techlibs/fabulous/synth_fabulous.cc
+++ b/techlibs/fabulous/synth_fabulous.cc
@@ -236,7 +236,7 @@ struct SynthPass : public ScriptPass
 			if (args[argidx] == "-carry") {
 				carry_mode = args[++argidx];
 				if (carry_mode != "none" && carry_mode != "ha")
-					log_cmd_error("Unsupported carry style: %s\n", carry_mode.c_str());
+					log_cmd_error("Unsupported carry style: %s\n", carry_mode);
 				continue;
 			}
 			if (args[argidx] == "-noflatten") {

--- a/techlibs/greenpak4/synth_greenpak4.cc
+++ b/techlibs/greenpak4/synth_greenpak4.cc
@@ -123,7 +123,7 @@ struct SynthGreenPAK4Pass : public ScriptPass
 			log_cmd_error("This command only operates on fully selected designs!\n");
 
 		if (part != "SLG46140V" && part != "SLG46620V" && part != "SLG46621V")
-			log_cmd_error("Invalid part name: '%s'\n", part.c_str());
+			log_cmd_error("Invalid part name: '%s'\n", part);
 
 		log_header(design, "Executing SYNTH_GREENPAK4 pass.\n");
 		log_push();

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -265,7 +265,7 @@ struct SynthIce40Pass : public ScriptPass
 		if (!design->full_selection())
 			log_cmd_error("This command only operates on fully selected designs!\n");
 		if (device_opt != "hx" && device_opt != "lp" && device_opt !="u")
-			log_cmd_error("Invalid or no device specified: '%s'\n", device_opt.c_str());
+			log_cmd_error("Invalid or no device specified: '%s'\n", device_opt);
 
 		if (abc9 && retime)
 			log_cmd_error("-retime option not currently compatible with -abc9!\n");

--- a/techlibs/intel/synth_intel.cc
+++ b/techlibs/intel/synth_intel.cc
@@ -174,7 +174,7 @@ struct SynthIntelPass : public ScriptPass {
 		    family_opt != "cycloneiv" &&
 		    family_opt != "cycloneive" &&
 		    family_opt != "cyclone10lp")
-			log_cmd_error("Invalid or no family specified: '%s'\n", family_opt.c_str());
+			log_cmd_error("Invalid or no family specified: '%s'\n", family_opt);
 
 		log_header(design, "Executing SYNTH_INTEL pass.\n");
 		log_push();

--- a/techlibs/intel/synth_intel.cc
+++ b/techlibs/intel/synth_intel.cc
@@ -242,7 +242,7 @@ struct SynthIntelPass : public ScriptPass {
 				run("memory_bram -rules +/intel/common/brams_m9k.txt", "(if applicable for family)");
 				run("techmap -map +/intel/common/brams_map_m9k.v", "(if applicable for family)");
 			} else {
-				log_warning("BRAM mapping is not currently supported for %s.\n", family_opt.c_str());
+				log_warning("BRAM mapping is not currently supported for %s.\n", family_opt);
 			}
 		}
 

--- a/techlibs/lattice/synth_lattice.cc
+++ b/techlibs/lattice/synth_lattice.cc
@@ -306,7 +306,7 @@ struct SynthLatticePass : public ScriptPass
 				family == "lifmd" ||
 				family == "lifmdf") {*/
 		} else
-			log_cmd_error("Invalid Lattice -family setting: '%s'.\n", family.c_str());
+			log_cmd_error("Invalid Lattice -family setting: '%s'.\n", family);
 
 		if (!design->full_selection())
 			log_cmd_error("This command only operates on fully selected designs!\n");

--- a/techlibs/microchip/synth_microchip.cc
+++ b/techlibs/microchip/synth_microchip.cc
@@ -234,7 +234,7 @@ struct SynthMicrochipPass : public ScriptPass {
 		if (family == "polarfire") {
 			lut_size = 4;
 		} else {
-			log_cmd_error("Invalid Microchip -family setting: '%s'.\n", family.c_str());
+			log_cmd_error("Invalid Microchip -family setting: '%s'.\n", family);
 		}
 
 		if (!design->full_selection())

--- a/techlibs/nanoxplore/synth_nanoxplore.cc
+++ b/techlibs/nanoxplore/synth_nanoxplore.cc
@@ -218,7 +218,7 @@ struct SynthNanoXplorePass : public ScriptPass
 		} else if (family == "large") {
 			postfix = "_l";
 		} else 
-			log_cmd_error("Invalid NanoXplore -family setting: '%s'.\n", family.c_str());
+			log_cmd_error("Invalid NanoXplore -family setting: '%s'.\n", family);
 
 		if (!design->full_selection())
 			log_cmd_error("This command only operates on fully selected designs!\n");

--- a/techlibs/nexus/synth_nexus.cc
+++ b/techlibs/nexus/synth_nexus.cc
@@ -249,7 +249,7 @@ struct SynthNexusPass : public ScriptPass
 	{
 
 		if (family != "lifcl" && family != "lfd2nx")
-			log_cmd_error("Invalid Nexus -family setting: '%s'.\n", family.c_str());
+			log_cmd_error("Invalid Nexus -family setting: '%s'.\n", family);
 
 		if (check_label("begin"))
 		{

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -176,7 +176,7 @@ struct SynthQuickLogicPass : public ScriptPass {
 			log_cmd_error("This command only operates on fully selected designs!\n");
 
 		if (family != "pp3" && family != "qlf_k6n10f")
-			log_cmd_error("Invalid family specified: '%s'\n", family.c_str());
+			log_cmd_error("Invalid family specified: '%s'\n", family);
 
 		if (abc9 && design->scratchpad_get_int("abc9.D", 0) == 0) {
 			log_warning("delay target has not been set via SDC or scratchpad; assuming 12 MHz clock.\n");

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -310,7 +310,7 @@ struct SynthXilinxPass : public ScriptPass
 			lut_size = 4;
 			widelut_size = 6;
 		} else
-			log_cmd_error("Invalid Xilinx -family setting: '%s'.\n", family.c_str());
+			log_cmd_error("Invalid Xilinx -family setting: '%s'.\n", family);
 
 		if (widemux != 0 && lut_size != 6)
 			log_cmd_error("-widemux is not currently supported for LUT4-based architectures.\n");

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -316,7 +316,7 @@ struct SynthXilinxPass : public ScriptPass
 			log_cmd_error("-widemux is not currently supported for LUT4-based architectures.\n");
 
 		if (lut_size != 6) {
-			log_warning("Shift register inference not yet supported for family %s.\n", family.c_str());
+			log_warning("Shift register inference not yet supported for family %s.\n", family);
 			nosrl = true;
 		}
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Makes code easier to read. May make some refactorings easier in the future when types don't need to be able to return a null-terminated string.

_Explain how this is achieved._

Just remove some `.c_str()` calls that aren't necessary anymore.