### PR TITLE
tribuf: -nested option: traverse muxes to find nested tribufs

### DIFF
--- a/tests/techmap/tribuf.ys
+++ b/tests/techmap/tribuf.ys
@@ -1,0 +1,15 @@
+read_verilog << EOT
+module tribuf_nested_simple(input [3:0] in1, input [3:0] in2, input [3:0] in3, input sel1, input sel2, input sel3, output [3:0] out1);
+  assign out1 = (sel1) ? in1 : ((sel2) ? in2 : 4'bzzzz);
+  assign out1 = (sel3) ? in3 : 4'bzzzz;
+endmodule
+
+EOT
+
+opt_clean
+tribuf -merge -nested
+
+# -assert ensures that we won't have
+# multiple drivers (as the first mux is recognized correctly).
+check -assert
+


### PR DESCRIPTION
Judging by how current `tribuf`-pass works, only muxes having the "direct" Z-operand are marked as `$tribuf` cells, while in more complex cases Z-operand muxes are used in other muxes, with latter being the "true" tristate cells:
```verilog
module top(input [3:0] in1, input [3:0] in2, input [3:0] in3, input sel1, input sel2, input sel3, output [3:0] out1);
  assign out1 = (sel1) ? in1 : ((sel2) ? in2 : 4'bzzzz);
  assign out1 = (sel3) ? in3 : 4'bzzzz;
endmodule
```
In the example above current `tribuf` pass does not recognize the first mux as a tristate cell.

This Pull Request introduces an option `-nested`, which traverses muxes in a recursive fashion trying to find the first Z-operand (specifically, the `$tribuf` cell, leading to Z-operand). If found, we construct a logical expression - a conjuntion of all traversed selectors' expressions - to form a condition which "leads" us to the Z-operand, then reverse it. The resulting condition is used as a selector in a newly created `$tribuf` cell. In the example above the expression would be `~((~sel) && (~sel2))`.

To put it simply, we "put forward" the Z-operand to create a "top-level" `$tribuf` cell to be picked by `-merge`-like options later.

The idea to put this functionality into a separate option rather than being used by default stems from the expansive muxes traversal needing to be done, which in most cases might impact the performance quite a lot.