### PR TITLE
Added ifndef SIMLIB_NOCONNECT

### DIFF
--- a/techlibs/common/simlib.v
+++ b/techlibs/common/simlib.v
@@ -3219,6 +3219,8 @@ endmodule
 
 // --------------------------------------------------------
 //* group wire
+`ifndef SIMLIB_NOCONNECT
+
 module \$connect (A, B);
 
 parameter WIDTH = 0;
@@ -3230,6 +3232,7 @@ tran connect[WIDTH-1:0] (A, B);
 
 endmodule
 
+`endif
 // --------------------------------------------------------
 //* group wire
 module \$input_port (Y);

--- a/techlibs/common/simlib.v
+++ b/techlibs/common/simlib.v
@@ -31,6 +31,14 @@
  *
  */
 
+// If using Verilator, define SIMLIB_VERILATOR_COMPAT
+`ifdef SIMLIB_VERILATOR_COMPAT
+ /* verilator lint_save */
+ /* verilator lint_off DEFOVERRIDE */
+ `define SIMLIB_NOCONNECT
+ /* verilator lint_restore */
+`endif
+
 // --------------------------------------------------------
 //* ver 2
 //* title Bit-wise inverter


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Fixes https://github.com/YosysHQ/yosys/issues/5367

_Explain how this is achieved._

I added in the `` `ifndef SIMLIB_NOCONNECT ``, as was mentioned in https://github.com/YosysHQ/yosys/issues/5367.

_If applicable, please suggest to reviewers how they can test the change._

Now Verilator can correctly read the file with:

```bash
verilator -DSIMLIB_NOCONNECT -Wno-fatal --lint-only techlibs/common/simlib.v
```

Possibly the next step would be to create a test that verifies this never happens again. Maybe there could be a new file `".github/workflows/test-techlibs.yml"`, that runs Icarus and Verilator on each of the techlib cells_sim.v files.