### PR TITLE
synth_gowin: make setundef an off by default option

### DIFF
--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -330,10 +330,10 @@ struct SynthGowinPass : public ScriptPass
 			run("techmap -map +/gowin/cells_map.v");
 			run("opt_lut_ins -tech gowin");
 			if (setundef || help_mode)
-				run("setundef -undriven -params -zero", "(only if -setundef used)");
+				run("setundef -undriven -params -zero", "(only if -setundef)");
 			run("hilomap -singleton -hicell VCC V -locell GND G");
 			if (!vout_file.empty() || help_mode) // vendor output requires 1-bit wires
-				run("splitnets -ports", "(only if -vout used)");
+				run("splitnets -ports", "(only if -vout)");
 			run("clean");
 			run("autoname");
 		}


### PR DESCRIPTION
When output port is left unconnected, `setundef -undriven -params -zero` assigns 0 to it. After that `synth_gowin` creates a buffer for this port that is connected to ground. This results in outputs being driven, even though they are unconnected in RTL, for example unconnected active 0 board LEDs start glowing. This doesn't happen in vendor IDE.

I've tested this change on variety of designs and haven't encountered any issues. But old step is provided as an option just in case something breaks.

By omitting `setundef` step, undriven ports keep `x` value. Buffers for those ports will miss input parameter after nextpnr, this way undriven outputs could be differentiated from outputs driven with 0 and properly handled. See [Apicula](https://github.com/YosysHQ/apicula/pull/404/files).

I'm not sure if any tests are required for this change, so let me know.