### PR TITLE
CI: Don't use self-hosted runner on forks

### DIFF
--- a/.github/workflows/prepare-docs.yml
+++ b/.github/workflows/prepare-docs.yml
@@ -26,7 +26,7 @@ jobs:
     # docs builds are needed for anything on main, any tagged versions, and any tag
     # or branch starting with docs-preview
     needs: check_docs_rebuild
-    if: ${{ needs.check_docs_rebuild.outputs.should_skip != 'true' }}
+    if: ${{ needs.check_docs_rebuild.outputs.should_skip != 'true' && github.repository == 'YosysHQ/Yosys' }}
     runs-on: [self-hosted, linux, x64, fast]
     steps:
       - name: Checkout Yosys

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -253,7 +253,7 @@ jobs:
     name: Try build docs
     runs-on: [self-hosted, linux, x64, fast]
     needs: [pre_docs_job]
-    if: needs.pre_docs_job.outputs.should_skip != 'true'
+    if: ${{ needs.pre_docs_job.outputs.should_skip != 'true' && github.repository == 'YosysHQ/Yosys' }}
     strategy:
       matrix:
         docs-target: [html, latexpdf]

--- a/.github/workflows/test-verific.yml
+++ b/.github/workflows/test-verific.yml
@@ -27,7 +27,7 @@ jobs:
 
   test-verific:
     needs: pre-job
-    if: needs.pre-job.outputs.should_skip != 'true'
+    if: ${{ needs.pre-job.outputs.should_skip != 'true' && github.repository == 'YosysHQ/Yosys' }}
     runs-on: [self-hosted, linux, x64, fast]
     steps:
       - name: Checkout Yosys


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

A few of the CI jobs use the YosysHQ self-hosted runner.  If someone makes a fork of Yosys (and enables actions), these jobs will be queued waiting for a self-hosted runner that probably doesn't exist (and if it does exist, it won't have the necessary configurations to be able to actually run Verific, which is generally what the YosysHQ self-hosted runner is used for).

_Explain how this is achieved._

Jobs targeting the self-hosted runner should only run if `github.repository == 'YosysHQ/Yosys'`.  This prevents the job from being queued on a fork entirely, without affecting PRs to this repo.

_If applicable, please suggest to reviewers how they can test the change._

This PR is coming from a fork.  The self-hosted jobs should run for this PR, but not on the fork.