### PR TITLE
verilog backend: runtime optimization for keyword pool

### DIFF
--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -38,7 +38,7 @@ USING_YOSYS_NAMESPACE
 
 using namespace VERILOG_BACKEND;
 
-const pool<string> VERILOG_BACKEND::verilog_keywords() {
+const pool<string> &VERILOG_BACKEND::verilog_keywords() {
 	static const pool<string> res = {
 		// IEEE 1800-2017 Annex B
 		"accept_on", "alias", "always", "always_comb", "always_ff", "always_latch", "and", "assert", "assign", "assume", "automatic", "before",

--- a/backends/verilog/verilog_backend.h
+++ b/backends/verilog/verilog_backend.h
@@ -29,7 +29,7 @@
 YOSYS_NAMESPACE_BEGIN
 namespace VERILOG_BACKEND {
 
-    const pool<string> verilog_keywords();
+    const pool<string> &verilog_keywords();
     bool char_is_verilog_escaped(char c);
     bool id_is_verilog_escaped(const std::string &str);
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
Runtime optimization, on some of our designs copying the keyword pool took about 5% of overall Yosys time (12 minutes on 4hr run).

_Explain how this is achieved._
Although `VERILOG_BACKEND::verilog_keywords()`'s keyword pool is defined as static it creates a copy of it at return.

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._
Profile diff: At our sampling rate, `VERILOG_BACKEND::verilog_keywords()` disappears from the profile entirely (100% relative speedup)
<img width="991" height="342" alt="image" src="https://github.com/user-attachments/assets/235e3af9-83de-4f20-b302-03565ba759c0" />