### PR TITLE
Fix share lookup for mingw builds

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -156,7 +156,7 @@ yosys_core(kernel
 
 set(yosys_cc_definitions
 	"$<$<BOOL:${YOSYS_ABC_EXECUTABLE}>:ABCEXTERNAL=\"${YOSYS_ABC_EXECUTABLE}\">"
-	$<$<BOOL:${MSYS}>:YOSYS_WIN32_UNIX_DIR>
+	$<$<BOOL:${MINGW}>:YOSYS_WIN32_UNIX_DIR>
 )
 set_source_files_properties(yosys.cc PROPERTIES
 	COMPILE_DEFINITIONS "${yosys_cc_definitions}"


### PR DESCRIPTION
This solves https://github.com/YosysHQ/oss-cad-suite-build/issues/208 

And also in of Makefile we did add this parameter for all mingw builds, being created under msys or not.