### PR TITLE
Include build datetime in scl cache hash

### DIFF
--- a/kernel/version.cc.in
+++ b/kernel/version.cc.in
@@ -1,4 +1,5 @@
 namespace Yosys {
 	const char *yosys_version_str = "@YOSYS_BUILD_INFO@";
 	const char *yosys_git_hash_str = "@YOSYS_CHECKOUT_INFO@";
+	const char *yosys_build_datetime_str = __DATE__ " " __TIME__;
 }

--- a/kernel/yosys.h
+++ b/kernel/yosys.h
@@ -82,6 +82,7 @@ extern std::set<std::string> yosys_input_files, yosys_output_files;
 // from kernel/version_*.o (cc source generated from Makefile)
 extern const char *yosys_version_str;
 extern const char *yosys_git_hash_str;
+extern const char *yosys_build_datetime_str;
 const char* yosys_maybe_version();
 
 // from passes/cmds/design.cc

--- a/passes/techmap/liberty_cache.h
+++ b/passes/techmap/liberty_cache.h
@@ -50,7 +50,6 @@ inline std::string convert_liberty_files_to_merged_scl(const std::vector<std::st
 
 	hash_input += dont_use_args;
 	// Include build datetime so caches from other builds are not reused
-	hash_input += "|";
 	hash_input += yosys_build_datetime_str;
 	unsigned int hash = 0;
 

--- a/passes/techmap/liberty_cache.h
+++ b/passes/techmap/liberty_cache.h
@@ -49,6 +49,9 @@ inline std::string convert_liberty_files_to_merged_scl(const std::vector<std::st
 	}
 
 	hash_input += dont_use_args;
+	// Include build datetime so caches from other builds are not reused
+	hash_input += "|";
+	hash_input += yosys_build_datetime_str;
 	unsigned int hash = 0;
 
 	for (char c : hash_input)

--- a/tests/liberty/scl_cache.ys
+++ b/tests/liberty/scl_cache.ys
@@ -1,0 +1,7 @@
+read_verilog small.v
+synth -top small
+abc -liberty normal.lib
+
+logger -expect log "using cached merged SCL" 1
+abc -liberty normal.lib
+logger -check-expected


### PR DESCRIPTION
Mixes the build datetime into the merged `scl` cache filename hash so caches from older builds are not reused across yosys/abc builds, potentially preventing confusing behavior for developers.