### PR TITLE
musllinux fix so wheels build can work

### DIFF
--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -253,7 +253,11 @@ std::optional<AbcProcess> spawn_abc(const char* abc_exe, DeferredLogs &logs) {
 	char arg1[] = "-s";
 	char* argv[] = { strdup(abc_exe), arg1, nullptr };
 	if (0 != posix_spawnp(&result.pid, abc_exe, &file_actions, nullptr, argv, environ)) {
+#if defined(__GLIBC__)
 		logs.log_error("posix_spawnp %s failed (errno=%s)", abc_exe, strerrorname_np(errno));
+#else
+		logs.log_error("posix_spawnp %s failed (errno=%s)", abc_exe, strerror(errno));
+#endif
 		return std::nullopt;
 	}
 	free(argv[0]);


### PR DESCRIPTION
noticed that wheels build is broken, and it fails on this call that is not posix.

@rocallahan by text in log message it should display errno and not string value (text message of error), but guess current implementation helps more during debugging.