### PR TITLE
synth_quicklogic: fix small multiplier inference

### DIFF
--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -236,6 +236,7 @@ struct SynthQuickLogicPass : public ScriptPass {
 			run("ql_dsp_macc");
 
 			run("techmap -map +/mul2dsp.v -D DSP_A_MAXWIDTH=20 -D DSP_B_MAXWIDTH=18 -D DSP_A_MINWIDTH=11 -D DSP_B_MINWIDTH=10 -D DSP_NAME=$__QL_MUL20X18");
+			run("chtype -set $mul t:$__soft_mul");
 			run("techmap -map +/mul2dsp.v -D DSP_A_MAXWIDTH=10 -D DSP_B_MAXWIDTH=9 -D DSP_A_MINWIDTH=4 -D DSP_B_MINWIDTH=4 -D DSP_NAME=$__QL_MUL10X9");
 			run("chtype -set $mul t:$__soft_mul");
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
The `mul2dsp` techmap file takes `$mul` cells and breaks them down into cells of configurable size that can be more-easily mapped to DSP blocks. If it can't achieve this, it outputs a `$__soft_mul` cell, which you are meant to `chtype -set $mul t:$__soft_mul` to run for another round of mapping to smaller blocks, or to give to `alumacc` to handle.

[The upstream] `synth_quicklogic` only calls `chtype -set $mul t:$__soft_mul` after running both `mul2dsp` techmaps, so the second one has zero `$mul` cells to operate on and amounts to a no-op.

_Explain how this is achieved._
Insert a `chtype -set $mul t:$__soft_mul` call between the `mul2dsp` techmaps, so the second one actually does something.