### PR TITLE
CONTRIBUTING: add link to dev jf doc, replace slack with Discourse

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,8 @@ merge; please do not use these labels if you are not a maintainer.
 
 # Asking questions
 
-If you have a question about how to use Yosys, please ask on our [discussions
-page](https://github.com/YosysHQ/yosys/discussions) or in our [Discourse forum](https://yosyshq.discourse.group/).
+If you have a question about how to use Yosys, please ask on our [Discourse forum](https://yosyshq.discourse.group/) or in our [discussions
+page](https://github.com/YosysHQ/yosys/discussions).
 The Discourse is also a great place to ask questions about developing or
 contributing to Yosys.
 


### PR DESCRIPTION
A view-only link to the dev jf doc is added instead of telling people to go through the abandoned public slack. I also added Discourse. Do we prefer Discourse over GH Discussions? If so, I'll also reorder those two