### PR TITLE
Fix a tsan warning by making the racing variable atomic

### DIFF
--- a/kernel/threading.h
+++ b/kernel/threading.h
@@ -237,7 +237,7 @@ private:
 	// Keeps a correct count even when threads are exiting.
 	int num_worker_threads_;
 	// The count of active workerthreads for the current `run()`.
-	int num_active_worker_threads_ = 0;
+	std::atomic<int> num_active_worker_threads_ = 0;
 
 #ifdef YOSYS_ENABLE_THREADS
 	// Not especially efficient for large numbers of threads. Worker wakeup could scale


### PR DESCRIPTION
```
WARNING: ThreadSanitizer: data race
  Write of size 4 at <address> by main thread:
    #0 Yosys::ParallelDispatchThreadPool::run(std::function<void (Yosys::ParallelDispatchThreadPool::RunCtx const&)>, int) yosys/kernel/threading.cc:122:29
    #1 run yosys/kernel/threading.h:206:11
    #2 Yosys::RTLIL::OwningIdString::collect_garbage() yosys/kernel/rtlil.cc:262:12
    #3 try_collect_garbage yosys/kernel/register.cc:60:2
    #4 Yosys::Pass::call(Yosys::RTLIL::Design*, std::vector<std::string>) yosys/kernel/register.cc:292:2
    #5 Yosys::Pass::call(Yosys::RTLIL::Design*, std::string) yosys/kernel/register.cc:272:2
    [... application logic and test framework frames elided ...]

  Previous read of size 4 at <address> by worker thread:
    #0 signal_worker_done yosys/kernel/threading.h:267:16
    #1 Yosys::ParallelDispatchThreadPool::run_worker(int) yosys/kernel/threading.cc:144:3
    [... std::thread internals elided ...]

  Worker thread created by main thread at:
    [... std::thread creation internals elided ...]
    #8 Yosys::ThreadPool::ThreadPool(int, std::function<void (int)>) yosys/kernel/threading.cc:68:25
    #9 std::make_unique<...>()
    #10 Yosys::ParallelDispatchThreadPool::ParallelDispatchThreadPool(int) yosys/kernel/threading.cc:102:16
    #11 Yosys::RTLIL::OwningIdString::collect_garbage() yosys/kernel/rtlil.cc:248:29
    #12 try_collect_garbage yosys/kernel/register.cc:60:2
    #13 Yosys::Pass::call(Yosys::RTLIL::Design*, std::vector<std::string>) yosys/kernel/register.cc:292:2
    #14 Yosys::Pass::call(Yosys::RTLIL::Design*, std::string) yosys/kernel/register.cc:272:2
    [... application logic and test framework frames elided ...]

SUMMARY: ThreadSanitizer: data race yosys/kernel/threading.cc:122:29 in Yosys::ParallelDispatchThreadPool::run(...)
```

Making the offending variable an atomic should silence this warning.
