### PR TITLE
Fix meminit enable for initialized memories

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -3687,14 +3687,22 @@ skip_dynamic_range_lvalue_expansion:;
 		}
 		if (assign_data)
 			newNode->children.push_back(std::move(assign_data));
+
+		std::unique_ptr<AstNode> meminit_en = nullptr;
+		if (current_always->type == AST_INITIAL && assign_en && assign_en->children[1]->isConst())
+			meminit_en = assign_en->children[1]->clone();
+
 		if (assign_en)
 			newNode->children.push_back(std::move(assign_en));
 
 		std::unique_ptr<AstNode> wrnode;
-		if (current_always->type == AST_INITIAL)
-			wrnode = std::make_unique<AstNode>(location, AST_MEMINIT, std::move(node_addr), std::move(node_data), std::move(node_en), mkconst_int(location, 1, false));
-		else
+		if (current_always->type == AST_INITIAL) {
+			if (!meminit_en)
+				meminit_en = std::move(node_en);
+			wrnode = std::make_unique<AstNode>(location, AST_MEMINIT, std::move(node_addr), std::move(node_data), std::move(meminit_en), mkconst_int(location, 1, false));
+		} else {
 			wrnode = std::make_unique<AstNode>(location, AST_MEMWR, std::move(node_addr), std::move(node_data), std::move(node_en));
+		}
 		wrnode->str = children[0]->str;
 		wrnode->id2ast = children[0]->id2ast;
 		wrnode->location = location;

--- a/tests/various/issue5853.ys
+++ b/tests/various/issue5853.ys
@@ -1,0 +1,16 @@
+read_verilog <<EOT
+module top(output [31:0] y);
+  reg [31:0] mem [0:3];
+
+  initial begin
+    mem[0] = 32'h00000000;
+    mem[1] = 32'h11111111;
+    mem[2] = 32'h22222222;
+    mem[3] = 32'h33333333;
+  end
+
+  assign y = mem[0];
+endmodule
+EOT
+
+write_verilog


### PR DESCRIPTION
# Fix write_verilog on initialized memories after read_verilog

Fixes #5853.

## Summary

This fixes a `write_verilog` failure after `read_verilog` on initialized memories:

```text
Non-constant enable ... in memory initialization ...
```

For procedural memory writes in an `initial` block, the AST frontend rewrites the assignment into an `AST_MEMINIT`. In the constant-write case, the rewrite already creates a constant assignment mask for the temporary enable signal, but the `AST_MEMINIT` node was still using the temporary enable wire itself.

Later, memory collection requires `$meminit_v2` `ADDR`, `DATA`, and `EN` values to be fully constant. Using the temporary enable wire made the memory initialization look non-constant even though the assignment mask was constant.

## Fix

When rewriting an `initial` memory write, preserve the constant enable mask directly on the generated `AST_MEMINIT` node when one is available. Non-constant/fallback cases keep the previous behavior.

## Test

Added `tests/various/issue5853.ys`, covering:

- `read_verilog` of a module with initialized memory writes
- immediate `write_verilog`
- no `Non-constant enable` error

## Verification

Built and tested in WSL from a clean checkout at `cc9692caa`:

```sh
cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug
cmake --build build --target yosys --parallel $(nproc)
build/yosys -q -s tests/various/issue5853.ys
```

The regression passes.