### PR TITLE
const2ast: handle constant parsing from the command-line again

### DIFF
--- a/frontends/verilog/const2ast.cc
+++ b/frontends/verilog/const2ast.cc
@@ -45,11 +45,13 @@ using namespace AST;
 using namespace VERILOG_FRONTEND;
 
 void ConstParser::log_maybe_loc_error(std::string msg) {
-	log_file_error(*loc.begin.filename, loc.begin.line, "%s", msg);
+	log_file_error(loc.begin.filename ? loc.begin.filename->c_str() : "INTERNAL",
+    loc.begin.line, "%s", msg);
 }
 
 void ConstParser::log_maybe_loc_warn(std::string msg) {
-	log_file_warning(*loc.begin.filename, loc.begin.line, "%s", msg);
+	log_file_warning(loc.begin.filename ? loc.begin.filename->c_str() : "INTERNAL",
+    loc.begin.line, "%s", msg);
 }
 
 // divide an arbitrary length decimal number by two and return the rest

--- a/frontends/verilog/const2ast.cc
+++ b/frontends/verilog/const2ast.cc
@@ -36,6 +36,7 @@
 
 #include "verilog_frontend.h"
 #include "kernel/log.h"
+#include "kernel/register.h"
 #include <string.h>
 #include <math.h>
 
@@ -47,6 +48,9 @@ using namespace VERILOG_FRONTEND;
 void ConstParser::log_maybe_loc_error(std::string msg) {
 	if (loc.begin.filename)
 		log_file_error(*loc.begin.filename, loc.begin.line, "%s", msg);
+	else if (!Frontend::current_script_filename.empty())
+		log_file_error(Frontend::current_script_filename, Frontend::current_script_lineno,
+			"Failed to parse constant `%s': %s", code_str, msg);
 	else
 		log_error("Failed to parse constant `%s': %s", code_str, msg);
 }
