### PR TITLE
opt_dff: skip convertion to dffe for keep wires

### DIFF
--- a/passes/opt/opt_dff.cc
+++ b/passes/opt/opt_dff.cc
@@ -55,6 +55,7 @@ struct OptDffWorker
 	FfInitVals initvals;
 	dict<SigBit, int> bitusers;       // Signal sink count
 	dict<SigBit, cell_int_t> bit2mux; // Signal bit to driving MUX
+	pool<SigBit> kept_bits;
 
 	std::vector<Cell *> dff_cells;
 
@@ -117,15 +118,26 @@ struct OptDffWorker
 		// - bit2mux: the mux cell and bit index that drives it, if any
 
 		for (auto wire : module->wires())
+		{
+			if (wire->get_bool_attribute(ID::keep))
+				for (auto bit : sigmap(wire))
+					kept_bits.insert(bit);
+
 			if (wire->port_output)
 				for (auto bit : sigmap(wire))
 					bitusers[bit]++;
+		}
 
 		for (auto cell : module->cells()) {
 			if (cell->type.in(ID($mux), ID($pmux), ID($_MUX_))) {
 				RTLIL::SigSpec sig_y = sigmap(cell->getPort(ID::Y));
-				for (int i = 0; i < GetSize(sig_y); i++)
-					bit2mux[sig_y[i]] = cell_int_t(cell, i);
+				for (int i = 0; i < GetSize(sig_y); i++) {
+					SigBit bit = sig_y[i];
+					// skip kept wires, remove once yosys has optimization barriers
+					if (kept_bits.count(bit))
+						continue;
+					bit2mux[bit] = cell_int_t(cell, i);
+				}
 			}
 
 			for (auto conn : cell->connections()) {
@@ -763,8 +775,14 @@ struct OptDffWorker
 				optimize_const_clk(ff, cell, changed);
 
 			// Feedback (D=Q) opt
-			if ((ff.has_clk || ff.has_gclk) && ff.sig_d == ff.sig_q)
-				optimize_d_equals_q(ff, cell, changed);
+			if ((ff.has_clk || ff.has_gclk) && ff.sig_d == ff.sig_q) {
+				// skip kept wires, remove once yosys has optimization barriers
+				bool d_has_kept_bit = false;
+				for (int i = 0; i < ff.width; i++)
+					if (kept_bits.count(ff.sig_d[i])) { d_has_kept_bit = true; break; }
+				if (!d_has_kept_bit)
+					optimize_d_equals_q(ff, cell, changed);
+			}
 
 			if (ff.has_aload && !ff.has_clk && ff.sig_ad == ff.sig_q) {
 				log("Handling AD = Q on %s (%s) from module %s (removing async load path).\n",


### PR DESCRIPTION
Assuming a module with a FF input marked as `keep` like this:
```verilog
module test (
    input  wire clk_i,
    input  wire data_i,
    input  wire select_i,
    output wire out_o
);
    (* keep *) wire ff_d;
    reg ff_q;

    assign ff_d = select_i ? data_i : ff_q;
    always @(posedge clk_i) ff_q <= ff_d;

    assign out_o = ff_q;
endmodule
```

Currently `opt_dff` will convert this unconditionally into a enable flop but because the signal is marked as `keep` no actual optimization is possible and the preceding MUX must be kept.  
This results in something like this:
```verilog
module test(clk_i, data_i, select_i, out_o);
  input clk_i;
  wire clk_i;
  input data_i;
  wire data_i;
  (* keep = 32'd1 *)
  (* unused_bits = "0" *)
  wire ff_d;
  wire ff_q;
  output out_o;
  wire out_o;
  input select_i;
  wire select_i;
  \$_MUX_  mux  (
    .A(ff_q),
    .B(data_i),
    .S(select_i),
    .Y(ff_d)
  );
  \$_DFFE_PP_  dffe  (
    .C(clk_i),
    .D(data_i),
    .E(select_i),
    .Q(ff_q)
  );
  assign out_o = ff_q;
endmodule
```
Note that `ff_d` is kept but is not functional anymore, instead the control signal directly controls the enable of the FF.  

In my opinion, this violates what `keep` is meant to do (even though technically it is 'kept') as it changes the signals functions.  
Sometimes it is important to keep these kind of signals exactly as-is, for example if constraints need to be applied at a later stage.


While searching for places to perform optimizations in `opt_dff`, it checks if the signal is marked as `keep` and skips it (does not add it to `bit2mux` which is then used to check for the specific optimizations).  
This should disable this specific dff->dffe conversion but also all others that may violate the `keep` (this could lose some optimization potential but since `keep` signals should be sparse, the penalty is likely extremely small).

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._
