### PR TITLE
CI: add support for merge queue

### DIFF
--- a/.github/workflows/extra-builds.yml
+++ b/.github/workflows/extra-builds.yml
@@ -1,23 +1,20 @@
 name: Test extra build flows
 
 on:
-  # always test main
-  push:
-    branches:
-      - main
-  merge_group:
-  # test PRs
   pull_request:
-  # allow triggering tests, ignores skip check
+  merge_group:
+  #push:
+  #  branches: [ main ]
   workflow_dispatch:
 
 jobs:
   pre_job:
     runs-on: ubuntu-latest
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_skip: ${{ steps.set_output.outputs.should_skip }}
     steps:
       - id: skip_check
+        if: ${{ github.event_name != 'merge_group' }}
         uses: fkirc/skip-duplicate-actions@v5
         with:
           # don't run on documentation changes
@@ -26,11 +23,19 @@ jobs:
           # but never cancel main
           cancel_others: ${{ github.ref != 'refs/heads/main' }}
 
+      - id: set_output
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "should_skip=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_skip=${{ steps.skip_check.outputs.should_skip }}" >> $GITHUB_OUTPUT
+          fi
+
   vs-prep:
     name: Prepare Visual Studio build
     runs-on: ubuntu-latest
     needs: [pre_job]
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -48,7 +53,7 @@ jobs:
     name: Visual Studio build
     runs-on: windows-latest
     needs: [vs-prep, pre_job]
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -65,7 +70,7 @@ jobs:
   wasi-build:
     name: WASI build
     needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -111,7 +116,7 @@ jobs:
   nix-build:
     name: "Build nix flake"
     needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -126,3 +131,13 @@ jobs:
         with:
           install_url: https://releases.nixos.org/nix/nix-2.30.0/install
       - run: nix build .?submodules=1 -L
+
+  extra-builds-result:
+    runs-on: ubuntu-latest
+    needs:
+      - vs-build
+      - wasi-build
+      - nix-build
+    if: always() && !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled')
+    steps:
+      - run: echo "All good"

--- a/.github/workflows/prepare-docs.yml
+++ b/.github/workflows/prepare-docs.yml
@@ -1,17 +1,24 @@
 name: Build docs artifact with Verific
 
-on: [push, pull_request, merge_group]
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: [ main, "docs-preview/**", "docs-preview*" ]
+    tags: [ "*" ]
+  workflow_dispatch:
 
 jobs:
   check_docs_rebuild:
     runs-on: ubuntu-latest
     outputs:
-      skip_check: ${{ steps.skip_check.outputs.should_skip }}
+      should_skip: ${{ steps.set_output.outputs.should_skip }}
       docs_export: ${{ steps.docs_var.outputs.docs_export }}
     env:
       docs_export: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/docs-preview') || startsWith(github.ref, 'refs/tags/') }}
     steps:
       - id: skip_check
+        if: ${{ github.event_name != 'merge_group' }}
         uses: fkirc/skip-duplicate-actions@v5
         with:
           paths_ignore: '["**/README.md"]'
@@ -22,11 +29,19 @@ jobs:
       - id: docs_var
         run: echo "docs_export=${docs_export}" >> $GITHUB_OUTPUT
 
+      - id: set_output
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "should_skip=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_skip=${{ steps.skip_check.outputs.should_skip }}" >> $GITHUB_OUTPUT
+          fi
+
   prepare-docs:
     # docs builds are needed for anything on main, any tagged versions, and any tag
     # or branch starting with docs-preview
     needs: check_docs_rebuild
-    if: ${{ needs.check_docs_rebuild.outputs.should_skip != 'true' && github.repository == 'YosysHQ/Yosys' }}
+    if: ${{ needs.check_docs_rebuild.outputs.should_skip != 'true' && github.repository_owner == 'YosysHQ' }}
     runs-on: [self-hosted, linux, x64, fast]
     steps:
       - name: Checkout Yosys
@@ -75,7 +90,7 @@ jobs:
           make -C docs html -j$procs TARGETS= EXTRA_TARGETS=
 
       - name: Trigger RTDs build
-        if: ${{ needs.check_docs_rebuild.outputs.docs_export == 'true' }}
+        if: ${{ needs.check_docs_rebuild.outputs.docs_export == 'true' && github.repository == 'YosysHQ/Yosys' }}
         uses: dfm/rtds-action@v1.1.0
         with:
           webhook_url: ${{ secrets.RTDS_WEBHOOK_URL }}

