### PR TITLE
Delete prefix strings on shutdown to avoid triggering leak warnings.

### DIFF
--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -299,8 +299,8 @@ RTLIL::IdString new_id_suffix(std::string_view file, int line, std::string_view 
 
 #define NEW_ID \
 	YOSYS_NAMESPACE_PREFIX RTLIL::IdString::new_autoidx_with_prefix([](std::string_view func) -> const std::string * { \
-		static const std::string *prefix = YOSYS_NAMESPACE_PREFIX create_id_prefix(__FILE__, __LINE__, func); \
-		return prefix; \
+		static std::unique_ptr<const std::string> prefix(YOSYS_NAMESPACE_PREFIX create_id_prefix(__FILE__, __LINE__, func)); \
+		return prefix.get(); \
 	}(__FUNCTION__))
 #define NEW_ID_SUFFIX(suffix) \
 	YOSYS_NAMESPACE_PREFIX new_id_suffix(__FILE__, __LINE__, __FUNCTION__, suffix)


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Fix #5532.