### PR TITLE
opt_muxtree: reuse knowledge_t and pass by reference

### DIFF
--- a/passes/opt/opt_muxtree.cc
+++ b/passes/opt/opt_muxtree.cc
@@ -200,6 +200,29 @@ struct OptMuxtreeWorker
 				root_muxes.at(driving_mux) = true;
 	}
 
+	struct knowledge_t
+	{
+		// Known inactive signals
+		// The payload is a reference counter used to manage the list
+		// When it is non-zero, the signal in known to be inactive
+		// When it reaches zero, the map element is removed
+		std::vector<int> known_inactive;
+
+		// database of known active signals
+		std::vector<int> known_active;
+
+		// this is just used to keep track of visited muxes in order to prohibit
+		// endless recursion in mux loops
+		std::vector<bool> visited_muxes;
+
+		// Initialize with the maximum possible sizes
+		knowledge_t(int num_bits, int num_muxes) {
+			known_inactive.assign(num_bits, 0);
+			known_active.assign(num_bits, 0);
+			visited_muxes.assign(num_muxes, false);
+		}
+	};
+
 	OptMuxtreeWorker(RTLIL::Design *design, RTLIL::Module *module) :
 			design(design), module(module), assign_map(module), removed_count(0)
 	{
@@ -227,11 +250,13 @@ struct OptMuxtreeWorker
 
 		populate_roots();
 
+		knowledge_t shared_knowledge(GetSize(bit2info), GetSize(mux2info));
+
 		for (int mux_idx = 0; mux_idx < GetSize(root_muxes); mux_idx++)
 			if (root_muxes.at(mux_idx)) {
 				log_debug("    Root of a mux tree: %s%s\n", log_id(mux2info[mux_idx].cell), root_enable_muxes.at(mux_idx) ? " (pure)" : "");
 				root_mux_rerun.erase(mux_idx);
-				eval_root_mux(mux_idx);
+				eval_root_mux(shared_knowledge, mux_idx);
 				if (glob_evals_left == 0) {
 					log("  Giving up (too many iterations)\n");
 					return;
@@ -243,7 +268,7 @@ struct OptMuxtreeWorker
 			log_debug("    Root of a mux tree: %s (rerun as non-pure)\n", log_id(mux2info[mux_idx].cell));
 			log_assert(root_enable_muxes.at(mux_idx));
 			root_mux_rerun.erase(mux_idx);
-			eval_root_mux(mux_idx);
+			eval_root_mux(shared_knowledge, mux_idx);
 			if (glob_evals_left == 0) {
 				log("  Giving up (too many iterations)\n");
 				return;
@@ -333,29 +358,6 @@ struct OptMuxtreeWorker
 				results.push_back(-1);
 		return results;
 	}
-
-	struct knowledge_t
-	{
-		// Known inactive signals
-		// The payload is a reference counter used to manage the list
-		// When it is non-zero, the signal in known to be inactive
-		// When it reaches zero, the map element is removed
-		std::vector<int> known_inactive;
-
-		// database of known active signals
-		std::vector<int> known_active;
-
-		// this is just used to keep track of visited muxes in order to prohibit
-		// endless recursion in mux loops
-		std::vector<bool> visited_muxes;
-
-		// Initialize with the maximum possible sizes
-		knowledge_t(int num_bits, int num_muxes) {
-			known_inactive.assign(num_bits, 0);
-			known_active.assign(num_bits, 0);
-			visited_muxes.assign(num_muxes, false);
-		}
-	};
 
 	static void activate_port(knowledge_t &knowledge, int port_idx, const muxinfo_t &muxinfo) {
 		// First, mark all other ports inactive
@@ -579,14 +581,14 @@ struct OptMuxtreeWorker
 		}
 	}
 
-	void eval_root_mux(int mux_idx)
+	void eval_root_mux(knowledge_t &knowledge, int mux_idx)
 	{
 		log_assert(glob_evals_left > 0);
-		knowledge_t knowledge(GetSize(bit2info), GetSize(mux2info));
 		knowledge.visited_muxes[mux_idx] = true;
 		limits_t limits = {};
 		limits.do_mark_ports_observable = root_enable_muxes.at(mux_idx);
 		eval_mux(knowledge, mux_idx, limits);
+		knowledge.visited_muxes[mux_idx] = false;
 	}
 };
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
Follow-up of https://github.com/YosysHQ/yosys/pull/5809. The optimizations there regressed certain other design types, this PR covers these other cases.

_Explain how this is achieved._
Reuse knowledge_t and pass by reference, to avoid the creation of large vectors repeatedly when the number of bits in the mux is high. For designs with high mux count with high bitwidth, these lines become hot: https://github.com/YosysHQ/yosys/blob/2046a23a2fe201118b27627dee50a742b86ddfba/passes/opt/opt_muxtree.cc#L354-L355

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._

Metrics:
Current baseline:
<img width="1428" height="558" alt="5zHQ6yWkq93R6EK" src="https://github.com/user-attachments/assets/e91e6406-bb9c-4be2-8d8b-c018a01bc724" />

With change:

<img width="1416" height="836" alt="4EuAx54KJsYwmhv" src="https://github.com/user-attachments/assets/9e2b1fe5-cc6a-41c9-b6e8-5c50b3f8fe32" />

For our design (~3M instances), this reduces the total runtime from 11h17m to 4h37m. For smaller designs, I don't anticipate this to make a difference.