### PR TITLE
VCD Writer Bug Fix

### DIFF
--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -2329,7 +2329,7 @@ struct VCDWriter : public OutputWriter
 		}
 
 		if (!worker->timescale.empty())
-			vcdfile << stringf("$timescale %s $end\n", worker->timescale);
+			vcdfile << stringf("$timescale 1%s $end\n", worker->timescale);
 
 		worker->top->write_output_header(
 			[this](IdString name) { vcdfile << stringf("$scope module %s $end\n", log_id(name)); },


### PR DESCRIPTION
The VCD writer does not follow the IEEE format for VCD files for the time_number for $timescale

To do this, it is very simple, just add a "1" to conform to the standard. This is okay since the number can be a 1|10|100

Please reference IEEE 1800-2017 page 657 as evidence for this bug.