### PR TITLE
sort: init

### DIFF
--- a/passes/cmds/Makefile.inc
+++ b/passes/cmds/Makefile.inc
@@ -57,3 +57,4 @@ OBJS += passes/cmds/abstract.o
 OBJS += passes/cmds/test_select.o
 OBJS += passes/cmds/timeest.o
 OBJS += passes/cmds/linecoverage.o
+OBJS += passes/cmds/sort.o

--- a/passes/cmds/sort.cc
+++ b/passes/cmds/sort.cc
@@ -1,0 +1,26 @@
+#include "kernel/yosys.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+struct SortPass : Pass {
+	SortPass() : Pass("sort", "sort the design objects") {}
+	void help() override
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    sort\n");
+		log("\n");
+		log("Sorts the design objects.\n");
+		log("\n");
+	}
+	void execute(std::vector<std::string> args, RTLIL::Design *d) override
+	{
+		log_header(d, "Executing SORT pass.\n");
+        if (args.size() != 1)
+            log_cmd_error("This pass takes no arguments.\n");
+        d->sort();
+	}
+} SortPass;
+
+PRIVATE_NAMESPACE_END


### PR DESCRIPTION
Since #5315 we no longer sort RTLIL designs when `write_rtlil` is run. We also might remove sorting from practically all passes with #5362 soon. I'm adding a utility function that does nothing but sort the current design. No test included because it's just a development utility that exposes existing `Design::sort()` code