### PR TITLE
hotfix: workaround for pyosys build failure

### DIFF
--- a/pyosys/generator.py
+++ b/pyosys/generator.py
@@ -192,7 +192,7 @@ pyosys_headers = [
             ),
             PyosysClass("SigChunk"),
             PyosysClass("SigBit", hash_expr="s"),
-            PyosysClass("SigSpec", hash_expr="s"),
+            PyosysClass("SigSpec", hash_expr="s", denylist={"chunks"}),
             PyosysClass(
                 "Cell",
                 ref_only=True,


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Pyosys build failure from new `chunks()` method which uses a nested class that is currently not properly bridged/recognized.

_Explain how this is achieved._

I just excluded the relevant method for now from the auto-generator.

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._

It should just build now.

_These template prompts can be deleted when you're done responding to them._