### PR TITLE
verific: add -set_relaxed_file_ext_modes option

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3688,23 +3688,23 @@ struct VerificPass : public Pass {
 				veri_file::AddLOption(args[++argidx].c_str());
 				continue;
 			}
-			if (args[argidx] == "-set_relaxed_file_ext_modes") {
-				veri_file::RemoveFileExt(".v");
-				veri_file::AddFileExtMode(".v", veri_file::SYSTEM_VERILOG);
-				veri_file::AddFileExtMode(".vh", veri_file::SYSTEM_VERILOG);
-				veri_file::AddFileExtMode(".sv", veri_file::SYSTEM_VERILOG);
-				veri_file::AddFileExtMode(".sv1", veri_file::SYSTEM_VERILOG);
-				veri_file::AddFileExtMode(".svh", veri_file::SYSTEM_VERILOG);
-				veri_file::AddFileExtMode(".svp", veri_file::SYSTEM_VERILOG);
-				veri_file::AddFileExtMode(".h", veri_file::SYSTEM_VERILOG);
-				veri_file::AddFileExtMode(".inc", veri_file::SYSTEM_VERILOG);
-				continue;
-			}
 #endif
 			break;
 		}
 
 #ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
+		if (GetSize(args) > argidx && args[argidx] == "-set_relaxed_file_ext_modes") {
+			veri_file::RemoveFileExt(".v");
+			veri_file::AddFileExtMode(".v", veri_file::SYSTEM_VERILOG);
+			veri_file::AddFileExtMode(".vh", veri_file::SYSTEM_VERILOG);
+			veri_file::AddFileExtMode(".sv", veri_file::SYSTEM_VERILOG);
+			veri_file::AddFileExtMode(".sv1", veri_file::SYSTEM_VERILOG);
+			veri_file::AddFileExtMode(".svh", veri_file::SYSTEM_VERILOG);
+			veri_file::AddFileExtMode(".svp", veri_file::SYSTEM_VERILOG);
+			veri_file::AddFileExtMode(".h", veri_file::SYSTEM_VERILOG);
+			veri_file::AddFileExtMode(".inc", veri_file::SYSTEM_VERILOG);
+			continue;
+		}
 		if (GetSize(args) > argidx && (args[argidx] == "-f" || args[argidx] == "-F"))
 		{
 			unsigned verilog_mode = veri_file::UNDEFINED;


### PR DESCRIPTION
This PR adds a `verific -set_relaxed_file_ext_modes` option that relaxes
Verific’s file extension to language mapping.

Silimate’s Yosys fork includes an option that configures Verific to treat a broader set of file extensions as SystemVerilog.

Upstreaming this option allows users to explicitly enable this relaxed behavior without changing default file handling semantics.

When specified, the option updates Verific’s file extension modes to associate several common extensions (e.g. `.v`, `.vh`, `.sv`, `.svh`) with SystemVerilog parsing. The change is guarded under `VERIFIC_SYSTEMVERILOG_SUPPORT` and does not alter behavior unless the option is used.
