### PR TITLE
Makefile: install frontends/verilog/verilog_location.h.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -654,6 +654,7 @@ $(eval $(call add_include_file,passes/techmap/libparse.h))
 $(eval $(call add_include_file,frontends/ast/ast.h))
 $(eval $(call add_include_file,frontends/ast/ast_binding.h))
 $(eval $(call add_include_file,frontends/blif/blifparse.h))
+$(eval $(call add_include_file,frontends/verilog/verilog_location.h))
 $(eval $(call add_include_file,backends/rtlil/rtlil_backend.h))
 
 OBJS += kernel/driver.o kernel/register.o kernel/rtlil.o kernel/log.o kernel/calc.o kernel/yosys.o kernel/io.o kernel/gzip.o


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

By installing Yosys includes with `install`-target we ultimately install `frontends/ast/ast.h`, which now includes `frontends/verilog/verilog_location.h`, yet `verilog_location.h` is not installed along with `ast.h`.

_Explain how this is achieved._

`frontends/verilog/verilog_location.h` is specified as an explicit header file in `Makefile` to be installed at some prefix.

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._

Just try to compile some C-code including `frontends/ast/ast.h`.
