### PR TITLE
modtools: fix database sanity

### DIFF
--- a/kernel/modtools.h
+++ b/kernel/modtools.h
@@ -151,11 +151,11 @@ struct ModIndex : public RTLIL::Monitor
 		}
 	}
 
-	void check()
+	bool ok()
 	{
 #ifndef NDEBUG
 		if (auto_reload_module)
-			return;
+			return true;
 
 		for (auto it : database)
 			log_assert(it.first == sigmap(it.first));
@@ -175,9 +175,15 @@ struct ModIndex : public RTLIL::Monitor
 				else if (!(it.second == database_bak.at(it.first)))
 					log("ModuleIndex::check(): Different content for database[%s].\n", log_signal(it.first));
 
-			log_assert(database == database_bak);
+			return false;
 		}
+		return true;
 #endif
+	}
+
+	void check()
+	{
+		log_assert(ok());
 	}
 
 	void notify_connect(RTLIL::Cell *cell, RTLIL::IdString port, const RTLIL::SigSpec &old_sig, const RTLIL::SigSpec &sig) override

--- a/tests/unit/kernel/modindexTest.cc
+++ b/tests/unit/kernel/modindexTest.cc
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+
+#include "kernel/modtools.h"
+#include "kernel/rtlil.h"
+
+YOSYS_NAMESPACE_BEGIN
+
+TEST(ModIndexSwapTest, has)
+{
+    Design* d = new Design;
+    Module* m = d->addModule("$m");
+    Wire* o = m->addWire("$o", 2);
+    o->port_input = true;
+    Wire* i = m->addWire("$i", 2);
+    i->port_input = true;
+    m->fixup_ports();
+    m->addNot("$not", i, o);
+    auto mi = ModIndex(m);
+    mi.reload_module();
+    for (auto [sb, info] : mi.database) {
+        EXPECT_TRUE(mi.database.find(sb) != mi.database.end());
+    }
+    m->swap_names(i, o);
+    for (auto [sb, info] : mi.database) {
+        EXPECT_TRUE(mi.database.find(sb) != mi.database.end());
+    }
+}
+
+TEST(ModIndexDeleteTest, has)
+{
+    if (log_files.empty()) log_files.emplace_back(stdout);
+    Design* d = new Design;
+    Module* m = d->addModule("$m");
+    Wire* w = m->addWire("$w");
+    Wire* o = m->addWire("$o");
+    o->port_output = true;
+    m->fixup_ports();
+    Cell* not_ = m->addNotGate("$not", w, o);
+    auto mi = ModIndex(m);
+    mi.reload_module();
+    mi.dump_db();
+    Wire* a = m->addWire("\\a");
+    not_->setPort(ID::A, a);
+    EXPECT_TRUE(mi.ok());
+}
+
+YOSYS_NAMESPACE_END


### PR DESCRIPTION
Fixes #5690. Erasing the sigbit entry entirely if no data about sigbit is required for the check to pass (for the index to track the current design as-is). Using pointer ordering for sigbits in `ModIndex` is required if swap_names is supposed to be legal while holding a `ModIndex`, otherwise `std::map` will fail to find out-of-order entries even though it can iterate over them. Both are covered with unit tests that fail on main