### PR TITLE
verific: add -set_relaxed_file_libext_modes option

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3688,6 +3688,17 @@ struct VerificPass : public Pass {
 				veri_file::AddLOption(args[++argidx].c_str());
 				continue;
 			}
+			if (args[argidx] == "-set_relaxed_file_libext_modes") {
+				veri_file::AddLibExt(".v");
+				veri_file::AddLibExt(".vh");
+				veri_file::AddLibExt(".sv");
+				veri_file::AddLibExt(".sv1");
+				veri_file::AddLibExt(".svh");
+				veri_file::AddLibExt(".svp");
+				veri_file::AddLibExt(".h");
+				veri_file::AddLibExt(".inc");
+				continue;
+			}
 #endif
 			break;
 		}

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3688,22 +3688,23 @@ struct VerificPass : public Pass {
 				veri_file::AddLOption(args[++argidx].c_str());
 				continue;
 			}
-			if (args[argidx] == "-set_relaxed_file_libext_modes") {
-				veri_file::AddLibExt(".v");
-				veri_file::AddLibExt(".vh");
-				veri_file::AddLibExt(".sv");
-				veri_file::AddLibExt(".sv1");
-				veri_file::AddLibExt(".svh");
-				veri_file::AddLibExt(".svp");
-				veri_file::AddLibExt(".h");
-				veri_file::AddLibExt(".inc");
-				continue;
-			}
 #endif
 			break;
 		}
 
 #ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
+
+		if (GetSize(args) > argidx && args[argidx] == "-set_relaxed_file_libext_modes") {
+			veri_file::AddLibExt(".v");
+			veri_file::AddLibExt(".vh");
+			veri_file::AddLibExt(".sv");
+			veri_file::AddLibExt(".sv1");
+			veri_file::AddLibExt(".svh");
+			veri_file::AddLibExt(".svp");
+			veri_file::AddLibExt(".h");
+			veri_file::AddLibExt(".inc");
+			continue;
+		}
 		if (GetSize(args) > argidx && (args[argidx] == "-f" || args[argidx] == "-F"))
 		{
 			unsigned verilog_mode = veri_file::UNDEFINED;


### PR DESCRIPTION
This PR adds a `verific -set_relaxed_file_libext_modes` option that relaxes Verific’s library file extension handling.

Silimate’s Yosys fork includes an option to extend Verific’s recognized library file extensions explicitly.

Upstreaming this option allows users to opt into broader library extension support while keeping default behavior unchanged.

The option updates Verific’s library extension list to include additional common HDL extensions. The behavior is guarded under
`VERIFIC_SYSTEMVERILOG_SUPPORT` and only takes effect when the option is explicitly specified.