### PR TITLE
TEST PR DO NOT MERGE

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -84,6 +84,8 @@ jobs:
         run: |
           mkdir build
           cd build
+          echo "Forcing a failure for test purposes"
+          exit 1
           make -f ../Makefile config-$CC
           make -f ../Makefile -j$procs
           make -f ../Makefile unit-test -j$procs


### PR DESCRIPTION
I already triggered the test to re-run so can't check if it was blocking the merge, but [`test-build-result`](https://github.com/YosysHQ/yosys/actions/runs/24846667335/job/72737809747?pr=5832) returns success even if the `build-yosys` job fails (because it only checks the test jobs, which all skip due to the earlier failure).  I don't have the repo permissions to check, but if the merge queue only requires `test-build-result` to succeed and doesn't also require `build-yosys` then I think it might be able to let a failing build into the merge queue?  But I also think that when I first looked at the report the failing `build-yosys` did have the `Required` label next to it, so it might be the case that any failure will prevent the merge, and the required checks are just ones that can't be skipped rather than the only ones that need to pass.  If there is a persistent failure to build then other jobs will fail (e.g. `test-docs-build` will trigger `test-build-result` to fail), and even it's a transient issue skipping a failing test then it should still get caught by `test-verific` (via `test-verific-result`), so the actual chance of this getting something broken to merge is miniscule... but just to be safe this PR should verify if it's possible.