### PR TITLE
write_verilog: Fix upto indexing for single bit

### DIFF
--- a/backends/verilog/verilog_backend.cc
+++ b/backends/verilog/verilog_backend.cc
@@ -197,14 +197,22 @@ bool is_reg_wire(RTLIL::SigSpec sig, std::string &reg_name)
 
 	reg_name = id(chunk.wire->name);
 	if (sig.size() != chunk.wire->width) {
-		if (sig.size() == 1)
-			reg_name += stringf("[%d]", chunk.wire->start_offset +  chunk.offset);
-		else if (chunk.wire->upto)
-			reg_name += stringf("[%d:%d]", (chunk.wire->width - (chunk.offset + chunk.width - 1) - 1) + chunk.wire->start_offset,
-					(chunk.wire->width - chunk.offset - 1) + chunk.wire->start_offset);
+		int idx;
+		if (chunk.wire->upto)
+			idx = (chunk.wire->width - chunk.offset - 1) + chunk.wire->start_offset;
 		else
-			reg_name += stringf("[%d:%d]", chunk.wire->start_offset +  chunk.offset + chunk.width - 1,
-					chunk.wire->start_offset +  chunk.offset);
+			idx = chunk.wire->start_offset + chunk.offset;
+
+		if (sig.size() == 1)
+			reg_name += stringf("[%d]", idx);
+		else {
+			int left_idx;
+			if (chunk.wire->upto)
+				left_idx = (chunk.wire->width - (chunk.offset + chunk.width - 1) - 1) + chunk.wire->start_offset;
+			else
+				left_idx = chunk.wire->start_offset +  chunk.offset + chunk.width - 1;
+			reg_name += stringf("[%d:%d]", left_idx, idx);
+		}
 	}
 
 	return true;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -75,6 +75,7 @@ MK_TEST_DIRS += ./memories
 MK_TEST_DIRS += ./aiger
 MK_TEST_DIRS += ./alumacc
 MK_TEST_DIRS += ./check_mem
+MK_TEST_DIRS += ./write_verilog
 
 all: vanilla-test
 

--- a/tests/write_verilog/generate_mk.py
+++ b/tests/write_verilog/generate_mk.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import glob
+
+import sys
+sys.path.append("..")
+
+import gen_tests_makefile
+
+def generate_write_test(sv_file: str):
+    # if the first line of the file starts with // (ie a comment), the rest of
+    # the line is treated as the commands to run after reading the input
+    header_cmds = ""
+    with open(sv_file, "r") as f:
+        line = f.readline().rstrip()
+        if line.startswith("//"):
+            header_cmds = line[3:]
+
+    # process input & write output
+    read_cmd = f"read -sv {sv_file}; {header_cmds}"
+    out_file = f"{sv_file}.out"
+    out_yosys_cmd = f"{read_cmd}; rename gold gate; write_verilog {out_file}"
+    out_cmd = f'$(YOSYS) -l {out_file}.err -p "{out_yosys_cmd}" && mv {out_file}.err {out_file}.log'
+    gen_tests_makefile.generate_target(out_file, out_cmd)
+
+    # test input & output equivalence
+    equiv = "equiv_make gold gate equiv; equiv_induct equiv; equiv_status -assert equiv"
+    yosys_cmd = f"{read_cmd}; design -stash gold; read -sv {out_file}; {header_cmds}; design -import gold; {equiv}"
+    cmd = f'$(YOSYS) -l {sv_file}.err -p "{yosys_cmd}" && mv {sv_file}.err {sv_file}.log'
+    gen_tests_makefile.generate_target(sv_file, cmd, [out_file])
+
+def generate_write_tests():
+    # currently configured to use `read -sv` on each
+    for f in sorted(glob.glob("*.sv")):
+        generate_write_test(f)
+
+gen_tests_makefile.generate_custom(generate_write_tests)

--- a/tests/write_verilog/mixed_upto.sv
+++ b/tests/write_verilog/mixed_upto.sv
@@ -1,0 +1,13 @@
+// hierarchy; proc;; simplemap
+module gold(
+  input clk,
+  input [1:0] in,
+  output reg [1:0] out
+);
+  reg [0:1] r;
+
+  always @(posedge clk) begin
+    out <= r;
+    r <= in;
+  end
+endmodule


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Fix #5969 

_Explain how this is achieved._

Previous behavior failed to check the `upto` field when `sig.size() == 1` when outputting register assignments, leading to problems with verilog output post techmapping when using upto ranges.

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._

I've added a `tests/write_verilog` directory; I feel like `write_verilog` equivalence checking comes up often enough that it's worth adding a specific test method for it.  The `mixed_upto.sv` test runs the example from #5969 and writes out the verilog.  The two verilog files are then compared with `equiv_induct`, failing if they don't match.