### PR TITLE
Set `port_id` for Verific `PortBus` wires

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -1576,6 +1576,7 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 		SetIter si ;
 		Port *port ;
 		FOREACH_PORT_OF_PORTBUS(portbus, si, port) {
+			wire->port_id = nl->IndexOf(port) + 1;
 			import_attributes(wire->attributes, port->GetNet(), nl, portbus->Size());
 			break;
 		}

--- a/tests/verific/port_bus_order.ys
+++ b/tests/verific/port_bus_order.ys
@@ -1,0 +1,13 @@
+verific -sv <<EOT
+module simple (
+  input  [3:0] I2,
+  input  [3:0] I1,
+  output [3:0] result
+);
+  assign result = I2 & I1;
+endmodule
+EOT
+verific -import simple
+
+write_verilog verilog_port_bus_order.out
+!grep -qF 'simple(I2, I1, result)' verilog_port_bus_order.out


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

`port_id` is not set for Verific `PortBus` wires, so those ports can be reordered unexpectedly. This appears to just be an oversight. This results in the following behavior, for example:
```
verific -sv <<EOT
module simple (
  input  [3:0] I2,
  input  [3:0] I1,
  output [3:0] result
);
  assign result = I2 & I1;
endmodule
EOT
verific -import simple
write_verilog verilog_port_bus_order.out
```
producing
```
...
module simple(I1, I2, result);
...
```
I realize that Yosys doesn't guarantee port ordering in general, but this still seems bad and is easy to fix.

_Explain how this is achieved._

Set the `port_id` for `PortBus` wires to be the `port_id` of the first `Port` associated with the `PortBus`, and add a testcase.