### PR TITLE
pyosys: fix install failure when ABCEXTERNAL is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1052,7 +1052,9 @@ ifeq ($(ENABLE_PYOSYS),1)
 	$(INSTALL_SUDO) cp libyosys.so $(DESTDIR)$(PYTHON_DESTDIR)/$(subst -,_,$(PROGRAM_PREFIX))pyosys/libyosys.so
 	$(INSTALL_SUDO) cp -r share $(DESTDIR)$(PYTHON_DESTDIR)/$(subst -,_,$(PROGRAM_PREFIX))pyosys
 ifeq ($(ENABLE_ABC),1)
-	$(INSTALL_SUDO) cp yosys-abc $(DESTDIR)$(PYTHON_DESTDIR)/$(subst -,_,$(PROGRAM_PREFIX))pyosys/yosys-abc
+ifeq ($(ABCEXTERNAL),)
+	$(INSTALL_SUDO) cp $(PROGRAM_PREFIX)yosys-abc$(EXE) $(DESTDIR)$(PYTHON_DESTDIR)/$(subst -,_,$(PROGRAM_PREFIX))pyosys/yosys-abc$(EXE)
+endif
 endif
 endif
 endif


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

While pyosys technically supports an external abc in installation, the attempt to always copy yosys-abc regardless would cause `make install` to crash.

_Explain how this is achieved._

`__init__.py` already handles yosys-abc not existing, so this just skips the install.

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._

Working on a Dockerfile to make sure this works as expected, please hold.

---

Resolves #5537 