### PR TITLE
Docs: ecp5 and nexus are under lattice

### DIFF
--- a/docs/source/cmd/index_techlibs_ecp5.rst
+++ b/docs/source/cmd/index_techlibs_ecp5.rst
@@ -1,5 +1,0 @@
-ECP5
-------------------
-
-.. autocmdgroup:: techlibs/ecp5
-   :members:

--- a/docs/source/cmd/index_techlibs_lattice_nexus.rst
+++ b/docs/source/cmd/index_techlibs_lattice_nexus.rst
@@ -1,5 +1,0 @@
-Lattice Nexus
-------------------
-
-.. autocmdgroup:: techlibs/nexus
-   :members:


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Since #3908 the `ecp5` and `lattice_nexus` cmd groups haven't existed and the [docs](https://yosyshq.readthedocs.io/projects/yosys/en/latest/cmd/index_techlibs_ecp5.html) [pages](https://yosyshq.readthedocs.io/projects/yosys/en/latest/cmd/index_techlibs_lattice_nexus.html) are empty.  The logs do show the following message:

```
unable to load techlibs/ecp5 with <class 'util.cmd_documenter.YosysCmdGroupDocumenter'>
```

But because it's a group it assumes that the build is missing `source_location` support and downgrades the warning to info, so it wasn't caught at the time.

_Explain how this is achieved._

Remove the docs pages for ecp5 and lattice nexus.  The commands which were there previously are already available on the [lattice page](https://yosyshq.readthedocs.io/projects/yosys/en/latest/cmd/index_techlibs_lattice.html), so no further change is necessary.

[Preview build](https://yosyshq.readthedocs.io/projects/yosys/en/docs-preview_lattice/cmd/index_techlibs.html).