### PR TITLE
Enable xaiger2 pass when not in NDEBUG

### DIFF
--- a/frontends/aiger2/xaiger.cc
+++ b/frontends/aiger2/xaiger.cc
@@ -110,7 +110,8 @@ struct Xaiger2Frontend : public Frontend {
 		for (int i = 0; i < (int) O; i++) {
 			int po;
 			*f >> po;
-			log_assert(f->get() == '\n');
+			int c = f->get();
+			log_assert(c == '\n');
 			outputs.push_back(po);
 		}
 


### PR DESCRIPTION
`log_assert()` is removed in compilation without NDEBUG. Without the call to `f->get()`, the commands cannot be read.