### PR TITLE
Deprecate `RTLIL::id2cstr()`

### DIFF
--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -3433,7 +3433,7 @@ struct CxxrtlWorker {
 
 			if (!design->selected_whole_module(module))
 				if (design->selected_module(module))
-					log_cmd_error("Can't handle partially selected module `%s'!\n", id2cstr(module->name));
+					log_cmd_error("Can't handle partially selected module `%s'!\n", log_id(module->name));
 			if (!design->selected_module(module))
 				continue;
 

--- a/docs/source/code_examples/functional/dummy.cc
+++ b/docs/source/code_examples/functional/dummy.cc
@@ -24,19 +24,19 @@ struct FunctionalDummyBackend : public Backend {
 
 			// write node functions
 			for (auto node : ir)
-				*f << "  assign " << id2cstr(node.name())
+				*f << "  assign " << log_id(node.name())
 				   << " = " << node.to_string() << "\n";
 			*f << "\n";
 
 			// write outputs and next state
 			for (auto output : ir.outputs())
-				*f << " " << id2cstr(output->kind)
-				   << " " << id2cstr(output->name)
-				   << " = " << id2cstr(output->value().name()) << "\n";
+				*f << " " << log_id(output->kind)
+				   << " " << log_id(output->name)
+				   << " = " << log_id(output->value().name()) << "\n";
 			for (auto state : ir.states())
-				*f << " " << id2cstr(state->kind)
-				   << " " << id2cstr(state->name)
-				   << " = " << id2cstr(state->next_value().name()) << "\n";
+				*f << " " << log_id(state->kind)
+				   << " " << log_id(state->name)
+				   << " = " << log_id(state->next_value().name()) << "\n";
 		}
 	}
 } FunctionalDummyBackend;

