### PR TITLE
Make `ID::` constants be `StaticIdString`s for better optimization

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -46,7 +46,7 @@ int RTLIL::IdString::last_created_idx_[8];
 int RTLIL::IdString::last_created_idx_ptr_;
 #endif
 
-#define X(N) const RTLIL::IdString RTLIL::ID::N(RTLIL::StaticId::N);
+#define X(_id) const RTLIL::IdString RTLIL::IDInternal::_id(RTLIL::StaticId::_id);
 #include "kernel/constids.inc"
 #undef X
 

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -495,8 +495,13 @@ inline bool RTLIL::IdString::operator!=(const RTLIL::StaticIdString &rhs) const 
 }
 
 namespace RTLIL {
-	namespace ID {
+	namespace IDInternal {
 #define X(_id) extern const IdString _id;
+#include "kernel/constids.inc"
+#undef X
+	}
+	namespace ID {
+#define X(_id) constexpr StaticIdString _id(StaticId::_id, IDInternal::_id);
 #include "kernel/constids.inc"
 #undef X
 	}
@@ -508,7 +513,7 @@ struct IdTableEntry {
 };
 
 constexpr IdTableEntry IdTable[] = {
-#define X(_id) {#_id, RTLIL::StaticIdString(RTLIL::StaticId::_id, RTLIL::ID::_id)},
+#define X(_id) {#_id, ID::_id},
 #include "kernel/constids.inc"
 #undef X
 };


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

PR #5324 didn't actually work as advertised in the title. We ended up making the `ID()` macro return `StaticIdString` for well-known IDs, whose internal index is known at compile time, but the `ID::` globals are still `const IdString` whose internal index is not known at compile time.

_Explain how this is achieved._

Define the `ID::` globals as `StaticIdString`. We still need `const IdString` globals around for `StaticIdString::operator const IdString &()` to return, so put them in an `IDInternal` namespace.