### PR TITLE
hotfix: headers mistakenly added to clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1131,7 +1131,7 @@ docs: docs/prep
 
 clean: clean-py
 	rm -rf share
-	rm -f $(OBJS) $(GENFILES) $(TARGETS) $(EXTRA_TARGETS) $(EXTRA_OBJS) $(PY_WRAP_INCLUDES)
+	rm -f $(OBJS) $(GENFILES) $(TARGETS) $(EXTRA_TARGETS) $(EXTRA_OBJS)
 	rm -f kernel/version_*.o kernel/version_*.cc
 	rm -f libs/*/*.d frontends/*/*.d passes/*/*.d backends/*/*.d kernel/*.d techlibs/*/*.d
 	rm -rf tests/asicworld/*.out tests/asicworld/*.log


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

I mistakenly included a bunch of headers in the clean target when `ENABLE_PYOSYS` is added to Makefile.conf/passed to `make clean`… 

_Explain how this is achieved._

- fix `make clean` deleting a number of headers when `ENABLE_PYOSYS` is set to `1`

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._

`make clean ENABLE_PYOSYS=1`, though without #5434 the headers will fail to enumerate anyway unless you have a venv set up…