### PR TITLE
Fix RAMB36E1/E2 SDP parity port mapping typo

### DIFF
--- a/techlibs/xilinx/brams_xc6v_map.v
+++ b/techlibs/xilinx/brams_xc6v_map.v
@@ -275,7 +275,7 @@ end else if (OPTION_MODE == "FULL") begin
 		.DIADI(DI[31:0]),
 		.DIBDI(PORT_W_WIDTH == 72 ? DI[63:32] : DI[31:0]),
 		.DIPADIP(DIP[3:0]),
-		.DIPBDIP(PORT_W_WIDTH == 71 ? DIP[7:4] : DIP[3:0]),
+		.DIPBDIP(PORT_W_WIDTH == 72 ? DIP[7:4] : DIP[3:0]),
 	);
 end
 

--- a/techlibs/xilinx/brams_xcu_map.v
+++ b/techlibs/xilinx/brams_xcu_map.v
@@ -215,7 +215,7 @@ end else if (OPTION_MODE == "FULL") begin
 		.DINADIN(DI[31:0]),
 		.DINBDIN(PORT_W_WIDTH == 72 ? DI[63:32] : DI[31:0]),
 		.DINPADINP(DIP[3:0]),
-		.DINPBDINP(PORT_W_WIDTH == 71 ? DIP[7:4] : DIP[3:0]),
+		.DINPBDINP(PORT_W_WIDTH == 72 ? DIP[7:4] : DIP[3:0]),
 	);
 end
 


### PR DESCRIPTION
DIPBDIP/DINPBDINP condition checked PORT_W_WIDTH == 71, which never matches any valid SDP width. Should be 72, matching the DIBDI/DINBDIN condition on the line above. This caused data bits 68-69 to be silently overwritten with copies of bits 64-65 on every write.

Affects both xc6v (RAMB36E1, Artix-7/Kintex-7/Virtex-7) and xcu (RAMB36E2, UltraScale/UltraScale+) mapping templates. The RAMB18E1/E2 equivalents correctly use == 36.

I spotted this when a calculation involving the mapping of a 70-bit array to RAMB36E1 in SDP mode at 72-bit width would give an incorrect answer using block RAM, but the correct answer when using distributed RAM. 

The ternary operator `PORT_W_WIDTH == 71 ? DIP[7:4] : DIP[3:0]` appears on line 278 of brams_xc6v_map.v and line 218 of brams_xcu_map.v. `DIP[3:0]` carries data bits [67:64], `DIP[7:4]` carries data bits [71:68]. So when using a bit width of 72 this conditional would always resolve to `DIP[3:0]`. So in this case bits 68-71 end up getting overwritten by copies of bits 64-67.

To verify this fix I synthesised a design with a 70-bit array using synth_xilinx, I ran it before and after the fix and compared the JSON netlists. Before the fix DIPADIP and DIPBDIP carried identical signals; after changing `PORT_W_WIDTH == 71 ? DIP[7:4] : DIP[3:0]` to `PORT_W_WIDTH == 72 ? DIP[7:4] : DIP[3:0]` they carried different signals. I also pushed this to my Basys 3 (Artix-7 FPGA); before the fix this was giving a deterministic wrong answer, but the fix gave the correct result. 
