### PR TITLE
smt2: use canonical SMT names in memory metadata

### DIFF
--- a/backends/smt2/smt2.cc
+++ b/backends/smt2/smt2.cc
@@ -788,7 +788,7 @@ struct Smt2Worker
 			if (has_async_wr && has_sync_wr)
 				log_error("Memory %s.%s has mixed clocked/nonclocked write ports. This is not supported by \"write_smt2\".\n", cell, module);
 
-			decls.push_back(stringf("; yosys-smt2-memory %s %d %d %d %d %s\n", mem->memid.unescape(), abits, mem->width, GetSize(mem->rd_ports), GetSize(mem->wr_ports), has_async_wr ? "async" : "sync"));
+			decls.push_back(stringf("; yosys-smt2-memory %s %d %d %d %d %s\n", get_id(mem->memid), abits, mem->width, GetSize(mem->rd_ports), GetSize(mem->wr_ports), has_async_wr ? "async" : "sync"));
 			decls.push_back(witness_memory(get_id(mem->memid), cell, mem));
 
 			string memstate;


### PR DESCRIPTION
## Summary

Fix `write_smt2` memory metadata to emit the same canonical SMT identifier that is used for the generated memory access functions.

The SMT2 backend already uses `get_id(mem->memid)` when declaring memory functions and witness metadata, but the `; yosys-smt2-memory` comment used `mem->memid.unescape()`. For memory names containing escaped hierarchy separators, such as `$flatten\wrapper.\uut...`, this produced metadata that did not match the actual SMT symbol names.

`smtbmc` parses `; yosys-smt2-memory` metadata and later constructs memory port expressions from that name when dumping traces. If the metadata name differs from the declared SMT function name, the solver reports an undefined symbol during VCD generation.

## Problem

With bitwuzla, a failing BMC trace could fail again while dumping VCD:

```text
yosys-smtbmc -s bitwuzla --presat --unroll --noprogress -t 6:7 --append 0 \
  --dump-vcd engine_0/trace.vcd \
  --dump-yw engine_0/trace.yw \
  --dump-vlogtb engine_0/trace_tb.v \
  --dump-smtc engine_0/trace.smtc \
  model/design_smt2.smt2

##   0:00:03  Writing trace to VCD file: engine_0/trace.vcd
Traceback (most recent call last):
  File "/home/gipsyh/.local/bin/yosys-smtbmc", line 2115, in <module>
    write_trace(0, last_check_step+1+append_steps, "%d" % traceidx if keep_going else '%')
  File "/home/gipsyh/.local/bin/yosys-smtbmc", line 1474, in write_trace
    write_vcd_trace(steps, index, seq_time=seq_time)
  File "/home/gipsyh/.local/bin/yosys-smtbmc", line 1103, in write_vcd_trace
    mem_trace_data = collect_mem_trace_data(steps, vcd)
  File "/home/gipsyh/.local/bin/yosys-smtbmc", line 999, in collect_mem_trace_data
    for eid, edat in zip(expr_id, smt.get_list(expr_list)):
  File "/home/gipsyh/.local/bin/../share/yosys/python3/smtio.py", line 1026, in get_list
    return [n[1] for n in self.parse(self.read()) if n]
IndexError: string index out of range