### PR TITLE
verific: add explicit System Verilog 2017 option

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -3114,10 +3114,11 @@ struct VerificPass : public Pass {
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
 #ifdef VERIFIC_SYSTEMVERILOG_SUPPORT
-		log("    verific {-vlog95|-vlog2k|-sv2005|-sv2009|-sv2012|-sv2017|-sv} <verilog-file>..\n");
+		log("    verific {-vlog95|-vlog2k|-sv2005|-sv2009|-sv2012|\n");
+		log("             -sv2017|-sv} <verilog-file>..\n");
 		log("\n");
 		log("Load the specified Verilog/SystemVerilog files into Verific.\n");
-		log("Note that -sv option will use parser for latest supported standard.\n");
+		log("Note that -sv option will use latest supported SystemVerilog standard.\n");
 		log("\n");
 		log("All files specified in one call to this command are one compilation unit.\n");
 		log("Files passed to different calls to this command are treated as belonging to\n");


### PR DESCRIPTION
Option "-sv2012" now properly set to SYSTEM_VERILOG_2012 and added option "-sv2017" to set to SYSTEM_VERILOG_2017

Option "-sv" will always use latest standard depending of current Verific support (when set to SYSTEM_VERILOG)