### PR TITLE
consteval: describe

### DIFF
--- a/kernel/consteval.h
+++ b/kernel/consteval.h
@@ -27,6 +27,10 @@
 
 YOSYS_NAMESPACE_BEGIN
 
+/**
+ * ConstEval provides on-demand constant propagation by traversing input cones
+ * with caching
+ */
 struct ConstEval
 {
 	RTLIL::Module *module;


### PR DESCRIPTION
Adds a single sentence comment describing the functionality: "ConstEval provides on-demand constant propagation by traversing input cones with caching"