### PR TITLE
Made autotest.sh print log on error for easier debugging in CI setups.

### DIFF
--- a/tests/tools/autotest.sh
+++ b/tests/tools/autotest.sh
@@ -235,6 +235,7 @@ do
 				echo "Note: Make sure that 'iverilog' is an up-to-date git checkout of Icarus Verilog."
 			fi
 		fi
+		sed -e "s,^,${bn}: ," ${bn}.err
 		$keeprunning || exit 1
 	fi
 done


### PR DESCRIPTION
Patch by Daniel Gröber via Debian.

See also issue #5805.