### PR TITLE
modtools: replace std::map with std::unordered_map for ModIndex::database

### DIFF
--- a/kernel/modtools.h
+++ b/kernel/modtools.h
@@ -78,6 +78,8 @@ struct ModIndex : public RTLIL::Monitor
 
 	SigMap sigmap;
 private:
+	friend class ModIndexTest;
+	FRIEND_TEST(ModIndexTest, swap);
 	struct sigbit_pointer_hash
 	{
 		std::size_t operator()(const Yosys::RTLIL::SigBit& s) const noexcept

--- a/tests/unit/kernel/modindexTest.cc
+++ b/tests/unit/kernel/modindexTest.cc
@@ -5,7 +5,7 @@
 
 YOSYS_NAMESPACE_BEGIN
 
-TEST(ModIndexSwapTest, has)
+TEST(ModIndexTest, swap)
 {
     Design* d = new Design;
     Module* m = d->addModule("$m");
@@ -26,7 +26,7 @@ TEST(ModIndexSwapTest, has)
     }
 }
 
-TEST(ModIndexDeleteTest, has)
+TEST(ModIndexTest, modify)
 {
     if (log_files.empty()) log_files.emplace_back(stdout);
     Design* d = new Design;


### PR DESCRIPTION
I don't think I'll be working on this further, and I don't think anybody else should pay much attention to it. I'm recording it in case I want to refer to it later. This was just something I noticed while making sure ModIndex really is correct now that it orders based on `Wire*` pointer values since #5692

The motivation for the change is logical consistency  - if iteration order doesn't matter, one should use `std::unordered_map` rather than `std::map`. You'd think this would be performance positive, but I'm seeing a fairly consistent miniscule worsening of both runtime and memory. At least we know that here as well using `hashlib::dict` would be even worse though.

```
Benchmark 1: ./uut/main-lto/bin/yosys -dp "read_verilog tests/functional/picorv32.v; synth -noabc"
  Time (mean ± σ):      1.931 s ±  0.008 s    [User: 1.954 s, System: 0.043 s]
  Range (min … max):    1.917 s …  1.950 s    30 runs

Benchmark 2: ./uut/modindex-std-reserve-lto/bin/yosys -dp "read_verilog tests/functional/picorv32.v; synth -noabc"
  Time (mean ± σ):      1.942 s ±  0.010 s    [User: 1.958 s, System: 0.049 s]
  Range (min … max):    1.925 s …  1.959 s    30 runs
```
```
Benchmark 1: ./uut/main-lto/bin/yosys -dp "read_verilog tests/functional/picorv32.v; synth -noabc"
  Time (mean ± σ):      1.931 s ±  0.010 s    [User: 1.954 s, System: 0.042 s]
  Range (min … max):    1.917 s …  1.960 s    30 runs

Benchmark 2: ./uut/modindex-pool-lto/bin/yosys -dp "read_verilog tests/functional/picorv32.v; synth -noabc"
  Time (mean ± σ):      1.948 s ±  0.023 s    [User: 1.966 s, System: 0.047 s]
  Range (min … max):    1.923 s …  2.056 s    30 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
```
