### PR TITLE
verific: add -set_vhdl_default_library_path option

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3688,6 +3688,14 @@ struct VerificPass : public Pass {
 				veri_file::AddLOption(args[++argidx].c_str());
 				continue;
 			}
+			if (GetSize(args) > argidx && args[argidx] == "-set_vhdl_default_library_path") {
+				for (argidx++; argidx < GetSize(args); argidx++) {
+#ifdef VERIFIC_VHDL_SUPPORT
+					vhdl_file::SetDefaultLibraryPath(args[argidx].c_str());
+#endif
+				}
+				goto check_error;
+			}
 #endif
 			break;
 		}

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3692,15 +3692,15 @@ struct VerificPass : public Pass {
 			break;
 		}
 
-#ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
-		if (GetSize(args) > argidx && args[argidx] == "-set_vhdl_default_library_path") {
-			for (argidx++; argidx < GetSize(args); argidx++) {
 #ifdef VERIFIC_VHDL_SUPPORT
+		if (GetSize(args) > argidx && args[argidx] == "-set_vhdl_default_library_path") {
+			for (argidx++; argidx < GetSize(args); argidx++)
 				vhdl_file::SetDefaultLibraryPath(args[argidx].c_str());
-#endif
-			}
 			goto check_error;
 		}
+#endif
+
+#ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
 		if (GetSize(args) > argidx && (args[argidx] == "-f" || args[argidx] == "-F"))
 		{
 			unsigned verilog_mode = veri_file::UNDEFINED;

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3695,9 +3695,9 @@ struct VerificPass : public Pass {
 #ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
 		if (GetSize(args) > argidx && args[argidx] == "-set_vhdl_default_library_path") {
 			for (argidx++; argidx < GetSize(args); argidx++) {
-		#ifdef VERIFIC_VHDL_SUPPORT
+#ifdef VERIFIC_VHDL_SUPPORT
 				vhdl_file::SetDefaultLibraryPath(args[argidx].c_str());
-		#endif
+#endif
 			}
 			goto check_error;
 		}

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3688,19 +3688,19 @@ struct VerificPass : public Pass {
 				veri_file::AddLOption(args[++argidx].c_str());
 				continue;
 			}
-			if (GetSize(args) > argidx && args[argidx] == "-set_vhdl_default_library_path") {
-				for (argidx++; argidx < GetSize(args); argidx++) {
-#ifdef VERIFIC_VHDL_SUPPORT
-					vhdl_file::SetDefaultLibraryPath(args[argidx].c_str());
-#endif
-				}
-				goto check_error;
-			}
 #endif
 			break;
 		}
 
 #ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
+		if (GetSize(args) > argidx && args[argidx] == "-set_vhdl_default_library_path") {
+			for (argidx++; argidx < GetSize(args); argidx++) {
+		#ifdef VERIFIC_VHDL_SUPPORT
+				vhdl_file::SetDefaultLibraryPath(args[argidx].c_str());
+		#endif
+			}
+			goto check_error;
+		}
 		if (GetSize(args) > argidx && (args[argidx] == "-f" || args[argidx] == "-F"))
 		{
 			unsigned verilog_mode = veri_file::UNDEFINED;


### PR DESCRIPTION
This PR adds a `verific -set_vhdl_default_library_path` option that allows users to specify default VHDL library search paths for the Verific frontend.

Silimate’s Yosys fork includes an option to configure Verific’s default VHDL library path from the command line.

Upstreaming this option enables better support for VHDL workflows without affecting existing behavior for users who do not rely on VHDL.

The option consumes the remaining command-line arguments as library paths and configures them via `vhdl_file::SetDefaultLibraryPath()`. Since the option consumes positional arguments, option parsing intentionally terminates after this flag. The behavior is guarded under `VERIFIC_SYSTEMVERILOG_SUPPORT` and `VERIFIC_VHDL_SUPPORT`.
