### PR TITLE
remove unused variable

### DIFF
--- a/passes/cmds/icell_liberty.cc
+++ b/passes/cmds/icell_liberty.cc
@@ -163,7 +163,6 @@ struct IcellLiberty : Pass {
 		log_header(d, "Executing ICELL_LIBERTY pass.\n");
 
 		size_t argidx;
-		IdString naming_attr;
 		std::string liberty_filename;
 		auto liberty_file = std::make_unique<std::ofstream>();
 


### PR DESCRIPTION
This removes variable definition, noticed mostly because it was anoying warning.