### PR TITLE
Makefile: error on unused variables, including hashlib containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ VPATH := $(YOSYS_SRC)
 UNITESTPATH := $(YOSYS_SRC)/tests/unit
 
 export CXXSTD ?= c++17
-CXXFLAGS := $(CXXFLAGS) -Wall -Wextra -ggdb -I. -I"$(YOSYS_SRC)" -MD -MP -D_YOSYS_ -fPIC -I$(PREFIX)/include
+CXXFLAGS := $(CXXFLAGS) -Wall -Wextra -Werror=unused -ggdb -I. -I"$(YOSYS_SRC)" -MD -MP -D_YOSYS_ -fPIC -I$(PREFIX)/include
 LIBS := $(LIBS) -lstdc++ -lm
 PLUGIN_LINKFLAGS :=
 PLUGIN_LIBS :=

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -55,6 +55,12 @@ namespace hashlib {
  * instead of pointers.
  */
 
+#if defined(__GNUC__) || defined(__clang__)
+#  define HASHLIB_ATTRIBUTE_WARN_UNUSED __attribute__((warn_unused))
+#else
+#  define HASHLIB_ATTRIBUTE_WARN_UNUSED
+#endif
+
 const int hashtable_size_trigger = 2;
 const int hashtable_size_factor = 3;
 
@@ -402,7 +408,7 @@ private:
 };
 
 template<typename K, typename T, typename OPS>
