### PR TITLE
Add unistd header for Linux

### DIFF
--- a/passes/cmds/linux_perf.cc
+++ b/passes/cmds/linux_perf.cc
@@ -23,12 +23,12 @@
 
 #include <fcntl.h>
 #include <stdlib.h>
-#include <unistd.h>
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
 #ifdef __linux__
+#include <unistd.h>
 struct LinuxPerf : public Pass {
 	LinuxPerf() : Pass("linux_perf", "turn linux perf recording off or on") {
 		internal();


### PR DESCRIPTION
Add unistd.h include for linux_perf to ensure "read", "write", "close" are properly declared on Linux. Those functions are declared indirectly via other headers but adding it avoids stuff like build errors / warnings from stricter tools. 