### PR TITLE
verific: add -set_ignore_translate_off option

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3688,15 +3688,15 @@ struct VerificPass : public Pass {
 				veri_file::AddLOption(args[++argidx].c_str());
 				continue;
 			}
-			if (args[argidx] == "-set_ignore_translate_off") {
-				veri_file::SetIgnoreTranslateOff(1);
-				continue;
-			}
 #endif
 			break;
 		}
 
 #ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
+		if (GetSize(args) > argidx && args[argidx] == "-set_ignore_translate_off") {
+			veri_file::SetIgnoreTranslateOff(1);
+			continue;
+		}
 		if (GetSize(args) > argidx && (args[argidx] == "-f" || args[argidx] == "-F"))
 		{
 			unsigned verilog_mode = veri_file::UNDEFINED;


### PR DESCRIPTION
This PR adds a `verific -set_ignore_translate_off` option that instructs Verific to ignore `translate_off/translate_on` pragmas during frontend elaboration.

Silimate’s Yosys fork includes an option to disable `translate_off/on` handling explicitly.

The change adds a simple option that invokes `veri_file::SetIgnoreTranslateOff(1)` when specified. The option is parsed as a boolean toggle, guarded under `VERIFIC_SYSTEMVERILOG_SUPPORT`, and does not affect default behavior unless explicitly enabled.