-class dict {
+class HASHLIB_ATTRIBUTE_WARN_UNUSED dict {
 	struct entry_t
 	{
 		std::pair<K, T> udata;
@@ -877,7 +883,7 @@ public:
 };
 
 template<typename K, typename OPS>
-class pool
+class HASHLIB_ATTRIBUTE_WARN_UNUSED pool
 {
 	template<typename, int, typename> friend class idict;
 
@@ -1257,7 +1263,7 @@ public:
 };
 
 template<typename K, int offset, typename OPS>
-class idict
+class HASHLIB_ATTRIBUTE_WARN_UNUSED idict
 {
 	pool<K, OPS> database;
 
@@ -1360,7 +1366,7 @@ public:
  * i-prefixed methods operate on indices in parents
 */
 template<typename K, typename OPS>
-class mfp
+class HASHLIB_ATTRIBUTE_WARN_UNUSED mfp
 {
 	idict<K, 0, OPS> database;
 	class AtomicParent {

--- a/kernel/threading.cc
+++ b/kernel/threading.cc
@@ -45,9 +45,12 @@ int ThreadPool::pool_size(int reserved_cores, int max_worker_threads)
 #ifdef YOSYS_ENABLE_THREADS
 	int available_threads = std::min<int>(std::thread::hardware_concurrency(), get_max_threads());
 	int num_threads = std::min(available_threads - reserved_cores, max_worker_threads);
-        return std::max(0, num_threads);
+	return std::max(0, num_threads);
 #else
-        return 0;
+	(void)reserved_cores;
+	(void)max_worker_threads;
+	(void)get_max_threads();
+	return 0;
 #endif
 }
 
@@ -146,6 +149,8 @@ void ParallelDispatchThreadPool::run_worker(int thread_num)
 		signal_worker_done();
 	}
 	signal_worker_done();
+#else
+	(void)current_work;
 #endif
 }
 

--- a/passes/equiv/equiv_make.cc
+++ b/passes/equiv/equiv_make.cc
@@ -79,6 +79,7 @@ struct EquivMakeWorker
 
 				if (token == ".fsm") {
 					IdString modname = RTLIL::escape_id(next_token(line));
+					(void)modname;
 					IdString signame = RTLIL::escape_id(next_token(line));
 					if (encdata.count(signame))
 						log_cmd_error("Re-definition of signal '%s' in encfile '%s'!\n", signame, fn);

--- a/passes/opt/muxpack.cc
+++ b/passes/opt/muxpack.cc
@@ -263,7 +263,6 @@ struct MuxpackWorker
 			int cases = GetSize(chain) - cursor;
 
 			Cell *first_cell = chain[cursor];
-			dict<int, SigBit> taps_dict;
 
 			if (cases < 2) {
 				cursor++;

--- a/passes/opt/opt_lut.cc
+++ b/passes/opt/opt_lut.cc
@@ -421,13 +421,12 @@ struct OptLutWorker
 					}
 
 					RTLIL::Cell *lutM, *lutR;
-					pool<SigBit> lutM_inputs, lutR_inputs;
+					pool<SigBit> lutR_inputs;
 					pool<int> lutM_dlogic_inputs;
 					if (combine == COMBINE_A)
 					{
 						log_debug("  Combining LUTs into cell A.\n");
 						lutM = lutA;
-						lutM_inputs = lutA_inputs;
 						lutM_dlogic_inputs = lutA_dlogic_inputs;
 						lutR = lutB;
 						lutR_inputs = lutB_inputs;
@@ -436,7 +435,6 @@ struct OptLutWorker
 					{
 						log_debug("  Combining LUTs into cell B.\n");
 						lutM = lutB;
-						lutM_inputs = lutB_inputs;
 						lutM_dlogic_inputs = lutB_dlogic_inputs;
 						lutR = lutA;
 						lutR_inputs = lutA_inputs;

--- a/passes/sat/qbfsat.h
+++ b/passes/sat/qbfsat.h
@@ -170,7 +170,6 @@ struct QbfSolutionType {
 		std::smatch m;
 		bool sat_regex_found = false;
 		bool unsat_regex_found = false;
-		dict<std::string, bool> hole_value_recovered;
 		for (const std::string &x : stdout_lines) {
 			if(std::regex_search(x, m, hole_value_regex)) {
 				std::string loc = m[1].str();

--- a/passes/techmap/abc9_ops.cc
+++ b/passes/techmap/abc9_ops.cc
@@ -97,7 +97,6 @@ void check(RTLIL::Design *design, bool dff_mode)
 			ID($_DLATCHSR_PNN_), ID($_DLATCHSR_PNP_), ID($_DLATCHSR_PPN_), ID($_DLATCHSR_PPP_),
 			ID($_SR_NN_), ID($_SR_NP_), ID($_SR_PN_), ID($_SR_PP_)
 		};
-		pool<IdString> processed;
 		for (auto module : design->selected_modules())
 			for (auto cell : module->cells()) {
 				auto inst_module = design->module(cell->type);

--- a/passes/techmap/flowmap.cc
+++ b/passes/techmap/flowmap.cc
@@ -1246,14 +1246,14 @@ struct FlowmapWorker
 				}
 			}
 			log("  Breaking LUT %s to %s LUT %s (potential %d).\n",
-			    log_signal(breaking_lut), lut_nodes[breaking_gate] ? "reuse" : "extract", log_signal(breaking_gate), best_potential);
+				log_signal(breaking_lut), lut_nodes[breaking_gate] ? "reuse" : "extract", log_signal(breaking_gate), best_potential);
 
 			if (debug_relax)
 				log("    Removing breaking gate %s from LUT.\n", log_signal(breaking_gate));
 			lut_gates[breaking_lut].erase(breaking_gate);
 
 			auto cut_inputs = cut_lut_at_gate(breaking_lut, breaking_gate);
-			pool<RTLIL::SigBit> gate_inputs = cut_inputs.first, other_inputs = cut_inputs.second;
+			pool<RTLIL::SigBit> gate_inputs = cut_inputs.first;
 
 			pool<RTLIL::SigBit> worklist = lut_gates[breaking_lut];
 			pool<RTLIL::SigBit> elim_gates = gate_inputs;


### PR DESCRIPTION
This change may be somewhat controversial

Code with unused variables sucks to read and may point to logical errors. Dicts and pools shouldn't be exluced just because of how C++ models side effects. This PR turns unused variables into an error and allows the reporting of unused hashlib containers on clang/gcc builds. Plugin authors may be affected, as they should, when `yosys-config --cxxflags` includes `-Werror=unused`

Explicit casts to void on results of side-effecty operations may be needed from time to time, but those were causing warnings before already