### PR TITLE
Let nested make calls parallelize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,10 @@ include(YosysAbcSubmodule)
 include(YosysVerific)
 include(UseHomebrew)
 
+# Fix for using Clang from nixpkgs
+# see https://github.com/YosysHQ/yosys/pull/5936#issuecomment-4637319568
+set(CMAKE_CXX_SCAN_FOR_MODULES NO)
+
 # Build options.
 set(YOSYS_COMPILER_LAUNCHER "" CACHE STRING "Compiler launcher (ccache, sccache)")
 option(YOSYS_ENABLE_COVERAGE "Enable code coverage" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if (CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR)
 	)
 endif()
 
-cmake_minimum_required(VERSION 3.27)
+cmake_minimum_required(VERSION 3.28)
 project(yosys LANGUAGES C CXX)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
@@ -532,6 +532,7 @@ if (NOT YOSYS_BUILD_PYTHON_ONLY)
 		COMMAND make vanilla-test ${makefile_vars}
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests
 		DEPENDS ${makefile_depends}
+		JOB_SERVER_AWARE TRUE
 	)
 
 	add_custom_target(test
@@ -543,6 +544,7 @@ if (NOT YOSYS_BUILD_PYTHON_ONLY)
 		COMMAND make gen ${makefile_vars}
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docs
 		DEPENDS ${makefile_depends}
+		JOB_SERVER_AWARE TRUE
 	)
 	foreach (format html latexpdf)
 		add_custom_target(docs-${format}
@@ -555,6 +557,7 @@ if (NOT YOSYS_BUILD_PYTHON_ONLY)
 		COMMAND make test ${makefile_vars}
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docs
 		DEPENDS ${makefile_depends}
+		JOB_SERVER_AWARE TRUE
 	)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ or
 	$ git submodule update --init --recursive
 
 A C++ compiler with C++20 support is required as well as some standard tools
-such as GNU Flex, GNU Bison (>=3.8), CMake (>=3.27), Make (or other CMake
+such as GNU Flex, GNU Bison (>=3.8), CMake (>=3.28), Make (or other CMake
 generator such as Ninja), and Python (>=3.11). Some additional tools: readline,
 libffi, Tcl and zlib; will be used if available but are optional. Graphviz and
 Xdot are used by the `show` command to display schematics.

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -88,7 +88,7 @@ Build prerequisites
 ^^^^^^^^^^^^^^^^^^^
 
 A C++ compiler with C++20 support is required as well as some standard tools
-such as GNU Flex, GNU Bison (>=3.8), CMake (>=3.27), Make (or other CMake
+such as GNU Flex, GNU Bison (>=3.8), CMake (>=3.28), Make (or other CMake
 generator such as Ninja), and Python (>=3.11). Some additional tools: readline,
 libffi, Tcl and zlib; will be used if available but are optional. Graphviz and
 Xdot are used by the `show` command to display schematics.


### PR DESCRIPTION
Bump minimum cmake version to 3.28 to use `JOB_SERVER_AWARE` when calling the `test-vanilla` target (and also `docs-prepare` and `test-docs`, though it's not as important there).

Sidenote that install instructions still specify 3.27 as the min because I used the web interface and could only edit the one file.  I'm not sure if there's a specific reason why we are targeting 3.27 as the min version, but if not I think this change might be nice to have (or I'm dumb and missing how to get the tests parallel without this, I'm also unclear if it's possible to do this when using Ninja).