### PR TITLE
Make ABC_DONE tracking more robust

### DIFF
--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -244,10 +244,6 @@ std::optional<AbcProcess> spawn_abc(const char* abc_exe, DeferredLogs &logs) {
 		logs.log_error("posix_spawn_file_actions_adddup2 failed");
 		return std::nullopt;
 	}
-	if (posix_spawn_file_actions_adddup2(&file_actions, from_child_pipe[1], STDERR_FILENO) != 0) {
-		logs.log_error("posix_spawn_file_actions_adddup2 failed");
-		return std::nullopt;
-	}
 	if (posix_spawn_file_actions_addclose(&file_actions, to_child_pipe[0]) != 0) {
 		logs.log_error("posix_spawn_file_actions_addclose failed");
 		return std::nullopt;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Currently in some configurations the ABC_DONE token is missed and ABC just hangs.

_Explain how this is achieved._

Moving the emission of the `ABC_DONE` token into the sourced script makes things simpler because we don't have to worry about ABC echoing the command before it runs, and the end of the ABC `source` command flushes stdout in a way that ensures our token appears.