### PR TITLE
Bump newest supported GCC

### DIFF
--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -42,7 +42,7 @@ jobs:
           - 'gcc-10'
           # newest, make sure to update maximum standard step to match
           - 'clang-19'
-          - 'gcc-13'
+          - 'gcc-14'
         include:
           # macOS x86
           - os: macos-13
@@ -81,7 +81,7 @@ jobs:
 
       # maximum standard, only on newest compilers
       - name: Build C++20
-        if: ${{ matrix.compiler == 'clang-19' || matrix.compiler == 'gcc-13' }}
+        if: ${{ matrix.compiler == 'clang-19' || matrix.compiler == 'gcc-14' }}
         shell: bash
         run: |
           make config-$CC_SHORT


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Newest GCC version tested is currently gcc-13.  gcc-15 exists, but is [not yet available through setup-cpp](https://github.com/YosysHQ/yosys/actions/runs/17844601984/job/50741447048) (it's trying to `apt-get`, but it doesn't exist for ubuntu-24.04).

_Explain how this is achieved._

Update `test-compile.yml` to use `gcc-14` instead of `gcc-13`.

_If applicable, please suggest to reviewers how they can test the change._

CI should compile and pass with C++17 and C++20 for [test-compile (ubuntu-latest, gcc-14)](https://github.com/YosysHQ/yosys/actions/runs/17844127761/job/50740030516#logs)