--- a/.github/workflows/source-vendor.yml
+++ b/.github/workflows/source-vendor.yml
@@ -1,6 +1,11 @@
 name: Create source archive with vendored dependencies
 
-on: [push, workflow_dispatch]
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   vendor-sources:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,23 +1,20 @@
 name: Build and run tests
 
 on:
-  # always test main
-  push:
-    branches:
-      - main
-  merge_group:
-  # test PRs
   pull_request:
-  # allow triggering tests, ignores skip check
+  merge_group:
+  #push:
+  #  branches: [ main ]
   workflow_dispatch:
 
 jobs:
   pre_job:
     runs-on: ubuntu-latest
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_skip: ${{ steps.set_output.outputs.should_skip }}
     steps:
       - id: skip_check
+        if: ${{ github.event_name != 'merge_group' }}
         uses: fkirc/skip-duplicate-actions@v5
         with:
           # don't run on documentation changes
@@ -26,12 +23,21 @@ jobs:
           # but never cancel main
           cancel_others: ${{ github.ref != 'refs/heads/main' }}
 
+      - id: set_output
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "should_skip=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_skip=${{ steps.skip_check.outputs.should_skip }}" >> $GITHUB_OUTPUT
+          fi
+
   pre_docs_job:
     runs-on: ubuntu-latest
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_skip: ${{ steps.set_output.outputs.should_skip }}
     steps:
       - id: skip_check
+        if: ${{ github.event_name != 'merge_group' }}
         uses: fkirc/skip-duplicate-actions@v5
         with:
           # don't run on readme changes
@@ -39,6 +45,14 @@ jobs:
           # cancel previous builds if a new commit is pushed
           # but never cancel main
           cancel_others: ${{ github.ref != 'refs/heads/main' }}
+
+      - id: set_output
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "should_skip=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_skip=${{ steps.skip_check.outputs.should_skip }}" >> $GITHUB_OUTPUT
+          fi
 
   build-yosys:
     name: Reusable build
@@ -226,7 +240,7 @@ jobs:
     name: Try build docs
     runs-on: [self-hosted, linux, x64, fast]
     needs: [pre_docs_job]
-    if: ${{ needs.pre_docs_job.outputs.should_skip != 'true' && github.repository == 'YosysHQ/Yosys' }}
+    if: ${{ needs.pre_docs_job.outputs.should_skip != 'true' && github.repository_owner == 'YosysHQ' }}
     strategy:
       matrix:
         docs-target: [html, latexpdf]
@@ -265,3 +279,14 @@ jobs:
           name: docs-build-${{ matrix.docs-target }}
           path: docs/build/
           retention-days: 7
+
+  test-build-result:
+    runs-on: ubuntu-latest
+    needs:
+      - test-yosys
+      - test-cells
+      - test-docs
+      - test-docs-build
+    if: always() && !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled')
+    steps:
+      - run: echo "All good"

--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -1,23 +1,20 @@
 name: Compiler testing
 
 on:
-  # always test main
-  push:
-    branches:
-      - main
-  merge_group:
-  # test PRs
   pull_request:
-  # allow triggering tests, ignores skip check
+  merge_group:
+  #push:
+  #  branches: [ main ]
   workflow_dispatch:
 
 jobs:
   pre_job:
     runs-on: ubuntu-latest
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_skip: ${{ steps.set_output.outputs.should_skip }}
     steps:
       - id: skip_check
+        if: ${{ github.event_name != 'merge_group' }}
         uses: fkirc/skip-duplicate-actions@v5
         with:
           # don't run on documentation changes
@@ -26,10 +23,18 @@ jobs:
           # but never cancel main
           cancel_others: ${{ github.ref != 'refs/heads/main' }}
 
+      - id: set_output
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "should_skip=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_skip=${{ steps.skip_check.outputs.should_skip }}" >> $GITHUB_OUTPUT
+          fi
+
   test-compile:
     runs-on: ${{ matrix.os }}
     needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
     env:
       CXXFLAGS: ${{ startsWith(matrix.compiler, 'gcc') && '-Wp,-D_GLIBCXX_ASSERTIONS' || ''}}
       CC_SHORT: ${{ startsWith(matrix.compiler, 'gcc') && 'gcc' || 'clang' }}
@@ -90,3 +95,11 @@ jobs:
         run: |
           make config-$CC_SHORT
           make -j$procs CXXSTD=c++20 compile-only
+
+  test-compile-result:
+    runs-on: ubuntu-latest
+    needs:
+      - test-compile
+    if: always() && !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled')
+    steps:
+      - run: echo "All good"

