### PR TITLE
opt_muxtree: fix OOB read on self-conflicting mux Y port

### DIFF
--- a/passes/opt/opt_muxtree.cc
+++ b/passes/opt/opt_muxtree.cc
@@ -144,6 +144,9 @@ struct OptMuxtreeWorker
 		// Analyze port A
 		muxinfo.ports.push_back(used_port_bit(sig_a, this_mux_idx, -1));
 
+		// push before the y port scan so self-conflicts can be reported too
+		mux2info.push_back(muxinfo);
+
 		for (int idx : sig2bits(sig_y)) {
 			if (bit2info[idx].mux_driver)
 				log_cmd_error("Cell %s Y port signal %s already driven by %s\n", cell->name, log_signal(sig_y), mux2info[*bit2info[idx].mux_driver].cell->name);
@@ -152,8 +155,6 @@ struct OptMuxtreeWorker
 
 		for (int idx : sig2bits(sig_s))
 			bit2info[idx].seen_non_mux = true;
-
-		mux2info.push_back(muxinfo);
 	}
 
 	void see_non_mux_cell(Cell* cell) {

--- a/tests/gen_tests_makefile.py
+++ b/tests/gen_tests_makefile.py
@@ -135,7 +135,7 @@ def generate_custom(callback, extra=None):
             callback()
 
 def generate_autotest_file(test_file, commands):
-    cmd = f"../tools/autotest.sh -G -j ${{SEEDOPT}} -Y ${{YOSYS}} ${{EXTRA_FLAGS}} {test_file}; \\\n{commands}"
+    cmd = f"../tools/autotest.sh -G -j ${{SEEDOPT}} -Y ${{YOSYS}} ${{EXTRA_FLAGS}} {test_file} || exit $$?; \\\n{commands}"
     generate_target(test_file, cmd)
 
 def generate_autotest(pattern, extra_flags, cmds=""):

--- a/tests/memories/wide_all.v
+++ b/tests/memories/wide_all.v
@@ -14,7 +14,7 @@ module test(
 reg [7:0] mem[3:254];
 
 assign rd[7:0] = mem[{ra, 1'b0}];
-assign rd[15:0] = mem[{ra, 1'b1}];
+assign rd[15:8] = mem[{ra, 1'b1}];
 
 initial begin
 	mem[5] = 8'h12;


### PR DESCRIPTION
`wide_all.v` had a `rd[15:0]` vs `rd[15:8]` typo that multi-drove `rd[7:0]`, making both read ports collapse into a wide port with duplicated data. `opt_muxtree` then read `mux2info` out of bounds while reporting the multi-driver error (the offending mux isn't pushed yet when its own Y port repeats a bit), crashing instead of erroring. Push before the Y scan so the error reports cleanly. Additionally, generated test makefiles ignored autotest exit codes, which is why CI never caught this.