### PR TITLE
read -vlog2k --> read_verilog

### DIFF
--- a/tests/various/check.ys
+++ b/tests/various/check.ys
@@ -1,5 +1,5 @@
 design -reset
-read -vlog2k <<EOF
+read_verilog <<EOF
 module top(input clk, input a, input b, output [9:0] x);
 	wire [9:0] ripple;
 	reg [9:0] prev_ripple = 9'b0;
@@ -14,7 +14,7 @@ prep
 check -assert
 
 design -reset
-read -vlog2k <<EOF
+read_verilog <<EOF
 module top(clk, y, sideread_addr, sideread_data);
 	input wire clk;
 


### PR DESCRIPTION
The tests were using read -vlog2k which is old Verific command. Use Yosys's read_verilog command. 

Just swapped out the command. Instead of verific -cfg veri_extract_multiport_rams 1 read -vlog2k <<EOF, it's now:
read_verilog <<EOF

Also removed the unnecessary verific -cfg config line since read_verilog doesn't need that.

Testing:
No special test needed beyond the existing ones. 
