### PR TITLE
Log infrastructure cleanup

### DIFF
--- a/backends/aiger2/aiger.cc
+++ b/backends/aiger2/aiger.cc
@@ -560,9 +560,9 @@ struct Index {
 				if (!first)
 					ret += ".";
 				if (!cell)
-					ret += RTLIL::unescape_id(minfo.module->name);
+					ret += minfo.module->name.unescape();
 				else
-					ret += RTLIL::unescape_id(cell->name);
+					ret += cell->name.unescape();
 				first = false;
 			}
 			return ret;
@@ -844,7 +844,7 @@ struct AigerWriter : Index<AigerWriter, unsigned int, 0, 1> {
 				char buf[32];
 				snprintf(buf, sizeof(buf), "o%d ", i);
 				f->write(buf, strlen(buf));
-				std::string name = RTLIL::unescape_id(bit.wire->name);
+				std::string name = bit.wire->name.unescape();
 				f->write(name.data(), name.size());
 				f->put('\n');
 			}
@@ -857,7 +857,7 @@ struct AigerWriter : Index<AigerWriter, unsigned int, 0, 1> {
 				char buf[32];
 				snprintf(buf, sizeof(buf), "i%d ", i);
 				f->write(buf, strlen(buf));
-				std::string name = RTLIL::unescape_id(bit.wire->name);
+				std::string name = bit.wire->name.unescape();
 				f->write(name.data(), name.size());
 				f->put('\n');
 			}