--- a/.github/workflows/test-sanitizers.yml
+++ b/.github/workflows/test-sanitizers.yml
@@ -1,32 +1,41 @@
 name: Check clang sanitizers
 
 on:
-  # always test main
-  push:
-    branches:
-      - main
+  pull_request:
   merge_group:
-  # ignore PRs due to time needed
-  # allow triggering tests, ignores skip check
+  #push:
+  #  branches: [ main ]
   workflow_dispatch:
 
 jobs:
   pre_job:
     runs-on: ubuntu-latest
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_skip: ${{ steps.set_output.outputs.should_skip }}
     steps:
       - id: skip_check
+        if: ${{ github.event_name != 'merge_group' }}
         uses: fkirc/skip-duplicate-actions@v5
         with:
           # don't run on documentation changes
           paths_ignore: '["**/README.md", "docs/**", "guidelines/**"]'
+          # cancel previous builds if a new commit is pushed
+          # but never cancel main
+          cancel_others: ${{ github.ref != 'refs/heads/main' }}
+
+      - id: set_output
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "should_skip=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_skip=${{ steps.skip_check.outputs.should_skip }}" >> $GITHUB_OUTPUT
+          fi
 
   run_san:
     name: Build and run tests
     runs-on: ${{ matrix.os }}
     needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
     env:
       CC: clang
       ASAN_OPTIONS: halt_on_error=1
@@ -73,3 +82,10 @@ jobs:
         run: |
           find tests/**/*.err -print -exec cat {} \;
 
+  test-sanitizers-result:
+    runs-on: ubuntu-latest
+    needs:
+      - run_san
+    if: always() && !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled')
+    steps:
+      - run: echo "All good"

--- a/.github/workflows/test-verific.yml
+++ b/.github/workflows/test-verific.yml
@@ -1,23 +1,20 @@
 name: Build and run tests with Verific (Linux)
 
 on:
-  # always test main
-  push:
-    branches:
-      - main
-  merge_group:
-  # test PRs
   pull_request:
-  # allow triggering tests, ignores skip check
+  merge_group:
+  #push:
+  #  branches: [ main ]
   workflow_dispatch:
 
 jobs:
-  pre-job:
+  pre_job:
     runs-on: ubuntu-latest
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_skip: ${{ steps.set_output.outputs.should_skip }}
     steps:
       - id: skip_check
+        if: ${{ github.event_name != 'merge_group' }}
         uses: fkirc/skip-duplicate-actions@v5
         with:
           # don't run on documentation changes
@@ -26,9 +23,17 @@ jobs:
           # but never cancel main
           cancel_others: ${{ github.ref != 'refs/heads/main' }}
 
+      - id: set_output
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "should_skip=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_skip=${{ steps.skip_check.outputs.should_skip }}" >> $GITHUB_OUTPUT
+          fi
+
   test-verific:
-    needs: pre-job
-    if: ${{ needs.pre-job.outputs.should_skip != 'true' && github.repository == 'YosysHQ/Yosys' }}
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' && github.repository_owner == 'YosysHQ' }}
     runs-on: [self-hosted, linux, x64, fast]
     steps:
       - name: Checkout Yosys
@@ -76,13 +81,13 @@ jobs:
           cd tests/svtypes && bash run-test.sh
 
       - name: Run SBY tests
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' }}
         run: |
           make -C sby run_ci
 
   test-pyosys:
-    needs: pre-job
-    if: ${{ needs.pre-job.outputs.should_skip != 'true' && github.repository == 'YosysHQ/Yosys' }}
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' && github.repository_owner == 'YosysHQ' }}
     runs-on: [self-hosted, linux, x64, fast]
     steps:
       - name: Checkout Yosys
@@ -118,3 +123,12 @@ jobs:
         run: |
           export PYTHONPATH=${GITHUB_WORKSPACE}/.local/usr/lib/python3/site-packages:$PYTHONPATH
           python3 tests/pyosys/run_tests.py
+
+  test-verific-result:
+    runs-on: ubuntu-latest
+    needs:
+      - test-verific
+      - test-pyosys
+    if: always() && !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled')
+    steps:
+      - run: echo "All good"


### PR DESCRIPTION
This PR adds additional checks for triggering jobs needed for merge queue, also it makes sure that extra builds and compiler builds are not run on pull request, but on merge queue only.
There are now just few jobs that will run on main, since pushing to main directly is prevented.