### PR TITLE
proc: ignore nosync temporaries in always_latch checks

### DIFF
--- a/passes/proc/proc_dlatch.cc
+++ b/passes/proc/proc_dlatch.cc
@@ -395,10 +395,17 @@ void proc_dlatch(proc_dlatch_db_t &db, RTLIL::Process *proc)
 	int offset = 0;
 	for (auto chunk : nolatches_bits.first.chunks()) {
 		SigSpec lhs = chunk, rhs = nolatches_bits.second.extract(offset, chunk.width);
-		if (proc->get_bool_attribute(ID::always_latch))
+		bool is_nosync = true;
+		for (auto bit : lhs)
+			if (bit.wire == nullptr || !bit.wire->get_bool_attribute(ID::nosync)) {
+				is_nosync = false;
+				break;
+			}
+
+		if (proc->get_bool_attribute(ID::always_latch) && !is_nosync)
 			log_error("No latch inferred for signal `%s.%s' from always_latch process `%s.%s'.\n",
 					db.module->name.c_str(), log_signal(lhs), db.module->name.c_str(), proc->name.c_str());
-		else
+		else if (!is_nosync)
 			log("No latch inferred for signal `%s.%s' from process `%s.%s'.\n",
 					db.module->name.c_str(), log_signal(lhs), db.module->name.c_str(), proc->name.c_str());
 		for (auto &bit : lhs) {

--- a/tests/various/svalways.sh
+++ b/tests/various/svalways.sh
@@ -18,6 +18,20 @@ always_latch
 endmodule
 EOT
 
+# Good case: dynamic memory writes in always_latch create nosync mem2reg
+# temporaries, but only the memory words themselves should be checked for
+# latch inference.
+${YOSYS} -f "verilog -sv" -qp proc - <<EOT
+module top(input [3:0] addr, input we, input [31:0] data);
+logic [31:0] regs [0:15];
+
+always_latch
+	if (we)
+		regs[addr] = data;
+
+endmodule
+EOT
+
 # Incorrect always_comb syntax
 ((${YOSYS} -f "verilog -sv" -qp proc -|| true) <<EOT
 module top(input d, output reg q);


### PR DESCRIPTION
fix this bug.https://github.com/YosysHQ/yosys/issues/5871
proc: ignore nosync temporaries in always_latch checks

mem2reg can generate nosync address/data temporaries for dynamic memory
writes inside always_latch blocks. These temporaries are combinational
implementation details and should not trigger the always_latch "no latch
inferred" error.

Add a SystemVerilog regression for dynamic memory writes in always_latch.