### PR TITLE
abc9: verify post-mapping equivalence by default

### DIFF
--- a/passes/techmap/abc9_exe.cc
+++ b/passes/techmap/abc9_exe.cc
@@ -248,7 +248,7 @@ void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe
 	}
 
 	abc9_script += stringf("; &ps -l; &write -n %s/output.aig", tempdir_name);
-	if (design->scratchpad_get_bool("abc9.verify")) {
+	if (design->scratchpad_get_bool("abc9.verify", true)) {
 		if (dff_mode)
 			abc9_script += "; &verify -s";
 		else


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
The medium-term plan is to use the equivalences found by `&verify` (more specifically `&verify -y`) to perform name recovery, akin to the `dress` command in ABC1 flows. I think it might be useful to gain some confidence in the stability of `&verify` (and perhaps catch some ABC9 bugs) by first simply running it by default; because it happens after the mapped result is written out, a potential crash should not stop the flow.

_Explain how this is achieved._
This option has been around since at least 9f3cb981d7c0767f40febf0b32e0a19c28d8e6a0 which makes it seven years old. Flip it on by default; we can chicken out of it with `scratchpad -set abc9.verify 0` before ABC9 runs.

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._
Because this is enabled by default, tests that run with ABC9 flows will call `&verify`. Hopefully that's sufficient.

Not part of the template, but because I think somebody will go googling, here are the `&verify` outputs I've encountered so far:

- `Networks are equivalent.`: this should be the normal output; ABC9 has proved it did not break the design.
- `Networks are NOT EQUIVALENT.`: if this is encountered, please report a bug; it needs to be minimised and sent upstream to ABC. When I encountered this, it was fixed by https://github.com/berkeley-abc/abc/commit/7f64516f23af558bc2a3e98756909d2fbbbdac20 - the issue may have cropped up again, or something else may be breaking.
- `Gia_ManMiter(): At least one of the designs has no registers.`: ABC9 has optimised out all the registers in the design so it can't equivalence-check it. This occurs in the test suite with a sequential [`-dff`] ABC9 flow with a flop that can't be mapped to an ABC9 boxff, but still calls `&verify -s`; I don't *think* it will occur in real-world designs.
- `Gia_ManMiter(): Designs have different number of CIs.`: ABC9 has optimised out a black-box cell connected to a top-level port, and gotten confused. This has been reported upstream; I am reasonably confident it won't occur in real-world designs either.

(This is marked as a draft because I'd like to discuss it a little before merging.)