### PR TITLE
cmake: allow system fmt/tomlplusplus/boost for bundled deps

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -9,33 +9,43 @@ add_subdirectory(sha1)
 add_subdirectory(subcircuit)
 block()
     set(BUILD_SHARED_LIBS OFF)
+    set(CMAKE_FIND_PACKAGE_TARGETS_GLOBAL TRUE)
     include(FetchContent)
     set(FETCHCONTENT_FULLY_DISCONNECTED ON)
 
     option(FMT_INSTALL OFF)
-    FetchContent_Declare(
-        fmt
-        EXCLUDE_FROM_ALL
-        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/fmt
-    )
-    FetchContent_MakeAvailable(fmt)
+    find_package(fmt QUIET)
+    if(NOT fmt_FOUND)
+        FetchContent_Declare(
+            fmt
+            EXCLUDE_FROM_ALL
+            SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/fmt
+        )
+        FetchContent_MakeAvailable(fmt)
+    endif()
 
-    FetchContent_Declare(
-        tomlplusplus
-        EXCLUDE_FROM_ALL
-        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tomlplusplus
-    )
-    FetchContent_MakeAvailable(tomlplusplus)
-
-    FetchContent_Declare(
-        boost_regex
-        EXCLUDE_FROM_ALL
-        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/boost_regex
-        SOURCE_SUBDIR _no_build_
-    )
-    FetchContent_MakeAvailable(boost_regex)
+    find_package(tomlplusplus QUIET)
+    if(NOT tomlplusplus_FOUND)
+        FetchContent_Declare(
+            tomlplusplus
+            EXCLUDE_FROM_ALL
+            SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tomlplusplus
+        )
+        FetchContent_MakeAvailable(tomlplusplus)
+    endif()
 
     if (NOT YOSYS_WITHOUT_SLANG)
+        find_package(Boost QUIET COMPONENTS regex)
+        if(NOT Boost_FOUND)
+            FetchContent_Declare(
+                boost_regex
+                EXCLUDE_FROM_ALL
+                SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/boost_regex
+                SOURCE_SUBDIR _no_build_
+            )
+            FetchContent_MakeAvailable(boost_regex)
+        endif()
+
         set(SLANG_USE_MIMALLOC OFF)
         add_subdirectory(slang)
         # Headers autodetect based on <boost/config.hpp> but when version


### PR DESCRIPTION
_If your work is part of a larger effort, please discuss your general plans on [Discourse](https://yosyshq.discourse.group/) first to align your vision with maintainers._

_What are the reasons/motivation for this change?_

Hopefully use system installed libraries not vendored.

_Explain how this is achieved._

First use find_package and after then fetch library if it is missing.

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._


_These template prompts can be deleted when you're done responding to them._

FetchContent now tries find_package() first for fmt, tomlplusplus and Boost.Regex, only falling back to the vendored copies when no system package is found. This lets distribution and package-manager builds (e.g. Homebrew) link against system libraries instead of the bundles, without changing the default behaviour for a plain source build.
