### PR TITLE
Fixed spelling error in message of frontends/ast/genrtlil.cc.

### DIFF
--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -798,7 +798,7 @@ struct AST_INTERNAL::ProcessGenerator
 			break;
 
 		case AST_ASSIGN:
-			ast->input_error("Found continous assignment in always/initial block!\n");
+			ast->input_error("Found continuous assignment in always/initial block!\n");
 			break;
 
 		case AST_PARAMETER:


### PR DESCRIPTION
Patch by Ruben Undheim via the Debian project.  The patch originated as 0009-Some-spelling-errors-fixed.patch and was dated 2018-07-12 there.

See also issue #5805.