### PR TITLE
Various logging fixes and cleanup

### DIFF
--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -407,6 +407,11 @@ void log_abort_internal(const char *file, int line)
 	log_error("Abort in %s:%d.\n", file, line);
 }
 
+void log_yosys_abort_message(std::string_view file, int line, std::string_view func, std::string_view message)
+{
+	log_error("Abort in %s:%d (%s): %s\n", file, line, func, message);
+}
+
 void log_formatted_cmd_error(std::string str)
 {
 	if (log_cmd_error_throw) {

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -331,10 +331,12 @@ static void log_error_with_prefix(std::string_view prefix, std::string str)
 	if (log_errfile != NULL)
 		log_files.push_back(log_errfile);
 
-	if (log_error_stderr)
+	if (log_error_stderr) {
+		log_flush(); // Make sure we flush stdout before replacing it with stderr
 		for (auto &f : log_files)
 			if (f == stdout)
 				f = stderr;
+	}
 
 	log_last_error = std::move(str);
 	log("%s%s", prefix, log_last_error);

--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -142,7 +142,12 @@
 #define YOSYS_CONSTEVAL constexpr
 #endif
 
-#define YOSYS_ABORT(s) abort()
+#define YOSYS_ABORT(s) YOSYS_NAMESPACE_PREFIX log_yosys_abort_message(__FILE__, __LINE__, __FUNCTION__, s)
+
+// This has to precede including "kernel/io.h"
+YOSYS_NAMESPACE_BEGIN
+[[noreturn]] void log_yosys_abort_message(std::string_view file, int line, std::string_view func, std::string_view message);
+YOSYS_NAMESPACE_END
 
 #include "kernel/io.h"
 

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -1600,7 +1600,6 @@ static void replace_zbufs(Design *design)
 					sig[i] = w;
 				}
 			}
-			log("XXX %s -> %s\n", log_signal(cell->getPort(ID::A)), log_signal(sig));
 			cell->setPort(ID::A, sig);
 		}
 

--- a/passes/techmap/simplemap.cc
+++ b/passes/techmap/simplemap.cc
@@ -18,7 +18,6 @@
  */
 
 #include "simplemap.h"
-#include "backends/rtlil/rtlil_backend.h"
 #include "kernel/sigtools.h"
 #include "kernel/ff.h"
 #include <stdlib.h>
@@ -156,14 +155,11 @@ void simplemap_reduce(RTLIL::Module *module, RTLIL::Cell *cell)
 			}
 
 			RTLIL::Cell *gate = module->addCell(NEW_ID, gate_type);
-			log("huh\n");
-			RTLIL_BACKEND::dump_cell(std::cout, "", cell);
 			transfer_src(gate, cell);
 			gate->setPort(ID::A, sig_a[i]);
 			gate->setPort(ID::B, sig_a[i+1]);
 			gate->setPort(ID::Y, sig_t[i/2]);
 			last_output_cell = gate;
-			RTLIL_BACKEND::dump_cell(std::cout, "", gate);
 		}
 
 		sig_a = sig_t;


### PR DESCRIPTION
This collects various logging fixes I made while debugging something unrelated.

This is removing some temporary debug log output that shouldn't have been merged, fixes a long standing bug where we don't flush stdout before we log fatal errors to stderr (which didn't occur with `-l` log targets or line-buffered stdout) and makes sure that YOSYS_ABORT macro outputs a helpful message.

_Explain how this is achieved._

Straightforward changes, YOSYS_ABORT now forwards to a new `log_yosys_abort_message` which has to be declared in an unusual place since the new template based printf-style formatting which everything depends on uses YOSYS_ABORT to bail out on format string vs argument mismatches when compiling with C++17 . 

_If applicable, please suggest to reviewers how they can test the change._

The log flushing issue can be reproduced by `yosys -p 'help; doesnt_exist' | cat` with `cat` used to stop stdout from being line buffered, but I don't know of portable and non-flaky way to test against this.