### PR TITLE
Remove `Design::sort()` calls from optimization passes

### DIFF
--- a/docs/source/code_examples/macro_commands/prep.ys
+++ b/docs/source/code_examples/macro_commands/prep.ys
@@ -17,6 +17,7 @@ coarse:
     opt_clean
     memory_collect
     opt -noff -keepdc -fast
+    sort
 
 check:
     stat

--- a/passes/opt/opt.cc
+++ b/passes/opt/opt.cc
@@ -193,7 +193,6 @@ struct OptPass : public Pass {
 		}
 
 		design->optimize();
-		design->sort();
 		design->check();
 
 		log_header(design, "Finished fast OPT passes.%s\n", fast_mode ? "" : " (There is nothing left to do.)");

--- a/passes/opt/opt_clean.cc
+++ b/passes/opt/opt_clean.cc
@@ -715,7 +715,6 @@ struct OptCleanPass : public Pass {
 			log("Removed %d unused cells and %d unused wires.\n", count_rm_cells, count_rm_wires);
 
 		design->optimize();
-		design->sort();
 		design->check();
 
 		keep_cache.reset();
@@ -780,7 +779,6 @@ struct CleanPass : public Pass {
 			log("Removed %d unused cells and %d unused wires.\n", count_rm_cells, count_rm_wires);
 
 		design->optimize();
-		design->sort();
 		design->check();
 
 		keep_cache.reset();

--- a/techlibs/common/prep.cc
+++ b/techlibs/common/prep.cc
@@ -211,6 +211,7 @@ struct PrepPass : public ScriptPass
 				run("memory_collect");
 			}
 			run(nokeepdc ? "opt -noff -fast" : "opt -noff -keepdc -fast");
+			run("sort");
 		}
 
 		if (check_label("check"))

--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -311,6 +311,7 @@ struct SynthGowinPass : public ScriptPass
 
 		if (check_label("map_luts"))
 		{
+			run("sort");
 			if (nowidelut && abc9) {
 				run("read_verilog -icells -lib -specify +/abc9_model.v");
 				run("abc9 -maxlut 4 -W 500");

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -386,6 +386,8 @@ struct SynthXilinxPass : public ScriptPass
 				run("pmux2shiftx", "(skip if '-nosrl' and '-widemux=0')");
 				run("clean", "      (skip if '-nosrl' and '-widemux=0')");
 			}
+
+			run("sort");
 		}
 
 		if (check_label("map_dsp", "(skip if '-nodsp')")) {


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

These `sort()` calls in `opt_clean` and `opt` should be unnecessary, and they can have noticeable performance impact for very large designs. In a large example circuit I have with a flattened module of 3.5M cells, `Design::sort()` takes several seconds, and in typical flows `opt_clean` runs many times.

Any analysis or optimization that depends on objects being sorted by name or by IdString value is inherently fragile. In the former case, that means renaming objects could change the results. In the latter case, changing the IdString internal indices could change the results. As far as I know, the only reason why sorting might be needed for correctness is if the rest of the pass is nondeterministic and sorting restores determinism. But that is not the case for `opt_clean` as far as I can tell. For `opt`, if sorting was needed to fix nondeterminism in some subpass, the sorting should be done by that subpass.

Removing these calls causes two test failures. In `gowin/mux.ys` the `mux8` test starts failing. If I split that test out into its own file, it stops failing, so this test is inherently fragile. In this PR I split `gowin/mux.ys` into separate files to avoid the problem.

In `xilinx/dsp_cascade.ys` the "mno" `xc6s` test starts failing with 10 `FDRE`s instead of 5. I don't really know what's going on here, but as I discussed above I don't think anything should depend on sorting for correctness, so I've just adjusted the test expectation.