### PR TITLE
avoid merging formal properties

### DIFF
--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -844,6 +844,7 @@ struct AST_INTERNAL::ProcessGenerator
 
 				RTLIL::Cell *cell = current_module->addCell(cellname, ID($check));
 				set_src_attr(cell, ast);
+				cell->set_bool_attribute(ID(keep));
 				for (auto &attr : ast->attributes) {
 					if (attr.second->type != AST_CONSTANT)
 						log_file_error(*ast->location.begin.filename, ast->location.begin.line, "Attribute `%s' with non-constant value!\n", attr.first);

--- a/frontends/verific/verificsva.cc
+++ b/frontends/verific/verificsva.cc
@@ -1846,7 +1846,10 @@ struct VerificSvaImporter
 				if (mode_assume) c = module->addAssume(root_name, sig_a_q, sig_en_q);
 				if (mode_cover) c = module->addCover(root_name, sig_a_q, sig_en_q);
 
-				if (c) importer->import_attributes(c->attributes, root);
+				if (c) {
+					c->set_bool_attribute(ID(keep));
+					importer->import_attributes(c->attributes, root);
+				}
 			}
 		}
 		catch (ParserErrorException)

--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -227,6 +227,11 @@ struct OptMergeWorker
 		ct.cell_types.erase(ID($anyconst));
 		ct.cell_types.erase(ID($allseq));
 		ct.cell_types.erase(ID($allconst));
+		ct.cell_types.erase(ID($check));
+		ct.cell_types.erase(ID($assert));
+		ct.cell_types.erase(ID($assume));
+		ct.cell_types.erase(ID($live));
+		ct.cell_types.erase(ID($cover));
 
 		log("Finding identical cells in module `%s'.\n", module->name);
 		assign_map.set(module);

--- a/tests/opt/opt_merge_properties.ys
+++ b/tests/opt/opt_merge_properties.ys
@@ -1,0 +1,16 @@
+read_verilog -sv <<EOF
+module top ();
+    always_comb begin
+        label1: cover(0);
+        label2: cover(0);
+    end
+endmodule
+EOF
+
+hierarchy -top top
+proc
+chformal -lower
+clean
+opt_merge
+select -assert-count 2 t:$cover
+


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
We recommend that SBY users use `prep` in the user script as a good general-purpose elaboration script. However, this runs some optimizations. If there are multiple properties in the design that `opt` can statically determine to always be true or false, they might end up getting merged by `opt_merge` and SBY never sees the removed properties. This produces confusing output with unpredictably missing properties.

_Explain how this is achieved._
1. Put the property cell types (`$check $assume $assert $cover $live`) on the ignore list in `opt_merge`.
2. Automatically add a `keep` attribute on the same cell types on import in the frontend, in case any other optimization might be tempted to touch them in the future or in another edge case we haven't considered yet.

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._
CI test case included. Here's the SBY file that demonstrates the bigger problem:
```
[options]
mode cover
depth 2

[engines]
smtbmc --keep-going

[script]
read -sv test.sv
prep -top top

[file test.sv]
module top(output [1:0] o);
assign o = 2'b10;
always_comb begin
    cover_false_1: cover (o[0] == 1'b1);
    cover_false_2: cover (o[1] == 1'b0);
end
endmodule
```