### PR TITLE
feat: add support for UDPs

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -28,6 +28,7 @@
  */
 
 #include "kernel/yosys.h"
+#include "kernel/udp.h"
 #include "libs/sha1/sha1.h"
 #include "ast.h"
 
@@ -1158,7 +1159,7 @@ static RTLIL::Module *process_module(RTLIL::Design *design, AstNode *ast, bool d
 
 		bool blackbox_module = flag_lib;
 
-		if (!blackbox_module && !flag_noblackbox) {
+		if (!blackbox_module && !flag_noblackbox && !ast->get_bool_attribute(ID(udp))) {
 			blackbox_module = true;
 			for (const auto& child : ast->children) {
 				if (child->type == AST_WIRE && (child->is_input || child->is_output))
@@ -1274,6 +1275,21 @@ static RTLIL::Module *process_module(RTLIL::Design *design, AstNode *ast, bool d
 			const auto& node = ast->children[i];
 			if (node->type == AST_WIRE || node->type == AST_MEMORY)
 				node->genRTLIL();
+		}
+		if (!blackbox_module && ast->get_bool_attribute(ID(udp))) {
+			RTLIL::UdpDefinition udp;
+			udp.sequential = ast->get_bool_attribute(ID(udp_sequential));
+			udp.entries = RTLIL::deserialize_udp_table(
+					ast->attributes.at(ID(udp_table))->asAttrConst().decode_string());
+
+			int num_ports = 0;
+			for (auto wire : module->wires())
+				num_ports = std::max(num_ports, wire->port_id);
+			udp.ports.resize(num_ports);
+			for (auto wire : module->wires())
+				if (wire->port_id > 0)
+					udp.ports.at(wire->port_id - 1) = wire->name;
+			RTLIL::import_udp(module, udp);
 		}
 		for (size_t i = 0; i < ast->children.size(); i++) {
 			const auto& node = ast->children[i];

--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -280,6 +280,7 @@ static parser::symbol_type process_str(char *str, int len, bool triple, parser::
 %x SYNOPSYS_FLAGS
 %x IMPORT_DPI
 %x BASED_CONST
+%x UDP_TABLE
 
 UNSIGNED_NUMBER [0-9][0-9_]*
 FIXED_POINT_NUMBER_DEC [0-9][0-9_]*\.[0-9][0-9_]*([eE][-+]?[0-9_]+)?
@@ -355,6 +356,20 @@ TIME_SCALE_SUFFIX [munpf]?s
 
 "module"       { return parser::make_TOK_MODULE(out_loc); }
 "endmodule"    { return parser::make_TOK_ENDMODULE(out_loc); }
+"primitive"    { return parser::make_TOK_PRIMITIVE_KW(out_loc); }
+"endprimitive" { return parser::make_TOK_ENDPRIMITIVE(out_loc); }
+"table"        { BEGIN(UDP_TABLE); return parser::make_TOK_TABLE(out_loc); }
+<UDP_TABLE>"endtable" {
+	BEGIN(INITIAL);
+	return parser::make_TOK_ENDTABLE(out_loc);
+}
+<UDP_TABLE>[-?*a-zA-Z0-9_$]+ {
+	auto val = std::make_unique<std::string>(YYText());
+	return parser::make_TOK_UDP_SYMBOL(std::move(val), out_loc);
+}
+<UDP_TABLE>[:;()] {
+	return char_tok(*YYText(), out_loc);
+}
 "function"     { return parser::make_TOK_FUNCTION(out_loc); }
 "endfunction"  { return parser::make_TOK_ENDFUNCTION(out_loc); }
 "task"         { return parser::make_TOK_TASK(out_loc); }
@@ -699,15 +714,15 @@ import[ \t\r\n]+\"(DPI|DPI-C)\"[ \t\r\n]+function[ \t\r\n]+ {
 {FIXED_POINT_NUMBER_DEC}{TIME_SCALE_SUFFIX} { return parser::make_TOK_TIME_SCALE(out_loc); }
 {FIXED_POINT_NUMBER_NO_DEC}{TIME_SCALE_SUFFIX} { return parser::make_TOK_TIME_SCALE(out_loc); }
 
-<INITIAL,BASED_CONST>"/*" { comment_caller=YY_START; BEGIN(COMMENT); }
+<INITIAL,BASED_CONST,UDP_TABLE>"/*" { comment_caller=YY_START; BEGIN(COMMENT); }
 <COMMENT>.    /* ignore comment body */
 <COMMENT>\n   /* ignore comment body */
 <COMMENT>"*/" { BEGIN(comment_caller); }
 
 
-<INITIAL,BASED_CONST>[ \t\r\n]		/* ignore whitespaces */
-<INITIAL,BASED_CONST>\\[\r\n]		/* ignore continuation sequence */
-<INITIAL,BASED_CONST>"//"[^\r\n]*	/* ignore one-line comments */
+<INITIAL,BASED_CONST,UDP_TABLE>[ \t\r\n]		/* ignore whitespaces */
+<INITIAL,BASED_CONST,UDP_TABLE>\\[\r\n]		/* ignore continuation sequence */
+<INITIAL,BASED_CONST,UDP_TABLE>"//"[^\r\n]*	/* ignore one-line comments */
 
 <INITIAL>. { return char_tok(*YYText(), out_loc); }
 <*>. { BEGIN(0); return char_tok(*YYText(), out_loc); }

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -47,6 +47,7 @@
 
 %code requires {
 	#include "kernel/yosys_common.h"
+	#include "kernel/udp.h"
 	#include "frontends/verilog/verilog_error.h"
 	#include "frontends/verilog/verilog_location.h"
 	YOSYS_NAMESPACE_BEGIN
@@ -87,6 +88,8 @@
 			bool current_wire_rand, current_wire_const, current_wire_automatic;
 			bool current_modport_input, current_modport_output;
 			bool default_nettype_wire = true;
+			std::vector<RTLIL::UdpTableEntry> udp_entries;
+			std::string udp_initial_port;
 			std::istream* lexin;
 
 			AstNode* saveChild(std::unique_ptr<AstNode> child);
@@ -239,6 +242,247 @@
 			if (before && after && *before != *after)
 				err_at_loc(loc, "%s (%s) and end label (%s) don't match.",
 					element, before->c_str() + 1, after->c_str() + 1);
+		}
+
+		static char normalize_udp_symbol(char symbol)
+		{
+			if ('A' <= symbol && symbol <= 'Z')
+				return symbol - 'A' + 'a';
+			return symbol;
+		}
+
+		static bool udp_has_transition(const std::string &inputs)
+		{
+			for (char symbol : inputs)
+				if (symbol == '(' || symbol == 'r' || symbol == 'f' ||
+						symbol == 'p' || symbol == 'n' || symbol == '*')
+					return true;
+			return false;
+		}
+
+		static std::string normalize_udp_inputs(const Location &loc, const std::string &inputs)
+		{
+			std::string result;
+			int transitions = 0;
+			for (size_t i = 0; i < inputs.size();) {
+				char symbol = normalize_udp_symbol(inputs[i]);
+				if (symbol == '(') {
+					size_t close = inputs.find(')', i + 1);
+					if (close == std::string::npos || close != i + 3)
+						err_at_loc(loc, "UDP edge indicator must contain exactly two symbols.");
+					result += '(';
+					char first_symbol = 0;
+					for (size_t j = i + 1; j < close; j++) {
+						char edge_symbol = normalize_udp_symbol(inputs[j]);
+						if (edge_symbol != '0' && edge_symbol != '1' && edge_symbol != 'x' &&
+								edge_symbol != '?' && edge_symbol != 'b')
+							err_at_loc(loc, "Invalid UDP edge symbol `%c'.", inputs[j]);
+						if (first_symbol == 0)
+							first_symbol = edge_symbol;
+						else if (first_symbol == edge_symbol && edge_symbol != 'b' && edge_symbol != '?')
+							err_at_loc(loc, "A UDP edge indicator cannot have identical level symbols.");
+						result += edge_symbol;
+					}
+					result += ')';
+					i = close + 1;
+					transitions++;
+					continue;
+				}
+
+				if (symbol != '0' && symbol != '1' && symbol != 'x' && symbol != '?' &&
+						symbol != 'b' && symbol != 'r' && symbol != 'f' &&
+						symbol != 'p' && symbol != 'n' && symbol != '*')
+					err_at_loc(loc, "Invalid UDP input symbol `%c'.", inputs[i]);
+				if (symbol == 'r' || symbol == 'f' || symbol == 'p' || symbol == 'n' || symbol == '*')
+					transitions++;
+				result += symbol;
+				i++;
+			}
+			if (transitions > 1)
+				err_at_loc(loc, "A UDP table row can contain at most one input transition.");
+			return result;
+		}
+
+		static int count_udp_inputs(const std::string &inputs)
+		{
+			int count = 0;
+			for (size_t i = 0; i < inputs.size(); i++, count++)
+				if (inputs[i] == '(') {
+					size_t close = inputs.find(')', i + 1);
+					log_assert(close != std::string::npos);
+					i = close;
+				}
+			return count;
+		}
+
+		static char normalize_udp_state(const Location &loc, const std::string &state, bool output)
+		{
+			if (state.size() != 1)
+				err_at_loc(loc, "UDP %s field must contain exactly one symbol.", output ? "output" : "current-state");
+			char symbol = normalize_udp_symbol(state[0]);
+			if (output) {
+				if (symbol != '0' && symbol != '1' && symbol != 'x' && symbol != '-')
+					err_at_loc(loc, "Invalid UDP output symbol `%c'.", state[0]);
+			} else if (symbol != '0' && symbol != '1' && symbol != 'x' && symbol != '?' && symbol != 'b') {
+				err_at_loc(loc, "Invalid UDP current-state symbol `%c'.", state[0]);
+			}
+			return symbol;
+		}
+
+		static void add_udp_entry(ParseState *extra, const Location &loc, const std::string &inputs,
+				const std::string *current, const std::string &output)
+		{
+			RTLIL::UdpTableEntry entry;
+			entry.inputs = normalize_udp_inputs(loc, inputs);
+			if (current != nullptr)
+				entry.curr = normalize_udp_state(loc, *current, false);
+			entry.next = normalize_udp_state(loc, output, true);
+			extra->udp_entries.push_back(std::move(entry));
+		}
+
+		static void finish_udp(ParseState *extra, const Location &loc)
+		{
+			AstNode *udp = extra->ast_stack.back();
+			log_assert(udp->type == AST_MODULE);
+
+			if (!extra->port_stubs.empty())
+				err_at_loc(loc, "Missing details for UDP port `%s'.", extra->port_stubs.begin()->first.c_str());
+
+			struct PortInfo {
+				int port_id = 0;
+				bool is_input = false;
+				bool is_output = false;
+				bool is_reg = false;
+				bool is_logic = false;
+				bool non_scalar = false;
+				Location location;
+			};
+			dict<std::string, PortInfo> port_info;
+			int initial_count = 0;
+			for (const auto &child : udp->children) {
+				if (child->type == AST_INITIAL) {
+					initial_count++;
+					continue;
+				}
+				if (child->type != AST_WIRE)
+					err_at_loc(child->location, "Only port declarations, an optional initial statement, and a table are allowed in a UDP.");
+
+				auto &info = port_info[child->str];
+				if (child->port_id != 0) {
+					if (info.port_id != 0 && info.port_id != child->port_id)
+						err_at_loc(child->location, "UDP port `%s' appears more than once in the port list.", child->str.c_str());
+					info.port_id = child->port_id;
+				}
+				info.is_input |= child->is_input;
+				info.is_output |= child->is_output;
+				info.is_reg |= child->is_reg;
+				info.is_logic |= child->is_logic;
+				info.non_scalar |= !child->children.empty();
+				info.location = child->location;
+			}
+
+			if (extra->port_counter < 2)
+				err_at_loc(loc, "A UDP must have one output and at least one input.");
+
+			std::vector<std::string> ordered_ports(extra->port_counter);
+			for (const auto &it : port_info) {
+				if (it.second.port_id == 0)
+					continue;
+				if (it.second.port_id < 1 || it.second.port_id > extra->port_counter ||
+						!ordered_ports[it.second.port_id - 1].empty())
+					err_at_loc(it.second.location, "Invalid or duplicate UDP port position.");
+				ordered_ports[it.second.port_id - 1] = it.first;
+			}
+			for (int i = 0; i < extra->port_counter; i++)
+				if (ordered_ports[i].empty())
+					err_at_loc(loc, "UDP port %d has no declaration.", i + 1);
+
+			auto &output = port_info.at(ordered_ports.front());
+			if (!output.is_output || output.is_input)
+				err_at_loc(output.location, "The first UDP port must be the single output port.");
+			if (output.is_logic)
+				err_at_loc(output.location, "A sequential UDP output must use the `reg' keyword.");
+			if (output.non_scalar)
+				err_at_loc(output.location, "UDP ports must be scalar.");
+
+			for (size_t i = 1; i < ordered_ports.size(); i++) {
+				auto &input = port_info.at(ordered_ports[i]);
+				if (!input.is_input || input.is_output || input.is_reg || input.is_logic)
+					err_at_loc(input.location, "UDP port `%s' must be a scalar input.", ordered_ports[i].c_str());
+				if (input.non_scalar)
+					err_at_loc(input.location, "UDP ports must be scalar.");
+			}
+
+			bool sequential = output.is_reg;
+			if (initial_count != 0 && !sequential)
+				err_at_loc(loc, "A combinational UDP cannot have an initial value.");
+			if (initial_count > 1)
+				err_at_loc(loc, "A UDP output can have only one initial value.");
+			if (!extra->udp_initial_port.empty() && extra->udp_initial_port != ordered_ports.front())
+				err_at_loc(loc, "UDP initial statement must assign the output port `%s'.", ordered_ports.front().c_str());
+
+			std::unique_ptr<AstNode> initial_value;
+			for (const auto &child : udp->children) {
+				if (child->type != AST_INITIAL)
+					continue;
+				if (child->children.size() != 1 || child->children[0]->type != AST_BLOCK ||
+						child->children[0]->children.size() != 1 ||
+						(child->children[0]->children[0]->type != AST_ASSIGN_EQ &&
+						 child->children[0]->children[0]->type != AST_ASSIGN_LE)) {
+					err_at_loc(child->location, "A UDP initial statement must be a single assignment to its output.");
+				}
+				AstNode *assign = child->children[0]->children[0].get();
+				if (assign->children.size() != 2 || assign->children[0]->type != AST_IDENTIFIER ||
+						assign->children[0]->str != ordered_ports.front())
+					err_at_loc(child->location, "UDP initial statement must assign the output port `%s'.", ordered_ports.front().c_str());
+				initial_value = assign->children[1]->clone();
+			}
+			if (initial_value != nullptr) {
+				if (initial_value->type != AST_CONSTANT)
+					err_at_loc(initial_value->location, "A UDP initial value must be 0, 1, or x.");
+				RTLIL::Const value = initial_value->bitsAsConst();
+				RTLIL::State state = RTLIL::State::Sx;
+				bool is_zero = !value.empty();
+				bool is_one = !value.empty() && value[0] == RTLIL::State::S1;
+				for (int i = 0; i < GetSize(value); i++) {
+					is_zero &= value[i] == RTLIL::State::S0;
+					is_one &= value[i] == (i == 0 ? RTLIL::State::S1 : RTLIL::State::S0);
+				}
+				if (is_zero)
+					state = RTLIL::State::S0;
+				else if (is_one)
+					state = RTLIL::State::S1;
+				else if (GetSize(value) != 1 || value[0] != RTLIL::State::Sx)
+					err_at_loc(initial_value->location, "A UDP initial value must be 0, 1, or x.");
+				initial_value = AstNode::mkconst_bits(initial_value->location, {state}, false);
+				for (auto &child : udp->children)
+					if (child->type == AST_WIRE && child->str == ordered_ports.front())
+						child->attributes[ID::init] = initial_value->clone();
+				udp->children.erase(std::remove_if(udp->children.begin(), udp->children.end(),
+						[](const std::unique_ptr<AstNode> &child) { return child->type == AST_INITIAL; }),
+						udp->children.end());
+			}
+			if (extra->udp_entries.empty())
+				err_at_loc(loc, "A UDP table must contain at least one entry.");
+
+			for (const auto &entry : extra->udp_entries) {
+				if (count_udp_inputs(entry.inputs) != extra->port_counter - 1)
+					err_at_loc(loc, "UDP table row has %d inputs; expected %d.",
+							count_udp_inputs(entry.inputs), extra->port_counter - 1);
+				if (sequential && entry.curr == 0)
+					err_at_loc(loc, "A sequential UDP table row requires a current-state field.");
+				if (!sequential && entry.curr != 0)
+					err_at_loc(loc, "A combinational UDP table row cannot have a current-state field.");
+				if (!sequential && udp_has_transition(entry.inputs))
+					err_at_loc(loc, "A combinational UDP table row cannot contain an input transition.");
+				if (!sequential && entry.next == '-')
+					err_at_loc(loc, "A combinational UDP table row cannot use `-' as its output.");
+			}
+
+			udp->set_attribute(ID(udp), AstNode::mkconst_int(loc, 1, false));
+			udp->set_attribute(ID(udp_sequential), AstNode::mkconst_int(loc, sequential, false));
+			udp->set_attribute(ID(udp_table),
+					AstNode::mkconst_str(loc, RTLIL::serialize_udp_table(extra->udp_entries)));
 		}
 
 		AstNode* ParseState::saveChild(std::unique_ptr<AstNode> child) {
@@ -483,13 +727,14 @@
 %token <integer_t> integer_t "integer"
 %token <ast_node_type_t> ast_node_type_t
 
-%token <string_t> TOK_STRING TOK_ID TOK_CONSTVAL TOK_REALVAL TOK_PRIMITIVE
+%token <string_t> TOK_STRING TOK_ID TOK_CONSTVAL TOK_REALVAL TOK_PRIMITIVE TOK_UDP_SYMBOL
 %token <string_t> TOK_SVA_LABEL TOK_SPECIFY_OPER TOK_MSG_TASKS
 %token <string_t> TOK_BASE TOK_BASED_CONSTVAL TOK_UNBASED_UNSIZED_CONSTVAL
 %token <string_t> TOK_USER_TYPE TOK_PKG_USER_TYPE
 %token TOK_ASSERT TOK_ASSUME TOK_RESTRICT TOK_COVER TOK_FINAL
 %token ATTR_BEGIN ATTR_END DEFATTR_BEGIN DEFATTR_END
 %token TOK_MODULE TOK_ENDMODULE TOK_PARAMETER TOK_LOCALPARAM TOK_DEFPARAM
+%token TOK_PRIMITIVE_KW TOK_ENDPRIMITIVE TOK_TABLE TOK_ENDTABLE
 %token TOK_PACKAGE TOK_ENDPACKAGE TOK_PACKAGESEP
 %token TOK_INTERFACE TOK_ENDINTERFACE TOK_MODPORT TOK_VAR TOK_WILDCARD_CONNECT
 %token TOK_INPUT TOK_OUTPUT TOK_INOUT TOK_WIRE TOK_WAND TOK_WOR TOK_REG TOK_LOGIC
@@ -548,6 +793,7 @@
 %type <ast_t> range range_or_multirange non_opt_range non_opt_multirange
 %type <ast_t> wire_type expr basic_expr concat_list assignment_pattern_list rvalue lvalue lvalue_concat_list non_io_wire_type io_wire_type
 %type <string_t> opt_label opt_sva_label tok_prim_wrapper hierarchical_id hierarchical_type_id integral_number
+%type <string_t> udp_input_list udp_input_field udp_edge_symbols udp_state_symbol udp_output_symbol
 %type <string_t> type_name
 %type <ast_t> opt_enum_init enum_type struct_type enum_struct_type func_return_type typedef_base_type
 %type <boolean_t> opt_property always_comb_or_latch always_or_always_ff
@@ -611,6 +857,7 @@ design:
 	import_stmt design |
 	interface design |
 	bind_directive design |
+	udp design |
 	%empty;
 
 attr:
@@ -805,6 +1052,99 @@ module_arg:
 	} module_arg_opt_assignment |
 	TOK_DOT TOK_DOT TOK_DOT {
 		extra->do_not_require_port_stubs = true;
+	};
+
+udp:
+	attr TOK_PRIMITIVE_KW {
+		extra->enterTypeScope();
+	} TOK_ID {
+		extra->do_not_require_port_stubs = false;
+		AstNode *node = extra->pushChild(std::make_unique<AstNode>(@$, AST_MODULE));
+		extra->current_ast_mod = node;
+		extra->port_stubs.clear();
+		extra->port_counter = 0;
+		extra->udp_entries.clear();
+		extra->udp_initial_port.clear();
+		node->str = *$4;
+		append_attr(node, std::move($1));
+	} TOK_LPAREN module_args optional_comma TOK_RPAREN TOK_SEMICOL udp_body TOK_ENDPRIMITIVE opt_label {
+		finish_udp(extra, location_range(@2, @$));
+		SET_AST_NODE_LOC(extra->ast_stack.back(), @2, @$);
+		extra->ast_stack.pop_back();
+		log_assert(extra->ast_stack.size() == 1);
+		checkLabelsMatch(@13, "Primitive name", $4.get(), $13.get());
+		extra->current_ast_mod = nullptr;
+		extra->udp_entries.clear();
+		extra->udp_initial_port.clear();
+		extra->exitTypeScope();
+	};
+
+udp_body:
+	udp_port_declaration_list udp_initial_opt udp_table;
+
+udp_port_declaration_list:
+	udp_port_declaration_list wire_decl |
+	%empty;
+
+udp_initial_opt:
+	TOK_INITIAL TOK_ID TOK_EQ expr TOK_SEMICOL {
+		extra->udp_initial_port = *$2;
+		auto ident = std::make_unique<AstNode>(@2, AST_IDENTIFIER);
+		ident->str = *$2;
+		auto assign = std::make_unique<AstNode>(@$, AST_ASSIGN_LE, std::move(ident), std::move($4));
+		auto block = std::make_unique<AstNode>(@$, AST_BLOCK, std::move(assign));
+		extra->ast_stack.back()->children.push_back(std::make_unique<AstNode>(@$, AST_INITIAL, std::move(block)));
+	} |
+	%empty;
+
+udp_table:
+	TOK_TABLE udp_table_entry_list TOK_ENDTABLE;
+
+udp_table_entry_list:
+	udp_table_entry | udp_table_entry_list udp_table_entry;
+
+udp_table_entry:
+	udp_input_list TOK_COL udp_output_symbol TOK_SEMICOL {
+		add_udp_entry(extra, location_range(@1, @4), *$1, nullptr, *$3);
+	} |
+	udp_input_list TOK_COL udp_state_symbol TOK_COL udp_output_symbol TOK_SEMICOL {
+		add_udp_entry(extra, location_range(@1, @6), *$1, $3.get(), *$5);
+	};
+
+udp_input_list:
+	udp_input_field {
+		$$ = std::move($1);
+	} |
+	udp_input_list udp_input_field {
+		*$1 += *$2;
+		$$ = std::move($1);
+	};
+
+udp_input_field:
+	TOK_UDP_SYMBOL {
+		$$ = std::move($1);
+	} |
+	TOK_LPAREN udp_edge_symbols TOK_RPAREN {
+		$$ = std::make_unique<std::string>("(" + *$2 + ")");
+	};
+
+udp_edge_symbols:
+	TOK_UDP_SYMBOL {
+		$$ = std::move($1);
+	} |
+	udp_edge_symbols TOK_UDP_SYMBOL {
+		*$1 += *$2;
+		$$ = std::move($1);
+	};
+
+udp_state_symbol:
+	TOK_UDP_SYMBOL {
+		$$ = std::move($1);
+	};
+
+udp_output_symbol:
+	TOK_UDP_SYMBOL {
+		$$ = std::move($1);
 	};
 
 package:

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -80,6 +80,7 @@ yosys_core(kernel
 	threading.h
 	timinginfo.h
 	topo_scc.h
+	udp.cc
 	utils.h
 	version.cc
 	yosys.cc

--- a/kernel/udp.cc
+++ b/kernel/udp.cc
@@ -1,0 +1,462 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2026  YosysHQ contributors
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "kernel/udp.h"
+#include "kernel/log.h"
+#include "kernel/rtlil.h"
+#include <cassert>
+#include <cctype>
+#include <iterator>
+
+YOSYS_NAMESPACE_BEGIN
+
+namespace RTLIL
+{
+std::string serialize_udp_table(const std::vector<UdpTableEntry> &entries)
+{
+	std::string result;
+	for (const auto &entry : entries) {
+		result += entry.inputs;
+		result += ':';
+		if (entry.curr != 0)
+			result += entry.curr;
+		result += ':';
+		result += entry.next;
+		result += '\n';
+	}
+	return result;
+}
+
+std::vector<UdpTableEntry> deserialize_udp_table(const std::string &table)
+{
+	std::vector<UdpTableEntry> result;
+	size_t pos = 0;
+	while (pos < table.size()) {
+		size_t end = table.find('\n', pos);
+		if (end == std::string::npos)
+			end = table.size();
+
+		std::string_view row(table.data() + pos, end - pos);
+		size_t colon1 = row.find(':');
+		size_t colon2 = colon1 == std::string_view::npos ? colon1 : row.find(':', colon1 + 1);
+		if (colon1 == std::string_view::npos || colon2 == std::string_view::npos || colon2 + 2 != row.size())
+			log_error("Malformed encoded UDP table row `%.*s'.\n", int(row.size()), row.data());
+
+		UdpTableEntry entry;
+		entry.inputs = std::string(row.substr(0, colon1));
+		if (colon2 != colon1 + 1) {
+			if (colon2 != colon1 + 2)
+				log_error("Malformed encoded UDP current-state field in row `%.*s'.\n", int(row.size()), row.data());
+			entry.curr = row[colon1 + 1];
+		}
+		entry.next = row[colon2 + 1];
+		result.push_back(std::move(entry));
+		pos = end + 1;
+	}
+	return result;
+}
+
+// static bool has_edge_symbol(const std::string &inputs)
+// {
+// 	for (char c : inputs)
+// 		if (c == '(' || c == '*' || c == 'r' || c == 'f' || c == 'p' || c == 'n')
+// 			return true;
+// 	return false;
+// }
+
+// static void append_level_symbol(std::vector<Const> &patterns, char symbol)
+// {
+// 	switch (symbol) {
+// 	case '0':
+// 		for (auto &pattern : patterns)
+// 			pattern.bits().push_back(State::S0);
+// 		break;
+// 	case '1':
+// 		for (auto &pattern : patterns)
+// 			pattern.bits().push_back(State::S1);
+// 		break;
+// 	case 'x':
+// 		// A high-impedance value on a UDP input is interpreted as unknown.
+// 		// Match both RTLIL states here to preserve that four-state behavior.
+// 		for (size_t i = 0, count = patterns.size(); i < count; i++) {
+// 			Const high_impedance = patterns[i];
+// 			patterns[i].bits().push_back(State::Sx);
+// 			high_impedance.bits().push_back(State::Sz);
+// 			patterns.push_back(std::move(high_impedance));
+// 		}
+// 		break;
+// 	case '?':
+// 		for (auto &pattern : patterns)
+// 			pattern.bits().push_back(State::Sa);
+// 		break;
+// 	case 'b': {
+// 		size_t count = patterns.size();
+// 		for (size_t i = 0; i < count; i++) {
+// 			Const one = patterns[i];
+// 			patterns[i].bits().push_back(State::S0);
+// 			one.bits().push_back(State::S1);
+// 			patterns.push_back(std::move(one));
+// 		}
+// 		break;
+// 	}
+// 	default:
+// 		log_error("Unsupported level symbol `%c' in normalized UDP table.\n", symbol);
+// 	}
+// }
+
+// static std::vector<Const> make_patterns(const UdpTableEntry &entry, bool sequential)
+// {
+// 	std::vector<Const> patterns(1);
+// 	for (char symbol : entry.inputs)
+// 		append_level_symbol(patterns, symbol);
+// 	if (sequential)
+// 		append_level_symbol(patterns, entry.current);
+// 	return patterns;
+// }
+
+// static SigSpec get_udp_inputs(Module *module, const UdpDefinition &udp)
+// {
+// 	SigSpec inputs;
+// 	for (size_t i = 1; i < udp.ports.size(); i++) {
+// 		Wire *wire = module->wire(udp.ports[i]);
+// 		if (wire == nullptr || wire->width != 1)
+// 			log_error("UDP module `%s' has a missing or non-scalar input port `%s'.\n", log_id(module), log_id(udp.ports[i]));
+// 		inputs.append(wire);
+// 	}
+// 	return inputs;
+// }
+
+// static void preserve_edge_udp(Module *module, const UdpDefinition &udp, const SigSpec &inputs, Wire *output)
+// {
+// 	Cell *cell = module->addCell(NEW_ID, ID($udp));
+// 	cell->parameters[ID(A_WIDTH)] = Const(GetSize(inputs));
+// 	cell->parameters[ID(TABLE)] = Const(serialize_udp_table(udp.entries));
+// 	cell->parameters[ID(SEQUENTIAL)] = Const(udp.sequential);
+// 	cell->setPort(ID::A, inputs);
+// 	cell->setPort(ID::Y, output);
+// }
+
+namespace
+{
+struct NormalizedUdpTableEntry {
+	std::vector<std::string> inputs;
+	char curr = 0;
+	char next = 0;
+};
+
+struct UDPImporter {
+	const UdpDefinition &udp;
+	std::vector<NormalizedUdpTableEntry> entries;
+	Module *container;
+	std::vector<Wire *> inputs;
+	Wire *output;
+
+	explicit UDPImporter(Module *module, const UdpDefinition &udp) : udp{udp}, container{module}
+	{
+		output = module->wire(udp.ports.front());
+		if (!output || output->width != 1)
+			log_error("UDP module `%s' has a missing or non-scalar output port `%s'.\n", log_id(module), log_id(udp.ports.front()));
+
+		for (auto it = std::next(udp.ports.begin()); it != udp.ports.end(); ++it) {
+			auto *n = module->wire(*it);
+			if (!n || n->width != 1)
+				log_error("UDP module `%s' has a missing or non-scalar input port `%s'.\n", log_id(module), log_id(*it));
+			inputs.push_back(n);
+		}
+	}
+
+	void run()
+	{
+		normalize();
+		if (udp.sequential) {
+			import_seq();
+		} else {
+			import_comb();
+		}
+	}
+
+	void normalize()
+	{
+		entries.clear();
+		entries.reserve(udp.entries.size());
+		for (const auto &entry : udp.entries) {
+			NormalizedUdpTableEntry normalized;
+			normalized.curr = tolower(entry.curr);
+			normalized.next = tolower(entry.next);
+
+			for (size_t i = 0; i < entry.inputs.size();) {
+				std::string state;
+				if (entry.inputs[i] == '(') {
+					log_assert(i + 3 < entry.inputs.size());
+					log_assert(entry.inputs[i + 3] == ')');
+					state = entry.inputs.substr(i, 4);
+					i += 4;
+					if (state == "(01)")
+						state = "r";
+					else if (state == "(10)")
+						state = "f";
+					else if (state == "(?"
+							  "?)") // Separate to avoid the 'trigraph' warning
+						state = "*";
+					else {
+						state = state.substr(1, 2);
+					}
+				} else {
+					state.push_back(entry.inputs[i++]);
+				}
+				for (auto &c : state) {
+					c = std::tolower(c);
+				}
+				normalized.inputs.push_back(std::move(state));
+			}
+			log_assert(normalized.inputs.size() == inputs.size());
+			entries.push_back(std::move(normalized));
+		}
+	}
+
+	void import_comb()
+	{
+		auto *sw = new SwitchRule;
+		sw->signal = [&] {
+			SigSpec ans;
+			for (auto *n : inputs) {
+				ans.append(n);
+			}
+			return ans;
+		}();
+		auto *next = container->addWire(NEW_ID);
+		for (const auto &item : entries) {
+			auto *br = new CaseRule;
+			br->compare.emplace_back(mk_pattern(item));
+			br->actions.emplace_back(next, mk_output_value(item.next));
+			sw->cases.push_back(br);
+		}
+
+		auto *sync = new SyncRule;
+		sync->type = STa;
+		sync->actions.emplace_back(output, next);
+
+		auto *proc = container->addProcess(NEW_ID);
+		proc->root_case.switches.push_back(sw);
+		proc->root_case.actions.emplace_back(next, State::Sx);  // Defaults to x.
+		proc->syncs.push_back(sync);
+	}
+
+	Const mk_pattern(const NormalizedUdpTableEntry &entry, std::optional<std::size_t> ignore_index = std::nullopt)
+	{
+		std::vector<State> ans;
+		for (std::size_t i = 0; i < entry.inputs.size(); ++i) {
+			if (ignore_index && *ignore_index == i)
+				continue;
+			const auto &state = entry.inputs[i];
+			if (state.size() != 1)
+				log_error("Invalid state '%s' in combinational UDP table.\n", state.c_str());
+			auto c = state.front();
+			switch (c) {
+			case '0':
+				ans.push_back(State::S0);
+				break;
+			case '1':
+				ans.push_back(State::S1);
+				break;
+			case '?':
+			case 'b':
+				ans.push_back(State::Sa);
+				break;
+			case 'x':
+				ans.push_back(State::Sx);
+				break;
+			default:
+				log_error("Invalid pattern bit '%c'", c);
+			}
+		}
+		return ans;
+	}
+
+	Const mk_output_value(char c)
+	{
+		switch (c) {
+		case '0':
+			return State::S0;
+		case '1':
+			return State::S1;
+		case 'x':
+			return State::Sx;
+		default:
+			log_error("Invalid output value '%c'", c);
+		}
+	}
+
+	void import_seq()
+	{
+		std::optional<std::size_t> clock_index;
+		std::optional<std::string> edge_symbol;
+		std::vector<std::size_t> edge_entries;
+		std::vector<std::size_t> level_entries;
+		std::vector<std::size_t> no_change_entries;
+		for (std::size_t i = 0; i < entries.size(); ++i) {
+			const auto &entry = entries[i];
+			for (std::size_t j = 0; j < entry.inputs.size(); ++j) {
+				const auto no_change = is_no_change(entry);
+				if (is_edge_sensitive(entry.inputs[j])) {
+					if (!clock_index) {
+						clock_index = j;
+						edge_symbol = entry.inputs[j];
+					} else if (clock_index.value() != j && !no_change) {
+						log_error("Multiple edge-sensitive inputs found in UDP definition. Only one edge-sensitive input is "
+							  "allowed for sequential UDPs.");
+					} else if (edge_symbol.value() != entry.inputs[j] && !no_change) {
+						log_error("Conflicting edge-sensitive symbols found for input %zu in UDP definition. Only one "
+							  "edge-sensitive symbol is allowed for sequential UDPs.",
+							  j);
+					}
+					edge_entries.push_back(i);
+				} else {
+					level_entries.push_back(i);
+				}
+			}
+		}
+
+		if (clock_index) {
+			// FF
+			auto *clk = inputs[clock_index.value()];
+
+			auto *next = container->addWire(NEW_ID);
+			auto *sw = new SwitchRule;
+			sw->signal = [&] {
+				SigSpec ans;
+				for (std::size_t i = 0; i < inputs.size(); ++i) {
+					if (i != clock_index.value()) {
+						ans.append(inputs[i]);
+					}
+				}
+				return ans;
+			}();
+
+			if (!no_change_entries.empty()) {
+				auto *br = new CaseRule;
+				for (auto index : no_change_entries) {
+					const auto &entry = entries[index];
+					br->compare.emplace_back(mk_pattern(entry, clock_index));
+					br->actions.emplace_back(next, sw->signal);
+					sw->cases.push_back(br);
+				}
+			}
+			if (!level_entries.empty()) {
+				auto *br = new CaseRule;
+				for (auto index : level_entries) {
+					const auto &entry = entries[index];
+					br->compare.emplace_back(mk_pattern(entry, clock_index));
+					br->actions.emplace_back(next, mk_output_value(entry.next));
+					sw->cases.push_back(br);
+				}
+			}
+			for (auto index : edge_entries) {
+				const auto &entry = entries[index];
+				auto *br = new CaseRule;
+				br->compare.emplace_back(mk_pattern(entry, clock_index));
+				br->actions.emplace_back(next, mk_output_value(entry.next));
+				sw->cases.push_back(br);
+			}
+
+			auto *sync = new SyncRule;
+			if (const auto &e = edge_symbol.value(); e == "r" || e == "p") {
+				sync->type = STp;
+			} else if (e == "f" || e == "n") {
+				sync->type = STn;
+			} else if (e == "*") {
+				sync->type = STa;
+			} else {
+				log_error("Invalid edge-sensitive symbol '%s' in sequential UDP table.\n", edge_symbol.value().c_str());
+			}
+			sync->signal = clk;
+			sync->actions.emplace_back(output, next);
+
+			auto *proc = container->addProcess(NEW_ID);
+			proc->root_case.switches.push_back(sw);
+			proc->syncs.push_back(sync);
+			if (udp.init) {
+				proc->root_case.actions.emplace_back(next, mk_output_value(udp.init));
+			}
+		} else {
+			// Latch
+		}
+	}
+
+	bool is_edge_sensitive(const std::string &state)
+	{
+		return state == "r" || state == "f" || state == "p" || state == "n" || state == "*" ||
+		       (state.size() == 4 && state.front() == '(' && state.back() == ')');
+	}
+
+	bool is_no_change(const NormalizedUdpTableEntry &entry)
+	{
+		assert(udp.sequential);
+		const auto curr = entry.curr;
+		const auto next = entry.next;
+		if (curr == '0' && next == '0')
+			return true;
+		if (curr == '1' && next == '1')
+			return true;
+		if (curr == '?' && next == '-')
+			return true;
+		return false;
+	}
+
+	std::tuple<std::size_t, std::string> extract_clock()
+	{
+		std::optional<std::size_t> clock_index;
+		std::optional<std::string> edge;
+		for (const auto &item : entries) {
+			for (std::size_t i = 0; i < item.inputs.size(); ++i) {
+				if (is_edge_sensitive(item.inputs[i])) {
+					if (!clock_index) {
+						clock_index = i;
+						edge = item.inputs[i];
+					} else if (clock_index.value() != i) {
+						log_error("Multiple edge-sensitive inputs found in UDP definition. Only one edge-sensitive input is "
+							  "allowed for sequential UDPs.");
+					} else if (edge.value() != item.inputs[i]) {
+						log_error("Conflicting edge-sensitive symbols found for input %zu in UDP definition. Only one "
+							  "edge-sensitive symbol is allowed for sequential UDPs.",
+							  i);
+					}
+					break;
+				}
+			}
+			if (clock_index)
+				break;
+		}
+		if (!clock_index)
+			log_error("No edge-sensitive input found in sequential UDP definition.\n");
+		return std::make_tuple(clock_index.value(), edge.value());
+	}
+};
+} // namespace
+
+void import_udp(Module *module, const UdpDefinition &udp)
+{
+	if (udp.ports.size() < 2)
+		log_error("UDP module `%s' must have one output and at least one input.\n", log_id(module));
+
+	UDPImporter imp(module, udp);
+	imp.run();
+}
+} // namespace RTLIL
+
+YOSYS_NAMESPACE_END

--- a/kernel/udp.h
+++ b/kernel/udp.h
@@ -1,0 +1,54 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2026  YosysHQ contributors
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef YOSYS_KERNEL_UDP_H
+#define YOSYS_KERNEL_UDP_H
+
+#include "kernel/rtlil.h"
+
+YOSYS_NAMESPACE_BEGIN
+
+namespace RTLIL
+{
+	struct UdpTableEntry
+	{
+		std::string inputs;
+		char curr = 0;
+		char next = 0;
+	};
+
+	struct UdpDefinition
+	{
+		std::vector<IdString> ports;
+		std::vector<UdpTableEntry> entries;
+		bool sequential = false;
+		char init = 0;
+	};
+
+	std::string serialize_udp_table(const std::vector<UdpTableEntry> &entries);
+	std::vector<UdpTableEntry> deserialize_udp_table(const std::string &table);
+
+	// Elaborate a UDP definition into a module whose wires and port directions
+	// have already been created. Frontends other than the built-in Verilog
+	// frontend can use this same entry point.
+	void import_udp(Module *module, const UdpDefinition &udp);
+}
+
+YOSYS_NAMESPACE_END
+
+#endif

--- a/passes/cmds/logger.cc
+++ b/passes/cmds/logger.cc
@@ -167,7 +167,7 @@ struct LoggerPass : public Pass {
 				if (pattern.front() == '\"' && pattern.back() == '\"') pattern = pattern.substr(1, pattern.size() - 2);
 				int count = atoi(args[++argidx].c_str());
 				if (count<=0)
-					log_cmd_error("Number of expected messages must be higher then 0 !\n");
+					log_cmd_error("Number of expected messages must be higher than 0 !\n");
 				if ((type=="error" || type=="prefix-error") && count!=1)
 					log_cmd_error("Expected error message occurrences must be 1 !\n");
 				log("Added regex '%s' to expected %s messages list.\n",

--- a/tests/verilog/udp_dff.ys
+++ b/tests/verilog/udp_dff.ys
@@ -1,0 +1,38 @@
+read_verilog -sv <<EOF
+module top (clk, d, ok);
+  input clk, d;
+  output ok;
+
+  logic q0, q1;
+
+  dff_ref dff_ref (.clk(clk), .d(d), .q(q0));
+  dff_udp dff_udp (.clk(clk), .d(d), .q(q1));
+
+  assign ok = (q0 == q1);
+endmodule
+
+primitive dff_udp (q, clk, d);
+  input clk, d;
+  output reg q;
+
+  table
+// clk  d   q   q+
+    r   0 : ? : 0 ;
+    r   1 : ? : 1 ;
+    f   ? : ? : - ;
+    ?   * : ? : - ;
+  endtable
+endprimitive
+
+module dff_ref (clk, d, q);
+  input clk, d;
+  output logic q;
+
+  always @(posedge clk)
+    q <= d;
+endmodule
+EOF
+
+prep -top top -flatten
+select -assert-count 2 t:$dff
+sat -verify -tempinduct -prove ok 1

--- a/tests/verilog/udp_dffsr.ys
+++ b/tests/verilog/udp_dffsr.ys
@@ -1,0 +1,31 @@
+# Picked from Verilator [#2808](https://github.com/verilator/verilator/issues/2808)
+
+read_verilog -sv <<EOF
+module top (clk, d, setn, rstn);
+endmodule
+
+primitive udp_dff_PWR_sc9mcpp84_14lppxl_base_slvt_c16 (out, in, clk, clr_, set_, VDD, VSS, NOTIFIER);
+   output out;
+   input  in, clk, clr_, set_, VDD, VSS, NOTIFIER;
+   reg    out;
+
+   table
+// in  clk  clr_  set_  VDD  VSS  NOTIFIER  : Qt : Qt+1
+//
+   0   r    ?     1     1    0    ?         : ?  :  0  ; // clock in 0
+   1   r    1     ?     1    0    ?         : ?  :  1  ; // clock in 1
+   1   *    1     ?     1    0    ?         : 1  :  1  ; // reduce pessimism
+   0   *    ?     1     1    0    ?         : 0  :  0  ; // reduce pessimism
+   ?   f    ?     ?     1    0    ?         : ?  :  -  ; // no changes on negedge clk
+   *   b    ?     ?     1    0    ?         : ?  :  -  ; // no changes when in switches
+   ?   ?    ?     0     1    0    ?         : ?  :  1  ; // set output
+   ?   b    1     *     1    0    ?         : 1  :  1  ; // cover all transistions on set_
+   1   x    1     *     1    0    ?         : 1  :  1  ; // cover all transistions on set_
+   ?   ?    0     1     1    0    ?         : ?  :  0  ; // reset output
+   ?   b    *     1     1    0    ?         : 0  :  0  ; // cover all transistions on clr_
+   0   x    *     1     1    0    ?         : 0  :  0  ; // cover all transistions on clr_
+   ?   ?    ?     ?     ?    ?    *         : ?  :  x  ; // any notifier changed
+   endtable
+endprimitive
+EOF
+

--- a/tests/verilog/udp_dlatch.ys
+++ b/tests/verilog/udp_dlatch.ys
@@ -1,0 +1,38 @@
+read_verilog -sv <<EOF
+module top (d, en, ok);
+  input d, en;
+  output ok;
+
+  logic q0, q1;
+
+  dlatch_ref dlatch_ref (.d(d), .en(en), .q(q0));
+  dlatch_udp dlatch_udp (.d(d), .en(en), .q(q1));
+
+  assign ok = (q0 == q1);
+endmodule
+
+module dlatch (d, en, q);
+  input d, en;
+  output logic q;
+
+  always @(*)
+    if (en)
+      q <= d;
+endmodule
+
+primitive udp_latch (q, d, en);
+  output q;
+  reg q;
+  input d, en;
+  initial q = 1'b0;
+  table
+    0 1 : ? : 0 ;
+    1 1 : ? : 1 ;
+    ? 0 : ? : - ;
+  endtable
+endprimitive
+EOF
+
+prep -top top -flatten
+select -assert-count 2 t:$dlatch
+sat -verify -tempinduct -prove ok 1

--- a/tests/verilog/udp_edge_indicator.ys
+++ b/tests/verilog/udp_edge_indicator.ys
@@ -1,0 +1,12 @@
+#logger -expect error "A UDP edge indicator cannot have identical level symbols" 1
+
+read_verilog -sv <<EOF
+primitive udp1 (q, clk, d);
+  input clk, d;
+  output reg q;
+
+  table
+    (00) ? : - ;
+  endtable
+endprimitive
+EOF

--- a/tests/verilog/udp_must_have_table.ys
+++ b/tests/verilog/udp_must_have_table.ys
@@ -1,0 +1,8 @@
+logger -expect error ".*syntax error.*" 1
+
+read_verilog -sv <<EOF
+primitive udp1 (q, s, a, b);
+  input s, a, b;
+  output q;
+endprimitive
+EOF

--- a/tests/verilog/udp_mux.ys
+++ b/tests/verilog/udp_mux.ys
@@ -1,0 +1,38 @@
+read_verilog -sv <<EOF
+module top (s, t, f, ok);
+  input s, t, f;
+  output ok;
+
+  logic q0, q1;
+
+  mux_ref mux_ref (.s(s), .t(t), .f(f), .q(q0));
+  mux_udp mux_udp (.s(s), .t(t), .f(f), .q(q1));
+
+  assign ok = (q0 == q1);
+endmodule
+
+module mux_ref (s, t, f, q);
+  input s, t, f;
+  output q;
+
+  assign q = s ? t : f;
+endmodule
+
+primitive mux_udp (q, s, t, f);
+  output q;
+  input s, t, f;
+
+  table
+//  s t f : q
+    1 0 ? : 0;
+    1 1 ? : 1;
+    0 ? 0 : 0;
+    0 ? 1 : 1;
+    x 0 0 : 0;
+    x 1 1 : 1;
+  endtable
+endprimitive
+EOF
+
+prep -top top -flatten
+sat -verify -prove ok 1

--- a/tests/verilog/udp_mux_pessimism.ys
+++ b/tests/verilog/udp_mux_pessimism.ys
@@ -1,0 +1,36 @@
+read_verilog -sv <<EOF
+module top (s, t, f, ok);
+  input s, t, f;
+  output ok;
+
+  logic q0, q1;
+
+  mux_ref mux_ref (.s(s), .t(t), .f(f), .q(q0));
+  mux_udp mux_udp (.s(s), .t(t), .f(f), .q(q1));
+
+  assign ok = (q0 == q1);
+endmodule
+
+module mux_ref (s, t, f, q);
+  input s, t, f;
+  output q;
+
+  assign q = s ? t : f;
+endmodule
+
+primitive mux_udp (q, s, t, f);
+  output q;
+  input s, t, f;
+
+  table
+//  s t f : q
+    1 0 ? : 0;
+    1 1 ? : 1;
+    0 ? 0 : 0;
+    0 ? 1 : 1;
+  endtable
+endprimitive
+EOF
+
+prep -top top -flatten
+sat -verify -prove ok 1

--- a/tests/verilog/udp_output_first.ys
+++ b/tests/verilog/udp_output_first.ys
@@ -1,0 +1,12 @@
+logger -expect error "The first UDP port must be the single output port." 1
+
+read_verilog -sv <<EOF
+primitive udp1 (s, a, b, q);
+  input s, a, b;
+  output q;
+
+  table
+    ? ? ? : x ;
+  endtable
+endprimitive
+EOF

--- a/tests/verilog/udp_seq_output_reg.ys
+++ b/tests/verilog/udp_seq_output_reg.ys
@@ -1,0 +1,12 @@
+logger -expect error "A sequential UDP output must use the `reg' keyword" 1
+
+read_verilog -sv <<EOF
+primitive udp1 (q, clk, d);
+  input clk, d;
+  output logic q;
+
+  table
+    ? ? ? : ? : - ;
+  endtable
+endprimitive
+EOF

--- a/tests/verilog/udp_table_size_mismatch.ys
+++ b/tests/verilog/udp_table_size_mismatch.ys
@@ -1,0 +1,12 @@
+logger -expect error "UDP table row has 2 inputs; expected 3" 1
+
+read_verilog -sv <<EOF
+primitive udp1 (q, s, a, b);
+  input s, a, b;
+  output q;
+
+  table
+    ? ? : - ;
+  endtable
+endprimitive
+EOF


### PR DESCRIPTION
**Motivation**

Provide support for user-defined primitives (UDP). See IEEE 1800-2023, Chapter 29.

**Changes**

- Added UDP lexer and parser in the verilog frontend
- Added a UDP importer from frontends to RTLIL `kernel/udp.{h,cc}`
- Added e2e tests