### PR TITLE
Store caches on main

### DIFF
--- a/.github/workflows/extra-builds.yml
+++ b/.github/workflows/extra-builds.yml
@@ -3,8 +3,8 @@ name: Test extra build flows
 on:
   pull_request:
   merge_group:
-  #push:
-  #  branches: [ main ]
+  push:
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
@@ -27,6 +27,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "merge_group" ]; then
             echo "should_skip=false" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            should_skip=false
           else
             echo "should_skip=${{ steps.skip_check.outputs.should_skip }}" >> $GITHUB_OUTPUT
           fi
@@ -35,7 +37,7 @@ jobs:
     name: Visual Studio build
     runs-on: windows-latest
     needs: [pre_job]
-    if: (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
     steps:
       - uses: actions/checkout@v7
         with:
@@ -51,6 +53,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: vs-build
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           restore-keys: |
             vs-build-
 
@@ -80,7 +83,7 @@ jobs:
     name: MINGW64 build
     runs-on: windows-latest
     needs: [pre_job]
-    if: (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
     steps:
       - uses: actions/checkout@v7
         with:
@@ -114,6 +117,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: mingw-build
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           restore-keys: |
             mingw-build-
 
@@ -130,7 +134,7 @@ jobs:
   wasi-build:
     name: WASI build
     needs: pre_job
-    if: (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -142,6 +146,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: wasi-build
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           restore-keys: |
             wasi-build-
 

--- a/.github/workflows/extra-builds.yml
+++ b/.github/workflows/extra-builds.yml
@@ -189,7 +189,7 @@ jobs:
       - uses: cachix/install-nix-action@v31
         with:
           install_url: https://releases.nixos.org/nix/nix-2.30.0/install
-      - run: nix build .?submodules=1 -L
+      - run: nix build -L
 
   extra-builds-result:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -3,8 +3,8 @@ name: Build and run tests
 on:
   pull_request:
   merge_group:
-  #push:
-  #  branches: [ main ]
+  push:
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
@@ -50,6 +50,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "merge_group" ]; then
             echo "should_skip=false" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            should_skip=false
           else
             echo "should_skip=${{ steps.skip_check.outputs.should_skip }}" >> $GITHUB_OUTPUT
           fi
@@ -83,6 +85,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: test-build-${{ matrix.os }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           restore-keys: |
             test-build-${{ matrix.os }}-
 
@@ -115,7 +118,7 @@ jobs:
     name: Run tests
     runs-on: ${{ matrix.os }}
     needs: [build-yosys, pre_job]
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: github.event_name != 'push' && needs.pre_job.outputs.should_skip != 'true'
     env:
       CC: clang
     strategy:
@@ -165,7 +168,7 @@ jobs:
     name: Run test_cell
     runs-on: ${{ matrix.os }}
     needs: [build-yosys, pre_job]
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: github.event_name != 'push' && needs.pre_job.outputs.should_skip != 'true'
     env:
       CC: clang
     strategy:
@@ -204,7 +207,7 @@ jobs:
     name: Run docs tests
     runs-on: ${{ matrix.os }}
     needs: [build-yosys, pre_docs_job]
-    if: needs.pre_docs_job.outputs.should_skip != 'true'
+    if: github.event_name != 'push' && needs.pre_job.outputs.should_skip != 'true'
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -246,7 +249,7 @@ jobs:
     name: Try build docs
     runs-on: [self-hosted, linux, x64, fast]
     needs: [pre_docs_job]
-    if: ${{ needs.pre_docs_job.outputs.should_skip != 'true' && github.repository_owner == 'YosysHQ' }}
+    if: ${{ github.event_name != 'push' && needs.pre_docs_job.outputs.should_skip != 'true' && github.repository_owner == 'YosysHQ' }}
     strategy:
       matrix:
         docs-target: [html, latexpdf]

--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -3,8 +3,8 @@ name: Compiler testing
 on:
   pull_request:
   merge_group:
-  #push:
-  #  branches: [ main ]
+  push:
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
@@ -27,6 +27,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "merge_group" ]; then
             echo "should_skip=false" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            should_skip=false
           else
             echo "should_skip=${{ steps.skip_check.outputs.should_skip }}" >> $GITHUB_OUTPUT
           fi
@@ -34,7 +36,7 @@ jobs:
   test-compile:
     runs-on: ${{ matrix.os }}
     needs: pre_job
-    if: (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
     env:
       CXXFLAGS: ${{ startsWith(matrix.compiler, 'gcc') && '-Wp,-D_GLIBCXX_ASSERTIONS' || ''}}
     strategy:
@@ -70,6 +72,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: test-compile-${{ matrix.os }}-${{ matrix.compiler }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           restore-keys: |
             test-compile-${{ matrix.os }}-${{ matrix.compiler }}-
 

--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -45,7 +45,7 @@ jobs:
           - ubuntu-latest
         compiler:
           # oldest supported
-          - 'clang-14'
+          - 'clang-16'
           - 'gcc-11'
           # newest, make sure to update maximum standard step to match
           - 'clang-22'
@@ -80,18 +80,12 @@ jobs:
         uses: aminya/setup-cpp@v1
         with:
           compiler: ${{ matrix.compiler }}
-          gcc: ${{ (matrix.os == 'ubuntu-latest' && matrix.compiler == 'clang-14') && '12' || '' }}
 
       - name: Tool versions
         shell: bash
         run: |
           $CC --version
           $CXX --version
-
-      - name: Fix clang-14 toolchain
-        if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'clang-14'
-        run: |
-          echo 'CXXFLAGS=--gcc-toolchain=/usr -isystem /usr/include/c++/12 -isystem /usr/include/x86_64-linux-gnu/c++/12' >> $GITHUB_ENV
 
       # minimum standard
       - name: Build C++20

--- a/.github/workflows/test-sanitizers.yml
+++ b/.github/workflows/test-sanitizers.yml
@@ -3,8 +3,8 @@ name: Check clang sanitizers
 on:
   pull_request:
   merge_group:
-  #push:
-  #  branches: [ main ]
+  push:
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
@@ -27,6 +27,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "merge_group" ]; then
             echo "should_skip=false" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            should_skip=false
           else
             echo "should_skip=${{ steps.skip_check.outputs.should_skip }}" >> $GITHUB_OUTPUT
           fi
@@ -35,7 +37,7 @@ jobs:
     name: Build and run tests
     runs-on: ${{ matrix.os }}
     needs: pre_job
-    if: (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
     env:
       CC: clang
       ASAN_OPTIONS: halt_on_error=1 detect_container_overflow=0
@@ -64,6 +66,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: test-san-${{ matrix.os }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           restore-keys: |
             test-san-${{ matrix.os }}-
 
@@ -82,6 +85,7 @@ jobs:
           ./build/yosys-config || true
 
       - name: Run tests
+        if: github.event_name != 'push'
         shell: bash
         run: |
           make -C tests -j$procs vanilla-test


### PR DESCRIPTION
Add a bit overhead but that stores cache on main, also it prevents cache pollution from branches and make overall process faster.
This one also bump clang to 16 and removes not needed nix parameter, and those from commits from other test branch.