### PR TITLE
add breaksop feature

### DIFF
--- a/passes/techmap/Makefile.inc
+++ b/passes/techmap/Makefile.inc
@@ -7,6 +7,7 @@ OBJS += passes/techmap/booth.o
 OBJS += passes/techmap/libparse.o
 OBJS += passes/techmap/libcache.o
 
+OBJS += passes/techmap/breaksop.o
 ifeq ($(ENABLE_ABC),1)
 OBJS += passes/techmap/abc.o
 OBJS += passes/techmap/abc9.o

--- a/passes/techmap/breaksop.cc
+++ b/passes/techmap/breaksop.cc
@@ -63,23 +63,23 @@ struct BreakSopPass : public Pass {
 					pool<SigBit> intermed_wires;
 					for (int i = 0; i < sop_depth; i++) {
 						// Wire for the output
-						auto and_out = module->addWire(NEW_ID2_SUFFIX("andterm_out"));
+						auto and_out = module->addWire(NEW_ID_SUFFIX("andterm_out"));
 						intermed_wires.insert(and_out);
 
 						// Signals for the inputs
 						pool<SigBit> and_in;
 						for (int j = 0; j < sop_width; j++)
 							if (sop_table[2 * (i * sop_width + j) + 0])
-								and_in.insert(module->Not(NEW_ID2_SUFFIX(stringf("sop_in_%d_comp", j)), sop_inputs[j], false, cell->get_src_attribute()));
+								and_in.insert(module->Not(NEW_ID_SUFFIX(stringf("sop_in_%d_comp", j)), sop_inputs[j], false, cell->get_src_attribute()));
 							else if (sop_table[2 * (i * sop_width + j) + 1])
 								and_in.insert(sop_inputs[j]);
 
 						// Construct the cell
-						module->addReduceAnd(NEW_ID2_SUFFIX("andterm"), and_in, and_out, false, cell->get_src_attribute());
+						module->addReduceAnd(NEW_ID_SUFFIX("andterm"), and_in, and_out, false, cell->get_src_attribute());
 					}
 
 					// Construct the $reduce_or cell
-					module->addReduceOr(NEW_ID2_SUFFIX("orterm"), intermed_wires, sop_output, false, cell->get_src_attribute());
+					module->addReduceOr(NEW_ID_SUFFIX("orterm"), intermed_wires, sop_output, false, cell->get_src_attribute());
 
 					// Mark the $sop cell for removal
 					cells_to_remove.insert(cell);

--- a/passes/techmap/breaksop.cc
+++ b/passes/techmap/breaksop.cc
@@ -1,0 +1,96 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2017 Robert Ou <rqou@robertou.com>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/yosys.h"
+#include "kernel/sigtools.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+struct BreakSopPass : public Pass {
+	BreakSopPass() : Pass("breaksop", "break $sop cells into $reduce_and/$reduce_or cells") { }
+	void help() override
+	{
+		log("\n");
+		log("    breaksop [selection]\n");
+		log("\n");
+		log("Break $sop cells into $reduce_and/$reduce_or cells.\n");
+		log("\n");
+	}
+	void execute(std::vector<std::string> args, RTLIL::Design *design) override
+	{
+		log_header(design, "Executing BREAKSOP pass (break $sop cells into $reduce_and/$reduce_or cells).\n");
+		extra_args(args, 1, design);
+
+		for (auto module : design->selected_modules())
+		{
+			// Data structures
+			pool<Cell*> cells_to_remove;
+			SigMap sigmap(module);
+
+			// Process $sop cells
+			for (auto cell : module->selected_cells())
+			{
+				if (cell->type == ID($sop))
+				{
+					// Read the inputs/outputs/parameters of the $sop cell
+					auto sop_inputs = sigmap(cell->getPort(ID::A));
+					auto sop_output = sigmap(cell->getPort(ID::Y))[0];
+					auto sop_depth = cell->getParam(ID::DEPTH).as_int();
+					auto sop_width = cell->getParam(ID::WIDTH).as_int();
+					auto sop_table = cell->getParam(ID::TABLE);
+
+					// Get $sop output wire name
+					module->rename(cell->name, module->uniquify(sop_output.wire->name.str() + "_sop"));
+
+					// Construct $reduce_and cells
+					pool<SigBit> intermed_wires;
+					for (int i = 0; i < sop_depth; i++) {
+						// Wire for the output
+						auto and_out = module->addWire(NEW_ID2_SUFFIX("andterm_out"));
+						intermed_wires.insert(and_out);
+
+						// Signals for the inputs
+						pool<SigBit> and_in;
+						for (int j = 0; j < sop_width; j++)
+							if (sop_table[2 * (i * sop_width + j) + 0])
+								and_in.insert(module->Not(NEW_ID2_SUFFIX(stringf("sop_in_%d_comp", j)), sop_inputs[j], false, cell->get_src_attribute()));
+							else if (sop_table[2 * (i * sop_width + j) + 1])
+								and_in.insert(sop_inputs[j]);
+
+						// Construct the cell
+						module->addReduceAnd(NEW_ID2_SUFFIX("andterm"), and_in, and_out, false, cell->get_src_attribute());
+					}
+
+					// Construct the $reduce_or cell
+					module->addReduceOr(NEW_ID2_SUFFIX("orterm"), intermed_wires, sop_output, false, cell->get_src_attribute());
+
+					// Mark the $sop cell for removal
+					cells_to_remove.insert(cell);
+				}
+			}
+
+			// Perform removal of $sop cells
+			for (auto cell : cells_to_remove)
+				module->remove(cell);
+		}
+	}
+} BreakSopPass;
+
+PRIVATE_NAMESPACE_END