@@ -54,6 +58,9 @@ void ConstParser::log_maybe_loc_error(std::string msg) {
 void ConstParser::log_maybe_loc_warn(std::string msg) {
 	if (loc.begin.filename)
 		log_file_warning(*loc.begin.filename, loc.begin.line, "%s", msg);
+	else if (!Frontend::current_script_filename.empty())
+		log_file_warning(Frontend::current_script_filename, Frontend::current_script_lineno,
+			"While parsing constant `%s': %s", code_str, msg);
 	else
 		log_warning("While parsing constant `%s': %s", code_str, msg);
 }

--- a/frontends/verilog/const2ast.cc
+++ b/frontends/verilog/const2ast.cc
@@ -45,13 +45,17 @@ using namespace AST;
 using namespace VERILOG_FRONTEND;
 
 void ConstParser::log_maybe_loc_error(std::string msg) {
-	log_file_error(loc.begin.filename ? loc.begin.filename->c_str() : "INTERNAL",
-    loc.begin.line, "%s", msg);
+	if (loc.begin.filename)
+		log_file_error(*loc.begin.filename, loc.begin.line, "%s", msg);
+	else
+		log_error("Failed to parse constant `%s': %s", code_str, msg);
 }
 
 void ConstParser::log_maybe_loc_warn(std::string msg) {
-	log_file_warning(loc.begin.filename ? loc.begin.filename->c_str() : "INTERNAL",
-    loc.begin.line, "%s", msg);
+	if (loc.begin.filename)
+		log_file_warning(*loc.begin.filename, loc.begin.line, "%s", msg);
+	else
+		log_warning("While parsing constant `%s': %s", code_str, msg);
 }
 
 // divide an arbitrary length decimal number by two and return the rest
@@ -160,6 +164,8 @@ void ConstParser::my_strtobin(std::vector<RTLIL::State> &data, const char *str, 
 // convert the Verilog code for a constant to an AST node
 std::unique_ptr<AstNode> ConstParser::const2ast(std::string code, char case_type, bool warn_z)
 {
+	code_str = code;
+
 	if (warn_z) {
 		auto ret = const2ast(code, case_type);
 		if (ret != nullptr && std::find(ret->bits.begin(), ret->bits.end(), RTLIL::State::Sz) != ret->bits.end())

--- a/frontends/verilog/verilog_frontend.h
+++ b/frontends/verilog/verilog_frontend.h
@@ -42,6 +42,8 @@ namespace VERILOG_FRONTEND
 	/* Ephemeral context class */
 	struct ConstParser {
 		AST::AstSrcLocType loc;
+		// original constant text, used in diagnostics when loc has no source file
+		std::string code_str = {};
 	private:
 		void log_maybe_loc_error(std::string msg);
 		void log_maybe_loc_warn(std::string msg);

--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -459,6 +459,8 @@ void Frontend::execute(std::vector<std::string> args, RTLIL::Design *design)
 
 FILE *Frontend::current_script_file = NULL;
 std::string Frontend::last_here_document;
+std::string Frontend::current_script_filename;
+int Frontend::current_script_lineno = 0;
 
 void Frontend::extra_args(std::istream *&f, std::string &filename, std::vector<std::string> args, size_t argidx, bool bin_input)
 {
@@ -496,6 +498,7 @@ void Frontend::extra_args(std::istream *&f, std::string &filename, std::vector<s
 					if (buffer.size() > 0 && (buffer[buffer.size() - 1] == '\n' || buffer[buffer.size() - 1] == '\r'))
 						break;
 				}
+				Frontend::current_script_lineno++;
 				size_t indent = buffer.find_first_not_of(" \t\r\n");
 				if (indent != std::string::npos && buffer.compare(indent, eot_marker.size(), eot_marker) == 0)
 					break;

--- a/kernel/register.h
+++ b/kernel/register.h
@@ -150,6 +150,10 @@ struct Frontend : Pass
 	static FILE *current_script_file;
 	static std::string last_here_document;
 
+	// script file and last line read from it
+	static std::string current_script_filename;
+	static int current_script_lineno;
+
 	std::string frontend_name;
 	Frontend(std::string name, std::string short_help = "** document me **",
 		source_location location = source_location::current());

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -792,15 +792,21 @@ bool run_frontend(std::string filename, std::string command, RTLIL::Design *desi
 			log_error("Can't open script file `%s' for reading: %s\n", filename, strerror(errno));
 
 		FILE *backup_script_file = Frontend::current_script_file;
+		std::string backup_script_filename = Frontend::current_script_filename;
+		int backup_script_lineno = Frontend::current_script_lineno;
 		Frontend::current_script_file = f;
+		Frontend::current_script_filename = filename;
+		Frontend::current_script_lineno = 0;
 
 		try {
 			std::string command;
 			while (fgetline(f, command)) {
+				Frontend::current_script_lineno++;
 				while (!command.empty() && command[command.size()-1] == '\\') {
 					std::string next_line;
 					if (!fgetline(f, next_line))
 						break;
+					Frontend::current_script_lineno++;
 					command.resize(command.size()-1);
 					command += next_line;
 				}
@@ -814,6 +820,7 @@ bool run_frontend(std::string filename, std::string command, RTLIL::Design *desi
 			if (!command.empty()) {
 				handle_label(command, from_to_active, run_from, run_to);
 				if (from_to_active) {
+					Frontend::current_script_lineno++;
 					Pass::call(design, command);
 					design->check();
 				}
@@ -821,10 +828,14 @@ bool run_frontend(std::string filename, std::string command, RTLIL::Design *desi
 		}
 		catch (...) {
 			Frontend::current_script_file = backup_script_file;
+			Frontend::current_script_filename = backup_script_filename;
+			Frontend::current_script_lineno = backup_script_lineno;
 			throw;
 		}
 
 		Frontend::current_script_file = backup_script_file;
+		Frontend::current_script_filename = backup_script_filename;
+		Frontend::current_script_lineno = backup_script_lineno;
 
 		if (filename != "-")
 			fclose(f);

--- a/tests/various/const_cmdline.ys
+++ b/tests/various/const_cmdline.ys
@@ -7,9 +7,9 @@ EOT
 prep -top top
 
 # width mismatch
-logger -expect warning "While parsing constant `2'd7'" 1
+logger -expect prefix-warning "const_cmdline.ys:[0-9]+: Warning: While parsing constant `2'd7'" 1
 setattr -set foo 2'd7 t:*
 
 # multi-bit unsized const
-logger -expect error "Failed to parse constant `8'00000101'" 1
+logger -expect prefix-error "const_cmdline.ys:[0-9]+: ERROR: Failed to parse constant `8'00000101'" 1
 setattr -set foo 8'00000101 t:*

--- a/tests/various/const_cmdline.ys
+++ b/tests/various/const_cmdline.ys
@@ -1,0 +1,15 @@
+# https://github.com/YosysHQ/yosys/issues/6009
+read_verilog <<EOT
+module top(output [7:0] o);
+assign o = 8'hAA;
+endmodule
+EOT
+prep -top top
+
+# width mismatch
+logger -expect warning "While parsing constant `2'd7'" 1
+setattr -set foo 2'd7 t:*
+
+# multi-bit unsized const
+logger -expect error "Failed to parse constant `8'00000101'" 1
+setattr -set foo 8'00000101 t:*

--- a/tests/various/const_cmdline_nested.sh
+++ b/tests/various/const_cmdline_nested.sh
@@ -1,0 +1,27 @@
+trap 'echo "ERROR in const_cmdline_nested.sh" >&2; exit 1' ERR
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+cat > "$tmp/design.v" <<'EOT'
+module top(output [7:0] o);
+assign o = 8'hAA;
+endmodule
+EOT
+
+printf "setattr -set foo 2'd7 t:*\n" > "$tmp/inner.ys"
+cat > "$tmp/outer.ys" <<EOT
+read_verilog $tmp/design.v
+prep -top top
+script $tmp/inner.ys
+setattr -set bar 3'd15 t:*
+EOT
+
+# nesting + revert
+out=$(${YOSYS} -q "$tmp/outer.ys" 2>&1)
+echo "$out" | grep -E "inner\.ys:1: Warning: While parsing constant \`2'd7'" > /dev/null
+echo "$out" | grep -E "outer\.ys:[0-9]+: Warning: While parsing constant \`3'd15'" > /dev/null
+
+# cmd fallback - no source location prefix
+out=$(${YOSYS} -q -p "read_verilog $tmp/design.v; prep -top top; setattr -set foo 2'd7 t:*" 2>&1)
+echo "$out" | grep -E "^Warning: While parsing constant \`2'd7'" > /dev/null


### PR DESCRIPTION
Fixes #6009. AST nodes produced by reading verilog always have locations, but that isn't the case for AST nodes created by parsing Verilog constants provided in the invocation of a pass. The new behavior is `INTERNAL:0: ERROR: Unsized constant must have width of 1 bit, but have 8 bits!` due to the use of `8'00000101` and not `8'b00000101`