--- a/docs/source/code_examples/stubnets/stubnets.cc
+++ b/docs/source/code_examples/stubnets/stubnets.cc
@@ -27,7 +27,7 @@ static void find_stub_nets(RTLIL::Design *design, RTLIL::Module *module, bool re
 	// count output lines for this module (needed only for summary output at the end)
 	int line_count = 0;
 
-	log("Looking for stub wires in module %s:\n", RTLIL::id2cstr(module->name));
+	log("Looking for stub wires in module %s:\n", log_id(module->name));
 
 	// For all ports on all cells
 	for (auto &cell_iter : module->cells_)
@@ -74,11 +74,11 @@ static void find_stub_nets(RTLIL::Design *design, RTLIL::Module *module, bool re
 		// report stub bits and/or stub wires, don't report single bits
 		// if called with report_bits set to false.
 		if (GetSize(stub_bits) == GetSize(sig)) {
-			log("  found stub wire: %s\n", RTLIL::id2cstr(wire->name));
+			log("  found stub wire: %s\n", log_id(wire->name));
 		} else {
 			if (!report_bits)
 				continue;
-			log("  found wire with stub bits: %s [", RTLIL::id2cstr(wire->name));
+			log("  found wire with stub bits: %s [", log_id(wire->name));
 			for (int bit : stub_bits)
 				log("%s%d", bit == *stub_bits.begin() ? "" : ", ", bit);
 			log("]\n");

--- a/docs/source/yosys_internals/extending_yosys/extensions.rst
+++ b/docs/source/yosys_internals/extending_yosys/extensions.rst
@@ -231,7 +231,7 @@ Use ``log_error()`` to report a non-recoverable error:
 
     if (design->modules.count(module->name) != 0)
         log_error("A module with the name %s already exists!\n",
-                   RTLIL::id2cstr(module->name));
+                   log_id(module->name));
 
 Use ``log_cmd_error()`` to report a recoverable error:
 

--- a/docs/source/yosys_internals/extending_yosys/functional_ir.rst
+++ b/docs/source/yosys_internals/extending_yosys/functional_ir.rst
@@ -181,7 +181,7 @@ pointer ``f`` to the output file, or stdout if none is given.
 
 For this minimal example all we are doing is printing out each node.  The
 ``node.name()`` method returns an ``RTLIL::IdString``, which we convert for
-printing with ``id2cstr()``.  Then, to print the function of the node, we use
+printing with ``log_id()``.  Then, to print the function of the node, we use
 ``node.to_string()`` which gives us a string of the form ``function(args)``. The
 ``function`` part is the result of ``Functional::IR::fn_to_string(node.fn())``;
 while ``args`` is the zero or more arguments passed to the function, most

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -1478,10 +1478,10 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 	design->add(module);
 
 	if (is_blackbox(nl)) {
-		log("Importing blackbox module %s.\n", RTLIL::id2cstr(module->name));
+		log("Importing blackbox module %s.\n", log_id(module->name));
 		module->set_bool_attribute(ID::blackbox);
 	} else {
-		log("Importing module %s.\n", RTLIL::id2cstr(module->name));
+		log("Importing module %s.\n", log_id(module->name));
 	}
 	import_attributes(module->attributes, nl, nl);
 	if (module->name.isPublic())

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1484,7 +1484,7 @@ void RTLIL::Module::makeblackbox()
 
 void RTLIL::Module::expand_interfaces(RTLIL::Design *, const dict<RTLIL::IdString, RTLIL::Module *> &)
 {
-	log_error("Class doesn't support expand_interfaces (module: `%s')!\n", id2cstr(name));
+	log_error("Class doesn't support expand_interfaces (module: `%s')!\n", log_id(name));
 }
 
 bool RTLIL::Module::reprocess_if_necessary(RTLIL::Design *)
@@ -1496,7 +1496,7 @@ RTLIL::IdString RTLIL::Module::derive(RTLIL::Design*, const dict<RTLIL::IdString
 {
 	if (mayfail)
 		return RTLIL::IdString();
-	log_error("Module `%s' is used with parameters but is not parametric!\n", id2cstr(name));
+	log_error("Module `%s' is used with parameters but is not parametric!\n", log_id(name));
 }
 
 
@@ -1504,7 +1504,7 @@ RTLIL::IdString RTLIL::Module::derive(RTLIL::Design*, const dict<RTLIL::IdString
 {
 	if (mayfail)
 		return RTLIL::IdString();
-	log_error("Module `%s' is used with parameters but is not parametric!\n", id2cstr(name));
+	log_error("Module `%s' is used with parameters but is not parametric!\n", log_id(name));
 }
 
 size_t RTLIL::Module::count_id(const RTLIL::IdString& id)

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -580,6 +580,7 @@ namespace RTLIL {
 		return unescape_id(str.str());
 	}
 
+	[[deprecated("Use log_id() instead")]]
 	static inline const char *id2cstr(const RTLIL::IdString &str) {
 		return log_id(str);
 	}

--- a/passes/cmds/scc.cc
+++ b/passes/cmds/scc.cc
@@ -87,7 +87,7 @@ struct SccWorker
 					RTLIL::Cell *c = cellStack.back();
 					cellStack.pop_back();
 					cellsOnStack.erase(c);
-					log(" %s", RTLIL::id2cstr(c->name));
+					log(" %s", log_id(c->name));
 					cell2scc[c] = sccList.size();
 					scc.insert(c);
 				}
@@ -201,7 +201,7 @@ struct SccWorker
 			if (!nofeedbackMode && cellToNextCell[cell].count(cell)) {
 				log("Found an SCC:");
 				pool<RTLIL::Cell*> scc;
-				log(" %s", RTLIL::id2cstr(cell->name));
+				log(" %s", log_id(cell->name));
 				cell2scc[cell] = sccList.size();
 				scc.insert(cell);
 				sccList.push_back(scc);
@@ -221,7 +221,7 @@ struct SccWorker
 			run(cell, 0, maxDepth);
 		}
 
-		log("Found %d SCCs in module %s.\n", int(sccList.size()), RTLIL::id2cstr(module->name));
+		log("Found %d SCCs in module %s.\n", int(sccList.size()), log_id(module->name));
 	}
 
 	void select(RTLIL::Selection &sel)

--- a/passes/cmds/select.cc
+++ b/passes/cmds/select.cc
@@ -25,8 +25,6 @@
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
-using RTLIL::id2cstr;
-
 static std::vector<RTLIL::Selection> work_stack;
 
 static bool match_ids(RTLIL::IdString id, const std::string &pattern)
@@ -1022,9 +1020,9 @@ static std::string describe_selection_for_assert(RTLIL::Design *design, RTLIL::S
 	for (auto mod : design->all_selected_modules())
 	{
 		if (whole_modules && sel->selected_whole_module(mod->name))
-			desc += stringf("%s\n", id2cstr(mod->name));
+			desc += stringf("%s\n", log_id(mod->name));
 		for (auto it : mod->selected_members())
-			desc += stringf("%s/%s\n", id2cstr(mod->name), id2cstr(it->name));
+			desc += stringf("%s/%s\n", log_id(mod->name), log_id(it->name));
 	}
 	if (push_selection) design->pop_selection();
 	return desc;
@@ -1414,7 +1412,7 @@ struct SelectPass : public Pass {
 			if (arg == "-module" && argidx+1 < args.size()) {
 				RTLIL::IdString mod_name = RTLIL::escape_id(args[++argidx]);
 				if (design->module(mod_name) == nullptr)
-					log_cmd_error("No such module: %s\n", id2cstr(mod_name));
+					log_cmd_error("No such module: %s\n", log_id(mod_name));
 				design->selected_active_module = mod_name.str();
 				got_module = true;
 				continue;
@@ -1527,10 +1525,10 @@ struct SelectPass : public Pass {
 			for (auto mod : design->all_selected_modules())
 			{
 				if (sel->selected_whole_module(mod->name) && list_mode)
-					log("%s\n", id2cstr(mod->name));
+					log("%s\n", log_id(mod->name));
 				if (!list_mod_mode)
 					for (auto it : mod->selected_members())
-						LOG_OBJECT("%s/%s\n", id2cstr(mod->name), id2cstr(it->name))
+						LOG_OBJECT("%s/%s\n", log_id(mod->name), log_id(it->name))
 			}
 			if (count_mode)
 			{
@@ -1654,10 +1652,10 @@ struct SelectPass : public Pass {
 			if (sel.full_selection)
 				log("*\n");
 			for (auto &it : sel.selected_modules)
-				log("%s\n", id2cstr(it));
+				log("%s\n", log_id(it));
 			for (auto &it : sel.selected_members)
 				for (auto &it2 : it.second)
-					log("%s/%s\n", id2cstr(it.first), id2cstr(it2));
+					log("%s/%s\n", log_id(it.first), log_id(it2));
 			return;
 		}
 
@@ -1779,7 +1777,7 @@ static void log_matches(const char *title, Module *module, const T &list)
 		log("\n%d %s:\n", int(matches.size()), title);
 		std::sort(matches.begin(), matches.end(), RTLIL::sort_by_id_str());
 		for (auto id : matches)
-			log("  %s\n", RTLIL::id2cstr(id));
+			log("  %s\n", log_id(id));
 	}
 }
 

--- a/passes/cmds/test_select.cc
+++ b/passes/cmds/test_select.cc
@@ -144,10 +144,10 @@ struct TestSelectPass : public Pass {
 
 		for (auto *mod : sub_sel) {
 			if (mod->is_selected_whole()) {
-				log_debug("  Adding %s.\n", id2cstr(mod->name));
+				log_debug("  Adding %s.\n", log_id(mod->name));
 				selected_modules.insert(mod->name);
 			} else for (auto *memb : mod->selected_members()) {
-				log_debug("  Adding %s.%s.\n", id2cstr(mod->name), id2cstr(memb->name));
+				log_debug("  Adding %s.%s.\n", log_id(mod->name), log_id(memb->name));
 				selected_members[mod->name].insert(memb);
 			}
 		}

--- a/passes/equiv/equiv_make.cc
+++ b/passes/equiv/equiv_make.cc
@@ -284,11 +284,11 @@ struct EquivMakeWorker
 
 					for (int i = 0; i < wire->width; i++) {
 						if (undriven_bits.count(assign_map(SigBit(gold_wire, i)))) {
-							log("  Skipping signal bit %s [%d]: undriven on gold side.\n", id2cstr(gold_wire->name), i);
+							log("  Skipping signal bit %s [%d]: undriven on gold side.\n", log_id(gold_wire->name), i);
 							continue;
 						}
 						if (undriven_bits.count(assign_map(SigBit(gate_wire, i)))) {
-							log("  Skipping signal bit %s [%d]: undriven on gate side.\n", id2cstr(gate_wire->name), i);
+							log("  Skipping signal bit %s [%d]: undriven on gate side.\n", log_id(gate_wire->name), i);
 							continue;
 						}
 						equiv_mod->addEquiv(NEW_ID, SigSpec(gold_wire, i), SigSpec(gate_wire, i), SigSpec(wire, i));

--- a/passes/fsm/fsm_detect.cc
+++ b/passes/fsm/fsm_detect.cc
@@ -61,7 +61,7 @@ ret_false:
 
 		if (recursion_monitor.count(cellport.first)) {
 			log_warning("logic loop in mux tree at signal %s in module %s.\n",
-					log_signal(sig), RTLIL::id2cstr(module->name));
+					log_signal(sig), log_id(module->name));
 			goto ret_false;
 		}
 

--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -29,8 +29,6 @@
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
-using RTLIL::id2cstr;
-
 struct keep_cache_t
 {
 	Design *design;

--- a/passes/sat/expose.cc
+++ b/passes/sat/expose.cc
@@ -471,7 +471,7 @@ struct ExposePass : public Pass {
 				{
 					if (!w->port_input) {
 						w->port_input = true;
-						log("New module port: %s/%s\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(w->name));
+						log("New module port: %s/%s\n", log_id(module->name), log_id(w->name));
 						wire_map[w] = NEW_ID;
 					}
 				}
@@ -479,7 +479,7 @@ struct ExposePass : public Pass {
 				{
 					if (!w->port_output) {
 						w->port_output = true;
-						log("New module port: %s/%s\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(w->name));
+						log("New module port: %s/%s\n", log_id(module->name), log_id(w->name));
 					}
 
 					if (flag_cut) {
@@ -555,7 +555,7 @@ struct ExposePass : public Pass {
 
 				RTLIL::Wire *wire_q = add_new_wire(module, wire->name.str() + sep + "q", wire->width);
 				wire_q->port_input = true;
-				log("New module port: %s/%s\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire_q->name));
+				log("New module port: %s/%s\n", log_id(module->name), log_id(wire_q->name));
 
 				RTLIL::SigSig connect_q;
 				for (size_t i = 0; i < wire_bits_vec.size(); i++) {
@@ -569,12 +569,12 @@ struct ExposePass : public Pass {
 
 				RTLIL::Wire *wire_d = add_new_wire(module, wire->name.str() + sep + "d", wire->width);
 				wire_d->port_output = true;
-				log("New module port: %s/%s\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire_d->name));
+				log("New module port: %s/%s\n", log_id(module->name), log_id(wire_d->name));
 				module->connect(RTLIL::SigSig(wire_d, info.sig_d));
 
 				RTLIL::Wire *wire_c = add_new_wire(module, wire->name.str() + sep + "c");
 				wire_c->port_output = true;
-				log("New module port: %s/%s\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire_c->name));
+				log("New module port: %s/%s\n", log_id(module->name), log_id(wire_c->name));
 				if (info.clk_polarity) {
 					module->connect(RTLIL::SigSig(wire_c, info.sig_clk));
 				} else {
@@ -590,7 +590,7 @@ struct ExposePass : public Pass {
 				{
 					RTLIL::Wire *wire_r = add_new_wire(module, wire->name.str() + sep + "r");
 					wire_r->port_output = true;
-					log("New module port: %s/%s\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire_r->name));
+					log("New module port: %s/%s\n", log_id(module->name), log_id(wire_r->name));
 					if (info.arst_polarity) {
 						module->connect(RTLIL::SigSig(wire_r, info.sig_arst));
 					} else {
@@ -604,7 +604,7 @@ struct ExposePass : public Pass {
 
 					RTLIL::Wire *wire_v = add_new_wire(module, wire->name.str() + sep + "v", wire->width);
 					wire_v->port_output = true;
-					log("New module port: %s/%s\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire_v->name));
+					log("New module port: %s/%s\n", log_id(module->name), log_id(wire_v->name));
 					module->connect(RTLIL::SigSig(wire_v, info.arst_value));
 				}
 			}
@@ -638,7 +638,7 @@ struct ExposePass : public Pass {
 							if (p->port_output)
 								w->port_input = true;
 
-							log("New module port: %s/%s (%s)\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(w->name), RTLIL::id2cstr(cell->type));
+							log("New module port: %s/%s (%s)\n", log_id(module->name), log_id(w->name), log_id(cell->type));
 
 							RTLIL::SigSpec sig;
 							if (cell->hasPort(p->name))
@@ -660,7 +660,7 @@ struct ExposePass : public Pass {
 							if (ct.cell_output(cell->type, it.first))
 								w->port_input = true;
 
-							log("New module port: %s/%s (%s)\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(w->name), RTLIL::id2cstr(cell->type));
+							log("New module port: %s/%s (%s)\n", log_id(module->name), log_id(w->name), log_id(cell->type));
 
 							if (w->port_input)
 								module->connect(RTLIL::SigSig(it.second, w));

--- a/passes/sat/freduce.cc
+++ b/passes/sat/freduce.cc
@@ -139,7 +139,7 @@ struct FindReducedInputs
 			if (ez_cells.count(drv.first) == 0) {
 				satgen.setContext(&sigmap, "A");
 				if (!satgen.importCell(drv.first))
-					log_error("Can't create SAT model for cell %s (%s)!\n", RTLIL::id2cstr(drv.first->name), RTLIL::id2cstr(drv.first->type));
+					log_error("Can't create SAT model for cell %s (%s)!\n", log_id(drv.first->name), log_id(drv.first->type));
 				satgen.setContext(&sigmap, "B");
 				if (!satgen.importCell(drv.first))
 					log_abort();
@@ -256,7 +256,7 @@ struct PerformReduction
 			std::pair<RTLIL::Cell*, std::set<RTLIL::SigBit>> &drv = drivers.at(out);
 			if (celldone.count(drv.first) == 0) {
 				if (!satgen.importCell(drv.first))
-					log_error("Can't create SAT model for cell %s (%s)!\n", RTLIL::id2cstr(drv.first->name), RTLIL::id2cstr(drv.first->type));
+					log_error("Can't create SAT model for cell %s (%s)!\n", log_id(drv.first->name), log_id(drv.first->type));
 				celldone.insert(drv.first);
 			}
 			int max_child_depth = 0;
@@ -595,14 +595,14 @@ struct FreduceWorker
 
 	void dump()
 	{
-		std::string filename = stringf("%s_%s_%05d.il", dump_prefix, RTLIL::id2cstr(module->name), reduce_counter);
+		std::string filename = stringf("%s_%s_%05d.il", dump_prefix, log_id(module->name), reduce_counter);
 		log("%s    Writing dump file `%s'.\n", reduce_counter ? "  " : "", filename);
 		Pass::call(design, stringf("dump -outfile %s %s", filename, design->selected_active_module.empty() ? module->name.c_str() : ""));
 	}
 
 	int run()
 	{
-		log("Running functional reduction on module %s:\n", RTLIL::id2cstr(module->name));
+		log("Running functional reduction on module %s:\n", log_id(module->name));
 
 		CellTypes ct;
 		ct.setup_internals();
@@ -749,7 +749,7 @@ struct FreduceWorker
 			}
 		}
 
-		log("  Rewired a total of %d signal bits in module %s.\n", rewired_sigbits, RTLIL::id2cstr(module->name));
+		log("  Rewired a total of %d signal bits in module %s.\n", rewired_sigbits, log_id(module->name));
 		return rewired_sigbits;
 	}
 };

--- a/passes/sat/miter.cc
+++ b/passes/sat/miter.cc
@@ -128,7 +128,7 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 		log_cmd_error("No matching port in gold module was found for %s!\n", gate_wire->name.c_str());
 	}
 
-	log("Creating miter cell \"%s\" with gold cell \"%s\" and gate cell \"%s\".\n", RTLIL::id2cstr(miter_name), RTLIL::id2cstr(gold_name), RTLIL::id2cstr(gate_name));
+	log("Creating miter cell \"%s\" with gold cell \"%s\" and gate cell \"%s\".\n", log_id(miter_name), log_id(gold_name), log_id(gate_name));
 
 	RTLIL::Module *miter_module = new RTLIL::Module;
 	miter_module->name = miter_name;

--- a/passes/sat/sat.cc
+++ b/passes/sat/sat.cc
@@ -227,16 +227,16 @@ struct SatHelper
 		int import_cell_counter = 0;
 		for (auto cell : module->cells())
 			if (design->selected(module, cell)) {
-				// log("Import cell: %s\n", RTLIL::id2cstr(cell->name));
+				// log("Import cell: %s\n", log_id(cell->name));
 				if (satgen.importCell(cell, timestep)) {
 					for (auto &p : cell->connections())
 						if (ct.cell_output(cell->type, p.first))
 							show_drivers.insert(sigmap(p.second), cell);
 					import_cell_counter++;
 				} else if (ignore_unknown_cells)
-					log_warning("Failed to import cell %s (type %s) to SAT database.\n", RTLIL::id2cstr(cell->name), RTLIL::id2cstr(cell->type));
+					log_warning("Failed to import cell %s (type %s) to SAT database.\n", log_id(cell->name), log_id(cell->type));
 				else
-					log_error("Failed to import cell %s (type %s) to SAT database.\n", RTLIL::id2cstr(cell->name), RTLIL::id2cstr(cell->type));
+					log_error("Failed to import cell %s (type %s) to SAT database.\n", log_id(cell->name), log_id(cell->type));
 		}
 		log("Imported %d cells to SAT database.\n", import_cell_counter);
 

--- a/passes/techmap/iopadmap.cc
+++ b/passes/techmap/iopadmap.cc
@@ -389,7 +389,7 @@ struct IopadmapPass : public Pass {
 
 				if (wire->port_input && !wire->port_output) {
 					if (inpad_celltype.empty()) {
-						log("Don't map input port %s.%s: Missing option -inpad.\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire->name));
+						log("Don't map input port %s.%s: Missing option -inpad.\n", log_id(module->name), log_id(wire->name));
 						continue;
 					}
 					celltype = inpad_celltype;
@@ -398,7 +398,7 @@ struct IopadmapPass : public Pass {
 				} else
 				if (!wire->port_input && wire->port_output) {
 					if (outpad_celltype.empty()) {
-						log("Don't map output port %s.%s: Missing option -outpad.\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire->name));
+						log("Don't map output port %s.%s: Missing option -outpad.\n", log_id(module->name), log_id(wire->name));
 						continue;
 					}
 					celltype = outpad_celltype;
@@ -407,7 +407,7 @@ struct IopadmapPass : public Pass {
 				} else
 				if (wire->port_input && wire->port_output) {
 					if (inoutpad_celltype.empty()) {
-						log("Don't map inout port %s.%s: Missing option -inoutpad.\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire->name));
+						log("Don't map inout port %s.%s: Missing option -inoutpad.\n", log_id(module->name), log_id(wire->name));
 						continue;
 					}
 					celltype = inoutpad_celltype;
@@ -417,11 +417,11 @@ struct IopadmapPass : public Pass {
 					log_abort();
 
 				if (!flag_bits && wire->width != 1 && widthparam.empty()) {
-					log("Don't map multi-bit port %s.%s: Missing option -widthparam or -bits.\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire->name));
+					log("Don't map multi-bit port %s.%s: Missing option -widthparam or -bits.\n", log_id(module->name), log_id(wire->name));
 					continue;
 				}
 
-				log("Mapping port %s.%s using %s.\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire->name), celltype);
+				log("Mapping port %s.%s using %s.\n", log_id(module->name), log_id(wire->name), celltype);
 
 				if (flag_bits)
 				{
@@ -442,7 +442,7 @@ struct IopadmapPass : public Pass {
 						if (!widthparam.empty())
 							cell->parameters[RTLIL::escape_id(widthparam)] = RTLIL::Const(1);
 						if (!nameparam.empty())
-							cell->parameters[RTLIL::escape_id(nameparam)] = RTLIL::Const(stringf("%s[%d]", RTLIL::id2cstr(wire->name), i));
+							cell->parameters[RTLIL::escape_id(nameparam)] = RTLIL::Const(stringf("%s[%d]", log_id(wire->name), i));
 						cell->attributes[ID::keep] = RTLIL::Const(1);
 					}
 				}
@@ -465,7 +465,7 @@ struct IopadmapPass : public Pass {
 					if (!widthparam.empty())
 						cell->parameters[RTLIL::escape_id(widthparam)] = RTLIL::Const(wire->width);
 					if (!nameparam.empty())
-						cell->parameters[RTLIL::escape_id(nameparam)] = RTLIL::Const(RTLIL::id2cstr(wire->name));
+						cell->parameters[RTLIL::escape_id(nameparam)] = RTLIL::Const(log_id(wire->name));
 					cell->attributes[ID::keep] = RTLIL::Const(1);
 				}
 

--- a/techlibs/ice40/ice40_braminit.cc
+++ b/techlibs/ice40/ice40_braminit.cc
@@ -46,7 +46,7 @@ static void run_ice40_braminit(Module *module)
 			continue;
 
 		/* Open file */
-		log("Processing %s : %s\n", RTLIL::id2cstr(cell->name), init_file);
+		log("Processing %s : %s\n", log_id(cell->name), init_file);
 
 		std::ifstream f;
 		f.open(init_file.c_str());


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

It's exactly the same as `log_id()`. `log_id()` occurs 1247 times before this PR, `id2cstr()` only occurs 77 times, so it makes sense to get rid of `id2cstr()` to reduce confusion/maintenance work.

_Explain how this is achieved._

Trivial change. We leave `id2cstr()` in place, but deprecated.