### PR TITLE
[docs] nit: least/most significant bits referred to using LSB/MSB instead of LSb/MSb

### DIFF
--- a/docs/source/yosys_internals/formats/rtlil_rep.rst
+++ b/docs/source/yosys_internals/formats/rtlil_rep.rst
@@ -158,8 +158,8 @@ An ``RTLIL::Wire`` object has the following properties:
 -  The wire name
 -  A list of attributes
 -  A width (buses are just wires with a width more than 1)
--  Bus direction (MSB to LSB or vice versa)
--  Lowest valid bit index (LSB or MSB depending on bus direction)
+-  Bus direction (MSb to LSb or vice versa)
+-  Lowest valid bit index (LSb or MSb depending on bus direction)
 -  If the wire is a port: port number and direction (input/output/inout)
 
 As with modules, the attributes can be Verilog attributes imported by the

--- a/docs/source/yosys_internals/formats/rtlil_rep.rst
+++ b/docs/source/yosys_internals/formats/rtlil_rep.rst
@@ -171,8 +171,8 @@ signals. This makes some aspects of RTLIL more complex but enables Yosys to be
 used for coarse grain synthesis where the cells of the target architecture
 operate on entire signal vectors instead of single bit wires.
 
-In Verilog and VHDL, busses may have arbitrary bounds, and LSB can have either
-the lowest or the highest bit index. In RTLIL, bit 0 always corresponds to LSB;
+In Verilog and VHDL, busses may have arbitrary bounds, and LSb can have either
+the lowest or the highest bit index. In RTLIL, bit 0 always corresponds to LSb;
 however, information from the HDL frontend is preserved so that the bus will be
 correctly indexed in error messages, backend output, constraint files, etc.
 


### PR DESCRIPTION
Tiny nit, but the description of `RTLIL::Wire` was using MSB and LSB to refer to the least and most significant *bits* of a wire and not Bytes, which should be referred to using LSb and MSb instead.