### PR TITLE
Add rtlil string getters

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -31,6 +31,7 @@
 #include <charconv>
 #include <optional>
 #include <string_view>
+#include <sstream>
 
 YOSYS_NAMESPACE_BEGIN
 
@@ -1546,6 +1547,13 @@ void RTLIL::Design::pop_selection()
 	// Default to a full_selection if we ran out of stack
 	if (selection_stack.empty())
 		push_full_selection();
+}
+
+std::string RTLIL::Design::to_rtlil_str(bool only_selected) const
+{
+	std::ostringstream f;
+	RTLIL_BACKEND::dump_design(f, const_cast<RTLIL::Design*>(this), only_selected);
+	return f.str();
 }
 
 std::vector<RTLIL::Module*> RTLIL::Design::selected_modules(RTLIL::SelectPartials partials, RTLIL::SelectBoxes boxes) const
@@ -4288,6 +4296,13 @@ RTLIL::SigSpec RTLIL::Module::FutureFF(RTLIL::IdString name, const RTLIL::SigSpe
 	return sig;
 }
 
+std::string RTLIL::Module::to_rtlil_str() const
+{
+	std::ostringstream f;
+	RTLIL_BACKEND::dump_module(f, "", const_cast<RTLIL::Module*>(this), design, false);
+	return f.str();
+}
+
 RTLIL::Wire::Wire()
 {
 	static unsigned int hashidx_count = 123456789;
@@ -4315,6 +4330,13 @@ RTLIL::Wire::~Wire()
 #endif
 }
 
+std::string RTLIL::Wire::to_rtlil_str() const
+{
+	std::ostringstream f;
+	RTLIL_BACKEND::dump_wire(f, "", this);
+	return f.str();
+}
+
 #ifdef YOSYS_ENABLE_PYTHON
 static std::map<unsigned int, RTLIL::Wire*> all_wires;
 std::map<unsigned int, RTLIL::Wire*> *RTLIL::Wire::get_all_wires(void)
@@ -4337,11 +4359,25 @@ RTLIL::Memory::Memory()
 #endif
 }
 
+std::string RTLIL::Memory::to_rtlil_str() const
+{
+	std::ostringstream f;
+	RTLIL_BACKEND::dump_memory(f, "", this);
+	return f.str();
+}
+
 RTLIL::Process::Process() : module(nullptr)
 {
 	static unsigned int hashidx_count = 123456789;
 	hashidx_count = mkhash_xorshift(hashidx_count);
 	hashidx_ = hashidx_count;
+}
+
+std::string RTLIL::Process::to_rtlil_str() const
+{
+	std::ostringstream f;
+	RTLIL_BACKEND::dump_proc(f, "", this);
+	return f.str();
 }
 
 RTLIL::Cell::Cell() : module(nullptr)
@@ -4363,6 +4399,13 @@ RTLIL::Cell::~Cell()
 #ifdef YOSYS_ENABLE_PYTHON
 	RTLIL::Cell::get_all_cells()->erase(hashidx_);
 #endif
+}
+
+std::string RTLIL::Cell::to_rtlil_str() const
+{
+	std::ostringstream f;
+	RTLIL_BACKEND::dump_cell(f, "", this);
+	return f.str();
 }
 
 #ifdef YOSYS_ENABLE_PYTHON

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -2032,6 +2032,8 @@ struct RTLIL::Design
 	// partially selected or boxed modules have been ignored
 	std::vector<RTLIL::Module*> selected_unboxed_whole_modules_warn() const { return selected_modules(SELECT_WHOLE_WARN, SB_UNBOXED_WARN); }
 	static std::map<unsigned int, RTLIL::Design*> *get_all_designs(void);
+
+	std::string to_rtlil_str(bool only_selected = true) const;
 };
 
 struct RTLIL::Module : public RTLIL::NamedObject
@@ -2395,6 +2397,7 @@ public:
 	RTLIL::SigSpec OriginalTag     (RTLIL::IdString name, const std::string &tag, const RTLIL::SigSpec &sig_a, const std::string &src = "");
 	RTLIL::SigSpec FutureFF        (RTLIL::IdString name, const RTLIL::SigSpec &sig_e, const std::string &src = "");
 
