### PR TITLE
Add static library option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -780,7 +780,7 @@ else
 endif
 
 libyosys.a: $(filter-out kernel/driver.o,$(OBJS))
-	$(P) ar rcs $@ $^
+	$(P) $(AR) rcs $@ $^
 
 %.o: %.cc
 	$(Q) mkdir -p $(dir $@)


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

For creating a `.so` object which combines Yosys with custom passes or a language binding, it's useful to have `libyosys.a` which can be further linked.