### PR TITLE
Tests: Don't mention iverilog if the error wasn't from iverilog

### DIFF
--- a/tests/tools/autotest.sh
+++ b/tests/tools/autotest.sh
@@ -162,9 +162,11 @@ do
 			cp ../${bn}_tb.v ${bn}_tb.v
 		fi
 		if $genvcd; then sed -i 's,// \$dump,$dump,g' ${bn}_tb.v; fi
+		touch ${bn}.iverilog
 		compile_and_run ${bn}_tb_ref ${bn}_out_ref ${bn}_tb.v ${bn}_ref.${refext} "${libs[@]}" \
 					"$toolsdir"/../../techlibs/common/simlib.v \
 					"$toolsdir"/../../techlibs/common/simcells.v
+		rm ${bn}.iverilog
 		if $genvcd; then mv testbench.vcd ${bn}_ref.vcd; fi
 
 		test_count=0


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

`autotest.sh` currently reports `Note: Make sure that 'iverilog' is an up-to-date git checkout of Icarus Verilog.` on any error, even if the failure occurred while calling Yosys.

_Explain how this is achieved._

Add a temporary file after running Yosys (before running iverilog), and then remove it after calling `cmp_tbdata` (which checks the output).  If the file still exists when we are reporting a failure it means either calling `iverilog` failed, or there was a mismatch in the output.  If the file doesn't exist, then the error is not related to iverilog.

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._

Get a yosys failure that isn't related to iverilog, e.g. https://github.com/YosysHQ/yosys/issues/5541#issuecomment-3652030684 on 2833a445 (i.e. without the fix), and see a note about iverilog.  The changes from this pr will prevent the note about iverilog.

Running tests without `iverilog` (simulated by adding an `exit 1` before calling `iverilog` in `autotest.sh:111`), or where output doesn't match reference (simulated by adding an `exit 1` before calling `cmp_tbdata` in `autotest.sh:181`) still includes the note about iverilog.