### PR TITLE
Enable abc_new pass when not in NDEBUG

### DIFF
--- a/passes/techmap/abc_new.cc
+++ b/passes/techmap/abc_new.cc
@@ -38,8 +38,8 @@ std::vector<Module*> order_modules(Design *design, std::vector<Module *> modules
 				sort.edge(submodule, m);
 		}
 	}
-	bool sorted = sort.sort();
-	log_assert(sorted);
+	bool is_sorted = sort.sort();
+	log_assert(is_sorted);
 	return sort.sorted;
 }
 


### PR DESCRIPTION
log_assert() is removed in compilation without NDEBUG. Without the call to `sort()`, `sort.sorted` is empty and the pass has no effect.