### PR TITLE
hotfix: wheel ci issues

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,7 +59,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p ffi
-          curl -L https://github.com/libffi/libffi/releases/download/v3.4.6/libffi-3.4.6.tar.gz | tar --strip-components=1 -xzC ffi
+          curl -L https://github.com/libffi/libffi/releases/download/v3.4.8/libffi-3.4.8.tar.gz | tar --strip-components=1 -xzC ffi
       - if: ${{ matrix.os.family == 'linux' }}
         name: "[Linux] Bison 3.8.2"
         shell: bash

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -54,11 +54,6 @@ jobs:
           fetch-depth: 0
           submodules: true
           persist-credentials: false
-      - if: ${{ matrix.os.family == 'linux' }}
-        name: "[Linux] Install UV"
-        shell: bash
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
       - uses: actions/setup-python@v5
       - name: Get FFI
         shell: bash

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ class libyosys_so_ext(Extension):
             "ENABLE_TCL=0",
             "ENABLE_READLINE=0",
             "ENABLE_EDITLINE=0",
+            "PYOSYS_USE_UV=0", # + install requires takes its role when building wheels
             # Always compile and include ABC in wheel
             "ABCEXTERNAL=",
             # Show compile commands


### PR DESCRIPTION
_If your work is part of a larger effort, please discuss your general plans on [Discourse](https://yosyshq.discourse.group/) first to align your vision with maintainers._

_What are the reasons/motivation for this change?_

Wheel builds are failing on macOS due to:

- a lack of uv
- incompatibility with the specific libffi version and macOS 15: https://github.com/libffi/libffi/issues/852

_Explain how this is achieved._

- I already added a flag to control the use of uv for this purpose that I neglected to add to `setup.py` - essentially uv is redundant when building wheels because an environment is created with whatever is in `install_requires`. This just adds the flag in question.
- Updated libffi to a version including https://github.com/libffi/libffi/pull/857

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._

I'm running the relevant CI job in my fork at https://github.com/donn/yosys/actions/runs/19069438740