### PR TITLE
opt_clean: Set group for docs gen

### DIFF
--- a/passes/opt/opt_clean/opt_clean.cc
+++ b/passes/opt/opt_clean/opt_clean.cc
@@ -19,6 +19,7 @@
 
 #include "kernel/register.h"
 #include "kernel/log.h"
+#include "kernel/log_help.h"
 #include "passes/opt/opt_clean/opt_clean.h"
 
 USING_YOSYS_NAMESPACE
@@ -43,6 +44,12 @@ void rmunused_module(RTLIL::Module *module, bool rminit, CleanRunContext &clean_
 
 struct OptCleanPass : public Pass {
 	OptCleanPass() : Pass("opt_clean", "remove unused cells and wires") { }
+	bool formatted_help() override
+	{
+		auto *help = PrettyHelp::get_current();
+		help->set_group("passes/opt");
+		return false;
+	}
 	void help() override
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
@@ -99,6 +106,12 @@ struct OptCleanPass : public Pass {
 
 struct CleanPass : public Pass {
 	CleanPass() : Pass("clean", "remove unused cells and wires") { }
+	bool formatted_help() override
+	{
+		auto *help = PrettyHelp::get_current();
+		help->set_group("passes/opt");
+		return false;
+	}
 	void help() override
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
`opt` and `opt_clean` are currently missing from docs; see [The coarse-grain representation/Part 1](https://yosyshq.readthedocs.io/projects/yosys/en/latest/getting_started/example_synth.html#part-1), instead of links (like `opt_expr`), it's just formatted text (which is the fallback behavior for a missing link).  Noticed this while building docs locally and seeing a lot of `Missing ref for opt_clean in getting_started/example_synth` messages.

_Explain how this is achieved._

The passes are still in the `cmds.json`, they're just in the `passes/opt/opt_clean` group, which doesn't get referenced anywhere so the commands are silently dropped.  This PR assigns them (back) to the `passes/opt` group (where they were automatically appearing prior to #5664 moving them into a sub folder).  From what I can see these are the only two passes in that folder, so I think it makes more sense to include them in the main opt group over adding in the new automatic group as a separate one.