### PR TITLE
opt_muxtree: error on multiple drivers

### DIFF
--- a/passes/opt/opt_muxtree.cc
+++ b/passes/opt/opt_muxtree.cc
@@ -68,7 +68,7 @@ struct OptMuxtreeWorker
 		// Is bit directly used by non-mux cells or ports?
 		bool seen_non_mux;
 		pool<int> mux_users;
-		pool<int> mux_drivers;
+		std::optional<int> mux_driver;
 	};
 
 	idict<SigBit> bit2num;
@@ -107,7 +107,7 @@ struct OptMuxtreeWorker
 		// Populate bit2info[]:
 		//	.seen_non_mux
 		//	.mux_users
-		//	.mux_drivers
+		//	.mux_driver
 		// Populate mux2info[].ports[]:
 		//	.ctrl_sig
 		//	.input_sigs
@@ -137,8 +137,11 @@ struct OptMuxtreeWorker
 		// Analyze port A
 		muxinfo.ports.push_back(used_port_bit(sig_a, this_mux_idx));
 
-		for (int idx : sig2bits(sig_y))
-			bit2info[idx].mux_drivers.insert(this_mux_idx);
+		for (int idx : sig2bits(sig_y)) {
+			if (bit2info[idx].mux_driver)
+				log_cmd_error("Cell %s Y port signal %s already driven by %s\n", cell->name, log_signal(sig_y), mux2info[*bit2info[idx].mux_driver].cell->name);
+			bit2info[idx].mux_driver = this_mux_idx;
+		}
 
 		for (int idx : sig2bits(sig_s))
 			bit2info[idx].seen_non_mux = true;
@@ -170,8 +173,8 @@ struct OptMuxtreeWorker
 		for (int j : bit2info[i].mux_users)
 		for (auto &p : mux2info[j].ports) {
 			if (p.input_sigs.count(i))
-				for (int k : bit2info[i].mux_drivers)
-					p.input_muxes.insert(k);
+				if (bit2info[i].mux_driver)
+					p.input_muxes.insert(*bit2info[i].mux_driver);
 		}
 	}
 
@@ -184,14 +187,14 @@ struct OptMuxtreeWorker
 		root_muxes.resize(GetSize(mux2info));
 
 		for (auto &bi : bit2info) {
-			for (int i : bi.mux_drivers)
+			if (bi.mux_driver)
 				for (int j : bi.mux_users)
-					mux_to_users[i].insert(j);
+					mux_to_users[*bi.mux_driver].insert(j);
 			if (!bi.seen_non_mux)
 				continue;
-			for (int mux_idx : bi.mux_drivers) {
-				root_muxes.at(mux_idx) = true;
-				root_enable_muxes.at(mux_idx) = true;
+			if (bi.mux_driver) {
+				root_muxes.at(*bi.mux_driver) = true;
+				root_enable_muxes.at(*bi.mux_driver) = true;
 			}
 		}
 

--- a/tests/hana/test_parse2synthtrans.v
+++ b/tests/hana/test_parse2synthtrans.v
@@ -23,33 +23,7 @@ always @(clk or reset) begin
 end
 endmodule
 
-// test_parse2synthtrans_case_1_test.v
-module f2_demultiplexer1_to_4 (out0, out1, out2, out3, in, s1, s0);
-output out0, out1, out2, out3;
-reg out0, out1, out2, out3;
-input in;
-input s1, s0;
-reg [3:0] encoding;
-reg [1:0] state;
-   always @(encoding) begin
-        case (encoding)
-        4'bxx11: state = 1;
-        4'bx0xx: state = 3;
-        4'b11xx: state = 4;
-        4'bx1xx: state = 2;
-        4'bxx1x: state = 1;
-        4'bxxx1: state = 0;
-        default: state = 0;
-        endcase
-   end
-   
-   always @(encoding) begin
-        case (encoding)
-        4'b0000: state = 1;
-        default: state = 0;
-        endcase
-   end
-endmodule
+// test_parse2synthtrans_case_1_test.v module f2_demultiplexer1_to_4 - REMOVED, multiple drivers
 
 // test_parse2synthtrans_contassign_1_test.v
 module f3_test(in, out);


### PR DESCRIPTION
It doesn't make sense for opt_muxtree to hold a pool of mux drivers of a signal bit since synthesizable designs can only have one driver of a wire bit. If there's multiple drivers, error and remove invalid test that breaks.