### PR TITLE
CMake: add missing dependency edges for `synth_*` passes

### DIFF
--- a/frontends/aiger/CMakeLists.txt
+++ b/frontends/aiger/CMakeLists.txt
@@ -1,4 +1,4 @@
-yosys_frontend(aigerparse
+yosys_frontend(aiger
 	aigerparse.cc
 	aigerparse.h
 	REQUIRES

--- a/passes/techmap/CMakeLists.txt
+++ b/passes/techmap/CMakeLists.txt
@@ -83,6 +83,7 @@ yosys_pass(abc9
 		design
 		opt
 		portarcs
+		read_aiger
 		read_verilog
 		scc
 		select
@@ -90,6 +91,7 @@ yosys_pass(abc9
 		submod
 		techmap
 		wbflip
+		write_xaiger
 )
 yosys_pass(abc_new
 	abc_new.cc

--- a/techlibs/analogdevices/CMakeLists.txt
+++ b/techlibs/analogdevices/CMakeLists.txt
@@ -33,6 +33,7 @@ yosys_pass(synth_analogdevices
 		share
 		simplemap
 		stat
+		synth
 		techmap
 		tribuf
 		wreduce

--- a/techlibs/fabulous/CMakeLists.txt
+++ b/techlibs/fabulous/CMakeLists.txt
@@ -22,6 +22,7 @@ yosys_pass(synth_fabulous
 		read_verilog
 		share
 		stat
+		synth
 		techmap
 		tribuf
 		wreduce

--- a/techlibs/gatemate/CMakeLists.txt
+++ b/techlibs/gatemate/CMakeLists.txt
@@ -40,6 +40,7 @@ yosys_pass(synth_gatemate
 		share
 		simplemap
 		stat
+		synth
 		techmap
 		tribuf
 		wreduce

--- a/techlibs/gowin/CMakeLists.txt
+++ b/techlibs/gowin/CMakeLists.txt
@@ -31,6 +31,7 @@ yosys_pass(synth_gowin
 		sort
 		splitnets
 		stat
+		synth
 		techmap
 		tribuf
 		wreduce

--- a/techlibs/ice40/CMakeLists.txt
+++ b/techlibs/ice40/CMakeLists.txt
@@ -60,6 +60,7 @@ yosys_pass(synth_ice40
 		share
 		simplemap
 		stat
+		synth
 		techmap
 		tribuf
 		wreduce

--- a/techlibs/intel/CMakeLists.txt
+++ b/techlibs/intel/CMakeLists.txt
@@ -24,6 +24,7 @@ yosys_pass(synth_intel
 		read_verilog
 		setundef
 		stat
+		synth
 		techmap
 		tribuf
 		wreduce

--- a/techlibs/intel_alm/CMakeLists.txt
+++ b/techlibs/intel_alm/CMakeLists.txt
@@ -25,6 +25,7 @@ yosys_pass(synth_intel_alm
 		read_verilog
 		share
 		stat
+		synth
 		techmap
 		tribuf
 		wreduce

--- a/techlibs/lattice/CMakeLists.txt
+++ b/techlibs/lattice/CMakeLists.txt
@@ -44,6 +44,7 @@ yosys_pass(synth_lattice
 		share
 		simplemap
 		stat
+		synth
 		techmap
 		tribuf
 		wreduce

--- a/techlibs/microchip/CMakeLists.txt
+++ b/techlibs/microchip/CMakeLists.txt
@@ -53,6 +53,7 @@ yosys_pass(synth_microchip
 		share
 		simplemap
 		stat
+		synth
 		techmap
 		tribuf
 		wreduce

--- a/techlibs/nanoxplore/CMakeLists.txt
+++ b/techlibs/nanoxplore/CMakeLists.txt
@@ -31,6 +31,7 @@ yosys_pass(synth_nanoxplore
 		setundef
 		share
 		stat
+		synth
 		techmap
 		tribuf
 		wreduce

--- a/techlibs/quicklogic/CMakeLists.txt
+++ b/techlibs/quicklogic/CMakeLists.txt
@@ -68,6 +68,7 @@ yosys_pass(synth_quicklogic
 		share
 		shregmap
 		stat
+		synth
 		techmap
 		tribuf
 		wreduce

--- a/techlibs/xilinx/CMakeLists.txt
+++ b/techlibs/xilinx/CMakeLists.txt
@@ -65,6 +65,7 @@ yosys_pass(synth_xilinx
 		simplemap
 		sort
 		stat
+		synth
 		techmap
 		tribuf
 		wreduce


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Being able to build Yosys with `-DCOMPONENTS=synth_ice40;synth_lattice`. Currently this fails due to undeclared runtime dependencies between passes.

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._

Unfortunately we don't have a good way to test this in CI.
