### PR TITLE
smtbmc: drop obsolete bitwuzla SMT2 CLI options

### DIFF
--- a/backends/smt2/smtio.py
+++ b/backends/smt2/smtio.py
@@ -226,11 +226,18 @@ class SmtIo:
                 print('timeout option is not supported for mathsat.')
                 sys.exit(1)
 
-        if self.solver in ["boolector", "bitwuzla"]:
+        if self.solver == "boolector":
             if self.noincr:
                 self.popen_vargs = [self.solver, '--smt2'] + self.solver_opts
             else:
                 self.popen_vargs = [self.solver, '--smt2', '-i'] + self.solver_opts
+            self.unroll = True
+            if self.timeout != 0:
+                print('timeout option is not supported for %s.' % self.solver)
+                sys.exit(1)
+
+        if self.solver == "bitwuzla":
+            self.popen_vargs = [self.solver] + self.solver_opts
             self.unroll = True
             if self.timeout != 0:
                 print('timeout option is not supported for %s.' % self.solver)

--- a/tests/functional/smtio.py
+++ b/tests/functional/smtio.py
@@ -225,11 +225,18 @@ class SmtIo:
                 print('timeout option is not supported for mathsat.')
                 sys.exit(1)
 
-        if self.solver in ["boolector", "bitwuzla"]:
+        if self.solver == "boolector":
             if self.noincr:
                 self.popen_vargs = [self.solver, '--smt2'] + self.solver_opts
             else:
                 self.popen_vargs = [self.solver, '--smt2', '-i'] + self.solver_opts
+            self.unroll = True
+            if self.timeout != 0:
+                print('timeout option is not supported for %s.' % self.solver)
+                sys.exit(1)
+
+        if self.solver == "bitwuzla":
+            self.popen_vargs = [self.solver] + self.solver_opts
             self.unroll = True
             if self.timeout != 0:
                 print('timeout option is not supported for %s.' % self.solver)


### PR DESCRIPTION
## Summary

Bitwuzla 0.9.0 no longer accepts the legacy `--smt2` and `-i` command line options. `yosys-smtbmc -s bitwuzla` currently passes those options unconditionally, which causes Bitwuzla to exit before reading the SMT2 stream and leaves `yosys-smtbmc` reporting a broken pipe.

This patch keeps the existing Boolector invocation unchanged and splits Bitwuzla into its own solver branch. Bitwuzla is now launched as `bitwuzla` plus any user-specified `-S` options.

## Testing

```
python3 -m py_compile backends/smt2/smtio.py tests/functional/smtio.py
python3 backends/smt2/smtbmc.py -s bitwuzla --presat --unroll --noprogress -t 20 --append 0 ../fifo/model/design_smt2.smt2
```

The local Bitwuzla 0.9.0 run reports `Status: PASSED`.
