### PR TITLE
Fix generatory.py location for out of tree builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,7 @@ CXXFLAGS += -I$(PYBIND11_INCLUDE) -DYOSYS_ENABLE_PYTHON
 CXXFLAGS += $(shell $(PYTHON_CONFIG) --includes) -DYOSYS_ENABLE_PYTHON
 
 OBJS += $(PY_WRAPPER_FILE).o
-PY_GEN_SCRIPT = pyosys/generator.py
+PY_GEN_SCRIPT = $(YOSYS_SRC)/pyosys/generator.py
 PY_WRAP_INCLUDES := $(shell $(UV_ENV) $(PYTHON_EXECUTABLE) $(PY_GEN_SCRIPT) --print-includes)
 endif # ENABLE_PYOSYS
 


### PR DESCRIPTION
_If your work is part of a larger effort, please discuss your general plans on [Discourse](https://yosyshq.discourse.group/) first to align your vision with maintainers._

_What are the reasons/motivation for this change?_

`make -C build -f ../Makefile -j9  CXX=clang` with PYOSYS enabled gives us

```
make: Entering directory '/home/xxx/src/yosys-python/build'
[Makefile.conf] CONFIG := clang
[Makefile.conf] ENABLE_PYOSYS := 1
python3: can't open file '/home/xxx/src/yosys-python/build/pyosys/generator.py': [Errno 2] No such file or directory
[  0%] Building kernel/version_e89c5914f.cc
[  0%] Building pyosys/wrappers.cc
[ 10%] Building yosys-config
```

_Explain how this is achieved._

By giving path to source location of PY_GEN_SCRIPT this is fixed and it is now possible to run out of tree builds with pyosys enabled.
