### PR TITLE
cxxrtl: Suppress another un/signed comparison warning!

### DIFF
--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -1119,7 +1119,7 @@ struct fmt_part {
 
 			case STRING: {
 				buf.reserve(Bits/8);
-				for (int i = 0; i < Bits; i += 8) {
+				for (size_t i = 0; i < Bits; i += 8) {
 					char ch = 0;
 					for (int j = 0; j < 8 && i + j < int(Bits); j++)
 						if (val.bit(i + j))


### PR DESCRIPTION
I knew I was forgetting one with #5739, but I hadn't used `$print` in a while and wasn't finding it 😓

Before:

```
In file included from /Users/kivikakk/g/mm/tests/simwav/build/test_mixer.cc:1:
In file included from /Users/kivikakk/g/mm/tests/simwav/build/test_mixer.h:18:
/nix/store/xkmirkwy6dj15z8c8a9sb9p1glrgdgb5-yosys-0.63-dev/share/yosys/include/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h:1122:23: warning: comparison of integers of differe
nt signs: 'int' and 'unsigned long' [-Wsign-compare]
 1122 |                                 for (int i = 0; i < Bits; i += 8) {
      |                                                 ~ ^ ~~~~
/Users/kivikakk/g/mm/tests/simwav/build/test_mixer.cc:10192:116: note: in instantiation of function template specialization 'cxxrtl::fmt_part::render<0UL>' requested here
 10192 |                                         buf += fmt_part { fmt_part::LITERAL, "L: ", fmt_part::RIGHT, (char)0, 0, 10, 0, fmt_part::MINUS, 0, 0, 0, 0 }.render(valu
e<0>(), performer);
       |                                                                                                                                                       ^
```

After: no warning.