### PR TITLE
Remove more uses of `.c_str()`

### DIFF
--- a/backends/aiger2/aiger.cc
+++ b/backends/aiger2/aiger.cc
@@ -1017,7 +1017,7 @@ struct XAigerWriter : AigerWriter {
 			auto &minfo = cursor.leaf_minfo(*this);
 
 			for (auto box : minfo.found_blackboxes) {
-				log_debug(" - %s.%s (type %s): ", cursor.path().c_str(),
+				log_debug(" - %s.%s (type %s): ", cursor.path(),
 						  RTLIL::unescape_id(box->name),
 						  log_id(box->type));
 

--- a/frontends/aiger/aigerparse.cc
+++ b/frontends/aiger/aigerparse.cc
@@ -476,7 +476,7 @@ void AigerReader::parse_xaiger()
 		else if (c == 'n') {
 			parse_xaiger_literal(f);
 			f >> s;
-			log_debug("n: '%s'\n", s.c_str());
+			log_debug("n: '%s'\n", s);
 		}
 		else if (c == 'h') {
 			f.ignore(sizeof(uint32_t));

--- a/frontends/rpc/rpc_frontend.cc
+++ b/frontends/rpc/rpc_frontend.cc
@@ -83,11 +83,11 @@ struct RpcServer {
 		std::string request;
 		json_request.dump(request);
 		request += '\n';
-		log_debug("RPC frontend request: %s", request.c_str());
+		log_debug("RPC frontend request: %s", request);
 		write(request);
 
 		std::string response = read();
-		log_debug("RPC frontend response: %s", response.c_str());
+		log_debug("RPC frontend response: %s", response);
 		std::string error;
 		Json json_response = Json::parse(response, error);
 		if (json_response.is_null())

--- a/kernel/cost.cc
+++ b/kernel/cost.cc
@@ -143,14 +143,14 @@ unsigned int CellCosts::get(RTLIL::Cell *cell)
 		return 1;
 
 	if (design_ && design_->module(cell->type) && cell->parameters.empty()) {
-		log_debug("%s is a module, recurse\n", cell->name.c_str());
+		log_debug("%s is a module, recurse\n", cell->name);
 		return get(design_->module(cell->type));
 	} else if (cell->is_builtin_ff()) {
 		log_assert(cell->hasPort(ID::Q) && "Weird flip flop");
-		log_debug("%s is ff\n", cell->name.c_str());
+		log_debug("%s is ff\n", cell->name);
 		return cell->getParam(ID::WIDTH).as_int();
 	} else if (cell->type.in(ID($mem), ID($mem_v2))) {
-		log_debug("%s is mem\n", cell->name.c_str());
+		log_debug("%s is mem\n", cell->name);
 		return cell->getParam(ID::WIDTH).as_int() * cell->getParam(ID::SIZE).as_int();
 	} else if (y_coef(cell->type)) {
 		// linear with Y_WIDTH or WIDTH
@@ -159,23 +159,23 @@ unsigned int CellCosts::get(RTLIL::Cell *cell)
 		int width = cell->getParam(param).as_int();
 		if (cell->type == ID($demux))
 			width <<= cell->getParam(ID::S_WIDTH).as_int();
-		log_debug("%s Y*coef %d * %d\n", cell->name.c_str(), width, y_coef(cell->type));
+		log_debug("%s Y*coef %d * %d\n", cell->name, width, y_coef(cell->type));
 		return width * y_coef(cell->type);
 	} else if (sum_coef(cell->type)) {
 		// linear with sum of port widths
 		unsigned int sum = port_width_sum(cell);
-		log_debug("%s sum*coef %d * %d\n", cell->name.c_str(), sum, sum_coef(cell->type));
+		log_debug("%s sum*coef %d * %d\n", cell->name, sum, sum_coef(cell->type));
 		return sum * sum_coef(cell->type);
 	} else if (max_inp_coef(cell->type)) {
 		// linear with largest input width
 		unsigned int max = max_inp_width(cell);
-		log_debug("%s max*coef %d * %d\n", cell->name.c_str(), max, max_inp_coef(cell->type));
+		log_debug("%s max*coef %d * %d\n", cell->name, max, max_inp_coef(cell->type));
 		return max * max_inp_coef(cell->type);
 	} else if (is_div_mod(cell->type) || cell->type == ID($mul)) {
 		// quadratic with sum of port widths
 		unsigned int sum = port_width_sum(cell);
 		unsigned int coef = cell->type == ID($mul) ? 3 : 5;
-		log_debug("%s coef*(sum**2) %d * %d\n", cell->name.c_str(), coef, sum * sum);
+		log_debug("%s coef*(sum**2) %d * %d\n", cell->name, coef, sum * sum);
 		return coef * sum * sum;
 	} else if (cell->type.in(ID($macc), ID($macc_v2))) {
 		// quadratic per term
@@ -196,15 +196,15 @@ unsigned int CellCosts::get(RTLIL::Cell *cell)
 	} else if (cell->type == ID($lut)) {
 		int width = cell->getParam(ID::WIDTH).as_int();
 		unsigned int cost = 1U << (unsigned int)width;
-		log_debug("%s is 2**%d\n", cell->name.c_str(), width);
+		log_debug("%s is 2**%d\n", cell->name, width);
 		return cost;
 	} else if (cell->type == ID($sop)) {
 		int width = cell->getParam(ID::WIDTH).as_int();
 		int depth = cell->getParam(ID::DEPTH).as_int();
-		log_debug("%s is (2*%d + 1)*%d\n", cell->name.c_str(), width, depth);
+		log_debug("%s is (2*%d + 1)*%d\n", cell->name, width, depth);
 		return (2 * width + 1) * depth;
 	} else if (is_free(cell->type)) {
-		log_debug("%s is free\n", cell->name.c_str());
+		log_debug("%s is free\n", cell->name);
 		return 0;
 	}
 	// TODO: $fsm

--- a/kernel/fstdata.cc
+++ b/kernel/fstdata.cc
@@ -162,7 +162,7 @@ void FstData::extractVarNames()
 					char *endptr;
 					int mem_addr = strtol(addr.c_str(), &endptr, 16);
 					if (*endptr) {
-						log_debug("Error parsing memory address in : %s\n", clean_name.c_str());
+						log_debug("Error parsing memory address in : %s\n", clean_name);
 					} else {
 						memory_to_handle[var.scope+"."+mem_cell][mem_addr] = var.id;
 					}
@@ -176,7 +176,7 @@ void FstData::extractVarNames()
 					char *endptr;
 					int mem_addr = strtol(addr.c_str(), &endptr, 10);
 					if (*endptr) {
-						log_debug("Error parsing memory address in : %s\n", clean_name.c_str());
+						log_debug("Error parsing memory address in : %s\n", clean_name);
 					} else {
 						memory_to_handle[var.scope+"."+mem_cell][mem_addr] = var.id;
 					}

--- a/passes/cmds/abstract.cc
+++ b/passes/cmds/abstract.cc
@@ -156,9 +156,9 @@ dict<SigBit, std::vector<SelReason>> gather_selected_reps(Module* mod, const std
 void explain_selections(const std::vector<SelReason>& reasons) {
 	for (std::variant<Wire*, Cell*> reason : reasons) {
 		if (Cell** cell_reason = std::get_if<Cell*>(&reason))
-			log_debug("\tcell %s\n", (*cell_reason)->name.c_str());
+			log_debug("\tcell %s\n", (*cell_reason)->name);
 		else if (Wire** wire_reason = std::get_if<Wire*>(&reason))
-			log_debug("\twire %s\n", (*wire_reason)->name.c_str());
+			log_debug("\twire %s\n", (*wire_reason)->name);
 		else
 			log_assert(false && "insane reason variant\n");
 	}

--- a/passes/cmds/box_derive.cc
+++ b/passes/cmds/box_derive.cc
@@ -96,7 +96,7 @@ struct BoxDerivePass : Pass {
 				IdString derived_type = base->derive(d, cell->parameters);
 				Module *derived = d->module(derived_type);
 				log_assert(derived && "Failed to derive module\n");
-				log_debug("derived %s\n", derived_type.c_str());
+				log_debug("derived %s\n", derived_type);
 
 				if (!naming_attr.empty() && derived->has_attribute(naming_attr)) {
 					IdString new_name = RTLIL::escape_id(derived->get_string_attribute(naming_attr));

--- a/passes/cmds/linecoverage.cc
+++ b/passes/cmds/linecoverage.cc
@@ -95,7 +95,7 @@ struct CoveragePass : public Pass {
 		{
 			log_debug("Module %s:\n", log_id(module));
 			for (auto wire: module->wires()) {
-				log_debug("%s\t%s\t%s\n", module->selected(wire) ? "*" : " ", wire->get_src_attribute().c_str(), log_id(wire->name));
+				log_debug("%s\t%s\t%s\n", module->selected(wire) ? "*" : " ", wire->get_src_attribute(), log_id(wire->name));
 				for (auto src: wire->get_strpool_attribute(ID::src)) {
 					auto filename = extract_src_filename(src);
 					if (filename.empty()) continue;
@@ -109,7 +109,7 @@ struct CoveragePass : public Pass {
 				}
 			}
 			for (auto cell: module->cells()) {
-				log_debug("%s\t%s\t%s\n", module->selected(cell) ? "*" : " ", cell->get_src_attribute().c_str(), log_id(cell->name));
+				log_debug("%s\t%s\t%s\n", module->selected(cell) ? "*" : " ", cell->get_src_attribute(), log_id(cell->name));
 				for (auto src: cell->get_strpool_attribute(ID::src)) {
 					auto filename = extract_src_filename(src);
 					if (filename.empty()) continue;

--- a/passes/memory/memory_libmap.cc
+++ b/passes/memory/memory_libmap.cc
@@ -392,7 +392,7 @@ void MemMapping::dump_configs(int stage) {
 void MemMapping::dump_config(MemConfig &cfg) {
 	log_debug("- %s:\n", log_id(cfg.def->id));
 	for (auto &it: cfg.def->options)
-		log_debug("  - option %s %s\n", it.first.c_str(), log_const(it.second));
+		log_debug("  - option %s %s\n", it.first, log_const(it.second));
 	log_debug("  - emulation score: %d\n", cfg.score_emu);
 	log_debug("  - replicates (for ports): %d\n", cfg.repl_port);
 	log_debug("  - replicates (for data): %d\n", cfg.repl_d);
@@ -403,7 +403,7 @@ void MemMapping::dump_config(MemConfig &cfg) {
 	for (int x: cfg.def->dbits)
 		os << " " << x;
 	std::string dbits_s = os.str();
-	log_debug("  - abits %d dbits%s\n", cfg.def->abits, dbits_s.c_str());
+	log_debug("  - abits %d dbits%s\n", cfg.def->abits, dbits_s);
 	if (cfg.def->byte != 0)
 		log_debug("  - byte width %d\n", cfg.def->byte);
 	log_debug("  - chosen base width %d\n", cfg.def->dbits[cfg.base_width_log2]);
@@ -414,25 +414,25 @@ void MemMapping::dump_config(MemConfig &cfg) {
 		else
 			os << " " << x;
 	std::string swizzle_s = os.str();
-	log_debug("  - swizzle%s\n", swizzle_s.c_str());
+	log_debug("  - swizzle%s\n", swizzle_s);
 	os.str("");
 	for (int i = 0; (1 << i) <= cfg.hard_wide_mask; i++)
 		if (cfg.hard_wide_mask & 1 << i)
 			os << " " << i;
 	std::string wide_s = os.str();
 	if (cfg.hard_wide_mask)
-		log_debug("  - hard wide bits%s\n", wide_s.c_str());
+		log_debug("  - hard wide bits%s\n", wide_s);
 	if (cfg.emu_read_first)
 		log_debug("  - emulate read-first behavior\n");
 	for (int i = 0; i < GetSize(mem.wr_ports); i++) {
 		auto &pcfg = cfg.wr_ports[i];
 		if (pcfg.rd_port == -1)
-			log_debug("  - write port %d: port group %s\n", i, cfg.def->port_groups[pcfg.port_group].names[0].c_str());
+			log_debug("  - write port %d: port group %s\n", i, cfg.def->port_groups[pcfg.port_group].names[0]);
 		else
-			log_debug("  - write port %d: port group %s (shared with read port %d)\n", i, cfg.def->port_groups[pcfg.port_group].names[0].c_str(), pcfg.rd_port);
+			log_debug("  - write port %d: port group %s (shared with read port %d)\n", i, cfg.def->port_groups[pcfg.port_group].names[0], pcfg.rd_port);
 
 		for (auto &it: pcfg.def->options)
-			log_debug("    - option %s %s\n", it.first.c_str(), log_const(it.second));
+			log_debug("    - option %s %s\n", it.first, log_const(it.second));
 		if (cfg.def->width_mode == WidthMode::PerPort) {
 			std::stringstream os;
 			for (int i = pcfg.def->min_wr_wide_log2; i <= pcfg.def->max_wr_wide_log2; i++)
@@ -441,7 +441,7 @@ void MemMapping::dump_config(MemConfig &cfg) {
 			const char *note = "";
 			if (pcfg.rd_port != -1)
 				note = pcfg.def->width_tied ? " (tied)" : " (independent)";
-			log_debug("    - widths%s%s\n", widths_s.c_str(), note);
+			log_debug("    - widths%s%s\n", widths_s, note);
 		}
 		for (auto i: pcfg.emu_prio)
 			log_debug("    - emulate priority over write port %d\n", i);
@@ -449,11 +449,11 @@ void MemMapping::dump_config(MemConfig &cfg) {
 	for (int i = 0; i < GetSize(mem.rd_ports); i++) {
 		auto &pcfg = cfg.rd_ports[i];
 		if (pcfg.wr_port == -1)
-			log_debug("  - read port %d: port group %s\n", i, cfg.def->port_groups[pcfg.port_group].names[0].c_str());
+			log_debug("  - read port %d: port group %s\n", i, cfg.def->port_groups[pcfg.port_group].names[0]);
 		else
-			log_debug("  - read port %d: port group %s (shared with write port %d)\n", i, cfg.def->port_groups[pcfg.port_group].names[0].c_str(), pcfg.wr_port);
+			log_debug("  - read port %d: port group %s (shared with write port %d)\n", i, cfg.def->port_groups[pcfg.port_group].names[0], pcfg.wr_port);
 		for (auto &it: pcfg.def->options)
-			log_debug("    - option %s %s\n", it.first.c_str(), log_const(it.second));
+			log_debug("    - option %s %s\n", it.first, log_const(it.second));
 		if (cfg.def->width_mode == WidthMode::PerPort) {
 			std::stringstream os;
 			for (int i = pcfg.def->min_rd_wide_log2; i <= pcfg.def->max_rd_wide_log2; i++)
@@ -462,7 +462,7 @@ void MemMapping::dump_config(MemConfig &cfg) {
 			const char *note = "";
 			if (pcfg.wr_port != -1)
 				note = pcfg.def->width_tied ? " (tied)" : " (independent)";
-			log_debug("    - widths%s%s\n", widths_s.c_str(), note);
+			log_debug("    - widths%s%s\n", widths_s, note);
 		}
 		if (pcfg.emu_sync)
 			log_debug("    - emulate data register\n");
@@ -2242,7 +2242,7 @@ struct MemoryLibMapPass : public Pass {
 				if (!map.logic_ok) {
 					if (map.cfgs.empty()) {
 						log_debug("Rejected candidates for mapping memory %s.%s:\n", log_id(module->name), log_id(mem.memid));
-						log_debug("%s", map.rejected_cfg_debug_msgs.c_str());
+						log_debug("%s", map.rejected_cfg_debug_msgs);
 						log_error("no valid mapping found for memory %s.%s\n", log_id(module->name), log_id(mem.memid));
 					}
 					idx = 0;

--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -204,7 +204,7 @@ void rmunused_module_cells(Module *module, bool verbose)
 
 	for (auto cell : unused) {
 		if (verbose)
-			log_debug("  removing unused `%s' cell `%s'.\n", cell->type.c_str(), cell->name.c_str());
+			log_debug("  removing unused `%s' cell `%s'.\n", cell->type, cell->name);
 		module->design->scratchpad_set_bool("opt.did_something", true);
 		if (cell->is_builtin_ff())
 			ffinit.remove_init(cell->getPort(ID::Q));
@@ -215,7 +215,7 @@ void rmunused_module_cells(Module *module, bool verbose)
 	for (auto it : mem_unused)
 	{
 		if (verbose)
-			log_debug("  removing unused memory `%s'.\n", it.c_str());
+			log_debug("  removing unused memory `%s'.\n", it);
 		delete module->memories.at(it);
 		module->memories.erase(it);
 	}
@@ -496,7 +496,7 @@ bool rmunused_module_signals(RTLIL::Module *module, bool purge_mode, bool verbos
 	int del_temp_wires_count = 0;
 	for (auto wire : del_wires_queue) {
 		if (ys_debug() || (check_public_name(wire->name) && verbose))
-			log_debug("  removing unused non-port wire %s.\n", wire->name.c_str());
+			log_debug("  removing unused non-port wire %s.\n", wire->name);
 		else
 			del_temp_wires_count++;
 	}
@@ -636,7 +636,7 @@ void rmunused_module(RTLIL::Module *module, bool purge_mode, bool verbose, bool 
 	}
 	for (auto cell : delcells) {
 		if (verbose)
-			log_debug("  removing buffer cell `%s': %s = %s\n", cell->name.c_str(),
+			log_debug("  removing buffer cell `%s': %s = %s\n", cell->name,
 					log_signal(cell->getPort(ID::Y)), log_signal(cell->getPort(ID::A)));
 		module->remove(cell);
 	}

--- a/passes/opt/opt_lut.cc
+++ b/passes/opt/opt_lut.cc
@@ -162,7 +162,7 @@ struct OptLutWorker
 					{
 						if (lut_width <= dlogic_conn.first)
 						{
-							log_debug("  LUT has illegal connection to %s cell %s.%s.\n", lut_dlogic.second->type.c_str(), log_id(module), log_id(lut_dlogic.second));
+							log_debug("  LUT has illegal connection to %s cell %s.%s.\n", lut_dlogic.second->type, log_id(module), log_id(lut_dlogic.second));
 							log_debug("    LUT input A[%d] not present.\n", dlogic_conn.first);
 							legal = false;
 							break;
@@ -173,8 +173,8 @@ struct OptLutWorker
 
 						if (sigmap(lut_input[dlogic_conn.first]) != sigmap(lut_dlogic.second->getPort(dlogic_conn.second)[0]))
 						{
-							log_debug("  LUT has illegal connection to %s cell %s.%s.\n", lut_dlogic.second->type.c_str(), log_id(module), log_id(lut_dlogic.second));
-							log_debug("    LUT input A[%d] (wire %s) not connected to %s port %s (wire %s).\n", dlogic_conn.first, log_signal(lut_input[dlogic_conn.first]), lut_dlogic.second->type.c_str(), dlogic_conn.second.c_str(), log_signal(lut_dlogic.second->getPort(dlogic_conn.second)));
+							log_debug("  LUT has illegal connection to %s cell %s.%s.\n", lut_dlogic.second->type, log_id(module), log_id(lut_dlogic.second));
+							log_debug("    LUT input A[%d] (wire %s) not connected to %s port %s (wire %s).\n", dlogic_conn.first, log_signal(lut_input[dlogic_conn.first]), lut_dlogic.second->type, dlogic_conn.second, log_signal(lut_dlogic.second->getPort(dlogic_conn.second)));
 							legal = false;
 							break;
 						}
@@ -182,7 +182,7 @@ struct OptLutWorker
 
 					if (legal)
 					{
-						log_debug("  LUT has legal connection to %s cell %s.%s.\n", lut_dlogic.second->type.c_str(), log_id(module), log_id(lut_dlogic.second));
+						log_debug("  LUT has legal connection to %s cell %s.%s.\n", lut_dlogic.second->type, log_id(module), log_id(lut_dlogic.second));
 						lut_legal_dlogics.insert(lut_dlogic);
 						for (auto &dlogic_conn : dlogic_map)
 							lut_dlogic_inputs.insert(dlogic_conn.first);
@@ -496,9 +496,9 @@ struct OptLutWorker
 						lutM_new_table.set(eval, (RTLIL::State) evaluate_lut(lutB, eval_inputs));
 					}
 
-					log_debug("  Cell A truth table: %s.\n", lutA->getParam(ID::LUT).as_string().c_str());
-					log_debug("  Cell B truth table: %s.\n", lutB->getParam(ID::LUT).as_string().c_str());
-					log_debug("  Merged truth table: %s.\n", lutM_new_table.as_string().c_str());
+					log_debug("  Cell A truth table: %s.\n", lutA->getParam(ID::LUT).as_string());
+					log_debug("  Cell B truth table: %s.\n", lutB->getParam(ID::LUT).as_string());
+					log_debug("  Merged truth table: %s.\n", lutM_new_table.as_string());
 
 					lutM->setParam(ID::LUT, lutM_new_table);
 					lutM->setPort(ID::A, lutM_new_inputs);

--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -300,11 +300,11 @@ struct OptMergeWorker
 					}
 
 					did_something = true;
-					log_debug("  Cell `%s' is identical to cell `%s'.\n", cell->name.c_str(), other_cell->name.c_str());
+					log_debug("  Cell `%s' is identical to cell `%s'.\n", cell->name, other_cell->name);
 					for (auto &it : cell->connections()) {
 						if (cell->output(it.first)) {
 							RTLIL::SigSpec other_sig = other_cell->getPort(it.first);
-							log_debug("    Redirecting output %s: %s = %s\n", it.first.c_str(),
+							log_debug("    Redirecting output %s: %s = %s\n", it.first,
 									log_signal(it.second), log_signal(other_sig));
 							Const init = initvals(other_sig);
 							initvals.remove_init(it.second);
@@ -314,7 +314,7 @@ struct OptMergeWorker
 							initvals.set_init(other_sig, init);
 						}
 					}
-					log_debug("    Removing %s cell `%s' from module `%s'.\n", cell->type.c_str(), cell->name.c_str(), module->name.c_str());
+					log_debug("    Removing %s cell `%s' from module `%s'.\n", cell->type, cell->name, module->name);
 					module->remove(cell);
 					total_count++;
 				}

--- a/passes/techmap/clockgate.cc
+++ b/passes/techmap/clockgate.cc
@@ -85,7 +85,7 @@ static std::pair<std::optional<ClockGateCell>, std::optional<ClockGateCell>>
 			continue;
 		}
 
-		log_debug("maybe valid icg: %s\n", cell_name.c_str());
+		log_debug("maybe valid icg: %s\n", cell_name);
 		ClockGateCell icg_interface;
 		icg_interface.name = RTLIL::escape_id(cell_name);
 
@@ -162,9 +162,9 @@ static std::pair<std::optional<ClockGateCell>, std::optional<ClockGateCell>>
 			winning = cost < goal;
 
 			if (winning)
-				log_debug("%s beats %s\n", icg_interface.name.c_str(), icg_to_beat->name.c_str());
+				log_debug("%s beats %s\n", icg_interface.name, icg_to_beat->name);
 		} else {
-			log_debug("%s is the first of its polarity\n", icg_interface.name.c_str());
+			log_debug("%s is the first of its polarity\n", icg_interface.name);
 			winning = true;
 		}
 		if (winning) {
@@ -395,7 +395,7 @@ struct ClockgatePass : public Pass {
 				if (!it->second.new_net)
 					continue;
 
-				log_debug("Fix up FF %s\n", cell->name.c_str());
+				log_debug("Fix up FF %s\n", cell->name);
 				// Now we start messing with the design
 				ff.has_ce = false;
 				// Construct the clock gate

--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -117,11 +117,11 @@ static bool parse_next_state(const LibertyAst *cell, const LibertyAst *attr, std
 	// the next_state variable isn't just a pin name; perhaps this is an enable?
 	auto helper = LibertyExpression::Lexer(expr);
 	auto tree = LibertyExpression::parse(helper);
-	// log_debug("liberty expression:\n%s\n", tree.str().c_str());
+	// log_debug("liberty expression:\n%s\n", tree.str());
 
 	if (tree.kind == LibertyExpression::Kind::EMPTY) {
 		if (!warned_cells.count(cell_name)) {
-			log_debug("Invalid expression '%s' in next_state attribute of cell '%s' - skipping.\n", expr.c_str(), cell_name.c_str());
+			log_debug("Invalid expression '%s' in next_state attribute of cell '%s' - skipping.\n", expr, cell_name);
 			warned_cells.insert(cell_name);
 		}
 		return false;
@@ -140,7 +140,7 @@ static bool parse_next_state(const LibertyAst *cell, const LibertyAst *attr, std
 	// position that gives better diagnostics here.
 	if (!pin_names.count(ff_output)) {
 		if (!warned_cells.count(cell_name)) {
-			log_debug("Inference failed on expression '%s' in next_state attribute of cell '%s' because it does not contain ff output '%s' - skipping.\n", expr.c_str(), cell_name.c_str(), ff_output.c_str());
+			log_debug("Inference failed on expression '%s' in next_state attribute of cell '%s' because it does not contain ff output '%s' - skipping.\n", expr, cell_name, ff_output);
 			warned_cells.insert(cell_name);
 		}
 		return false;
@@ -189,7 +189,7 @@ static bool parse_next_state(const LibertyAst *cell, const LibertyAst *attr, std
 	}
 
 	if (!warned_cells.count(cell_name)) {
-		log_debug("Inference failed on expression '%s' in next_state attribute of cell '%s' because it does not evaluate to an enable flop - skipping.\n", expr.c_str(), cell_name.c_str());
+		log_debug("Inference failed on expression '%s' in next_state attribute of cell '%s' because it does not evaluate to an enable flop - skipping.\n", expr, cell_name);
 		warned_cells.insert(cell_name);
 	}
 	return false;
@@ -225,10 +225,10 @@ static bool parse_pin(const LibertyAst *cell, const LibertyAst *attr, std::strin
        For now, we'll simply produce a warning to let the user know something is up.
 	*/
 	if (pin_name.find_first_of("^*|&") == std::string::npos) {
-		log_debug("Malformed liberty file - cannot find pin '%s' in cell '%s' - skipping.\n", pin_name.c_str(), cell->args[0].c_str());
+		log_debug("Malformed liberty file - cannot find pin '%s' in cell '%s' - skipping.\n", pin_name, cell->args[0]);
 	}
 	else {
-		log_debug("Found unsupported expression '%s' in pin attribute of cell '%s' - skipping.\n", pin_name.c_str(), cell->args[0].c_str());
+		log_debug("Found unsupported expression '%s' in pin attribute of cell '%s' - skipping.\n", pin_name, cell->args[0]);
 	}
 
 	return false;

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -582,7 +582,7 @@ struct TechmapWorker
 							log_msg_cache.insert(msg);
 							log("%s\n", msg);
 						}
-						log_debug("%s %s.%s (%s) to %s.\n", mapmsg_prefix.c_str(), log_id(module), log_id(cell), log_id(cell->type), log_id(extmapper_module));
+						log_debug("%s %s.%s (%s) to %s.\n", mapmsg_prefix, log_id(module), log_id(cell), log_id(cell->type), log_id(extmapper_module));
 					}
 					else
 					{
@@ -591,7 +591,7 @@ struct TechmapWorker
 							log_msg_cache.insert(msg);
 							log("%s\n", msg);
 						}
-						log_debug("%s %s.%s (%s) with %s.\n", mapmsg_prefix.c_str(), log_id(module), log_id(cell), log_id(cell->type), extmapper_name.c_str());
+						log_debug("%s %s.%s (%s) with %s.\n", mapmsg_prefix, log_id(module), log_id(cell), log_id(cell->type), extmapper_name);
 
 						if (extmapper_name == "simplemap") {
 							if (simplemap_mappers.count(cell->type) == 0)
@@ -943,7 +943,7 @@ struct TechmapWorker
 						module_queue.insert(m);
 					}
 
-					log_debug("%s %s.%s to imported %s.\n", mapmsg_prefix.c_str(), log_id(module), log_id(cell), log_id(m_name));
+					log_debug("%s %s.%s to imported %s.\n", mapmsg_prefix, log_id(module), log_id(cell), log_id(m_name));
 					cell->type = m_name;
 					cell->parameters.clear();
 				}
@@ -954,7 +954,7 @@ struct TechmapWorker
 						log_msg_cache.insert(msg);
 						log("%s\n", msg);
 					}
-					log_debug("%s %s.%s (%s) using %s.\n", mapmsg_prefix.c_str(), log_id(module), log_id(cell), log_id(cell->type), log_id(tpl));
+					log_debug("%s %s.%s (%s) using %s.\n", mapmsg_prefix, log_id(module), log_id(cell), log_id(cell->type), log_id(tpl));
 					techmap_module_worker(design, module, cell, tpl);
 					cell = nullptr;
 				}
@@ -1285,7 +1285,7 @@ struct TechmapPass : public Pass {
 			std::string maps = "";
 			for (auto &map : i.second)
 				maps += stringf(" %s", log_id(map));
-			log_debug("    %s:%s\n", log_id(i.first), maps.c_str());
+			log_debug("    %s:%s\n", log_id(i.first), maps);
 		}
 		log_debug("\n");
 

--- a/passes/tests/test_cell.cc
+++ b/passes/tests/test_cell.cc
@@ -1185,7 +1185,7 @@ struct TestCellPass : public Pass {
 							// Expected to run once
 							int num_cells_estimate = costs.get(uut);
 							if (num_cells <= num_cells_estimate) {
-								log_debug("Correct upper bound for %s: %d <= %d\n", cell_type.c_str(), num_cells, num_cells_estimate);
+								log_debug("Correct upper bound for %s: %d <= %d\n", cell_type, num_cells, num_cells_estimate);
 							} else {
 								failed++;
 								if (worst_abs < num_cells - num_cells_estimate) {

--- a/techlibs/quicklogic/ql_ioff.cc
+++ b/techlibs/quicklogic/ql_ioff.cc
@@ -42,7 +42,7 @@ struct QlIoffPass : public Pass {
 
 		for (auto cell : module->selected_cells()) {
 			if (cell->type.in(ID(dffsre), ID(sdffsre))) {
-				log_debug("Checking cell %s.\n", cell->name.c_str());
+				log_debug("Checking cell %s.\n", cell->name);
 				bool e_const = cell->getPort(ID::E).is_fully_ones();
 				bool r_const = cell->getPort(ID::R).is_fully_ones();
 				bool s_const = cell->getPort(ID::S).is_fully_ones();
@@ -55,7 +55,7 @@ struct QlIoffPass : public Pass {
 				SigSpec d = cell->getPort(ID::D);
 				log_assert(GetSize(d) == 1);
 				if (modwalker.has_inputs(d)) {
-					log_debug("Cell %s is potentially eligible for promotion to input IOFF.\n", cell->name.c_str());
+					log_debug("Cell %s is potentially eligible for promotion to input IOFF.\n", cell->name);
 					// check that d_sig has no other consumers
 					pool<ModWalker::PortBit> portbits;
 					modwalker.get_consumers(portbits, d);
@@ -70,7 +70,7 @@ struct QlIoffPass : public Pass {
 				SigSpec q = cell->getPort(ID::Q);
 				log_assert(GetSize(q) == 1);
 				if (modwalker.has_outputs(q) && !modwalker.has_consumers(q)) {
-					log_debug("Cell %s is potentially eligible for promotion to output IOFF.\n", cell->name.c_str());
+					log_debug("Cell %s is potentially eligible for promotion to output IOFF.\n", cell->name);
 					for (SigBit bit : output_bit_aliases[modwalker.sigmap(q)]) {
 						log_assert(bit.is_wire());
 						output_ffs[bit.wire][bit.offset] = cell;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Makes code more readable.

_Explain how this is achieved._

I missed converting the arguments to `log_debug` before, so do that.

Another thing we can do is call `std::stoi()` instead of `atoi()`.