### PR TITLE
Add missing `YOSYS_NAMESPACE_PREFIX` to fix callers of `NEW_ID` that aren't in the Yosys namespace

### DIFF
--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -276,7 +276,7 @@ RTLIL::IdString new_id_suffix(std::string_view file, int line, std::string_view 
 
 #define NEW_ID \
 	YOSYS_NAMESPACE_PREFIX RTLIL::IdString::new_autoidx_with_prefix([](std::string_view func) -> const std::string * { \
-		static const std::string *prefix = create_id_prefix(__FILE__, __LINE__, func); \
+		static const std::string *prefix = YOSYS_NAMESPACE_PREFIX create_id_prefix(__FILE__, __LINE__, func); \
 		return prefix; \
 	}(__FUNCTION__))
 #define NEW_ID_SUFFIX(suffix) \


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

PR #5417 broke compilation for these callers, sorry.