### PR TITLE
Upgrade CI actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         submodules: true
         persist-credentials: false
@@ -23,7 +23,7 @@ jobs:
         get-build-deps: true
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: cpp
         queries: security-extended,security-and-quality
@@ -32,4 +32,4 @@ jobs:
       run: make yosys -j6
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/extra-builds.yml
+++ b/.github/workflows/extra-builds.yml
@@ -37,14 +37,14 @@ jobs:
     needs: [pre_job]
     if: (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
           persist-credentials: false
       - run: sudo apt-get install libfl-dev
       - name: Build
         run: make vcxsrc YOSYS_COMPILER="Visual Studio" VCX_DIR_NAME=yosys-win32-vcxsrc-latest
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: vcxsrc
           path: yosys-win32-vcxsrc-latest.zip
@@ -55,7 +55,7 @@ jobs:
     needs: [vs-prep, pre_job]
     if: (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: vcxsrc
           path: .
@@ -73,7 +73,7 @@ jobs:
     if: (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
           persist-credentials: false
@@ -123,7 +123,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
           persist-credentials: false

--- a/.github/workflows/source-vendor.yml
+++ b/.github/workflows/source-vendor.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           persist-credentials: false
@@ -32,7 +32,7 @@ jobs:
           gzip yosys-src-vendored.tar
 
       - name: Store tarball artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vendored-sources
           path: yosys-src-vendored.tar.gz

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout Yosys
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
           persist-credentials: false
@@ -99,7 +99,7 @@ jobs:
           tar -cvf ../build.tar share/ yosys yosys-* libyosys.so
 
       - name: Store build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-${{ matrix.os }}
           path: build.tar
@@ -118,7 +118,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout Yosys
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -130,7 +130,7 @@ jobs:
           get-iverilog: true
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-${{ matrix.os }}
 
@@ -166,7 +166,7 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - name: Checkout Yosys
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -176,7 +176,7 @@ jobs:
           runs-on: ${{ matrix.os }}
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-${{ matrix.os }}
 
@@ -206,7 +206,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout Yosys
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -218,7 +218,7 @@ jobs:
           get-docs-deps: true
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-${{ matrix.os }}
 

--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout Yosys
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
           persist-credentials: false

--- a/.github/workflows/test-sanitizers.yml
+++ b/.github/workflows/test-sanitizers.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout Yosys
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
           persist-credentials: false

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -49,7 +49,7 @@ jobs:
     name: Build Wheels | ${{ matrix.os.name }} | ${{ matrix.os.archs }}
     runs-on: ${{ matrix.os.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: true
@@ -108,7 +108,7 @@ jobs:
             PATH="$PWD/bison/src:$PATH"
           CIBW_BEFORE_BUILD: bash ./.github/workflows/wheels/cibw_before_build.sh
           CIBW_TEST_COMMAND: python3 {project}/tests/pyosys/run_tests.py
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: python-wheels-${{ matrix.os.runner }}
           path: ./wheelhouse/*.whl
@@ -123,7 +123,7 @@ jobs:
       id-token: write
     needs: build_wheels
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: "."
           pattern: python-wheels-*


### PR DESCRIPTION
Upgrades CI actions to remove warnings. Some actions like microsoft/setup-msbuild@v2 still do not have modern upgrade. Anyway less warnings -> better

NOTE: Private runners still do not support this new version
