### PR TITLE
Makefile: Add gatemate genfiles

### DIFF
--- a/techlibs/gatemate/Makefile.inc
+++ b/techlibs/gatemate/Makefile.inc
@@ -2,6 +2,9 @@
 OBJS += techlibs/gatemate/synth_gatemate.o
 OBJS += techlibs/gatemate/gatemate_foldinv.o
 
+GENFILES += techlibs/gatemate/lut_tree_cells.genlib
+GENFILES += techlibs/gatemate/lut_tree_map.v
+
 $(eval $(call add_share_file,share/gatemate,techlibs/gatemate/reg_map.v))
 $(eval $(call add_share_file,share/gatemate,techlibs/gatemate/mux_map.v))
 $(eval $(call add_share_file,share/gatemate,techlibs/gatemate/lut_map.v))
@@ -28,3 +31,4 @@ techlibs/gatemate/lut_tree_map.v: techlibs/gatemate/lut_tree_lib.mk
 
 $(eval $(call add_gen_share_file,share/gatemate,techlibs/gatemate/lut_tree_cells.genlib))
 $(eval $(call add_gen_share_file,share/gatemate,techlibs/gatemate/lut_tree_map.v))
+


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

The following should work but currently fails with missing `techlibs/gatemate/lut_tree_cells.genlib`.
```
make
make clean
mkdir build; cd build
make -f ../Makefile
```

_Explain how this is achieved._

Add generated files to `GENFILES` make var, allowing them to be cleaned with `make clean`.