### PR TITLE
Defer redirecting cell outputs when merging cells in `opt_merge` untill after we've done a full pass over the cells.

### DIFF
--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -284,6 +284,7 @@ struct OptMergeWorker
 				CellPtrHash,
 				CellPtrEqual> known_cells (0, CellPtrHash(*this), CellPtrEqual(*this));
 
+			std::vector<RTLIL::SigSig> redirects;
 			for (auto cell : cells)
 			{
 				auto [cell_in_map, inserted] = known_cells.insert(cell);
@@ -305,18 +306,21 @@ struct OptMergeWorker
 							RTLIL::SigSpec other_sig = other_cell->getPort(it.first);
 							log_debug("    Redirecting output %s: %s = %s\n", it.first,
 									log_signal(it.second), log_signal(other_sig));
-							Const init = initvals(other_sig);
-							initvals.remove_init(it.second);
-							initvals.remove_init(other_sig);
-							module->connect(RTLIL::SigSig(it.second, other_sig));
-							assign_map.add(it.second, other_sig);
-							initvals.set_init(other_sig, init);
+							redirects.push_back(RTLIL::SigSig(it.second, std::move(other_sig)));
 						}
 					}
 					log_debug("    Removing %s cell `%s' from module `%s'.\n", cell->type, cell->name, module->name);
 					module->remove(cell);
 					total_count++;
 				}
+			}
+			for (const RTLIL::SigSig &redirect : redirects) {
+				module->connect(redirect);
+				Const init = initvals(redirect.second);
+				initvals.remove_init(redirect.first);
+				initvals.remove_init(redirect.second);
+				assign_map.add(redirect.first, redirect.second);
+				initvals.set_init(redirect.second, init);
 			}
 		}
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

This PR avoids changing `assign_map` and `initvals`, which are inputs to the hash function for `known_cells`, while `known_cells` exists. Changing the hash function for a hashtable while it exists leads to confusing behavior. That also means the exact behavior of `opt_merge` cannot be reproduced by a parallel implementation.

This (admittedly strange) testcase exhibits the confusing (internal) behavior: [test.rtlil.txt](https://github.com/user-attachments/files/24248127/test.rtlil.txt)
`opt_merge` first adds `\cell_d_4` to `known_cells`. Then it detects that `\cell_d_3` can be merged with `\cell_d_4`, and merges them. Merging them sets `\wire_a` to `32'0` in `assign_map`. Then it checks `\cell_d_2`, which is the same as `\cell_d_4` but we compute a different hash value because `assign_map` has a value for `\wire_a` now! So after the first run through the cells, we are left with `\cell_d_2` and `\cell_d_4` in the design, whereas we really should have only `\cell_d_4`. Of course there is no actual correctness bug because we run through the cells again and eliminate `\cell_d_2` at that point.