### PR TITLE
wheels: force static libffi in build

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -93,14 +93,14 @@ jobs:
           CIBW_BEFORE_ALL: bash ./.github/workflows/wheels/cibw_before_all.sh
           CIBW_ENVIRONMENT: >
             OPTFLAGS=-O3
-            PKG_CONFIG_PATH=./ffi/pfx/lib/pkgconfig
-            PATH="$PWD/bison/src:$PATH"
+            PKG_CONFIG_PATH={project}/ffi/pfx/lib/pkgconfig
+            PATH="{project}/bison/src:$PATH"
             CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release"
           CIBW_ENVIRONMENT_MACOS: >
             OPTFLAGS=-O3
-            PKG_CONFIG_PATH=./ffi/pfx/lib/pkgconfig
+            PKG_CONFIG_PATH={project}/ffi/pfx/lib/pkgconfig
             MACOSX_DEPLOYMENT_TARGET=11
-            PATH="$PWD/bison/src:$PATH"
+            PATH="{project}/bison/src:$PATH"
             CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release"
           CIBW_BEFORE_BUILD: bash ./.github/workflows/wheels/cibw_before_build.sh
           CIBW_TEST_COMMAND: python3 {project}/tests/pyosys/run_tests.py

--- a/.github/workflows/wheels/cibw_before_all.sh
+++ b/.github/workflows/wheels/cibw_before_all.sh
@@ -29,9 +29,7 @@ fi
 	set -e -x
 	cd ffi
 	## Ultimate libyosys.so will be shared, so we need fPIC for the static libraries
-	CFLAGS=-fPIC CXXFLAGS=-fPIC ./configure --prefix=$PWD/pfx
+	LDFLAGS=-fPIC CFLAGS=-fPIC CXXFLAGS=-fPIC ./configure --prefix=$PWD/pfx --enable-static --disable-shared
 	make clean
 	make install -j$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu)
-	## Forces static library to be used in all situations
-	sed -i.bak 's@-L${toolexeclibdir} -lffi@${toolexeclibdir}/libffi.a@' ./pfx/lib/pkgconfig/libffi.pc
 )


### PR DESCRIPTION


_If your work is part of a larger effort, please discuss your general plans on [Discourse](https://yosyshq.discourse.group/) first to align your vision with maintainers._

_What are the reasons/motivation for this change?_

Requested by @mmicko, libffi was not being used because of a detection bug and now that it is used, wheels are not importable as some symbols were not being successfully embedded.

Unlike the Makefile, CMake does not appear to respect the `sed` changes in `./pfx/lib/pkgconfig/libffi.pc`.

_Explain how this is achieved._

Apparently, there's a `--disable-shared` option. By adding that and making sure environment variables are not PWD-sensitive, the hope is it just embeds the .a file uncritically.

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._

https://github.com/donn/yosys/actions/runs/30266910312

