### PR TITLE
genrtlil: don't avoid emitting flops for nosync

### DIFF
--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -406,18 +406,6 @@ struct AST_INTERNAL::ProcessGenerator
 				if (GetSize(syncrule->signal) != 1)
 					always->input_error("Found posedge/negedge event on a signal that is not 1 bit wide!\n");
 				addChunkActions(syncrule->actions, subst_lvalue_from, subst_lvalue_to, true);
-				// Automatic (nosync) variables must not become flip-flops: remove
-				// them from clocked sync rules so that proc_dff does not infer
-				// an unnecessary register for a purely combinational temporary.
-				syncrule->actions.erase(
-					std::remove_if(syncrule->actions.begin(), syncrule->actions.end(),
-						[](const RTLIL::SigSig &ss) {
-							for (auto &chunk : ss.first.chunks())
-								if (chunk.wire && chunk.wire->get_bool_attribute(ID::nosync))
-									return true;
-							return false;
-						}),
-					syncrule->actions.end());
 				proc->syncs.push_back(syncrule);
 			}
 		if (proc->syncs.empty()) {

--- a/tests/verilog/automatic_lifetime.ys
+++ b/tests/verilog/automatic_lifetime.ys
@@ -15,6 +15,7 @@ module t1(input a, b, c, output reg y);
 endmodule
 EOF
 proc
+opt_clean
 async2sync
 # no state elements for tmp
 select -assert-none t:$dff t:$dlatch %%
@@ -39,6 +40,7 @@ module t2(input [3:0] a, b, input sel, output reg [3:0] y, output reg co);
 endmodule
 EOF
 proc
+opt_clean
 async2sync
 select -assert-none t:$dff t:$dlatch %%
 sat -verify -prove-asserts -show-all
@@ -59,6 +61,7 @@ module t3(input clk, rst, input [7:0] data, output reg [7:0] result);
 endmodule
 EOF
 proc
+opt_clean
 # Exactly one DFF (for result), zero latches, no DFF for tmp
 select -assert-count 1 t:$dff %%
 select -assert-none t:$dlatch %%
@@ -80,6 +83,7 @@ module t4(input [7:0] a, b, input sub, output reg [7:0] y);
 endmodule
 EOF
 proc
+opt_clean
 async2sync
 select -assert-none t:$dff t:$dlatch %%
 sat -verify -prove-asserts -show-all
@@ -100,5 +104,6 @@ module t5(input en, d, output reg q);
 endmodule
 EOF
 proc
+opt_clean
 # No latch for tmp — X propagates instead of old value
 select -assert-none t:$dff t:$dlatch %%


### PR DESCRIPTION
Fixes #5911 by removing nosync handling added in #5714 which wasn't necessary to support automatic lifetime qualifiers. It is preferrable to continue to emit flops for nosync if it causes issues with unused drivers for unused designs, if it was only added for convenience in a test and for logical consistency. I'd be happy to re-add the removal of those syncrule actions in genrtlil already, if somebody figures out how to do it safely wrt #5911.

The idea is this: it is bad but acceptable to emit an unused flop from a nosync wire, but it is unacceptable to fail `check -assert`