### PR TITLE
abc9: remove abc9.if.C [sc-269]

### DIFF
--- a/passes/techmap/abc9.cc
+++ b/passes/techmap/abc9.cc
@@ -38,53 +38,53 @@ struct Abc9Pass : public ScriptPass
 	Abc9Pass() : ScriptPass("abc9", "use ABC9 for technology mapping") { }
 	void on_register() override
 	{
-		RTLIL::constpad["abc9.script.default"] = "+&scorr; &sweep; &dc2; &dch -f -r; &ps; &if {C} {W} {D} {R} -v; &mfs";
-		RTLIL::constpad["abc9.script.default.area"] = "+&scorr; &sweep; &dc2; &dch -f -r; &ps; &if {C} {W} {D} {R} -a -v; &mfs";
-		RTLIL::constpad["abc9.script.default.fast"] = "+&if {C} {W} {D} {R} -v";
+		RTLIL::constpad["abc9.script.default"] = "+&scorr; &sweep; &dc2; &dch -f -r; &ps; &if {W} {D} {R} -v; &mfs";
+		RTLIL::constpad["abc9.script.default.area"] = "+&scorr; &sweep; &dc2; &dch -f -r; &ps; &if {W} {D} {R} -a -v; &mfs";
+		RTLIL::constpad["abc9.script.default.fast"] = "+&if {W} {D} {R} -v";
 		// Based on ABC's &flow
 		RTLIL::constpad["abc9.script.flow"] = "+&scorr; &sweep;" \
 			"&dch -C 500;" \
 			/* Round 1 */ \
-			/* Map 1 */ "&unmap; &if {C} {W} {D} {R} -v; &save; &load; &mfs;" \
+			/* Map 1 */ "&unmap; &if {W} {D} {R} -v; &save; &load; &mfs;" \
 			"&st; &dsdb;" \
-			/* Map 2 */ "&unmap; &if {C} {W} {D} {R} -v; &save; &load; &mfs;" \
+			/* Map 2 */ "&unmap; &if {W} {D} {R} -v; &save; &load; &mfs;" \
 			"&st; &syn2 -m -R 10; &dsdb;" \
 			"&blut -a -K 6;" \
-			/* Map 3 */ "&unmap; &if {C} {W} {D} {R} -v; &save; &load; &mfs;" \
+			/* Map 3 */ "&unmap; &if {W} {D} {R} -v; &save; &load; &mfs;" \
 			/* Round 2 */ \
 			"&st; &sopb;" \
-			/* Map 1 */ "&unmap; &if {C} {W} {D} {R} -v; &save; &load; &mfs;" \
+			/* Map 1 */ "&unmap; &if {W} {D} {R} -v; &save; &load; &mfs;" \
 			"&st; &dsdb;" \
-			/* Map 2 */ "&unmap; &if {C} {W} {D} {R} -v; &save; &load; &mfs;" \
+			/* Map 2 */ "&unmap; &if {W} {D} {R} -v; &save; &load; &mfs;" \
 			"&st; &syn2 -m -R 10; &dsdb;" \
 			"&blut -a -K 6;" \
-			/* Map 3 */ "&unmap; &if {C} {W} {D} {R} -v; &save; &load; &mfs;" \
+			/* Map 3 */ "&unmap; &if {W} {D} {R} -v; &save; &load; &mfs;" \
 			/* Round 3 */ \
-			/* Map 1 */ "&unmap; &if {C} {W} {D} {R} -v; &save; &load; &mfs;" \
+			/* Map 1 */ "&unmap; &if {W} {D} {R} -v; &save; &load; &mfs;" \
 			"&st; &dsdb;" \
-			/* Map 2 */ "&unmap; &if {C} {W} {D} {R} -v; &save; &load; &mfs;" \
+			/* Map 2 */ "&unmap; &if {W} {D} {R} -v; &save; &load; &mfs;" \
 			"&st; &syn2 -m -R 10; &dsdb;" \
 			"&blut -a -K 6;" \
-			/* Map 3 */ "&unmap; &if {C} {W} {D} {R} -v; &save; &load; &mfs;";
+			/* Map 3 */ "&unmap; &if {W} {D} {R} -v; &save; &load; &mfs;";
 		// Based on ABC's &flow2
 		RTLIL::constpad["abc9.script.flow2"] = "+&scorr; &sweep;" \
-			/* Comm1 */ "&synch2 -K 6 -C 500; &if -m {C} {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save;"\
-			/* Comm2 */ "&dch -C 500; &if -m {C} {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save;"\
+			/* Comm1 */ "&synch2 -K 6 -C 500; &if -m {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save;"\
+			/* Comm2 */ "&dch -C 500; &if -m {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save;"\
 			"&load; &st; &sopb -R 10 -C 4; " \
-			/* Comm3 */ "&synch2 -K 6 -C 500; &if -m "/*"-E 5"*/" {C} {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save;"\
-			/* Comm2 */ "&dch -C 500; &if -m {C} {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save; "\
+			/* Comm3 */ "&synch2 -K 6 -C 500; &if -m "/*"-E 5"*/" {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save;"\
+			/* Comm2 */ "&dch -C 500; &if -m {W} {D} {R} -v; &mfs "/*"-W 4 -M 500 -C 7000"*/"; &save; "\
 			"&load";
 		// Based on ABC's &flow3 -m
 		RTLIL::constpad["abc9.script.flow3"] = "+&scorr; &sweep;" \
-			"&if {C} {W} {D}; &save; &st; &syn2; &if {C} {W} {D} {R} -v; &save; &load;"\
-			"&st; &if {C} -g -K 6; &dch -f; &if {C} {W} {D} {R} -v; &save; &load;"\
-			"&st; &if {C} -g -K 6; &synch2; &if {C} {W} {D} {R} -v; &save; &load;"\
+			"&if {W} {D}; &save; &st; &syn2; &if {W} {D} {R} -v; &save; &load;"\
+			"&st; &if -g -K 6; &dch -f; &if {W} {D} {R} -v; &save; &load;"\
+			"&st; &if -g -K 6; &synch2; &if {W} {D} {R} -v; &save; &load;"\
 			"&mfs";
 		// As above, but with &mfs calls as in the original &flow3
 		RTLIL::constpad["abc9.script.flow3mfs"] = "+&scorr; &sweep;" \
-			"&if {C} {W} {D}; &save; &st; &syn2; &if {C} {W} {D} {R} -v; &save; &load;"\
-			"&st; &if {C} -g -K 6; &dch -f; &if {C} {W} {D} {R} -v; &mfs; &save; &load;"\
-			"&st; &if {C} -g -K 6; &synch2; &if {C} {W} {D} {R} -v; &mfs; &save; &load;"\
+			"&if {W} {D}; &save; &st; &syn2; &if {W} {D} {R} -v; &save; &load;"\
+			"&st; &if -g -K 6; &dch -f; &if {W} {D} {R} -v; &mfs; &save; &load;"\
+			"&st; &if -g -K 6; &synch2; &if {W} {D} {R} -v; &mfs; &save; &load;"\
 			"&mfs";
 	}
 	void help() override

--- a/passes/techmap/abc9_exe.cc
+++ b/passes/techmap/abc9_exe.cc
@@ -224,12 +224,6 @@ void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe
 	for (size_t pos = abc9_script.find("{W}"); pos != std::string::npos; pos = abc9_script.find("{W}", pos))
 		abc9_script = abc9_script.substr(0, pos) + wire_delay + abc9_script.substr(pos+3);
 
-	std::string C;
-	if (design->scratchpad.count("abc9.if.C"))
-		C = "-C " + design->scratchpad_get_string("abc9.if.C");
-	for (size_t pos = abc9_script.find("{C}"); pos != std::string::npos; pos = abc9_script.find("{C}", pos))
-		abc9_script = abc9_script.substr(0, pos) + C + abc9_script.substr(pos+3);
-
 	std::string R;
 	if (design->scratchpad.count("abc9.if.R"))
 		R = "-R " + design->scratchpad_get_string("abc9.if.R");


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
This scratchpad option controls `&if -C`, which is documented as:
```
        -C num   : the max number of priority cuts (0 < num < 2^12) [default = 8]
```
Having written my own priority cut mapper, 8 is *absolutely fine* and there is no reason to ever need to change it.

_Explain how this is achieved._
Yeet.