### PR TITLE
Add dependencies to gtests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,6 +535,7 @@ if (NOT YOSYS_BUILD_PYTHON_ONLY)
 	add_custom_target(test-unit
 		COMMAND ${CMAKE_CTEST_COMMAND} --test-dir tests/unit --output-on-failure
 		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+		DEPENDS $<$<TARGET_EXISTS:yosys-gtest-all>:yosys-gtest-all>
 	)
 
 	add_custom_target(test-vanilla

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -14,6 +14,7 @@ function(yosys_gtest arg_TARGET)
 	)
 	yosys_expand_components(test_components essentials ${arg_COMPONENTS})
 	yosys_link_components(${target} PRIVATE ${test_components})
+	add_dependencies(yosys-gtest-all ${target})
 
 	if(NOT CMAKE_CROSSCOMPILING)
 		gtest_discover_tests(${target})
@@ -21,6 +22,8 @@ function(yosys_gtest arg_TARGET)
 endfunction()
 
 if (GTest_FOUND)
+	add_custom_target(yosys-gtest-all)
+
 	add_subdirectory(kernel)
 	add_subdirectory(opt)
 	add_subdirectory(techmap)


### PR DESCRIPTION
Required to be able to run unit tests only, but also makes sure all is built in time in other use cases
```
make clean
make test-unit -j9
```
