### PR TITLE
Add sys/wait.h header to bugpoint to bring in constants.

### DIFF
--- a/passes/cmds/bugpoint.cc
+++ b/passes/cmds/bugpoint.cc
@@ -28,6 +28,8 @@
 #  define WEXITSTATUS(x) ((x) & 0xff)
 #  define WTERMSIG(x) SIGTERM
 #  define WSTOPSIG(x) 0
+#else
+#include <sys/wait.h>
 #endif
 
 USING_YOSYS_NAMESPACE


### PR DESCRIPTION
POSIX [requires](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/sys_wait.h.html) the `sys/wait.h` for the various `W_` constants. This doesn't seem to be required for Linux, but I needed this to get a FreeBSD build to complete (among other small changes, but all the others can be solved with setting Makefile vars for now).