### PR TITLE
Make `proc_self_dirname()` work for non-ASCII paths to the binary

### DIFF
--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -537,18 +537,16 @@ std::string proc_self_dirname()
 #elif defined(_WIN32)
 std::string proc_self_dirname()
 {
-	int i = 0;
-	char longpath[MAX_PATH + 1];
-	char shortpath[MAX_PATH + 1];
-	if (!GetModuleFileNameA(0, longpath, MAX_PATH+1))
-		log_error("GetModuleFileName() failed.\n");
-	if (!GetShortPathNameA(longpath, shortpath, MAX_PATH+1))
-		log_error("GetShortPathName() failed.\n");
-	while (shortpath[i] != 0)
-		i++;
-	while (i > 0 && shortpath[i-1] != '/' && shortpath[i-1] != '\\')
-		shortpath[--i] = 0;
-	return shortpath;
+	wchar_t binpath[MAX_PATH + 1];
+	if (!GetModuleFileNameW(0, binpath, MAX_PATH+1))
+		log_error("GetModuleFileNameW() failed.\n");
+	for (int i = wcslen(binpath); i > 0; i--)
+		if (binpath[i] == L'\\') {
+			binpath[i] = 0;
+			break;
+		}
+	_wchdir(binpath);
+	return "./";
 }
 #elif defined(__wasm)
 std::string proc_self_dirname()


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Yosys crashes if launched from a directory containing Unicode characters on Windows, e.g. `C:\Program Files\Glasgow 可重构数字接口调试器`.

Since the installation directory is user-configurable this has to be fixed in Yosys itself.

_Explain how this is achieved._

This is achieved by using wide character functions to get the actual path (there is no workaround here that will do the job) and then changing the current directory so that no other part of Yosys has to care about Unicode.

This works because Yosys doesn't try to use absolute paths and does not change the current directory anywhere else.
