### PR TITLE
README: cmake build and test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,7 @@ sure to call e.g.
 	$ git submodule update --init
 
 A C++ compiler with C++20 support is required as well as some standard tools
-such as GNU Flex, GNU Bison (>=3.8), CMake (>=3.28), Make (or other CMake
-generator such as Ninja), and Python (>=3.11). Some additional tools: readline,
+such as GNU Flex, GNU Bison (>=3.8), CMake (>=3.28), GNU Make, and Python (>=3.11). Some additional tools: readline,
 libffi, Tcl and zlib; will be used if available but are optional. Graphviz and
 Xdot are used by the `show` command to display schematics.
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ file which enables ccache and sets the default compiler to clang when calling
 	"version": 1,
 	"configurePresets": [
 		{
-			"name": "default",
+			"name": "clang",
 			"binaryDir": "build",
 			"generator": "Unix Makefiles",
 			"cacheVariables": {

--- a/README.md
+++ b/README.md
@@ -128,15 +128,13 @@ file which enables ccache and sets the default compiler to clang when calling
 }
 ```
 
-Once generated, the build system can be run as follows:
+Once generated, build yosys like this:
 
-	$ cmake --build build       #..or..
-	$ cd build
-	$ cmake --build .
+	$ cmake --build build
 
-To quickly install Yosys with the default settings:
+To build and install a release build of Yosys:
 
-	$ cmake -B build . -DCMAKE_BUILD_TYPE=Release
+	$ cmake -B build -DCMAKE_BUILD_TYPE=Release
 	$ cmake --build build --config Release --parallel $(nproc)
 	$ sudo cmake --install build --strip
 


### PR DESCRIPTION
I'm struggling a bit to use CMake with Yosys so I'm adapting the README with what I learned, but I'm pretty unsure about if it's the right approach, so, draft for now.

IMO Ninja still can't be used since tests can't be run through cmake if ninja is used. If you configure for Ninja to build, and then you decide to run tests, requiring users to reconfigure to make is inconvenient, and so is requiring users to use undocumented make invocations. So I'm making it clear that GNU Make is required. An alternate approach would be to document how to run tests with make directly, would it be preferrable to forbid using CMake to run tests instead? Maybe making it an error?

I'm also fixing the preset file name, which prevented it from doing anything. Also, `-S .` can stay implicit, simplifying the release build cmake invocation.

Why is the release build specified with both `-DCMAKE_BUILD_TYPE=Release` at config time and `--config Release`? Does it have something to do with Ninja Multi-Config? I would far more prefer to configure once and choose a build config at build time. Should we instead turn asking cmake for tests into an error and document how to run tests without cmake to be able to benefit from Ninja Multi-Config?