### PR TITLE
ABC9: Fix crash on bad box topology

### DIFF
--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -38,8 +38,8 @@ struct Abc9Pass : public ScriptPass
 	Abc9Pass() : ScriptPass("abc9", "use ABC9 for technology mapping") { }
 	void on_register() override
 	{
-		RTLIL::constpad["abc9.script.default"] = "+&scorr; &sweep; &dc2; &dch -f; &ps; &if {C} {W} {D} {R} -v; &mfs";
-		RTLIL::constpad["abc9.script.default.area"] = "+&scorr; &sweep; &dc2; &dch -f; &ps; &if {C} {W} {D} {R} -a -v; &mfs";
+		RTLIL::constpad["abc9.script.default"] = "+&scorr; &sweep; &dc2; &dch -f -r; &ps; &if {C} {W} {D} {R} -v; &mfs";
+		RTLIL::constpad["abc9.script.default.area"] = "+&scorr; &sweep; &dc2; &dch -f -r; &ps; &if {C} {W} {D} {R} -a -v; &mfs";
 		RTLIL::constpad["abc9.script.default.fast"] = "+&if {C} {W} {D} {R} -v";
 		// Based on ABC's &flow
 		RTLIL::constpad["abc9.script.flow"] = "+&scorr; &sweep;" \


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Fix #5091 

_Explain how this is achieved._

Use `&dch -r`, as per https://github.com/berkeley-abc/abc/issues/432

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._

Currently minimizing a test case, though so far actual cases of this crash have been very transient.