### PR TITLE
BUGFIX: pyosys cannot parse header with omitted function args

### DIFF
--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1244,8 +1244,8 @@ private:
 public:
 	SigSpec() : width_(0), hash_(0) {}
 	SigSpec(std::initializer_list<RTLIL::SigSpec> parts);
-	SigSpec(const SigSpec &) = default;
-	SigSpec(SigSpec &&) = default;
+	SigSpec(const SigSpec &value) = default;
+	SigSpec(SigSpec &&value) = default;
 	SigSpec(const RTLIL::Const &value);
 	SigSpec(RTLIL::Const &&value);
 	SigSpec(const RTLIL::SigChunk &chunk);


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

`pyosys` build is failing since https://github.com/YosysHQ/yosys/commit/1c73011e7e8236c88157d37bd22a456b47c459d1 (blame: @rocallahan)

_Explain how this is achieved._

`pyosys` cannot parse headers with omitted function args. This fix populates the (unused) function args to support `pyosys`.

(Ideally, `pyosys` would support omitted function args, but this fix is easier than rearchitecting that...)

_If applicable, please suggest to reviewers how they can test the change._

Run: `make ENABLE_PYOSYS=1`. Will fail to build before this change, will build after.
