### PR TITLE
Don't stop parsing sigspec after a {} group.

### DIFF
--- a/frontends/rtlil/rtlil_frontend.cc
+++ b/frontends/rtlil/rtlil_frontend.cc
@@ -324,29 +324,27 @@ struct RTLILFrontendWorker {
 
 	RTLIL::SigSpec parse_sigspec()
 	{
+		RTLIL::SigSpec sig;
+
 		if (try_parse_char('{')) {
 			std::vector<SigSpec> parts;
 			while (!try_parse_char('}'))
 				parts.push_back(parse_sigspec());
-			RTLIL::SigSpec sig;
 			for (auto it = parts.rbegin(); it != parts.rend(); ++it)
 				sig.append(std::move(*it));
-			return sig;
-		}
-
-		RTLIL::SigSpec sig;
-
-		// We could add a special path for parsing IdStrings that must already exist,
-		// as here.
-		// We don't need to addref/release in this case.
-		std::optional<RTLIL::IdString> id = try_parse_id();
-		if (id.has_value()) {
-			RTLIL::Wire *wire = current_module->wire(*id);
-			if (wire == nullptr)
-				error("Wire `%s' not found.", *id);
-			sig = RTLIL::SigSpec(wire);
 		} else {
-			sig = RTLIL::SigSpec(parse_const());
+			// We could add a special path for parsing IdStrings that must already exist,
+			// as here.
+			// We don't need to addref/release in this case.
+			std::optional<RTLIL::IdString> id = try_parse_id();
+			if (id.has_value()) {
+				RTLIL::Wire *wire = current_module->wire(*id);
+				if (wire == nullptr)
+					error("Wire `%s' not found.", *id);
+				sig = RTLIL::SigSpec(wire);
+			} else {
+				sig = RTLIL::SigSpec(parse_const());
+			}
 		}
 
 		while (try_parse_char('[')) {

--- a/tests/rtlil/bug5424.ys
+++ b/tests/rtlil/bug5424.ys
@@ -1,0 +1,12 @@
+read_rtlil <<EOT
+module \meow
+	wire width 8 \nya
+	wire width 8 output 1 \mrrp
+	wire width 1 input 0 \purr
+	process $cat
+		assign \nya { \mrrp \purr } [7:0]
+	end
+end
+EOT
+
+select -assert-count 1 meow/$cat

--- a/tests/rtlil/run-test.sh
+++ b/tests/rtlil/run-test.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -eu
 source ../gen-tests-makefile.sh
-generate_mk --bash
+generate_mk --bash --yosys-scripts


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Resolve #5424.

_Explain how this is achieved._

Accept a `{}` group as the first component of a compound sigspec.