### PR TITLE
hierarchy: fix keep cache usage by caching false too

### DIFF
--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -684,24 +684,30 @@ void hierarchy_clean(RTLIL::Design *design, RTLIL::Module *top, bool purge_lib)
 
 bool set_keep_print(std::map<RTLIL::Module*, bool> &cache, RTLIL::Module *mod)
 {
-	if (cache.count(mod) == 0)
-		for (auto c : mod->cells()) {
-			RTLIL::Module *m = mod->design->module(c->type);
-			if ((m != nullptr && set_keep_print(cache, m)) || c->type == ID($print))
-				return cache[mod] = true;
-		}
-	return cache[mod];
+	auto it = cache.find(mod);
+	if (it != cache.end())
+		return it->second;
+	cache[mod] = false;
+	for (auto c : mod->cells()) {
+		RTLIL::Module *m = mod->design->module(c->type);
+		if ((m != nullptr && set_keep_print(cache, m)) || c->type == ID($print))
+			return cache[mod] = true;
+	}
+	return false;
 }
 
 bool set_keep_assert(std::map<RTLIL::Module*, bool> &cache, RTLIL::Module *mod)
 {
-	if (cache.count(mod) == 0)
-		for (auto c : mod->cells()) {
-			RTLIL::Module *m = mod->design->module(c->type);
-			if ((m != nullptr && set_keep_assert(cache, m)) || c->type.in(ID($check), ID($assert), ID($assume), ID($live), ID($fair), ID($cover)))
-				return cache[mod] = true;
-		}
-	return cache[mod];
+	auto it = cache.find(mod);
+	if (it != cache.end())
+		return it->second;
+	cache[mod] = false;
+	for (auto c : mod->cells()) {
+		RTLIL::Module *m = mod->design->module(c->type);
+		if ((m != nullptr && set_keep_assert(cache, m)) || c->type.in(ID($check), ID($assert), ID($assume), ID($live), ID($fair), ID($cover)))
+			return cache[mod] = true;
+	}
+	return false;
 }
 
 int find_top_mod_score(Design *design, Module *module, dict<Module*, int> &db)

--- a/tests/various/hierarchy_recursive.v
+++ b/tests/various/hierarchy_recursive.v
@@ -1,0 +1,3 @@
+module top(input x, output y);
+top top_i(.x(x), .y(y));
+endmodule

--- a/tests/various/hierarchy_recursive.ys
+++ b/tests/various/hierarchy_recursive.ys
@@ -1,0 +1,25 @@
+read_verilog hierarchy_recursive.v
+hierarchy -auto-top
+select -assert-any top
+select -assert-none a:keep
+
+design -reset
+read_verilog <<EOT
+module top(input x, output y);
+top top_i(.x(x), .y(y));
+always @(x) $display("x=%d", x);
+endmodule
+EOT
+hierarchy -auto-top
+select -assert-any top %% a:keep
+
+design -reset
+read_verilog -formal <<EOT
+module a(input x); b b_i(.x(x)); endmodule
+module b(input x); a a_i(.x(x)); always @(x) assert (x == x); endmodule
+module top(input x); a a_i(.x(x)); endmodule
+EOT
+hierarchy -top top
+select -assert-any a %% a:keep
+select -assert-any b %% a:keep
+select -assert-any top %% a:keep


### PR DESCRIPTION
Fixes #1689. Previously, only the fact that a module is known to be "keep" was cached. With this change, it is also cached that a module is known to NOT be "keep"

This is ~~vibe coded with~~ _code generated by_ opus 5 ($1.48 if I was at API pricing) and the prompt "Fix ./y -p "read_verilog ../yosys/g/recurse.v; hierarchy -auto-top" segfault. Rebuild with cmake --workflow --preset d" with g/recurse.v the issue repro.

Correction: I was reminded that "vibe coding" refers to "not even checking the code". Here I checked the code, liked it well enough for the scope of the bug, and commited the code *without modifying it*. This differs from any of my other LLM usage, where I rewrite any LLM generated code entirely based on my own knowledge and taste, so that the LLM provides only a proof-of-concept based on a combination either my ideas or simple debugging/profiing jobs, and the code isn't pushed without a near total rewrite