### PR TITLE
verific: add -set_relaxed_checking option

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3688,15 +3688,16 @@ struct VerificPass : public Pass {
 				veri_file::AddLOption(args[++argidx].c_str());
 				continue;
 			}
-			if (args[argidx] == "-set_relaxed_checking") {
-				VeriNode::SetRelaxedChecking(1);
-				continue;
-			}
 #endif
 			break;
 		}
 
 #ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
+		if (GetSize(args) > argidx && args[argidx] == "-set_relaxed_checking") {
+			VeriNode::SetRelaxedChecking(1);
+			continue;
+		}
+		
 		if (GetSize(args) > argidx && (args[argidx] == "-f" || args[argidx] == "-F"))
 		{
 			unsigned verilog_mode = veri_file::UNDEFINED;

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3688,6 +3688,10 @@ struct VerificPass : public Pass {
 				veri_file::AddLOption(args[++argidx].c_str());
 				continue;
 			}
+			if (args[argidx] == "-set_relaxed_checking") {
+				VeriNode::SetRelaxedChecking(0);
+				continue;
+			}
 #endif
 			break;
 		}

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3689,7 +3689,7 @@ struct VerificPass : public Pass {
 				continue;
 			}
 			if (args[argidx] == "-set_relaxed_checking") {
-				VeriNode::SetRelaxedChecking(0);
+				VeriNode::SetRelaxedChecking(1);
 				continue;
 			}
 #endif


### PR DESCRIPTION
This PR adds a `verific -set_relaxed_checking` option that enables relaxed semantic checking in the Verific frontend.

Silimate’s Yosys fork includes an option to relax Verific’s checking rules to allow such designs to be processed.

Upstreaming this option provides users with an explicit, opt-in mechanism to enable relaxed checking while preserving default strict behavior.

The change introduces a boolean option that calls `VeriNode::SetRelaxedChecking(1)` when specified. The behavior is fully
guarded under `VERIFIC_SYSTEMVERILOG_SUPPORT` and only takes effect when the option is explicitly passed.
