### PR TITLE
opt_expr: Respect keep attribute for double-inverter folding

### DIFF
--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -1056,6 +1056,7 @@ skip_fine_alu:
 		}
 
 		if (cell->type.in(ID($_NOT_), ID($not), ID($logic_not)) && GetSize(cell->getPort(ID::Y)) == 1 &&
+				!cell->has_keep_attr() &&
 				invert_map.count(assign_map(cell->getPort(ID::A))) != 0) {
 			replace_cell(assign_map, module, cell, "double_invert", ID::Y, invert_map.at(assign_map(cell->getPort(ID::A))));
 			goto next_cell;


### PR DESCRIPTION
Problem: Ring oscillator PUFs and other intentional feedback loops rely on consecutive inverters that must not be optimized away. When cells are marked with `(* keep *)`, the user explicitly requests preservation, but `opt_expr`'s double-inverter folding ignores this attribute and removes the cells anyway.

Solution: Added a `!cell->has_keep_attr()` check to the double-inverter folding condition in `opt_expr`, consistent with how `opt_clean` already handles the keep attribute.

Test case:
```verilog
module test_keep_inverter(input a, output y);
    wire w;
    (* keep *) _NOT_ inv1 (.A(a), .Y(w));
    (* keep *) _NOT_ inv2 (.A(w), .Y(y));
endmodule
```

Before this patch: `opt_expr` folds both inverters, connecting `y` directly to `a`.  
After this patch: Both inverters are preserved due to the keep attribute.