### PR TITLE
Remove unused variable for WIN32

### DIFF
--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -664,6 +664,7 @@ int main(int argc, char **argv)
 
 #ifdef _WIN32
 		log("End of script. Logfile hash: %s\n", hash);
+		(void)wall_clock_start;
 #else
 		std::string meminfo;
 		std::string stats_divider = ", ";


### PR DESCRIPTION
As flag is recently added to convert unused variable to error, this is triggered on MINGW build on Windows. 