### PR TITLE
Make `mfp` const methods thread-safe.

### DIFF
--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -21,6 +21,7 @@
 #define YOSYS_COMMON_H
 
 #include <array>
+#include <atomic>
 #include <map>
 #include <set>
 #include <tuple>


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

As dsicussed in https://yosyshq.discourse.group/t/parallel-optmergepass-implementation we want to make RTLIL more compatible with multithreaded read-only access, by making access to `const` objects thread-safe.

_Explain how this is achieved._

We make the parent links relaxed atomics so concurrent `ifind()` calls are safe.

This may appear to cause a tiny performance regression but as discussed in https://yosyshq.discourse.group/t/parallel-optmergepass-implementation/87/16 this is probably just noise.