### PR TITLE
sim: Make cycle width small as possible and configurable

### DIFF
--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -2692,7 +2692,7 @@ struct SimPass : public Pass {
 	{
 		SimWorker worker;
 		int numcycles = 20;
-		int cycle_width = 2;
+		int cycle_width = 10;
 		int append = 0;
 		bool start_set = false, stop_set = false, at_set = false;
 

--- a/tests/sim/sim_cycles.ys
+++ b/tests/sim/sim_cycles.ys
@@ -2,7 +2,7 @@ read_verilog dff.v
 prep
 
 # create fst with 20 clock cycles (41 samples, 202ns)
-sim -clock clk -fst sim_cycles.fst -n 20
+sim -clock clk -fst sim_cycles.fst -width 2 -n 20
 
 logger -expect-no-warnings
 


### PR DESCRIPTION
Default size is made 2 since number must be even since we do add half cycle size on some places.

Since one test case did utilize time as well, needed to update it.