### PR TITLE
flatten: update scopename regardless of hdlname existance

### DIFF
--- a/passes/hierarchy/flatten.cc
+++ b/passes/hierarchy/flatten.cc
@@ -105,7 +105,8 @@ struct FlattenWorker
 					new_hdlname += orig_object_name.c_str() + 1;
 				}
 				object->set_string_attribute(ID(hdlname), new_hdlname);
-			} else if (object->has_attribute(ID(scopename))) {
+			}
+			if (object->has_attribute(ID(scopename))) {
 				std::string new_scopename;
 
 				if (cell->has_attribute(ID::hdlname)) {


### PR DESCRIPTION
Noticed this with bram cells, since they usually do have hdlname and in that case cell will only have that attribute set
`(* hdlname = "soc cpu cpuregs regs1.0.0" *)`

But with  this change we will also get additional attribute  `(* scopename = "soc cpu cpuregs" *)` so we can make sure that even cells with public name hdlname will have scopename set.
