### PR TITLE
synth_intel: fix broken dsp mapping

### DIFF
--- a/techlibs/intel/CMakeLists.txt
+++ b/techlibs/intel/CMakeLists.txt
@@ -40,6 +40,7 @@ yosys_pass(synth_intel
 
 		max10/cells_sim.v
 		max10/cells_map.v
+		max10/dsp_map.v
 
 		cyclone10lp/cells_sim.v
 		cyclone10lp/cells_map.v

--- a/techlibs/intel/synth_intel.cc
+++ b/techlibs/intel/synth_intel.cc
@@ -176,6 +176,9 @@ struct SynthIntelPass : public ScriptPass {
 		    family_opt != "cyclone10lp")
 			log_cmd_error("Invalid or no family specified: '%s'\n", family_opt);
 
+		if (family_opt != "max10")
+			nodsp = true;
+
 		log_header(design, "Executing SYNTH_INTEL pass.\n");
 		log_push();
 


### PR DESCRIPTION
synth_intel is deprecated for a while, but still this was quite broken, so now DSP mapping is working where applicable (feature added in https://github.com/YosysHQ/yosys/pull/4262)