### PR TITLE
abc9_exe: fix typo [sc-269]

### DIFF
--- a/passes/techmap/abc9_exe.cc
+++ b/passes/techmap/abc9_exe.cc
@@ -513,7 +513,7 @@ struct Abc9ExePass : public Pass {
 				continue;
 			}
 			if (arg == "-luts" && argidx+1 < args.size()) {
-				lut_arg = args[++argidx];
+				luts_arg = args[++argidx];
 				continue;
 			}
 			if (arg == "-fast") {


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
abc9's lut options are an absolute mess, and I want to rework them. While doing so, I noticed that the `abc9_exe` argument parser for `-luts` updates `lut_arg` and not `luts_arg`, meaning this option has been broken for - according to a quick `git blame` - seven years. Honestly that's a pretty strong argument that this functionality should be removed, but, for now just fix the typo.

_Explain how this is achieved._
One-character change.