### PR TITLE
plugins: add search paths

### DIFF
--- a/passes/cmds/plugin.cc
+++ b/passes/cmds/plugin.cc
@@ -41,6 +41,9 @@ std::map<std::string, void*> loaded_python_plugins;
 std::map<std::string, std::string> loaded_plugin_aliases;
 
 #ifdef YOSYS_ENABLE_PLUGINS
+
+static constexpr const char *path_delimiters = fs::path::preferred_separator == '\\' ? ";" : ":" ;
+
 inline const std::vector<fs::path> get_plugin_search_paths() {
 	std::vector<fs::path> result;
 	const char *yosys_plugin_path = std::getenv("YOSYS_PLUGIN_PATH");
@@ -50,7 +53,7 @@ inline const std::vector<fs::path> get_plugin_search_paths() {
 		std::string copy{yosys_plugin_path};
 		char *token = nullptr;
 		char *rest = &copy[0];
-		while ((token = strtok_r(rest, ":", &rest))) {
+		while ((token = strtok_r(rest, path_delimiters, &rest))) {
 			result.push_back(fs::path(token));
 		}
 	}

--- a/tests/various/.gitignore
+++ b/tests/various/.gitignore
@@ -2,6 +2,7 @@
 /write_gzip.v
 /write_gzip.v.gz
 /plugin.so
+/plugin_search
 /plugin.so.dSYM
 /temp
 /smtlib2_module.smt2

--- a/tests/various/plugin.sh
+++ b/tests/various/plugin.sh
@@ -1,8 +1,12 @@
 set -e
 rm -f plugin.so
+rm -rf plugin_search
 CXXFLAGS=$(../../yosys-config --cxxflags)
 DATDIR=$(../../yosys-config --datdir)
 DATDIR=${DATDIR//\//\\\/}
 CXXFLAGS=${CXXFLAGS//$DATDIR/..\/..\/share}
 ../../yosys-config --exec --cxx ${CXXFLAGS} --ldflags -shared -o plugin.so plugin.cc
 ../../yosys -m ./plugin.so -p "test" | grep -q "Plugin test passed!"
+mkdir -p plugin_search
+mv plugin.so plugin_search/plugin.so
+YOSYS_PLUGIN_PATH=$PWD/plugin_search ../../yosys -m plugin.so -p "test" | grep -q "Plugin test passed!"


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

https://github.com/YosysHQ/yosys/issues/2545 — On the nixpkgs side, there's been a hot-patch for this since 2021: https://github.com/NixOS/nixpkgs/commits/9720de3f1f7f8ad28cf3fafbf1349037ce2895d6/pkgs/development/compilers/yosys/plugin-search-dirs.patch

_Explain how this is achieved._

This uses the environment variable `YOSYS_PLUGIN_PATH` to provide multiple colon-delimited search paths for native plugins in a similar manner to `PATH` for executables and `PYTHONPATH` for Python modules.

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._

I have updated `tests/various/plugin.sh` to test exactly this functionality.

---

Some notes:

- I did not test this on Windows. I don't know what the standard is over there.
- ~~Still testing in Nix, should have results shortly (after I open this PR)~~
   - Building fine https://github.com/fossi-foundation/nix-eda/pull/35/files
   
   ```diff
    -       --set NIX_YOSYS_PLUGIN_DIRS $out/share/yosys/plugins \
    +       --suffix YOSYS_PLUGIN_PATH : $out/share/yosys/plugins \
    ```
- I picked the name `YOSYS_PLUGIN_PATH` arbitrarily, but any other name would work.
- This is the second file in the codebase to use `std::filesystem` since Yosys is compiled under C++17 now. This shouldn't affect wasm because afaict plugins aren't available under wasm anyways…? But anyways, it makes a couple things a bit more idiomatic/neater. [EDIT: See @whitequark's post below for more context]