### PR TITLE
Check for missing port in SDC code to work around compiler bug

### DIFF
--- a/passes/cmds/sdc/sdc.cc
+++ b/passes/cmds/sdc/sdc.cc
@@ -165,7 +165,12 @@ struct SdcObjects {
 		if (!top)
 			log_error("Top module couldn't be determined. Check 'top' attribute usage");
 		for (auto port : top->ports) {
-			design_ports.push_back(std::make_pair(port.str().substr(1), top->wire(port)));
+			RTLIL::Wire *wire = top->wire(port);
+			if (!wire) {
+				// This should not be possible. See https://github.com/YosysHQ/yosys/pull/5594#issue-3791198573
+				log_error("Port %s doesn't exist", log_id(port));
+			}
+			design_ports.push_back(std::make_pair(port.str().substr(1), wire));
 		}
 		std::list<std::string> hierarchy{};
 		sniff_module(hierarchy, top);


### PR DESCRIPTION
I am getting weird crashes on `main` in `tests/sdc/alu_sub.ys` which I traced to a null `Wire*` in `SdcObjects::constrained_ports`. The null `Wire*` is being set in the `SdcObjects` constructor. I don't understand what's going on here, so I added this check to detect the missing wire early ... and that made the crash go away. Compiler bug maybe? I have `Debian clang version 19.1.7 (3+build5)`, default build configuration.

Anyway this code seems fine to have.