### PR TITLE
verific: add -ignore_module option

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3688,6 +3688,13 @@ struct VerificPass : public Pass {
 				veri_file::AddLOption(args[++argidx].c_str());
 				continue;
 			}
+			if (args[argidx] == "-ignore_module") {
+				for (argidx++; argidx < GetSize(args); argidx++) {
+					string name = args[argidx];
+					veri_file::AddToIgnoredParsedModuleNames(name.c_str());
+				}
+				goto check_error;
+			}
 #endif
 			break;
 		}

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3688,18 +3688,18 @@ struct VerificPass : public Pass {
 				veri_file::AddLOption(args[++argidx].c_str());
 				continue;
 			}
-			if (args[argidx] == "-ignore_module") {
-				for (argidx++; argidx < GetSize(args); argidx++) {
-					string name = args[argidx];
-					veri_file::AddToIgnoredParsedModuleNames(name.c_str());
-				}
-				goto check_error;
-			}
 #endif
 			break;
 		}
 
 #ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
+		if (GetSize(args) > argidx && args[argidx] == "-ignore_module") {
+			for (argidx++; argidx < GetSize(args); argidx++) {
+				string name = args[argidx];
+				veri_file::AddToIgnoredParsedModuleNames(name.c_str());
+			}
+			goto check_error;
+		}
 		if (GetSize(args) > argidx && (args[argidx] == "-f" || args[argidx] == "-F"))
 		{
 			unsigned verilog_mode = veri_file::UNDEFINED;


### PR DESCRIPTION
This PR adds a `verific -ignore_module` option that allows users to specify module names that should be ignored during Verific frontend elaboration.

Silimate’s Yosys fork includes an option to explicitly list module names to be ignored by Verific.

Upstreaming this option provides a clear and explicit mechanism to exclude such modules without modifying source files.

The option consumes the remaining command-line arguments as module names and registers them via `veri_file::AddToIgnoredParsedModuleNames()`. Because the option consumes positional arguments, option parsing intentionally terminates after this flag. The behavior is guarded under `VERIFIC_SYSTEMVERILOG_SUPPORT`.