### PR TITLE
Implement at() methods on SigSpec so that SigSpec::bits().at() continues to work as it did

### DIFF
--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1726,6 +1726,8 @@ public:
 	operator std::vector<RTLIL::SigChunk>() const;
 	operator std::vector<RTLIL::SigBit>() const { return to_sigbit_vector(); }
 	const RTLIL::SigBit &at(int offset, const RTLIL::SigBit &defval) { return offset < size() ? (*this)[offset] : defval; }
+	RTLIL::SigBit& at(int offset) { return (*this)[offset]; }
+	RTLIL::SigBit at(int offset) const { return (*this)[offset]; }
 
 	[[nodiscard]] Hasher hash_into(Hasher h) const {
 		Hasher::hash_t val;


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Fixes a regression caused by commit 745222fa3bf2ac570935ffd044c86fa2eb12d123, which caused some third-party code to fail to build, e.g.:
https://github.com/google/heir/blob/5d7aa035c6e42394cd4dd45faca0b0933af89950/lib/Transforms/YosysOptimizer/RTLILImporter.cpp#L229