+	std::string to_rtlil_str() const;
 #ifdef YOSYS_ENABLE_PYTHON
 	static std::map<unsigned int, RTLIL::Module*> *get_all_modules(void);
 #endif
@@ -2448,6 +2451,7 @@ public:
 		return zero_index + start_offset;
 	}
 
+	std::string to_rtlil_str() const;
 #ifdef YOSYS_ENABLE_PYTHON
 	static std::map<unsigned int, RTLIL::Wire*> *get_all_wires(void);
 #endif
@@ -2465,6 +2469,8 @@ struct RTLIL::Memory : public RTLIL::NamedObject
 	Memory();
 
 	int width, start_offset, size;
+
+	std::string to_rtlil_str() const;
 #ifdef YOSYS_ENABLE_PYTHON
 	~Memory();
 	static std::map<unsigned int, RTLIL::Memory*> *get_all_memorys(void);
@@ -2522,6 +2528,8 @@ public:
 
 	template<typename T> void rewrite_sigspecs(T &functor);
 	template<typename T> void rewrite_sigspecs2(T &functor);
+
+	std::string to_rtlil_str() const;
 
 #ifdef YOSYS_ENABLE_PYTHON
 	static std::map<unsigned int, RTLIL::Cell*> *get_all_cells(void);
@@ -2601,6 +2609,7 @@ public:
 	template<typename T> void rewrite_sigspecs(T &functor);
 	template<typename T> void rewrite_sigspecs2(T &functor);
 	RTLIL::Process *clone() const;
+	std::string to_rtlil_str() const;
 };
 
 

--- a/tests/unit/kernel/rtlilStringTest.cc
+++ b/tests/unit/kernel/rtlilStringTest.cc
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+
+#include "kernel/rtlil.h"
+#include "kernel/yosys.h"
+
+YOSYS_NAMESPACE_BEGIN
+
+namespace RTLIL {
+
+	TEST(RtlilStrTest, DesignToString) {
+		Design design;
+		Module *mod = design.addModule(ID(my_module));
+		mod->addWire(ID(my_wire), 1);
+
+		std::string design_str = design.to_rtlil_str();
+
+		EXPECT_NE(design_str.find("module \\my_module"), std::string::npos);
+		EXPECT_NE(design_str.find("end"), std::string::npos);
+	}
+
+	TEST(RtlilStrTest, ModuleToString) {
+		Design design;
+		Module *mod = design.addModule(ID(test_mod));
+		Wire *wire = mod->addWire(ID(clk), 1);
+		wire->port_input = true;
+
+		std::string mod_str = mod->to_rtlil_str();
+
+		EXPECT_NE(mod_str.find("module \\test_mod"), std::string::npos);
+		EXPECT_NE(mod_str.find("wire"), std::string::npos);
+		EXPECT_NE(mod_str.find("\\clk"), std::string::npos);
+		EXPECT_NE(mod_str.find("input"), std::string::npos);
+	}
+
+	TEST(RtlilStrTest, WireToString) {
+		Design design;
+		Module *mod = design.addModule(ID(m));
+		Wire *wire = mod->addWire(ID(data), 8);
+
+		std::string wire_str = wire->to_rtlil_str();
+
+		EXPECT_NE(wire_str.find("wire"), std::string::npos);
+		EXPECT_NE(wire_str.find("width 8"), std::string::npos);
+		EXPECT_NE(wire_str.find("\\data"), std::string::npos);
+	}
+
+	TEST(RtlilStrTest, CellToString) {
+		Design design;
+		Module *mod = design.addModule(ID(m));
+		Cell *cell = mod->addCell(ID(u1), ID(my_cell_type));
+
+		std::string cell_str = cell->to_rtlil_str();
+
+		EXPECT_NE(cell_str.find("cell"), std::string::npos);
+		EXPECT_NE(cell_str.find("\\my_cell_type"), std::string::npos);
+		EXPECT_NE(cell_str.find("\\u1"), std::string::npos);
+	}
+
+}
+
+YOSYS_NAMESPACE_END


### PR DESCRIPTION
This PR implements a fix for issue [#5597](https://github.com/YosysHQ/yosys/issues/5597)

Implemented `to_rtlil_str` methods for the `Design`, `Module`, `Wire`, `Memory`,  `Cell`, and `Process` objects. 