### PR TITLE
gatemate: fix CC_FIFO_40K sim for non 2^n width usages

### DIFF
--- a/techlibs/gatemate/cells_sim.v
+++ b/techlibs/gatemate/cells_sim.v
@@ -1683,8 +1683,8 @@ module CC_FIFO_40K (
 	 end
 
 	always @(*) begin
-		fifo_wraddr = {wr_pointer[tp-1:0], {(15-tp){1'b0}}};
-		fifo_rdaddr = {rd_pointer[tp-1:0], {(15-tp){1'b0}}};
+		fifo_wraddr = wr_pointer[tp-1:0] * B_WIDTH;
+		fifo_rdaddr = rd_pointer[tp-1:0] * A_WIDTH;
 
 		rdaddr = {rd_pointer[tp], rd_pointer_int[tp-1:0]};
 		wraddr = {{(15-tp){1'b0}}, wr_pointer[tp], wr_pointer_int[tp:0]};


### PR DESCRIPTION
The fifo address calculation  is not correct for the the non power of 2  fifo WIDTHs. When using only power of 2 data, the behavior of the fifo is correct (for example 32 bits in 40 bits mode). When using the full bits, the MSB is incorrect (bit 39:32 for 40 bits mode for example).

This PR correct the address computation.

I don't have a working build of Yosys and I am not very familiar with the project. So I was not able to test the fix with unit tests in Yosys. Perhaps someone that know better the project can.

I have some fifo unit tests with a wrapper of CC_FIFO_40K in SpinalHDL. With power of 2 width my test are passing using the unpatched version, but not non power of 2. With this fix it works with various sizes. The test is done with verilator.

Also, perhaps this file come from somewhere else and the upstream should also be notified of the bug/fix.