### PR TITLE
Remove FHS dependency by replacing /bin/bash with /usr/bin/env bash

### DIFF
--- a/.github/workflows/wheels/cibw_before_all.sh
+++ b/.github/workflows/wheels/cibw_before_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -x
 
 # Build-time dependencies

--- a/docs/source/using_yosys/bugpoint.rst
+++ b/docs/source/using_yosys/bugpoint.rst
@@ -293,7 +293,7 @@ is still valid.
    :caption: Example test.sh for C-Reduce
    :name: egtest
 
-   #!/bin/bash
+   #!/usr/bin/env bash
    verilator --lint-only test.v &&/
    yosys -p 'logger -expect error "unsupported" 1; read_verilog test.v'
 
@@ -333,7 +333,7 @@ an input argument: ``sv-bugpoint outDir/ test.sh test.v``
 .. code-block:: bash
    :caption: Example test.sh for sv-bugpoint
 
-   #!/bin/bash
+   #!/usr/bin/env bash
    verilator --lint-only $1 &&/
    yosys -p "logger -expect error \"unsupported\" 1; read_verilog $1"
 

--- a/examples/aiger/README
+++ b/examples/aiger/README
@@ -14,7 +14,7 @@ in the PATH. E.g. extract the release to /usr/local/libexec/super_prove
 and then create a /usr/local/bin/super_prove file with the following
 contents (and "chmod +x" that file):
 
-	#!/bin/bash
+	#!/usr/bin/env bash
 	exec /usr/local/libexec/super_prove/bin/super_prove.sh "$@"
 
 The "demo.sh" script also expects the "z3" SMT2 solver in the PATH for

--- a/examples/aiger/demo.sh
+++ b/examples/aiger/demo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 yosys -p '
 	read_verilog -formal demo.v

--- a/examples/anlogic/build.sh
+++ b/examples/anlogic/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 yosys demo.ys
 $TD_HOME/bin/td build.tcl

--- a/examples/basys3/run.sh
+++ b/examples/basys3/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 yosys run_yosys.ys
 vivado -nolog -nojournal -mode batch -source run_vivado.tcl
 vivado -nolog -nojournal -mode batch -source run_prog.tcl

--- a/examples/cmos/testbench.sh
+++ b/examples/cmos/testbench.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/examples/cmos/testbench_digital.sh
+++ b/examples/cmos/testbench_digital.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/examples/gowin/run.sh
+++ b/examples/gowin/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 yosys -p "synth_gowin -top demo -vout demo_syn.v" demo.v
 $GOWIN_HOME/bin/gowin -d demo_syn.v -cst demo.cst -sdc demo.sdc -p GW1NR-9-QFN88-6 -pn GW1NR-LV9QN88C6/I5 -cfg device.cfg -bit -tr -ph -timing -gpa -rpt -warning_all

--- a/examples/igloo2/runme.sh
+++ b/examples/igloo2/runme.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 yosys -p 'synth_sf2 -top example -edif netlist.edn -vlog netlist.vm' example.v
 export LM_LICENSE_FILE=${LM_LICENSE_FILE:-1702@localhost}

--- a/examples/intel/DE2i-150/quartus_compile/runme_quartus
+++ b/examples/intel/DE2i-150/quartus_compile/runme_quartus
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export REV="de2i"
 

--- a/examples/intel/MAX10/runme_postsynth
+++ b/examples/intel/MAX10/runme_postsynth
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 iverilog -D POST_IMPL -o verif_post -s tb_top tb_top.v top.vqm $(yosys-config --datdir/altera_intel/max10/cells_comb_max10.v)
 vvp -N verif_post

--- a/examples/intel/asicworld_lfsr/run_cycloneiv
+++ b/examples/intel/asicworld_lfsr/run_cycloneiv
@@ -1,2 +1,2 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 yosys -p "synth_intel -family cycloneiv -top lfsr_updown -vqm top.vqm" lfsr_updown.v

--- a/examples/intel/asicworld_lfsr/run_max10
+++ b/examples/intel/asicworld_lfsr/run_max10
@@ -1,2 +1,2 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 yosys -p "synth_intel -family max10 -top lfsr_updown -vqm top.vqm" lfsr_updown.v

--- a/examples/intel/asicworld_lfsr/runme_postsynth
+++ b/examples/intel/asicworld_lfsr/runme_postsynth
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 iverilog -D POST_IMPL -o verif_post -s tb lfsr_updown_tb.v top.vqm $(yosys-config --datdir/altera_intel/max10/cells_comb_max10.v)
 vvp -N verif_post

--- a/examples/intel/asicworld_lfsr/runme_presynth
+++ b/examples/intel/asicworld_lfsr/runme_presynth
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 iverilog -o presynth lfsr_updown_tb.v lfsr_updown.v &&\
 

--- a/examples/mimas2/run.sh
+++ b/examples/mimas2/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e
 yosys run_yosys.ys
 edif2ngd example.edif

--- a/misc/create_vcxsrc.sh
+++ b/misc/create_vcxsrc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 vcxsrc="$1"

--- a/techlibs/sf2/NOTES.txt
+++ b/techlibs/sf2/NOTES.txt
@@ -12,7 +12,7 @@ You'd better to write a simple script, like this one (assuming the top module
 is top):
 
 ----------- run_yosys.sh --------------
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -e
 

--- a/tests/aiger/generate_mk.py
+++ b/tests/aiger/generate_mk.py
@@ -54,6 +54,6 @@ def create_tests():
         "rm -f aigmap.err"
     ]))
 
-extra = [ f"ABC ?= {gen_tests_makefile.yosys_basedir}/yosys-abc", "SHELL := /bin/bash" ]
+extra = [ f"ABC ?= {gen_tests_makefile.yosys_basedir}/yosys-abc", "SHELL := /usr/bin/env bash" ]
 
 gen_tests_makefile.generate_custom(create_tests, extra)

--- a/tests/various/ezcmdline_dummy_solver
+++ b/tests/various/ezcmdline_dummy_solver
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # Dummy SAT solver for ezCmdlineSAT tests.
 # Accepts exactly two CNF shapes:
 #  - SAT:   p cnf 1 1; clause: "1 0"  -> exits 10 with v 1


### PR DESCRIPTION
Fixes #5768 on nixOS particularly due to `tests/aiger/generate_mk.py`, verified locally on nixOS