### PR TITLE
Add check before flatten in synth - Fix #429

### DIFF
--- a/docs/source/code_examples/macro_commands/synth_ice40.ys
+++ b/docs/source/code_examples/macro_commands/synth_ice40.ys
@@ -6,6 +6,7 @@ begin:
     proc
 
 flatten:
+    check
     flatten
     tribuf -logic
     deminout

--- a/techlibs/achronix/synth_achronix.cc
+++ b/techlibs/achronix/synth_achronix.cc
@@ -129,6 +129,7 @@ struct SynthAchronixPass : public ScriptPass {
     if (flatten && check_label("flatten", "(unless -noflatten)"))
       {
         run("proc");
+        run("check");
         run("flatten");
         run("tribuf -logic");
         run("deminout");

--- a/techlibs/analogdevices/synth_analogdevices.cc
+++ b/techlibs/analogdevices/synth_analogdevices.cc
@@ -277,8 +277,10 @@ struct SynthAnalogDevicesPass : public ScriptPass
 
 		if (check_label("prepare")) {
 			run("proc");
-			if (flatten || help_mode)
+			if (flatten || help_mode) {
+				run("check");
 				run("flatten", "(with '-flatten')");
+			}
 			if (active_design)
 				active_design->scratchpad_unset("tribuf.added_something");
 			run("tribuf -logic");
@@ -447,8 +449,10 @@ struct SynthAnalogDevicesPass : public ScriptPass
 
 		if (check_label("map_luts")) {
 			run("opt_expr -mux_undef -noclkinv");
-			if (flatten_before_abc)
+			if (flatten_before_abc) {
+				run("check");
 				run("flatten");
+			}
 			if (help_mode)
 				run("abc -luts 2:2,3,6:5[,10,20] [-dff] [-D 1]", "(option for '-nowidelut', '-dff', '-retime')");
 			else if (abc9) {

--- a/techlibs/anlogic/synth_anlogic.cc
+++ b/techlibs/anlogic/synth_anlogic.cc
@@ -156,6 +156,7 @@ struct SynthAnlogicPass : public ScriptPass
 		if (flatten && check_label("flatten", "(unless -noflatten)"))
 		{
 			run("proc");
+			run("check");
 			run("flatten");
 			run("tribuf -logic");
 			run("deminout");

--- a/techlibs/common/synth.cc
+++ b/techlibs/common/synth.cc
@@ -277,9 +277,10 @@ struct SynthPass : public ScriptPass {
 
 		if (check_label("coarse")) {
 			run("proc");
-			run("check");
-			if (flatten || help_mode)
+			if (flatten || help_mode) {
+				run("check");
 				run("flatten", "  (if -flatten)");
+			}
 			run("opt_expr");
 			run("opt_clean");
 			run("check");

--- a/techlibs/common/synth.cc
+++ b/techlibs/common/synth.cc
@@ -277,6 +277,7 @@ struct SynthPass : public ScriptPass {
 
 		if (check_label("coarse")) {
 			run("proc");
+			run("check");
 			if (flatten || help_mode)
 				run("flatten", "  (if -flatten)");
 			run("opt_expr");

--- a/techlibs/coolrunner2/synth_coolrunner2.cc
+++ b/techlibs/coolrunner2/synth_coolrunner2.cc
@@ -132,6 +132,7 @@ struct SynthCoolrunner2Pass : public ScriptPass
 		if (flatten && check_label("flatten", "(unless -noflatten)"))
 		{
 			run("proc");
+			run("check");
 			run("flatten");
 			run("tribuf -logic");
 		}

--- a/techlibs/easic/synth_easic.cc
+++ b/techlibs/easic/synth_easic.cc
@@ -142,6 +142,7 @@ struct SynthEasicPass : public ScriptPass
 		if (flatten && check_label("flatten", "(unless -noflatten)"))
 		{
 			run("proc");
+			run("check");
 			run("flatten");
 		}
 

--- a/techlibs/efinix/synth_efinix.cc
+++ b/techlibs/efinix/synth_efinix.cc
@@ -148,6 +148,7 @@ struct SynthEfinixPass : public ScriptPass
 		if (flatten && check_label("flatten", "(unless -noflatten)"))
 		{
 			run("proc");
+			run("check");
 			run("flatten");
 			run("tribuf -logic");
 			run("deminout");

--- a/techlibs/fabulous/synth_fabulous.cc
+++ b/techlibs/fabulous/synth_fabulous.cc
@@ -286,6 +286,7 @@ struct SynthPass : public ScriptPass
 		if (check_label("flatten", "(unless -noflatten)"))
 		{
 			if (flatten) {
+				run("check");
 				run("flatten");
 				run("tribuf -logic");
 				run("deminout");

--- a/techlibs/gatemate/synth_gatemate.cc
+++ b/techlibs/gatemate/synth_gatemate.cc
@@ -210,6 +210,7 @@ struct SynthGateMatePass : public ScriptPass
 		{
 			run("proc");
 			if (!noflatten) {
+				run("check");
 				run("flatten");
 			}
 			run("tribuf -logic");

--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -265,8 +265,10 @@ struct SynthGowinPass : public ScriptPass
 		if (check_label("coarse"))
 		{
 			run("proc");
-			if (flatten || help_mode)
+			if (flatten || help_mode) {
+				run("check");
 				run("flatten", "(unless -noflatten)");
+			}
 			run("tribuf -logic");
 			run("deminout");
 			run("opt_expr");

--- a/techlibs/greenpak4/synth_greenpak4.cc
+++ b/techlibs/greenpak4/synth_greenpak4.cc
@@ -144,6 +144,7 @@ struct SynthGreenPAK4Pass : public ScriptPass
 		if (flatten && check_label("flatten", "(unless -noflatten)"))
 		{
 			run("proc");
+			run("check");
 			run("flatten");
 			run("tribuf -logic");
 		}

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -309,6 +309,7 @@ struct SynthIce40Pass : public ScriptPass
 		if (check_label("flatten", "(unless -noflatten)"))
 		{
 			if (flatten) {
+				run("check");
 				run("flatten");
 				run("tribuf -logic");
 				run("deminout");

--- a/techlibs/intel/synth_intel.cc
+++ b/techlibs/intel/synth_intel.cc
@@ -198,9 +198,11 @@ struct SynthIntelPass : public ScriptPass {
 
 		if (check_label("coarse")) {
 			run("proc");
-			if (flatten || help_mode)
+			if (flatten || help_mode) {
+				run("check");
 				run("flatten", "(skip if -noflatten)");
-                        run("tribuf -logic");
+			}
+			run("tribuf -logic");
 			run("deminout");
 			run("opt_expr");
 			run("opt_clean");

--- a/techlibs/intel_alm/synth_intel_alm.cc
+++ b/techlibs/intel_alm/synth_intel_alm.cc
@@ -184,8 +184,10 @@ struct SynthIntelALMPass : public ScriptPass {
 
 		if (check_label("coarse")) {
 			run("proc");
-			if (flatten || help_mode)
+			if (flatten || help_mode) {
+				run("check");
 				run("flatten", "(skip if -noflatten)");
+			}
 			run("tribuf -logic");
 			run("deminout");
 			run("opt_expr");

--- a/techlibs/lattice/synth_lattice.cc
+++ b/techlibs/lattice/synth_lattice.cc
@@ -402,8 +402,10 @@ struct SynthLatticePass : public ScriptPass
 		if (check_label("coarse"))
 		{
 			run("proc");
-			if (flatten || help_mode)
+			if (flatten || help_mode) {
+				run("check");
 				run("flatten");
+			}
 			run("tribuf -logic");
 			run("deminout");
 			run("opt_expr");

--- a/techlibs/microchip/synth_microchip.cc
+++ b/techlibs/microchip/synth_microchip.cc
@@ -267,8 +267,10 @@ struct SynthMicrochipPass : public ScriptPass {
 
 		if (check_label("prepare")) {
 			run("proc");
-			if (flatten || help_mode)
+			if (flatten || help_mode) {
+				run("check");
 				run("flatten", "(with '-flatten')");
+			}
 			if (active_design)
 				active_design->scratchpad_unset("tribuf.added_something");
 			run("tribuf -logic");

--- a/techlibs/nanoxplore/synth_nanoxplore.cc
+++ b/techlibs/nanoxplore/synth_nanoxplore.cc
@@ -250,8 +250,10 @@ struct SynthNanoXplorePass : public ScriptPass
 		if (check_label("coarse"))
 		{
 			run("proc");
-			if (flatten || help_mode)
+			if (flatten || help_mode) {
+				run("check");
 				run("flatten", "(skip if -noflatten)");
+			}
 			run("tribuf -logic");
 			run("deminout");
 			run("opt_expr");

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -212,8 +212,10 @@ struct SynthQuickLogicPass : public ScriptPass {
 
 		if (check_label("prepare")) {
 			run("proc");
-			if (flatten)
+			if (flatten) {
+				run("check");
 				run("flatten", "(unless -noflatten)");
+			}
 			if (help_mode || family == "pp3") {
 				run("tribuf -logic", "                   (for pp3)");
 			}

--- a/techlibs/sf2/synth_sf2.cc
+++ b/techlibs/sf2/synth_sf2.cc
@@ -172,6 +172,7 @@ struct SynthSf2Pass : public ScriptPass
 		if (flatten && check_label("flatten", "(unless -noflatten)"))
 		{
 			run("proc");
+			run("check");
 			run("flatten");
 			run("tribuf -logic");
 			run("deminout");

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -355,8 +355,10 @@ struct SynthXilinxPass : public ScriptPass
 
 		if (check_label("prepare")) {
 			run("proc");
-			if (flatten || help_mode)
+			if (flatten || help_mode) {
+				run("check");
 				run("flatten", "(with '-flatten')");
+			}
 			if (active_design)
 				active_design->scratchpad_unset("tribuf.added_something");
 			run("tribuf -logic");
@@ -637,8 +639,10 @@ struct SynthXilinxPass : public ScriptPass
 
 		if (check_label("map_luts")) {
 			run("opt_expr -mux_undef -noclkinv");
-			if (flatten_before_abc)
+			if (flatten_before_abc) {
+				run("check");
 				run("flatten");
+			}
 			if (help_mode)
 				run("abc -luts 2:2,3,6:5[,10,20] [-dff] [-D 1]", "(option for '-nowidelut', '-dff', '-retime')");
 			else if (abc9) {


### PR DESCRIPTION
This PR adds `check` immediately before the `flatten` step in the generic synth command to make it easier to notice potentially subtle bugs as described in #429.