### PR TITLE
modtools, wreduce: check_db sanity check

### DIFF
--- a/kernel/modtools.h
+++ b/kernel/modtools.h
@@ -297,6 +297,13 @@ struct ModIndex : public RTLIL::Monitor
 		return info->ports;
 	}
 
+	void check_db()
+	{
+		for (auto &it : database) {
+			log_assert(database.find(it.first) != database.end());
+		}
+	}
+
 	void dump_db()
 	{
 		log("--- ModIndex Dump ---\n");

--- a/passes/opt/wreduce.cc
+++ b/passes/opt/wreduce.cc
@@ -489,6 +489,7 @@ struct WreduceWorker
 		for (auto w : module->wires())
 			complete_wires.insert(mi.sigmap(w));
 
+		mi.dump_db();
 		for (auto w : module->selected_wires())
 		{
 			int unused_top_bits = 0;
@@ -496,6 +497,8 @@ struct WreduceWorker
 			if (w->port_id > 0 || count_nontrivial_wire_attrs(w) > 0)
 				continue;
 
+			log_debug("wire %s\n", w->name);
+			mi.check_db();
 			for (int i = GetSize(w)-1; i >= 0; i--) {
 				SigBit bit(w, i);
 				auto info = mi.query(bit);


### PR DESCRIPTION
Exposes #5690 `ModIndex` database insanity. Some tests fail this assert, which seems alarming