### PR TITLE
abc9: remove -liberty

### DIFF
--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -219,8 +219,7 @@ struct Abc9Pass : public ScriptPass
 		for (argidx = 1; argidx < args.size(); argidx++) {
 			std::string arg = args[argidx];
 			if ((arg == "-exe" || arg == "-script" || arg == "-D" ||
-						arg == "-lut" || arg == "-luts" ||
-						arg == "-W" || arg == "-dont_use") &&
+						arg == "-lut" || arg == "-luts" || arg == "-W") &&
 					argidx+1 < args.size()) {
 				if (arg == "-lut" || arg == "-luts")
 					lut_mode = true;


### PR DESCRIPTION
There was an internal ticket for this, it is a bit misleading to just pass it on if our `abc9` command isn't set up to make use of Liberty files. The change does make `abc9 -liberty foo` error out. Should `-genlib` stay or go as well?