### PR TITLE
Makefile: no longer install ast.h and ast_binding.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -645,8 +645,6 @@ $(eval $(call add_include_file,libs/sha1/sha1.h))
 $(eval $(call add_include_file,libs/json11/json11.hpp))
 $(eval $(call add_include_file,passes/fsm/fsmdata.h))
 $(eval $(call add_include_file,passes/techmap/libparse.h))
-$(eval $(call add_include_file,frontends/ast/ast.h))
-$(eval $(call add_include_file,frontends/ast/ast_binding.h))
 $(eval $(call add_include_file,frontends/blif/blifparse.h))
 $(eval $(call add_include_file,backends/rtlil/rtlil_backend.h))
 


### PR DESCRIPTION
The evil version of #5529, see [here](https://github.com/YosysHQ/yosys/pull/5529#issuecomment-3606908524). Previously discussed at dev JF as a good idea