### PR TITLE
Fix segfault from shift with 0-width signed arg.

### DIFF
--- a/kernel/calc.cc
+++ b/kernel/calc.cc
@@ -291,7 +291,7 @@ static RTLIL::Const const_shift_worker(const RTLIL::Const &arg1, const RTLIL::Co
 		if (pos < 0)
 			result.set(i, vacant_bits);
 		else if (pos >= BigInteger(GetSize(arg1)))
-			result.set(i, sign_ext ? arg1.back() : vacant_bits);
+			result.set(i, sign_ext && !arg1.empty() ? arg1.back() : vacant_bits);
 		else
 			result.set(i, arg1[pos.toInt()]);
 	}

--- a/tests/various/const_shift_empty_arg.ys
+++ b/tests/various/const_shift_empty_arg.ys
@@ -1,0 +1,49 @@
+# Regression test for #5684: const_shift_worker must not crash when arg1 is
+# empty.
+
+read_json << EOF
+{
+    "modules": {
+        "sshl": {
+            "cells": {
+                "sshlCell": {
+                    "connections": {
+                        "A": [],
+                        "B": [3],
+                        "Y": [1]
+                    },
+                    "parameters": {
+                        "A_SIGNED": "1",
+                        "A_WIDTH": "0",
+                        "B_SIGNED": "0",
+                        "B_WIDTH": "1",
+                        "Y_WIDTH": "1"
+                    },
+                    "port_directions": {
+                        "A": "input",
+                        "B": "input",
+                        "Y": "output"
+                    },
+                    "type": "$sshl"
+                }
+            },
+            "ports": {
+                "A": {
+                    "bits": [],
+                    "direction": "input"
+                },
+                "B": {
+                    "bits": [3],
+                    "direction": "input"
+                },
+                "Y": {
+                    "bits": [1],
+                    "direction": "output"
+                }
+            }
+        }
+    }
+}
+EOF
+
+eval -set B 0 -show Y sshl


### PR DESCRIPTION
This is just a minor issue I ran into while attempting to use the `eval` command to explore various edge cases for the semantics of the internal cell types.

Fixes #5684.