### PR TITLE
Check ENABLE_ABC validity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -474,6 +474,9 @@ else
 ifeq ($(ABCEXTERNAL),)
 TARGETS := $(PROGRAM_PREFIX)yosys-abc$(EXE) $(TARGETS)
 endif
+ifeq ($(DISABLE_SPAWN),1)
+$(error ENABLE_ABC=1 requires either LINK_ABC=1 or DISABLE_SPAWN=0)
+endif
 endif
 endif
 


### PR DESCRIPTION
 _What are the reasons/motivation for this change?_

From https://github.com/YosysHQ/yosys/pull/5497#issuecomment-3561398279, for ENABLE_ABC=1 to be valid, either ABC must be linked (LINK_ABC=1), or it must be possible to spawn executables (DISABLE_SPAWN=0).

_Explain how this is achieved._

This configuration (ENABLE_ABC=1 LINK_ABC=0 DISABLE_SPAWN=1) already fails compilation in `abc.cc` trying to call `run_command()` which doesn't exist if DISABLE_SPAWN=1.  All we are doing here is catching the known bad configuration and providing an explanation for why it isn't working.

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._

`make ENABLE_ABC=1 LINK_ABC=0 DISABLE_SPAWN=1` without this change fails during compilation (though probably not until halfway through).  With this change it will instead error before compiling anything.