### PR TITLE
Use CPPFLAGS and CXXFLAGS when compiling in autotest.sh.

### DIFF
--- a/tests/tools/autotest.sh
+++ b/tests/tools/autotest.sh
@@ -26,7 +26,7 @@ xfirrtl="../xfirrtl"
 abcprog="$toolsdir/../../yosys-abc"
 
 if [ ! -f "$toolsdir/cmp_tbdata" -o "$toolsdir/cmp_tbdata.c" -nt "$toolsdir/cmp_tbdata" ]; then
-	( set -ex; ${CXX:-g++} -Wall -o "$toolsdir/cmp_tbdata" "$toolsdir/cmp_tbdata.c"; ) || exit 1
+	( set -ex; ${CXX:-g++} -Wall ${CPPFLAGS} ${CXXFLAGS:-} -o "$toolsdir/cmp_tbdata" "$toolsdir/cmp_tbdata.c"; ) || exit 1
 fi
 
 while getopts xmGl:wkjvref:s:p:n:S:I:A:-: opt; do


### PR DESCRIPTION
This ensure the build flags used elsewhere are included also during testing.

Patch based on change from Daniel Gröber via Debian.

See also issue #5805.