### PR TITLE
Don't update `used_signals` for retained wires in `rmunused_module_signals`.

### DIFF
--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -467,8 +467,6 @@ bool rmunused_module_signals(RTLIL::Module *module, bool purge_mode, bool verbos
 					wire->attributes.erase(ID::init);
 				else
 					wire->attributes.at(ID::init) = initval;
-				used_signals.add(new_conn.first);
-				used_signals.add(new_conn.second);
 				module->connect(new_conn);
 			}
 

--- a/tests/opt/opt_clean_standalone_wires.ys
+++ b/tests/opt/opt_clean_standalone_wires.ys
@@ -1,0 +1,10 @@
+read_rtlil << EOT
+module \test
+  wire \wire_a
+  wire \wire_f
+  connect \wire_f \wire_a
+end
+EOT
+
+opt_clean
+select -assert-count 0 */*


### PR DESCRIPTION
These updates should not be necessary. In fact, if they were necessary, this code would be buggy, because the results would depend on the order in which wires are traversed: If wire A is retained, which causes an update to `used_signals`, which then causes wire B to be retained when it otherwise wouldn't be, then we would get different results depending on whether A is visited before B.

These updates will also make it difficult to process these wires in parallel.