### PR TITLE
hashlib: noexcept moves for performance

### DIFF
--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -423,6 +423,7 @@ class HASHLIB_ATTRIBUTE_WARN_UNUSED dict {
 	std::vector<int> hashtable;
 	std::vector<entry_t> entries;
 	OPS ops;
+	static_assert(std::is_nothrow_default_constructible_v<OPS>, "move ops are noexcept and default-construct OPS");
 
 #ifdef NDEBUG
 	static inline void do_assert(bool) { }
@@ -641,7 +642,7 @@ public:
 		do_rehash();
 	}
 
-	dict(dict &&other)
+	dict(dict &&other) noexcept
 	{
 		swap(other);
 	}
@@ -652,7 +653,7 @@ public:
 		return *this;
 	}
 
-	dict &operator=(dict &&other) {
+	dict &operator=(dict &&other) noexcept {
 		clear();
 		swap(other);
 		return *this;
@@ -901,6 +902,7 @@ protected:
 	std::vector<int> hashtable;
 	std::vector<entry_t> entries;
 	OPS ops;
+	static_assert(std::is_nothrow_default_constructible_v<OPS>, "move ops are noexcept and default-construct OPS");
 
 #ifdef NDEBUG
 	static inline void do_assert(bool) { }
@@ -1091,7 +1093,7 @@ public:
 		do_rehash();
 	}
 
-	pool(pool &&other)
+	pool(pool &&other) noexcept
 	{
 		swap(other);
 	}
@@ -1102,7 +1104,7 @@ public:
 		return *this;
 	}
 
-	pool &operator=(pool &&other) {
+	pool &operator=(pool &&other) noexcept {
 		clear();
 		swap(other);
 		return *this;


### PR DESCRIPTION
noexcept is required in C++ to get moves rather than copies in some cases. This particularly affects hashmaps of hashmaps, which is a common pattern in yosys, such as `dict<RTLIL::SigBit, pool<PortBit>> signal_drivers;` in `ModWalker`, which provides the traversal in hot passes like `opt_dff`. This results in a meaningful performance improvement:

```
../yosys/uut/noexcept/bin/yosys: jpeg-SYNTH
End of script. Logfile hash: e1fcc72043, time: 3.93s, user: 2.02s, system: 0.19s, MEM: 59.52 MB peak
../yosys/ref: jpeg-SYNTH
End of script. Logfile hash: 2ce0ec6e85, time: 4.05s, user: 2.17s, system: 0.16s, MEM: 61.45 MB peak
```

In the past I've converted hashlib::dict to std::unordered_map etc because testing revealed it to be faster. This was possibly mostly due to the unnecessary copies, rather than other implementation details. Even as we fix this, it's still an argument in favor of std - maybe we should just accept that DIYing isolated parts of the codebase backfires easily