### PR TITLE
opt_reduce: derive pmux helper names from source cells

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -3053,6 +3053,15 @@ RTLIL::IdString RTLIL::Module::uniquify(RTLIL::IdString name)
 	return uniquify(name, index);
 }
 
+RTLIL::IdString RTLIL::Module::derive_id(RTLIL::IdString base, std::string_view suffix)
+{
+	log_assert(!suffix.empty());
+	std::string name = base.str();
+	name += "_";
+	name += suffix;
+	return uniquify(name);
+}
+
 RTLIL::IdString RTLIL::Module::uniquify(RTLIL::IdString name, int &index)
 {
 	if (index == 0) {

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -2179,6 +2179,7 @@ public:
 
 	RTLIL::IdString uniquify(RTLIL::IdString name);
 	RTLIL::IdString uniquify(RTLIL::IdString name, int &index);
+	RTLIL::IdString derive_id(RTLIL::IdString base, std::string_view suffix);
 
 	RTLIL::Wire *addWire(RTLIL::IdString name, int width = 1);
 	RTLIL::Wire *addWire(RTLIL::IdString name, const RTLIL::Wire *other);

--- a/passes/opt/opt_reduce.cc
+++ b/passes/opt/opt_reduce.cc
@@ -126,13 +126,13 @@ struct OptReduceWorker
 			RTLIL::SigSpec this_s{this_s_bit};
 			if (this_s.size() > 1)
 			{
-				RTLIL::Cell *reduce_or_cell = module->addCell(NEW_ID, ID($reduce_or));
+				RTLIL::Cell *reduce_or_cell = module->addCell(module->derive_id(cell->name, "reduce_or"), ID($reduce_or));
 				reduce_or_cell->setPort(ID::A, this_s);
 				reduce_or_cell->parameters[ID::A_SIGNED] = RTLIL::Const(0);
 				reduce_or_cell->parameters[ID::A_WIDTH] = RTLIL::Const(this_s.size());
 				reduce_or_cell->parameters[ID::Y_WIDTH] = RTLIL::Const(1);
 
-				RTLIL::Wire *reduce_or_wire = module->addWire(NEW_ID);
+				RTLIL::Wire *reduce_or_wire = module->addWire(module->derive_id(cell->name, "reduce_or_wire"));
 				this_s = RTLIL::SigSpec(reduce_or_wire);
 				reduce_or_cell->setPort(ID::Y, this_s);
 			}

--- a/tests/opt/opt_reduce_pmux_names.ys
+++ b/tests/opt/opt_reduce_pmux_names.ys
@@ -1,0 +1,20 @@
+read_rtlil << EOT
+module \top
+  wire width 3 input 0 \S
+  wire output 1 \Y
+
+  cell $pmux \selmux
+    parameter \WIDTH 1
+    parameter \S_WIDTH 3
+    connect \A 1'0
+    connect \B 3'101
+    connect \S \S
+    connect \Y \Y
+  end
+end
+EOT
+
+opt_reduce
+select -assert-count 1 c:selmux_reduce_or
+select -assert-count 1 w:selmux_reduce_or_wire
+select -assert-count 1 c:selmux r:S_WIDTH=2 %i


### PR DESCRIPTION
## Summary

Add `RTLIL::Module::derive_id()` for generating a unique name from an existing object name plus a descriptive suffix, and use it for the helper `$reduce_or` cell and wire created by `opt_reduce` when it merges duplicate `$pmux` select cases.

This keeps generated helper objects tied to the source `$pmux` name instead of assigning opaque `$auto$...` names. The helper is intentionally small so other passes can adopt the same pattern incrementally.

## Testing

Built locally on Windows with CMake/MSBuild, configured with ABC, Tcl, readline/editline, zlib, and Python disabled.

Ran:

- `build-es3298\Release\yosys.exe -q tests\opt\opt_reduce_pmux_names.ys`
- `build-es3298\Release\yosys.exe -q tests\opt\opt_reduce_bmux.ys`
- `build-es3298\Release\yosys.exe -q tests\opt\opt_reduce_andor.ys`
