### PR TITLE
.github: trigger everything that triggers on main or PRs on merge queue

### DIFF
--- a/.github/workflows/extra-builds.yml
+++ b/.github/workflows/extra-builds.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
   # test PRs
   pull_request:
   # allow triggering tests, ignores skip check

--- a/.github/workflows/prepare-docs.yml
+++ b/.github/workflows/prepare-docs.yml
@@ -1,6 +1,6 @@
 name: Build docs artifact with Verific
 
-on: [push, pull_request]
+on: [push, pull_request, merge_group]
 
 jobs:
   check_docs_rebuild:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
   # test PRs
   pull_request:
   # allow triggering tests, ignores skip check

--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
   # test PRs
   pull_request:
   # allow triggering tests, ignores skip check

--- a/.github/workflows/test-sanitizers.yml
+++ b/.github/workflows/test-sanitizers.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
   # ignore PRs due to time needed
   # allow triggering tests, ignores skip check
   workflow_dispatch:

--- a/.github/workflows/test-verific.yml
+++ b/.github/workflows/test-verific.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
   # test PRs
   pull_request:
   # allow triggering tests, ignores skip check


### PR DESCRIPTION
To enable merge queues we should first make sure we actually trigger everything we want to test