### PR TITLE
abc9: remove -fast [sc-269]

### DIFF
--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -121,11 +121,6 @@ struct Abc9Pass : public ScriptPass
 		log("        if no -script parameter is given, the following scripts are used:\n");
 		log("%s\n", fold_abc9_cmd(RTLIL::constpad.at("abc9.script.default").substr(1,std::string::npos)));
 		log("\n");
-		log("    -fast\n");
-		log("        use different default scripts that are slightly faster (at the cost\n");
-		log("        of output quality):\n");
-		log("%s\n", fold_abc9_cmd(RTLIL::constpad.at("abc9.script.default.fast").substr(1,std::string::npos)));
-		log("\n");
 		log("    -D <picoseconds>\n");
 		log("        set delay target. the string {D} in the default scripts above is\n");
 		log("        replaced by this option when used, and an empty string otherwise\n");
@@ -222,7 +217,7 @@ struct Abc9Pass : public ScriptPass
 				exe_cmd << " " << arg << " " << args[++argidx];
 				continue;
 			}
-			if (arg == "-fast" || arg == "-showtmp") {
+			if (arg == "-showtmp") {
 				exe_cmd << " " << arg;
 				continue;
 			}

--- a/passes/techmap/abc9_exe.cc
+++ b/passes/techmap/abc9_exe.cc
@@ -165,7 +165,7 @@ struct abc9_output_filter
 };
 
 void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe_file,
-		vector<int> lut_costs, bool dff_mode, std::string delay_target, bool fast_mode,
+		vector<int> lut_costs, bool dff_mode, std::string delay_target,
 		bool show_tempdir, std::string box_file, std::string lut_file,
 		std::vector<std::string> liberty_files, std::string wire_delay, std::string tempdir_name,
 		std::string constr_file, std::vector<std::string> dont_use_cells, std::vector<std::string> genlib_files)
@@ -210,8 +210,7 @@ void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe
 		} else
 			abc9_script += stringf("source %s", script_file);
 	} else if (!lut_costs.empty() || !lut_file.empty()) {
-		abc9_script += fast_mode ? RTLIL::constpad.at("abc9.script.default.fast").substr(1,std::string::npos)
-			: RTLIL::constpad.at("abc9.script.default").substr(1,std::string::npos);
+		abc9_script += RTLIL::constpad.at("abc9.script.default").substr(1,std::string::npos);
 	} else
 		log_abort();
 
@@ -366,11 +365,6 @@ struct Abc9ExePass : public Pass {
 		log("        if no -script parameter is given, the following scripts are used:\n");
 		log("%s\n", fold_abc9_cmd(RTLIL::constpad.at("abc9.script.default").substr(1,std::string::npos)));
 		log("\n");
-		log("    -fast\n");
-		log("        use different default scripts that are slightly faster (at the cost\n");
-		log("        of output quality):\n");
-		log("%s\n", fold_abc9_cmd(RTLIL::constpad.at("abc9.script.default.fast").substr(1,std::string::npos)));
-		log("\n");
 		log("    -constr <file>\n");
 		log("        pass this file with timing constraints to ABC.\n");
 		log("        use with -liberty.\n");
@@ -452,7 +446,7 @@ struct Abc9ExePass : public Pass {
 		std::vector<std::string> liberty_files, genlib_files, dont_use_cells;
 		std::string delay_target, wire_delay;
 		std::string tempdir_name;
-		bool fast_mode = false, dff_mode = false;
+		bool dff_mode = false;
 		bool show_tempdir = false;
 		vector<int> lut_costs;
 
@@ -469,7 +463,6 @@ struct Abc9ExePass : public Pass {
 		}
 		lut_arg = design->scratchpad_get_string("abc9.lut", lut_arg);
 		luts_arg = design->scratchpad_get_string("abc9.luts", luts_arg);
-		fast_mode = design->scratchpad_get_bool("abc9.fast", fast_mode);
 		dff_mode = design->scratchpad_get_bool("abc9.dff", dff_mode);
 		show_tempdir = design->scratchpad_get_bool("abc9.showtmp", show_tempdir);
 		box_file = design->scratchpad_get_string("abc9.box", box_file);
@@ -507,10 +500,6 @@ struct Abc9ExePass : public Pass {
 			}
 			if (arg == "-luts" && argidx+1 < args.size()) {
 				luts_arg = args[++argidx];
-				continue;
-			}
-			if (arg == "-fast") {
-				fast_mode = true;
 				continue;
 			}
 			if (arg == "-dff") {
@@ -615,7 +604,7 @@ struct Abc9ExePass : public Pass {
 			log_cmd_error("abc9_exe '-genlib' is incompatible with '-dont_use'.\n");
 
 		abc9_module(design, script_file, exe_file, lut_costs, dff_mode,
-				delay_target, fast_mode, show_tempdir,
+				delay_target, show_tempdir,
 				box_file, lut_file, liberty_files, wire_delay, tempdir_name,
 				constr_file, dont_use_cells, genlib_files);
 	}


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
My understanding was that this was meant to be exposed as an option to `synth_xxx` passes. That never happened, and honestly I think that functionality can be achieved through changing `abc9.script` in the scratchpad (which is why I've kept `abc9.script.default.fast`.)

_Explain how this is achieved._
Yeet.