### PR TITLE
pyosys: fix a number of regressions from 0.58

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -3088,6 +3088,14 @@ RTLIL::Cell *RTLIL::Module::addCell(RTLIL::IdString name, const RTLIL::Cell *oth
 	return cell;
 }
 
+RTLIL::Memory *RTLIL::Module::addMemory(RTLIL::IdString name)
+{
+	RTLIL::Memory *mem = new RTLIL::Memory;
+	mem->name = std::move(name);
+	memories[mem->name] = mem;
+	return mem;
+}
+
 RTLIL::Memory *RTLIL::Module::addMemory(RTLIL::IdString name, const RTLIL::Memory *other)
 {
 	RTLIL::Memory *mem = new RTLIL::Memory;

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1827,6 +1827,7 @@ public:
 	RTLIL::Cell *addCell(RTLIL::IdString name, RTLIL::IdString type);
 	RTLIL::Cell *addCell(RTLIL::IdString name, const RTLIL::Cell *other);
 
+	RTLIL::Memory *addMemory(RTLIL::IdString name);
 	RTLIL::Memory *addMemory(RTLIL::IdString name, const RTLIL::Memory *other);
 
 	RTLIL::Process *addProcess(RTLIL::IdString name);

--- a/pyosys/wrappers_tpl.cc
+++ b/pyosys/wrappers_tpl.cc
@@ -21,6 +21,12 @@
 // <!-- generated includes -->
 #include <pybind11/pybind11.h>
 #include <pybind11/native_enum.h>
+#include <pybind11/functional.h>
+
+// duplicates for LSPs
+#include "kernel/register.h"
+#include "kernel/yosys_common.h"
+
 #include "pyosys/hashlib.h"
 
 namespace py = pybind11;
@@ -28,7 +34,7 @@ namespace py = pybind11;
 USING_YOSYS_NAMESPACE
 
 using std::set;
-using std::regex;
+using std::function;
 using std::ostream;
 using namespace RTLIL;
 

--- a/tests/pyosys/test_idstring_lifetime.py
+++ b/tests/pyosys/test_idstring_lifetime.py
@@ -1,0 +1,28 @@
+
+from pyosys import libyosys as ys
+from pathlib import Path
+
+__file_dir__ = Path(__file__).absolute().parent
+
+d = ys.Design()
+ys.run_pass(f"read_verilog {__file_dir__ / 'spm.cut.v.gz'}", d)
+ys.run_pass("hierarchy -top spm", d)
+
+external_idstring_holder_0 = None
+external_idstring_holder_1 = None
+
+def get_top_module_idstring():
+	global external_idstring_holder_0, external_idstring_holder_1
+	d = ys.Design()
+	ys.run_pass(f"read_verilog {__file_dir__ / 'spm.cut.v.gz'}", d)
+	ys.run_pass("hierarchy -top spm", d)
+	external_idstring_holder_0 = d.top_module().name
+	for cell in d.top_module().cells_:
+		print(f"TARGETED: {cell}", flush=True)
+		external_idstring_holder_1 = cell
+		break
+	# d deallocates
+
+get_top_module_idstring()
+print(external_idstring_holder_0, flush=True)
+print(external_idstring_holder_1, flush=True)

--- a/tests/pyosys/test_indirect_inheritance.py
+++ b/tests/pyosys/test_indirect_inheritance.py
@@ -1,0 +1,15 @@
+
+from pyosys import libyosys as ys
+from pathlib import Path
+
+__file_dir__ = Path(__file__).absolute().parent
+
+
+d = ys.Design()
+ys.run_pass(f"read_verilog {__file_dir__ / 'spm.cut.v.gz'}", d)
+ys.run_pass("hierarchy -top spm", d)
+
+for idstr, cell in d.top_module().cells_.items():
+    cell.set_bool_attribute("\\set")
+    print(cell.attributes)
+    break

--- a/tests/pyosys/test_monitor.py
+++ b/tests/pyosys/test_monitor.py
@@ -14,7 +14,7 @@ class Monitor(ys.Monitor):
 		self.mods.append(mod.name.str())
 
 m = Monitor()
-d.monitors.add(m)
+d.monitors = [m]
 
 ys.run_pass(f"read_verilog {__file_dir__ / 'spm.cut.v.gz'}", d)
 ys.run_pass("hierarchy -top spm", d)


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

- An overwhelming number of dangling reference-related issues
- AttrObject methods were not available for Cell

_Explain how this is achieved._

- all class members, including pointers and containers, are now copied by value
  - pybind11 does a decent job bridging them appropriately-- the only surprising element to this is that `a.b.append(x)` mutates a copy of `a.b`. but this was the previous behavior.
- add new overload of RTLIL::Module::addMemory that does not require a "donor" object
  - the idea is `Module`, `Memory`, `Wire`, `Cell` and `Process` cannot be directly constructed in Python and can only be added to the existing memory hierarchy in `Design` using the `add` methods - `Memory` requiring a donor object was the odd one out here
- fix superclass member wrapping only looking at direct superclass for inheritance instead of recursively checking superclasses
- fix superclass member wrapping not using superclass's denylists
- fix Design's `__str__` function not returning a string
- fix the generator crashing if there's any `std::function` in a header
- misc: add a crude `__repr__` based on `__str__`

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._

With a Yosys compiled with ENABLE_PYTHON, `python3 ./tests/pyosys/run_tests.py yosys`