### PR TITLE
cxxrtl: Suppress un/signed comparison warning; this is positive

### DIFF
--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -614,7 +614,7 @@ struct value : public expr_base<value<Bits>> {
 		int64_t divisor_shift = divisor.ctlz() - dividend.ctlz();
 		assert(divisor_shift >= 0);
 		divisor = divisor.shl(value<Bits>{(chunk::type) divisor_shift});
-		for (size_t step = 0; step <= divisor_shift; step++) {
+		for (size_t step = 0; step <= (uint64_t) divisor_shift; step++) {
 			quotient = quotient.shl(value<Bits>{1u});
 			if (!dividend.ucmp(divisor)) {
 				dividend = dividend.sub(divisor);


### PR DESCRIPTION
This output is typical when using unsigned division/modulo:

```
In file included from /Users/kivikakk/g/mm/tests/test_wavegen/build/test_wavegen.cc:1:
In file included from /Users/kivikakk/g/mm/tests/test_wavegen/build/test_wavegen.h:18:
/nix/store/xkmirkwy6dj15z8c8a9sb9p1glrgdgb5-yosys-0.63-dev/share/yosys/include/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h:617:30: warning: comparison of integers of differen
t signs: 'size_t' (aka 'unsigned long') and 'int64_t' (aka 'long long') [-Wsign-compare]
  617 |                 for (size_t step = 0; step <= divisor_shift; step++) {
      |                                       ~~~~ ^  ~~~~~~~~~~~~~
/nix/store/xkmirkwy6dj15z8c8a9sb9p1glrgdgb5-yosys-0.63-dev/share/yosys/include/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h:2015:43: note: in instantiation of member function
'cxxrtl::value<18>::udivmod' requested here
 2015 |         std::tie(quotient, remainder) = dividend.udivmod(divisor);
      |                                                  ^
/nix/store/xkmirkwy6dj15z8c8a9sb9p1glrgdgb5-yosys-0.63-dev/share/yosys/include/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h:2058:9: note: in instantiation of function template
 specialization 'cxxrtl_yosys::divmod_uu<18UL, 18UL, 15UL>' requested here
 2058 |         return divmod_uu<BitsY>(a, b).second;
      |                ^
/Users/kivikakk/g/mm/tests/test_wavegen/build/test_wavegen.cc:5095:64: note: in instantiation of function template specialization 'cxxrtl_yosys::modfloor_uu<18UL, 18UL, 1
5UL>' requested here
 5095 |                 p_vibrato__en.next = (p_rst ? value<1>{0x1u} : (logic_not<1>(modfloor_uu<18>(p_c.curr, value<15>{0x5dc0u}).slice<14,0>().val()) ? not_u<1>(p_vibra
to__en.curr) : p_vibrato__en.curr));
      |                                                                              ^
1 warning generated.
```

18d1907fa85eebb2c1d1ac9457b2f3d5928970be changed `divisor_shift` to signed to then assert the well-formedness of the subtraction; let's silence the warning about mixing signs in the comparison, as it's asserted to be positive.

After this change, the same compilation process that produced the above is now silent.