### PR TITLE
opt_expr: treat z inputs as undef

### DIFF
--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -1017,11 +1017,11 @@ skip_fine_alu:
 				sig_a = RTLIL::SigSpec();
 
 			for (auto &bit : sig_a.to_sigbit_vector())
-				if (bit == RTLIL::State::Sx)
+				if (bit == RTLIL::State::Sx || bit == RTLIL::State::Sz)
 					goto found_the_x_bit;
 
 			for (auto &bit : sig_b.to_sigbit_vector())
-				if (bit == RTLIL::State::Sx)
+				if (bit == RTLIL::State::Sx || bit == RTLIL::State::Sz)
 					goto found_the_x_bit;
 
 			if (0) {

--- a/tests/opt/opt_expr_sub_not.ys
+++ b/tests/opt/opt_expr_sub_not.ys
@@ -88,6 +88,45 @@ select -assert-none t:$sub t:$add t:$alu
 
 design -reset
 
+# Arithmetic cells must treat z inputs as undef before applying further rewrites.
+read_rtlil <<EOF
+module \test
+  wire input 1 \b
+  wire width 4 output 2 \y_a
+  wire width 4 output 3 \y_b
+
+  cell $sub \sub_z_a
+    parameter \A_WIDTH 4
+    parameter \B_WIDTH 4
+    parameter \Y_WIDTH 4
+    parameter \A_SIGNED 0
+    parameter \B_SIGNED 0
+    connect \A { 3'00z \b }
+    connect \B 4'0101
+    connect \Y \y_a
+  end
+
+  cell $sub \sub_z_b
+    parameter \A_WIDTH 4
+    parameter \B_WIDTH 4
+    parameter \Y_WIDTH 4
+    parameter \A_SIGNED 0
+    parameter \B_SIGNED 0
+    connect \A 4'1111
+    connect \B { 3'00z \b }
+    connect \Y \y_b
+  end
+end
+EOF
+
+check
+opt_expr -fine -keepdc
+select -assert-none t:*
+sat -verify -enable_undef -set b 0 -prove y_a[0] 1'x
+sat -verify -enable_undef -set b 0 -prove y_b[0] 1'x
+
+design -reset
+
 read_verilog <<EOT
 module test(input sel, input [0:1] data, output out);
 assign out = data[sel];


### PR DESCRIPTION
## Summary

  Treat `State::Sz` like `State::Sx` when propagating undefined inputs through arithmetic cells in `opt_expr`.

  This fixes a four-state correctness issue under `-keepdc` and also allows arithmetic cells with known `z` inputs to be folded to undefined outputs earlier.

  ## Problem

  `opt_expr` has an early undef-propagation step for arithmetic cells. When an operand contains an explicitly undefined bit, the pass replaces the cell output with `State::Sx` before applying further expression rewrites.

  The check previously recognized only `State::Sx`:

  ```cpp
  if (bit == RTLIL::State::Sx)
      goto found_the_x_bit;
```
  State::Sz was not recognized, even though a z bit used as an arithmetic operand also makes the result undefined.

  This had two consequences.

  ### Missed optimization

  For example:

  A = {2'b00, 1'bz, b}
  B = 4'b0101
  Y = A - B

  The result is 4'bxxxx for either value of b. Before this change, the $sub cell remained in the design because the z bit was not recognized by the undef-propagation step.

  After this change, the result is directly replaced with 4'bxxxx and the unnecessary arithmetic cell is removed.

  ### Incorrect subsequent rewrite

  A more serious case occurs when the missed z input reaches a later two-valued rewrite:

  A = 4'b1111
  B = {2'b00, 1'bz, b}
  Y = A - B

  The original $sub evaluates to 4'bxxxx for both values of b.

  However, opt_expr -fine -keepdc could continue to the following rewrite:

  (2^k - 1) - B -> ~B

  For this example, that changed the result to:

  b = 0: 4'b11x1
  b = 1: 4'b11x0

  This makes previously undefined output bits defined and violates the undef-preservation expected from -keepdc.

  ## Fix

  Check for both State::Sx and State::Sz on the A and B operands:
```cpp
  if (bit == RTLIL::State::Sx || bit == RTLIL::State::Sz)
      goto found_the_x_bit;
```
  This routes z inputs through the existing undef-propagation path, which replaces the arithmetic output with State::Sx before any later expression rewrite can run.

  The change does not affect fully defined two-valued inputs.

  ## Tests

  Extend tests/opt/opt_expr_sub_not.ys with two RTLIL regression cases:

  - z on the A operand verifies that the arithmetic cell is folded to an undefined result instead of being left in the design.

  - z on the B operand reproduces the incorrect  (2^k - 1) - B -> ~B rewrite.

  The test checks that:

  - the generated RTLIL is valid;
  - no arithmetic or replacement cells remain after optimization;
  - the affected outputs remain undefined using
    sat -verify -enable_undef.

  The regression fails on the parent commit and passes with this change.

  All 15 tests/opt/opt_expr*.ys test scripts also pass.