### PR TITLE
Calling `abc` fails when `ABCEXTERNAL` relies on path expansion

### DIFF
--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -252,8 +252,8 @@ std::optional<AbcProcess> spawn_abc(const char* abc_exe, DeferredLogs &logs) {
 
 	char arg1[] = "-s";
 	char* argv[] = { strdup(abc_exe), arg1, nullptr };
-	if (0 != posix_spawn(&result.pid, abc_exe, &file_actions, nullptr, argv, environ)) {
-		logs.log_error("posix_spawn %s failed", abc_exe);
+	if (0 != posix_spawnp(&result.pid, abc_exe, &file_actions, nullptr, argv, environ)) {
+		logs.log_error("posix_spawnp %s failed", abc_exe);
 		return std::nullopt;
 	}
 	free(argv[0]);


### PR DESCRIPTION
Fix #5541 by switching `posix_spawn` to `posix_spawnp`.  @rocallahan can you check this is fine?  It works for me locally but I'm not sure if this has ramifications for the pid matching and process reuse.

Reproduction steps for testing in https://github.com/YosysHQ/yosys/issues/5541#issuecomment-3652030684