### PR TITLE
Fix ABC: Merged scl conversion failed, using liberty format warning when using -genlib.

### DIFF
--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1030,7 +1030,7 @@ void AbcModuleState::prepare_module(RTLIL::Design *design, RTLIL::Module *module
 		std::string merged_scl = convert_liberty_files_to_merged_scl(config.liberty_files, run_abc.dont_use_args, config.exe_file);
 		if (!merged_scl.empty()) {
 			run_abc.abc_script += stringf("read_scl \"%s\" ; ", merged_scl.c_str());
-		} else {
+		} else if(!config.liberty_files.empty()) {
 			log_warning("ABC: Merged scl conversion failed, using liberty format\n");
 			bool first_lib = true;
 			for (std::string liberty_file : config.liberty_files) {

--- a/passes/techmap/abc9_exe.cc
+++ b/passes/techmap/abc9_exe.cc
@@ -186,7 +186,7 @@ void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe
 		std::string merged_scl = convert_liberty_files_to_merged_scl(liberty_files, dont_use_args, exe_file);
 		if (!merged_scl.empty()) {
 			abc9_script += stringf("read_scl \"%s\" ; ", merged_scl.c_str());
-		} else {
+		} else if(!liberty_files.empty()) {
 			log_warning("ABC: Merged scl conversion failed, using liberty format\n");
 			bool first_lib = true;
 			for (std::string liberty_file : liberty_files) {


### PR DESCRIPTION
Removes an incorrect warning generated by abc/abc_new when using abc with the `-genlib` option.
```
ABC: Merged scl conversion failed, using liberty format warning when using -genlib
```
