### PR TITLE
Document nesting packages as unsupported

### DIFF
--- a/docs/source/using_yosys/verilog.rst
+++ b/docs/source/using_yosys/verilog.rst
@@ -355,6 +355,9 @@ from SystemVerilog:
   design with `read_verilog`, all its packages are available to SystemVerilog
   files being read into the same design afterwards.
 
+  - nested packages are currently not supported (i.e. calling ``import`` inside
+    a ``package`` .. ``endpackage`` block)
+
 - typedefs are supported (including inside packages)
 
   - type casts are currently not supported


### PR DESCRIPTION
The [docs](https://yosyshq.readthedocs.io/projects/yosys/en/latest/using_yosys/verilog.html#supported-features-from-systemverilog) mentions that SystemVerilog packages are supported when calling `read_verilog -sv`.  As per #5533, *nested* packages are not, and we should clarify that.