### PR TITLE
kernel/tclapi: check return values of libtommath mp_* calls

### DIFF
--- a/kernel/tclapi.cc
+++ b/kernel/tclapi.cc
@@ -206,13 +206,13 @@ bool mp_int_to_const(mp_int *a, Const &b, bool is_signed)
 		return false;
 
 	if (negative) {
-		mp_neg(a, a);
-		mp_sub_d(a, 1, a);
+		if (mp_neg(a, a) != MP_OKAY) return false;
+		if (mp_sub_d(a, 1, a) != MP_OKAY) return false;
 	}
 
 	std::vector<unsigned char> buf;
 	buf.resize(mp_unsigned_bin_size(a));
-	mp_to_unsigned_bin(a, buf.data());
+	if (mp_to_unsigned_bin(a, buf.data()) != MP_OKAY) return false;
 
 	Const::Builder b_bits(mp_count_bits(a) + is_signed);
 	for (int i = 0; i < mp_count_bits(a);) {


### PR DESCRIPTION
Fixes #5925.

Yosys fails to build on macOS (and any system) where the `libtommath` (1.3.0 on my machine installed via `brew`) headers expand `MP_WUR` to `__attribute__((warn_unused_result))`. `kernel/tclapi.cc:209-215` ignores the return values of `mp_neg`, `mp_sub_d`, and `mp_to_unsigned_bin`, and `-Werror=unused` (`Makefile:107`) promotes the warning to a hard error.

Each of the three calls now checks for `MP_OKAY` and returns `false` on failure.