### PR TITLE
Add -nocells flag to equiv_make and equiv_opt

### DIFF
--- a/passes/equiv/equiv_make.cc
+++ b/passes/equiv/equiv_make.cc
@@ -34,6 +34,7 @@ struct EquivMakeWorker
 	vector<string> blacklists;
 	vector<string> encfiles;
 	bool make_assert;
+	bool nocells;
 
 	pool<IdString> blacklist_names;
 	dict<IdString, dict<Const, Const>> encdata;
@@ -419,7 +420,8 @@ struct EquivMakeWorker
 		copy_to_equiv();
 		find_undriven_nets(false);
 		find_same_wires();
-		find_same_cells();
+		if (!nocells)
+			find_same_cells();
 		find_undriven_nets(true);
 	}
 };
@@ -450,6 +452,9 @@ struct EquivMakePass : public Pass {
 		log("        Check equivalence with $assert cells instead of $equiv.\n");
 		log("        $eqx (===) is used to compare signals.");
 		log("\n");
+		log("    -nocells\n");
+		log("        Do not check for equivalent cells, just wires.\n");
+		log("\n");
 		log("Note: The circuit created by this command is not a miter (with something like\n");
 		log("a trigger output), but instead uses $equiv cells to encode the equivalence\n");
 		log("checking problem. Use 'miter -equiv' if you want to create a miter circuit.\n");
@@ -461,6 +466,7 @@ struct EquivMakePass : public Pass {
 		worker.ct.setup(design);
 		worker.inames = false;
 		worker.make_assert = false;
+		worker.nocells = false;
 
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
@@ -479,6 +485,10 @@ struct EquivMakePass : public Pass {
 			}
 			if (args[argidx] == "-make_assert") {
 				worker.make_assert = true;
+				continue;
+			}
+			if (args[argidx] == "-nocells") {
+				worker.nocells = true;
 				continue;
 			}
 			break;

--- a/passes/equiv/equiv_opt.cc
+++ b/passes/equiv/equiv_opt.cc
@@ -60,6 +60,9 @@ struct EquivOptPass:public ScriptPass
 		log("    -undef\n");
 		log("        enable modelling of undef states during equiv_induct.\n");
 		log("\n");
+		log("    -nocells\n");
+		log("        Do not check for equivalent cells, just wires.\n");
+		log("\n");
 		log("    -nocheck\n");
 		log("        disable running check before and after the command under test.\n");
 		log("\n");
@@ -124,6 +127,10 @@ struct EquivOptPass:public ScriptPass
 			}
 			if (args[argidx] == "-async2sync") {
 				async2sync = true;
+				continue;
+			}
+			if (args[argidx] == "-nocells") {
+				make_opts += " -nocells";
 				continue;
 			}
 			break;

--- a/tests/various/equiv_nocells.ys
+++ b/tests/various/equiv_nocells.ys
@@ -1,0 +1,13 @@
+read_verilog <<EOT
+module gold(input a, input b, output y);
+    assign y = a & b;
+endmodule
+
+module gate(input a, input b, output y);
+    assign y = a & b;
+endmodule
+EOT
+
+equiv_make -nocells gold gate equiv
+equiv_simple equiv
+equiv_status -assert equiv


### PR DESCRIPTION
Passes like `opt_dff` and `dfflegalize` can change cell structure (parameters, types, or names) while preserving wire-level functionality. The `-nocells` flag allows equivalence checking to skip cell matching and verify only wire equivalence, which is more appropriate when cell structure is intentionally modified. 

The `-nocells` flag is added to both `equiv_make` and `equiv_opt` passes. When set, `equiv_make` skips the `find_same_cells()` call, checking only wire equivalence.

For testing, I added `tests/various/equiv_nocells.ys`. 