### PR TITLE
autoname: avoid O(iterations x module size) full rescan

### DIFF
--- a/passes/cmds/autoname.cc
+++ b/passes/cmds/autoname.cc
@@ -35,76 +35,69 @@ typedef struct name_proposal {
 	}
 } name_proposal;
 
-int autoname_worker(Module *module, const dict<Wire*, unsigned int>& wire_score)
+// Recompute the current best name proposal for a single $-named cell, using
+// only that cell's own connections (bounded by its arity, not module size).
+// Mirrors the per-cell inner loop of the original single-pass algorithm.
+bool recompute_cell_proposal(Cell *cell, const dict<Wire*, unsigned int> &wire_score, name_proposal &out)
 {
-	dict<Cell*, name_proposal> proposed_cell_names;
-	dict<Wire*, name_proposal> proposed_wire_names;
-	name_proposal best_name;
-
-	for (auto cell : module->selected_cells()) {
-		if (cell->name[0] == '$') {
-			for (auto &conn : cell->connections()) {
-				string suffix;
-				for (auto bit : conn.second)
-					if (bit.wire != nullptr && bit.wire->name[0] != '$') {
-						if (suffix.empty())
-							suffix = stringf("_%s_%s", cell->type.unescape(), conn.first.unescape());
-						name_proposal proposed_name(
-							bit.wire->name.str() + suffix,
-							cell->output(conn.first) ? 0 : wire_score.at(bit.wire)
-						);
-						if (!proposed_cell_names.count(cell) || proposed_name < proposed_cell_names.at(cell)) {
-							if (proposed_name < best_name)
-								best_name = proposed_name;
-							proposed_cell_names[cell] = proposed_name;
-						}
-					}
+	bool found = false;
+	for (auto &conn : cell->connections()) {
+		string suffix;
+		for (auto bit : conn.second)
+			if (bit.wire != nullptr && bit.wire->name[0] != '$') {
+				if (suffix.empty())
+					suffix = stringf("_%s_%s", cell->type.unescape(), conn.first.unescape());
+				name_proposal proposed_name(
+					bit.wire->name.str() + suffix,
+					cell->output(conn.first) ? 0 : wire_score.at(bit.wire)
+				);
+				if (!found || proposed_name < out) {
+					out = proposed_name;
+					found = true;
+				}
 			}
-		} else {
-			for (auto &conn : cell->connections()) {
-				string suffix;
-				for (auto bit : conn.second)
-					if (bit.wire != nullptr && bit.wire->name[0] == '$' && !bit.wire->port_id) {
-						if (suffix.empty())
-							suffix = stringf("_%s", conn.first.unescape());
-						name_proposal proposed_name(
-							cell->name.str() + suffix,
-							cell->output(conn.first) ? 0 : wire_score.at(bit.wire)
-						);
-						if (!proposed_wire_names.count(bit.wire) || proposed_name < proposed_wire_names.at(bit.wire)) {
-							if (proposed_name < best_name)
-								best_name = proposed_name;
-							proposed_wire_names[bit.wire] = proposed_name;
-						}
-					}
+	}
+	return found;
+}
+
+// Recompute the current best name proposal for a single $-named, non-port
+// wire, using only the (public-named) cells connected to it. Bounded by the
+// wire's fanout, not module size.
+//
+// module->selected(cell) is re-checked here (not just cached from the initial
+// module->selected_cells() scan) because a cell renamed earlier in this same
+// autoname invocation can fall out of a name/type-based selection (e.g.
+// "t:$or") -- Module::selected() looks the cell up by its *current* name, so
+// a rename can make an otherwise-matching cell invisible to it. The original
+// full-rescan algorithm calls module->selected_cells() fresh every round and
+// so naturally observes the same drop-out; this targeted recheck reproduces
+// it without having to rescan the whole module.
+bool recompute_wire_proposal(Module *module, Wire *wire, const pool<Cell*> &touching_cells, const dict<Wire*, unsigned int> &wire_score, name_proposal &out)
+{
+	bool found = false;
+	for (auto cell : touching_cells) {
+		if (cell->name[0] == '$' || !module->selected(cell))
+			continue;
+		for (auto &conn : cell->connections()) {
+			bool touches = false;
+			for (auto bit : conn.second)
+				if (bit.wire == wire) {
+					touches = true;
+					break;
+				}
+			if (!touches)
+				continue;
+			name_proposal proposed_name(
+				cell->name.str() + stringf("_%s", conn.first.unescape()),
+				cell->output(conn.first) ? 0 : wire_score.at(wire)
+			);
+			if (!found || proposed_name < out) {
+				out = proposed_name;
+				found = true;
 			}
 		}
 	}
-
-	int count = 0;
-	// compare against double best score for following comparisons so we don't
-	// pre-empt a future iteration
-	best_name.score *= 2;
-
-	for (auto &it : proposed_cell_names) {
-		if (best_name < it.second)
-			continue;
-		IdString n = module->uniquify(IdString(it.second.name));
-		log_debug("Rename cell %s in %s to %s.\n", it.first, module, n.unescape());
-		module->rename(it.first, n);
-		count++;
-	}
-
-	for (auto &it : proposed_wire_names) {
-		if (best_name < it.second)
-			continue;
-		IdString n = module->uniquify(IdString(it.second.name));
-		log_debug("Rename wire %s in %s to %s.\n", it.first, module, n.unescape());
-		module->rename(it.first, n);
-		count++;
-	}
-
-	return count;
+	return found;
 }
 
 struct AutonamePass : public Pass {
@@ -136,19 +129,121 @@ struct AutonamePass : public Pass {
 
 		for (auto module : design->selected_modules())
 		{
+			// wire_score, and the wire<->cell adjacency needed to know which
+			// objects to re-examine when a neighbor gets renamed, are each
+			// computed once up front (same complexity as a single pass of
+			// the original algorithm's inner loop).
 			dict<Wire*, unsigned int> wire_score;
+			dict<Wire*, pool<Cell*>> wire_users;
+			dict<Cell*, pool<Wire*>> cell_wires;
+
 			for (auto cell : module->selected_cells())
-			for (auto &conn : cell->connections())
-			for (auto bit : conn.second)
-				if (bit.wire != nullptr)
-					wire_score[bit.wire]++;
+				for (auto &conn : cell->connections())
+					for (auto bit : conn.second)
+						if (bit.wire != nullptr) {
+							wire_score[bit.wire]++;
+							wire_users[bit.wire].insert(cell);
+							cell_wires[cell].insert(bit.wire);
+						}
+
+			// pending_cells/pending_wires hold the *current* best proposal
+			// for every $-named object that is currently reachable from a
+			// public name at all (objects with no path to any public name
+			// never enter these maps, unlike a naive "still unresolved"
+			// worklist would). This persists across rounds instead of being
+			// rebuilt via a full module rescan every round -- the original
+			// algorithm recomputes every object's proposal every round, but
+			// an object's proposal only ever changes when a directly
+			// connected neighbor is renamed, so incrementally maintaining it
+			// here yields the identical fixed point (same round-by-round
+			// "accept everything within 2x of this round's best" commit
+			// decisions) without the O(iterations x module size) rescan.
+			dict<Cell*, name_proposal> pending_cells;
+			dict<Wire*, name_proposal> pending_wires;
+
+			for (auto cell : module->selected_cells()) {
+				if (cell->name[0] != '$')
+					continue;
+				name_proposal p;
+				if (recompute_cell_proposal(cell, wire_score, p))
+					pending_cells[cell] = p;
+			}
+			for (auto &it : wire_users) {
+				Wire *wire = it.first;
+				if (wire->name[0] != '$' || wire->port_id)
+					continue;
+				name_proposal p;
+				if (recompute_wire_proposal(module, wire, it.second, wire_score, p))
+					pending_wires[wire] = p;
+			}
 
 			int count = 0, iter = 0;
-			while (1) {
+			while (!pending_cells.empty() || !pending_wires.empty()) {
 				iter++;
-				int n = autoname_worker(module, wire_score);
-				if (!n) break;
-				count += n;
+
+				// compare against double best score for following comparisons
+				// so we don't pre-empt a future iteration
+				name_proposal best_name;
+				for (auto &it : pending_cells)
+					if (it.second < best_name)
+						best_name = it.second;
+				for (auto &it : pending_wires)
+					if (it.second < best_name)
+						best_name = it.second;
+				best_name.score *= 2;
+
+				pool<Cell*> committed_cells;
+				pool<Wire*> committed_wires;
+
+				for (auto &it : pending_cells)
+					if (!(best_name < it.second)) {
+						IdString n = module->uniquify(IdString(it.second.name));
+						log_debug("Rename cell %s in %s to %s.\n", it.first, module, n.unescape());
+						module->rename(it.first, n);
+						committed_cells.insert(it.first);
+						count++;
+					}
+
+				for (auto &it : pending_wires)
+					if (!(best_name < it.second)) {
+						IdString n = module->uniquify(IdString(it.second.name));
+						log_debug("Rename wire %s in %s to %s.\n", it.first, module, n.unescape());
+						module->rename(it.first, n);
+						committed_wires.insert(it.first);
+						count++;
+					}
+
+				// Committing a cell/wire can only change the reachability of
+				// its direct neighbors, so only those need their proposal
+				// recomputed for the next round.
+				pool<Cell*> cells_to_recompute;
+				pool<Wire*> wires_to_recompute;
+
+				for (auto cell : committed_cells) {
+					pending_cells.erase(cell);
+					if (cell_wires.count(cell))
+						for (auto wire : cell_wires.at(cell))
+							if (wire->name[0] == '$' && !wire->port_id)
+								wires_to_recompute.insert(wire);
+				}
+				for (auto wire : committed_wires) {
+					pending_wires.erase(wire);
+					if (wire_users.count(wire))
+						for (auto cell : wire_users.at(wire))
+							if (cell->name[0] == '$')
+								cells_to_recompute.insert(cell);
+				}
+
+				for (auto cell : cells_to_recompute) {
+					name_proposal p;
+					if (recompute_cell_proposal(cell, wire_score, p))
+						pending_cells[cell] = p;
+				}
+				for (auto wire : wires_to_recompute) {
+					name_proposal p;
+					if (recompute_wire_proposal(module, wire, wire_users.at(wire), wire_score, p))
+						pending_wires[wire] = p;
+				}
 			}
 			if (count > 0)
 				log("Renamed %d objects in module %s (%d iterations).\n", count, module, iter);


### PR DESCRIPTION
## Summary

`AutonamePass::execute()` calls `autoname_worker()` in a loop, and every call rescans every selected cell's every connection's every bit from scratch. Naming only propagates one hop per call (an object becomes nameable only once a directly connected neighbor already has a public name), so the number of iterations scales with the propagation depth through the design's connectivity graph. On a large, fully flattened netlist with long dependency chains this becomes `O(iterations x module_size)`.

We hit this synthesizing an RV64 CPU + 4-lane SIMT GPU SoC for ECP5 (`synth_ecp5`'s `check:` stage runs `autoname`): 40+ GB RSS and 30+ minutes with no end in sight, on a ~500k-wire post-techmap netlist. A `perf record` profile of the running process showed ~73% of CPU time in `autoname_worker` / `Module::selected_cells()` / `IdString::operator[]`, confirming the rescan is the bottleneck rather than anything design-specific.

This looks like the same underlying issue reported in #5394, #4509, and #2816.

## What this changes

Replaces the full-rescan loop with a persistent worklist: `pending_cells`/`pending_wires` hold the current best proposal only for `$`-named objects that are *currently* reachable from a public name (objects with no such path never enter these maps at all, unlike a naive "still unresolved" set would). Recomputing an object's proposal only happens when one of its direct neighbors was just renamed, via precomputed wire<->cell adjacency built once up front, instead of rescanning the whole module every round.

This preserves the original's round-by-round "accept everything within 2x of this round's best" batching behavior, so the final naming is unchanged — verified against `tests/various/autoname.ys`, including the "don't rename prematurely" ordering test that specifically exercises this scheduling behavior.

One subtlety found along the way: `Module::selected(cell)` looks a cell up by its *current* name, so a cell renamed earlier in the same `autoname` invocation can fall out of a name/type-based selection (e.g. `autoname t:$or`) that matched it before the rename. The original algorithm observes this naturally because it calls `module->selected_cells()` fresh every round; this patch re-checks `module->selected(cell)` at the point a wire proposal is (re)computed to reproduce the same behavior without a full rescan. (`tests/various/autoname.ys`'s "wires get autonames too" test exercises exactly this case.)

## Test plan

- [x] `tests/various/autoname.ys` passes unchanged (all expected log messages/rename counts match, including the selection-staleness edge case)
- [x] Re-ran the ECP5 synthesis flow that previously never completed (40+ GB RSS, 30+ min with no end in sight) — now proceeds through `autoname` with stable, modest (~150-200MB) memory use and completes
- [x] `hardware.borg`/CPU Chisel test suites for the design that triggered this (unrelated to yosys itself, just confirming the underlying RTL was unaffected)

Happy to add a regression test to `tests/various/` covering a large/deep design shape if that's useful — let me know what form would be most useful (e.g. a generated wide+deep chain of anonymous cells).

🤖 Generated with [Claude Code](https://claude.com/claude-code)