### PR TITLE
Michaelbaier/sc 649/segmentation fault during proc init with

### DIFF
--- a/frontends/rtlil/rtlil_frontend.cc
+++ b/frontends/rtlil/rtlil_frontend.cc
@@ -31,10 +31,6 @@
 YOSYS_NAMESPACE_BEGIN
 
 struct RTLILFrontendWorker {
-	// Forbid constants of more than 1 Gb.
-	// This will help us not explode on malicious RTLIL.
-	static constexpr int MAX_CONST_WIDTH = 1024 * 1024 * 1024;
-
 	std::istream *f = nullptr;
 	RTLIL::Design *design;
 	bool flag_nooverwrite = false;
@@ -283,7 +279,7 @@ struct RTLILFrontendWorker {
 			++idx;
 
 		std::vector<RTLIL::State> bits;
-		if (width > MAX_CONST_WIDTH)
+		if (width >= RTLIL::WIDTH_LIMIT)
 			error("Constant width %lld out of range before `%s`.", width, error_token());
 		bits.reserve(width);
 		int start_idx = idx;
@@ -532,8 +528,11 @@ struct RTLILFrontendWorker {
 				wire = current_module->addWire(std::move(*id));
 				break;
 			}
-			if (try_parse_keyword("width"))
+			if (try_parse_keyword("width")){
 				width = parse_integer();
+				if (width >= RTLIL::WIDTH_LIMIT)
+					error("Wire width %lld out of range before `%s`.", width, error_token());
+			}
 			else if (try_parse_keyword("upto"))
 				upto = true;
 			else if (try_parse_keyword("signed"))
@@ -589,8 +588,11 @@ struct RTLILFrontendWorker {
 				memory->name = std::move(*id);
 				break;
 			}
-			if (try_parse_keyword("width"))
+			if (try_parse_keyword("width")){
 				width = parse_integer();
+				if (width >= RTLIL::WIDTH_LIMIT)
+					error("Memory width %lld out of range before `%s`.", width, error_token());
+			}
 			else if (try_parse_keyword("size"))
 				size = parse_integer();
 			else if (try_parse_keyword("offset"))

--- a/frontends/rtlil/rtlil_frontend.cc
+++ b/frontends/rtlil/rtlil_frontend.cc
@@ -538,8 +538,12 @@ struct RTLILFrontendWorker {
 				upto = true;
 			else if (try_parse_keyword("signed"))
 				is_signed = true;
-			else if (try_parse_keyword("offset"))
-				start_offset = parse_integer();
+			else if (try_parse_keyword("offset")) {
+				long long offset_val = parse_integer();
+				if (offset_val < INT_MIN || offset_val > INT_MAX)
+					error("Wire offset %lld out of range before `%s`.", offset_val, error_token());
+				start_offset = offset_val;
+			}
 			else if (try_parse_keyword("input")) {
 				port_id = parse_integer();
 				port_input = true;
@@ -595,10 +599,18 @@ struct RTLILFrontendWorker {
 					error("Memory width %lld out of range before `%s`.", width_val, error_token());
 				width = width_val;
 			}
-			else if (try_parse_keyword("size"))
-				size = parse_integer();
-			else if (try_parse_keyword("offset"))
-				start_offset = parse_integer();
+			else if (try_parse_keyword("size")) {
+				long long size_val = parse_integer();
+				if (size_val < INT_MIN || size_val > INT_MAX)
+					error("Memory size %lld out of range before `%s`.", size_val, error_token());
+				size = size_val;
+			}
+			else if (try_parse_keyword("offset")) {
+				long long offset_val = parse_integer();
+				if (offset_val < INT_MIN || offset_val > INT_MAX)
+					error("Memory offset %lld out of range before `%s`.", offset_val, error_token());
+				start_offset = offset_val;
+			}
 			else if (try_parse_eol())
 				error("Missing memory ID");
 			else

--- a/frontends/rtlil/rtlil_frontend.cc
+++ b/frontends/rtlil/rtlil_frontend.cc
@@ -529,9 +529,10 @@ struct RTLILFrontendWorker {
 				break;
 			}
 			if (try_parse_keyword("width")){
-				width = parse_integer();
-				if (width >= RTLIL::WIDTH_LIMIT)
-					error("Wire width %lld out of range before `%s`.", width, error_token());
+				long long width_val = parse_integer();
+				if (width_val < 0 || width_val >= RTLIL::WIDTH_LIMIT)
+					error("Wire width %lld out of range before `%s`.", width_val, error_token());
+				width = width_val;
 			}
 			else if (try_parse_keyword("upto"))
 				upto = true;
@@ -589,9 +590,10 @@ struct RTLILFrontendWorker {
 				break;
 			}
 			if (try_parse_keyword("width")){
-				width = parse_integer();
-				if (width >= RTLIL::WIDTH_LIMIT)
-					error("Memory width %lld out of range before `%s`.", width, error_token());
+				long long width_val = parse_integer();
+				if (width_val < 0 || width_val >= RTLIL::WIDTH_LIMIT)
+					error("Memory width %lld out of range before `%s`.", width_val, error_token());
+				width = width_val;
 			}
 			else if (try_parse_keyword("size"))
 				size = parse_integer();

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -379,6 +379,7 @@ RTLIL::Const::Const(long long val) // default width 32
 
 RTLIL::Const::Const(long long val, int width)
 {
+	log_assert(width >= 0 && width < RTLIL::WIDTH_LIMIT);
 	flags = RTLIL::CONST_FLAG_NONE;
 	if ((width & 7) == 0) {
 		new ((void*)&str_) std::string();
@@ -407,6 +408,7 @@ RTLIL::Const::Const(long long val, int width)
 
 RTLIL::Const::Const(RTLIL::State bit, int width)
 {
+	log_assert(width >= 0 && width < RTLIL::WIDTH_LIMIT);
 	flags = RTLIL::CONST_FLAG_NONE;
 	new ((void*)&bits_) bitvectype();
 	tag = backing_tag::bits;
@@ -3170,6 +3172,7 @@ void RTLIL::Module::fixup_ports()
 
 RTLIL::Wire *RTLIL::Module::addWire(RTLIL::IdString name, int width)
 {
+	log_assert(width >= 0 && width < RTLIL::WIDTH_LIMIT);
 	RTLIL::Wire *wire = new RTLIL::Wire;
 	wire->name = std::move(name);
 	wire->width = width;

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -1109,6 +1109,7 @@ public:
 		bits_internal()[i] = state;
 	}
 	void resize(int size, RTLIL::State fill) {
+    log_assert(size >= 0 && size < RTLIL::WIDTH_LIMIT);
 		bits_internal().resize(size, fill);
 	}
 

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -99,6 +99,9 @@ namespace RTLIL
 		PD_INOUT = 3
 	};
 
+	// Maximum width in bits of RTLIL::Wire or RTLIL::Const
+	constexpr int WIDTH_LIMIT = 1 << 30;
+
 	struct Const;
 	struct AttrObject;
 	struct NamedObject;

--- a/pyosys/generator.py
+++ b/pyosys/generator.py
@@ -631,7 +631,7 @@ class PyosysWrapperGenerator(object):
         self.register_containers(variable)
 
         definition_fn = (
-            f"def_{'readonly' if variable.type.const else 'readwrite'}_static"
+            f"def_{'readonly' if (variable.type.const or variable.constexpr) else 'readwrite'}_static"
         )
 
         variable_python_basename = keyword_aliases.get(

--- a/tests/rtlil/bug1206.ys
+++ b/tests/rtlil/bug1206.ys
@@ -1,0 +1,6 @@
+logger -expect error "Wire width .* out of range" 1
+read_rtlil <<EOT
+module \foo
+	wire width 1073741824 \bar
+end
+EOT

--- a/tests/rtlil/bug1206_memory.ys
+++ b/tests/rtlil/bug1206_memory.ys
@@ -1,0 +1,6 @@
+logger -expect error "Memory width .* out of range" 1
+read_rtlil <<EOT
+module \foo
+	memory width 1073741824 \mem
+end
+EOT

--- a/tests/rtlil/bug1206_memory_offset_negative_overflow.ys
+++ b/tests/rtlil/bug1206_memory_offset_negative_overflow.ys
@@ -1,0 +1,6 @@
+logger -expect error "Memory offset .* out of range" 1
+read_rtlil <<EOT
+module \foo
+	memory width 8 offset -4294967396 \mem
+end
+EOT

--- a/tests/rtlil/bug1206_memory_offset_overflow.ys
+++ b/tests/rtlil/bug1206_memory_offset_overflow.ys
@@ -1,0 +1,6 @@
+logger -expect error "Memory offset .* out of range" 1
+read_rtlil <<EOT
+module \foo
+	memory width 8 offset 4294967396 \mem
+end
+EOT

--- a/tests/rtlil/bug1206_memory_overflow.ys
+++ b/tests/rtlil/bug1206_memory_overflow.ys
@@ -1,0 +1,6 @@
+logger -expect error "Memory width .* out of range" 1
+read_rtlil <<EOT
+module \foo
+	memory width 4294967396 \mem
+end
+EOT

--- a/tests/rtlil/bug1206_memory_size_overflow.ys
+++ b/tests/rtlil/bug1206_memory_size_overflow.ys
@@ -1,0 +1,6 @@
+logger -expect error "Memory size .* out of range" 1
+read_rtlil <<EOT
+module \foo
+	memory width 8 size 4294967396 \mem
+end
+EOT

--- a/tests/rtlil/bug1206_overflow.ys
+++ b/tests/rtlil/bug1206_overflow.ys
@@ -1,0 +1,6 @@
+logger -expect error "Wire width .* out of range" 1
+read_rtlil <<EOT
+module \foo
+	wire width 4294967396 \bar
+end
+EOT

--- a/tests/rtlil/bug1206_wire_offset_negative_overflow.ys
+++ b/tests/rtlil/bug1206_wire_offset_negative_overflow.ys
@@ -1,0 +1,6 @@
+logger -expect error "Wire offset .* out of range" 1
+read_rtlil <<EOT
+module \foo
+	wire width 8 offset -4294967396 \bar
+end
+EOT

--- a/tests/rtlil/bug1206_wire_offset_overflow.ys
+++ b/tests/rtlil/bug1206_wire_offset_overflow.ys
@@ -1,0 +1,6 @@
+logger -expect error "Wire offset .* out of range" 1
+read_rtlil <<EOT
+module \foo
+	wire width 8 offset 4294967396 \bar
+end
+EOT

--- a/tests/unit/kernel/rtlilTest.cc
+++ b/tests/unit/kernel/rtlilTest.cc
@@ -284,6 +284,28 @@ namespace RTLIL {
 		EXPECT_EQ(c, Const(0xe, 4));
 	}
 
+	TEST_F(KernelRtlilTest, ConstResizeWidthLimit) {
+		Const c;
+		EXPECT_DEATH(c.resize(RTLIL::WIDTH_LIMIT, Sx), "");
+		EXPECT_NO_FATAL_FAILURE(c.resize(RTLIL::WIDTH_LIMIT - 1, Sx));
+	}
+
+	TEST_F(KernelRtlilTest, ConstFromLongLongWidthLimit) {
+		EXPECT_DEATH(Const(0, RTLIL::WIDTH_LIMIT), "");
+		EXPECT_NO_FATAL_FAILURE(Const(0, RTLIL::WIDTH_LIMIT - 1));
+	}
+
+	TEST_F(KernelRtlilTest, ConstFromStateWidthLimit) {
+		EXPECT_DEATH(Const(Sx, RTLIL::WIDTH_LIMIT), "");
+		EXPECT_NO_FATAL_FAILURE(Const(Sx, RTLIL::WIDTH_LIMIT - 1));
+	}
+
+	TEST_F(KernelRtlilTest, ModuleAddWireWidthLimit) {
+		std::unique_ptr<Module> mod = std::make_unique<Module>();
+		EXPECT_DEATH(mod->addWire(ID(test), RTLIL::WIDTH_LIMIT), "");
+		EXPECT_NO_FATAL_FAILURE(mod->addWire(ID(test), RTLIL::WIDTH_LIMIT - 1));
+	}
+
 	TEST_F(KernelRtlilTest, ConstEqualStr) {
 		EXPECT_EQ(Const("abc"), Const("abc"));
 		EXPECT_NE(Const("abc"), Const("def"));


### PR DESCRIPTION
This is a proposed fix to the issue #1206, considering all the changes proposed in PR #3460

To solve the problems,I have added a constant to rtlil.h that is used to check if wires or constants get to big.