@@ -1088,7 +1088,7 @@ struct XAigerWriter : AigerWriter {
 
 			for (auto box : minfo.found_blackboxes) {
 				log_debug(" - %s.%s (type %s): ", cursor.path(),
-						  RTLIL::unescape_id(box->name),
+						  box,
 						  box->type.unescape());
 
 				Module *box_module = design->module(box->type), *box_derived;

--- a/backends/blif/blif.cc
+++ b/backends/blif/blif.cc
@@ -91,7 +91,7 @@ struct BlifDumper
 
 	const std::string str(RTLIL::IdString id)
 	{
-		std::string str = RTLIL::unescape_id(id);
+		std::string str = id.unescape();
 		for (size_t i = 0; i < str.size(); i++)
 			if (str[i] == '#' || str[i] == '=' || str[i] == '<' || str[i] == '>')
 				str[i] = '?';
@@ -108,7 +108,7 @@ struct BlifDumper
 			return config->undef_type == "-" || config->undef_type == "+" ? config->undef_out.c_str() : "$undef";
 		}
 
-		std::string str = RTLIL::unescape_id(sig.wire->name);
+		std::string str = sig.wire->name.unescape();
 		for (size_t i = 0; i < str.size(); i++)
 			if (str[i] == '#' || str[i] == '=' || str[i] == '<' || str[i] == '>')
 				str[i] = '?';

--- a/backends/cxxrtl/cxxrtl_backend.cc
+++ b/backends/cxxrtl/cxxrtl_backend.cc
@@ -3420,7 +3420,7 @@ struct CxxrtlWorker {
 
 			if (!design->selected_whole_module(module))
 				if (design->selected_module(module))
-					log_cmd_error("Can't handle partially selected module `%s'!\n", id2cstr(module->name));
+					log_cmd_error("Can't handle partially selected module `%s'!\n", module);
 			if (!design->selected_module(module))
 				continue;
 

--- a/backends/edif/edif.cc
+++ b/backends/edif/edif.cc
@@ -30,9 +30,11 @@
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
-#define EDIF_DEF(_id) edif_names(RTLIL::unescape_id(_id), true)
-#define EDIF_DEFR(_id, _ren, _bl, _br) edif_names(RTLIL::unescape_id(_id), true, _ren, _bl, _br)
-#define EDIF_REF(_id) edif_names(RTLIL::unescape_id(_id), false)
+#define EDIF_DEF(_id) edif_names(_id.unescape(), true)
+#define EDIF_DEFR(_id, _ren, _bl, _br) edif_names(_id.unescape(), true, _ren, _bl, _br)
+#define EDIF_REF(_id) edif_names(_id.unescape(), false)
+#define EDIF_DEF_STR(_id) edif_names(RTLIL::unescape_id(_id), true)
+#define EDIF_REF_STR(_id) edif_names(RTLIL::unescape_id(_id), false)
 
 struct EdifNames
 {
@@ -227,7 +229,7 @@ struct EdifBackend : public Backend {
 		if (top_module_name.empty())
 			log_error("No module found in design!\n");
 
-		*f << stringf("(edif %s\n", EDIF_DEF(top_module_name));
+		*f << stringf("(edif %s\n", EDIF_DEF_STR(top_module_name));
 		*f << stringf("  (edifVersion 2 0 0)\n");
 		*f << stringf("  (edifLevel 0)\n");
 		*f << stringf("  (keywordMap (keywordLevel 0))\n");
@@ -534,7 +536,7 @@ struct EdifBackend : public Backend {
 						if (netname[i] == ' ' || netname[i] == '\\')
 							netname.erase(netname.begin() + i--);
 				}
-				*f << stringf("          (net %s (joined\n", EDIF_DEF(netname));
+				*f << stringf("          (net %s (joined\n", EDIF_DEF_STR(netname));
 				for (auto &ref : it.second)
 					*f << stringf("              %s\n", ref.first);
 				if (sig.wire == NULL) {
@@ -572,7 +574,7 @@ struct EdifBackend : public Backend {
 
 					if (keepmode)
 					{
-						*f << stringf("          (net %s (joined\n", EDIF_DEF(netname));
+						*f << stringf("          (net %s (joined\n", EDIF_DEF_STR(netname));
 
 						auto &refs = net_join_db.at(mapped_sig);
 						for (auto &ref : refs)
@@ -588,7 +590,7 @@ struct EdifBackend : public Backend {
 					}
 					else
 					{
-						log_warning("Ignoring conflicting 'keep' property on net %s. Use -keep to generate the extra net nevertheless.\n", EDIF_DEF(netname));
+						log_warning("Ignoring conflicting 'keep' property on net %s. Use -keep to generate the extra net nevertheless.\n", EDIF_DEF_STR(netname));
 					}
 				}
 			}
@@ -599,8 +601,8 @@ struct EdifBackend : public Backend {
 		}
 		*f << stringf("  )\n");
 
-		*f << stringf("  (design %s\n", EDIF_DEF(top_module_name));
-		*f << stringf("    (cellRef %s (libraryRef DESIGN))\n", EDIF_REF(top_module_name));
+		*f << stringf("  (design %s\n", EDIF_DEF_STR(top_module_name));
+		*f << stringf("    (cellRef %s (libraryRef DESIGN))\n", EDIF_REF_STR(top_module_name));
 		*f << stringf("  )\n");
 
 		*f << stringf(")\n");

--- a/backends/functional/cxx.cc
+++ b/backends/functional/cxx.cc
@@ -89,7 +89,7 @@ struct CxxStruct {
 		}
 		f.print("\n\t\ttemplate <typename T> void visit(T &&fn) {{\n");
 		for (auto p : types) {
-			f.print("\t\t\tfn(\"{}\", {});\n", RTLIL::unescape_id(p.first), scope(p.first, p.first));
+			f.print("\t\t\tfn(\"{}\", {});\n", p.first.unescape(), scope(p.first, p.first));
 		}
 		f.print("\t\t}}\n");
 		f.print("\t}};\n\n");

--- a/backends/functional/smtlib.cc
+++ b/backends/functional/smtlib.cc
@@ -80,7 +80,7 @@ public:
 	SmtStruct(std::string name, SmtScope &scope) : scope(scope), name(name) {}
 	void insert(IdString field_name, SmtSort sort) {
 		field_names(field_name);
-		auto accessor = scope.unique_name("\\" + name + "_" + RTLIL::unescape_id(field_name));
+		auto accessor = scope.unique_name("\\" + name + "_" + field_name.unescape());
 		fields.emplace_back(Field{sort, accessor});
 	}
 	void write_definition(SExprWriter &w) {
@@ -99,7 +99,7 @@ public:
 			w.open(list(name));
 			for(auto field_name : field_names) {
 				w << fn(field_name);
-				w.comment(RTLIL::unescape_id(field_name), true);
+				w.comment(field_name.unescape(), true);
 			}
 			w.close();
 		}

--- a/backends/functional/smtlib_rosette.cc
+++ b/backends/functional/smtlib_rosette.cc
@@ -106,7 +106,7 @@ public:
 		w.open(list(name));
 		for(auto field_name : field_names) {
 			w << fn(field_name);
-			w.comment(RTLIL::unescape_id(field_name), true);
+			w.comment(field_name.unescape(), true);
 		}
 		w.close();
 	}
@@ -281,7 +281,7 @@ struct SmtrModule {
 			w.push();
 			w.open(list());
 			w.open(list("assoc-result"));
-			w << list("assoc", "\"" + RTLIL::unescape_id(input->name) + "\"", inputs_name);
+			w << list("assoc", "\"" + input->name.unescape() + "\"", inputs_name);
 			w.pop();
 			w.open(list("if", "assoc-result"));
 			w << list("cdr", "assoc-result");
@@ -298,7 +298,7 @@ struct SmtrModule {
 		w << list(*output_helper_name, outputs_name);
 		w.open(list("list"));
 		for (auto output : ir.outputs()) {
-			w << list("cons", "\"" + RTLIL::unescape_id(output->name) + "\"", output_struct.access("outputs", output->name));
+			w << list("cons", "\"" + output->name.unescape() + "\"", output_struct.access("outputs", output->name));
 		}
 		w.pop();
 	}

--- a/backends/functional/test_generic.cc
+++ b/backends/functional/test_generic.cc
@@ -146,11 +146,11 @@ struct FunctionalTestGeneric : public Pass
             log("Dumping module `%s'.\n", module->name);
 			auto fir = Functional::IR::from_module(module);
 			for(auto node : fir)
-				std::cout << RTLIL::unescape_id(node.name()) << " = " << node.to_string([](auto n) { return RTLIL::unescape_id(n.name()); }) << "\n";
+				std::cout << node.name().unescape() << " = " << node.to_string([](auto n) { return n.name().unescape(); }) << "\n";
 			for(auto output : fir.all_outputs())
-				std::cout << RTLIL::unescape_id(output->kind) << " " << RTLIL::unescape_id(output->name) << " = " << RTLIL::unescape_id(output->value().name()) << "\n";
+				std::cout << output->kind.unescape() << " " << output->name.unescape() << " = " << output->value().name().unescape() << "\n";
 			for(auto state : fir.all_states())
-				std::cout << RTLIL::unescape_id(state->kind) << " " << RTLIL::unescape_id(state->name) << " = " << RTLIL::unescape_id(state->next_value().name()) << "\n";
+				std::cout << state->kind.unescape() << " " << state->name.unescape() << " = " << state->next_value().name().unescape() << "\n";
 		}
 	}
 } FunctionalCxxBackend;

--- a/backends/intersynth/intersynth.cc
+++ b/backends/intersynth/intersynth.cc
@@ -41,7 +41,7 @@ static std::string netname(std::set<std::string> &conntypes_code, std::set<std::
 		return stringf("CONST_%d_0x%x", sig.size(), sig.as_int());
 	}
 
-	return RTLIL::unescape_id(sig.as_wire()->name);
+	return sig.as_wire()->name.unescape();
 }
 
 struct IntersynthBackend : public Backend {

--- a/backends/jny/jny.cc
+++ b/backends/jny/jny.cc
@@ -91,7 +91,7 @@ struct JnyWriter
         {
             _cells.clear();
             for (auto cell : mod->cells()) {
-                const auto cell_type = escape_string(RTLIL::unescape_id(cell->type));
+                const auto cell_type = escape_string(cell->type.unescape());
 
                 if (_cells.find(cell_type) == _cells.end())
                     _cells.emplace(cell_type, std::vector<Cell*>());
@@ -214,7 +214,7 @@ struct JnyWriter
     void write_cell_conn(const std::pair<RTLIL::IdString, RTLIL::SigSpec>& sig, uint16_t indent_level = 0) {
         const auto _indent = gen_indent(indent_level);
         f << _indent << "  {\n";
-        f << _indent << "    \"name\": \"" << escape_string(RTLIL::unescape_id(sig.first)) << "\",\n";
+        f << _indent << "    \"name\": \"" << escape_string(sig.first.unescape()) << "\",\n";
         f << _indent << "    \"signals\": [\n";
 
         write_sigspec(sig.second, indent_level + 2);
@@ -232,7 +232,7 @@ struct JnyWriter
         const auto _indent = gen_indent(indent_level);
 
         f << _indent << "{\n";
-        f << stringf("  %s\"name\": \"%s\",\n", _indent, escape_string(RTLIL::unescape_id(mod->name)));
+        f << stringf("  %s\"name\": \"%s\",\n", _indent, escape_string(mod->name.unescape()));
         f << _indent << "  \"cell_sorts\": [\n";
 
         bool first_sort{true};
@@ -280,7 +280,7 @@ struct JnyWriter
                 f << ",\n";
 
             f << _indent << "  {\n";
-            f << stringf("    %s\"name\": \"%s\",\n", _indent, escape_string(RTLIL::unescape_id(con.first)));
+            f << stringf("    %s\"name\": \"%s\",\n", _indent, escape_string(con.first.unescape()));
             f << _indent << "    \"direction\": \"";
             if (port_cell->input(con.first))
                 f << "i";
@@ -351,10 +351,10 @@ struct JnyWriter
                 f << stringf(",\n");
             const auto param_val = param.second;
             if (!param_val.empty()) {
-                f << stringf("  %s\"%s\": ", _indent, escape_string(RTLIL::unescape_id(param.first)));
+                f << stringf("  %s\"%s\": ", _indent, escape_string(param.first.unescape()));
                 write_param_val(param_val);
             } else {
-                f << stringf("  %s\"%s\": true", _indent, escape_string(RTLIL::unescape_id(param.first)));
+                f << stringf("  %s\"%s\": true", _indent, escape_string(param.first.unescape()));
             }
 
             first_param = false;
@@ -366,7 +366,7 @@ struct JnyWriter
         log_assert(cell != nullptr);
 
         f << _indent << "  {\n";
-        f << stringf("    %s\"name\": \"%s\"", _indent, escape_string(RTLIL::unescape_id(cell->name)));
+        f << stringf("    %s\"name\": \"%s\"", _indent, escape_string(cell->name.unescape()));
 
         if (_include_connections) {
             f << ",\n" << _indent << "    \"connections\": [\n";

--- a/backends/json/json.cc
+++ b/backends/json/json.cc
@@ -76,7 +76,7 @@ struct JsonWriter
 
 	string get_name(IdString name)
 	{
-		return get_string(RTLIL::unescape_id(name));
+		return get_string(name.unescape());
 	}
 
 	string get_bits(SigSpec sig)

--- a/backends/spice/spice.cc
+++ b/backends/spice/spice.cc
@@ -30,7 +30,7 @@ PRIVATE_NAMESPACE_BEGIN
 static string spice_id2str(IdString id)
 {
 	static const char *escape_chars = "$\\[]()<>=";
-	string s = RTLIL::unescape_id(id);
+	string s = id.unescape();
 
 	for (auto &ch : s)
 		if (strchr(escape_chars, ch) != nullptr) ch = '_';

--- a/docs/source/code_examples/functional/dummy.cc
+++ b/docs/source/code_examples/functional/dummy.cc
@@ -24,19 +24,19 @@ struct FunctionalDummyBackend : public Backend {
 
 			// write node functions
 			for (auto node : ir)
-				*f << "  assign " << id2cstr(node.name())
+				*f << "  assign " << node.name().unescape()
 				   << " = " << node.to_string() << "\n";
 			*f << "\n";
 
 			// write outputs and next state
 			for (auto output : ir.outputs())
-				*f << " " << id2cstr(output->kind)
-				   << " " << id2cstr(output->name)
-				   << " = " << id2cstr(output->value().name()) << "\n";
+				*f << " " << output->kind.unescape()
+				   << " " << output->name.unescape()
+				   << " = " << output->value().name().unescape() << "\n";
 			for (auto state : ir.states())
-				*f << " " << id2cstr(state->kind)
-				   << " " << id2cstr(state->name)
-				   << " = " << id2cstr(state->next_value().name()) << "\n";
+				*f << " " << state->kind.unescape()
+				   << " " << state->name.unescape()
+				   << " = " << state->next_value().name().unescape() << "\n";
 		}
 	}
 } FunctionalDummyBackend;

--- a/docs/source/code_examples/stubnets/stubnets.cc
+++ b/docs/source/code_examples/stubnets/stubnets.cc
@@ -27,7 +27,7 @@ static void find_stub_nets(RTLIL::Design *design, RTLIL::Module *module, bool re
 	// count output lines for this module (needed only for summary output at the end)
 	int line_count = 0;
 
-	log("Looking for stub wires in module %s:\n", RTLIL::id2cstr(module->name));
+	log("Looking for stub wires in module %s:\n", module);
 
 	// For all ports on all cells
 	for (auto &cell_iter : module->cells_)
@@ -74,11 +74,11 @@ static void find_stub_nets(RTLIL::Design *design, RTLIL::Module *module, bool re
 		// report stub bits and/or stub wires, don't report single bits
 		// if called with report_bits set to false.
 		if (GetSize(stub_bits) == GetSize(sig)) {
-			log("  found stub wire: %s\n", RTLIL::id2cstr(wire->name));
+			log("  found stub wire: %s\n", wire);
 		} else {
 			if (!report_bits)
 				continue;
-			log("  found wire with stub bits: %s [", RTLIL::id2cstr(wire->name));
+			log("  found wire with stub bits: %s [", wire);
 			for (int bit : stub_bits)
 				log("%s%d", bit == *stub_bits.begin() ? "" : ", ", bit);
 			log("]\n");

--- a/docs/source/yosys_internals/extending_yosys/extensions.rst
+++ b/docs/source/yosys_internals/extending_yosys/extensions.rst
@@ -230,8 +230,7 @@ Use ``log_error()`` to report a non-recoverable error:
 .. code:: C++
 
     if (design->modules.count(module->name) != 0)
-        log_error("A module with the name %s already exists!\n",
-                   RTLIL::id2cstr(module->name));
+        log_error("A module with the name %s already exists!\n", module);
 
 Use ``log_cmd_error()`` to report a recoverable error:
 

--- a/docs/source/yosys_internals/extending_yosys/functional_ir.rst
+++ b/docs/source/yosys_internals/extending_yosys/functional_ir.rst
@@ -181,7 +181,7 @@ pointer ``f`` to the output file, or stdout if none is given.
 
 For this minimal example all we are doing is printing out each node.  The
 ``node.name()`` method returns an ``RTLIL::IdString``, which we convert for
-printing with ``id2cstr()``.  Then, to print the function of the node, we use
+printing with ``unescape()``.  Then, to print the function of the node, we use
 ``node.to_string()`` which gives us a string of the form ``function(args)``. The
 ``function`` part is the result of ``Functional::IR::fn_to_string(node.fn())``;
 while ``args`` is the zero or more arguments passed to the function, most

--- a/frontends/liberty/liberty.cc
+++ b/frontends/liberty/liberty.cc
@@ -41,14 +41,14 @@ static RTLIL::SigSpec parse_func_identifier(RTLIL::Module *module, const char *&
 			expr[id_len] == '_' || expr[id_len] == '[' || expr[id_len] == ']') id_len++;
 
 	if (id_len == 0)
-		log_error("Expected identifier at `%s' in %s.\n", expr, RTLIL::unescape_id(module->name));
+		log_error("Expected identifier at `%s' in %s.\n", expr, module);
 
 	if (id_len == 1 && (*expr == '0' || *expr == '1'))
 		return *(expr++) == '0' ? RTLIL::State::S0 : RTLIL::State::S1;
 
 	std::string id = RTLIL::escape_id(std::string(expr, id_len));
 	if (!module->wires_.count(id))
-		log_error("Can't resolve wire name %s in %s.\n", RTLIL::unescape_id(id), RTLIL::unescape_id(module->name));
+		log_error("Can't resolve wire name %s in %s.\n", RTLIL::unescape_id(id), module);
 
 	expr += id_len;
 	return module->wires_.at(id);
@@ -175,7 +175,7 @@ static RTLIL::SigSpec parse_func_expr(RTLIL::Module *module, const char *expr)
 #endif
 
 	if (stack.size() != 1 || stack.back().type != 3)
-		log_error("Parser error in function expr `%s'in %s.\n", orig_expr, RTLIL::unescape_id(module->name));
+		log_error("Parser error in function expr `%s'in %s.\n", orig_expr, module);
 
 	return stack.back().sig;
 }
@@ -211,7 +211,7 @@ static void create_ff(RTLIL::Module *module, const LibertyAst *node)
 	auto [iq_sig, iqn_sig] = find_latch_ff_wires(module, node);
 	RTLIL::SigSpec clk_sig, data_sig, clear_sig, preset_sig;
 	bool clk_polarity = true, clear_polarity = true, preset_polarity = true;
-	const std::string name = RTLIL::unescape_id(module->name);
+	const std::string name = module->name.unescape();
 
 	std::optional<char> clear_preset_var1;
 	std::optional<char> clear_preset_var2;
@@ -339,9 +339,9 @@ static bool create_latch(RTLIL::Module *module, const LibertyAst *node, bool fla
 
 	if (enable_sig.size() == 0 || data_sig.size() == 0) {
 		if (!flag_ignore_miss_data_latch)
-			log_error("Latch cell %s has no data_in and/or enable attribute.\n", RTLIL::unescape_id(module->name));
+			log_error("Latch cell %s has no data_in and/or enable attribute.\n", module);
 		else
-			log("Ignored latch cell %s with no data_in and/or enable attribute.\n", RTLIL::unescape_id(module->name));
+			log("Ignored latch cell %s with no data_in and/or enable attribute.\n", module);
 
 		return false;
 	}
@@ -632,9 +632,9 @@ struct LibertyFrontend : public Frontend {
 					{
 						if (!flag_ignore_miss_dir)
 						{
-							log_error("Missing or invalid direction for pin %s on cell %s.\n", node->args.at(0), RTLIL::unescape_id(module->name));
+							log_error("Missing or invalid direction for pin %s on cell %s.\n", node->args.at(0), module);
 						} else {
-							log("Ignoring cell %s with missing or invalid direction for pin %s.\n", RTLIL::unescape_id(module->name), node->args.at(0));
+							log("Ignoring cell %s with missing or invalid direction for pin %s.\n", module, node->args.at(0));
 							delete module;
 							goto skip_cell;
 						}
@@ -646,7 +646,7 @@ struct LibertyFrontend : public Frontend {
 				if (node->id == "bus" && node->args.size() == 1)
 				{
 					if (flag_ignore_buses) {
-						log("Ignoring cell %s with a bus interface %s.\n", RTLIL::unescape_id(module->name), node->args.at(0));
+						log("Ignoring cell %s with a bus interface %s.\n", module, node->args.at(0));
 						delete module;
 						goto skip_cell;
 					}
@@ -663,7 +663,7 @@ struct LibertyFrontend : public Frontend {
 					}
 
 					if (!dir || (dir->value != "input" && dir->value != "output" && dir->value != "inout" && dir->value != "internal"))
-						log_error("Missing or invalid direction for bus %s on cell %s.\n", node->args.at(0), RTLIL::unescape_id(module->name));
+						log_error("Missing or invalid direction for bus %s on cell %s.\n", node->args.at(0), module);
 
 					simple_comb_cell = false;
 
@@ -758,9 +758,9 @@ struct LibertyFrontend : public Frontend {
 						if (dir->value != "inout") { // allow inout with missing function, can be used for power pins
 							if (!flag_ignore_miss_func)
 							{
-								log_error("Missing function on output %s of cell %s.\n", RTLIL::unescape_id(wire->name), RTLIL::unescape_id(module->name));
+								log_error("Missing function on output %s of cell %s.\n", wire, module);
 							} else {
-								log("Ignoring cell %s with missing function on output %s.\n", RTLIL::unescape_id(module->name), RTLIL::unescape_id(wire->name));
+								log("Ignoring cell %s with missing function on output %s.\n", module, wire);
 								delete module;
 								goto skip_cell;
 							}

--- a/frontends/verific/verific.cc
+++ b/frontends/verific/verific.cc
@@ -1492,10 +1492,10 @@ void VerificImporter::import_netlist(RTLIL::Design *design, Netlist *nl, std::ma
 	design->add(module);
 
 	if (is_blackbox(nl)) {
-		log("Importing blackbox module %s.\n", RTLIL::id2cstr(module->name));
+		log("Importing blackbox module %s.\n", module);
 		module->set_bool_attribute(ID::blackbox);
 	} else {
-		log("Importing module %s.\n", RTLIL::id2cstr(module->name));
+		log("Importing module %s.\n", module);
 	}
 	import_attributes(module->attributes, nl, nl);
 	if (module->name.isPublic())

--- a/kernel/functional.cc
+++ b/kernel/functional.cc
@@ -136,7 +136,7 @@ struct PrintVisitor : DefaultVisitor<std::string> {
 
 std::string Node::to_string()
 {
-	return to_string([](Node n) { return RTLIL::unescape_id(n.name()); });
+	return to_string([](Node n) { return n.name().unescape(); });
 }
 
 std::string Node::to_string(std::function<std::string(Node)> np)
@@ -677,7 +677,7 @@ public:
 							factory.update_pending(pending, node);
 						} else {
 							DriveSpec driver = driver_map(DriveSpec(wire_chunk));
-							check_undriven(driver, RTLIL::unescape_id(wire_chunk.wire->name));
+							check_undriven(driver, wire_chunk.wire->name.unescape());
 							Node node = enqueue(driver);
 							factory.suggest_name(node, wire_chunk.wire->name);
 							factory.update_pending(pending, node);
@@ -695,7 +695,7 @@ public:
 							factory.update_pending(pending, node);
 						} else {
 							DriveSpec driver = driver_map(DriveSpec(port_chunk));
-							check_undriven(driver, RTLIL::unescape_id(port_chunk.cell->name) + " port " + RTLIL::unescape_id(port_chunk.port));
+							check_undriven(driver, port_chunk.cell->name.unescape() + " port " + port_chunk.port.unescape());
 							factory.update_pending(pending, enqueue(driver));
 						}
 					} else {
@@ -744,7 +744,7 @@ void IR::topological_sort() {
             log_warning("Combinational loop:\n");
             for (int *i = begin; i != end; ++i) {
 				Node node(_graph[*i]);
-                log("- %s = %s\n", RTLIL::unescape_id(node.name()), node.to_string());
+                log("- %s = %s\n", node.name().unescape(), node.to_string());
 			}
             log("\n");
             scc = true;

--- a/kernel/functional.h
+++ b/kernel/functional.h
@@ -588,7 +588,7 @@ namespace Functional {
 			_used_names.insert(std::move(name));
 		}
 		std::string unique_name(IdString suggestion) {
-			std::string str = RTLIL::unescape_id(suggestion);
+			std::string str = suggestion.unescape();
 			for(size_t i = 0; i < str.size(); i++)
 				if(!is_character_legal(str[i], i))
 					str[i] = substitution_character;

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -614,7 +614,7 @@ std::string log_const(const RTLIL::Const &value, bool autoint)
 
 const char *log_id(const RTLIL::IdString &str)
 {
-	std::string unescaped = RTLIL::unescape_id(str);
+	std::string unescaped = str.unescape();
 	log_id_cache.push_back(strdup(unescaped.c_str()));
 	return log_id_cache.back();
 }

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1579,7 +1579,7 @@ void RTLIL::Module::makeblackbox()
 
 void RTLIL::Module::expand_interfaces(RTLIL::Design *, const dict<RTLIL::IdString, RTLIL::Module *> &)
 {
-	log_error("Class doesn't support expand_interfaces (module: `%s')!\n", id2cstr(name));
+	log_error("Class doesn't support expand_interfaces (module: `%s')!\n", name.unescape());
 }
 
 bool RTLIL::Module::reprocess_if_necessary(RTLIL::Design *)
@@ -1591,7 +1591,7 @@ RTLIL::IdString RTLIL::Module::derive(RTLIL::Design*, const dict<RTLIL::IdString
 {
 	if (mayfail)
 		return RTLIL::IdString();
-	log_error("Module `%s' is used with parameters but is not parametric!\n", id2cstr(name));
+	log_error("Module `%s' is used with parameters but is not parametric!\n", name.unescape());
 }
 
 
@@ -1599,7 +1599,7 @@ RTLIL::IdString RTLIL::Module::derive(RTLIL::Design*, const dict<RTLIL::IdString
 {
 	if (mayfail)
 		return RTLIL::IdString();
-	log_error("Module `%s' is used with parameters but is not parametric!\n", id2cstr(name));
+	log_error("Module `%s' is used with parameters but is not parametric!\n", name.unescape());
 }
 
 size_t RTLIL::Module::count_id(RTLIL::IdString id)

--- a/kernel/satgen.h
+++ b/kernel/satgen.h
@@ -102,7 +102,7 @@ struct SatGen
 				else
 					vec.push_back(bit == (undef_mode ? RTLIL::State::Sx : RTLIL::State::S1) ? ez->CONST_TRUE : ez->CONST_FALSE);
 			} else {
-				std::string wire_name = RTLIL::unescape_id(bit.wire->name);
+				std::string wire_name = bit.wire->name.unescape();
 				std::string name = pf +
 					(bit.wire->width == 1 ? wire_name : stringf("%s [%d]", wire_name, bit.offset));
 				vec.push_back(ez->frozen_literal(name));

--- a/kernel/scopeinfo.cc
+++ b/kernel/scopeinfo.cc
@@ -100,13 +100,13 @@ static const char *attr_prefix(ScopeinfoAttrs attrs)
 bool scopeinfo_has_attribute(const RTLIL::Cell *scopeinfo, ScopeinfoAttrs attrs, RTLIL::IdString id)
 {
 	log_assert(scopeinfo->type == ID($scopeinfo));
-	return scopeinfo->has_attribute(attr_prefix(attrs) + RTLIL::unescape_id(id));
+	return scopeinfo->has_attribute(attr_prefix(attrs) + id.unescape());
 }
 
 RTLIL::Const scopeinfo_get_attribute(const RTLIL::Cell *scopeinfo, ScopeinfoAttrs attrs, RTLIL::IdString id)
 {
 	log_assert(scopeinfo->type == ID($scopeinfo));
-	auto found = scopeinfo->attributes.find(attr_prefix(attrs) + RTLIL::unescape_id(id));
+	auto found = scopeinfo->attributes.find(attr_prefix(attrs) + id.unescape());
 	if (found == scopeinfo->attributes.end())
 		return RTLIL::Const();
 	return found->second;

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -953,7 +953,7 @@ static char *readline_obj_generator(const char *text, int state)
 		if (design->selected_active_module.empty())
 		{
 			for (auto mod : design->modules())
-				if (RTLIL::unescape_id(mod->name).compare(0, len, text) == 0)
+				if (mod->name.unescape().compare(0, len, text) == 0)
 					obj_names.push_back(strdup(mod->name.unescape().c_str()));
 		}
 		else if (design->module(design->selected_active_module) != nullptr)
@@ -961,19 +961,19 @@ static char *readline_obj_generator(const char *text, int state)
 			RTLIL::Module *module = design->module(design->selected_active_module);
 
 			for (auto w : module->wires())
-				if (RTLIL::unescape_id(w->name).compare(0, len, text) == 0)
+				if (w->name.unescape().compare(0, len, text) == 0)
 					obj_names.push_back(strdup(w->name.unescape().c_str()));
 
 			for (auto &it : module->memories)
-				if (RTLIL::unescape_id(it.first).compare(0, len, text) == 0)
+				if (it.first.unescape().compare(0, len, text) == 0)
 					obj_names.push_back(strdup(it.first.unescape().c_str()));
 
 			for (auto cell : module->cells())
-				if (RTLIL::unescape_id(cell->name).compare(0, len, text) == 0)
+				if (cell->name.unescape().compare(0, len, text) == 0)
 					obj_names.push_back(strdup(cell->name.unescape().c_str()));
 
 			for (auto &it : module->processes)
-				if (RTLIL::unescape_id(it.first).compare(0, len, text) == 0)
+				if (it.first.unescape().compare(0, len, text) == 0)
 					obj_names.push_back(strdup(it.first.unescape().c_str()));
 		}
 

--- a/passes/cmds/icell_liberty.cc
+++ b/passes/cmds/icell_liberty.cc
@@ -71,10 +71,10 @@ struct LibertyStubber {
 		std::sort(sorted_ports.begin(), sorted_ports.end(), cmp);
 		std::string clock_pin_name = "";
 		for (auto x : sorted_ports) {
-			std::string port_name = RTLIL::unescape_id(x);
+			std::string port_name = x.unescape();
 			bool is_input = base_type.inputs.count(x);
 			bool is_output = base_type.outputs.count(x);
-			f << "\t\tpin (" << RTLIL::unescape_id(x.str()) << ") {\n";
+			f << "\t\tpin (" << x.unescape() << ") {\n";
 			if (is_input && !is_output) {
 				i.item("direction", "input");
 			} else if (!is_input && is_output) {
@@ -132,7 +132,7 @@ struct LibertyStubber {
 		for (auto x : derived->ports) {
 			bool is_input = base_type.inputs.count(x);
 			bool is_output = base_type.outputs.count(x);
-			f << "\t\tpin (" << RTLIL::unescape_id(x.str()) << ") {\n";
+			f << "\t\tpin (" << x.unescape() << ") {\n";
 			if (is_input && !is_output) {
 				f << "\t\t\tdirection : input;\n";
 			} else if (!is_input && is_output) {

--- a/passes/cmds/portarcs.cc
+++ b/passes/cmds/portarcs.cc
@@ -244,7 +244,7 @@ struct PortarcsPass : Pass {
 
 			if (draw_mode) {
 				auto bit_str = [](SigBit bit) {
-					return stringf("%s%d", RTLIL::unescape_id(bit.wire->name.str()), bit.offset);
+					return stringf("%s%d", bit.wire, bit.offset);
 				};
 
 				std::vector<std::string> headings;

--- a/passes/cmds/rename.cc
+++ b/passes/cmds/rename.cc
@@ -621,7 +621,7 @@ struct RenamePass : public Pass {
 
 				RTLIL::Module *module_to_rename = nullptr;
 				for (auto module : design->modules())
-					if (module->name == from_name || RTLIL::unescape_id(module->name) == from_name) {
+					if (module->name == from_name || module->name.unescape() == from_name) {
 						module_to_rename = module;
 						break;
 					}

--- a/passes/cmds/scc.cc
+++ b/passes/cmds/scc.cc
@@ -87,7 +87,7 @@ struct SccWorker
 					RTLIL::Cell *c = cellStack.back();
 					cellStack.pop_back();
 					cellsOnStack.erase(c);
-					log(" %s", RTLIL::id2cstr(c->name));
+					log(" %s", c);
 					cell2scc[c] = sccList.size();
 					scc.insert(c);
 				}
@@ -201,7 +201,7 @@ struct SccWorker
 			if (!nofeedbackMode && cellToNextCell[cell].count(cell)) {
 				log("Found an SCC:");
 				pool<RTLIL::Cell*> scc;
-				log(" %s", RTLIL::id2cstr(cell->name));
+				log(" %s", cell);
 				cell2scc[cell] = sccList.size();
 				scc.insert(cell);
 				sccList.push_back(scc);
@@ -221,7 +221,7 @@ struct SccWorker
 			run(cell, 0, maxDepth);
 		}
 
-		log("Found %d SCCs in module %s.\n", int(sccList.size()), RTLIL::id2cstr(module->name));
+		log("Found %d SCCs in module %s.\n", int(sccList.size()), module);
 	}
 
 	void select(RTLIL::Selection &sel)

--- a/passes/cmds/select.cc
+++ b/passes/cmds/select.cc
@@ -25,8 +25,6 @@
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
-using RTLIL::id2cstr;
-
 static std::vector<RTLIL::Selection> work_stack;
 
 static bool match_ids(RTLIL::IdString id, const std::string &pattern)
@@ -1022,9 +1020,9 @@ static std::string describe_selection_for_assert(RTLIL::Design *design, RTLIL::S
 	for (auto mod : design->all_selected_modules())
 	{
 		if (whole_modules && sel->selected_whole_module(mod->name))
-			desc += stringf("%s\n", id2cstr(mod->name));
+			desc += stringf("%s\n", mod);
 		for (auto it : mod->selected_members())
-			desc += stringf("%s/%s\n", id2cstr(mod->name), id2cstr(it->name));
+			desc += stringf("%s/%s\n", mod, it);
 	}
 	if (push_selection) design->pop_selection();
 	return desc;
@@ -1414,7 +1412,7 @@ struct SelectPass : public Pass {
 			if (arg == "-module" && argidx+1 < args.size()) {
 				RTLIL::IdString mod_name = RTLIL::escape_id(args[++argidx]);
 				if (design->module(mod_name) == nullptr)
-					log_cmd_error("No such module: %s\n", id2cstr(mod_name));
+					log_cmd_error("No such module: %s\n", mod_name.unescape());
 				design->selected_active_module = mod_name.str();
 				got_module = true;
 				continue;
@@ -1527,10 +1525,10 @@ struct SelectPass : public Pass {
 			for (auto mod : design->all_selected_modules())
 			{
 				if (sel->selected_whole_module(mod->name) && list_mode)
-					log("%s\n", id2cstr(mod->name));
+					log("%s\n", mod);
 				if (!list_mod_mode)
 					for (auto it : mod->selected_members())
-						LOG_OBJECT("%s/%s\n", id2cstr(mod->name), id2cstr(it->name))
+						LOG_OBJECT("%s/%s\n", mod->name.unescape().c_str(), it->name.unescape().c_str())
 			}
 			if (count_mode)
 			{
@@ -1654,10 +1652,10 @@ struct SelectPass : public Pass {
 			if (sel.full_selection)
 				log("*\n");
 			for (auto &it : sel.selected_modules)
-				log("%s\n", id2cstr(it));
+				log("%s\n", it.unescape());
 			for (auto &it : sel.selected_members)
 				for (auto &it2 : it.second)
-					log("%s/%s\n", id2cstr(it.first), id2cstr(it2));
+					log("%s/%s\n", it.first.unescape(), it2.unescape());
 			return;
 		}
 
@@ -1779,7 +1777,7 @@ static void log_matches(const char *title, Module *module, const T &list)
 		log("\n%d %s:\n", int(matches.size()), title);
 		std::sort(matches.begin(), matches.end(), RTLIL::sort_by_id_str());
 		for (auto id : matches)
-			log("  %s\n", RTLIL::id2cstr(id));
+			log("  %s\n", id.unescape());
 	}
 }
 

--- a/passes/cmds/show.cc
+++ b/passes/cmds/show.cc
@@ -549,7 +549,7 @@ struct ShowWorker
 				net_conn_map[node].color = nextColor(sig, net_conn_map[node].color);
 			}
 
-			std::string proc_src = RTLIL::unescape_id(proc->name);
+			std::string proc_src = proc->name.unescape();
 			if (proc->attributes.count(ID::src) > 0)
 				proc_src = proc->attributes.at(ID::src).decode_string();
 			fprintf(f, "p%d [shape=box, style=rounded, label=\"PROC %s\\n%s\", %s];\n", pidx, findLabel(proc->name.str()), proc_src.c_str(), findColor(proc->name).c_str());

--- a/passes/cmds/test_select.cc
+++ b/passes/cmds/test_select.cc
@@ -144,10 +144,10 @@ struct TestSelectPass : public Pass {
 
 		for (auto *mod : sub_sel) {
 			if (mod->is_selected_whole()) {
-				log_debug("  Adding %s.\n", id2cstr(mod->name));
+				log_debug("  Adding %s.\n", mod);
 				selected_modules.insert(mod->name);
 			} else for (auto *memb : mod->selected_members()) {
-				log_debug("  Adding %s.%s.\n", id2cstr(mod->name), id2cstr(memb->name));
+				log_debug("  Adding %s.%s.\n", mod, memb);
 				selected_members[mod->name].insert(memb);
 			}
 		}

--- a/passes/cmds/wrapcell.cc
+++ b/passes/cmds/wrapcell.cc
@@ -227,7 +227,7 @@ struct WrapcellPass : Pass {
 				if (!unused_outputs.empty()) {
 					context.unused_outputs += "_unused";
 					for (auto chunk : collect_chunks(unused_outputs))
-						context.unused_outputs += "_" + RTLIL::unescape_id(chunk.format(cell));
+						context.unused_outputs += "_" + chunk.format(cell).unescape();
 				}
 
 				std::optional<std::string> unescaped_name = format_with_params(name_fmt, cell->parameters, context);

--- a/passes/equiv/equiv_make.cc
+++ b/passes/equiv/equiv_make.cc
@@ -285,11 +285,11 @@ struct EquivMakeWorker
 
 					for (int i = 0; i < wire->width; i++) {
 						if (undriven_bits.count(assign_map(SigBit(gold_wire, i)))) {
-							log("  Skipping signal bit %s [%d]: undriven on gold side.\n", id2cstr(gold_wire->name), i);
+							log("  Skipping signal bit %s [%d]: undriven on gold side.\n", gold_wire, i);
 							continue;
 						}
 						if (undriven_bits.count(assign_map(SigBit(gate_wire, i)))) {
-							log("  Skipping signal bit %s [%d]: undriven on gate side.\n", id2cstr(gate_wire->name), i);
+							log("  Skipping signal bit %s [%d]: undriven on gate side.\n", gate_wire, i);
 							continue;
 						}
 						equiv_mod->addEquiv(NEW_ID, SigSpec(gold_wire, i), SigSpec(gate_wire, i), SigSpec(wire, i));

--- a/passes/equiv/equiv_make.cc.orig
+++ b/passes/equiv/equiv_make.cc.orig
@@ -1,0 +1,520 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Claire Xenia Wolf <claire@yosyshq.com>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/yosys.h"
+#include "kernel/sigtools.h"
+#include "kernel/celltypes.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+struct EquivMakeWorker
+{
+	Module *gold_mod, *gate_mod, *equiv_mod;
+	pool<IdString> wire_names, cell_names;
+	CellTypes ct;
+
+	bool inames;
+	vector<string> blacklists;
+	vector<string> encfiles;
+	bool make_assert;
+
+	pool<IdString> blacklist_names;
+	dict<IdString, dict<Const, Const>> encdata;
+
+	pool<SigBit> undriven_bits;
+	SigMap assign_map;
+
+	void read_blacklists()
+	{
+		for (auto fn : blacklists)
+		{
+			std::ifstream f(fn);
+			if (f.fail())
+				log_cmd_error("Can't open blacklist file '%s'!\n", fn);
+
+			string line, token;
+			while (std::getline(f, line)) {
+				while (1) {
+					token = next_token(line);
+					if (token.empty())
+						break;
+					blacklist_names.insert(RTLIL::escape_id(token));
+				}
+			}
+		}
+	}
+
+	void read_encfiles()
+	{
+		for (auto fn : encfiles)
+		{
+			std::ifstream f(fn);
+			if (f.fail())
+				log_cmd_error("Can't open encfile '%s'!\n", fn);
+
+			dict<Const, Const> *ed = nullptr;
+			string line, token;
+			while (std::getline(f, line))
+			{
+				token = next_token(line);
+				if (token.empty() || token[0] == '#')
+					continue;
+
+				if (token == ".fsm") {
+					IdString modname = RTLIL::escape_id(next_token(line));
+					(void)modname;
+					IdString signame = RTLIL::escape_id(next_token(line));
+					if (encdata.count(signame))
+						log_cmd_error("Re-definition of signal '%s' in encfile '%s'!\n", signame, fn);
+					encdata[signame] = dict<Const, Const>();
+					ed = &encdata[signame];
+					continue;
+				}
+
+				if (token == ".map") {
+					Const gold_bits = Const::from_string(next_token(line));
+					Const gate_bits = Const::from_string(next_token(line));
+					(*ed)[gold_bits] = gate_bits;
+					continue;
+				}
+
+				log_cmd_error("Syntax error in encfile '%s'!\n", fn);
+			}
+		}
+	}
+
+	void copy_to_equiv()
+	{
+		Module *gold_clone = gold_mod->clone();
+		Module *gate_clone = gate_mod->clone();
+
+		for (auto it : gold_clone->wires().to_vector()) {
+			if ((it->name.isPublic() || inames) && blacklist_names.count(it->name) == 0)
+				wire_names.insert(it->name);
+			gold_clone->rename(it, it->name.str() + "_gold");
+		}
+
+		for (auto it : gold_clone->cells().to_vector()) {
+			if ((it->name.isPublic() || inames) && blacklist_names.count(it->name) == 0)
+				cell_names.insert(it->name);
+			gold_clone->rename(it, it->name.str() + "_gold");
+		}
+
+		for (auto it : gate_clone->wires().to_vector()) {
+			if ((it->name.isPublic() || inames) && blacklist_names.count(it->name) == 0)
+				wire_names.insert(it->name);
+			gate_clone->rename(it, it->name.str() + "_gate");
+		}
+
+		for (auto it : gate_clone->cells().to_vector()) {
+			if ((it->name.isPublic() || inames) && blacklist_names.count(it->name) == 0)
+				cell_names.insert(it->name);
+			gate_clone->rename(it, it->name.str() + "_gate");
+		}
+
+		gold_clone->cloneInto(equiv_mod);
+		gate_clone->cloneInto(equiv_mod);
+		delete gold_clone;
+		delete gate_clone;
+	}
+
+	void add_eq_assertion(const SigSpec &gold_sig, const SigSpec &gate_sig)
+	{
+		auto eq_wire = equiv_mod->Eqx(NEW_ID, gold_sig, gate_sig);
+		equiv_mod->addAssert(NEW_ID_SUFFIX("assert"), eq_wire, State::S1);
+	}
+
+	void find_same_wires()
+	{
+		SigMap assign_map(equiv_mod);
+		SigMap rd_signal_map;
+		SigPool primary_inputs;
+
+		// list of cells without added $equiv cells
+		auto cells_list = equiv_mod->cells().to_vector();
+
+		for (auto id : wire_names)
+		{
+			IdString gold_id = id.str() + "_gold";
+			IdString gate_id = id.str() + "_gate";
+
+			Wire *gold_wire = equiv_mod->wire(gold_id);
+			Wire *gate_wire = equiv_mod->wire(gate_id);
+
+			if (encdata.count(id))
+			{
+				log("Creating encoder/decoder for signal %s.\n", id.unescape());
+
+				Wire *dec_wire = equiv_mod->addWire(id.str() + "_decoded", gold_wire->width);
+				Wire *enc_wire = equiv_mod->addWire(id.str() + "_encoded", gate_wire->width);
+
+				SigSpec dec_a, dec_b, dec_s;
+				SigSpec enc_a, enc_b, enc_s;
+
+				dec_a = SigSpec(State::Sx, dec_wire->width);
+				enc_a = SigSpec(State::Sx, enc_wire->width);
+
+				for (auto &it : encdata.at(id))
+				{
+					SigSpec dec_sig = gate_wire, dec_pat = it.second;
+					SigSpec enc_sig = dec_wire, enc_pat = it.first;
+
+					if (GetSize(dec_sig) != GetSize(dec_pat))
+						log_error("Invalid pattern %s for signal %s of size %d!\n",
+								log_signal(dec_pat), log_signal(dec_sig), GetSize(dec_sig));
+
+					if (GetSize(enc_sig) != GetSize(enc_pat))
+						log_error("Invalid pattern %s for signal %s of size %d!\n",
+								log_signal(enc_pat), log_signal(enc_sig), GetSize(enc_sig));
+
+					SigSpec reduced_dec_sig, reduced_dec_pat;
+					for (int i = 0; i < GetSize(dec_sig); i++)
+						if (dec_pat[i] == State::S0 || dec_pat[i] == State::S1) {
+							reduced_dec_sig.append(dec_sig[i]);
+							reduced_dec_pat.append(dec_pat[i]);
+						}
+
+					SigSpec reduced_enc_sig, reduced_enc_pat;
+					for (int i = 0; i < GetSize(enc_sig); i++)
+						if (enc_pat[i] == State::S0 || enc_pat[i] == State::S1) {
+							reduced_enc_sig.append(enc_sig[i]);
+							reduced_enc_pat.append(enc_pat[i]);
+						}
+
+					SigSpec dec_result = it.first;
+					for (auto &bit : dec_result)
+						if (bit != State::S1) bit = State::S0;
+
+					SigSpec enc_result = it.second;
+					for (auto &bit : enc_result)
+						if (bit != State::S1) bit = State::S0;
+
+					SigSpec dec_eq = equiv_mod->addWire(NEW_ID);
+					SigSpec enc_eq = equiv_mod->addWire(NEW_ID);
+
+					equiv_mod->addEq(NEW_ID, reduced_dec_sig, reduced_dec_pat, dec_eq);
+					cells_list.push_back(equiv_mod->addEq(NEW_ID, reduced_enc_sig, reduced_enc_pat, enc_eq));
+
+					dec_s.append(dec_eq);
+					enc_s.append(enc_eq);
+					dec_b.append(dec_result);
+					enc_b.append(enc_result);
+				}
+
+				equiv_mod->addPmux(NEW_ID, dec_a, dec_b, dec_s, dec_wire);
+				equiv_mod->addPmux(NEW_ID, enc_a, enc_b, enc_s, enc_wire);
+
+				rd_signal_map.add(assign_map(gate_wire), enc_wire);
+				gate_wire = dec_wire;
+			}
+
+			if (gold_wire == nullptr || gate_wire == nullptr || gold_wire->width != gate_wire->width) {
+				if (gold_wire && gold_wire->port_id)
+					log_error("Can't match gold port `%s' to a gate port.\n", gold_wire);
+				if (gate_wire && gate_wire->port_id)
+					log_error("Can't match gate port `%s' to a gold port.\n", gate_wire);
+				continue;
+			}
+
+			log("Presumably equivalent wires: %s (%s), %s (%s) -> %s\n",
+					gold_wire, log_signal(assign_map(gold_wire)),
+					gate_wire, log_signal(assign_map(gate_wire)), id.unescape());
+
+			if (gold_wire->port_output || gate_wire->port_output)
+			{
+				gold_wire->port_input = false;
+				gate_wire->port_input = false;
+				gold_wire->port_output = false;
+				gate_wire->port_output = false;
+
+				Wire *wire = equiv_mod->addWire(id, gold_wire->width);
+				wire->port_output = true;
+
+				if (make_assert)
+				{
+					add_eq_assertion(gold_wire, gate_wire);
+					equiv_mod->connect(wire, gold_wire);
+				}
+				else
+				{
+					for (int i = 0; i < wire->width; i++)
+						equiv_mod->addEquiv(NEW_ID, SigSpec(gold_wire, i), SigSpec(gate_wire, i), SigSpec(wire, i));
+				}
+
+				rd_signal_map.add(assign_map(gold_wire), wire);
+				rd_signal_map.add(assign_map(gate_wire), wire);
+			}
+			else
+			if (gold_wire->port_input || gate_wire->port_input)
+			{
+				Wire *wire = equiv_mod->addWire(id, gold_wire->width);
+				wire->port_input = true;
+				gold_wire->port_input = false;
+				gate_wire->port_input = false;
+				equiv_mod->connect(gold_wire, wire);
+				equiv_mod->connect(gate_wire, wire);
+				primary_inputs.add(assign_map(gold_wire));
+				primary_inputs.add(assign_map(gate_wire));
+				primary_inputs.add(wire);
+			}
+			else
+			{
+				if (make_assert)
+					add_eq_assertion(gold_wire, gate_wire);
+
+				else {
+					Wire *wire = equiv_mod->addWire(id, gold_wire->width);
+					SigSpec rdmap_gold, rdmap_gate, rdmap_equiv;
+
+					for (int i = 0; i < wire->width; i++) {
+						if (undriven_bits.count(assign_map(SigBit(gold_wire, i)))) {
+							log("  Skipping signal bit %s [%d]: undriven on gold side.\n", id2cstr(gold_wire->name), i);
+							continue;
+						}
+						if (undriven_bits.count(assign_map(SigBit(gate_wire, i)))) {
+							log("  Skipping signal bit %s [%d]: undriven on gate side.\n", id2cstr(gate_wire->name), i);
+							continue;
+						}
+						equiv_mod->addEquiv(NEW_ID, SigSpec(gold_wire, i), SigSpec(gate_wire, i), SigSpec(wire, i));
+						rdmap_gold.append(SigBit(gold_wire, i));
+						rdmap_gate.append(SigBit(gate_wire, i));
+						rdmap_equiv.append(SigBit(wire, i));
+					}
+
+					rd_signal_map.add(rdmap_gold, rdmap_equiv);
+					rd_signal_map.add(rdmap_gate, rdmap_equiv);
+				}
+			}
+		}
+
+		for (auto c : cells_list)
+		for (auto &conn : c->connections())
+			if (!ct.cell_output(c->type, conn.first)) {
+				SigSpec old_sig = assign_map(conn.second);
+				SigSpec new_sig = rd_signal_map(old_sig);
+				for (int i = 0; i < GetSize(old_sig); i++)
+					if (primary_inputs.check(old_sig[i]))
+						new_sig[i] = old_sig[i];
+				if (old_sig != new_sig) {
+					log("Changing input %s of cell %s (%s): %s -> %s\n",
+							conn.first.unescape(), c, c->type.unescape(),
+							log_signal(old_sig), log_signal(new_sig));
+					c->setPort(conn.first, new_sig);
+				}
+			}
+
+		equiv_mod->fixup_ports();
+	}
+
+	void find_same_cells()
+	{
+		SigMap assign_map(equiv_mod);
+
+		for (auto id : cell_names)
+		{
+			IdString gold_id = id.str() + "_gold";
+			IdString gate_id = id.str() + "_gate";
+
+			Cell *gold_cell = equiv_mod->cell(gold_id);
+			Cell *gate_cell = equiv_mod->cell(gate_id);
+
+			if (gold_cell == nullptr || gate_cell == nullptr || gold_cell->type != gate_cell->type || !ct.cell_known(gold_cell->type) ||
+					gold_cell->parameters != gate_cell->parameters || GetSize(gold_cell->connections()) != GetSize(gate_cell->connections()))
+		try_next_cell_name:
+				continue;
+
+			for (auto gold_conn : gold_cell->connections())
+				if (!gate_cell->connections().count(gold_conn.first))
+					goto try_next_cell_name;
+
+			log("Presumably equivalent cells: %s %s (%s) -> %s\n",
+					gold_cell, gate_cell, gold_cell->type.unescape(), id.unescape());
+
+			for (auto gold_conn : gold_cell->connections())
+			{
+				SigSpec gold_sig = assign_map(gold_conn.second);
+				SigSpec gate_sig = assign_map(gate_cell->getPort(gold_conn.first));
+
+				if (ct.cell_output(gold_cell->type, gold_conn.first)) {
+					equiv_mod->connect(gate_sig, gold_sig);
+					continue;
+				}
+
+				if (make_assert)
+				{
+					if (gold_sig != gate_sig)
+						add_eq_assertion(gold_sig, gate_sig);
+				}
+				else
+				{
+					for (int i = 0; i < GetSize(gold_sig); i++)
+						if (gold_sig[i] != gate_sig[i]) {
+							Wire *w = equiv_mod->addWire(NEW_ID);
+							equiv_mod->addEquiv(NEW_ID, gold_sig[i], gate_sig[i], w);
+							gold_sig[i] = w;
+						}
+				}
+
+				gold_cell->setPort(gold_conn.first, gold_sig);
+			}
+
+			equiv_mod->remove(gate_cell);
+			equiv_mod->rename(gold_cell, id);
+		}
+	}
+
+	void find_undriven_nets(bool mark)
+	{
+		undriven_bits.clear();
+		assign_map.set(equiv_mod);
+
+		for (auto wire : equiv_mod->wires()) {
+			for (auto bit : assign_map(wire))
+				if (bit.wire)
+					undriven_bits.insert(bit);
+		}
+
+		for (auto wire : equiv_mod->wires()) {
+			if (wire->port_input)
+				for (auto bit : assign_map(wire))
+					undriven_bits.erase(bit);
+		}
+
+		for (auto cell : equiv_mod->cells()) {
+			for (auto &conn : cell->connections())
+				if (!ct.cell_known(cell->type) || ct.cell_output(cell->type, conn.first))
+					for (auto bit : assign_map(conn.second))
+						undriven_bits.erase(bit);
+		}
+
+		if (mark) {
+			SigSpec undriven_sig(undriven_bits);
+			undriven_sig.sort_and_unify();
+
+			for (auto chunk : undriven_sig.chunks()) {
+				log("Setting undriven nets to undef: %s\n", log_signal(chunk));
+				equiv_mod->connect(chunk, SigSpec(State::Sx, chunk.width));
+			}
+		}
+	}
+
+	void run()
+	{
+		copy_to_equiv();
+		find_undriven_nets(false);
+		find_same_wires();
+		find_same_cells();
+		find_undriven_nets(true);
+	}
+};
+
+struct EquivMakePass : public Pass {
+	EquivMakePass() : Pass("equiv_make", "prepare a circuit for equivalence checking") { }
+	void help() override
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    equiv_make [options] gold_module gate_module equiv_module\n");
+		log("\n");
+		log("This creates a module annotated with $equiv cells from two presumably\n");
+		log("equivalent modules. Use commands such as 'equiv_simple' and 'equiv_status'\n");
+		log("to work with the created equivalent checking module.\n");
+		log("\n");
+		log("    -inames\n");
+		log("        Also match cells and wires with $... names.\n");
+		log("\n");
+		log("    -blacklist <file>\n");
+		log("        Do not match cells or signals that match the names in the file.\n");
+		log("\n");
+		log("    -encfile <file>\n");
+		log("        Match FSM encodings using the description from the file.\n");
+		log("        See 'help fsm_recode' for details.\n");
+		log("\n");
+		log("    -make_assert\n");
+		log("        Check equivalence with $assert cells instead of $equiv.\n");
+		log("        $eqx (===) is used to compare signals.");
+		log("\n");
+		log("Note: The circuit created by this command is not a miter (with something like\n");
+		log("a trigger output), but instead uses $equiv cells to encode the equivalence\n");
+		log("checking problem. Use 'miter -equiv' if you want to create a miter circuit.\n");
+		log("\n");
+	}
+	void execute(std::vector<std::string> args, RTLIL::Design *design) override
+	{
+		EquivMakeWorker worker;
+		worker.ct.setup(design);
+		worker.inames = false;
+		worker.make_assert = false;
+
+		size_t argidx;
+		for (argidx = 1; argidx < args.size(); argidx++)
+		{
+			if (args[argidx] == "-inames") {
+				worker.inames = true;
+				continue;
+			}
+			if (args[argidx] == "-blacklist" && argidx+1 < args.size()) {
+				worker.blacklists.push_back(args[++argidx]);
+				continue;
+			}
+			if (args[argidx] == "-encfile" && argidx+1 < args.size()) {
+				worker.encfiles.push_back(args[++argidx]);
+				continue;
+			}
+			if (args[argidx] == "-make_assert") {
+				worker.make_assert = true;
+				continue;
+			}
+			break;
+		}
+
+		if (argidx+3 != args.size())
+			log_cmd_error("Invalid number of arguments.\n");
+
+		worker.gold_mod = design->module(RTLIL::escape_id(args[argidx]));
+		worker.gate_mod = design->module(RTLIL::escape_id(args[argidx+1]));
+		worker.equiv_mod = design->module(RTLIL::escape_id(args[argidx+2]));
+
+		if (worker.gold_mod == nullptr)
+			log_cmd_error("Can't find gold module %s.\n", args[argidx]);
+
+		if (worker.gate_mod == nullptr)
+			log_cmd_error("Can't find gate module %s.\n", args[argidx+1]);
+
+		if (worker.equiv_mod != nullptr)
+			log_cmd_error("Equiv module %s already exists.\n", args[argidx+2]);
+
+		if (worker.gold_mod->has_memories() || worker.gold_mod->has_processes())
+			log_cmd_error("Gold module contains memories or processes. Run 'memory' or 'proc' respectively.\n");
+
+		if (worker.gate_mod->has_memories() || worker.gate_mod->has_processes())
+			log_cmd_error("Gate module contains memories or processes. Run 'memory' or 'proc' respectively.\n");
+
+		worker.read_blacklists();
+		worker.read_encfiles();
+
+		log_header(design, "Executing EQUIV_MAKE pass (creating equiv checking module).\n");
+
+		worker.equiv_mod = design->addModule(RTLIL::escape_id(args[argidx+2]));
+		worker.run();
+	}
+} EquivMakePass;
+
+PRIVATE_NAMESPACE_END

--- a/passes/fsm/fsm_detect.cc
+++ b/passes/fsm/fsm_detect.cc
@@ -61,7 +61,7 @@ ret_false:
 
 		if (recursion_monitor.count(cellport.first)) {
 			log_warning("logic loop in mux tree at signal %s in module %s.\n",
-					log_signal(sig), RTLIL::id2cstr(module->name));
+					log_signal(sig), module);
 			goto ret_false;
 		}
 

--- a/passes/fsm/fsm_recode.cc
+++ b/passes/fsm/fsm_recode.cc
@@ -39,7 +39,7 @@ static void fm_set_fsm_print(RTLIL::Cell *cell, RTLIL::Module *module, FsmData &
 	for (int i = fsm_data.state_bits-1; i >= 0; i--)
 		fprintf(f, " %s_reg[%d]", name[0] == '\\' ?  name.substr(1).c_str() : name.c_str(), i);
 	fprintf(f, " } -name {%s_%s} {%s:/WORK/%s}\n", prefix, RTLIL::unescape_id(name).c_str(),
-			prefix, RTLIL::unescape_id(module->name).c_str());
+			prefix, module->name.unescape().c_str());
 
 	fprintf(f, "set_fsm_encoding {");
 	for (int i = 0; i < GetSize(fsm_data.state_table); i++) {
@@ -49,7 +49,7 @@ static void fm_set_fsm_print(RTLIL::Cell *cell, RTLIL::Module *module, FsmData &
 	}
 	fprintf(f, " } -name {%s_%s} {%s:/WORK/%s}\n",
 			prefix, RTLIL::unescape_id(name).c_str(),
-			prefix, RTLIL::unescape_id(module->name).c_str());
+			prefix, module->name.unescape().c_str());
 }
 
 static void fsm_recode(RTLIL::Cell *cell, RTLIL::Module *module, FILE *fm_set_fsm_file, FILE *encfile, std::string default_encoding)

--- a/passes/hierarchy/flatten.cc
+++ b/passes/hierarchy/flatten.cc
@@ -281,13 +281,13 @@ struct FlattenWorker
 				if (attr.first == ID::hdlname)
 					scopeinfo->attributes.insert(attr);
 				else
-					scopeinfo->attributes.emplace(stringf("\\cell_%s", RTLIL::unescape_id(attr.first)), attr.second);
+					scopeinfo->attributes.emplace(stringf("\\cell_%s", attr.first.unescape()), attr.second);
 			}
 
 			for (auto const &attr : tpl->attributes)
-				scopeinfo->attributes.emplace(stringf("\\module_%s", RTLIL::unescape_id(attr.first)), attr.second);
+				scopeinfo->attributes.emplace(stringf("\\module_%s", attr.first.unescape()), attr.second);
 
-			scopeinfo->attributes.emplace(ID(module), RTLIL::unescape_id(tpl->name));
+			scopeinfo->attributes.emplace(ID(module), tpl->name.unescape());
 		}
 
 		module->remove(cell);

--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -50,7 +50,7 @@ void generate(RTLIL::Design *design, const std::vector<std::string> &celltypes, 
 		if (cell->type.begins_with("$") && !cell->type.begins_with("$__"))
 			continue;
 		for (auto &pattern : celltypes)
-			if (patmatch(pattern.c_str(), RTLIL::unescape_id(cell->type).c_str()))
+			if (patmatch(pattern.c_str(), cell->type.unescape().c_str()))
 				found_celltypes.insert(cell->type);
 	}
 
@@ -100,7 +100,7 @@ void generate(RTLIL::Design *design, const std::vector<std::string> &celltypes, 
 		while (portnames.size() > 0) {
 			RTLIL::IdString portname = *portnames.begin();
 			for (auto &decl : portdecls)
-				if (decl.index == 0 && patmatch(decl.portname.c_str(), RTLIL::unescape_id(portname).c_str())) {
+				if (decl.index == 0 && patmatch(decl.portname.c_str(), portname.unescape().c_str())) {
 					generate_port_decl_t d = decl;
 					d.portname = portname.str();
 					d.index = *indices.begin();
@@ -397,7 +397,7 @@ RTLIL::Module *get_module(RTLIL::Design                  &design,
 			};
 
 		for (auto &ext : extensions_list) {
-			std::string filename = dir + "/" + RTLIL::unescape_id(cell.type) + ext.first;
+			std::string filename = dir + "/" + cell.type.unescape() + ext.first;
 			if (!check_file_exists(filename))
 				continue;
 

--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -87,7 +87,7 @@ void generate(RTLIL::Design *design, const std::vector<std::string> &celltypes, 
 			if (decl.index > 0) {
 				portwidths[decl.portname] = max(portwidths[decl.portname], 1);
 				portwidths[decl.portname] = max(portwidths[decl.portname], portwidths[stringf("$%d", decl.index)]);
-				log("  port %d: %s [%d:0] %s\n", decl.index, decl.input ? decl.output ? "inout" : "input" : "output", portwidths[decl.portname]-1, RTLIL::id2cstr(decl.portname));
+				log("  port %d: %s [%d:0] %s\n", decl.index, decl.input ? decl.output ? "inout" : "input" : "output", portwidths[decl.portname]-1, RTLIL::unescape_id(decl.portname));
 				if (indices.count(decl.index) > ports.size())
 					log_error("Port index (%d) exceeds number of found ports (%d).\n", decl.index, int(ports.size()));
 				if (indices.count(decl.index) == 0)
@@ -108,10 +108,10 @@ void generate(RTLIL::Design *design, const std::vector<std::string> &celltypes, 
 					indices.erase(d.index);
 					ports[d.index-1] = d;
 					portwidths[d.portname] = max(portwidths[d.portname], 1);
-					log("  port %d: %s [%d:0] %s\n", d.index, d.input ? d.output ? "inout" : "input" : "output", portwidths[d.portname]-1, RTLIL::id2cstr(d.portname));
+					log("  port %d: %s [%d:0] %s\n", d.index, d.input ? d.output ? "inout" : "input" : "output", portwidths[d.portname]-1, RTLIL::unescape_id(d.portname));
 					goto found_matching_decl;
 				}
-			log_error("Can't match port %s.\n", RTLIL::id2cstr(portname));
+			log_error("Can't match port %s.\n", portname.unescape());
 		found_matching_decl:;
 			portnames.erase(portname);
 		}
@@ -133,9 +133,9 @@ void generate(RTLIL::Design *design, const std::vector<std::string> &celltypes, 
 		mod->fixup_ports();
 
 		for (auto &para : parameters)
-			log("  ignoring parameter %s.\n", RTLIL::id2cstr(para));
+			log("  ignoring parameter %s.\n", para.unescape());
 
-		log("  module %s created.\n", RTLIL::id2cstr(mod->name));
+		log("  module %s created.\n", mod);
 	}
 }
 
@@ -597,7 +597,7 @@ bool expand_module(RTLIL::Design *design, RTLIL::Module *module, bool flag_check
 		int idx = it.second.first, num = it.second.second;
 
 		if (design->module(cell->type) == nullptr)
-			log_error("Array cell `%s.%s' of unknown type `%s'.\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(cell->name), RTLIL::id2cstr(cell->type));
+			log_error("Array cell `%s.%s' of unknown type `%s'.\n", module, cell, cell->type.unescape());
 
 		RTLIL::Module *mod = design->module(cell->type);
 
@@ -613,12 +613,12 @@ bool expand_module(RTLIL::Design *design, RTLIL::Module *module, bool flag_check
 					}
 			}
 			if (mod->wire(portname) == nullptr)
-				log_error("Array cell `%s.%s' connects to unknown port `%s'.\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(cell->name), RTLIL::id2cstr(conn.first));
+				log_error("Array cell `%s.%s' connects to unknown port `%s'.\n", module, cell, conn.first.unescape());
 			int port_size = mod->wire(portname)->width;
 			if (conn_size == port_size || conn_size == 0)
 				continue;
 			if (conn_size != port_size*num)
-				log_error("Array cell `%s.%s' has invalid port vs. signal size for port `%s'.\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(cell->name), RTLIL::id2cstr(conn.first));
+				log_error("Array cell `%s.%s' has invalid port vs. signal size for port `%s'.\n", module, cell, conn.first.unescape());
 			conn.second = conn.second.extract(port_size*idx, port_size);
 		}
 	}
@@ -1219,7 +1219,7 @@ struct HierarchyPass : public Pass {
 					if (read_id_num(p.first, &id)) {
 						if (id <= 0 || id > GetSize(cell_mod->avail_parameters)) {
 							log("  Failed to map positional parameter %d of cell %s.%s (%s).\n",
-									id, RTLIL::id2cstr(mod->name), RTLIL::id2cstr(cell->name), RTLIL::id2cstr(cell->type));
+									id, mod, cell, cell->type.unescape());
 						} else {
 							params_rename.insert(std::make_pair(p.first, cell_mod->avail_parameters[id - 1]));
 						}
@@ -1241,7 +1241,7 @@ struct HierarchyPass : public Pass {
 				RTLIL::Module *module = work.first;
 				RTLIL::Cell *cell = work.second;
 				log("Mapping positional arguments of cell %s.%s (%s).\n",
-						RTLIL::id2cstr(module->name), RTLIL::id2cstr(cell->name), RTLIL::id2cstr(cell->type));
+						module, cell, cell->type.unescape());
 				dict<RTLIL::IdString, RTLIL::SigSpec> new_connections;
 				for (auto &conn : cell->connections()) {
 					int id;
@@ -1249,7 +1249,7 @@ struct HierarchyPass : public Pass {
 						std::pair<RTLIL::Module*,int> key(design->module(cell->type), id);
 						if (pos_map.count(key) == 0) {
 							log("  Failed to map positional argument %d of cell %s.%s (%s).\n",
-									id, RTLIL::id2cstr(module->name), RTLIL::id2cstr(cell->name), RTLIL::id2cstr(cell->type));
+									id, module, cell, cell->type.unescape());
 							new_connections[conn.first] = conn.second;
 						} else
 							new_connections[pos_map.at(key)] = conn.second;
@@ -1283,7 +1283,7 @@ struct HierarchyPass : public Pass {
 
 				if (m == nullptr)
 					log_error("Cell %s.%s (%s) has implicit port connections but the module it instantiates is unknown.\n",
-							RTLIL::id2cstr(module->name), RTLIL::id2cstr(cell->name), RTLIL::id2cstr(cell->type));
+							module, cell, cell->type.unescape());
 
 				// Need accurate port widths for error checking; so must derive blackboxes with dynamic port widths
 				if (m->get_blackbox_attribute() && !cell->parameters.empty() && m->get_bool_attribute(ID::dynports)) {
@@ -1312,11 +1312,11 @@ struct HierarchyPass : public Pass {
 
 					if (parent_wire == nullptr)
 						log_error("No matching wire for implicit port connection `%s' of cell %s.%s (%s).\n",
-								RTLIL::id2cstr(wire->name), RTLIL::id2cstr(module->name), RTLIL::id2cstr(cell->name), RTLIL::id2cstr(cell->type));
+								wire, module, cell, cell->type.unescape());
 					if (parent_wire->width != wire->width)
 						log_error("Width mismatch between wire (%d bits) and port (%d bits) for implicit port connection `%s' of cell %s.%s (%s).\n",
 								parent_wire->width, wire->width,
-								RTLIL::id2cstr(wire->name), RTLIL::id2cstr(module->name), RTLIL::id2cstr(cell->name), RTLIL::id2cstr(cell->type));
+								wire, module, cell, cell->type.unescape());
 					cell->setPort(wire->name, parent_wire);
 				}
 				cell->attributes.erase(ID::wildcard_port_conns);

--- a/passes/sat/cutpoint.cc
+++ b/passes/sat/cutpoint.cc
@@ -159,7 +159,7 @@ struct CutpointPass : public Pass {
 						if (attr.first == ID::hdlname)
 							scopeinfo->attributes.insert(attr);
 						else
-							scopeinfo->attributes.emplace(stringf("\\cell_%s", RTLIL::unescape_id(attr.first)), attr.second);
+							scopeinfo->attributes.emplace(stringf("\\cell_%s", attr.first.unescape()), attr.second);
 					}
 				}
 

--- a/passes/sat/cutpoint.cc
+++ b/passes/sat/cutpoint.cc
@@ -132,7 +132,7 @@ struct CutpointPass : public Pass {
 						if (cell->input(conn.first))
 							for (auto bit : sigmap(conn.second))
 								if (wire_drivers.count(bit)) {
-									log_debug("  Treating inout port '%s' as input.\n", id2cstr(conn.first));
+									log_debug("  Treating inout port '%s' as input.\n", conn.first.unescape());
 									do_cut = false;
 									break;
 								}
@@ -140,7 +140,7 @@ struct CutpointPass : public Pass {
 						if (do_cut) {
 							module->connect(conn.second, flag_undef ? Const(State::Sx, GetSize(conn.second)) : module->Anyseq(NEW_ID, GetSize(conn.second)));
 							if (cell->input(conn.first)) {
-								log_debug("  Treating inout port '%s' as output.\n", id2cstr(conn.first));
+								log_debug("  Treating inout port '%s' as output.\n", conn.first.unescape());
 								for (auto bit : sigmap(conn.second))
 									wire_drivers.insert(bit);
 							}

--- a/passes/sat/expose.cc
+++ b/passes/sat/expose.cc
@@ -471,7 +471,7 @@ struct ExposePass : public Pass {
 				{
 					if (!w->port_input) {
 						w->port_input = true;
-						log("New module port: %s/%s\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(w->name));
+						log("New module port: %s/%s\n", module, w);
 						wire_map[w] = NEW_ID;
 					}
 				}
@@ -479,7 +479,7 @@ struct ExposePass : public Pass {
 				{
 					if (!w->port_output) {
 						w->port_output = true;
-						log("New module port: %s/%s\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(w->name));
+						log("New module port: %s/%s\n", module, w);
 					}
 
 					if (flag_cut) {
@@ -555,7 +555,7 @@ struct ExposePass : public Pass {
 
 				RTLIL::Wire *wire_q = add_new_wire(module, wire->name.str() + sep + "q", wire->width);
 				wire_q->port_input = true;
-				log("New module port: %s/%s\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire_q->name));
+				log("New module port: %s/%s\n", module, wire_q);
 
 				RTLIL::SigSig connect_q;
 				for (size_t i = 0; i < wire_bits_vec.size(); i++) {
@@ -569,12 +569,12 @@ struct ExposePass : public Pass {
 
 				RTLIL::Wire *wire_d = add_new_wire(module, wire->name.str() + sep + "d", wire->width);
 				wire_d->port_output = true;
-				log("New module port: %s/%s\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire_d->name));
+				log("New module port: %s/%s\n", module, wire_d);
 				module->connect(RTLIL::SigSig(wire_d, info.sig_d));
 
 				RTLIL::Wire *wire_c = add_new_wire(module, wire->name.str() + sep + "c");
 				wire_c->port_output = true;
-				log("New module port: %s/%s\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire_c->name));
+				log("New module port: %s/%s\n", module, wire_c);
 				if (info.clk_polarity) {
 					module->connect(RTLIL::SigSig(wire_c, info.sig_clk));
 				} else {
@@ -590,7 +590,7 @@ struct ExposePass : public Pass {
 				{
 					RTLIL::Wire *wire_r = add_new_wire(module, wire->name.str() + sep + "r");
 					wire_r->port_output = true;
-					log("New module port: %s/%s\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire_r->name));
+					log("New module port: %s/%s\n", module, wire_r);
 					if (info.arst_polarity) {
 						module->connect(RTLIL::SigSig(wire_r, info.sig_arst));
 					} else {
@@ -604,7 +604,7 @@ struct ExposePass : public Pass {
 
 					RTLIL::Wire *wire_v = add_new_wire(module, wire->name.str() + sep + "v", wire->width);
 					wire_v->port_output = true;
-					log("New module port: %s/%s\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire_v->name));
+					log("New module port: %s/%s\n", module, wire_v);
 					module->connect(RTLIL::SigSig(wire_v, info.arst_value));
 				}
 			}
@@ -638,7 +638,7 @@ struct ExposePass : public Pass {
 							if (p->port_output)
 								w->port_input = true;
 
-							log("New module port: %s/%s (%s)\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(w->name), RTLIL::id2cstr(cell->type));
+							log("New module port: %s/%s (%s)\n", module, w, cell->type.unescape());
 
 							RTLIL::SigSpec sig;
 							if (cell->hasPort(p->name))
@@ -660,7 +660,7 @@ struct ExposePass : public Pass {
 							if (ct.cell_output(cell->type, it.first))
 								w->port_input = true;
 
-							log("New module port: %s/%s (%s)\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(w->name), RTLIL::id2cstr(cell->type));
+							log("New module port: %s/%s (%s)\n", module, w, cell->type.unescape());
 
 							if (w->port_input)
 								module->connect(RTLIL::SigSig(it.second, w));

--- a/passes/sat/expose.cc
+++ b/passes/sat/expose.cc
@@ -632,7 +632,7 @@ struct ExposePass : public Pass {
 							if (!p->port_input && !p->port_output)
 								continue;
 
-							RTLIL::Wire *w = add_new_wire(module, cell->name.str() + sep + RTLIL::unescape_id(p->name), p->width);
+							RTLIL::Wire *w = add_new_wire(module, cell->name.str() + sep + p->name.unescape(), p->width);
 							if (p->port_input)
 								w->port_output = true;
 							if (p->port_output)
@@ -654,7 +654,7 @@ struct ExposePass : public Pass {
 					{
 						for (auto &it : cell->connections())
 						{
-							RTLIL::Wire *w = add_new_wire(module, cell->name.str() + sep + RTLIL::unescape_id(it.first), it.second.size());
+							RTLIL::Wire *w = add_new_wire(module, cell->name.str() + sep + it.first.unescape(), it.second.size());
 							if (ct.cell_input(cell->type, it.first))
 								w->port_output = true;
 							if (ct.cell_output(cell->type, it.first))

--- a/passes/sat/freduce.cc
+++ b/passes/sat/freduce.cc
@@ -139,7 +139,7 @@ struct FindReducedInputs
 			if (ez_cells.count(drv.first) == 0) {
 				satgen.setContext(&sigmap, "A");
 				if (!satgen.importCell(drv.first))
-					log_error("Can't create SAT model for cell %s (%s)!\n", RTLIL::id2cstr(drv.first->name), RTLIL::id2cstr(drv.first->type));
+					log_error("Can't create SAT model for cell %s (%s)!\n", drv.first, drv.first->type.unescape());
 				satgen.setContext(&sigmap, "B");
 				if (!satgen.importCell(drv.first))
 					log_abort();
@@ -256,7 +256,7 @@ struct PerformReduction
 			std::pair<RTLIL::Cell*, std::set<RTLIL::SigBit>> &drv = drivers.at(out);
 			if (celldone.count(drv.first) == 0) {
 				if (!satgen.importCell(drv.first))
-					log_error("Can't create SAT model for cell %s (%s)!\n", RTLIL::id2cstr(drv.first->name), RTLIL::id2cstr(drv.first->type));
+					log_error("Can't create SAT model for cell %s (%s)!\n", drv.first, drv.first->type.unescape());
 				celldone.insert(drv.first);
 			}
 			int max_child_depth = 0;
@@ -595,14 +595,14 @@ struct FreduceWorker
 
 	void dump()
 	{
-		std::string filename = stringf("%s_%s_%05d.il", dump_prefix, RTLIL::id2cstr(module->name), reduce_counter);
+		std::string filename = stringf("%s_%s_%05d.il", dump_prefix, module, reduce_counter);
 		log("%s    Writing dump file `%s'.\n", reduce_counter ? "  " : "", filename);
 		Pass::call(design, stringf("dump -outfile %s %s", filename, design->selected_active_module.empty() ? module->name.c_str() : ""));
 	}
 
 	int run()
 	{
-		log("Running functional reduction on module %s:\n", RTLIL::id2cstr(module->name));
+		log("Running functional reduction on module %s:\n", module);
 
 		CellTypes ct;
 		ct.setup_internals();
@@ -749,7 +749,7 @@ struct FreduceWorker
 			}
 		}
 
-		log("  Rewired a total of %d signal bits in module %s.\n", rewired_sigbits, RTLIL::id2cstr(module->name));
+		log("  Rewired a total of %d signal bits in module %s.\n", rewired_sigbits, module);
 		return rewired_sigbits;
 	}
 };

--- a/passes/sat/miter.cc
+++ b/passes/sat/miter.cc
@@ -143,7 +143,7 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 	{
 		if (gold_cross_ports.count(gold_wire))
 		{
-			SigSpec w = miter_module->addWire("\\cross_" + RTLIL::unescape_id(gold_wire->name), gold_wire->width);
+			SigSpec w = miter_module->addWire("\\cross_" + gold_wire->name.unescape(), gold_wire->width);
 			gold_cell->setPort(gold_wire->name, w);
 			if (flag_ignore_gold_x) {
 				RTLIL::SigSpec w_x = miter_module->addWire(NEW_ID, GetSize(w));
@@ -159,7 +159,7 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 
 		if (gold_wire->port_input)
 		{
-			RTLIL::Wire *w = miter_module->addWire("\\in_" + RTLIL::unescape_id(gold_wire->name), gold_wire->width);
+			RTLIL::Wire *w = miter_module->addWire("\\in_" + gold_wire->name.unescape(), gold_wire->width);
 			w->port_input = true;
 
 			gold_cell->setPort(gold_wire->name, w);
@@ -168,10 +168,10 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 
 		if (gold_wire->port_output)
 		{
-			RTLIL::Wire *w_gold = miter_module->addWire("\\gold_" + RTLIL::unescape_id(gold_wire->name), gold_wire->width);
+			RTLIL::Wire *w_gold = miter_module->addWire("\\gold_" + gold_wire->name.unescape(), gold_wire->width);
 			w_gold->port_output = flag_make_outputs;
 
-			RTLIL::Wire *w_gate = miter_module->addWire("\\gate_" + RTLIL::unescape_id(gold_wire->name), gold_wire->width);
+			RTLIL::Wire *w_gate = miter_module->addWire("\\gate_" + gold_wire->name.unescape(), gold_wire->width);
 			w_gate->port_output = flag_make_outputs;
 
 			gold_cell->setPort(gold_wire->name, w_gold);
@@ -244,7 +244,7 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 
 			if (flag_make_outcmp)
 			{
-				RTLIL::Wire *w_cmp = miter_module->addWire("\\cmp_" + RTLIL::unescape_id(gold_wire->name));
+				RTLIL::Wire *w_cmp = miter_module->addWire("\\cmp_" + gold_wire->name.unescape());
 				w_cmp->port_output = true;
 				miter_module->connect(RTLIL::SigSig(w_cmp, this_condition));
 			}
@@ -252,7 +252,7 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 			if (flag_make_cover)
 			{
 				auto cover_condition = miter_module->Not(NEW_ID, this_condition);
-				miter_module->addCover("\\cover_" + RTLIL::unescape_id(gold_wire->name), cover_condition, State::S1);
+				miter_module->addCover("\\cover_" + gold_wire->name.unescape(), cover_condition, State::S1);
 			}
 
 			all_conditions.append(this_condition);

--- a/passes/sat/miter.cc
+++ b/passes/sat/miter.cc
@@ -128,7 +128,7 @@ void create_miter_equiv(struct Pass *that, std::vector<std::string> args, RTLIL:
 		log_cmd_error("No matching port in gold module was found for %s!\n", gate_wire->name);
 	}
 
-	log("Creating miter cell \"%s\" with gold cell \"%s\" and gate cell \"%s\".\n", RTLIL::id2cstr(miter_name), RTLIL::id2cstr(gold_name), RTLIL::id2cstr(gate_name));
+	log("Creating miter cell \"%s\" with gold cell \"%s\" and gate cell \"%s\".\n", miter_name.unescape(), gold_name.unescape(), gate_name.unescape());
 
 	RTLIL::Module *miter_module = new RTLIL::Module;
 	miter_module->name = miter_name;

--- a/passes/sat/sim.cc
+++ b/passes/sat/sim.cc
@@ -275,9 +275,9 @@ struct SimInstance
 			}
 
 			if ((shared->fst) && !(shared->hide_internal && wire->name[0] == '$')) {
-				fstHandle id = shared->fst->getHandle(scope + "." + RTLIL::unescape_id(wire->name));
+				fstHandle id = shared->fst->getHandle(scope + "." + wire->name.unescape());
 				if (id==0 && wire->name.isPublic())
-					log_warning("Unable to find wire %s in input file.\n", (scope + "." + RTLIL::unescape_id(wire->name)));
+					log_warning("Unable to find wire %s in input file.\n", (scope + "." + wire->name.unescape()));
 				fst_handles[wire] = id;
 			}
 
@@ -316,7 +316,7 @@ struct SimInstance
 			Module *mod = module->design->module(cell->type);
 
 			if (mod != nullptr) {
-				dirty_children.insert(new SimInstance(shared, scope + "." + RTLIL::unescape_id(cell->name), mod, cell, this));
+				dirty_children.insert(new SimInstance(shared, scope + "." + cell->name.unescape(), mod, cell, this));
 			}
 
 			for (auto &port : cell->connections()) {
@@ -1209,7 +1209,7 @@ struct SimInstance
 						}
 					}
 					if (!found)
-						log_error("Unable to find required '%s' signal in file\n",(scope + "." + RTLIL::unescape_id(sig_y.as_wire()->name)));
+						log_error("Unable to find required '%s' signal in file\n",(scope + "." + sig_y.as_wire()->name.unescape()));
 				}
 			}
 		}
@@ -1495,7 +1495,7 @@ struct SimWorker : SimShared
 				log_error("Can't find port %s on module %s.\n", portname.unescape(), top->module);
 			if (!w->port_input)
 				log_error("Clock port %s on module %s is not input.\n", portname.unescape(), top->module);
-			fstHandle id = fst->getHandle(scope + "." + RTLIL::unescape_id(portname));
+			fstHandle id = fst->getHandle(scope + "." + portname.unescape());
 			if (id==0)
 				log_error("Can't find port %s.%s in FST.\n", scope, portname.unescape());
 			fst_clock.push_back(id);
@@ -1507,7 +1507,7 @@ struct SimWorker : SimShared
 				log_error("Can't find port %s on module %s.\n", portname.unescape(), top->module);
 			if (!w->port_input)
 				log_error("Clock port %s on module %s is not input.\n", portname.unescape(), top->module);
-			fstHandle id = fst->getHandle(scope + "." + RTLIL::unescape_id(portname));
+			fstHandle id = fst->getHandle(scope + "." + portname.unescape());
 			if (id==0)
 				log_error("Can't find port %s.%s in FST.\n", scope, portname.unescape());
 			fst_clock.push_back(id);
@@ -1517,9 +1517,9 @@ struct SimWorker : SimShared
 
 		for (auto wire : topmod->wires()) {
 			if (wire->port_input) {
-				fstHandle id = fst->getHandle(scope + "." + RTLIL::unescape_id(wire->name));
+				fstHandle id = fst->getHandle(scope + "." + wire->name.unescape());
 				if (id==0)
-					log_error("Unable to find required '%s' signal in file\n",(scope + "." + RTLIL::unescape_id(wire->name)));
+					log_error("Unable to find required '%s' signal in file\n",(scope + "." + wire->name.unescape()));
 				top->fst_inputs[wire] = id;
 			}
 		}
@@ -2114,12 +2114,12 @@ struct SimWorker : SimShared
 		std::stringstream f;
 
 		if (wire->width==1)
-			f << stringf("%s", RTLIL::unescape_id(wire->name));
+			f << stringf("%s", wire);
 		else
 			if (wire->upto)
-				f << stringf("[%d:%d] %s", wire->start_offset, wire->width - 1 + wire->start_offset, RTLIL::unescape_id(wire->name));
+				f << stringf("[%d:%d] %s", wire->start_offset, wire->width - 1 + wire->start_offset, wire);
 			else
-				f << stringf("[%d:%d] %s", wire->width - 1 + wire->start_offset, wire->start_offset, RTLIL::unescape_id(wire->name));
+				f << stringf("[%d:%d] %s", wire->width - 1 + wire->start_offset, wire->start_offset, wire);
 		return f.str();
 	}
 
@@ -2127,7 +2127,7 @@ struct SimWorker : SimShared
 	{
 		std::stringstream f;
 		for(auto item=signals.begin();item!=signals.end();item++)
-			f << stringf("%c%s", (item==signals.begin() ? ' ' : ','), RTLIL::unescape_id(item->first->name));
+			f << stringf("%c%s", (item==signals.begin() ? ' ' : ','), item->first);
 		return f.str();
 	}
 
@@ -2151,7 +2151,7 @@ struct SimWorker : SimShared
 				log_error("Can't find port %s on module %s.\n", portname.unescape(), top->module);
 			if (!w->port_input)
 				log_error("Clock port %s on module %s is not input.\n", portname.unescape(), top->module);
-			fstHandle id = fst->getHandle(scope + "." + RTLIL::unescape_id(portname));
+			fstHandle id = fst->getHandle(scope + "." + portname.unescape());
 			if (id==0)
 				log_error("Can't find port %s.%s in FST.\n", scope, portname.unescape());
 			fst_clock.push_back(id);
@@ -2164,7 +2164,7 @@ struct SimWorker : SimShared
 				log_error("Can't find port %s on module %s.\n", portname.unescape(), top->module);
 			if (!w->port_input)
 				log_error("Clock port %s on module %s is not input.\n", portname.unescape(), top->module);
-			fstHandle id = fst->getHandle(scope + "." + RTLIL::unescape_id(portname));
+			fstHandle id = fst->getHandle(scope + "." + portname.unescape());
 			if (id==0)
 				log_error("Can't find port %s.%s in FST.\n", scope, portname.unescape());
 			fst_clock.push_back(id);
@@ -2176,9 +2176,9 @@ struct SimWorker : SimShared
 		std::map<Wire*,fstHandle> outputs;
 
 		for (auto wire : topmod->wires()) {
-			fstHandle id = fst->getHandle(scope + "." + RTLIL::unescape_id(wire->name));
+			fstHandle id = fst->getHandle(scope + "." + wire->name.unescape());
 			if (id==0 && (wire->port_input || wire->port_output))
-				log_error("Unable to find required '%s' signal in file\n",(scope + "." + RTLIL::unescape_id(wire->name)));
+				log_error("Unable to find required '%s' signal in file\n",(scope + "." + wire->name.unescape()));
 			if (wire->port_input)
 				if (clocks.find(wire)==clocks.end())
 					inputs[wire] = id;
@@ -2244,13 +2244,13 @@ struct SimWorker : SimShared
 		}
 		int data_len = clk_len + inputs_len + outputs_len + 32;
 		f << "\n";
-		f << stringf("\t%s uut(",RTLIL::unescape_id(topmod->name));
+		f << stringf("\t%s uut(",topmod);
 		for(auto item=clocks.begin();item!=clocks.end();item++)
-			f << stringf("%c.%s(%s)", (item==clocks.begin() ? ' ' : ','), RTLIL::unescape_id(item->first->name), RTLIL::unescape_id(item->first->name));
+			f << stringf("%c.%s(%s)", (item==clocks.begin() ? ' ' : ','), item->first, item->first);
 		for(auto &item : inputs)
-			f << stringf(",.%s(%s)", RTLIL::unescape_id(item.first->name), RTLIL::unescape_id(item.first->name));
+			f << stringf(",.%s(%s)", item.first, item.first);
 		for(auto &item : outputs)
-			f << stringf(",.%s(%s)", RTLIL::unescape_id(item.first->name), RTLIL::unescape_id(item.first->name));
+			f << stringf(",.%s(%s)", item.first, item.first);
 		f << ");\n";
 		f << "\n";
 		f << "\tinteger i;\n";

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1565,7 +1565,7 @@ void AbcModuleState::extract(AbcSigMap &assign_map, RTLIL::Design *design, RTLIL
 	{
 		if (builtin_lib)
 		{
-			cell_stats[RTLIL::unescape_id(c->type)]++;
+			cell_stats[c->type.unescape()]++;
 			if (c->type.in(ID(ZERO), ID(ONE))) {
 				RTLIL::SigSig conn;
 				RTLIL::IdString name_y = remap_name(c->getPort(ID::Y).as_wire()->name);
@@ -1706,7 +1706,7 @@ void AbcModuleState::extract(AbcSigMap &assign_map, RTLIL::Design *design, RTLIL
 			}
 		}
 		else
-			cell_stats[RTLIL::unescape_id(c->type)]++;
+			cell_stats[c->type.unescape()]++;
 
 		if (c->type.in(ID(_const0_), ID(_const1_))) {
 			RTLIL::SigSig conn;

--- a/passes/techmap/extract.cc
+++ b/passes/techmap/extract.cc
@@ -626,7 +626,7 @@ struct ExtractPass : public Pass {
 		if (!mine_mode)
 			for (auto module : map->modules()) {
 				SubCircuit::Graph mod_graph;
-				std::string graph_name = "needle_" + RTLIL::unescape_id(module->name);
+				std::string graph_name = "needle_" + module->name.unescape();
 				log("Creating needle graph %s.\n", graph_name);
 				if (module2graph(mod_graph, module, constports)) {
 					solver.addGraph(graph_name, mod_graph);
@@ -637,7 +637,7 @@ struct ExtractPass : public Pass {
 
 		for (auto module : design->modules()) {
 			SubCircuit::Graph mod_graph;
-			std::string graph_name = "haystack_" + RTLIL::unescape_id(module->name);
+			std::string graph_name = "haystack_" + module->name.unescape();
 			log("Creating haystack graph %s.\n", graph_name);
 			if (module2graph(mod_graph, module, constports, design, mine_mode ? mine_max_fanout : -1, mine_mode ? &mine_split : nullptr)) {
 				solver.addGraph(graph_name, mod_graph);
@@ -654,8 +654,8 @@ struct ExtractPass : public Pass {
 
 			for (auto needle : needle_list)
 			for (auto &haystack_it : haystack_map) {
-				log("Solving for %s in %s.\n", ("needle_" + RTLIL::unescape_id(needle->name)), haystack_it.first);
-				solver.solve(results, "needle_" + RTLIL::unescape_id(needle->name), haystack_it.first, false);
+				log("Solving for %s in %s.\n", ("needle_" + needle->name.unescape()), haystack_it.first);
+				solver.solve(results, "needle_" + needle->name.unescape(), haystack_it.first, false);
 			}
 			log("Found %d matches.\n", GetSize(results));
 

--- a/passes/techmap/iopadmap.cc
+++ b/passes/techmap/iopadmap.cc
@@ -389,7 +389,7 @@ struct IopadmapPass : public Pass {
 
 				if (wire->port_input && !wire->port_output) {
 					if (inpad_celltype.empty()) {
-						log("Don't map input port %s.%s: Missing option -inpad.\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire->name));
+						log("Don't map input port %s.%s: Missing option -inpad.\n", module, wire);
 						continue;
 					}
 					celltype = inpad_celltype;
@@ -398,7 +398,7 @@ struct IopadmapPass : public Pass {
 				} else
 				if (!wire->port_input && wire->port_output) {
 					if (outpad_celltype.empty()) {
-						log("Don't map output port %s.%s: Missing option -outpad.\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire->name));
+						log("Don't map output port %s.%s: Missing option -outpad.\n", module, wire);
 						continue;
 					}
 					celltype = outpad_celltype;
@@ -407,7 +407,7 @@ struct IopadmapPass : public Pass {
 				} else
 				if (wire->port_input && wire->port_output) {
 					if (inoutpad_celltype.empty()) {
-						log("Don't map inout port %s.%s: Missing option -inoutpad.\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire->name));
+						log("Don't map inout port %s.%s: Missing option -inoutpad.\n", module, wire);
 						continue;
 					}
 					celltype = inoutpad_celltype;
@@ -417,11 +417,11 @@ struct IopadmapPass : public Pass {
 					log_abort();
 
 				if (!flag_bits && wire->width != 1 && widthparam.empty()) {
-					log("Don't map multi-bit port %s.%s: Missing option -widthparam or -bits.\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire->name));
+					log("Don't map multi-bit port %s.%s: Missing option -widthparam or -bits.\n", module, wire);
 					continue;
 				}
 
-				log("Mapping port %s.%s using %s.\n", RTLIL::id2cstr(module->name), RTLIL::id2cstr(wire->name), celltype);
+				log("Mapping port %s.%s using %s.\n", module, wire, celltype);
 
 				if (flag_bits)
 				{
@@ -442,7 +442,7 @@ struct IopadmapPass : public Pass {
 						if (!widthparam.empty())
 							cell->parameters[RTLIL::escape_id(widthparam)] = RTLIL::Const(1);
 						if (!nameparam.empty())
-							cell->parameters[RTLIL::escape_id(nameparam)] = RTLIL::Const(stringf("%s[%d]", RTLIL::id2cstr(wire->name), i));
+							cell->parameters[RTLIL::escape_id(nameparam)] = RTLIL::Const(stringf("%s[%d]", wire, i));
 						cell->attributes[ID::keep] = RTLIL::Const(1);
 					}
 				}
@@ -465,7 +465,7 @@ struct IopadmapPass : public Pass {
 					if (!widthparam.empty())
 						cell->parameters[RTLIL::escape_id(widthparam)] = RTLIL::Const(wire->width);
 					if (!nameparam.empty())
-						cell->parameters[RTLIL::escape_id(nameparam)] = RTLIL::Const(RTLIL::id2cstr(wire->name));
+						cell->parameters[RTLIL::escape_id(nameparam)] = RTLIL::Const(wire->name.unescape());
 					cell->attributes[ID::keep] = RTLIL::Const(1);
 				}
 

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -616,9 +616,9 @@ struct TechmapWorker
 				}
 
 				if (tpl->avail_parameters.count(ID::_TECHMAP_CELLTYPE_) != 0)
-					parameters.emplace(ID::_TECHMAP_CELLTYPE_, RTLIL::unescape_id(cell->type));
+					parameters.emplace(ID::_TECHMAP_CELLTYPE_, cell->type.unescape());
 				if (tpl->avail_parameters.count(ID::_TECHMAP_CELLNAME_) != 0)
-					parameters.emplace(ID::_TECHMAP_CELLNAME_, RTLIL::unescape_id(cell->name));
+					parameters.emplace(ID::_TECHMAP_CELLNAME_, cell->name.unescape());
 
 				for (auto &conn : cell->connections()) {
 					if (tpl->avail_parameters.count(stringf("\\_TECHMAP_CONSTMSK_%s_", conn.first.unescape())) != 0) {

--- a/techlibs/common/opensta.cc
+++ b/techlibs/common/opensta.cc
@@ -98,7 +98,7 @@ struct OpenstaPass : public Pass
 
 		f_script << "read_verilog " << verilog_filename << "\n";
 		f_script << "read_lib " << liberty_filename << "\n";
-		f_script << "link_design " << RTLIL::unescape_id(top_mod->name) << "\n";
+		f_script << "link_design " << top_mod->name.unescape() << "\n";
 		f_script << "read_sdc " << sdc_filename << "\n";
 		f_script << "write_sdc " << sdc_expanded_filename << "\n";
 		f_script.close();

--- a/techlibs/ice40/ice40_braminit.cc
+++ b/techlibs/ice40/ice40_braminit.cc
@@ -46,7 +46,7 @@ static void run_ice40_braminit(Module *module)
 			continue;
 
 		/* Open file */
-		log("Processing %s : %s\n", RTLIL::id2cstr(cell->name), init_file);
+		log("Processing %s : %s\n", cell, init_file);
 
 		std::ifstream f;
 		f.open(init_file.c_str());


### PR DESCRIPTION
This PR includes some further cleanup work after #5862 

- Since `RTLIL::id2cstr` was just wrapper for `log_id` removed places used in our code
- `RTLIL::unescape_id` usages when parameter is `IdString` are replaced with `.unescape()`, those that are left are for strings
- Not to break plugins API is not changed