### PR TITLE
add lut2bmux

### DIFF
--- a/passes/techmap/Makefile.inc
+++ b/passes/techmap/Makefile.inc
@@ -39,6 +39,7 @@ OBJS += passes/techmap/muxcover.o
 OBJS += passes/techmap/aigmap.o
 OBJS += passes/techmap/tribuf.o
 OBJS += passes/techmap/lut2mux.o
+OBJS += passes/techmap/lut2bmux.o
 OBJS += passes/techmap/nlutmap.o
 OBJS += passes/techmap/shregmap.o
 OBJS += passes/techmap/deminout.o

--- a/passes/techmap/lut2bmux.cc
+++ b/passes/techmap/lut2bmux.cc
@@ -1,0 +1,58 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Claire Xenia Wolf <claire@yosyshq.com>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/yosys.h"
+#include "kernel/sigtools.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+struct Lut2BmuxPass : public Pass {
+	Lut2BmuxPass() : Pass("lut2bmux", "convert $lut to $bmux") { }
+	void help() override
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    lut2bmux [options] [selection]\n");
+		log("\n");
+		log("This pass converts $lut cells to $bmux cells.\n");
+		log("\n");
+	}
+	void execute(std::vector<std::string> args, RTLIL::Design *design) override
+	{
+		log_header(design, "Executing LUT2BMUX pass (convert $lut to $bmux).\n");
+
+		size_t argidx = 1;
+		extra_args(args, argidx, design);
+
+		for (auto module : design->selected_modules())
+		for (auto cell : module->selected_cells()) {
+			if (cell->type == ID($lut)) {
+				cell->type = ID($bmux);
+				cell->setPort(ID::S, cell->getPort(ID::A));
+				cell->setPort(ID::A, cell->getParam(ID::LUT));
+				cell->unsetParam(ID::LUT);
+				cell->fixup_parameters();
+				log("Converted %s.%s to BMUX cell.\n", log_id(module), log_id(cell));
+			}
+		}
+	}
+} Lut2BmuxPass;
+
+PRIVATE_NAMESPACE_END

--- a/tests/techmap/lut2bmux.ys
+++ b/tests/techmap/lut2bmux.ys
@@ -1,0 +1,24 @@
+read_rtlil << EOT
+module \top
+  wire width 4 input 0 \A
+  wire output 1 \Y
+
+  cell $lut $0
+    parameter \WIDTH 4
+    parameter \LUT 16'0110100110010110
+    connect \A \A
+    connect \Y \Y
+  end
+end
+EOT
+
+hierarchy -auto-top
+
+
+equiv_opt -assert lut2bmux
+
+
+lut2bmux
+
+select -assert-count 0 t:$lut
+select -assert-count 1 t:$bmux r:WIDTH=1 r:S_WIDTH=4 %i


### PR DESCRIPTION
Some downstream Yosys passes and mappings operate on $bmux but not $lut so designs synthesized to $lut cannot benefit from them. This PR implements the rewrite from $lut to $bmux without changing default behavior. This way those flows can be leveraged. 

lut2bmux transforms each selected $lut cell into an equivalent $bmux cell by:
1. Moving $lut input port A to $bmux select port S
2. Replacing the $lut parameter with the $bmux data input
3. Removing the $lut parameter and fixing parameters

For testing, use tests/techmap/lut2bmux.ys. 