### PR TITLE
Don't recompute hash using moved-out-of value

### DIFF
--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -1021,7 +1021,7 @@ protected:
 		if (hashtable.empty()) {
 			entries.emplace_back(std::forward<K>(rvalue), -1);
 			do_rehash();
-			hash = do_hash(rvalue);
+			hash = do_hash(entries.back().udata);
 		} else {
 			entries.emplace_back(std::forward<K>(rvalue), hashtable[hash]);
 			hashtable[hash] = entries.size() - 1;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

It is a bug to reuse a value after it has been moved out of.

_Explain how this is achieved._

Recompute the hash using the entry that we moved to the value into.