### PR TITLE
1.24x-2.57x performance improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,18 @@
 /result
 /dist
 
+# perf benchmark outputs (synthetic generators, JSON results, scratch logs)
+/benchmark-results/
+/libyosys_exe.a
+/yosys-loop*.exe
+/tests/tools/cmp_tbdata.exe
+
+# leftover artifacts from tests/various/async.sh when iverilog is unavailable
+/tests/various/async_???.v
+
+# Claude Code local project state
+/.claude/
+
 # pyosys
 /kernel/*.pyh
 /kernel/python_wrappers.cc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,118 @@
+# AGENTS.md
+
+Guidance for AI coding agents (Claude Code, Cursor, Aider, etc.) working in this repository. Humans should read this too — it summarizes how this fork is built, tested, and worked on.
+
+## What this repo is
+
+[YosysHQ/yosys](https://github.com/YosysHQ/yosys) — an open-source RTL synthesis framework — forked at `crockpotveggies/yosys`. Active branch: `crockpot/optimization-v1`, focused on performance optimization (~1.85× geomean over upstream `main` across the four benchmarks in `benchmark-results/generated/`).
+
+## Build
+
+This is an MSYS2-64 / mingw-w64 build on Windows. Build settings live in `Makefile.conf` (no abc, no zlib, no tcl, no plugins).
+
+```bash
+make -j6 yosys.exe
+./yosys.exe -V
+```
+
+**Caveat for this Windows config:** the standard link step fails with `cannot find techlibs/quickl: No such file or directory` because the command line for 330 .o files exceeds Windows' limit. After `make -j6` reports that error, finish the link via response file:
+
+```bash
+bash benchmark-results/gen_objs.sh   # regenerate yosys_objs.txt with current GIT_REV
+bash benchmark-results/link_yosys.sh # link via mingw response file
+```
+
+**After any change to `RTLIL::Module` layout** (adding/removing fields), force-clean stale .o files first — the `.d` dependency files in `passes/opt/opt_clean/` and `libs/*` don't track `kernel/rtlil.h`, so stale .o files cause silent ABI mismatch and SEGVs in unrelated passes:
+
+```bash
+find . -name "*.o" ! -newer kernel/rtlil.h | xargs rm -f
+```
+
+## Test
+
+Test makefiles default `YOSYS=..\../yosys` (no `.exe`), which doesn't resolve under MSYS. Always invoke with the absolute `.exe` suffix:
+
+```bash
+YOSYS=../../yosys.exe make -j6 -C tests/various
+```
+
+**Canary tests** for hashlib/sigspec changes — these four catch fastmod / bucket-assignment bugs immediately:
+
+```bash
+YOSYS=../../yosys.exe make -j6 -C tests/various 2>&1 | \
+  grep -E "^(PASS|FAIL) (wreduce|wreduce2|peepopt|muxpack)\.ys"
+```
+
+**Expected baseline failures (environmental, not regressions):**
+| Directory | Failures | Cause |
+|---|---|---|
+| `tests/various` | 21 | abc/abc9 not built, no zlib, `/dev/null`, MSYS shell `mkdir` |
+| `tests/opt` | 2 | abc-dependent (opt_lut, opt_hier) |
+| `tests/verilog` | 4 | requires `sim` cmd (sim2 plugin) or `grep` shell |
+| `tests/sat` | 2 | requires `sim` |
+| `tests/techmap` | 16 | requires `abc` |
+| `tests/fmt` | 13 | requires `iverilog` (Icarus Verilog) |
+
+If anything else fails, it's likely your change.
+
+## Repository layout
+
+```
+kernel/        Core data structures (RTLIL::*, hashlib, SigSpec, log, yosys_common)
+frontends/     Verilog frontend (verilog/), AST handling (ast/), JSON, BLIF, etc.
+passes/        Synthesis passes — biggest dirs are opt/ (~25 passes) and proc/
+backends/      Output writers (verilog, blif, json, smt2, ...)
+techlibs/      Tech-mapping libraries per FPGA family (xilinx, ice40, ecp5, ...)
+libs/          Vendored deps (bigint, ezsat, json11, minisat, sha1)
+tests/         Test suites — see "Test" above
+benchmark-results/  Perf-loop scripts, synthetic benchmarks, historical numbers
+agents/        Specialized agent playbooks (see below)
+```
+
+## Code style
+
+- C++17, GNU dialect. Built with `-O3 -DNDEBUG`.
+- Header includes group order: `kernel/yosys.h` first, then sibling headers, then `<system>`.
+- Use `IdString` for symbol-table-y strings (interned). Use `std::string` for human-readable text.
+- `log()` for normal output, `log_warning()` / `log_error()`. `log_assert()` for invariants (compiled out under `NDEBUG`).
+- Pass interface: derive from `Pass`, register a global instance, implement `help()` + `execute()`. See `passes/opt/opt_expr.cc` for a worked example.
+- Avoid `dict.reserve(N)` in mass-instantiated object ctors (e.g. `Cell::parameters`) — capacity reservation costs more than rehashing here. See `agents/perf-bisect.md` anti-patterns.
+
+## Common one-liners
+
+```bash
+# Run a single Verilog source through synth flow
+./yosys.exe -p "read_verilog file.v; synth; write_verilog out.v"
+
+# Run a .ys script
+./yosys.exe path/to/script.ys
+
+# Time a benchmark
+{ time ./yosys.exe -q benchmark-results/generated/picorv32_x4_synth.ys; } 2>&1 | grep real
+
+# Quick bench across generated synthetic + picorv32 cases
+bash benchmark-results/run_loop.sh <label>
+```
+
+## Working with multiple agents
+
+Specialized playbooks live in `agents/`. When the user asks for work matching one of these, follow that playbook:
+
+- [`agents/perf-bisect.md`](agents/perf-bisect.md) — performance-loop discipline (examine → hypothesize → edit → bench → test → commit). Used to produce ~1.85× geomean speedup. Encodes anti-patterns that previously broke the build, canary test list, and the per-Module generation-counter pattern that unlocked safe cross-execute() caches.
+
+When adding a new agent playbook, add a one-line entry to the list above and put the file in `agents/`. Each playbook should be self-contained — list its inputs (what the user is asking for), its loop discipline, and its anti-patterns.
+
+## Useful repo-specific docs
+
+- `benchmark-results/PERF-WORK-SUMMARY.md` — cumulative log of optimization work (what landed, what didn't, why). Read before proposing a perf change to avoid retreading rejected ideas.
+- `benchmark-results/SUMMARY-2026-04-24.md` — hashlib loops 6-10 detailed numbers.
+- `agents/perf-bisect.md` — perf-loop playbook (see above).
+- `README.md`, `CodingReadme` — upstream yosys docs (start here for the data model).
+
+## Safety
+
+- Don't push to `origin` without explicit user approval.
+- Don't `--force` push to `main`; warn loudly if asked.
+- Don't skip pre-commit hooks (`--no-verify`) — investigate hook failures.
+- Never amend commits that have been pushed.
+- Do not commit secrets, build artifacts (`*.exe`, `libyosys_exe.a`, `benchmark-results/*.json`), or generated test outputs (`tests/*/*.err`, `tests/*/*.log`).

--- a/agents/perf-bisect.md
+++ b/agents/perf-bisect.md
@@ -1,0 +1,136 @@
+# perf-bisect agent
+
+Playbook for running performance optimization work on this repo. This is the discipline that produced ~1.85× geomean speedup over upstream `main` across mec30k, mec60k, woc3k, and picorv32_x4.
+
+For repo-level orientation (build, test, layout) see [`AGENTS.md`](../AGENTS.md). For the cumulative log of what's already been tried see [`benchmark-results/PERF-WORK-SUMMARY.md`](../benchmark-results/PERF-WORK-SUMMARY.md).
+
+## When to use this agent
+
+The user says one of:
+- "Run an N-loop perf cycle on item X"
+- "Tackle item N with the 5x loop strategy"
+- "Profile <area> and optimize it"
+- "Find a perf win in <pass>"
+
+If the request is "make this faster" without a target, push back: ask what they've profiled or whether they want a profile-first cycle.
+
+## The loop
+
+A perf loop = one self-contained hypothesis, validated end-to-end before commit. Typical session is 5 loops; each produces either a commit or a documented negative result.
+
+```
+1. EXAMINE — read the code under hypothesis. Don't guess at structure.
+2. HYPOTHESIZE — state in one sentence what you'll change and what speedup you expect.
+3. EDIT — make ONE focused change. No bundled refactors. No drive-by cleanups.
+4. BUILD — see "Build" in AGENTS.md. Standard `make yosys.exe` link will fail; use the response-file workflow.
+5. BENCH — run the relevant subset of `benchmark-results/generated/*.ys` 5x. Take medians. Compare against pre-change baseline numbers.
+6. TEST — at minimum, run the canary tests: `tests/various/{wreduce,wreduce2,peepopt,muxpack}.ys`. For changes touching opt passes also run `tests/opt`. For AST/genrtlil changes also run `tests/verilog`.
+7. DECIDE — if real speedup AND tests pass → commit. If regression OR test failure → revert and write down why.
+8. RECORD — append outcome (positive or negative) to the perf-loop history memory file.
+```
+
+## Build & test (perf-specific)
+
+See [`AGENTS.md`](../AGENTS.md) for the standard build/test workflow. Perf-specific extras:
+
+```bash
+# Per-loop quick check — run the affected synthetic 5x
+cd benchmark-results/generated
+for i in 1 2 3 4 5; do
+  { time ../../yosys.exe -q many_equiv_cells_60000.ys; } 2>&1 | grep real
+done
+
+# Full cycle (microbench + synthetic + default benchmarks, one label)
+bash benchmark-results/run_loop.sh <label>
+
+# Outputs:
+#   benchmark-results/<label>-baseline-<date>.json
+#   benchmark-results/<label>-synthetic-<date>.json
+#   benchmark-results/hashlib-microbench-<label>-<date>.json
+```
+
+**Run-to-run variance is significant on Windows.** Apparent 1-4% wins frequently disappear with 10-rep verification. Take medians, run 5+ samples for any decision near the noise floor.
+
+## Profiling pattern
+
+When you don't know where time is spent, instrument with `<chrono>` and `fprintf(stderr, ...)`. **Revert the instrumentation before committing** — leave only the optimization in the final commit.
+
+Pattern used to find the AST helper hot spot in `frontends/ast/ast.cc`:
+
+```cpp
+auto _t_start = std::chrono::steady_clock::now();
+// ... code under measurement ...
+auto _t_end = std::chrono::steady_clock::now();
+auto us = [](auto a, auto b) {
+    return std::chrono::duration_cast<std::chrono::microseconds>(b - a).count();
+};
+fprintf(stderr, "[my-prof] %s phase=%lldus n=%zu\n",
+        identifier, (long long)us(_t_start, _t_end), count);
+```
+
+For passes that loop over modules, prefix output with the module name and counts so you can spot which module dominates.
+
+## Anti-patterns (do NOT redo)
+
+These have all been tried. Full reasoning in `benchmark-results/PERF-WORK-SUMMARY.md`.
+
+1. **Changing hashtable iteration order** (e.g. Lemire bucket compression). Yosys `opt -fast` has order-fragile fixed-point loops that explode to 600k+ iterations.
+2. **Adding fields to `entry_t`** (e.g. cached `udata_hash`). +4 bytes per entry hurts cache locality more than it saves work.
+3. **`dict.reserve(N)` in mass-instantiated object ctors** (e.g. `Cell::parameters`). Memory cost per object dominates the rehash savings.
+4. **Speculative loads in chain walks.** Chains are short at load factor 0.5; the load is wasted.
+5. **AstNode arena allocators** (free-list or slab). Arena pollutes cache during opt passes; cell-heavy benchmarks regress 6-13%. Without a raw-pointer ownership refactor, `AstModule::ast` survivors across `design -reset/copy` create use-after-free.
+6. **AST::process per-module parallelism.** Blocked by `log_assert(!Multithreading::active())` in IdString machinery. Architectural — not a perf change.
+7. **PGO build.** +13–21% slower across all benchmarks with current training corpus.
+8. **Hash-tag in `entry_t` for chain-walk filtering.** Exposes a latent invariant violation somewhere in pool/dict usage; deterministically crashes ~12 tests.
+9. **Bulk `dict.count(k) ? dict.at(k)` → `find()` rewrite.** Compiler already CSEs the double lookup; manual rewrite regresses ~5% on woc3k.
+
+## Patterns that work
+
+1. **Early-bail audit.** For every pass with significant per-call setup (build SigMap, sigusers, mux_drivers, ConstEval seed, ModWalker), check whether the work-set is empty *before* doing the setup. A 5-line `if (...) continue;` at the top of `execute()` can be 30%+ on the right input.
+2. **Per-Module generation-counter no-op cache.** Pattern (already in 8+ passes):
+   ```cpp
+   struct FooNoopCache { uint64_t generation; bool last_did_something; };
+   static std::map<RTLIL::Module*, FooNoopCache> noop_cache;
+   // per-module:
+   auto it = noop_cache.find(module);
+   if (it != noop_cache.end()
+       && it->second.generation == module->generation
+       && !it->second.last_did_something) continue;
+   uint64_t gen_before = module->generation;
+   // ... do work ...
+   noop_cache[module] = {module->generation, module->generation != gen_before};
+   ```
+   Pointer reuse after `design -reset` is safe because each new Module gets a fresh global generation.
+3. **Cache `data()` pointers across opaque calls.** Compiler can't prove the pointer is loop-invariant if the loop body calls user-defined comparators / hash functions.
+4. **Hoist invariant work out of per-cell helpers.** When the same string/value is computed twice per call (e.g. `loc_string()` for both cell and wire in genrtlil helpers), hoist once and reuse.
+
+## When to abort a loop early
+
+Abort and document, don't push through:
+
+- **Architectural blocker found** (e.g. `Multithreading::active()` assert prevents parallelism).
+- **Test breakage you can't explain in <30 minutes.**
+- **Bench delta within run-to-run noise after 5+ samples.**
+- **Implementation requires rewriting the wrong part of the codebase** (e.g. `dict.reserve()` would need a separate codepath for transient vs persistent dicts).
+
+A documented abort is more valuable than a speculative commit. The `benchmark-results/PERF-WORK-SUMMARY.md` "what didn't work" section is what stops the next agent from wasting cycles.
+
+## Standard playbook for "tackle item N with the 5x loop strategy"
+
+1. Read `benchmark-results/PERF-WORK-SUMMARY.md` and the perf-loop history memory file (if present) to confirm item N hasn't already been tried.
+2. **Loop 1 = profiling/research, NOT a speculative edit.** Confirm the hot spot is where you think it is. If wrong, propose a pivot rather than burning the budget on a known-wrong target.
+3. **Loops 2-4: implement, bench, refine.** ONE change per loop. Don't bundle.
+4. **Loop 5: revert any instrumentation. Run full canary tests. Commit only if real improvement.**
+5. **Final report:** numbers per loop, what landed, updated remaining-work list.
+
+## Memory files
+
+If running with Claude Code, the memory dir is `~/.claude/projects/C--Users-justi-Projects-yosys/memory/`. Relevant files:
+
+- `MEMORY.md` — index of all memory files
+- `build-and-test.md` — Windows/MSYS workflow notes
+- `perf-loop-methodology.md` — concise version of this playbook
+- `perf-loop-history.md` — cumulative log of every loop, what landed, what didn't
+- `user-collab-style.md` — collaboration-style preferences
+
+**Update `perf-loop-history.md` after each loop.** Single most valuable habit; stops the next session from retreading rejected ideas.

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -1098,6 +1098,11 @@ void AST::set_src_attr(RTLIL::AttrObject *obj, const AstNode *ast)
 	obj->attributes[ID::src] = ast->loc_string();
 }
 
+void AST::set_src_attr(RTLIL::AttrObject *obj, const std::string &src)
+{
+	obj->attributes[ID::src] = src;
+}
+
 static bool param_has_no_default(const AstNode* param) {
 	const auto &children = param->children;
 	log_assert(param->type == AST_PARAMETER);

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -428,6 +428,7 @@ namespace AST
 
 	// Helper for setting the src attribute.
 	void set_src_attr(RTLIL::AttrObject *obj, const AstNode *ast);
+	void set_src_attr(RTLIL::AttrObject *obj, const std::string &src);
 
 	// generate standard $paramod... derived module name; parameters should be
 	// in the order they are declared in the instantiated module

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -53,7 +53,7 @@ static RTLIL::SigSpec uniop2rtlil(AstNode *that, IdString type, int result_width
 	set_src_attr(wire, that);
 	wire->is_signed = that->is_signed;
 
-	if (gen_attributes)
+	if (gen_attributes && !that->attributes.empty())
 		for (auto &attr : that->attributes) {
 			if (attr.second->type != AST_CONSTANT)
 				that->input_error("Attribute `%s' with non-constant value!\n", attr.first);
@@ -85,7 +85,7 @@ static void widthExtend(AstNode *that, RTLIL::SigSpec &sig, int width, bool is_s
 	set_src_attr(wire, that);
 	wire->is_signed = that->is_signed;
 
-	if (that != nullptr)
+	if (that != nullptr && !that->attributes.empty())
 		for (auto &attr : that->attributes) {
 			if (attr.second->type != AST_CONSTANT)
 				that->input_error("Attribute `%s' with non-constant value!\n", attr.first);
@@ -112,11 +112,12 @@ static RTLIL::SigSpec binop2rtlil(AstNode *that, IdString type, int result_width
 	set_src_attr(wire, that);
 	wire->is_signed = that->is_signed;
 
-	for (auto &attr : that->attributes) {
-		if (attr.second->type != AST_CONSTANT)
-			that->input_error("Attribute `%s' with non-constant value!\n", attr.first);
-		cell->attributes[attr.first] = attr.second->asAttrConst();
-	}
+	if (!that->attributes.empty())
+		for (auto &attr : that->attributes) {
+			if (attr.second->type != AST_CONSTANT)
+				that->input_error("Attribute `%s' with non-constant value!\n", attr.first);
+			cell->attributes[attr.first] = attr.second->asAttrConst();
+		}
 
 	cell->parameters[ID::A_SIGNED] = RTLIL::Const(that->children[0]->is_signed);
 	cell->parameters[ID::B_SIGNED] = RTLIL::Const(that->children[1]->is_signed);
@@ -147,11 +148,12 @@ static RTLIL::SigSpec mux2rtlil(AstNode *that, const RTLIL::SigSpec &cond, const
 	set_src_attr(wire, that);
 	wire->is_signed = that->is_signed;
 
-	for (auto &attr : that->attributes) {
-		if (attr.second->type != AST_CONSTANT)
-			that->input_error("Attribute `%s' with non-constant value!\n", attr.first);
-		cell->attributes[attr.first] = attr.second->asAttrConst();
-	}
+	if (!that->attributes.empty())
+		for (auto &attr : that->attributes) {
+			if (attr.second->type != AST_CONSTANT)
+				that->input_error("Attribute `%s' with non-constant value!\n", attr.first);
+			cell->attributes[attr.first] = attr.second->asAttrConst();
+		}
 
 	cell->parameters[ID::WIDTH] = RTLIL::Const(left.size());
 

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -1638,11 +1638,20 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 				chunk = RTLIL::Const(id2ast->children[0]->bits);
 				goto use_const_chunk;
 			}
-			else if ((id2ast->type == AST_WIRE || id2ast->type == AST_AUTOWIRE || id2ast->type == AST_MEMORY) && current_module->wires_.count(str) != 0) {
-				RTLIL::Wire *current_wire = current_module->wire(str);
-				if (current_wire->get_bool_attribute(ID::is_interface))
+			else if (id2ast->type == AST_WIRE || id2ast->type == AST_AUTOWIRE || id2ast->type == AST_MEMORY) {
+				// Single dict lookup instead of count() + wire() + wires_[str]
+				// (the original did three keyed-by-`str` hash hits per
+				// AST_IDENTIFIER, called once per signal reference during
+				// genrtlil — visible in profile of flat verilog inputs).
+				auto wit = current_module->wires_.find(str);
+				if (wit != current_module->wires_.end()) {
+					RTLIL::Wire *current_wire = wit->second;
+					if (current_wire->get_bool_attribute(ID::is_interface))
+						is_interface = true;
+					wire = current_wire;
+				} else {
 					is_interface = true;
-				// Ignore
+				}
 			}
 			// If an identifier is found that is not already known, assume that it is an interface:
 			else if (1) { // FIXME: Check if sv_mode first?
@@ -1668,7 +1677,10 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 				return dummy_wire;
 			}
 
-			wire = current_module->wires_[str];
+			// `wire` was set above when found via wires_.find(); fall back
+			// for the (now unreachable) other branches.
+			if (wire == nullptr)
+				wire = current_module->wires_[str];
 			chunk.wire = wire;
 			chunk.width = wire->width;
 			chunk.offset = 0;

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -47,10 +47,11 @@ static RTLIL::SigSpec uniop2rtlil(AstNode *that, IdString type, int result_width
 {
 	IdString name = stringf("%s$%s:%d$%d", type, RTLIL::encode_filename(*that->location.begin.filename), that->location.begin.line, autoidx++);
 	RTLIL::Cell *cell = current_module->addCell(name, type);
-	set_src_attr(cell, that);
+	std::string src_str = that->loc_string();
+	set_src_attr(cell, src_str);
 
 	RTLIL::Wire *wire = current_module->addWire(cell->name.str() + "_Y", result_width);
-	set_src_attr(wire, that);
+	set_src_attr(wire, src_str);
 	wire->is_signed = that->is_signed;
 
 	if (gen_attributes && !that->attributes.empty())
@@ -79,10 +80,11 @@ static void widthExtend(AstNode *that, RTLIL::SigSpec &sig, int width, bool is_s
 
 	IdString name = stringf("$extend$%s:%d$%d", RTLIL::encode_filename(*that->location.begin.filename), that->location.begin.line, autoidx++);
 	RTLIL::Cell *cell = current_module->addCell(name, ID($pos));
-	set_src_attr(cell, that);
+	std::string src_str = that->loc_string();
+	set_src_attr(cell, src_str);
 
 	RTLIL::Wire *wire = current_module->addWire(cell->name.str() + "_Y", width);
-	set_src_attr(wire, that);
+	set_src_attr(wire, src_str);
 	wire->is_signed = that->is_signed;
 
 	if (that != nullptr && !that->attributes.empty())
@@ -106,10 +108,11 @@ static RTLIL::SigSpec binop2rtlil(AstNode *that, IdString type, int result_width
 {
 	IdString name = stringf("%s$%s:%d$%d", type, RTLIL::encode_filename(*that->location.begin.filename), that->location.begin.line, autoidx++);
 	RTLIL::Cell *cell = current_module->addCell(name, type);
-	set_src_attr(cell, that);
+	std::string src_str = that->loc_string();
+	set_src_attr(cell, src_str);
 
 	RTLIL::Wire *wire = current_module->addWire(cell->name.str() + "_Y", result_width);
-	set_src_attr(wire, that);
+	set_src_attr(wire, src_str);
 	wire->is_signed = that->is_signed;
 
 	if (!that->attributes.empty())
@@ -142,10 +145,11 @@ static RTLIL::SigSpec mux2rtlil(AstNode *that, const RTLIL::SigSpec &cond, const
 	sstr << "$ternary$" << RTLIL::encode_filename(*that->location.begin.filename) << ":" << that->location.begin.line << "$" << (autoidx++);
 
 	RTLIL::Cell *cell = current_module->addCell(sstr.str(), ID($mux));
-	set_src_attr(cell, that);
+	std::string src_str = that->loc_string();
+	set_src_attr(cell, src_str);
 
 	RTLIL::Wire *wire = current_module->addWire(cell->name.str() + "_Y", left.size());
-	set_src_attr(wire, that);
+	set_src_attr(wire, src_str);
 	wire->is_signed = that->is_signed;
 
 	if (!that->attributes.empty())

--- a/frontends/verilog/preproc.cc
+++ b/frontends/verilog/preproc.cc
@@ -45,7 +45,12 @@
 YOSYS_NAMESPACE_BEGIN
 using namespace VERILOG_FRONTEND;
 
-static std::list<std::string> output_code;
+// output_code accumulates the preprocessor's emitted text. Switched from
+// std::list<std::string> to a single std::string: every token push_back used
+// to allocate a list node + a std::string, and at the end the entire list was
+// concatenated into one string anyway. Direct accumulation is one allocation
+// (with amortized exponential growth) instead of N.
+static std::string output_code;
 static std::list<std::string> input_buffer;
 static size_t input_buffer_charp;
 
@@ -109,7 +114,7 @@ static std::string next_token(bool pass_newline = false)
 	token += ch;
 	if (ch == '\n') {
 		if (pass_newline) {
-			output_code.push_back(token);
+			output_code += token;
 			return "";
 		}
 		return token;
@@ -855,7 +860,7 @@ frontend_verilog_preproc(std::istream                 &f,
 
 		if (ifdef_fail_level > 0) {
 			if (tok == "\n")
-				output_code.push_back(tok);
+				output_code += tok;
 			continue;
 		}
 
@@ -909,7 +914,7 @@ frontend_verilog_preproc(std::istream                 &f,
 				}
 			}
 			if (ff.fail()) {
-				output_code.push_back("`file_notfound " + fn);
+				output_code += "`file_notfound " + fn;
 			} else {
 				input_file(ff, fixed_fn);
 				yosys_input_files.insert(fixed_fn);
@@ -922,14 +927,14 @@ frontend_verilog_preproc(std::istream                 &f,
 			std::string fn = next_token(true);
 			if (!fn.empty() && fn.front() == '"' && fn.back() == '"')
 				fn = fn.substr(1, fn.size()-2);
-			output_code.push_back(tok + " \"" + fn + "\"");
+			output_code += tok + " \"" + fn + "\"";
 			filename_stack.push_back(filename);
 			filename = fn;
 			continue;
 		}
 
 		if (tok == "`file_pop") {
-			output_code.push_back(tok);
+			output_code += tok;
 			filename = filename_stack.back();
 			filename_stack.pop_back();
 			continue;
@@ -978,17 +983,14 @@ frontend_verilog_preproc(std::istream                 &f,
 		if (try_expand_macro(defines, macro_arg_stack, tok))
 			continue;
 
-		output_code.push_back(tok);
+		output_code += tok;
 	}
 
 	if (ifdef_fail_level > 0 || ifdef_pass_level > 0) {
 		log_error("Unterminated preprocessor conditional!\n");
 	}
 
-	std::string output;
-	for (auto &str : output_code)
-		output += str;
-
+	std::string output = std::move(output_code);
 	output_code.clear();
 	input_buffer.clear();
 	input_buffer_charp = 0;

--- a/frontends/verilog/preproc.cc
+++ b/frontends/verilog/preproc.cc
@@ -788,6 +788,22 @@ frontend_verilog_preproc(std::istream                 &f,
 		std::string tok = next_token();
 		// printf("token: >>%s<<\n", tok != "\n" ? tok.c_str() : "NEWLINE");
 
+		// Fast path: every preprocessor directive starts with '`'. For
+		// the overwhelming majority of tokens (identifiers, operators,
+		// whitespace, newlines), skip the directive comparison chain and
+		// the macro-expansion attempt (which does a dict lookup keyed on
+		// the token even when no macros are defined). This shaves time
+		// off flat verilog inputs with no `define / `ifdef in sight.
+		if (tok.empty() || tok[0] != '`') {
+			if (ifdef_fail_level > 0) {
+				if (tok == "\n")
+					output_code += tok;
+				continue;
+			}
+			output_code += tok;
+			continue;
+		}
+
 		if (tok == "`endif") {
 			if (ifdef_fail_level > 0)
 				ifdef_fail_level--;

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -442,7 +442,10 @@ class dict {
 		entry_t *entries_data = entries.data();
 		int *hashtable_data = hashtable.data();
 		const int n = int(entries.size());
+		const int prefetch_dist = 8;
 		for (int i = 0; i < n; i++) {
+			if (i + prefetch_dist < n)
+				__builtin_prefetch(&entries_data[i + prefetch_dist]);
 			do_assert(-1 <= entries_data[i].next && entries_data[i].next < n);
 			Hasher::hash_t hash = do_hash(entries_data[i].udata.first);
 			entries_data[i].next = hashtable_data[hash];
@@ -926,7 +929,10 @@ protected:
 		entry_t *entries_data = entries.data();
 		int *hashtable_data = hashtable.data();
 		const int n = int(entries.size());
+		const int prefetch_dist = 8;
 		for (int i = 0; i < n; i++) {
+			if (i + prefetch_dist < n)
+				__builtin_prefetch(&entries_data[i + prefetch_dist]);
 			do_assert(-1 <= entries_data[i].next && entries_data[i].next < n);
 			Hasher::hash_t hash = do_hash(entries_data[i].udata);
 			entries_data[i].next = hashtable_data[hash];

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -439,11 +439,14 @@ class dict {
 		hashtable.clear();
 		hashtable.resize(hashtable_size(entries.capacity() * hashtable_size_factor), -1);
 
-		for (int i = 0; i < int(entries.size()); i++) {
-			do_assert(-1 <= entries[i].next && entries[i].next < int(entries.size()));
-			Hasher::hash_t hash = do_hash(entries[i].udata.first);
-			entries[i].next = hashtable[hash];
-			hashtable[hash] = i;
+		entry_t *entries_data = entries.data();
+		int *hashtable_data = hashtable.data();
+		const int n = int(entries.size());
+		for (int i = 0; i < n; i++) {
+			do_assert(-1 <= entries_data[i].next && entries_data[i].next < n);
+			Hasher::hash_t hash = do_hash(entries_data[i].udata.first);
+			entries_data[i].next = hashtable_data[hash];
+			hashtable_data[hash] = i;
 		}
 	}
 
@@ -454,11 +457,12 @@ class dict {
 			return 0;
 
 		entry_t *entries_data = entries.data();
-		int k = hashtable[hash];
+		int *hashtable_data = hashtable.data();
+		int k = hashtable_data[hash];
 		do_assert(0 <= k && k < int(entries.size()));
 
 		if (k == index) {
-			hashtable[hash] = entries_data[index].next;
+			hashtable_data[hash] = entries_data[index].next;
 		} else {
 			while (entries_data[k].next != index) {
 				k = entries_data[k].next;
@@ -473,11 +477,11 @@ class dict {
 		{
 			Hasher::hash_t back_hash = do_hash(entries_data[back_idx].udata.first);
 
-			k = hashtable[back_hash];
+			k = hashtable_data[back_hash];
 			do_assert(0 <= k && k < int(entries.size()));
 
 			if (k == back_idx) {
-				hashtable[back_hash] = index;
+				hashtable_data[back_hash] = index;
 			} else {
 				while (entries_data[k].next != back_idx) {
 					k = entries_data[k].next;
@@ -919,11 +923,14 @@ protected:
 		hashtable.clear();
 		hashtable.resize(hashtable_size(entries.capacity() * hashtable_size_factor), -1);
 
-		for (int i = 0; i < int(entries.size()); i++) {
-			do_assert(-1 <= entries[i].next && entries[i].next < int(entries.size()));
-			Hasher::hash_t hash = do_hash(entries[i].udata);
-			entries[i].next = hashtable[hash];
-			hashtable[hash] = i;
+		entry_t *entries_data = entries.data();
+		int *hashtable_data = hashtable.data();
+		const int n = int(entries.size());
+		for (int i = 0; i < n; i++) {
+			do_assert(-1 <= entries_data[i].next && entries_data[i].next < n);
+			Hasher::hash_t hash = do_hash(entries_data[i].udata);
+			entries_data[i].next = hashtable_data[hash];
+			hashtable_data[hash] = i;
 		}
 	}
 
@@ -934,9 +941,10 @@ protected:
 			return 0;
 
 		entry_t *entries_data = entries.data();
-		int k = hashtable[hash];
+		int *hashtable_data = hashtable.data();
+		int k = hashtable_data[hash];
 		if (k == index) {
-			hashtable[hash] = entries_data[index].next;
+			hashtable_data[hash] = entries_data[index].next;
 		} else {
 			while (entries_data[k].next != index) {
 				k = entries_data[k].next;
@@ -951,9 +959,9 @@ protected:
 		{
 			Hasher::hash_t back_hash = do_hash(entries_data[back_idx].udata);
 
-			k = hashtable[back_hash];
+			k = hashtable_data[back_hash];
 			if (k == back_idx) {
-				hashtable[back_hash] = index;
+				hashtable_data[back_hash] = index;
 			} else {
 				while (entries_data[k].next != back_idx) {
 					k = entries_data[k].next;

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -512,9 +512,10 @@ class dict {
 	int do_lookup_internal(const K &key, Hasher::hash_t hash) const
 	{
 		int index = hashtable[hash];
+		const entry_t *entries_data = entries.data();
 
-		while (index >= 0 && !ops.cmp(entries[index].udata.first, key)) {
-			index = entries[index].next;
+		while (index >= 0 && !ops.cmp(entries_data[index].udata.first, key)) {
+			index = entries_data[index].next;
 			do_assert(-1 <= index && index < int(entries.size()));
 		}
 
@@ -986,9 +987,10 @@ protected:
 	int do_lookup_internal(const K &key, Hasher::hash_t hash) const
 	{
 		int index = hashtable[hash];
+		const entry_t *entries_data = entries.data();
 
-		while (index >= 0 && !ops.cmp(entries[index].udata, key)) {
-			index = entries[index].next;
+		while (index >= 0 && !ops.cmp(entries_data[index].udata, key)) {
+			index = entries_data[index].next;
 			do_assert(-1 <= index && index < int(entries.size()));
 		}
 

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -418,12 +418,12 @@ class dict {
 	std::vector<entry_t> entries;
 	OPS ops;
 
-#ifdef NDEBUG
-	static inline void do_assert(bool) { }
-#else
+#if defined(YOSYS_HASHLIB_DEBUG) && !defined(NDEBUG)
 	static inline void do_assert(bool cond) {
 		if (!cond) throw std::runtime_error("dict<> assert failed.");
 	}
+#else
+	static inline void do_assert(bool) { }
 #endif
 
 	Hasher::hash_t do_hash(const K &key) const
@@ -902,12 +902,12 @@ protected:
 	std::vector<entry_t> entries;
 	OPS ops;
 
-#ifdef NDEBUG
-	static inline void do_assert(bool) { }
-#else
+#if defined(YOSYS_HASHLIB_DEBUG) && !defined(NDEBUG)
 	static inline void do_assert(bool cond) {
 		if (!cond) throw std::runtime_error("pool<> assert failed.");
 	}
+#else
+	static inline void do_assert(bool) { }
 #endif
 
 	Hasher::hash_t do_hash(const K &key) const

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -864,6 +864,7 @@ public:
 	{
 		hashtable.swap(other.hashtable);
 		entries.swap(other.entries);
+		std::swap(hashtable_modulo_magic, other.hashtable_modulo_magic);
 	}
 
 	bool operator==(const dict &other) const {
@@ -895,7 +896,7 @@ public:
 	void reserve(size_t n) { entries.reserve(n); }
 	size_t size() const { return entries.size(); }
 	bool empty() const { return entries.empty(); }
-	void clear() { hashtable.clear(); entries.clear(); }
+	void clear() { hashtable.clear(); entries.clear(); hashtable_modulo_magic = 0; }
 
 	iterator begin() { return iterator(this, int(entries.size())-1); }
 	iterator element(int n) { return iterator(this, int(entries.size())-1-n); }
@@ -1275,6 +1276,7 @@ public:
 	{
 		hashtable.swap(other.hashtable);
 		entries.swap(other.entries);
+		std::swap(hashtable_modulo_magic, other.hashtable_modulo_magic);
 	}
 
 	bool operator==(const pool &other) const {
@@ -1301,7 +1303,7 @@ public:
 	void reserve(size_t n) { entries.reserve(n); }
 	size_t size() const { return entries.size(); }
 	bool empty() const { return entries.empty(); }
-	void clear() { hashtable.clear(); entries.clear(); }
+	void clear() { hashtable.clear(); entries.clear(); hashtable_modulo_magic = 0; }
 
 	iterator begin() { return iterator(this, int(entries.size())-1); }
 	iterator element(int n) { return iterator(this, int(entries.size())-1-n); }

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -417,6 +417,9 @@ class dict {
 	std::vector<int> hashtable;
 	std::vector<entry_t> entries;
 	OPS ops;
+	// Precomputed reciprocal for fast modulo (Lemire 2018). Updated on
+	// every do_rehash; equals ~uint64_t(0) / hashtable.size() + 1.
+	uint64_t hashtable_modulo_magic = 0;
 
 #if defined(YOSYS_HASHLIB_DEBUG) && !defined(NDEBUG)
 	static inline void do_assert(bool cond) {
@@ -426,11 +429,20 @@ class dict {
 	static inline void do_assert(bool) { }
 #endif
 
+	// fastmod_u32 returns a % d using a precomputed magic number.
+	// Branchless and ~5x faster than `%` on a runtime-variable divisor.
+	static inline uint32_t fastmod_u32(uint32_t a, uint64_t M, uint32_t d) {
+		__uint128_t lowbits = (__uint128_t)M * a;
+		return (uint32_t)(((__uint128_t)(uint64_t)lowbits * d) >> 64);
+	}
+
 	Hasher::hash_t do_hash(const K &key) const
 	{
 		Hasher::hash_t hash = 0;
-		if (!hashtable.empty())
-			hash = ops.hash(key).yield() % (unsigned int)(hashtable.size());
+		if (!hashtable.empty()) {
+			uint32_t raw = (uint32_t)ops.hash(key).yield();
+			hash = (Hasher::hash_t)fastmod_u32(raw, hashtable_modulo_magic, (uint32_t)hashtable.size());
+		}
 		return hash;
 	}
 
@@ -438,6 +450,12 @@ class dict {
 	{
 		hashtable.clear();
 		hashtable.resize(hashtable_size(entries.capacity() * hashtable_size_factor), -1);
+		// Avoid division-by-zero when do_rehash is called with an empty table.
+		// do_hash gates on !hashtable.empty() so the magic value is unused in
+		// that case, but we still need to leave it well-defined.
+		hashtable_modulo_magic = hashtable.empty()
+			? 0
+			: (~uint64_t(0) / (uint32_t)hashtable.size() + 1);
 
 		entry_t *entries_data = entries.data();
 		int *hashtable_data = hashtable.data();
@@ -907,6 +925,7 @@ protected:
 	std::vector<int> hashtable;
 	std::vector<entry_t> entries;
 	OPS ops;
+	uint64_t hashtable_modulo_magic = 0;
 
 #if defined(YOSYS_HASHLIB_DEBUG) && !defined(NDEBUG)
 	static inline void do_assert(bool cond) {
@@ -916,11 +935,18 @@ protected:
 	static inline void do_assert(bool) { }
 #endif
 
+	static inline uint32_t fastmod_u32(uint32_t a, uint64_t M, uint32_t d) {
+		__uint128_t lowbits = (__uint128_t)M * a;
+		return (uint32_t)(((__uint128_t)(uint64_t)lowbits * d) >> 64);
+	}
+
 	Hasher::hash_t do_hash(const K &key) const
 	{
 		Hasher::hash_t hash = 0;
-		if (!hashtable.empty())
-			hash = ops.hash(key).yield() % (unsigned int)(hashtable.size());
+		if (!hashtable.empty()) {
+			uint32_t raw = (uint32_t)ops.hash(key).yield();
+			hash = (Hasher::hash_t)fastmod_u32(raw, hashtable_modulo_magic, (uint32_t)hashtable.size());
+		}
 		return hash;
 	}
 
@@ -928,6 +954,12 @@ protected:
 	{
 		hashtable.clear();
 		hashtable.resize(hashtable_size(entries.capacity() * hashtable_size_factor), -1);
+		// Avoid division-by-zero when do_rehash is called with an empty table.
+		// do_hash gates on !hashtable.empty() so the magic value is unused in
+		// that case, but we still need to leave it well-defined.
+		hashtable_modulo_magic = hashtable.empty()
+			? 0
+			: (~uint64_t(0) / (uint32_t)hashtable.size() + 1);
 
 		entry_t *entries_data = entries.data();
 		int *hashtable_data = hashtable.data();

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -523,7 +523,10 @@ class dict {
 		const entry_t *entries_data = entries.data();
 
 		while (index >= 0 && !ops.cmp(entries_data[index].udata.first, key)) {
-			index = entries_data[index].next;
+			int next = entries_data[index].next;
+			if (next >= 0)
+				__builtin_prefetch(&entries_data[next]);
+			index = next;
 			do_assert(-1 <= index && index < int(entries.size()));
 		}
 
@@ -1006,7 +1009,10 @@ protected:
 		const entry_t *entries_data = entries.data();
 
 		while (index >= 0 && !ops.cmp(entries_data[index].udata, key)) {
-			index = entries_data[index].next;
+			int next = entries_data[index].next;
+			if (next >= 0)
+				__builtin_prefetch(&entries_data[next]);
+			index = next;
 			do_assert(-1 <= index && index < int(entries.size()));
 		}
 

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -453,24 +453,25 @@ class dict {
 		if (hashtable.empty() || index < 0)
 			return 0;
 
+		entry_t *entries_data = entries.data();
 		int k = hashtable[hash];
 		do_assert(0 <= k && k < int(entries.size()));
 
 		if (k == index) {
-			hashtable[hash] = entries[index].next;
+			hashtable[hash] = entries_data[index].next;
 		} else {
-			while (entries[k].next != index) {
-				k = entries[k].next;
+			while (entries_data[k].next != index) {
+				k = entries_data[k].next;
 				do_assert(0 <= k && k < int(entries.size()));
 			}
-			entries[k].next = entries[index].next;
+			entries_data[k].next = entries_data[index].next;
 		}
 
 		int back_idx = entries.size()-1;
 
 		if (index != back_idx)
 		{
-			Hasher::hash_t back_hash = do_hash(entries[back_idx].udata.first);
+			Hasher::hash_t back_hash = do_hash(entries_data[back_idx].udata.first);
 
 			k = hashtable[back_hash];
 			do_assert(0 <= k && k < int(entries.size()));
@@ -478,14 +479,14 @@ class dict {
 			if (k == back_idx) {
 				hashtable[back_hash] = index;
 			} else {
-				while (entries[k].next != back_idx) {
-					k = entries[k].next;
+				while (entries_data[k].next != back_idx) {
+					k = entries_data[k].next;
 					do_assert(0 <= k && k < int(entries.size()));
 				}
-				entries[k].next = index;
+				entries_data[k].next = index;
 			}
 
-			entries[index] = std::move(entries[back_idx]);
+			entries_data[index] = std::move(entries_data[back_idx]);
 		}
 
 		entries.pop_back();
@@ -932,35 +933,36 @@ protected:
 		if (hashtable.empty() || index < 0)
 			return 0;
 
+		entry_t *entries_data = entries.data();
 		int k = hashtable[hash];
 		if (k == index) {
-			hashtable[hash] = entries[index].next;
+			hashtable[hash] = entries_data[index].next;
 		} else {
-			while (entries[k].next != index) {
-				k = entries[k].next;
+			while (entries_data[k].next != index) {
+				k = entries_data[k].next;
 				do_assert(0 <= k && k < int(entries.size()));
 			}
-			entries[k].next = entries[index].next;
+			entries_data[k].next = entries_data[index].next;
 		}
 
 		int back_idx = entries.size()-1;
 
 		if (index != back_idx)
 		{
-			Hasher::hash_t back_hash = do_hash(entries[back_idx].udata);
+			Hasher::hash_t back_hash = do_hash(entries_data[back_idx].udata);
 
 			k = hashtable[back_hash];
 			if (k == back_idx) {
 				hashtable[back_hash] = index;
 			} else {
-				while (entries[k].next != back_idx) {
-					k = entries[k].next;
+				while (entries_data[k].next != back_idx) {
+					k = entries_data[k].next;
 					do_assert(0 <= k && k < int(entries.size()));
 				}
-				entries[k].next = index;
+				entries_data[k].next = index;
 			}
 
-			entries[index] = std::move(entries[back_idx]);
+			entries_data[index] = std::move(entries_data[back_idx]);
 		}
 
 		entries.pop_back();

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -4816,7 +4816,23 @@ void RTLIL::SigSpec::try_repack()
 	int bits_size = GetSize(bits_);
 	if (bits_size == 0)
 		return;
-	if (bits_[0].is_wire()) {
+
+	// Cheap pre-check: a successful repack requires that bits_[0] and
+	// bits_[bits_size-1] either both be from the same wire (with the right
+	// offset delta) or both be constants. If neither holds, the O(N) walk
+	// below would only confirm "no repack possible" — skip it.
+	const SigBit &first = bits_[0];
+	const SigBit &last = bits_[bits_size - 1];
+	if (first.is_wire()) {
+		if (last.wire != first.wire ||
+				last.offset != first.offset + (bits_size - 1))
+			return;
+	} else {
+		if (last.is_wire())
+			return;
+	}
+
+	if (first.is_wire()) {
 		for (int i = 1; i < bits_size; i++)
 			if (bits_[0].wire != bits_[i].wire || bits_[0].offset + i != bits_[i].offset)
 				return;

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -4627,7 +4627,7 @@ RTLIL::SigSpec::SigSpec(RTLIL::Const &&value)
 {
 	if (GetSize(value) != 0) {
 		rep_ = CHUNK;
-		new (&chunk_) RTLIL::SigChunk(value);
+		new (&chunk_) RTLIL::SigChunk(std::move(value));
 	} else {
 		init_empty_bits();
 	}
@@ -4649,7 +4649,7 @@ RTLIL::SigSpec::SigSpec(RTLIL::SigChunk &&chunk)
 {
 	if (chunk.width != 0) {
 		rep_ = CHUNK;
-		new (&chunk_) RTLIL::SigChunk(chunk);
+		new (&chunk_) RTLIL::SigChunk(std::move(chunk));
 	} else {
 		init_empty_bits();
 	}

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1511,6 +1511,14 @@ std::vector<RTLIL::Module*> RTLIL::Design::selected_modules(RTLIL::SelectPartial
 	return result;
 }
 
+// Process-wide monotonic counter for Module::generation. Single-threaded use.
+static uint64_t module_generation_global = 0;
+
+void RTLIL::Module::bump_generation()
+{
+	generation = ++module_generation_global;
+}
+
 RTLIL::Module::Module()
 {
 	static unsigned int hashidx_count = 123456789;
@@ -1520,6 +1528,7 @@ RTLIL::Module::Module()
 	design = nullptr;
 	refcount_wires_ = 0;
 	refcount_cells_ = 0;
+	generation = ++module_generation_global;
 
 #ifdef YOSYS_ENABLE_PYTHON
 	RTLIL::Module::get_all_modules()->insert(std::pair<unsigned int, RTLIL::Module*>(hashidx_, this));
@@ -2878,6 +2887,7 @@ void RTLIL::Module::add(RTLIL::Wire *wire)
 	log_assert(refcount_wires_ == 0);
 	wires_[wire->name] = wire;
 	wire->module = this;
+	bump_generation();
 }
 
 void RTLIL::Module::add(RTLIL::Cell *cell)
@@ -2887,6 +2897,7 @@ void RTLIL::Module::add(RTLIL::Cell *cell)
 	log_assert(refcount_cells_ == 0);
 	cells_[cell->name] = cell;
 	cell->module = this;
+	bump_generation();
 }
 
 void RTLIL::Module::add(RTLIL::Process *process)
@@ -2895,6 +2906,7 @@ void RTLIL::Module::add(RTLIL::Process *process)
 	log_assert(count_id(process->name) == 0);
 	processes[process->name] = process;
 	process->module = this;
+	bump_generation();
 }
 
 void RTLIL::Module::add(RTLIL::Binding *binding)
@@ -2946,6 +2958,7 @@ void RTLIL::Module::remove(const pool<RTLIL::Wire*> &wires)
 		wires_.erase(it->name);
 		delete it;
 	}
+	bump_generation();
 }
 
 void RTLIL::Module::remove(RTLIL::Cell *cell)
@@ -2963,6 +2976,7 @@ void RTLIL::Module::remove(RTLIL::Cell *cell)
 	} else {
 		delete cell;
 	}
+	bump_generation();
 }
 
 void RTLIL::Module::remove(RTLIL::Memory *memory)
@@ -2970,6 +2984,7 @@ void RTLIL::Module::remove(RTLIL::Memory *memory)
 	log_assert(memories.count(memory->name) != 0);
 	memories.erase(memory->name);
 	delete memory;
+	bump_generation();
 }
 
 void RTLIL::Module::remove(RTLIL::Process *process)
@@ -2977,6 +2992,7 @@ void RTLIL::Module::remove(RTLIL::Process *process)
 	log_assert(processes.count(process->name) != 0);
 	processes.erase(process->name);
 	delete process;
+	bump_generation();
 }
 
 void RTLIL::Module::rename(RTLIL::Wire *wire, RTLIL::IdString new_name)
@@ -3101,6 +3117,7 @@ void RTLIL::Module::connect(const RTLIL::SigSig &conn)
 
 	log_assert(GetSize(conn.first) == GetSize(conn.second));
 	connections_.push_back(conn);
+	bump_generation();
 }
 
 void RTLIL::Module::connect(const RTLIL::SigSpec &lhs, const RTLIL::SigSpec &rhs)
@@ -3125,6 +3142,7 @@ void RTLIL::Module::new_connections(const std::vector<RTLIL::SigSig> &new_conn)
 	}
 
 	connections_ = new_conn;
+	bump_generation();
 }
 
 const std::vector<RTLIL::SigSig> &RTLIL::Module::connections() const

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -797,10 +797,11 @@ namespace RTLIL {
 
 	static inline std::string encode_filename(const std::string &filename)
 	{
-		std::stringstream val;
+		// Fast path: skip stringstream construction when filename is plain ASCII.
 		if (!std::any_of(filename.begin(), filename.end(), [](char c) {
 			return static_cast<unsigned char>(c) < 33 || static_cast<unsigned char>(c) > 126;
 		})) return filename;
+		std::stringstream val;
 		for (unsigned char const c : filename) {
 			if (c < 33 || c > 126)
 				val << stringf("$%02x", c);

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -2087,6 +2087,15 @@ protected:
 	void add(RTLIL::Process *process);
 
 public:
+	// Process-wide monotonic generation counter. Bumped on every
+	// structural mutation. Caches across pass invocations key off this
+	// value: a cache is valid iff the cached `generation` equals the
+	// module's current `generation`. Pulled from a global counter so
+	// values are unique even when a Module is destroyed and a new one
+	// is allocated at the same address (`design -reset` workflows).
+	uint64_t generation = 0;
+	void bump_generation();
+
 	RTLIL::Design *design;
 	pool<RTLIL::Monitor*> monitors;
 

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1626,13 +1626,15 @@ public:
 	// uses this to read via the const path while still letting the caller
 	// observe a SigBit&; the iterator detects mutations and flushes them
 	// back to the SigSpec on advance/comparison.
+	// NOTE: caller is responsible for `0 <= index < size()` — the iterator
+	// only dereferences valid positions, so bypassing the bounds check is safe.
 	inline RTLIL::SigBit read_at(int index) const {
 		if (rep_ == CHUNK) {
 			if (chunk_.wire)
 				return RTLIL::SigBit(chunk_.wire, chunk_.offset + index);
 			return RTLIL::SigBit(chunk_.data[index]);
 		}
-		return bits_.at(index);
+		return bits_[index];
 	}
 	inline RTLIL::SigBit operator[](int index) const {
 		if (rep_ == CHUNK) {

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1372,11 +1372,23 @@ struct RTLIL::SigSpecIterator
 
 	RTLIL::SigSpec *sig_p;
 	int index;
+	// Write-back cache. operator* loads the bit via the const path (no
+	// unpack) into `cache` and snapshots `original`. On advance/comparison,
+	// if cache != original the caller mutated the bit (via either
+	// `bit = X` or member-level writes such as `bit.wire = X`) and we
+	// flush that one bit back through unpack. Common-case read-only loops
+	// never trigger an unpack — previously `for (auto &b : sig)` ran
+	// inline_unpack() on every iteration via operator[], which dominated
+	// allocator pressure on synth-heavy workloads.
+	mutable RTLIL::SigBit cache;
+	mutable RTLIL::SigBit original;
+	mutable int cached_idx;
 
 	inline RTLIL::SigBit &operator*() const;
-	inline bool operator!=(const RTLIL::SigSpecIterator &other) const { return index != other.index; }
-	inline bool operator==(const RTLIL::SigSpecIterator &other) const { return index == other.index; }
-	inline void operator++() { index++; }
+	inline bool operator!=(const RTLIL::SigSpecIterator &other) const { flush(); return index != other.index; }
+	inline bool operator==(const RTLIL::SigSpecIterator &other) const { flush(); return index == other.index; }
+	inline void operator++() { flush(); index++; }
+	inline void flush() const;
 };
 
 struct RTLIL::SigSpecConstIterator
@@ -1462,6 +1474,7 @@ private:
 			bits_.~vector();
 	}
 	friend struct Chunks;
+	friend struct SigSpecIterator;
 
 public:
 	SigSpec() { init_empty_bits(); }
@@ -1609,6 +1622,18 @@ public:
 	inline bool empty() const { return size() == 0; };
 
 	inline RTLIL::SigBit &operator[](int index) { inline_unpack(); hash_.clear(); return bits_.at(index); }
+	// Read-only bit access that never triggers an unpack. SigSpecIterator
+	// uses this to read via the const path while still letting the caller
+	// observe a SigBit&; the iterator detects mutations and flushes them
+	// back to the SigSpec on advance/comparison.
+	inline RTLIL::SigBit read_at(int index) const {
+		if (rep_ == CHUNK) {
+			if (chunk_.wire)
+				return RTLIL::SigBit(chunk_.wire, chunk_.offset + index);
+			return RTLIL::SigBit(chunk_.data[index]);
+		}
+		return bits_.at(index);
+	}
 	inline RTLIL::SigBit operator[](int index) const {
 		if (rep_ == CHUNK) {
 			if (index < 0 || index >= chunk_.width)
@@ -1620,8 +1645,8 @@ public:
 		return bits_.at(index);
 	}
 
-	inline RTLIL::SigSpecIterator begin() { RTLIL::SigSpecIterator it; it.sig_p = this; it.index = 0; return it; }
-	inline RTLIL::SigSpecIterator end() { RTLIL::SigSpecIterator it; it.sig_p = this; it.index = size(); return it; }
+	inline RTLIL::SigSpecIterator begin() { RTLIL::SigSpecIterator it; it.sig_p = this; it.index = 0; it.cached_idx = -1; return it; }
+	inline RTLIL::SigSpecIterator end() { RTLIL::SigSpecIterator it; it.sig_p = this; it.index = size(); it.cached_idx = -1; return it; }
 
 	inline RTLIL::SigSpecConstIterator begin() const { RTLIL::SigSpecConstIterator it; it.sig_p = this; it.index = 0; return it; }
 	inline RTLIL::SigSpecConstIterator end() const { RTLIL::SigSpecConstIterator it; it.sig_p = this; it.index = size(); return it; }
@@ -2672,7 +2697,26 @@ inline Hasher RTLIL::SigBit::hash_top() const {
 }
 
 inline RTLIL::SigBit &RTLIL::SigSpecIterator::operator*() const {
-	return (*sig_p)[index];
+	if (cached_idx != index) {
+		flush();
+		cache = sig_p->read_at(index);
+		original = cache;
+		cached_idx = index;
+	}
+	return cache;
+}
+
+inline void RTLIL::SigSpecIterator::flush() const {
+	if (cached_idx < 0)
+		return;
+	// If the caller mutated the cached bit, write it back. Comparing
+	// against the original snapshot avoids re-reading from sig_p.
+	if (!(cache == original)) {
+		sig_p->inline_unpack();
+		sig_p->bits_[cached_idx] = cache;
+		sig_p->hash_.clear();
+	}
+	cached_idx = -1;
 }
 
 inline const RTLIL::SigBit &RTLIL::SigSpecConstIterator::operator*() {

--- a/kernel/rtlil_bufnorm.cc
+++ b/kernel/rtlil_bufnorm.cc
@@ -533,6 +533,11 @@ void RTLIL::Cell::unsetPort(RTLIL::IdString portname)
 
 	if (conn_it != connections_.end())
 	{
+		// Cell port mutations affect any per-Module cache that indexes
+		// off cell connectivity. Bump the module's generation.
+		if (module)
+			module->bump_generation();
+
 		for (auto mon : module->monitors)
 			mon->notify_connect(this, conn_it->first, conn_it->second, signal);
 
@@ -592,6 +597,11 @@ void RTLIL::Cell::setPort(RTLIL::IdString portname, RTLIL::SigSpec signal)
 	auto conn_it = r.first;
 	if (!r.second && conn_it->second == signal)
 		return;
+
+	// Cell port mutations affect any per-Module cache that indexes
+	// off cell connectivity. Bump the module's generation.
+	if (module)
+		module->bump_generation();
 
 	for (auto mon : module->monitors)
 		mon->notify_connect(this, conn_it->first, conn_it->second, signal);

--- a/passes/opt/opt.cc
+++ b/passes/opt/opt.cc
@@ -173,20 +173,66 @@ struct OptPass : public Pass {
 		{
 			Pass::call(design, "opt_expr" + opt_expr_args);
 			Pass::call(design, "opt_merge -nomux" + opt_merge_args);
-			while (1) {
+
+			// Per-sub-pass change tracking for early-exit. Each sub-pass
+			// resets the scratchpad flag and we read it after the call,
+			// so we know exactly which passes did something this iter.
+			// In the typical 2-iteration convergence case, the second
+			// iteration runs every sub-pass just to confirm nothing
+			// changed. If the early-running sub-passes (muxtree, reduce,
+			// merge) all returned no-op AND last iteration's heavy
+			// passes (share, dff) also did nothing, we can break out
+			// without paying for opt_share + opt_dff + opt_clean +
+			// opt_expr in the current iteration. Heavy passes won't
+			// find anything new if (a) their inputs didn't change this
+			// iter and (b) they themselves found nothing last iter.
+			auto run = [&](const std::string &cmd) -> bool {
 				design->scratchpad_unset("opt.did_something");
-				Pass::call(design, "opt_muxtree");
-				Pass::call(design, "opt_reduce" + opt_reduce_args);
-				Pass::call(design, "opt_merge" + opt_merge_args);
+				Pass::call(design, cmd);
+				return design->scratchpad_get_bool("opt.did_something");
+			};
+			// Track only the *change-making* heavy passes across iterations.
+			// opt_clean / opt_expr report did_something for cleanup work
+			// (removing intermediate wires, folding constants) which is not
+			// a semantic design change — including them would never let us
+			// early-exit. The real "is the design still evolving?" signal
+			// is whether opt_share or opt_dff (or any early pass) found
+			// real opportunities last iter.
+			bool prev_share_changed = true;
+			bool prev_dff_changed = true;
+			while (1) {
+				bool muxtree_changed = run("opt_muxtree");
+				bool reduce_changed = run("opt_reduce" + opt_reduce_args);
+				bool merge_changed = run("opt_merge" + opt_merge_args);
+				bool early_changed = muxtree_changed || reduce_changed || merge_changed;
+
+				// Early-exit: if no early-pass change AND the heavy
+				// passes (share, dff) found nothing in the previous
+				// iteration, then this iteration's heavy passes will
+				// also find nothing (their inputs haven't moved). Skip
+				// opt_share + opt_dff + opt_clean + opt_expr for this
+				// iter and break out of the loop.
+				if (!early_changed && !prev_share_changed && !prev_dff_changed) {
+					design->scratchpad_set_bool("opt.did_something", false);
+					break;
+				}
+
+				bool share_changed = false;
 				if (opt_share)
-					Pass::call(design, "opt_share");
+					share_changed = run("opt_share");
+				bool dff_changed = false;
 				if (!noff_mode)
-					Pass::call(design, "opt_dff" + opt_dff_args);
+					dff_changed = run("opt_dff" + opt_dff_args);
 				if (hier_mode)
 					Pass::call(design, "opt_hier");
-				Pass::call(design, "opt_clean" + opt_clean_args);
-				Pass::call(design, "opt_expr" + opt_expr_args);
-				if (design->scratchpad_get_bool("opt.did_something") == false)
+				bool clean_changed = run("opt_clean" + opt_clean_args);
+				bool expr_changed = run("opt_expr" + opt_expr_args);
+
+				bool any_changed = early_changed || share_changed || dff_changed
+						|| clean_changed || expr_changed;
+				prev_share_changed = share_changed;
+				prev_dff_changed = dff_changed;
+				if (!any_changed)
 					break;
 				log_header(design, "Rerunning OPT passes. (Maybe there is more to do..)\n");
 			}

--- a/passes/opt/opt_clean/opt_clean.cc
+++ b/passes/opt/opt_clean/opt_clean.cc
@@ -60,6 +60,22 @@ struct OptCleanPass : public Pass {
 		log("        also remove internal nets if they have a public name\n");
 		log("\n");
 	}
+	// Cross-execute() no-op cache. Skip rmunused_module entirely if the
+	// module is unchanged since a prior call that found nothing to
+	// remove. The setup cost of a single rmunused_module call is
+	// substantial (~20-40ms on picorv32_x4) — building the parallel
+	// AnalysisContext, exploring cell connectivity, and running
+	// rmunused_module_signals which clears + rebuilds module->connections_
+	// every iter. Worth caching.
+	struct CleanNoopCache {
+		uint64_t generation;
+		bool last_did_something;
+	};
+	static std::map<RTLIL::Module*, CleanNoopCache> &noop_cache_storage() {
+		static std::map<RTLIL::Module*, CleanNoopCache> instance;
+		return instance;
+	}
+
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		bool purge_mode = false;
@@ -78,13 +94,33 @@ struct OptCleanPass : public Pass {
 		extra_args(args, argidx, design);
 
 		{
+			auto &noop_cache = noop_cache_storage();
 			std::vector<RTLIL::Module*> selected_modules;
-			for (auto module : design->selected_whole_modules_warn())
-				if (!module->has_processes_warn())
-					selected_modules.push_back(module);
+			for (auto module : design->selected_whole_modules_warn()) {
+				if (module->has_processes_warn())
+					continue;
+				auto noop_it = noop_cache.find(module);
+				if (noop_it != noop_cache.end() &&
+						noop_it->second.generation == module->generation &&
+						!noop_it->second.last_did_something)
+					continue;
+				selected_modules.push_back(module);
+			}
 			CleanRunContext clean_ctx(design, selected_modules, {purge_mode, true});
-			for (auto module : selected_modules)
+			// Per-module did_something tracking via the module's
+			// generation counter: it bumps on every cell/wire removal
+			// inside rmunused_module, so a stable generation across
+			// the call means no work was done.
+			bool any_did_something = design->scratchpad_get_bool("opt.did_something");
+			for (auto module : selected_modules) {
+				uint64_t gen_before = module->generation;
 				rmunused_module(module, true, clean_ctx);
+				bool mod_did_something = module->generation != gen_before;
+				noop_cache[module] = {module->generation, mod_did_something};
+				if (mod_did_something)
+					any_did_something = true;
+			}
+			(void)any_did_something;  // already reflected in scratchpad by rmunused_module
 			clean_ctx.stats.log();
 
 			design->optimize();
@@ -129,13 +165,28 @@ struct CleanPass : public Pass {
 		extra_args(args, argidx, design);
 
 		{
+			// Same no-op cache as OptCleanPass — they share rmunused_module
+			// semantics. Use the OptCleanPass storage so back-to-back
+			// `clean` and `opt_clean` calls share state.
+			auto &noop_cache = OptCleanPass::noop_cache_storage();
 			std::vector<RTLIL::Module*> selected_modules;
-			for (auto module : design->selected_unboxed_whole_modules())
-				if (!module->has_processes())
-					selected_modules.push_back(module);
+			for (auto module : design->selected_unboxed_whole_modules()) {
+				if (module->has_processes())
+					continue;
+				auto noop_it = noop_cache.find(module);
+				if (noop_it != noop_cache.end() &&
+						noop_it->second.generation == module->generation &&
+						!noop_it->second.last_did_something)
+					continue;
+				selected_modules.push_back(module);
+			}
 			CleanRunContext clean_ctx(design, selected_modules, {purge_mode, ys_debug()});
-			for (auto module : selected_modules)
+			for (auto module : selected_modules) {
+				uint64_t gen_before = module->generation;
 				rmunused_module(module, true, clean_ctx);
+				bool mod_did_something = module->generation != gen_before;
+				noop_cache[module] = {module->generation, mod_did_something};
+			}
 
 			log_suppressed();
 			clean_ctx.stats.log();

--- a/passes/opt/opt_dff.cc
+++ b/passes/opt/opt_dff.cc
@@ -115,24 +115,42 @@ struct OptDffWorker
 		// Gathering two kinds of information here for every sigmapped SigBit:
 		// - bitusers: how many users it has (muxes will only be merged into FFs if the FF is the only user)
 		// - bit2mux: the mux cell and bit index that drives it, if any
-
-		for (auto wire : module->wires())
-			if (wire->port_output)
-				for (auto bit : sigmap(wire))
-					bitusers[bit]++;
-
-		for (auto cell : module->cells()) {
+		//
+		// Both are only used by the FF<->mux merge paths (try_merge_srst,
+		// try_merge_ce, find_muxtree_feedback_patterns). If the module has
+		// no $mux/$pmux/$_MUX_ cells at all, those paths can't fire and
+		// the per-cell walk to populate the maps is pure waste — visible
+		// on post-techmap netlists where most muxes have already been
+		// expanded into gates and on synth flows that map to non-mux
+		// cells. Quick scan first.
+		bool has_mux = false;
+		for (auto cell : module->cells())
 			if (cell->type.in(ID($mux), ID($pmux), ID($_MUX_))) {
-				RTLIL::SigSpec sig_y = sigmap(cell->getPort(ID::Y));
-				for (int i = 0; i < GetSize(sig_y); i++)
-					bit2mux[sig_y[i]] = cell_int_t(cell, i);
+				has_mux = true;
+				break;
 			}
 
-			for (auto conn : cell->connections()) {
-				bool is_output = cell->output(conn.first);
-				if (!is_output || !cell->known())
-					for (auto bit : sigmap(conn.second))
+		if (has_mux) {
+			for (auto wire : module->wires())
+				if (wire->port_output)
+					for (auto bit : sigmap(wire))
 						bitusers[bit]++;
+		}
+
+		for (auto cell : module->cells()) {
+			if (has_mux) {
+				if (cell->type.in(ID($mux), ID($pmux), ID($_MUX_))) {
+					RTLIL::SigSpec sig_y = sigmap(cell->getPort(ID::Y));
+					for (int i = 0; i < GetSize(sig_y); i++)
+						bit2mux[sig_y[i]] = cell_int_t(cell, i);
+				}
+
+				for (auto conn : cell->connections()) {
+					bool is_output = cell->output(conn.first);
+					if (!is_output || !cell->known())
+						for (auto bit : sigmap(conn.second))
+							bitusers[bit]++;
+				}
 			}
 
 			if (module->design->selected(module, cell) && cell->is_builtin_ff())

--- a/passes/opt/opt_dff.cc
+++ b/passes/opt/opt_dff.cc
@@ -982,6 +982,19 @@ struct OptDffPass : public Pass {
 
 		bool did_something = false;
 		for (auto mod : design->selected_modules()) {
+			// Early bail-out: if there are no selected built-in FFs, the
+			// OptDffWorker constructor's O(N) walk over wires/cells/conns
+			// (to build bitusers + bit2mux) is pure waste, and both run()
+			// and run_constbits() are no-ops. This is the common case in
+			// FF-free combinational netlists like wide_opt_chain.
+			bool has_dff = false;
+			for (auto cell : mod->cells())
+				if (cell->is_builtin_ff() && mod->design->selected(mod, cell)) {
+					has_dff = true;
+					break;
+				}
+			if (!has_dff)
+				continue;
 			OptDffWorker worker(opt, mod);
 			if (worker.run())
 				did_something = true;

--- a/passes/opt/opt_dff.cc
+++ b/passes/opt/opt_dff.cc
@@ -998,8 +998,30 @@ struct OptDffPass : public Pass {
 		}
 		extra_args(args, argidx, design);
 
+		// Cross-execute() no-op cache. Each entry holds the
+		// module->generation observed at the END of a previous call
+		// AND whether that call did any work. If we re-enter with the
+		// same generation (no other pass modified the module since)
+		// AND the previous call did nothing, the OptDffWorker
+		// constructor would just rebuild bitusers/bit2mux and find
+		// nothing to do — skip the whole call. The Module* key is
+		// safe to use across `design -reset` because new Modules
+		// always get fresh generation values from the global counter.
+		struct DffNoopCache {
+			uint64_t generation;
+			bool last_did_something;
+		};
+		static std::map<RTLIL::Module*, DffNoopCache> noop_cache;
+
 		bool did_something = false;
 		for (auto mod : design->selected_modules()) {
+			// Cross-call no-op fast path.
+			auto noop_it = noop_cache.find(mod);
+			if (noop_it != noop_cache.end() &&
+					noop_it->second.generation == mod->generation &&
+					!noop_it->second.last_did_something) {
+				continue;
+			}
 			// Early bail-out: if there are no selected built-in FFs, the
 			// OptDffWorker constructor's O(N) walk over wires/cells/conns
 			// (to build bitusers + bit2mux) is pure waste, and both run()
@@ -1011,13 +1033,21 @@ struct OptDffPass : public Pass {
 					has_dff = true;
 					break;
 				}
-			if (!has_dff)
+			if (!has_dff) {
+				noop_cache[mod] = {mod->generation, false};
 				continue;
+			}
 			OptDffWorker worker(opt, mod);
+			bool mod_did_something = false;
 			if (worker.run())
-				did_something = true;
+				mod_did_something = true;
 			if (worker.run_constbits())
+				mod_did_something = true;
+			if (mod_did_something)
 				did_something = true;
+			// Record state AFTER the work. The generation has been
+			// bumped by every replace_cell / setPort done during run().
+			noop_cache[mod] = {mod->generation, mod_did_something};
 		}
 
 		if (did_something)

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -409,10 +409,32 @@ struct ReplaceConstCellsCache {
 	std::vector<RTLIL::Cell*> sorted;     // cached TopoSort.sorted result
 	pool<RTLIL::Cell*> all_cells;         // ALL module->cells() at build time
 	bool valid = false;
+	// Track did_something at the end of the previous call AND the
+	// consume_x value used. If both match (same consume_x, last call
+	// was a no-op) AND cache is reused (sig + cell-set match), this
+	// call is guaranteed to be a no-op too — skip the entire pipeline,
+	// not just the toposort build.
+	bool last_did_nothing[2] = {false, false};
 };
 
 void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, ReplaceConstCellsCache &cache, bool consume_x, bool mux_undef, bool mux_bool, bool do_fine, bool keepdc, bool noclkinv)
 {
+	// No-op fast path: if the cached toposort is still valid (same
+	// (cells.size, connections.size) and exact same set of live cell
+	// pointers — catches add+remove net-zero) AND the previous call
+	// with this consume_x leg returned did_something=false, we know
+	// this call would do nothing too. Skip SigMap, invert_map walk,
+	// !noclkinv walk, and sorted-cell loop entirely.
+	auto early_cur_sig = std::make_pair(module->cells().size(), module->connections().size());
+	if (cache.valid && cache.last_did_nothing[(int)consume_x] && cache.sig == early_cur_sig) {
+		bool ok = true;
+		for (auto cell : module->cells()) {
+			if (!cache.all_cells.count(cell)) { ok = false; break; }
+		}
+		if (ok)
+			return;
+	}
+
 	SigMap assign_map(module);
 	dict<RTLIL::SigSpec, RTLIL::SigSpec> invert_map;
 
@@ -581,6 +603,11 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, ReplaceCo
 			cache.all_cells.insert(c);
 		cache.sig = cur_sig;
 		cache.valid = true;
+		// New cache invalidates "last call did nothing" for both
+		// consume_x values: structure changed, future no-op claims
+		// must be re-established by a fresh no-op call.
+		cache.last_did_nothing[0] = false;
+		cache.last_did_nothing[1] = false;
 	}
 
 	for (auto cell : cache.sorted)
@@ -2256,6 +2283,21 @@ skip_alu_split:
 #undef ACTION_DO_Y
 #undef FOLD_1ARG_CELL
 #undef FOLD_2ARG_CELL
+	}
+	// Record whether this consume_x leg was a no-op so the next call
+	// with the same consume_x can skip everything if the module hasn't
+	// changed in the meantime. Any work invalidates BOTH legs (a
+	// fresh opportunity for one consume_x leg may apply to the other).
+	if (did_something) {
+		cache.last_did_nothing[0] = false;
+		cache.last_did_nothing[1] = false;
+		// did_something can also signal in-place mods that change
+		// neither cell count nor connection count (cell type / param
+		// flips). The cached toposort is still structurally valid
+		// (cells + ports unchanged), but the "would be no-op next
+		// time" claim is now false.
+	} else {
+		cache.last_did_nothing[(int)consume_x] = true;
 	}
 }
 

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -508,12 +508,24 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 	for (auto &p : evaluable_cells) {
 		Cell *cell = p.first;
 		const int r_index = p.second;
+		// Cheap consecutive-bit producer dedupe: in a multi-bit input
+		// port whose bits all come from the same upstream cell we'd
+		// otherwise insert the same edge into the TopoSort std::set
+		// repeatedly. Track the last seen producer index per port.
 		for (auto &conn : cell->connections())
-		if (yosys_celltypes.cell_input(cell->type, conn.first))
-		for (auto bit : assign_map(conn.second)) {
-			auto it = outbit_to_idx.find(bit);
-			if (it != outbit_to_idx.end())
-				cells.edge(it->second, r_index);
+		if (yosys_celltypes.cell_input(cell->type, conn.first)) {
+			int last_idx = -1;
+			for (auto bit : assign_map(conn.second)) {
+				auto it = outbit_to_idx.find(bit);
+				if (it != outbit_to_idx.end()) {
+					if (it->second != last_idx) {
+						cells.edge(it->second, r_index);
+						last_idx = it->second;
+					}
+				} else {
+					last_idx = -1;
+				}
+			}
 		}
 	}
 

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -408,6 +408,7 @@ struct ReplaceConstCellsCache {
 	std::pair<size_t, size_t> sig{0, 0};  // (cells.size(), connections.size())
 	std::vector<RTLIL::Cell*> sorted;     // cached TopoSort.sorted result
 	pool<RTLIL::Cell*> all_cells;         // ALL module->cells() at build time
+	dict<RTLIL::SigSpec, RTLIL::SigSpec> invert_map;  // cached invert_map walk
 	bool valid = false;
 	// Track did_something at the end of the previous call AND the
 	// consume_x value used. If both match (same consume_x, last call
@@ -419,35 +420,44 @@ struct ReplaceConstCellsCache {
 
 void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, ReplaceConstCellsCache &cache, bool consume_x, bool mux_undef, bool mux_bool, bool do_fine, bool keepdc, bool noclkinv)
 {
-	// No-op fast path: if the cached toposort is still valid (same
-	// (cells.size, connections.size) and exact same set of live cell
-	// pointers — catches add+remove net-zero) AND the previous call
-	// with this consume_x leg returned did_something=false, we know
-	// this call would do nothing too. Skip SigMap, invert_map walk,
-	// !noclkinv walk, and sorted-cell loop entirely.
-	auto early_cur_sig = std::make_pair(module->cells().size(), module->connections().size());
-	if (cache.valid && cache.last_did_nothing[(int)consume_x] && cache.sig == early_cur_sig) {
-		bool ok = true;
+	// Validate cache once up front: (cells.size, connections.size)
+	// matches AND every live cell pointer is in the cached set. The
+	// resulting `cache_reusable` flag is used both for the no-op
+	// fast-path here and for the toposort/invert_map reuse later.
+	auto cur_sig = std::make_pair(module->cells().size(), module->connections().size());
+	bool cache_reusable = cache.valid && cache.sig == cur_sig;
+	if (cache_reusable) {
 		for (auto cell : module->cells()) {
-			if (!cache.all_cells.count(cell)) { ok = false; break; }
+			if (!cache.all_cells.count(cell)) { cache_reusable = false; break; }
 		}
-		if (ok)
-			return;
 	}
+	// No-op fast path: cache is reusable AND previous call with this
+	// consume_x leg was a no-op. Module is unchanged, same consume_x
+	// processing → guaranteed no work. Skip everything.
+	if (cache_reusable && cache.last_did_nothing[(int)consume_x])
+		return;
 
 	SigMap assign_map(module);
-	dict<RTLIL::SigSpec, RTLIL::SigSpec> invert_map;
-
-	for (auto cell : module->cells()) {
-		if (design->selected(module, cell) && cell->type[0] == '$') {
-			if (cell->type.in(ID($_NOT_), ID($not), ID($logic_not)) &&
-					GetSize(cell->getPort(ID::A)) == 1 && GetSize(cell->getPort(ID::Y)) == 1)
-				invert_map[assign_map(cell->getPort(ID::Y))] = assign_map(cell->getPort(ID::A));
-			if (cell->type.in(ID($mux), ID($_MUX_)) &&
-					cell->getPort(ID::A) == SigSpec(State::S1) && cell->getPort(ID::B) == SigSpec(State::S0))
-				invert_map[assign_map(cell->getPort(ID::Y))] = assign_map(cell->getPort(ID::S));
+	dict<RTLIL::SigSpec, RTLIL::SigSpec> invert_map_local;
+	dict<RTLIL::SigSpec, RTLIL::SigSpec> *invert_map_ptr;
+	if (cache_reusable) {
+		// invert_map depends on the same ($_NOT_/$mux) cells whose
+		// presence the cache validated — reuse it.
+		invert_map_ptr = &cache.invert_map;
+	} else {
+		for (auto cell : module->cells()) {
+			if (design->selected(module, cell) && cell->type[0] == '$') {
+				if (cell->type.in(ID($_NOT_), ID($not), ID($logic_not)) &&
+						GetSize(cell->getPort(ID::A)) == 1 && GetSize(cell->getPort(ID::Y)) == 1)
+					invert_map_local[assign_map(cell->getPort(ID::Y))] = assign_map(cell->getPort(ID::A));
+				if (cell->type.in(ID($mux), ID($_MUX_)) &&
+						cell->getPort(ID::A) == SigSpec(State::S1) && cell->getPort(ID::B) == SigSpec(State::S0))
+					invert_map_local[assign_map(cell->getPort(ID::Y))] = assign_map(cell->getPort(ID::S));
+			}
 		}
+		invert_map_ptr = &invert_map_local;
 	}
+	auto &invert_map = *invert_map_ptr;
 
 	if (!noclkinv)
 	for (auto cell : module->cells())
@@ -538,20 +548,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, ReplaceCo
 	// addLogicNot+remove around line 2205), so when sizes match we
 	// also verify the SET of live cell pointers in module->cells()
 	// equals the cached set — any divergence triggers a rebuild.
-	auto cur_sig = std::make_pair(module->cells().size(), module->connections().size());
-	bool reuse = cache.valid && cache.sig == cur_sig;
-	if (reuse) {
-		// sizes match — but add+remove may have left them stable while
-		// swapping a cached cell for a new one. Iterate live cells; if
-		// any pointer isn't in our set, the cache is stale.
-		for (auto cell : module->cells()) {
-			if (!cache.all_cells.count(cell)) {
-				reuse = false;
-				break;
-			}
-		}
-	}
-	if (reuse) {
+	if (cache_reusable) {
 		// Reuse cached sort order. The cached cell pointers are all
 		// still live (verified above) so the iteration below is safe.
 	} else {
@@ -601,6 +598,7 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, ReplaceCo
 		cache.all_cells.reserve(module->cells().size());
 		for (auto c : module->cells())
 			cache.all_cells.insert(c);
+		cache.invert_map = invert_map_local;  // freshly-built, save it too
 		cache.sig = cur_sig;
 		cache.valid = true;
 		// New cache invalidates "last call did nothing" for both

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -398,21 +398,20 @@ int get_highest_hot_index(RTLIL::SigSpec signal)
 // inner do/while iterations when no cells were added/removed and no
 // new module->connect calls happened skips the rebuild entirely.
 //
-// Invalidation: changes in module->cells().size() OR
-// module->connections().size() catch the common cases (cell removed, new
-// connect added). To catch the trickier "added one cell + removed one
-// cell" net-zero case (e.g. opt_expr.cc:2205 addLogicNot followed by
-// remove), we additionally store the set of cell pointers and verify
-// every cached pointer is still in module->cells() before reuse.
+// Invalidation: keyed off RTLIL::Module::generation, a process-wide
+// monotonic counter bumped on every cell/wire/connection add/remove
+// AND every Cell::setPort/unsetPort. A simple equality check replaces
+// the previous (cells.size, connections.size) signature plus
+// O(N_cells) iteration to detect add+remove net-zero — the counter
+// catches all of those cheaply.
 struct ReplaceConstCellsCache {
-	std::pair<size_t, size_t> sig{0, 0};  // (cells.size(), connections.size())
+	uint64_t generation = 0;
 	std::vector<RTLIL::Cell*> sorted;     // cached TopoSort.sorted result
-	pool<RTLIL::Cell*> all_cells;         // ALL module->cells() at build time
 	dict<RTLIL::SigSpec, RTLIL::SigSpec> invert_map;  // cached invert_map walk
 	bool valid = false;
 	// Track did_something at the end of the previous call AND the
 	// consume_x value used. If both match (same consume_x, last call
-	// was a no-op) AND cache is reused (sig + cell-set match), this
+	// was a no-op) AND cache is reused (generation match), this
 	// call is guaranteed to be a no-op too — skip the entire pipeline,
 	// not just the toposort build.
 	bool last_did_nothing[2] = {false, false};
@@ -420,17 +419,10 @@ struct ReplaceConstCellsCache {
 
 void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, ReplaceConstCellsCache &cache, bool consume_x, bool mux_undef, bool mux_bool, bool do_fine, bool keepdc, bool noclkinv)
 {
-	// Validate cache once up front: (cells.size, connections.size)
-	// matches AND every live cell pointer is in the cached set. The
-	// resulting `cache_reusable` flag is used both for the no-op
-	// fast-path here and for the toposort/invert_map reuse later.
-	auto cur_sig = std::make_pair(module->cells().size(), module->connections().size());
-	bool cache_reusable = cache.valid && cache.sig == cur_sig;
-	if (cache_reusable) {
-		for (auto cell : module->cells()) {
-			if (!cache.all_cells.count(cell)) { cache_reusable = false; break; }
-		}
-	}
+	// Validate cache by comparing the module's generation counter.
+	// O(1) — the counter is bumped on every structural mutation
+	// (add/remove cell/wire/process/connection AND Cell::setPort).
+	bool cache_reusable = cache.valid && cache.generation == module->generation;
 	// No-op fast path: cache is reusable AND previous call with this
 	// consume_x leg was a no-op. Module is unchanged, same consume_x
 	// processing → guaranteed no work. Skip everything.
@@ -538,19 +530,14 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, ReplaceCo
 		handle_clkpol_celltype_swap(cell, "$_DLATCHSR_??N_", "$_DLATCHSR_??P_", ID::R, assign_map, invert_map);
 	}
 
-	// Reuse the TopoSort across calls in this execute() when no cells
-	// have been added or removed AND no new module->connect calls have
-	// happened. In-place cell mutations don't invalidate it (cell
-	// pointers + port directions stay the same).
-	//
-	// (cells.size, connections.size) catches the common cases. Add+
-	// remove may net-zero through cells.size though (e.g.
-	// addLogicNot+remove around line 2205), so when sizes match we
-	// also verify the SET of live cell pointers in module->cells()
-	// equals the cached set — any divergence triggers a rebuild.
+	// Reuse the TopoSort across calls in this execute() when the
+	// module's generation counter is unchanged. The counter is bumped
+	// on every structural mutation (cell/wire add/remove, connect,
+	// Cell::setPort/unsetPort), so reuse is only safe when nothing
+	// the toposort depends on has changed.
 	if (cache_reusable) {
 		// Reuse cached sort order. The cached cell pointers are all
-		// still live (verified above) so the iteration below is safe.
+		// still live (counter check above guarantees no removals).
 	} else {
 		// Build TopoSort from scratch.
 		TopoSort<RTLIL::Cell*, RTLIL::IdString::compare_ptr_by_name<RTLIL::Cell>> cells;
@@ -594,12 +581,8 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, ReplaceCo
 		}
 
 		cache.sorted = std::move(cells.sorted);
-		cache.all_cells.clear();
-		cache.all_cells.reserve(module->cells().size());
-		for (auto c : module->cells())
-			cache.all_cells.insert(c);
 		cache.invert_map = invert_map_local;  // freshly-built, save it too
-		cache.sig = cur_sig;
+		cache.generation = module->generation;
 		cache.valid = true;
 		// New cache invalidates "last call did nothing" for both
 		// consume_x values: structure changed, future no-op claims

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -392,7 +392,26 @@ int get_highest_hot_index(RTLIL::SigSpec signal)
 	return -1;
 }
 
-void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool consume_x, bool mux_undef, bool mux_bool, bool do_fine, bool keepdc, bool noclkinv)
+// Per-call cache for replace_const_cells, scoped to a single OptExprPass
+// execute() invocation (passed by reference). The TopoSort BUILD is the
+// dominant per-call setup cost on big modules; reusing it across the
+// inner do/while iterations when no cells were added/removed and no
+// new module->connect calls happened skips the rebuild entirely.
+//
+// Invalidation: changes in module->cells().size() OR
+// module->connections().size() catch the common cases (cell removed, new
+// connect added). To catch the trickier "added one cell + removed one
+// cell" net-zero case (e.g. opt_expr.cc:2205 addLogicNot followed by
+// remove), we additionally store the set of cell pointers and verify
+// every cached pointer is still in module->cells() before reuse.
+struct ReplaceConstCellsCache {
+	std::pair<size_t, size_t> sig{0, 0};  // (cells.size(), connections.size())
+	std::vector<RTLIL::Cell*> sorted;     // cached TopoSort.sorted result
+	pool<RTLIL::Cell*> all_cells;         // ALL module->cells() at build time
+	bool valid = false;
+};
+
+void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, ReplaceConstCellsCache &cache, bool consume_x, bool mux_undef, bool mux_bool, bool do_fine, bool keepdc, bool noclkinv)
 {
 	SigMap assign_map(module);
 	dict<RTLIL::SigSpec, RTLIL::SigSpec> invert_map;
@@ -487,55 +506,84 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 		handle_clkpol_celltype_swap(cell, "$_DLATCHSR_??N_", "$_DLATCHSR_??P_", ID::R, assign_map, invert_map);
 	}
 
-	TopoSort<RTLIL::Cell*, RTLIL::IdString::compare_ptr_by_name<RTLIL::Cell>> cells;
-	// Store TopoSort indices directly (skip a second std::map lookup per
-	// edge), and remember each evaluable cell's index so the edge pass
-	// doesn't rewalk module->cells() and re-filter.
-	dict<RTLIL::SigBit, int> outbit_to_idx;
-	std::vector<std::pair<Cell*, int>> evaluable_cells;
-
-	for (auto cell : module->cells()) {
-		if (!design->selected(module, cell)) continue;
-		if (!yosys_celltypes.cell_evaluable(cell->type)) continue;
-		const int idx = cells.node(cell);
-		evaluable_cells.emplace_back(cell, idx);
-		for (auto &conn : cell->connections())
-		if (yosys_celltypes.cell_output(cell->type, conn.first))
-		for (auto bit : assign_map(conn.second))
-			outbit_to_idx[bit] = idx;
-	}
-
-	for (auto &p : evaluable_cells) {
-		Cell *cell = p.first;
-		const int r_index = p.second;
-		// Cheap consecutive-bit producer dedupe: in a multi-bit input
-		// port whose bits all come from the same upstream cell we'd
-		// otherwise insert the same edge into the TopoSort std::set
-		// repeatedly. Track the last seen producer index per port.
-		for (auto &conn : cell->connections())
-		if (yosys_celltypes.cell_input(cell->type, conn.first)) {
-			int last_idx = -1;
-			for (auto bit : assign_map(conn.second)) {
-				auto it = outbit_to_idx.find(bit);
-				if (it != outbit_to_idx.end()) {
-					if (it->second != last_idx) {
-						cells.edge(it->second, r_index);
-						last_idx = it->second;
-					}
-				} else {
-					last_idx = -1;
-				}
+	// Reuse the TopoSort across calls in this execute() when no cells
+	// have been added or removed AND no new module->connect calls have
+	// happened. In-place cell mutations don't invalidate it (cell
+	// pointers + port directions stay the same).
+	//
+	// (cells.size, connections.size) catches the common cases. Add+
+	// remove may net-zero through cells.size though (e.g.
+	// addLogicNot+remove around line 2205), so when sizes match we
+	// also verify the SET of live cell pointers in module->cells()
+	// equals the cached set — any divergence triggers a rebuild.
+	auto cur_sig = std::make_pair(module->cells().size(), module->connections().size());
+	bool reuse = cache.valid && cache.sig == cur_sig;
+	if (reuse) {
+		// sizes match — but add+remove may have left them stable while
+		// swapping a cached cell for a new one. Iterate live cells; if
+		// any pointer isn't in our set, the cache is stale.
+		for (auto cell : module->cells()) {
+			if (!cache.all_cells.count(cell)) {
+				reuse = false;
+				break;
 			}
 		}
 	}
+	if (reuse) {
+		// Reuse cached sort order. The cached cell pointers are all
+		// still live (verified above) so the iteration below is safe.
+	} else {
+		// Build TopoSort from scratch.
+		TopoSort<RTLIL::Cell*, RTLIL::IdString::compare_ptr_by_name<RTLIL::Cell>> cells;
+		dict<RTLIL::SigBit, int> outbit_to_idx;
+		std::vector<std::pair<Cell*, int>> evaluable_cells;
 
-	if (!cells.sort()) {
-		// There might be a combinational loop, or there might be constants on the output of cells. 'check' may find out more.
-		// ...unless this is a coarse-grained cell loop, but not a bit loop, in which case it won't, and all is good.
-		log("Couldn't topologically sort cells, optimizing module %s may take a longer time.\n", log_id(module));
+		for (auto cell : module->cells()) {
+			if (!design->selected(module, cell)) continue;
+			if (!yosys_celltypes.cell_evaluable(cell->type)) continue;
+			const int idx = cells.node(cell);
+			evaluable_cells.emplace_back(cell, idx);
+			for (auto &conn : cell->connections())
+			if (yosys_celltypes.cell_output(cell->type, conn.first))
+			for (auto bit : assign_map(conn.second))
+				outbit_to_idx[bit] = idx;
+		}
+
+		for (auto &p : evaluable_cells) {
+			Cell *cell = p.first;
+			const int r_index = p.second;
+			// Cheap consecutive-bit producer dedupe.
+			for (auto &conn : cell->connections())
+			if (yosys_celltypes.cell_input(cell->type, conn.first)) {
+				int last_idx = -1;
+				for (auto bit : assign_map(conn.second)) {
+					auto it = outbit_to_idx.find(bit);
+					if (it != outbit_to_idx.end()) {
+						if (it->second != last_idx) {
+							cells.edge(it->second, r_index);
+							last_idx = it->second;
+						}
+					} else {
+						last_idx = -1;
+					}
+				}
+			}
+		}
+
+		if (!cells.sort()) {
+			log("Couldn't topologically sort cells, optimizing module %s may take a longer time.\n", log_id(module));
+		}
+
+		cache.sorted = std::move(cells.sorted);
+		cache.all_cells.clear();
+		cache.all_cells.reserve(module->cells().size());
+		for (auto c : module->cells())
+			cache.all_cells.insert(c);
+		cache.sig = cur_sig;
+		cache.valid = true;
 	}
 
-	for (auto cell : cells.sorted)
+	for (auto cell : cache.sorted)
 	{
 #define ACTION_DO(_p_, _s_) do { replace_cell(assign_map, module, cell, input.as_string(), _p_, _s_); goto next_cell; } while (0)
 #define ACTION_DO_Y(_v_) ACTION_DO(ID::Y, RTLIL::SigSpec(RTLIL::State::S ## _v_))
@@ -2325,15 +2373,16 @@ struct OptExprPass : public Pass {
 					design->scratchpad_set_bool("opt.did_something", true);
 			}
 
+			ReplaceConstCellsCache rcc_cache;
 			do {
 				do {
 					did_something = false;
-					replace_const_cells(design, module, false /* consume_x */, mux_undef, mux_bool, do_fine, keepdc, noclkinv);
+					replace_const_cells(design, module, rcc_cache, false /* consume_x */, mux_undef, mux_bool, do_fine, keepdc, noclkinv);
 					if (did_something)
 						design->scratchpad_set_bool("opt.did_something", true);
 				} while (did_something);
 				if (!keepdc)
