### PR TITLE
Remove define since snprintf is supported in MSVC now

### DIFF
--- a/kernel/yosys_common.h
+++ b/kernel/yosys_common.h
@@ -77,7 +77,6 @@
 
 #  define strtok_r strtok_s
 #  define strdup _strdup
-#  define snprintf _snprintf
 #  define getcwd _getcwd
 #  define mkdir _mkdir
 #  define popen _popen


### PR DESCRIPTION
This actually brakes code that uses std::snprintf and due to macro gets converted into something non-existing.