### PR TITLE
Optimize `IdString::empty()`

### DIFF
--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -411,7 +411,7 @@ struct RTLIL::IdString
 	}
 
 	bool empty() const {
-		return c_str()[0] == 0;
+		return index_ == 0;
 	}
 
 	void clear() {


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

I actually saw this take 0.6% of the time in an `opt_clean` pass (under Module::check()). Trivial issue, but the fix is also trivial and simple.