### PR TITLE
Upgrade to WASI SDK 33 and drop exception workaround

### DIFF
--- a/.github/workflows/extra-builds.yml
+++ b/.github/workflows/extra-builds.yml
@@ -79,8 +79,8 @@ jobs:
           persist-credentials: false
       - name: Build
         run: |
-          WASI_SDK=wasi-sdk-27.0-x86_64-linux
-          WASI_SDK_URL=https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-27/wasi-sdk-27.0-x86_64-linux.tar.gz
+          WASI_SDK=wasi-sdk-33.0-x86_64-linux
+          WASI_SDK_URL=https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-linux.tar.gz
           if ! [ -d ${WASI_SDK} ]; then curl -L ${WASI_SDK_URL} | tar xzf -; fi
 
           FLEX_VER=2.6.4

--- a/Makefile
+++ b/Makefile
@@ -291,18 +291,19 @@ ifeq ($(WASI_SDK),)
 CXX = clang++
 AR = llvm-ar
 RANLIB = llvm-ranlib
-WASIFLAGS := -target wasm32-wasi $(WASIFLAGS)
+WASIFLAGS := -target wasm32-wasip1 $(WASIFLAGS)
 else
 CXX = $(WASI_SDK)/bin/clang++
 AR = $(WASI_SDK)/bin/ar
 RANLIB = $(WASI_SDK)/bin/ranlib
 endif
-CXXFLAGS := $(WASIFLAGS) -std=$(CXXSTD) $(OPT_LEVEL) -D_WASI_EMULATED_PROCESS_CLOCKS $(filter-out -fPIC,$(CXXFLAGS))
-LINKFLAGS := $(WASIFLAGS) -Wl,-z,stack-size=1048576 $(filter-out -rdynamic,$(LINKFLAGS))
+CXXFLAGS := $(WASIFLAGS) -std=$(CXXSTD) $(OPT_LEVEL) -D_WASI_EMULATED_PROCESS_CLOCKS -fwasm-exceptions -mllvm -wasm-use-legacy-eh=false $(filter-out -fPIC,$(CXXFLAGS))
+LINKFLAGS := $(WASIFLAGS) -Wl,-z,stack-size=1048576 $(filter-out -rdynamic,$(LINKFLAGS)) -fwasm-exceptions -lunwind
 LIBS := -lwasi-emulated-process-clocks $(filter-out -lrt,$(LIBS))
 ABCMKARGS += AR="$(AR)" RANLIB="$(RANLIB)"
 ABCMKARGS += ARCHFLAGS="$(WASIFLAGS) -D_WASI_EMULATED_PROCESS_CLOCKS -DABC_USE_STDINT_H -DABC_NO_DYNAMIC_LINKING -DABC_NO_RLIMIT"
 ABCMKARGS += OPTFLAGS="-Os"
+LTOFLAGS =
 EXE = .wasm
 
 DISABLE_SPAWN := 1

--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -144,19 +144,6 @@ int yosys_history_offset = 0;
 std::string yosys_history_file;
 #endif
 
-#if defined(__wasm)
-extern "C" {
-	// FIXME: WASI does not currently support exceptions.
-	void* __cxa_allocate_exception(size_t thrown_size) throw() {
-		return malloc(thrown_size);
-	}
-	bool __cxa_uncaught_exception() throw();
-	void __cxa_throw(void* thrown_exception, struct std::type_info * tinfo, void (*dest)(void*)) {
-		std::terminate();
-	}
-}
-#endif
-
 void yosys_atexit()
 {
 #if defined(YOSYS_ENABLE_READLINE) || defined(YOSYS_ENABLE_EDITLINE)

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -70,6 +70,9 @@
 #  include <dirent.h>
 #  include <sys/stat.h>
 #endif
+#if defined(__wasm)
+#include <wasi/libc.h>
+#endif
 
 #include "frontends/blif/blifparse.h"
 #include "liberty_cache.h"
@@ -1382,7 +1385,7 @@ void RunAbcState::run(ConcurrentStack<AbcProcess> &)
 		FILE *old_stdout = fopen(temp_stdouterr_name.c_str(), "r"); // need any fd for renumbering
 		FILE *old_stderr = fopen(temp_stdouterr_name.c_str(), "r"); // need any fd for renumbering
 #if defined(__wasm)
-#define fd_renumber(from, to) (void)__wasi_fd_renumber(from, to)
+#define fd_renumber(from, to) (void)__wasilibc_fd_renumber(from, to)
 #else
 #define fd_renumber(from, to) dup2(from, to)
 #endif

--- a/passes/techmap/abc9_exe.cc
+++ b/passes/techmap/abc9_exe.cc
@@ -30,6 +30,9 @@
 #  include <unistd.h>
 #  include <dirent.h>
 #endif
+#if defined(__wasm)
+#include <wasi/libc.h>
+#endif
 
 #ifdef YOSYS_LINK_ABC
 namespace abc {
@@ -296,7 +299,7 @@ void abc9_module(RTLIL::Design *design, std::string script_file, std::string exe
 	FILE *old_stdout = fopen(temp_stdouterr_name.c_str(), "r"); // need any fd for renumbering
 	FILE *old_stderr = fopen(temp_stdouterr_name.c_str(), "r"); // need any fd for renumbering
 #if defined(__wasm)
-#define fd_renumber(from, to) (void)__wasi_fd_renumber(from, to)
+#define fd_renumber(from, to) (void)__wasilibc_fd_renumber(from, to)
 #else
 #define fd_renumber(from, to) dup2(from, to)
 #endif


### PR DESCRIPTION
The latest WASI SDK ships with support for C++ exceptions, so the previous workaround is no longer required.

Includes small fixes to fix compilation on newer WASI SDKs and disables LTO (as it is currently not compatible with exceptions).