### PR TITLE
Self hosted sanitizer

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -26,7 +26,7 @@ jobs:
       - id: set_output
         run: |
           if [ "${{ github.event_name }}" = "merge_group" ]; then
-            echo "should_skip=false" >> $GITHUB_OUTPUT
+            echo "should_skip=true" >> $GITHUB_OUTPUT
           else
             echo "should_skip=${{ steps.skip_check.outputs.should_skip }}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/test-sanitizers.yml
+++ b/.github/workflows/test-sanitizers.yml
@@ -3,8 +3,8 @@ name: Check clang sanitizers
 on:
   pull_request:
   merge_group:
-  push:
-    branches: [ main ]
+  #push:
+  #  branches: [ main ]
   workflow_dispatch:
 
 jobs:
@@ -33,20 +33,14 @@ jobs:
             echo "should_skip=${{ steps.skip_check.outputs.should_skip }}" >> $GITHUB_OUTPUT
           fi
 
-  run_san:
-    name: Build and run tests
-    runs-on: ${{ matrix.os }}
+  test-sanitizers:
+    runs-on: [self-hosted, linux, x64, fast]
     needs: pre_job
-    if: (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
+    if: (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && needs.pre_job.outputs.should_skip != 'true'
     env:
       CC: clang
       ASAN_OPTIONS: halt_on_error=1 detect_container_overflow=0
       UBSAN_OPTIONS: halt_on_error=1
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        sanitizer: ['undefined,address']
-      fail-fast: false
     steps:
       - name: Checkout Yosys
         uses: actions/checkout@v7
@@ -54,21 +48,9 @@ jobs:
           submodules: true
           persist-credentials: false
 
-      - name: Setup environment
-        uses: ./.github/actions/setup-build-env
-        with:
-          runs-on: ${{ matrix.os }}
-          get-build-deps: true
-          get-test-deps: true
-          get-iverilog: true
-
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
-        with:
-          key: test-san-${{ matrix.os }}
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          restore-keys: |
-            test-san-${{ matrix.os }}-
+      - name: Runtime environment
+        run: |
+          echo "procs=$(nproc)" >> $GITHUB_ENV
 
       - name: Build
         shell: bash
@@ -76,7 +58,7 @@ jobs:
           rm -rf build
           cmake -B build . \
                 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
-                -DCMAKE_BUILD_TYPE=Sanitize -DSANITIZE=${{ matrix.sanitizer }} \
+                -DCMAKE_BUILD_TYPE=Sanitize -DSANITIZE='undefined,address' \
                 -DYOSYS_COMPILER_LAUNCHER=ccache
           cmake --build build -j$procs
 
@@ -85,7 +67,6 @@ jobs:
           ./build/yosys-config || true
 
       - name: Run tests
-        if: github.event_name != 'push'
         shell: bash
         run: |
           make -C tests -j$procs vanilla-test
@@ -99,7 +80,7 @@ jobs:
   test-sanitizers-result:
     runs-on: ubuntu-latest
     needs:
-      - run_san
+      - test-sanitizers
     if: always()
     steps:
       - name: Check results


### PR DESCRIPTION
Use our CI machine to run sanitizer checks (linux only for now) and skip test-build during merge queue since those must pass to reach it anyway.