### PR TITLE
GOWIN. Disable read-before-write mode.

### DIFF
--- a/techlibs/gowin/brams.txt
+++ b/techlibs/gowin/brams.txt
@@ -51,11 +51,6 @@ ram block $__GOWIN_DP_ {
 		portoption "WRITE_MODE" 1 {
 			rdwr new;
 		}
-		ifndef gw5a {
-			portoption "WRITE_MODE" 2 {
-				rdwr old;
-			}
-		}
 		wrbe_separate;
 	}
 }


### PR DESCRIPTION
According to the latest documentation from GOWIN - "UG285-1.4E Gowin BSRAM & SSRAM User Guide"

The dual port BSRAM of all 55nm devices (including GW1N, GW2A and GW1A series) does not support the read-before-write mode (WRITE_MODE = 2)

