### PR TITLE
Turn conflicting init values into a warning instead of a fatal error

### DIFF
--- a/kernel/ffinit.h
+++ b/kernel/ffinit.h
@@ -52,7 +52,7 @@ struct FfInitVals
 
 				if (initbits.count(bit)) {
 					if (initbits.at(bit).first != val)
-						log_error("Conflicting init values for signal %s (%s = %s != %s).\n",
+						log_warning("Conflicting init values for signal %s (%s = %s != %s).\n",
 								log_signal(bit), log_signal(SigBit(wire, i)),
 								log_signal(val), log_signal(initbits.at(bit).first));
 					continue;


### PR DESCRIPTION
Fuzzing can generate test cases that trigger this.

An alternative approach would be to have some kind of global flag that we set while fuzzing to turn errors like this into warnings. That's a little more complicated. Let me know whether that is preferred.