### PR TITLE
abc_new: Avoid bufnorm helper cell churn

### DIFF
--- a/passes/cmds/portarcs.cc
+++ b/passes/cmds/portarcs.cc
@@ -125,7 +125,7 @@ struct PortarcsPass : Pass {
 
 				for (auto cell : m->cells())
 				// Ignore all bufnorm helper cells
-				if (!cell->type.in(ID($buf), ID($input_port), ID($connect))) {
+				if (!cell->type.in(ID($buf), ID($input_port), ID($connect), ID($tribuf))) {
 					auto tdata = tinfo.find(cell->type);
 					if (tdata == tinfo.end())
 						log_cmd_error("Missing timing data for module '%s'.\n", log_id(cell->type));

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -1605,6 +1605,7 @@ static void replace_zbufs(Design *design)
 
 		mod->bufNormalize();
 	}
+	design->bufNormalize(false);
 }
 
 
@@ -1624,7 +1625,6 @@ static void restore_zbufs(Design *design)
 			mod->addBuf(NEW_ID, Const(State::Sz, GetSize(sig_y)), sig_y);
 			mod->remove(cell);
 		}
-		mod->bufNormalize();
 	}
 }
 

--- a/passes/techmap/abc_new.cc
+++ b/passes/techmap/abc_new.cc
@@ -141,7 +141,11 @@ struct AbcNewPass : public ScriptPass {
 				selected_modules = order_modules(active_design,
 												 active_design->selected_whole_modules_warn());
 				active_design->push_empty_selection();
-			} else {
+			}
+
+			run("abc9_ops -replace_zbufs");
+
+			if (help_mode) {
 				selected_modules = {nullptr};
 				run("foreach module in selection");
 			}
@@ -169,13 +173,10 @@ struct AbcNewPass : public ScriptPass {
 				}
 
 				run(stringf("  abc9_ops -write_box %s/input.box", tmpdir));
-				run("  abc9_ops -replace_zbufs");
 				run(stringf("  write_xaiger2 -mapping_prep -map2 %s/input.map2 %s/input.xaig", tmpdir, tmpdir));
 				run(stringf("  abc9_exe %s -cwd %s -box %s/input.box", exe_options, tmpdir, tmpdir));
 				run(stringf("  read_xaiger2 -sc_mapping -module_name %s -map2 %s/input.map2 %s/output.aig",
 							modname.c_str(), tmpdir.c_str(), tmpdir.c_str()));
-				run("  abc9_ops -restore_zbufs");
-
 				if (!help_mode && mod->has_attribute(ID(abc9_script))) {
 					if (script_save.empty())
 						active_design->scratchpad_unset("abc9.script");
@@ -195,6 +196,8 @@ struct AbcNewPass : public ScriptPass {
 					}
 				}
 			}
+
+			run("abc9_ops -restore_zbufs");
 
 			if (!help_mode) {
 				active_design->pop_selection();


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

We were performing the helper passes `abc9_ops -replace_zbufs` and `abc9_ops -restore_zbufs` for every module, but those passes act on the full design (and can't be applied entirely selectively due to entering and leaving bufnorm).

This lead to an explosive creation of a lot of redundant bufnorm helper cells that would have been cleaned up by `clean` but that never ran. 

_Explain how this is achieved._

Instead we now run each helper pass once, one before and one after iterating over the selected modules. This limits the number of bufnorm helper cells.

Since this just reduces memory usage, we can't easily test for it as part of our testsuite, but #5404 contains a reproducer (but I'd recommend running it with something like `systemd-run --scope -p MemoryLimit=5G ...` when using a yosys version that is affected by this). 

This fixes #5404

@mmicko this is the last release blocker on my end