### PR TITLE
cmake: use homebrew from PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,7 @@ if (MINGW AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSIO
 endif()
 
 # Required dependencies.
-if (APPLE)
+if (APPLE AND (NOT DEFINED YOSYS_ENABLE_HOMEBREW OR YOSYS_ENABLE_HOMEBREW))
 	# In practice, we can't expect paths to Homebrew packages to be configured.
 	use_homebrew()
 endif()

--- a/cmake/UseHomebrew.cmake
+++ b/cmake/UseHomebrew.cmake
@@ -2,13 +2,28 @@
 #
 # 	use_homebrew([ROOT <root>])
 #
-# Includes all packages installed in `<root>` (`/opt/homebrew/Cellar` if not specified)
-# in `CMAKE_FIND_ROOT_PATH`.
+# Includes all packages installed in `<root>` (output of brew --prefix if not
+# specified) in `CMAKE_FIND_ROOT_PATH`.
 #
 function(use_homebrew)
 	cmake_parse_arguments(PARSE_ARGV 0 arg "" "ROOT" "")
 	if (NOT arg_ROOT)
-		set(arg_ROOT /opt/homebrew/Cellar)
+		execute_process(
+			COMMAND brew --prefix
+			WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+			RESULT_VARIABLE brew_prefix_result
+			OUTPUT_VARIABLE brew_prefix_out
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+			ERROR_QUIET
+		)
+		if (${brew_prefix_result} EQUAL 0)
+			set (arg_ROOT "${brew_prefix_out}/Cellar")
+		endif()
+	endif()
+
+	if (NOT arg_ROOT)
+		# unset and no brew binary available
+		return()
 	endif()
 
 	file(GLOB package_roots ${arg_ROOT}/*/*) # e.g. `/opt/homebrew/Cellar/bison/3.8.2/`


### PR DESCRIPTION


_If your work is part of a larger effort, please discuss your general plans on [Discourse](https://yosyshq.discourse.group/) first to align your vision with maintainers._

_What are the reasons/motivation for this change?_

The current version of UseHomebrew defaults to /opt/homebrew/Cellar and prioritizes it over anything currently existing in PATH. This has two issues:

- On x86_64 installations of Homebrew (including when emulating on ARM), the path is /usr/local/
- When building in a `nix develop` environment, the homebrew versions take priority, complicating testing

_Explain how this is achieved._

This addresses this issue by using the output of the `brew --prefix` subprocess, doing nothing if brew is not in `PATH`.

Additionally, CMakeLists.txt was updated such that if `YOSYS_ENABLE_HOMEBREW` is defined as OFF, using Homebrew is skipped entirely.

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._

It should just build fine on the macOS CI with these changes.

I've also confirmed they behave as expected in a `nix develop` environment:

```
$ rm -rf * && cmake .. 2>&1 | grep "Found FLEX"
-- Found FLEX: /nix/store/rj872hqzghsgbi6dbcs6zvwxwv44y8ll-flex-2.6.4/bin/flex (found suitable version "2.6.4", minimum required is "2.6")
$ export PATH=/opt/homebrew/bin:$PATH
$ rm -rf * && cmake .. 2>&1 | grep "Found FLEX"
-- Found FLEX: /opt/homebrew/Cellar/flex/2.6.4_2/bin/flex (found suitable version "2.6.4", minimum required is "2.6")
```

_These template prompts can be deleted when you're done responding to them._
