### PR TITLE
Check that we don't use logging during multithreading

### DIFF
--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -203,6 +203,8 @@ static void logv_string(std::string_view format, std::string str) {
 
 void log_formatted_string(std::string_view format, std::string str)
 {
+	log_assert(!Multithreading::active());
+
 	if (log_make_debug && !ys_debug(1))
 		return;
 	logv_string(format, std::move(str));
@@ -210,6 +212,8 @@ void log_formatted_string(std::string_view format, std::string str)
 
 void log_formatted_header(RTLIL::Design *design, std::string_view format, std::string str)
 {
+	log_assert(!Multithreading::active());
+
 	bool pop_errfile = false;
 
 	log_spacer();
@@ -249,6 +253,8 @@ void log_formatted_header(RTLIL::Design *design, std::string_view format, std::s
 
 void log_formatted_warning(std::string_view prefix, std::string message)
 {
+	log_assert(!Multithreading::active());
+
 	bool suppressed = false;
 
 	for (auto &re : log_nowarn_regexes)


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

All the logging infrastructure is single-threaded-only. We should probably fix that sometime but it's not clear what the right approach is.

_Explain how this is achieved._

For now let's just dynamically check logging isn't used during a multithreaded episode.