### PR TITLE
Avoid scanning entire module in `Module::remove()` if there are no wires to remove

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -2990,6 +2990,8 @@ void RTLIL::Module::add(RTLIL::Binding *binding)
 void RTLIL::Module::remove(const pool<RTLIL::Wire*> &wires)
 {
 	log_assert(refcount_wires_ == 0);
+	if (wires.empty())
+		return;
 
 	struct DeleteWireWorker
 	{


### PR DESCRIPTION
It's pretty common for `opt_clean` to find no wires to remove. In that case, there is no point scanning the entire design, which can be significantly expensive for huge designs.