### PR TITLE
Fix regression in configuring ABC techmapping

### DIFF
--- a/tests/techmap/abc_state.ys
+++ b/tests/techmap/abc_state.ys
@@ -1,0 +1,26 @@
+read_verilog <<EOT
+module simple(I1, I2, O);
+	input wire I1;
+	input wire I2;
+	output wire O;
+
+	assign O = I1 | I2;
+endmodule
+EOT
+abc -g all
+
+design -reset
+read_verilog <<EOT
+module simple(I1, I2, O);
+	input wire I1;
+	input wire I2;
+	output wire O;
+
+	assign O = I1 | I2;
+endmodule
+EOT
+techmap
+abc -g AND
+
+select -assert-count 0 t:$_OR_
+select -assert-count 1 t:$_AND_


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

My commit 4ba42c4752795e5d7db003b330d904ad61d1ba8b caused a bad regression in configuring the `abc` command. I removed the code that reset `enabled_gates`, `cmos_cost`, `markgroups`, `mux4`, `mux8` and `mux16`. This causes incorrect results when multiple `abc` commands are run with different parameters. See the testcase in this PR. _Sorry!_

_Explain how this is achieved._

Move those global variables into `AbcConfig` and initialize them properly.