### PR TITLE
memlib: fix documentation for `PORT_<name>_CLK_POL`

### DIFF
--- a/passes/memory/memlib.md
+++ b/passes/memory/memlib.md
@@ -310,7 +310,7 @@ The port clock is always provided on the memory cell as `PORT_<name>_CLK` signal
 (even if it is also shared).  Shared clocks are also provided as `CLK_<shared_name>`
 signals.
 
-For `anyedge` clocks, the cell gets a `PORT_<name>_CLKPOL` parameter that is set
+For `anyedge` clocks, the cell gets a `PORT_<name>_CLK_POL` parameter that is set
 to 1 for `posedge` clocks and 0 for `negedge` clocks.  If the clock is shared,
 the same information will also be provided as `CLK_<shared_name>_POL` parameter.
 


### PR DESCRIPTION
Fix a minor but important typo in the memlib documentation.
The parameter for anyedge clocks is `PORT_<name>_CLK_POL`, not `PORT_<name>_CLKPOL`. Please note the additional underscore.

This can also be seen in the source code here: https://github.com/YosysHQ/yosys/blob/1f023432681c159885f0b834a2e0717e67c4c115/passes/memory/memory_libmap.cc#L1755