### PR TITLE
Install just some brew packages

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -56,7 +56,7 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew bundle
+        brew install bison flex gawk libffi git pkg-config python3 bash googletest tcl-tk llvm
 
     - name: Linux runtime environment
       if: runner.os == 'Linux'


### PR DESCRIPTION
Manually install brew packages.
`xdot` have lot of dependencies and it is not used in build nor test process.