--- a/tests/techmap/breaksop.ys
+++ b/tests/techmap/breaksop.ys
@@ -1,0 +1,194 @@
+log -header "Simple positive case"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [2:0] a,
+  output wire x
+);
+  assign x = a[0] | (a[1] & a[2]);
+endmodule
+EOF
+check -assert
+
+# Generate $sop
+techmap
+abc -sop
+select -assert-count 1 t:$sop
+
+# Check equivalence after breaksop
+equiv_opt -assert breaksop
+
+# Check final design has correct number of gates
+design -load postopt
+select -assert-count 2 t:$reduce_and
+select -assert-count 1 t:$reduce_or
+
+design -reset
+log -pop
+
+
+
+log -header "With negation"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [2:0] a,
+  output wire x
+);
+  assign x = ~a[0] | (~a[1] & ~a[2]);
+endmodule
+EOF
+check -assert
+
+# Generate $sop
+techmap
+abc -sop
+select -assert-count 1 t:$sop
+
+# Check equivalence after breaksop
+equiv_opt -assert breaksop
+
+# Check final design has correct number of gates
+design -load postopt
+write_verilog dump_post.v
+select -assert-count 2 t:$reduce_and
+select -assert-count 1 t:$reduce_or
+
+design -reset
+log -pop
+
+
+
+log -header "More depth"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [3:0] a,
+  output wire x
+);
+  assign x = (a[0] & a[1]) | (~a[2] & a[3]) | (a[0] & ~a[1] & a[2]);
+endmodule
+EOF
+check -assert
+
+# Generate $sop
+techmap
+abc -sop
+select -assert-count 1 t:$sop
+
+# Check equivalence after breaksop
+equiv_opt -assert breaksop
+
+# Check final design has correct number of gates
+design -load postopt
+select -assert-count 3 t:$reduce_and
+select -assert-count 1 t:$reduce_or
+
+design -reset
+log -pop
+
+
+
+log -header "Only ORs"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [3:0] a,
+  output wire x
+);
+  assign x = a[0] | a[1] | a[2] | a[3];
+endmodule
+EOF
+check -assert
+
+# Generate $sop
+techmap
+abc -sop
+select -assert-count 1 t:$sop
+
+# Check equivalence after breaksop
+equiv_opt -assert breaksop
+
+# Check final design has correct number of gates
+# We only have one AND gate since breaksop turns the OR gate into an AND gate
+# The inputs to this gate are inverted and the outputs are also inverted, so with 
+# DeMorgan's law, they are equivalent
+design -load postopt
+opt     # Run opt to remove unneeded OR gate
+select -assert-count 1 t:$reduce_and
+select -assert-count 0 t:$reduce_or
+
+design -reset
+log -pop
+
+
+
+log -header "With constants"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [3:0] a,
+  output wire x
+);
+  assign x = (~a[0] & 1'b1) | (a[1] & 1'b0) | (a[2] & a[3]);
+endmodule
+EOF
+check -assert
+
+# Generate $sop
+techmap
+abc -sop
+select -assert-count 1 t:$sop
+
+# Check equivalence after breaksop
+write_verilog dump_pre.v
+equiv_opt -assert breaksop
+
+# Check final design has correct number of gates
+design -load postopt
+opt
+write_verilog dump_post.v
+select -assert-count 2 t:$reduce_and
+select -assert-count 1 t:$reduce_or
+
+design -reset
+log -pop
+
+
+
+log -header "Multiple sops"
+log -push
+design -reset
+read_verilog <<EOF
+module top (
+  input wire [3:0] a,
+  input wire [3:0] b,
+  output wire x,
+  output wire y
+);
+  assign x = (a[0] & a[1]) | (~a[2] & a[3]) | (a[0] & ~a[1] & a[2]);
+  assign y = (b[0] & b[1]) | (~b[2] & b[3]) | (b[0] & ~b[1] & b[2]);
+endmodule
+EOF
+check -assert
+
+# Generate $sop
+techmap
+abc -sop
+select -assert-count 2 t:$sop
+
+# Check equivalence after breaksop
+equiv_opt -assert breaksop
+
+# Check final design has correct number of gates
+design -load postopt
+select -assert-count 6 t:$reduce_and
+select -assert-count 2 t:$reduce_or
+
+design -reset
+log -pop


### PR DESCRIPTION
SOP-style logic with multiple outputs can be hard to reason about when debugging or dealing with mapping/optimization downstream flows. breaksop breaks apart this logic into simpler pieces. 

Adds a new breaksop techmap pass that rewrites multi-output SOP structures into simpler, equivalent logic. The pass is implemented in passes/techmap/breaksop.cc and registered via the techmap Makefile.

Adds a .ys test that runs breaksop on single and multiple SOP cases and checks that the rewritten netlist matches the expected structure.
