### PR TITLE
simplify.cc: Fix crash when identifier matches module

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1057,7 +1057,7 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 
 #if 0
 	log("-------------\n");
-	log("AST simplify[%d] depth %d at %s:%d on %s %p:\n", stage, recursion_counter, location.begin.filename, location.begin.line, type2str(type), this);
+	log("AST simplify[%d] depth %d at %s on %s %p:\n", stage, recursion_counter, location.to_string(), type2str(type), this);
 	log("const_fold=%d, stage=%d, width_hint=%d, sign_hint=%d\n",
 			int(const_fold), int(stage), int(width_hint), int(sign_hint));
 	// dumpAst(nullptr, "> ");
@@ -5041,7 +5041,7 @@ void AstNode::expand_genblock(const std::string &prefix)
 			if (!child->str.empty() && prefix.size() > 0) {
 				bool is_resolved = false;
 				std::string identifier_str = child->str;
-				if (current_ast_mod != nullptr && identifier_str.compare(0, current_ast_mod->str.size(), current_ast_mod->str) == 0) {
+				if (current_ast_mod != nullptr && identifier_str.size() > current_ast_mod->str.size() && identifier_str.compare(0, current_ast_mod->str.size(), current_ast_mod->str) == 0) {
 					if (identifier_str.at(current_ast_mod->str.size()) == '.') {
 						identifier_str = '\\' + identifier_str.substr(current_ast_mod->str.size()+1, identifier_str.size());
 					}


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Fix #5954.  #4235 added auto identifiers such as `\a.x`, and then extracts them as `\x` during simplification if the current scope is `\a`.  If the identifier (`identifier_str`) starts with the scope name (`current_ast_mod->str`), it tries to evaluate `identifier_str.at(current_ast_mod->str.size()) == '.'`.  If the two strings are exactly the same, then it tries to access the next character (to check if it's a `\a.x` situation) which is out of bands and crashes.

_Explain how this is achieved._

Only check for the `.` if the identifier string is longer than the scope string, preventing the out of bounds access.  Not sure if it's worth including a test case here, but the minimal script is:

```
read_verilog << EOT
module pdm #(
    parameter PHY = "zero"
)(
    output wire pdm
);
    if (PHY == "zero") begin
        assign pdm = 1'b0;
    end
endmodule
EOT
```