### PR TITLE
xilinx_srl: keep the clock enable on FDRE shift registers

### DIFF
--- a/techlibs/xilinx/xilinx_srl.cc
+++ b/techlibs/xilinx/xilinx_srl.cc
@@ -77,7 +77,7 @@ void run_fixed(xilinx_srl_pm &pm)
 		}
 		else
 			log_abort();
-		if (first_cell->type.in(ID($_DFFE_NP_), ID($_DFFE_PP_)))
+		if (first_cell->type.in(ID($_DFFE_NP_), ID($_DFFE_PP_), ID(FDRE), ID(FDRE_1)))
 			c->setParam(ID(ENPOL), 1);
 		else if (first_cell->type.in(ID($_DFFE_NN_), ID($_DFFE_PN_)))
 			c->setParam(ID(ENPOL), 0);

--- a/tests/arch/xilinx/xilinx_srl_enable.ys
+++ b/tests/arch/xilinx/xilinx_srl_enable.ys
@@ -1,0 +1,46 @@
+# Regression test for a xilinx_srl bug where a fixed shift register inferred
+# from FDRE cells dropped the clock enable. FDRE has an active high clock
+# enable but run_fixed assigned it ENPOL 2 (no enable) instead of ENPOL 1,
+# so the resulting shift register shifted every cycle and ignored stalls.
+read_verilog <<EOT
+module xilinx_srl_enable_test(input i, clk, ce, output q);
+reg [3:0] shift = 4'b0000;
+always @(posedge clk)
+    if (ce)
+        shift <= {shift[2:0], i};
+assign q = shift[3];
+endmodule
+
+module $__XILINX_SHREG_(input C, D, E, input [1:0] L, output Q);
+parameter CLKPOL = 1;
+parameter ENPOL = 1;
+parameter DEPTH = 2;
+parameter [DEPTH-1:0] INIT = {DEPTH{1'b0}};
+reg [DEPTH-1:0] r = INIT;
+wire ce = (ENPOL == 2) ? 1'b1 : (ENPOL == 1) ? E : ~E;
+always @(posedge C)
+    if (ce)
+        r <= { r[DEPTH-2:0], D };
+assign Q = r[L];
+endmodule
+EOT
+design -copy-to model $__XILINX_SHREG_
+hierarchy -top xilinx_srl_enable_test
+prep
+design -save gold
+
+synth_xilinx -noiopad -noclkbuf -run begin:map_luts
+opt_expr -mux_undef -noclkinv
+techmap -map +/xilinx/ff_map.v
+xilinx_srl -fixed
+opt
+
+select -assert-count 1 t:$__XILINX_SHREG_
+
+design -stash gate
+design -import gold -as gold
+design -import gate -as gate
+design -copy-from model -as $__XILINX_SHREG_ \$__XILINX_SHREG_
+prep
+miter -equiv -flatten -make_assert -make_outputs gold gate miter
+sat -verify -prove-asserts -show-ports -seq 6 miter


### PR DESCRIPTION
xilinx_srl inferred a fixed length shift register from a chain of FDRE flops and dropped the clock enable. The fix gives FDRE and FDRE_1 chains ENPOL 1 so the shift register keeps its active high enable instead of shifting every cycle.

FDRE has an active high clock enable. run_fixed set ENPOL to 2 for FDRE, which the cells_map template reads as no enable and ties the enable high, so the connected enable was ignored. Any design where an enabled register chain of depth 3 or more feeds a wider datapath got a shift register that advanced during stalls. On a pipelined RV32I core this corrupted the delayed pc plus 4 value, so the jal link register received the wrong value and every function return looped.

The change adds FDRE and FDRE_1 to the branch that sets ENPOL 1. $_DFFE_NP_ and $_DFFE_PP_ already used that branch because they also have an active high enable.

A minimal example.
```verilog
module m(input clk, ce, i, output q);
  reg [3:0] sr = 0;
  always @(posedge clk) if (ce) sr <= {sr[2:0], i};
  assign q = sr[3];
endmodule
```
Before the fix the inferred SRL16E ignored ce and shifted every cycle. After the fix it shifts only when ce is high and matches the source.

The new test tests/arch/xilinx/xilinx_srl_enable.ys infers the shift register from the FDRE path and proves it equivalent to the source with a SAT miter. It fails before this change and passes after.

Fixes #6058
