### PR TITLE
Improve source path fixup

### DIFF
--- a/kernel/log_help.cc
+++ b/kernel/log_help.cc
@@ -44,7 +44,7 @@ void ContentListing::usage(const string &text,
 void ContentListing::option(const string &text, const string &description,
 	const source_location location)
 {
-	auto option = open_option(text);
+	auto option = open_option(text, source_location());
 	if (description.length())
 		option->add_content("text", description, location);
 }

--- a/kernel/log_help.cc
+++ b/kernel/log_help.cc
@@ -21,16 +21,45 @@
 
 USING_YOSYS_NAMESPACE
 
-Json ContentListing::to_json() const {
+std::filesystem::path Yosys::fixup_source_path (const char* source_file,
+	const std::filesystem::path &source_root, bool* skip_source_group)
+{
+	std::filesystem::path source_path(source_file);
+	if (source_path.is_absolute()) {
+		// using proximate instead of relative means that we
+		// still get the source path if they aren't relative
+		auto proximate_path = std::filesystem::proximate(source_path, source_root);
+		if (proximate_path == proximate_path.lexically_normal()) {
+			// we're only interested if it's a subpath of our root dir
+			// if the normal form differs, then the proximate path includes ".."
+			return proximate_path;
+		} else if (skip_source_group != nullptr) {
+			// don't try to group external paths
+			*skip_source_group = true;
+		}
+	}
+	return source_path;
+}
+
+Json ContentListing::to_json(const std::filesystem::path &source_root) const {
 	Json::object object;
+
 	object["type"] = type;
-	if (body.length()) object["body"] = body;
-	if (strcmp(source_file, "unknown") != 0) object["source_file"] = source_file;
-	if (source_line != 0) object["source_line"] = source_line;
+	if (body.length())
+		object["body"] = body;
+
+	if (has_source())
+		object["source_file"] = fixup_source_path(source_file, source_root).string();
+	if (source_line != 0)
+		object["source_line"] = source_line;
+
 	object["options"] = Json(options);
+
 	Json::array content_array;
-	for (auto child : _content) content_array.push_back(child.to_json());
+	for (auto child : _content)
+		content_array.push_back(child.to_json(source_root));
 	object["content"] = content_array;
+
 	return object;
 }
 

--- a/kernel/log_help.h
+++ b/kernel/log_help.h
@@ -22,8 +22,13 @@
 
 #include "kernel/yosys_common.h"
 #include "kernel/json.h"
+#include <filesystem>
+#include <string_view>
 
 YOSYS_NAMESPACE_BEGIN
+
+std::filesystem::path fixup_source_path (const char* source_file,
+	const std::filesystem::path &source_root, bool* skip_source_group = nullptr);
 
 class ContentListing {
 	vector<ContentListing> _content;
@@ -49,6 +54,7 @@ public:
 		_content.push_back({type, body, location});
 	}
 
+	bool has_source() const { return strlen(source_file) && strcmp(source_file, "unknown") != 0; }
 	bool has_content() const { return _content.size() != 0; }
 
 	vector<ContentListing>::const_iterator begin() const { return _content.cbegin(); }
@@ -90,7 +96,7 @@ public:
 		const source_location location = source_location::current()
 	);
 
-	Json to_json() const;
+	Json to_json(const std::filesystem::path &source_root) const;
 };
 
 class PrettyHelp

--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -921,20 +921,10 @@ struct HelpPass : public Pass {
 			string source_file = pass->location.file_name();
 			bool has_source = source_file.compare("unknown") != 0;
 			std::filesystem::path source_path;
-			auto no_source_group = false;
+			auto skip_source_group = false;
+
 			if (has_source) {
-				source_path = std::filesystem::path(pass->location.file_name());
-				if (source_path.is_absolute()) {
-					// using proximate instead of relative means that we
-					// still get the source path if they aren't relative
-					auto proximate_path = std::filesystem::proximate(source_path, source_root);
-					if (proximate_path == std::filesystem::weakly_canonical(proximate_path))
-						// we're only interested if it's a subpath of our root dir
-						source_path = proximate_path;
-					else
-						// don't try to group external paths
-						no_source_group = true;
-				}
+				source_path = fixup_source_path(pass->location.file_name(), source_root, &skip_source_group);
 				source_file = source_path.string();
 			}
 
@@ -947,7 +937,7 @@ struct HelpPass : public Pass {
 				else if (source_file.find("frontends/") == 0 || (!has_source && name.find("write_") == 0))
 					cmd_help.group = "frontends";
 				else if (has_source) {
-					if (source_path.has_parent_path() && !no_source_group)
+					if (source_path.has_parent_path() && !skip_source_group)
 						cmd_help.group = source_path.parent_path().string();
 				}
 				// implicit !has_source
@@ -973,7 +963,7 @@ struct HelpPass : public Pass {
 			json.entry("title", title);
 			json.name("content"); json.begin_array();
 			for (auto &content : cmd_help)
-				json.value(content.to_json());
+				json.value(content.to_json(source_root));
 			json.end_array();
 			json.entry("group", cmd_help.group);
 			json.entry("source_file", source_file);


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

1. `ContentListing::option` was erroneously reporting its own location.
2. #5927 fixed relative paths for commands (`Pass::location`), but missed the absolute paths in `ContentListing::source_file`. This location isn't used anywhere, and doesn't appear in the docs, but it would be nice to make it consistent.

_Explain how this is achieved._

1. `ContentListing::option` uses the null location when calling `open_option` (with the contents still getting the source location of the caller).
2. Move the source path fixup logic into a separate function which can be called for the commands source location and each item of the help contents (if it has a source location). Note that memory ownership was making it difficult to update the paths in the `ContentListing` itself, so the fixup only occurs during the json export instead.

The previous logic replaced the original source path with the proximate path only if `proximate_path == std::filesystem::weakly_canonical(proximate_path)`.  The idea was to check for any `..` in the path, to avoid treating something like `yosys/../plugin/source.cc` as a subpath of `yosys`.  However, the `weakly_canonical` function returns an absolute path, so I have no idea how this was actually working before.  The new method checks `proximate_path == proximate_path.lexically_normal()`, which still resolves the `..` in the path but without making it absolute.