### PR TITLE
Add verific -set interface for Yosys-Verific settings

### DIFF
--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -4495,10 +4495,6 @@ struct VerificPass : public Pass {
 
 		if (argidx < GetSize(args) && args[argidx] == "-set-reset")
 		{
-			if (!yosys_verific_settings_initialized) {
-				yosys_verific_settings.init();
-				yosys_verific_settings_initialized = true;
-			}
 			yosys_verific_settings.reset();
 			yosys_verific_settings.apply_all();
 			log("All Yosys-Verific settings reset to defaults.\n");
@@ -4507,11 +4503,6 @@ struct VerificPass : public Pass {
 
 		if (argidx < GetSize(args) && args[argidx] == "-set")
 		{
-			if (!yosys_verific_settings_initialized) {
-				yosys_verific_settings.init();
-				yosys_verific_settings_initialized = true;
-			}
-
 			// No arguments: list all settings
 			if (argidx+1 == GetSize(args)) {
 				log("Yosys-Verific settings:\n");

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -172,10 +172,6 @@ struct YosysVerificSettings {
 		}
 	}
 
-	bool has_option(const std::string &name) const {
-		return options.find(name) != options.end();
-	}
-
 	bool get_bool(const std::string &name) const {
 		auto it = options.find(name);
 		if (it == options.end() || it->second.type != Type::BOOL)
@@ -4546,7 +4542,7 @@ struct VerificPass : public Pass {
 			// One argument: show specific setting
 			if (argidx+2 == GetSize(args)) {
 				const std::string &name = args[argidx+1];
-				if (!yosys_verific_settings.has_option(name))
+				if (!yosys_verific_settings.options.count(name))
 					log_cmd_error("Unknown Yosys-Verific setting '%s'.\n", name.c_str());
 				const auto &opt = yosys_verific_settings.options.at(name);
 				switch (opt.type) {
@@ -4570,7 +4566,7 @@ struct VerificPass : public Pass {
 			if (argidx+3 == GetSize(args)) {
 				const std::string &name = args[argidx+1];
 				const std::string &value = args[argidx+2];
-				if (!yosys_verific_settings.has_option(name))
+				if (!yosys_verific_settings.options.count(name))
 					log_cmd_error("Unknown Yosys-Verific setting '%s'.\n", name.c_str());
 				auto &opt = yosys_verific_settings.options.at(name);
 				switch (opt.type) {


### PR DESCRIPTION
This PR introduces a verific -set command interface for managing Yosys-specific Verific options, similar to the existing verific -cfg for Verific runtime flags.

Implemented Features :
```
verific -set                    # List all settings with current/default values
verific -set <name>             # Show specific setting
verific -set <name> <value>     # Set a value
verific -set-reset              # Reset all to defaults
```
Usage Examples :
verific -set ignore_translate_off true
verific -set vlog_file_extensions ".v,.sv,.vh,.svh,.h,.inc"

ref: https://yosyshq.discourse.group/t/rfc-upstreaming-a-small-set-of-verific-frontend-options-from-silimate-fork/113