### PR TITLE
Support multiple lib files in abc9_exe

### DIFF
--- a/passes/techmap/abc9_exe.cc
+++ b/passes/techmap/abc9_exe.cc
@@ -181,8 +181,10 @@ void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe
 		for (std::string dont_use_cell : dont_use_cells) {
 			dont_use_args += stringf("-X \"%s\" ", dont_use_cell);
 		}
+		bool first_lib = true;
 		for (std::string liberty_file : liberty_files) {
-			abc9_script += stringf("read_lib %s -w \"%s\" ; ", dont_use_args, liberty_file);
+			abc9_script += stringf("read_lib %s %s -w \"%s\" ; ", dont_use_args, first_lib ? "" : "-m", liberty_file);
+			first_lib = false;
 		}
 		if (!constr_file.empty())
 			abc9_script += stringf("read_constr -v \"%s\"; ", constr_file);


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

For `abc9_exe` to work with multiple `-liberty` arguments it requires the same change done to `abc` in https://github.com/YosysHQ/yosys/pull/4340.

_Explain how this is achieved._

_If applicable, please suggest to reviewers how they can test the change._
