### PR TITLE
Adjusted dot call to avoid pdflatex rejecting input due to too high resolution.

### DIFF
--- a/docs/source/_images/Makefile
+++ b/docs/source/_images/Makefile
@@ -33,7 +33,7 @@ TEX_FILES := $(shell find . -name *.tex)
 all_tex: $(TEX_FILES:.tex=.pdf) $(TEX_FILES:.tex=.svg)
 
 %.pdf: %.dot
-	$(FAKETIME) dot -Tpdf -o $@ $<
+	$(FAKETIME) dot -Tpdf -Gsize="9x15!" -o $@ $<
 
 %.pdf: %.tex
 	cd $(@D) && $(FAKETIME) pdflatex $(<F) --interaction=nonstopmode

--- a/docs/source/_images/Makefile
+++ b/docs/source/_images/Makefile
@@ -32,8 +32,9 @@ FORCE:
 TEX_FILES := $(shell find . -name *.tex)
 all_tex: $(TEX_FILES:.tex=.pdf) $(TEX_FILES:.tex=.svg)
 
+# limit output size to US letter (same as latexpdf output) to avoid oversize error
 %.pdf: %.dot
-	$(FAKETIME) dot -Tpdf -Gsize="9x15!" -o $@ $<
+	$(FAKETIME) dot -Tpdf -Gsize="8.5,11" -o $@ $<
 
 %.pdf: %.tex
 	cd $(@D) && $(FAKETIME) pdflatex $(<F) --interaction=nonstopmode


### PR DESCRIPTION
Set fairly randomly picked size when generating dot graphs based on example I came across, to avoid the following error from pdflatex when building documentation:

```
  [46 <./rdata_map_luts.pdf>]
  ! Dimension too large.
```

I am not sure which size make sense, nor how to decide which value are best.

This issue is a fix for a build problem reported in <URL: https://bugs.debian.org/1133986 >, which include a link to the build log of the failed build.