### PR TITLE
Use `Tcl_Size` instead of `int` to fix build errors

### DIFF
--- a/passes/cmds/sdc/sdc.cc
+++ b/passes/cmds/sdc/sdc.cc
@@ -8,6 +8,11 @@
 #include <optional>
 #include <iostream>
 
+#if TCL_MAJOR_VERSION < 9
+typedef int YS_Tcl_Size;
+#else
+typedef Tcl_Size YS_Tcl_Size;
+#endif
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
@@ -432,7 +437,7 @@ static size_t get_node_count(Tcl_Interp* interp) {
 std::vector<std::vector<std::string>> gather_nested_calls(Tcl_Interp* interp) {
 
 	Tcl_Obj* listObj = Tcl_GetVar2Ex(interp, "sdc_calls", nullptr, TCL_GLOBAL_ONLY);
-	int listLength;
+	YS_Tcl_Size listLength;
 
 	std::vector<std::vector<std::string>> sdc_calls;
 	if (Tcl_ListObjLength(interp, listObj, &listLength) == TCL_OK) {
@@ -442,7 +447,7 @@ std::vector<std::vector<std::string>> gather_nested_calls(Tcl_Interp* interp) {
 			if (Tcl_ListObjIndex(interp, listObj, i, &subListObj) != TCL_OK) {
 				log_error("broken list of lists\n");
 			}
-			int subListLength;
+			YS_Tcl_Size subListLength;
 			if (Tcl_ListObjLength(interp, subListObj, &subListLength) == TCL_OK) {
 				// Valid list - extract elements
 				for (int j = 0; j < subListLength; j++) {


### PR DESCRIPTION
Fixes these build errors I'm getting locally with `tcl-devel-9.0.0-7.fc42.x86_64`. I guess Tcl 9 broke this.

```
passes/cmds/sdc/sdc.cc:438:6: error: no matching function for call to 'Tcl_ListObjLength'
  438 |         if (Tcl_ListObjLength(interp, listObj, &listLength) == TCL_OK) {
      |             ^~~~~~~~~~~~~~~~~
/usr/include/tclDecls.h:1788:13: note: candidate function not viable: no known conversion from 'int *' to 'Tcl_Size *' (aka 'long *') for 3rd argument
 1788 | EXTERN int              Tcl_ListObjLength(Tcl_Interp *interp,
      |                         ^
 1789 |                                 Tcl_Obj *listPtr, Tcl_Size *lengthPtr);
      |                                                   ~~~~~~~~~~~~~~~~~~~
passes/cmds/sdc/sdc.cc:446:8: error: no matching function for call to 'Tcl_ListObjLength'
  446 |                         if (Tcl_ListObjLength(interp, subListObj, &subListLength) == TCL_OK) {
      |                             ^~~~~~~~~~~~~~~~~
/usr/include/tclDecls.h:1788:13: note: candidate function not viable: no known conversion from 'int *' to 'Tcl_Size *' (aka 'long *') for 3rd argument
 1788 | EXTERN int              Tcl_ListObjLength(Tcl_Interp *interp,
      |                         ^
 1789 |                                 Tcl_Obj *listPtr, Tcl_Size *lengthPtr);
      |                                                   ~~~~~~~~~~~~~~~~~~~
```