### PR TITLE
Move `OptMerge` cell filtering logic to happen while building the cell vector

### DIFF
--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -249,10 +249,15 @@ struct OptMergeWorker
 					// mem can have an excessively large parameter holding the init data
 					continue;
 				}
+				if (cell->type == ID($scopeinfo))
+					continue;
 				if (mode_keepdc && has_dont_care_initval(cell))
 					continue;
-				if (ct.cell_known(cell->type) || (mode_share_all && cell->known()))
-					cells.push_back(cell);
+				if (!cell->known())
+					continue;
+				if (!mode_share_all && !ct.cell_known(cell->type))
+					continue;
+				cells.push_back(cell);
 			}
 
 			did_something = false;
@@ -281,12 +286,6 @@ struct OptMergeWorker
 
 			for (auto cell : cells)
 			{
-				if ((!mode_share_all && !ct.cell_known(cell->type)) || !cell->known())
-					continue;
-
-				if (cell->type == ID($scopeinfo))
-					continue;
-
 				auto [cell_in_map, inserted] = known_cells.insert(cell);
 				if (!inserted) {
 					// We've failed to insert since we already have an equivalent cell


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

This code is quite confusing because there are two "is the cell known" filters applied, one while building the cell vector and one after building the cell vector, and they're subtly different. I'm preserving the actual behaviour here but it looks like there is, or was, a bug here.

Having all the filtering happen while building the cell vector is less confusing and a tiny bit more efficient.