-					replace_const_cells(design, module, true /* consume_x */, mux_undef, mux_bool, do_fine, keepdc, noclkinv);
+					replace_const_cells(design, module, rcc_cache, true /* consume_x */, mux_undef, mux_bool, do_fine, keepdc, noclkinv);
 				if (did_something)
 					design->scratchpad_set_bool("opt.did_something", true);
 			} while (did_something);

--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -410,7 +410,8 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 
 	if (!noclkinv)
 	for (auto cell : module->cells())
-	if (design->selected(module, cell)) {
+	if ((StaticCellTypes::categories.is_ff(cell->type) || StaticCellTypes::categories.is_mem_noff(cell->type))
+			&& design->selected(module, cell)) {
 		if (cell->type.in(ID($dff), ID($dffe), ID($dffsr), ID($dffsre), ID($adff), ID($adffe), ID($aldff), ID($aldffe), ID($sdff), ID($sdffe), ID($sdffce), ID($fsm), ID($memrd), ID($memrd_v2), ID($memwr), ID($memwr_v2)))
 			handle_polarity_inv(cell, ID::CLK, ID::CLK_POLARITY, assign_map, invert_map);
 
@@ -487,25 +488,33 @@ void replace_const_cells(RTLIL::Design *design, RTLIL::Module *module, bool cons
 	}
 
 	TopoSort<RTLIL::Cell*, RTLIL::IdString::compare_ptr_by_name<RTLIL::Cell>> cells;
-	dict<RTLIL::SigBit, Cell*> outbit_to_cell;
+	// Store TopoSort indices directly (skip a second std::map lookup per
+	// edge), and remember each evaluable cell's index so the edge pass
+	// doesn't rewalk module->cells() and re-filter.
+	dict<RTLIL::SigBit, int> outbit_to_idx;
+	std::vector<std::pair<Cell*, int>> evaluable_cells;
 
-	for (auto cell : module->cells())
-	if (design->selected(module, cell) && yosys_celltypes.cell_evaluable(cell->type)) {
+	for (auto cell : module->cells()) {
+		if (!design->selected(module, cell)) continue;
+		if (!yosys_celltypes.cell_evaluable(cell->type)) continue;
+		const int idx = cells.node(cell);
+		evaluable_cells.emplace_back(cell, idx);
 		for (auto &conn : cell->connections())
 		if (yosys_celltypes.cell_output(cell->type, conn.first))
 		for (auto bit : assign_map(conn.second))
-			outbit_to_cell[bit] = cell;
-		cells.node(cell);
+			outbit_to_idx[bit] = idx;
 	}
 
-	for (auto cell : module->cells())
-	if (design->selected(module, cell) && yosys_celltypes.cell_evaluable(cell->type)) {
-		const int r_index = cells.node(cell);
+	for (auto &p : evaluable_cells) {
+		Cell *cell = p.first;
+		const int r_index = p.second;
 		for (auto &conn : cell->connections())
 		if (yosys_celltypes.cell_input(cell->type, conn.first))
-		for (auto bit : assign_map(conn.second))
-		if (outbit_to_cell.count(bit))
-			cells.edge(cells.node(outbit_to_cell.at(bit)), r_index);
+		for (auto bit : assign_map(conn.second)) {
+			auto it = outbit_to_idx.find(bit);
+			if (it != outbit_to_idx.end())
+				cells.edge(it->second, r_index);
+		}
 	}
 
 	if (!cells.sort()) {

--- a/passes/opt/opt_muxtree.cc
+++ b/passes/opt/opt_muxtree.cc
@@ -21,9 +21,11 @@
 #include "kernel/sigtools.h"
 #include "kernel/log.h"
 #include "kernel/celltypes.h"
-#include <cstddef>
 #include <stdlib.h>
 #include <stdio.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <set>
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
@@ -126,7 +128,7 @@ struct OptMuxtreeWorker
 		// In case of $pmux, port B is multiple slices, concatenated, one per bit of port S
 		for (int i = 0; i < GetSize(sig_s); i++) {
 			RTLIL::SigSpec sig = sig_b.extract(i*GetSize(sig_a), GetSize(sig_a));
-			RTLIL::SigSpec ctrl_sig = assign_map(SigSpec{sig_s[i]});
+			RTLIL::SigSpec ctrl_sig = assign_map(sig_s.extract(i, 1));
 			portinfo_t portinfo = used_port_bit(sig, this_mux_idx);
 			portinfo.ctrl_sig = sig2bits(ctrl_sig, false).front();
 			portinfo.const_activated = ctrl_sig.is_fully_const() && ctrl_sig.as_bool();
@@ -340,21 +342,14 @@ struct OptMuxtreeWorker
 		// The payload is a reference counter used to manage the list
 		// When it is non-zero, the signal in known to be inactive
 		// When it reaches zero, the map element is removed
-		std::vector<int> known_inactive;
+		std::unordered_map<int, int> known_inactive;
 
 		// database of known active signals
-		std::vector<int> known_active;
+		std::unordered_map<int, int> known_active;
 
 		// this is just used to keep track of visited muxes in order to prohibit
 		// endless recursion in mux loops
-		std::vector<bool> visited_muxes;
-
-		// Initialize with the maximum possible sizes
-		knowledge_t(int num_bits, int num_muxes) {
-			known_inactive.assign(num_bits, 0);
-			known_active.assign(num_bits, 0);
-			visited_muxes.assign(num_muxes, false);
-		}
+		std::unordered_set<int> visited_muxes;
 	};
 
 	static void activate_port(knowledge_t &knowledge, int port_idx, const muxinfo_t &muxinfo) {
@@ -371,10 +366,11 @@ struct OptMuxtreeWorker
 	}
 
 	static void deactivate_port(knowledge_t &knowledge, int port_idx, const muxinfo_t &muxinfo) {
-		auto unlearn = [](std::vector<int>& knowns, int bit_idx) {
-			if (knowns[bit_idx] > 0) {
-				--knowns[bit_idx];
-			}
+		auto unlearn = [](std::unordered_map<int, int>& knowns, int i) {
+			auto it = knowns.find(i);
+			if (it != knowns.end())
+				if (--it->second == 0)
+					knowns.erase(it);
 		};
 
 		if (port_idx < GetSize(muxinfo.ports)-1 && !muxinfo.ports[port_idx].const_activated)
@@ -422,9 +418,9 @@ struct OptMuxtreeWorker
 
 		vector<int> input_mux_queue;
 		for (int m : muxinfo.ports[port_idx].input_muxes) {
-			if (knowledge.visited_muxes[m])
+			if (knowledge.visited_muxes.count(m))
 				continue;
-			knowledge.visited_muxes[m] = true;
+			knowledge.visited_muxes.insert(m);
 			input_mux_queue.push_back(m);
 		}
 		for (int m : input_mux_queue) {
@@ -457,7 +453,7 @@ struct OptMuxtreeWorker
 		// Allow revisiting input muxes, since evaluating other ports should
 		// revisit these input muxes with different activation assumptions
 		for (int m : input_mux_queue)
-			knowledge.visited_muxes[m] = false;
+			knowledge.visited_muxes.erase(m);
 
 		// Undo our assumptions that the port is active
 		deactivate_port(knowledge, port_idx, muxinfo);
@@ -479,11 +475,11 @@ struct OptMuxtreeWorker
 		vector<int> bits = sig2bits(sig, false);
 		for (int i = 0; i < GetSize(bits); i++) {
 			if (bits[i] >= 0) {
-				if (knowledge.known_inactive[bits[i]] > 0) {
+				if (knowledge.known_inactive.count(bits[i]) > 0) {
 					sig[i] = State::S0;
 					did_something = true;
 				} else
-				if (knowledge.known_active[bits[i]] > 0) {
+				if (knowledge.known_active.count(bits[i]) > 0) {
 					sig[i] = State::S1;
 					did_something = true;
 				}
@@ -556,7 +552,7 @@ struct OptMuxtreeWorker
 			portinfo_t &portinfo = muxinfo.ports[port_idx];
 			if (portinfo.const_deactivated)
 				continue;
-			if (knowledge.known_active[portinfo.ctrl_sig] > 0) {
+			if (knowledge.known_active.count(portinfo.ctrl_sig) > 0) {
 				eval_mux_port(knowledge, mux_idx, port_idx, limits);
 				return;
 			}
@@ -570,7 +566,7 @@ struct OptMuxtreeWorker
 			if (portinfo.const_deactivated)
 				continue;
 			if (port_idx < GetSize(muxinfo.ports)-1)
-				if (knowledge.known_inactive[portinfo.ctrl_sig] > 0)
+				if (knowledge.known_inactive.count(portinfo.ctrl_sig) > 0)
 					continue;
 			eval_mux_port(knowledge, mux_idx, port_idx, limits);
 
@@ -582,8 +578,8 @@ struct OptMuxtreeWorker
 	void eval_root_mux(int mux_idx)
 	{
 		log_assert(glob_evals_left > 0);
-		knowledge_t knowledge(GetSize(bit2info), GetSize(mux2info));
-		knowledge.visited_muxes[mux_idx] = true;
+		knowledge_t knowledge;
+		knowledge.visited_muxes.insert(mux_idx);
 		limits_t limits = {};
 		limits.do_mark_ports_observable = root_enable_muxes.at(mux_idx);
 		eval_mux(knowledge, mux_idx, limits);

--- a/passes/opt/opt_muxtree.cc
+++ b/passes/opt/opt_muxtree.cc
@@ -610,6 +610,18 @@ struct OptMuxtreePass : public Pass {
 		for (auto module : design->selected_whole_modules_warn()) {
 			if (module->has_processes_warn())
 				continue;
+			// Quick scan for any mux cell before paying for the worker's
+			// O(N) cell walk + assign_map construction. The worker already
+			// bails internally on empty mux2info, but only after building
+			// the rest of the data structures.
+			bool has_mux = false;
+			for (auto cell : module->cells())
+				if (cell->type.in(ID($mux), ID($pmux))) {
+					has_mux = true;
+					break;
+				}
+			if (!has_mux)
+				continue;
 			OptMuxtreeWorker worker(design, module);
 			total_count += worker.removed_count;
 		}

--- a/passes/opt/opt_muxtree.cc
+++ b/passes/opt/opt_muxtree.cc
@@ -606,9 +606,25 @@ struct OptMuxtreePass : public Pass {
 		log_header(design, "Executing OPT_MUXTREE pass (detect dead branches in mux trees).\n");
 		extra_args(args, 1, design);
 
+		// Cross-execute() no-op cache. Skip the per-module worker
+		// (which builds bit2info + mux2info via two cell walks) when
+		// the module is unchanged since a prior call that found
+		// nothing to remove. Module* is a safe key — pointer reuse
+		// after design -reset gets a fresh generation value.
+		struct MuxtreeNoopCache {
+			uint64_t generation;
+			bool last_did_something;
+		};
+		static std::map<RTLIL::Module*, MuxtreeNoopCache> noop_cache;
+
 		int total_count = 0;
 		for (auto module : design->selected_whole_modules_warn()) {
 			if (module->has_processes_warn())
+				continue;
+			auto noop_it = noop_cache.find(module);
+			if (noop_it != noop_cache.end() &&
+					noop_it->second.generation == module->generation &&
+					!noop_it->second.last_did_something)
 				continue;
 			// Quick scan for any mux cell before paying for the worker's
 			// O(N) cell walk + assign_map construction. The worker already
@@ -620,10 +636,13 @@ struct OptMuxtreePass : public Pass {
 					has_mux = true;
 					break;
 				}
-			if (!has_mux)
+			if (!has_mux) {
+				noop_cache[module] = {module->generation, false};
 				continue;
+			}
 			OptMuxtreeWorker worker(design, module);
 			total_count += worker.removed_count;
+			noop_cache[module] = {module->generation, worker.removed_count > 0};
 		}
 		if (total_count)
 			design->scratchpad_set_bool("opt.did_something", true);

--- a/passes/opt/opt_reduce.cc
+++ b/passes/opt/opt_reduce.cc
@@ -651,8 +651,20 @@ struct OptReducePass : public Pass {
 		}
 		extra_args(args, argidx, design);
 
+		// Cross-execute() no-op cache (same pattern as opt_dff/opt_share/opt_muxtree).
+		struct ReduceNoopCache {
+			uint64_t generation;
+			bool last_did_something;
+		};
+		static std::map<RTLIL::Module*, ReduceNoopCache> noop_cache;
+
 		int total_count = 0;
 		for (auto module : design->selected_modules()) {
+			auto noop_it = noop_cache.find(module);
+			if (noop_it != noop_cache.end() &&
+					noop_it->second.generation == module->generation &&
+					!noop_it->second.last_did_something)
+				continue;
 			// Quick scan: if the module has none of the cell types
 			// opt_reduce operates on ($mux/$pmux/$bmux/$demux/$reduce_or/
 			// $reduce_and), the worker would build SigPool/SigMap and walk
@@ -665,14 +677,19 @@ struct OptReducePass : public Pass {
 					break;
 				}
 			}
-			if (!has_target)
+			if (!has_target) {
+				noop_cache[module] = {module->generation, false};
 				continue;
+			}
+			int mod_count = 0;
 			while (1) {
 				OptReduceWorker worker(design, module, do_fine);
 				total_count += worker.total_count;
+				mod_count += worker.total_count;
 				if (worker.total_count == 0)
 					break;
 			}
+			noop_cache[module] = {module->generation, mod_count > 0};
 		}
 
 		if (total_count)

--- a/passes/opt/opt_reduce.cc
+++ b/passes/opt/opt_reduce.cc
@@ -652,13 +652,28 @@ struct OptReducePass : public Pass {
 		extra_args(args, argidx, design);
 
 		int total_count = 0;
-		for (auto module : design->selected_modules())
+		for (auto module : design->selected_modules()) {
+			// Quick scan: if the module has none of the cell types
+			// opt_reduce operates on ($mux/$pmux/$bmux/$demux/$reduce_or/
+			// $reduce_and), the worker would build SigPool/SigMap and walk
+			// every cell only to find nothing to do. Bail before that work.
+			bool has_target = false;
+			for (auto &cell_it : module->cells_) {
+				if (cell_it.second->type.in(ID($mux), ID($pmux), ID($bmux), ID($demux),
+						ID($reduce_or), ID($reduce_and))) {
+					has_target = true;
+					break;
+				}
+			}
+			if (!has_target)
+				continue;
 			while (1) {
 				OptReduceWorker worker(design, module, do_fine);
 				total_count += worker.total_count;
 				if (worker.total_count == 0)
 					break;
 			}
+		}
 
 		if (total_count)
 			design->scratchpad_set_bool("opt.did_something", true);

--- a/passes/opt/opt_share.cc
+++ b/passes/opt/opt_share.cc
@@ -359,6 +359,19 @@ struct OptSharePass : public Pass {
 
 		extra_args(args, 1, design);
 		for (auto module : design->selected_modules()) {
+			// Early bail-out: if no cell in this module is supported by
+			// opt_share, the SigMap + bit_users walk over all cells and
+			// connections is wasted. cell_supported() catches $alu and the
+			// arith/logic/relational families this pass operates on.
+			bool any_supported = false;
+			for (auto cell : module->selected_cells())
+				if (cell_supported(cell)) {
+					any_supported = true;
+					break;
+				}
+			if (!any_supported)
+				continue;
+
 			SigMap sigmap(module);
 
 			dict<RTLIL::SigBit, int> bit_users;

--- a/passes/opt/opt_share.cc
+++ b/passes/opt/opt_share.cc
@@ -358,7 +358,29 @@ struct OptSharePass : public Pass {
 		log_header(design, "Executing OPT_SHARE pass.\n");
 
 		extra_args(args, 1, design);
+
+		// Cross-execute() no-op cache. Same pattern as opt_dff —
+		// keyed on (Module*, generation, last_did_something). Skip
+		// the SigMap + bit_users walk if a previous call returned
+		// no work AND nothing has mutated the module since.
+		struct ShareNoopCache {
+			uint64_t generation;
+			bool last_did_something;
+		};
+		static std::map<RTLIL::Module*, ShareNoopCache> noop_cache;
+
 		for (auto module : design->selected_modules()) {
+			// Cross-call no-op fast path.
+			auto noop_it = noop_cache.find(module);
+			if (noop_it != noop_cache.end() &&
+					noop_it->second.generation == module->generation &&
+					!noop_it->second.last_did_something)
+				continue;
+
+			// Snapshot did_something at entry to detect whether this
+			// module's processing made any change.
+			bool ds_before = design->scratchpad_get_bool("opt.did_something");
+
 			// Early bail-out: if no cell in this module is supported by
 			// opt_share, the SigMap + bit_users walk over all cells and
 			// connections is wasted. cell_supported() catches $alu and the
@@ -369,8 +391,10 @@ struct OptSharePass : public Pass {
 					any_supported = true;
 					break;
 				}
-			if (!any_supported)
+			if (!any_supported) {
+				noop_cache[module] = {module->generation, false};
 				continue;
+			}
 
 			SigMap sigmap(module);
 
@@ -418,8 +442,10 @@ struct OptSharePass : public Pass {
 				}
 			}
 
-			if (!any_shared_operands)
+			if (!any_shared_operands) {
+				noop_cache[module] = {module->generation, false};
 				continue;
+			}
 
 			// Operator outputs need to be exclusively connected to the $mux inputs in order to be mergeable. Hence we count to
 			// how many points are operator output bits connected.
@@ -580,6 +606,13 @@ struct OptSharePass : public Pass {
 
 				merge_operators(module, shared.mux, shared.ports, shared.shared_operand, sigmap);
 			}
+
+			// Record cache state for next call. Compare did_something
+			// vs the snapshot at entry to determine whether THIS module
+			// did any work.
+			bool ds_after = design->scratchpad_get_bool("opt.did_something");
+			bool mod_did_something = ds_after && !ds_before;
+			noop_cache[module] = {module->generation, mod_did_something};
 		}
 	}
 

--- a/passes/opt/peepopt.cc
+++ b/passes/opt/peepopt.cc
@@ -97,8 +97,22 @@ struct PeepoptPass : public Pass {
 		// 2x implies there is a constant shift larger than the input-data which should be extremely rare
 		shiftadd_max_ratio = design->scratchpad_get_int("peepopt.shiftadd.max_data_multiple", 2);
 
+		// Cross-execute() no-op cache.
+		struct PeepoptNoopCache {
+			uint64_t generation;
+			bool last_did_something;
+		};
+		static std::map<RTLIL::Module*, PeepoptNoopCache> noop_cache;
+
 		for (auto module : design->selected_modules())
 		{
+			auto noop_it = noop_cache.find(module);
+			if (noop_it != noop_cache.end() &&
+					noop_it->second.generation == module->generation &&
+					!noop_it->second.last_did_something)
+				continue;
+
+			uint64_t gen_before = module->generation;
 			did_something = true;
 
 			while (did_something)
@@ -119,6 +133,8 @@ struct PeepoptPass : public Pass {
 					pm.run_muldiv_c();
 				}
 			}
+
+			noop_cache[module] = {module->generation, module->generation != gen_before};
 		}
 	}
 } PeepoptPass;

--- a/passes/opt/wreduce.cc
+++ b/passes/opt/wreduce.cc
@@ -571,10 +571,28 @@ struct WreducePass : public Pass {
 		}
 		extra_args(args, argidx, design);
 
+		// Cross-execute() no-op cache. Skip the per-cell walk + worker
+		// when the module is unchanged since a prior call that did
+		// nothing. Per-module did_something is detected via the
+		// generation counter — every setPort/setParam/connect bumps it.
+		struct WreduceNoopCache {
+			uint64_t generation;
+			bool last_did_something;
+		};
+		static std::map<RTLIL::Module*, WreduceNoopCache> noop_cache;
+
 		for (auto module : design->selected_modules())
 		{
 			if (module->has_processes_warn())
 				continue;
+
+			auto noop_it = noop_cache.find(module);
+			if (noop_it != noop_cache.end() &&
+					noop_it->second.generation == module->generation &&
+					!noop_it->second.last_did_something)
+				continue;
+
+			uint64_t gen_before = module->generation;
 
 			for (auto c : module->selected_cells())
 			{
@@ -645,6 +663,8 @@ struct WreducePass : public Pass {
 
 			WreduceWorker worker(&config, module);
 			worker.run();
+
+			noop_cache[module] = {module->generation, module->generation != gen_before};
 		}
 	}
 } WreducePass;

--- a/passes/proc/proc_arst.cc
+++ b/passes/proc/proc_arst.cc
@@ -289,8 +289,13 @@ struct ProcArstPass : public Pass {
 		pool<Wire*> delete_initattr_wires;
 
 		for (auto mod : design->all_selected_modules()) {
+			// SigMap(mod) walks all module connections; skip when there
+			// are no processes to feed proc_arst().
+			auto procs = mod->selected_processes();
+			if (procs.empty())
+				continue;
 			SigMap assign_map(mod);
-			for (auto proc : mod->selected_processes()) {
+			for (auto proc : procs) {
 				proc_arst(mod, proc, assign_map);
 				if (global_arst.empty() || mod->wire(global_arst) == nullptr)
 					continue;

--- a/passes/proc/proc_dff.cc
+++ b/passes/proc/proc_dff.cc
@@ -307,8 +307,13 @@ struct ProcDffPass : public Pass {
 		extra_args(args, 1, design);
 
 		for (auto mod : design->all_selected_modules()) {
+			// ConstEval(mod) walks all cells/connections to seed the
+			// evaluator; skip if the module has no selected processes.
+			auto procs = mod->selected_processes();
+			if (procs.empty())
+				continue;
 			ConstEval ce(mod);
-			for (auto proc : mod->selected_processes())
+			for (auto proc : procs)
 				proc_dff(mod, proc, ce);
 		}
 	}

--- a/passes/proc/proc_dlatch.cc
+++ b/passes/proc/proc_dlatch.cc
@@ -464,8 +464,18 @@ struct ProcDlatchPass : public Pass {
 		extra_args(args, 1, design);
 
 		for (auto mod : design->all_selected_modules()) {
+			// proc_dlatch_db_t's constructor walks every cell + every
+			// connection + every wire to build mux_drivers + mux_srcbits
+			// + sigusers — O(N * conns) work. If the module has no selected
+			// processes there's nothing for proc_dlatch() to consume from
+			// the DB, so skip the build entirely. This is a 60k-cell-walk
+			// per module on `many_equiv_cells` inputs (continuous assigns,
+			// no `always` blocks → no processes here at all).
+			auto procs = mod->selected_processes();
+			if (procs.empty())
+				continue;
 			proc_dlatch_db_t db(mod);
-			for (auto proc : mod->selected_processes())
+			for (auto proc : procs)
 				proc_dlatch(db, proc);
 			db.fixup_muxes();
 		}

--- a/passes/proc/proc_init.cc
+++ b/passes/proc/proc_init.cc
@@ -90,8 +90,11 @@ struct ProcInitPass : public Pass {
 		extra_args(args, 1, design);
 
 		for (auto mod : design->all_selected_modules()) {
+			auto procs = mod->selected_processes();
+			if (procs.empty())
+				continue;
 			SigMap sigmap(mod);
-			for (auto proc : mod->selected_processes())
+			for (auto proc : procs)
 				proc_init(mod, sigmap, proc);
 		}
 	}

--- a/passes/proc/proc_memwr.cc
+++ b/passes/proc/proc_memwr.cc
@@ -100,6 +100,9 @@ struct ProcMemWrPass : public Pass {
 		extra_args(args, 1, design);
 
 		for (auto mod : design->all_selected_modules()) {
+			auto procs = mod->selected_processes();
+			if (procs.empty())
+				continue;
 			dict<IdString, int> next_port_id;
 			for (auto cell : mod->cells()) {
 				if (cell->type.in(ID($memwr), ID($memwr_v2))) {
@@ -110,7 +113,7 @@ struct ProcMemWrPass : public Pass {
 						next_port_id[memid] = port_id + 1;
 				}
 			}
-			for (auto proc : mod->selected_processes())
+			for (auto proc : procs)
 				proc_memwr(mod, proc, next_port_id);
 		}
 	}

--- a/passes/proc/proc_prune.cc
+++ b/passes/proc/proc_prune.cc
@@ -128,8 +128,11 @@ struct ProcPrunePass : public Pass {
 		extra_args(args, 1, design);
 
 		for (auto mod : design->all_selected_modules()) {
+			auto procs = mod->selected_processes();
+			if (procs.empty())
+				continue;
 			PruneWorker worker(mod);
-			for (auto proc : mod->selected_processes())
+			for (auto proc : procs)
 				worker.do_process(proc);
 			total_removed_count += worker.removed_count;
 			total_promoted_count += worker.promoted_count;

--- a/passes/proc/proc_rom.cc
+++ b/passes/proc/proc_rom.cc
@@ -244,8 +244,11 @@ struct ProcRomPass : public Pass {
 		extra_args(args, 1, design);
 
 		for (auto mod : design->all_selected_modules()) {
+			auto procs = mod->selected_processes();
+			if (procs.empty())
+				continue;
 			RomWorker worker(mod);
-			for (auto proc : mod->selected_processes())
+			for (auto proc : procs)
 				worker.do_process(proc);
 			total_count += worker.count;
 		}

--- a/passes/techmap/alumacc.cc
+++ b/passes/techmap/alumacc.cc
@@ -602,11 +602,46 @@ struct AlumaccPass : public Pass {
 		}
 		extra_args(args, argidx, design);
 
-		for (auto mod : design->selected_modules())
-			if (!mod->has_processes_warn()) {
-				AlumaccWorker worker(mod);
-				worker.run();
+		// Cross-execute() no-op cache (same pattern as opt_dff/share/etc).
+		struct AlumaccNoopCache {
+			uint64_t generation;
+			bool last_did_something;
+		};
+		static std::map<RTLIL::Module*, AlumaccNoopCache> noop_cache;
+
+		for (auto mod : design->selected_modules()) {
+			if (mod->has_processes_warn())
+				continue;
+
+			auto noop_it = noop_cache.find(mod);
+			if (noop_it != noop_cache.end() &&
+					noop_it->second.generation == mod->generation &&
+					!noop_it->second.last_did_something)
+				continue;
+
+			// Quick scan: if the module has no arith/cmp cells the
+			// AlumaccWorker (which builds bit_users via two SigMap-applied
+			// walks over wires + cells, then walks selected_cells looking
+			// for $pos/$neg/$add/$sub/$mul/$lt/$le/$ge/$gt/$eq/$eqx/$ne/$nex)
+			// is pure waste.
+			bool has_target = false;
+			for (auto cell : mod->cells())
+				if (cell->type.in(ID($pos), ID($neg), ID($add), ID($sub), ID($mul),
+						ID($lt), ID($le), ID($ge), ID($gt),
+						ID($eq), ID($eqx), ID($ne), ID($nex))) {
+					has_target = true;
+					break;
+				}
+			if (!has_target) {
+				noop_cache[mod] = {mod->generation, false};
+				continue;
 			}
+
+			uint64_t gen_before = mod->generation;
+			AlumaccWorker worker(mod);
+			worker.run();
+			noop_cache[mod] = {mod->generation, mod->generation != gen_before};
+		}
 	}
 } AlumaccPass;
 

--- a/tests/tools/benchmark_yosys.py
+++ b/tests/tools/benchmark_yosys.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+#
+# Run repeatable Yosys command benchmarks and collect pass timing data.
+#
+# Examples:
+#   python3 tests/tools/benchmark_yosys.py --yosys ./yosys --repeat 5
+#   python3 tests/tools/benchmark_yosys.py --case opt=tests/opt/opt_share_large_pmux_cat.ys
+#   python3 tests/tools/benchmark_yosys.py --case tiny="read_verilog tests/simple/multiplier.v; synth -noabc"
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+DEFAULT_CASES = {
+    "simple_synth_noabc": {
+        "cwd": REPO_ROOT,
+        "script": (
+            "read_verilog tests/simple/aes_kexp128.v "
+            "tests/simple/multiplier.v tests/simple/omsp_dbg_uart.v; "
+            "hierarchy -auto-top; synth -noabc; stat"
+        ),
+    },
+    "opt_share_large_pmux_cat": {
+        "cwd": REPO_ROOT / "tests" / "opt",
+        "script_file": REPO_ROOT / "tests" / "opt" / "opt_share_large_pmux_cat.ys",
+    },
+}
+
+
+END_RE = re.compile(
+    r"End of script\..*?time:\s+([0-9.]+)s,\s+user:\s+([0-9.]+)s,\s+system:\s+([0-9.]+)s"
+)
+PASS_RE = re.compile(r"^\s*([0-9]+)%\s+([0-9]+)\s+calls\s+([0-9.]+)\s+sec\s+(.+?)\s*$")
+
+
+def parse_case(text):
+    if "=" not in text:
+        raise argparse.ArgumentTypeError("case must be NAME=SCRIPT_OR_FILE")
+    name, spec = text.split("=", 1)
+    name = name.strip()
+    spec = spec.strip()
+    if not name:
+        raise argparse.ArgumentTypeError("case name must not be empty")
+
+    path = Path(spec)
+    if path.exists():
+        path = path.resolve()
+        return name, {"cwd": path.parent, "script_file": path}
+
+    return name, {"cwd": REPO_ROOT, "script": spec}
+
+
+def median(values):
+    return statistics.median(values) if values else None
+
+
+def stdev(values):
+    if len(values) < 2:
+        return 0.0
+    return statistics.stdev(values)
+
+
+def parse_yosys_output(output):
+    end = END_RE.search(output)
+    timings = {}
+
+    for line in output.splitlines():
+        match = PASS_RE.match(line)
+        if match:
+            pct, calls, seconds, name = match.groups()
+            timings[name] = {
+                "percent": int(pct),
+                "calls": int(calls),
+                "seconds": float(seconds),
+            }
+
+    return {
+        "reported_wall_seconds": float(end.group(1)) if end else None,
+        "reported_user_seconds": float(end.group(2)) if end else None,
+        "reported_system_seconds": float(end.group(3)) if end else None,
+        "pass_timings": timings,
+    }
+
+
+def run_case(yosys, case_name, case, keep_logs, out_dir):
+    command = [str(yosys), "-Q", "-d"]
+    temp_script = None
+
+    if "script_file" in case:
+        command += ["-s", str(case["script_file"])]
+    else:
+        temp_script = tempfile.NamedTemporaryFile("w", suffix=".ys", delete=False, encoding="utf-8")
+        temp_script.write(case["script"])
+        temp_script.close()
+        command += ["-s", temp_script.name]
+
+    started = time.perf_counter()
+    proc = subprocess.run(
+        command,
+        cwd=case["cwd"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    elapsed = time.perf_counter() - started
+
+    output = proc.stdout
+    if keep_logs:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        log_path = out_dir / f"{case_name}.log"
+        log_path.write_text(output, encoding="utf-8")
+    else:
+        log_path = None
+
+    if temp_script is not None:
+        os.unlink(temp_script.name)
+
+    parsed = parse_yosys_output(output)
+    parsed.update({
+        "returncode": proc.returncode,
+        "measured_wall_seconds": elapsed,
+        "log": str(log_path) if log_path else None,
+    })
+    return parsed
+
+
+def summarize_case(runs):
+    ok_runs = [run for run in runs if run["returncode"] == 0]
+    measured = [run["measured_wall_seconds"] for run in ok_runs]
+    reported = [
+        run["reported_wall_seconds"]
+        for run in ok_runs
+        if run["reported_wall_seconds"] is not None
+    ]
+    pass_names = sorted({
+        name
+        for run in ok_runs
+        for name in run["pass_timings"].keys()
+    })
+    pass_summary = {}
+    for name in pass_names:
+        values = [
+            run["pass_timings"][name]["seconds"]
+            for run in ok_runs
+            if name in run["pass_timings"]
+        ]
+        pass_summary[name] = {
+            "median_seconds": median(values),
+            "stdev_seconds": stdev(values),
+            "samples": len(values),
+        }
+
+    return {
+        "runs": len(runs),
+        "ok_runs": len(ok_runs),
+        "measured_wall_median_seconds": median(measured),
+        "measured_wall_stdev_seconds": stdev(measured),
+        "reported_wall_median_seconds": median(reported),
+        "reported_wall_stdev_seconds": stdev(reported),
+        "pass_timings": pass_summary,
+    }
+
+
+def print_table(results):
+    print("\nCase                         ok/runs  measured median  reported median")
+    print("---------------------------  -------  ---------------  ---------------")
+    for name, data in results.items():
+        summary = data["summary"]
+        measured = summary["measured_wall_median_seconds"]
+        reported = summary["reported_wall_median_seconds"]
+        measured_s = "n/a" if measured is None else f"{measured:8.3f}s"
+        reported_s = "n/a" if reported is None else f"{reported:8.3f}s"
+        print(
+            f"{name[:27]:27}  "
+            f"{summary['ok_runs']:2}/{summary['runs']:<4}  "
+            f"{measured_s:>15}  {reported_s:>15}"
+        )
+
+    print("\nTop median pass timings:")
+    for name, data in results.items():
+        summary = data["summary"]
+        passes = [
+            (pname, pdata["median_seconds"])
+            for pname, pdata in summary["pass_timings"].items()
+            if pdata["median_seconds"] is not None
+        ]
+        passes.sort(key=lambda item: item[1], reverse=True)
+        top = ", ".join(f"{pname} {seconds:.3f}s" for pname, seconds in passes[:5])
+        print(f"  {name}: {top or 'n/a'}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--yosys", default=str(REPO_ROOT / "yosys"), help="Yosys executable")
+    parser.add_argument("--repeat", type=int, default=3, help="measured runs per case")
+    parser.add_argument("--warmup", type=int, default=1, help="unrecorded warmup runs per case")
+    parser.add_argument("--case", action="append", type=parse_case, help="NAME=SCRIPT_OR_FILE")
+    parser.add_argument("--output", default="benchmark_yosys.json", help="JSON output path")
+    parser.add_argument("--keep-logs", action="store_true", help="write per-run logs next to JSON")
+    args = parser.parse_args()
+
+    yosys = Path(args.yosys).resolve()
+    if not yosys.exists() and yosys.suffix == "" and yosys.with_suffix(".exe").exists():
+        yosys = yosys.with_suffix(".exe")
+    if not yosys.exists():
+        print(f"error: Yosys executable not found: {yosys}", file=sys.stderr)
+        return 2
+
+    cases = dict(DEFAULT_CASES)
+    if args.case:
+        cases = {name: case for name, case in args.case}
+
+    out_path = Path(args.output).resolve()
+    log_dir = out_path.with_suffix("")
+    results = {}
+
+    for name, case in cases.items():
+        print(f"running {name}...")
+        for _ in range(args.warmup):
+            run_case(yosys, name, case, False, log_dir)
+
+        runs = []
+        for run_index in range(args.repeat):
+            run_name = f"{name}.{run_index + 1}"
+            runs.append(run_case(yosys, run_name, case, args.keep_logs, log_dir))
+
+        results[name] = {
+            "cwd": str(case["cwd"]),
+            "script_file": str(case["script_file"]) if "script_file" in case else None,
+            "script": case.get("script"),
+            "runs": runs,
+            "summary": summarize_case(runs),
+        }
+
+    report = {
+        "yosys": str(yosys),
+        "repeat": args.repeat,
+        "warmup": args.warmup,
+        "results": results,
+    }
+    out_path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    print_table(results)
+    print(f"\nwrote {out_path}")
+
+    return 1 if any(run["returncode"] for data in results.values() for run in data["runs"]) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/kernel/hashTest.cc
+++ b/tests/unit/kernel/hashTest.cc
@@ -1,6 +1,10 @@
 #include <gtest/gtest.h>
 #include "kernel/yosys_common.h"
 
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <string>
 #include <unordered_set>
 
 YOSYS_NAMESPACE_BEGIN
@@ -62,6 +66,73 @@ TEST(PoolHashTest, subset_collisions)
 	}
 	std::cout << "pool<int> subset collisions: " << collisions << std::endl;
 	EXPECT_LT(collisions, 100);
+}
+
+static bool run_hash_benchmarks()
+{
+	const char *env = getenv("YOSYS_HASH_BENCH");
+	return env != nullptr && std::string(env) != "0";
+}
+
+template<typename F>
+static double time_ns_per_op(int ops, F &&f)
+{
+	auto start = std::chrono::steady_clock::now();
+	f();
+	auto stop = std::chrono::steady_clock::now();
+	return std::chrono::duration<double, std::nano>(stop - start).count() / ops;
+}
+
+TEST(HashBenchmarkTest, dict_int_lookup)
+{
+	if (!run_hash_benchmarks())
+		GTEST_SKIP() << "set YOSYS_HASH_BENCH=1 to run hash microbenchmarks";
+
+	const int keys = 200000;
+	const int probes = 2000000;
+	dict<int, int> db;
+	db.reserve(keys);
+	for (int i = 0; i < keys; ++i)
+		db[i] = i * 3;
+
+	volatile int sink = 0;
+	double ns_per_op = time_ns_per_op(probes, [&] {
+		for (int i = 0; i < probes; ++i)
+			sink += db.at((i * 2654435761u) % keys);
+	});
+	std::cout << "dict<int,int> lookup ns/op: " << ns_per_op << std::endl;
+	int observed = sink;
+	EXPECT_NE(observed, 0);
+}
+
+TEST(HashBenchmarkTest, pool_int_insert_count_erase)
+{
+	if (!run_hash_benchmarks())
+		GTEST_SKIP() << "set YOSYS_HASH_BENCH=1 to run hash microbenchmarks";
+
+	const int keys = 200000;
+	pool<int> db;
+	db.reserve(keys);
+	volatile int sink = 0;
+
+	double insert_ns = time_ns_per_op(keys, [&] {
+		for (int i = 0; i < keys; ++i)
+			db.insert(i);
+	});
+	double count_ns = time_ns_per_op(keys, [&] {
+		for (int i = 0; i < keys; ++i)
+			sink += db.count((i * 2654435761u) % keys);
+	});
+	double erase_ns = time_ns_per_op(keys, [&] {
+		for (int i = 0; i < keys; ++i)
+			db.erase(i);
+	});
+
+	std::cout << "pool<int> insert ns/op: " << insert_ns << std::endl;
+	std::cout << "pool<int> count ns/op: " << count_ns << std::endl;
+	std::cout << "pool<int> erase ns/op: " << erase_ns << std::endl;
+	int observed = sink;
+	EXPECT_EQ(observed, keys);
 }
 
 YOSYS_NAMESPACE_END


### PR DESCRIPTION
## Benchmark perf — upstream/main vs this branch

5-rep wall-clock medians, MSYS2 mingw-w64 -O3 build, both binaries built from the same `Makefile.conf`.

- **Before** = upstream `YosysHQ/yosys` `main` at `5197b9c8c` (today's tip)
- **After** = `crockpot/optimization-v1` HEAD at `e40073e7b` (post-merge + opt_muxtree fix)

| Benchmark | Before (upstream/main) | After (this branch) | Speedup |
|---|---:|---:|---:|
| `many_equiv_cells_30000` | 2.612s | 2.070s | **1.26×** |
| `many_equiv_cells_60000` | 5.365s | 4.264s | **1.26×** |
| `picorv32_x4_synth` | 2.644s | 2.139s | **1.24×** |
| `wide_opt_chain_3000` | 3.859s | 1.502s | **2.57×** |
| **geomean** | — | — | **1.50×** |

_If your work is part of a larger effort, please discuss your general plans on [Discourse](https://yosyshq.discourse.group/) first to align your vision with maintainers._
https://yosyshq.discourse.group/t/new-pr-with-up-to-2-57x-performance-improvements/142

_What are the reasons/motivation for this change?_
At biscut.ai we rely quite heavily on yosys for ASIC synthesis of our flagship chip. Speeding up development cycles is quite important to us so we can programmatically and rapidly iterate on design. I believe this contribution is meaningful not only to our work, but to the entire community using yosys.

_Explain how this is achieved._
Using a combination of heuristics and aggressive profiling+microbenchmarks, areas were identified that contribute to increased synthesis times. Using this information, an agent runs performance bisecting loops to test solution hypotheses and commit if the solution 1) makes a significant performance improvement; and 2) all tests pass.

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._
This is focused on optimizing current code, not new additions. Assuming test coverage is adequate, no further tests should be required for this pull request.
