### PR TITLE
Increase test timeout to 10 seconds

### DIFF
--- a/tests/techmap/bug5495.sh
+++ b/tests/techmap/bug5495.sh
@@ -5,7 +5,7 @@ if ! which timeout ; then
     exit 0
 fi
 
-if ! timeout 5 ../../yosys bug5495.v -p 'hierarchy; techmap; abc -script bug5495.abc' ; then
+if ! timeout 10 ../../yosys bug5495.v -p 'hierarchy; techmap; abc -script bug5495.abc' ; then
     echo "Yosys failed to complete"
     exit 1
 fi


### PR DESCRIPTION
On my machine, this test regularly times out when doing "make -j" (which defaults to 128). The high degree of parallelism seems to slow down the spwaning of ABC processes.