### PR TITLE
setundef: strip init attributes from undriven wires (fixes #5835)

### DIFF
--- a/passes/cmds/setundef.cc
+++ b/passes/cmds/setundef.cc
@@ -355,6 +355,28 @@ struct SetundefPass : public Pass {
 								bits.append(worker.next_bit());
 						module->connect(RTLIL::SigSig(c, bits));
 					}
+					// Remove init attributes from undriven wires to prevent
+					// conflicts with the values we just assigned (issue #5835).
+					for (auto &c : sig.chunks()) {
+						if (c.wire && c.wire->attributes.count(ID::init)) {
+							if (c.wire->width == c.width && c.offset == 0) {
+								c.wire->attributes.erase(ID::init);
+								log("Removing init attribute from undriven wire %s.\n", log_id(c.wire));
+							} else {
+								Const &initval = c.wire->attributes[ID::init];
+								initval.resize(GetSize(c.wire), State::Sx);
+								for (int i = c.offset; i < c.offset + c.width; i++)
+									initval.set(i, State::Sx);
+								if (initval.is_fully_undef()) {
+									c.wire->attributes.erase(ID::init);
+									log("Removing init attribute from undriven wire %s.\n", log_id(c.wire));
+								} else {
+									log("Clearing init attribute bits [%d:%d] from partially undriven wire %s.\n",
+										c.offset + c.width - 1, c.offset, log_id(c.wire));
+								}
+							}
+						}
+					}
 				}
 			}
 

--- a/tests/various/setundef_init.ys
+++ b/tests/various/setundef_init.ys
@@ -1,0 +1,61 @@
+# Test for issue #5835: setundef -undriven should not cause conflicts
+# with init attributes on undriven wires.
+
+# Test 1: Basic case from the bug report - undriven wire with init attribute
+read_rtlil << EOT
+module \top
+    attribute \init 3
+    wire width 4 \i
+end
+EOT
+setundef -undriven -undef
+# Verify that the init attribute was removed from the undriven wire
+select -assert-count 0 w:* a:init %i
+# Verify that opt doesn't crash with "Conflicting init values" error
+opt
+design -reset
+
+# Test 2: setundef -undriven -zero with init attribute
+read_rtlil << EOT
+module \top
+    attribute \init 3
+    wire width 4 \i
+end
+EOT
+setundef -undriven -zero
+select -assert-count 0 w:* a:init %i
+opt
+design -reset
+
+# Test 3: setundef -undriven -one with init attribute
+read_rtlil << EOT
+module \top
+    attribute \init 3
+    wire width 4 \i
+end
+EOT
+setundef -undriven -one
+select -assert-count 0 w:* a:init %i
+opt
+design -reset
+
+# Test 4: Wire driven by a cell should keep its init attribute
+read_rtlil << EOT
+module \top
+    wire width 1 input 1 \clk
+    wire width 1 input 2 \d
+    attribute \init 1'0
+    wire width 1 output 3 \q
+    cell $dff \myff
+        parameter \CLK_POLARITY 1'1
+        parameter \WIDTH 1
+        connect \CLK \clk
+        connect \D \d
+        connect \Q \q
+    end
+end
+EOT
+setundef -undriven -zero
+# The init attribute should still be present since the wire is driven by a FF
+select -assert-count 1 w:* a:init %i
+design -reset


### PR DESCRIPTION
## Summary

Fix `setundef -undriven` causing "Conflicting init values" errors when applied to undriven wires that have an `\init` attribute.

## Problem

When running:
```
read_rtlil << EOT
module \top
    attribute \init 3
    wire width 4 \i
end
EOT
setundef -undriven -undef
opt
```

The `setundef` pass connects the undriven wire `\i` to `4'x`, but leaves the `\init 3` attribute intact. The subsequent `opt` pass (specifically `opt_merge`) then detects a contradiction between the init value and the driven constant, producing:

```
ERROR: Conflicting init values for signal 1'x (\i [2] = 1'0 != 1'1).
```

## Fix

After connecting undriven wires to replacement values in the `-undriven` (non-expose) code path, the `\init` attribute is now removed from those wires:

- **Fully undriven wires**: the `\init` attribute is removed entirely.
- **Partially undriven wires** (only some bits undriven): only the corresponding init bits are cleared to `x`. If all bits become `x`, the attribute is removed.

Wires driven by cells (e.g., flip-flops) are unaffected since they are excluded from the undriven signal set before this code runs.

## Testing

Added `tests/various/setundef_init.ys` with 4 test cases:
1. Bug reproduction case (`-undriven -undef` + init attribute)
2. `-undriven -zero` + init attribute
3. `-undriven -one` + init attribute
4. Regression: FF-driven wire correctly retains its init attribute

All existing setundef tests (`setundef.ys`, `setundef_selection.ys`) continue to pass.

Closes #5835