### PR TITLE
Make coverage data thread-safe

### DIFF
--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -720,7 +720,7 @@ dict<std::string, std::pair<std::string, int>> get_coverage_data()
 		if (coverage_data.count(p->id))
 			log_warning("found duplicate coverage id \"%s\".\n", p->id);
 		coverage_data[p->id].first = stringf("%s:%d:%s", p->file, p->line, p->func);
-		coverage_data[p->id].second += p->counter;
+		coverage_data[p->id].second += p->counter.load(std::memory_order_relaxed);
 	}
 
 	for (auto &it : coverage_data)

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -24,6 +24,7 @@
 
 #include <time.h>
 
+#include <atomic>
 #include <regex>
 #define YS_REGEX_COMPILE(param) std::regex(param, \
 				std::regex_constants::nosubs | \
@@ -298,13 +299,14 @@ void log_abort_internal(const char *file, int line);
 
 #define cover(_id) do { \
     static CoverData __d __attribute__((section("yosys_cover_list"), aligned(1), used)) = { __FILE__, __FUNCTION__, _id, __LINE__, 0 }; \
-    __d.counter++; \
+    __d.counter.fetch_add(1, std::memory_order_relaxed); \
 } while (0)
 
 struct CoverData {
 	const char *file, *func, *id;
-	int line, counter;
-} YS_ATTRIBUTE(packed);
+	int line;
+	std::atomic<int> counter;
+};
 
 // this two symbols are created by the linker for the "yosys_cover_list" ELF section
 extern "C" struct CoverData __start_yosys_cover_list[];


### PR DESCRIPTION
_If your work is part of a larger effort, please discuss your general plans on [Discourse](https://yosyshq.discourse.group/) first to align your vision with maintainers._

This is following up on [discussion](https://yosyshq.discourse.group/t/parallel-optmergepass-implementation) where we agreed to pursue making RTLIL safe for multithreaded read-only access, at least.

_What are the reasons/motivation for this change?_

Running Yosys with TSAN and multithreaded `opt_merge` produces warnings about data races on the coverage counters.

_Explain how this is achieved._

Use atomics for the coverage counters.

In my measurements this actually makes runtime performance a little *better*, which is weird so I don't trust the numbers very much, but at least I'm not seeing a regression.