### PR TITLE
xprop: ignore $scopeinfo cells

### DIFF
--- a/passes/cmds/xprop.cc
+++ b/passes/cmds/xprop.cc
@@ -463,6 +463,10 @@ struct XpropWorker
 			return;
 		}
 
+		if (cell->type.in(ID($scopeinfo))) {
+			return;
+		}
+
 		log_warning("Unhandled cell %s (%s) during maybe-x marking\n", log_id(cell), log_id(cell->type));
 		mark_outputs_maybe_x(cell);
 	}


### PR DESCRIPTION
Reduce some warning spam of the form `Warning: Unhandled cell gold ($scopeinfo) during maybe-x marking`. There's nothing `xprop` needs to do for these cells anyway.