### PR TITLE
verific: add -optimization option

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -109,6 +109,7 @@ int verific_verbose;
 bool verific_import_pending;
 string verific_error_msg;
 int verific_sva_fsm_limit;
+bool verific_opt = false;  // enable Verific optimizations
 
 #ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
 vector<string> verific_incdirs, verific_libdirs, verific_libexts;
@@ -3071,6 +3072,23 @@ std::string verific_import(Design *design, const std::map<std::string,std::strin
 	while (!nl_todo.empty()) {
 		auto it = nl_todo.begin();
 		Netlist *nl = it->second;
+
+		// use Verific optimizations
+		#ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
+		if (verific_opt) {
+			log("  Running Verific optimizations for %s.\n", it->first.c_str());
+
+			// log("    Inferring clock enable muxes for %s.\n", it->first.c_str());
+			// nl->InferClockEnableMux();
+
+			log("    Running post-elaboration for %s.\n", it->first.c_str());
+			nl->PostElaborationProcess();
+
+			log("    Running operator optimization for %s.\n", it->first.c_str());
+			nl->OperatorOptimization();
+		}
+		#endif
+
 		if (nl_done.count(it->first) == 0) {
 			VerificImporter importer(false, false, false, false, false, false, false, false);
 			nl_done[it->first] = it->second;
@@ -3691,6 +3709,13 @@ struct VerificPass : public Pass {
 #endif
 			break;
 		}
+
+#ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
+		if (args[argidx] == "-optimization") {
+			verific_opt = true;
+			continue;
+		}
+	#endif
 
 #ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
 		if (GetSize(args) > argidx && (args[argidx] == "-f" || args[argidx] == "-F"))

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3074,7 +3074,7 @@ std::string verific_import(Design *design, const std::map<std::string,std::strin
 		Netlist *nl = it->second;
 
 		// use Verific optimizations
-		#ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
+#ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
 		if (verific_opt) {
 			log("  Running Verific optimizations for %s.\n", it->first.c_str());
 
@@ -3084,7 +3084,7 @@ std::string verific_import(Design *design, const std::map<std::string,std::strin
 			log("    Running operator optimization for %s.\n", it->first.c_str());
 			nl->OperatorOptimization();
 		}
-		#endif
+#endif
 
 		if (nl_done.count(it->first) == 0) {
 			VerificImporter importer(false, false, false, false, false, false, false, false);

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3703,15 +3703,16 @@ struct VerificPass : public Pass {
 				veri_file::AddLOption(args[++argidx].c_str());
 				continue;
 			}
-			if (args[argidx] == "-optimization") {
-				verific_opt = true;
-				continue;
-			}
 #endif
 			break;
 		}
 
 #ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
+		if (GetSize(args) > argidx && args[argidx] == "-optimization") {
+			verific_opt = true;
+			continue;
+		}
+
 		if (GetSize(args) > argidx && (args[argidx] == "-f" || args[argidx] == "-F"))
 		{
 			unsigned verilog_mode = veri_file::UNDEFINED;

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3074,7 +3074,6 @@ std::string verific_import(Design *design, const std::map<std::string,std::strin
 		Netlist *nl = it->second;
 
 		// use Verific optimizations
-#ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
 		if (verific_opt) {
 			log("  Running Verific optimizations for %s.\n", it->first.c_str());
 
@@ -3084,7 +3083,6 @@ std::string verific_import(Design *design, const std::map<std::string,std::strin
 			log("    Running operator optimization for %s.\n", it->first.c_str());
 			nl->OperatorOptimization();
 		}
-#endif
 
 		if (nl_done.count(it->first) == 0) {
 			VerificImporter importer(false, false, false, false, false, false, false, false);
@@ -3707,12 +3705,12 @@ struct VerificPass : public Pass {
 			break;
 		}
 
-#ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
 		if (GetSize(args) > argidx && args[argidx] == "-optimization") {
 			verific_opt = true;
-			continue;
+			goto check_error;
 		}
 
+#ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
 		if (GetSize(args) > argidx && (args[argidx] == "-f" || args[argidx] == "-F"))
 		{
 			unsigned verilog_mode = veri_file::UNDEFINED;

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3078,9 +3078,6 @@ std::string verific_import(Design *design, const std::map<std::string,std::strin
 		if (verific_opt) {
 			log("  Running Verific optimizations for %s.\n", it->first.c_str());
 
-			// log("    Inferring clock enable muxes for %s.\n", it->first.c_str());
-			// nl->InferClockEnableMux();
-
 			log("    Running post-elaboration for %s.\n", it->first.c_str());
 			nl->PostElaborationProcess();
 
@@ -3706,16 +3703,13 @@ struct VerificPass : public Pass {
 				veri_file::AddLOption(args[++argidx].c_str());
 				continue;
 			}
+			if (args[argidx] == "-optimization") {
+				verific_opt = true;
+				continue;
+			}
 #endif
 			break;
 		}
-
-#ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
-		if (args[argidx] == "-optimization") {
-			verific_opt = true;
-			continue;
-		}
-	#endif
 
 #ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
 		if (GetSize(args) > argidx && (args[argidx] == "-f" || args[argidx] == "-F"))


### PR DESCRIPTION
This PR adds a new `verific -optimization` option that enables Verific’s internal frontend optimizations during elaboration.

Silimate’s Yosys fork already uses this option to allow users to explicitly enable Verific post-elaboration and operator optimizations. Upstreaming this flag allows users to access the same functionality in a controlled, opt-in
manner without changing default behavior.

The change introduces a boolean `verific_opt` flag that is set when the `-optimization` option is passed to the `verific` frontend.

When enabled, Verific’s `PostElaborationProcess()` and `OperatorOptimization()` are invoked on each imported netlist. The behavior is fully guarded under `VERIFIC_SYSTEMVERILOG_SUPPORT` and does not alter existing behavior unless the flag is explicitly used.

#closes #5577
