### PR TITLE
Gowin. Renaming inputs of the DCS primitive.

### DIFF
--- a/techlibs/gowin/cells_sim.v
+++ b/techlibs/gowin/cells_sim.v
@@ -1959,14 +1959,6 @@ parameter REGULATOR_EN = 1'b0;
 endmodule
 
 (* blackbox *)
-module DCS (CLK0, CLK1, CLK2, CLK3, CLKSEL, SELFORCE, CLKOUT);
-input CLK0, CLK1, CLK2, CLK3, SELFORCE;
-input [3:0] CLKSEL;
-output CLKOUT;
-parameter DCS_MODE = "RISING";
-endmodule
-
-(* blackbox *)
 module EMCU (
   input          FCLK,
   input          PORESETN,

--- a/techlibs/gowin/cells_xtra.py
+++ b/techlibs/gowin/cells_xtra.py
@@ -25,7 +25,7 @@ _skip = { # These are already described, no need to extract them from the vendor
           'OSCO', 'OSCW', 'OSCZ', 'OSER10', 'OSER16', 'OSER10', 'OSER4',
           'OSER8', 'OVIDEO', 'PLLVR', 'RAM16S1', 'RAM16S2', 'RAM16S4',
           'RAM16SDP1', 'RAM16SDP2', 'RAM16SDP4', 'rPLL', 'SDP',
-          'SDPX9', 'SP', 'SPX9', 'TBUF', 'TLVDS_OBUF', 'VCC', 'DCS', 'EMCU',
+          'SDPX9', 'SP', 'SPX9', 'TBUF', 'TLVDS_OBUF', 'VCC', 'EMCU',
           # These are not planned for implementation
           'MUX2_MUX8', 'MUX2_MUX16', 'MUX2_MUX32', 'MUX4', 'MUX8', 'MUX16',
           'MUX32', 'DL', 'DLE', 'DLC', 'DLCE', 'DLP', 'DLPE', 'DLN', 'DLNE',
@@ -50,7 +50,7 @@ def xtract_cells_decl(dir, fout):
                     fout.write('\n')
                 if l.rstrip()[-1] != ';':
                     state = State.IN_MODULE_MULTILINE
-            elif l.startswith('parameter') and state == State.IN_MODULE:
+            elif l.lstrip().startswith('parameter') and state == State.IN_MODULE:
                 fout.write(l)
                 if l.rstrip()[-1] == ',':
                     state = State.IN_PARAMETER

--- a/techlibs/gowin/cells_xtra_gw1n.v
+++ b/techlibs/gowin/cells_xtra_gw1n.v
@@ -1109,6 +1109,13 @@ parameter IDLE    =  4'd0,
 		  RD_S2   =  4'd12;
 endmodule
 
+module DCS (...);
+input CLK0, CLK1, CLK2, CLK3, SELFORCE;
+input [3:0] CLKSEL;
+output CLKOUT;
+  parameter DCS_MODE = "RISING";  
+endmodule
+
 module DQCE (...);
 input CLKIN;
 input CE;

--- a/techlibs/gowin/cells_xtra_gw2a.v
+++ b/techlibs/gowin/cells_xtra_gw2a.v
@@ -1082,6 +1082,11 @@ input RLOADN, RMOVE, RDIR, WLOADN, WMOVE, WDIR, HOLD;
 output DQSR90, DQSW0, DQSW270; 
 output [2:0] RPOINT, WPOINT;
 output RVALID,RBURST, RFLAG, WFLAG;
+    parameter FIFO_MODE_SEL = 1'b0; 
+    parameter RD_PNTR = 3'b000; 
+    parameter DQS_MODE = "X1"; 
+    parameter HWL = "false";     
+    parameter GSREN = "false"; 
 endmodule
 
 module DLLDLY (...);
@@ -1093,6 +1098,13 @@ output FLAG;
 parameter DLL_INSEL = 1'b1; 
 parameter DLY_SIGN = 1'b0; 
 parameter DLY_ADJ = 0; 
+endmodule
+
+module DCS (...);
+input CLK0, CLK1, CLK2, CLK3, SELFORCE;
+input [3:0] CLKSEL;
+output CLKOUT;
+  parameter DCS_MODE = "RISING";  
 endmodule
 
 module DQCE (...);

--- a/techlibs/gowin/cells_xtra_gw5a.v
+++ b/techlibs/gowin/cells_xtra_gw5a.v
@@ -1143,6 +1143,13 @@ input CE;
 output CLKOUT;
 endmodule
 
+module DCS (...);
+input CLKIN0, CLKIN1, CLKIN2, CLKIN3, SELFORCE;
+input [3:0] CLKSEL;
+output CLKOUT;
+parameter DCS_MODE = "RISING";  
+endmodule
+
 module DDRDLL (...);
 input CLKIN;
 input STOP;
@@ -1714,18 +1721,94 @@ input LOAD;
 endmodule
 
 module ADCLRC (...);
+  parameter DYN_BKEN = "FALSE";
+  parameter BUF_SERDES_Q1_EN = 3'b000;    
+  parameter BUF_BK2_EN       = 6'b000000; 
+  parameter BUF_BK3_EN       = 6'b000000; 
+  parameter BUF_BK4_EN       = 6'b000000; 
+  parameter BUF_BK5_EN       = 6'b000000; 
+  parameter BUF_BK10_EN      = 5'b00000;  
+  parameter BUF_BK11_EN      = 5'b00000;  
+  parameter CLK_SEL          = 1'b0;      
+  parameter PIOCLK_SEL       = 1'b0;      
+  parameter VSEN_CTL         = 3'b000;    
+  parameter VSEN_CTL_SEL     = 1'b0;      
+  parameter ADC_MODE      = 1'b0;      
+  parameter DIV_CTL       = 2'd0;      
+  parameter SAMPLE_CNT_SEL   = 3'd4;      
+  parameter RATE_CHANGE_CTRL = 3'd4;      
 endmodule
 
 module ADCULC (...);
+  parameter DYN_BKEN = "FALSE";
+  parameter BUF_VCC_EN       = 1'b0;      
+  parameter BUF_VCCM_EN      = 1'b0;      
+  parameter BUF_MIPI_M0_EN   = 3'b000;    
+  parameter BUF_MIPI_M1_EN   = 3'b000;    
+  parameter BUF_SERDES_Q0_EN = 3'b000;    
+  parameter BUF_BK6_EN       = 6'b000000; 
+  parameter BUF_BK7_EN       = 6'b000000; 
+  parameter CLK_SEL          = 1'b0;      
+  parameter PIOCLK_SEL       = 1'b0;      
+  parameter VSEN_CTL         = 3'b000;    
+  parameter VSEN_CTL_SEL     = 1'b0;      
+  parameter ADC_MODE      = 1'b0;      
+  parameter DIV_CTL          = 2'd0;      
+  parameter SAMPLE_CNT_SEL   = 3'd4;      
+  parameter RATE_CHANGE_CTRL = 3'd4;      
 endmodule
 
 module ADC (...);
+  parameter CLK_SEL         = 1'b0;      
+  parameter DIV_CTL         = 2'd0;      
+  parameter BUF_EN          = 12'b000000000000; 
+  parameter BUF_BK0_VREF_EN = 1'b0;  
+  parameter BUF_BK1_VREF_EN = 1'b0;  
+  parameter BUF_BK2_VREF_EN = 1'b0;  
+  parameter BUF_BK3_VREF_EN = 1'b0;  
+  parameter BUF_BK4_VREF_EN = 1'b0;  
+  parameter BUF_BK5_VREF_EN = 1'b0;  
+  parameter BUF_BK6_VREF_EN = 1'b0;  
+  parameter BUF_BK7_VREF_EN = 1'b0;  
+  parameter CSR_ADC_MODE      = 1'b1;       
+  parameter CSR_VSEN_CTRL        = 3'd0;       
+  parameter CSR_SAMPLE_CNT_SEL   = 3'd4;       
+  parameter CSR_RATE_CHANGE_CTRL = 3'd4;       
+  parameter CSR_FSCAL            = 10'd730;    
+  parameter CSR_OFFSET           = -12'd1180;  
 endmodule
 
 module ADC_SAR (...);
+  parameter BUF_EN = 29'b0;    
+  parameter CLK_SEL        = 1'b1;     
+  parameter DIV_CTL        = 2'd2;     
+  parameter ADC_EN_SEL     = 1'b0;     
+  parameter PHASE_SEL      = 1'b0;     
+  parameter CSR_ADC_MODE         = 1'b1;          
+  parameter CSR_VSEN_CTRL        = 3'd0;       
+  parameter CSR_SAMPLE_CNT_SEL   = 3'd4;       
+  parameter CSR_RATE_CHANGE_CTRL = 3'd4;       
+  parameter CSR_FSCAL            = 10'd730;    
+  parameter CSR_OFFSET           = -12'd1180;  
+  parameter ADC_CLK_DIV        = 2'b00;     
+  parameter ADC_CLKDIV_EN      = 1'b0;     
+  parameter CLK_SRC_SEL        = 1'b1;     
+  parameter VREF_BUF_EN        = 1'b1;     
+  parameter COUNT_LEN          = 5'b10100; 
+  parameter DAC_SAMPLE_END     = 5'b10010; 
+  parameter DAC_SAMPLE_START   = 5'b01101; 
+  parameter SH_SAMPLE_END      = 5'b01011; 
+  parameter SH_SAMPLE_START    = 5'b00001; 
+  parameter AUTO_CHOP_EN       = 1'b0;     
+  parameter CHOP_CLK_DIV       = 4'b0;     
 endmodule
 
 module LICD (...);
+    parameter   STAGE_NUM = 2'b00;        
+    parameter   ENCDEC_NUM = 2'b00;       
+    parameter   CODE_WIDTH = 2'b00;       
+    parameter   INTERLEAVE_EN = 3'b000;   
+    parameter   INTERLEAVE_MODE = 3'b000;  
 endmodule
 
 module MIPI_DPHY (...);
@@ -2456,6 +2539,7 @@ parameter EQ_ZLD_LN2 = 4'b1000;
 endmodule
 
 module GTR12_QUAD (...);
+    parameter POSITION = "Q0";
 endmodule
 
 module GTR12_UPAR (...);


### PR DESCRIPTION
The dynamic clock selection (DCS) primitive has undergone changes with the release of the GW5A series—the CLK0,1,2,3 inputs are now CLKIN0,1,2,3, but only for GW5A series chips.

There are no functional changes, only renaming.

Here we are transferring the description of the DCS primitive from general to specialized files for each chip series.

We have also fixed a bug in the generation script that caused the loss of primitive parameters. Fortunately, this only affected the analog-to-digital converter, which has not yet been implemented.

Testing: in the apicula/examples directory, run `make clean; make`.

The entire compilation should complete without errors. This will test the pre-GW5A chips, DCS for the new series under development, and this PR is part of it.