### PR TITLE
Fix off-by-one error in bounds check in `RTLIL::SigChunk::operator[]`

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -4399,7 +4399,7 @@ RTLIL::SigChunk RTLIL::SigChunk::extract(int offset, int length) const
 RTLIL::SigBit RTLIL::SigChunk::operator[](int offset) const
 {
 	log_assert(offset >= 0);
-	log_assert(offset <= width);
+	log_assert(offset < width);
 	RTLIL::SigBit ret;
 	if (wire) {
 		ret.wire = wire;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Trivial bug, easily fixed.