### PR TITLE
dfflibmap: fix resetval clobber

### DIFF
--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -272,17 +272,18 @@ static void find_cell(std::vector<const LibertyAst *> cells, IdString cell_type,
 		if (!parse_next_state(cell, ff->find("next_state"), cell_next_pin, cell_next_pol, cell_enable_pin, cell_enable_pol) || (has_enable && (cell_enable_pin.empty() || cell_enable_pol != enapol)))
 			continue;
 
+		bool cell_rstval = rstval;
 		if (has_reset && !cell_next_pol) {
 			// next_state is negated
 			// we later propagate this inversion to the output,
 			// which requires the negation of the reset value
-			rstval = !rstval;
+			cell_rstval = !rstval;
 		}
-		if (has_reset && rstval == false) {
+		if (has_reset && cell_rstval == false) {
 			if (!parse_pin(cell, ff->find("clear"), cell_rst_pin, cell_rst_pol) || cell_rst_pol != rstpol)
 				continue;
 		}
-		if (has_reset && rstval == true) {
+		if (has_reset && cell_rstval == true) {
 			if (!parse_pin(cell, ff->find("preset"), cell_rst_pin, cell_rst_pol) || cell_rst_pol != rstpol)
 				continue;
 		}

--- a/tests/techmap/dfflibmap_resetval_clobber.lib
+++ b/tests/techmap/dfflibmap_resetval_clobber.lib
@@ -1,0 +1,52 @@
+library(test) {
+  cell (bad_dff) {
+    area : 1;
+    ff("IQ", "IQN") {
+      next_state : "!D"; // Look here
+      clocked_on : "CLK";
+      preset     : "!RST"; // Look here
+    }
+    pin(D) {
+      direction : input;
+    }
+    pin(CLK) {
+      direction : input;
+    }
+    pin(RST) {
+      direction : input;
+    }
+    pin(Q) {
+      direction: output;
+      function : "IQ";
+    }
+    pin(QN) {
+      direction: output;
+      function : "IQN";
+    }
+  }
+  cell (good_dff) {
+    area : 1;
+    ff("IQ", "IQN") {
+      next_state : "D"; // Look here
+      clocked_on : "CLK";
+      clear      : "RST"; // Look here
+    }
+    pin(D) {
+      direction : input;
+    }
+    pin(CLK) {
+      direction : input;
+    }
+    pin(RST) {
+      direction : input;
+    }
+    pin(Q) {
+      direction: output;
+      function : "IQ";
+    }
+    pin(QN) {
+      direction: output;
+      function : "IQN";
+    }
+  }
+}

--- a/tests/techmap/dfflibmap_resetval_clobber.ys
+++ b/tests/techmap/dfflibmap_resetval_clobber.ys
@@ -1,0 +1,13 @@
+read_verilog -icells <<EOT
+module top(input C, D, R, output Q);
+$_DFF_PP0_ ff (.C(C), .D(D), .R(R), .Q(Q));
+endmodule
+EOT
+
+dfflibmap -liberty dfflibmap_resetval_clobber.lib top
+read_liberty dfflibmap_resetval_clobber.lib
+flatten -noscopeinfo
+opt_clean
+
+select -assert-count 1 t:* top %i
+select -assert-count 1 t:$_DFF_PP0_ top %i


### PR DESCRIPTION
While looking at #5976 I realized we're searching for a matching liberty cell for a given RTLIL cell, but clobbering the reset value of the RTLIL cell, whenever we reject a liberty cell if we've flipped its polarity. The solution is to get a fresh copy of the input function argument and to flip and use that copy only within one iteration of the loop. A regression test is included, the flop should cleanly map to good_dff but would previously map to bad_dff with only an invertor on the reset.