### PR TITLE
dfflibmap: pass selection to dfflegalize

### DIFF
--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -694,6 +694,8 @@ struct DfflibmapPass : public Pass {
 			for (auto it : cell_mappings)
 				dfflegalize_cmd += stringf(" -cell %s 01", it.first);
 			dfflegalize_cmd += " t:$_DFF* t:$_SDFF*";
+			for (auto module : design->selected_modules())
+				dfflegalize_cmd += " " + module -> name.str();
 			if (info_mode) {
 				log("dfflegalize command line: %s\n", dfflegalize_cmd);
 			} else {

--- a/tests/techmap/dfflibmap.ys
+++ b/tests/techmap/dfflibmap.ys
@@ -97,3 +97,14 @@ select -assert-count 1 t:dffe
 # but we have to invert it because the CLEAR pin is active low.
 # ff2.CLEAR = !R
 select -assert-count 1 c:ff2 %x:+[CLEAR] %ci t:$_NOT_ %i
+
+# Test that dfflibmap respects selection and doesn't run dfflegalize on unselected modules
+design -load orig
+copy top top_unmapped
+dfflibmap -liberty dfflibmap.lib top
+# top should be mapped
+select -module top -assert-count 1 t:dffn
+# top_unmapped should have no mapped cells
+select -module top_unmapped -assert-none t:dffn
+select -module top_unmapped -assert-none t:dffe
+select -module top_unmapped -assert-none t:dffsr


### PR DESCRIPTION
Fixes #5650 

dfflibmap was calling dfflegalize on the whole design regardless of the active selection, causing unselected modules to be modified unexpectedly.

Fix by appending the selected module names to the dfflegalize command string.

Added a test to tests/techmap/dfflibmap.ys that verifies unselected modules are not modified after calling dfflibmap with a selection.