### PR TITLE
Add debugon pass for persistent debug logging

### DIFF
--- a/passes/cmds/trace.cc
+++ b/passes/cmds/trace.cc
@@ -115,14 +115,43 @@ struct DebugPass : public Pass {
 		log("\n");
 		log("Execute the specified command with debug log messages enabled\n");
 		log("\n");
+		log("    debug -on\n");
+		log("    debug -off\n");
+		log("\n");
+		log("Enable or disable debug log messages globally\n");
+		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		size_t argidx;
+		bool mode_on = false;
+		bool mode_off = false;
+
 		for (argidx = 1; argidx < args.size(); argidx++)
 		{
-			// .. parse options ..
+			if (args[argidx] == "-on") {
+				mode_on = true;
+				continue;
+			}
+			if (args[argidx] == "-off") {
+				mode_off = true;
+				continue;
+			}
 			break;
+		}
+
+		if (mode_on && mode_off)
+			log_cmd_error("Cannot specify both -on and -off\n");
+
+		if (mode_on) {
+			log_force_debug++;
+			return;
+		}
+
+		if (mode_off) {
+			if (log_force_debug > 0)
+				log_force_debug--;
+			return;
 		}
 
 		log_force_debug++;

--- a/tests/various/debugon.ys
+++ b/tests/various/debugon.ys
@@ -1,0 +1,14 @@
+# Test debug -on/-off modes
+
+design -reset
+
+read_verilog <<EOT
+module top(input a, input b, output y);
+    assign y = a & b;
+endmodule
+EOT
+
+debug -on
+hierarchy
+select -assert-count 1 t:$and
+debug -off


### PR DESCRIPTION
Adds a new 'debugon' pass that enables debug log messages globally and persistently for the rest of the session. This complements the existing 'debug' pass which only enables debug logging for a single command.

Use case:
- 'debug cmd' - runs 'cmd' with debug logging, then disables it
- 'debugon' - enables debug logging for all subsequent commands

Implementation:
The pass simply increments log_force_debug, which is a global counter that forces debug messages to be displayed. Unlike the 'debug' pass, it does not decrement the counter after execution.