### PR TITLE
`opt_reduce`: restore pmux b-slice == a elim

### DIFF
--- a/passes/opt/opt_reduce.cc
+++ b/passes/opt/opt_reduce.cc
@@ -115,6 +115,8 @@ struct OptReduceWorker
 		int port_width = sig_a.size();
 		for (int i = 0; i < sig_s.size(); i++) {
 			RTLIL::SigSpec this_b = sig_b.extract(i*port_width, port_width);
+			if (this_b == sig_a)
+				continue;
 			if (grouped_b_to_s.count(this_b)) {
 				grouped_b_to_s[this_b].push_back(sig_s[i]);
 			} else {

--- a/tests/opt/opt_reduce_pmux.ys
+++ b/tests/opt/opt_reduce_pmux.ys
@@ -1,0 +1,50 @@
+read_rtlil << EOT
+
+module \top
+	wire width 4 input 0 \A
+	wire width 4 input 1 \C
+	wire width 2 input 2 \S
+	wire width 4 output 3 \Y
+
+	cell $pmux $0
+		parameter \WIDTH 4
+		parameter \S_WIDTH 2
+		connect \A \A
+		connect \B { \C \A }
+		connect \S \S
+		connect \Y \Y
+	end
+end
+
+EOT
+
+equiv_opt -assert opt_reduce
+opt_reduce
+select -assert-count 0 t:$pmux
+select -assert-count 1 t:$mux
+
+design -reset
+
+read_rtlil << EOT
+
+module \top
+	wire width 4 input 0 \A
+	wire width 2 input 1 \S
+	wire width 4 output 2 \Y
+
+	cell $pmux $0
+		parameter \WIDTH 4
+		parameter \S_WIDTH 2
+		connect \A \A
+		connect \B { \A \A }
+		connect \S \S
+		connect \Y \Y
+	end
+end
+
+EOT
+
+equiv_opt -assert opt_reduce
+opt_reduce
+select -assert-count 0 t:$pmux
+select -assert-count 0 t:$mux


### PR DESCRIPTION
Fixes a QoR regression in `opt_reduce` flagged by @maliberty (for more details please see https://github.com/YosysHQ/yosys/pull/5809#issuecomment-4790551106). 