### PR TITLE
opt_expr: fix const lhs of $pow to $shl

### DIFF
--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -1667,7 +1667,11 @@ skip_identity:
 			int bit_idx;
 			const auto onehot = sig_a.is_onehot(&bit_idx);
 
-			if (onehot) {
+			// Power of two
+			// A is unsigned or positive
+			if (onehot && (!cell->parameters[ID::A_SIGNED].as_bool() || bit_idx < sig_a.size() - 1)) {
+				cell->parameters[ID::A_SIGNED] = 0;
+				// 2^B = 1<<B
 				if (bit_idx == 1) {
 					log_debug("Replacing pow cell `%s' in module `%s' with left-shift\n",
 							cell->name.c_str(), module->name.c_str());
@@ -1679,7 +1683,6 @@ skip_identity:
 					log_debug("Replacing pow cell `%s' in module `%s' with multiply and left-shift\n",
 							cell->name.c_str(), module->name.c_str());
 					cell->type = ID($mul);
-					cell->parameters[ID::A_SIGNED] = 0;
 					cell->setPort(ID::A, Const(bit_idx, cell->parameters[ID::A_WIDTH].as_int()));
 
 					SigSpec y_wire = module->addWire(NEW_ID, y_size);

--- a/tests/opt/opt_expr.ys
+++ b/tests/opt/opt_expr.ys
@@ -319,3 +319,59 @@ check
 equiv_opt -assert opt_expr -keepdc
 design -load postopt
 select -assert-count 1 t:$mul r:A_WIDTH=4 %i r:B_WIDTH=4 %i r:Y_WIDTH=8 %i
+
+###########
+
+design -reset
+read_rtlil <<EOF
+module \top
+  wire width 3 input 2 \binary
+
+  wire width 32 output 3 \y
+
+  cell $pow $0
+    parameter \A_WIDTH 32
+    parameter \B_WIDTH 3
+    parameter \A_SIGNED 1
+    parameter \B_SIGNED 0
+    parameter \Y_WIDTH 32
+    connect \A 2
+    connect \B \binary
+    connect \Y \y
+  end
+end
+EOF
+
+scratchpad -set opt.did_something false
+opt_expr
+scratchpad -assert opt.did_something true
+sat -verify -set binary 0 -prove y 1
+sat -verify -set binary 1 -prove y 2
+sat -verify -set binary 2 -prove y 4
+sat -verify -set binary 3 -prove y 8
+
+###########
+
+design -reset
+read_rtlil <<EOF
+module \top
+  wire width 3 input 2 \binary
+
+  wire width 32 output 3 \y
+
+  cell $pow $0
+    parameter \A_WIDTH 2
+    parameter \B_WIDTH 3
+    parameter \A_SIGNED 1
+    parameter \B_SIGNED 0
+    parameter \Y_WIDTH 32
+    connect \A 2'10
+    connect \B \binary
+    connect \Y \y
+  end
+end
+EOF
+
+scratchpad -set opt.did_something false
+opt_expr
+scratchpad -assert opt.did_something false


### PR DESCRIPTION
Set A input signedness to unsigned in $pow -> $shl rewrite in opt_expr, even if it's a single-bit $pow. Fixes #5661. Can't prove correct with equiv since `$pow` isn't modeled with `SatGen` for computational complexity reasons, but the meaning of the change seems pretty self-evident. It's not too surprising that `$pow` cells would be mishandled due to how rarely exponentiation operators get used in real designs