### PR TITLE
Fixed failing test on i386 due to floating point inaccuracies.

### DIFF
--- a/kernel/fstdata.cc
+++ b/kernel/fstdata.cc
@@ -46,7 +46,7 @@ FstData::FstData(std::string filename) : ctx(nullptr)
 	if (!ctx)
 		log_error("Error opening '%s' as FST file\n", filename);
 	int scale = (int)fstReaderGetTimescale(ctx);	
-	timescale = pow(10.0, scale);
+	timescale = powl(10.0, scale);
 	timescale_str = "";
 	int unit = 0;
 	int zeros = 0;

--- a/kernel/fstdata.h
+++ b/kernel/fstdata.h
@@ -55,7 +55,7 @@ class FstData
 	std::string valueOf(fstHandle signal);
 	fstHandle getHandle(std::string name);
 	dict<int,fstHandle> getMemoryHandles(std::string name);
-	double getTimescale() { return timescale; }
+	long double getTimescale() { return timescale; }
 	const char *getTimescaleString() { return timescale_str.c_str(); }
 private:
 	void extractVarNames();
@@ -69,7 +69,7 @@ private:
 	uint64_t last_time;
 	std::map<fstHandle, std::string> past_data;
 	uint64_t past_time;
-	double timescale;
+	long double timescale;
 	std::string timescale_str;
 	uint64_t start_time;
 	uint64_t end_time;

--- a/libs/fst/fstapi.cc
+++ b/libs/fst/fstapi.cc
@@ -4552,7 +4552,7 @@ int fstReaderInit(struct fstReaderContext *xc)
                    /*
                     * Yosys patch: Fix double endian check for i386 targets built in modern gcc
                     */
-                    xc->double_endian_match = (dcheck == (double)FST_DOUBLE_ENDTEST);
+                    xc->double_endian_match = ((double)dcheck == (double)FST_DOUBLE_ENDTEST);
                     if (!xc->double_endian_match) {
                         union
                         {

--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -53,7 +53,7 @@ static const std::map<std::string, int> g_units =
 	{ "zs", -21 },
 };
 
-static double stringToTime(std::string str)
+static long double stringToTime(std::string str)
 {
 	if (str=="END") return -1;
 
@@ -66,7 +66,7 @@ static double stringToTime(std::string str)
 	if (value < 0)
 		log_error("Time value '%s' must be positive\n", str);
 
-	return value * pow(10.0, g_units.at(endptr));
+	return value * powl(10.0, g_units.at(endptr));
 }
 
 struct SimWorker;
@@ -110,8 +110,8 @@ struct SimShared
 	bool hdlname = false;
 	int rstlen = 1;
 	FstData *fst = nullptr;
-	double start_time = 0;
-	double stop_time = -1;
+	long double start_time = 0;
+	long double stop_time = -1;
 	SimulationMode sim_mode = SimulationMode::sim;
 	bool cycles_set = false;
 	std::vector<std::unique_ptr<OutputWriter>> outputfiles;


### PR DESCRIPTION
Calculating the numer of passes give the incorrect result on i386 when using double.  Switching to long double avoid the problem.

Fixes #5822.