### PR TITLE
celltypes: include newcelltypes to allow legacy code access to migrat…

### DIFF
--- a/kernel/celltypes.h
+++ b/kernel/celltypes.h
@@ -21,6 +21,7 @@
 #define CELLTYPES_H
 
 #include "kernel/yosys.h"
+#include "kernel/newcelltypes.h"
 
 YOSYS_NAMESPACE_BEGIN
 


### PR DESCRIPTION
…ed yosys_celltypes

Fixes that `yosys_celltypes` was hidden from external celltypes.h users in #5512