### PR TITLE
Fix assert on signed-cast bare identifier used as cell port argument

### DIFF
--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -2210,8 +2210,23 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 								// fully-sliced signed wire will be resolved
 								// once the module becomes available
 								log_assert(attributes.count(ID::reprocess_after));
-							else
-								log_assert(arg->is_signed == sig.as_wire()->is_signed);
+							else if (arg->is_signed != sig.as_wire()->is_signed) {
+								// A signedness cast ($signed()/$unsigned()) applied
+								// directly to a plain identifier reuses that
+								// identifier's own underlying wire as its SigSpec (no
+								// new wire is allocated for a "trivial" cast), so the
+								// returned wire's is_signed still reflects the
+								// ORIGINAL declaration, not the cast. Indirect through
+								// a fresh wire carrying the cast's actual signedness,
+								// exactly as the non-trivial-signed-node case below
+								// already does, instead of asserting the two must
+								// already agree.
+								RTLIL::IdString wire_name = NEW_ID;
+								RTLIL::Wire *wire = current_module->addWire(wire_name, GetSize(sig));
+								wire->is_signed = arg->is_signed;
+								current_module->connect(wire, sig);
+								sig = wire;
+							}
 						} else if (arg->is_signed) {
 							// non-trivial signed nodes are indirected through
 							// signed wires to enable sign extension

--- a/tests/various/signed_cast_cell_arg.ys
+++ b/tests/various/signed_cast_cell_arg.ys
@@ -1,0 +1,23 @@
+read_verilog <<EOT
+module leaf (
+    input wire signed [7:0] x_in,
+    output wire signed [7:0] y
+);
+    assign y = x_in;
+endmodule
+
+module top (
+    input wire [7:0] activation_scalar_data,
+    output wire [7:0] out
+);
+    leaf u_leaf (
+        .x_in($signed(activation_scalar_data)),
+        .y(out)
+    );
+endmodule
+EOT
+
+hierarchy -check -top top
+proc
+opt
+select -assert-count 1 t:leaf


### PR DESCRIPTION
## Summary

`genRTLIL()`'s `AST_CELL` port-argument handling asserts when a
`$signed()`/`$unsigned()` cast is applied directly to a bare, plain
(non-`signed`-declared) identifier and connected to a module instance
port:

```
ERROR: Assert `arg->is_signed == sig.as_wire()->is_signed' failed in frontends/ast/genrtlil.cc:2214.
```

Minimal reproduction (`tests/various/signed_cast_cell_arg.ys` in this PR):

```verilog
module leaf (
    input wire signed [7:0] x_in,
    output wire signed [7:0] y
);
    assign y = x_in;
endmodule

module top (
    input wire [7:0] activation_scalar_data,
    output wire [7:0] out
);
    leaf u_leaf (
        .x_in($signed(activation_scalar_data)),
        .y(out)
    );
endmodule
```

This is accepted without complaint by Icarus Verilog, Verilator, and a
commercial synthesis tool; only yosys's frontend crashes on it.

## Root cause

When the cast is applied to a bare identifier, `genRTLIL()` treats it as
a "trivial" cast and returns the identifier's own underlying wire object
as the port's `SigSpec`, rather than allocating a fresh indirection wire.
That wire's `is_signed` still reflects the identifier's *original*
declaration (unsigned, here), not the cast — so it disagrees with
`arg->is_signed` (true, from the cast). The one escape hatch in this code
path (a `reprocess_after`-gated case for "fully-sliced signed wire")
doesn't cover this situation; every other mismatch falls into an
unconditional `log_assert`.

## Fix

Extend the *already-existing* sibling mechanism used a few lines below
for non-wire signed expressions ("non-trivial signed nodes are
indirected through signed wires to enable sign extension") to also cover
this case: when the returned `SigSpec` is a wire but its signedness
disagrees with the argument node's, allocate a fresh wire carrying the
argument's actual signedness, connect it, and use that as the port
connection — instead of asserting the two must already agree.

Verified this doesn't regress the "fully-sliced signed wire" case (left
untouched) and that the new code path is only reached on an actual
mismatch (identical behavior for every previously-passing case, since
the `else` branch is now `else if (mismatch) { ... }` rather than
`else { assert(...) }`, and takes the same assert-free path as before
whenever there's no mismatch).

## Testing

Added `tests/various/signed_cast_cell_arg.ys`. Also manually verified on
a real, much larger production RTL file (part of an FPGA LLM-inference
project) that previously crashed `synth_gowin` at this exact assert and
now synthesizes cleanly to a full netlist with real block-RAM primitives
correctly inferred.

## Context

Found while trying to get a real (large, BSRAM-heavy) FPGA design through
`yosys` + `nextpnr` for a Gowin GW5AST target, as an experiment in
whether the open-source toolchain's routing behavior differs from the
vendor's closed PnR under BSRAM congestion. Happy to adjust naming,
comments, or test style to match project conventions — this is my first
contribution here.