### PR TITLE
Update contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,15 +6,14 @@ body:
     attributes:
       value: >
 
-        If you have a general question, please ask it in the [Discussions](https://github.com/YosysHQ/yosys/discussions) area
-        or join our [IRC Channel](https://web.libera.chat/#yosys) or [Community Slack](https://join.slack.com/t/yosyshq/shared_invite/zt-1aopkns2q-EiQ97BeQDt_pwvE41sGSuA).
+        If you have a general question, please ask it on the [Discourse forum](https://yosyshq.discourse.group/).
 
 
         If you have a feature request, please fill out the appropriate issue form, this form is for bugs and/or regressions.
 
 
         Please contact [YosysHQ GmbH](https://www.yosyshq.com/) if you need
-        commercial support for Yosys.
+        commercial support or work done for Yosys.
 
   - type: input
     id: yosys_version

--- a/.github/ISSUE_TEMPLATE/docs_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_report.yml
@@ -6,8 +6,7 @@ body:
     attributes:
       value: >
 
-        If you have a general question, please ask it in the [Discussions](https://github.com/YosysHQ/yosys/discussions) area
-        or join our [IRC Channel](https://web.libera.chat/#yosys) or [Community Slack](https://join.slack.com/t/yosyshq/shared_invite/zt-1aopkns2q-EiQ97BeQDt_pwvE41sGSuA).
+        If you have a general question, please ask it on the [Discourse forum](https://yosyshq.discourse.group/).
 
 
         If you have found a bug in Yosys, or in building the documentation,

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,18 +1,17 @@
 name: Feature Request
-description: "Submit a feature request for Yosys" 
+description: "Submit a feature request for Yosys"
 labels: ["feature-request"]
 body:
   - type: markdown
     attributes:
       value: >
 
-        If you have a general question, please ask it in the [Discussions](https://github.com/YosysHQ/yosys/discussions) area
-        or join our [IRC Channel](https://web.libera.chat/#yosys) or [Community Slack](https://join.slack.com/t/yosyshq/shared_invite/zt-1aopkns2q-EiQ97BeQDt_pwvE41sGSuA).
-        
+        If you have a general question, please ask it on the [Discourse forum](https://yosyshq.discourse.group/).
+
 
         If you have a bug report, please fill out the appropriate issue form, this form is for feature requests.
 
-        
+
         Please contact [YosysHQ GmbH](https://www.yosyshq.com/) if you need
         commercial support or work done for Yosys.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,9 @@
+_If your work is part of a larger effort, please discuss your general plans on [Discourse](https://yosyshq.discourse.group/) first to align your vision with maintainers._
+
 _What are the reasons/motivation for this change?_
 
 _Explain how this is achieved._
 
-_If applicable, please suggest to reviewers how they can test the change._
+_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._
+
+_These template prompts can be deleted when you're done responding to them_

--- a/docs/source/yosys_internals/extending_yosys/extensions.rst
+++ b/docs/source/yosys_internals/extending_yosys/extensions.rst
@@ -9,7 +9,7 @@ Writing extensions
 .. todo:: update to use :file:`/code_examples/extensions/test*.log`
 
 This chapter contains some bits and pieces of information about programming
-yosys extensions. Don't be afraid to ask questions on the YosysHQ Slack.
+yosys extensions. Don't be afraid to ask questions on the Yosys HQ Discourse.
 
 .. todo:: mention coding guide
 


### PR DESCRIPTION
On bigger changes, we want to align with contributors on the Discourse forum. Since I checked out CONTRIBUTING.md I felt it's intended as a gentle introduction to contributing to open source projects more broadly, and adjusted the pull request tempalte instead.

We also want to stop pointing people to the Slack in favor of Discourse, so I'm doing that here as well