### PR TITLE
verific: do not link TCL command line interface

### DIFF
--- a/cmake/YosysVerific.cmake
+++ b/cmake/YosysVerific.cmake
@@ -25,6 +25,9 @@ function(get_verific_components result)
 		list(APPEND components ${component})
 	endforeach()
 
+	# Always remove TCL command interface
+	list(REMOVE_ITEM components commands)
+
 	set(${result} ${components})
 	return(PROPAGATE ${result})
 endfunction()


### PR DESCRIPTION
This also enables yosys binary to use TCL 9 even if Verific library has modules that are using TCL 8.
