### PR TITLE
synth_*: remove classic ABC mapping

### DIFF
--- a/docs/source/code_examples/macro_commands/synth_ice40.ys
+++ b/docs/source/code_examples/macro_commands/synth_ice40.ys
@@ -54,7 +54,6 @@ map_gates:
     ice40_wrapcarry
     techmap
     opt -fast
-    abc -dff -D 1
     ice40_opt
 
 map_ffs:
@@ -65,8 +64,6 @@ map_ffs:
     ice40_opt -full
 
 map_luts:
-    abc
-    ice40_opt
     check
     techmap
     simplemap

--- a/techlibs/achronix/synth_achronix.cc
+++ b/techlibs/achronix/synth_achronix.cc
@@ -51,9 +51,6 @@ struct SynthAchronixPass : public ScriptPass {
     log("    -noflatten\n");
     log("        do not flatten design before synthesis\n");
     log("\n");
-    log("    -retime\n");
-    log("        run 'abc' with '-dff -D 1' options\n");
-    log("\n");
     log("\n");
     log("The following commands are executed by this synthesis command:\n");
     help_script();
@@ -61,13 +58,12 @@ struct SynthAchronixPass : public ScriptPass {
   }
 
   string top_opt, family_opt, vout_file;
-  bool retime, flatten;
+  bool flatten;
 
   void clear_flags() override
   {
     top_opt = "-auto-top";
     vout_file = "";
-    retime = false;
     flatten = true;
   }
 
@@ -100,7 +96,7 @@ struct SynthAchronixPass : public ScriptPass {
           continue;
         }
         if (args[argidx] == "-retime") {
-          retime = true;
+          // Removed: ABC9 does not support retiming.
           continue;
         }
         break;
@@ -151,13 +147,11 @@ struct SynthAchronixPass : public ScriptPass {
         run("clean -purge");
         run("setundef -undriven -zero");
         run("dfflegalize -cell $_DFF_P_ x");
-        if (retime || help_mode)
-          run("abc -markgroups -dff -D 1", "(only if -retime)");
       }
 
     if (check_label("map_luts"))
       {
-        run("abc -lut 4" + string(retime ? " -dff -D 1" : ""));
+        run("abc9 -lut 4");
         run("clean");
       }
 

--- a/techlibs/analogdevices/synth_analogdevices.cc
+++ b/techlibs/analogdevices/synth_analogdevices.cc
@@ -99,15 +99,7 @@ struct SynthAnalogDevicesPass : public ScriptPass
 		log("        do not flatten design before synthesis\n");
 		log("\n");
 		log("    -dff\n");
-		log("        run 'abc'/'abc9' with -dff option\n");
-		log("\n");
-		log("    -retime\n");
-		log("        run 'abc' with '-D 1' option to enable flip-flop retiming.\n");
-		log("        implies -dff.\n");
-		log("\n");
-		log("    -noabc9\n");
-		log("        disable use of new ABC9 flow\n");
-		log("\n");
+		log("        run 'abc9' with -dff option\n");
 		log("\n");
 		log("The following commands are executed by this synthesis command:\n");
 		help_script();
@@ -115,8 +107,8 @@ struct SynthAnalogDevicesPass : public ScriptPass
 	}
 
 	std::string top_opt, edif_file, json_file, tech, tech_param;
-	bool flatten, retime, noiopad, noclkbuf, nobram, nolutram, nosrl, nocarry, nowidelut, nodsp;
-	bool abc9, dff;
+	bool flatten, noiopad, noclkbuf, nobram, nolutram, nosrl, nocarry, nowidelut, nodsp;
+	bool dff;
 	bool flatten_before_abc;
 	int widemux;
 	int widelut_size;
@@ -128,7 +120,6 @@ struct SynthAnalogDevicesPass : public ScriptPass
 		tech = "t16ffc";
 		tech_param = " -D IS_T16FFC";
 		flatten = true;
-		retime = false;
 		noiopad = false;
 		noclkbuf = false;
 		nocarry = false;
@@ -138,7 +129,6 @@ struct SynthAnalogDevicesPass : public ScriptPass
 		nocarry = false;
 		nowidelut = false;
 		nodsp = false;
-		abc9 = true;
 		dff = false;
 		flatten_before_abc = false;
 		widemux = 0;
@@ -186,7 +176,7 @@ struct SynthAnalogDevicesPass : public ScriptPass
 			}
 			if (args[argidx] == "-retime") {
 				dff = true;
-				retime = true;
+				// ABC9 does not support retiming
 				continue;
 			}
 			if (args[argidx] == "-nocarry") {
@@ -229,7 +219,7 @@ struct SynthAnalogDevicesPass : public ScriptPass
 				continue;
 			}
 			if (args[argidx] == "-noabc9") {
-				abc9 = false;
+				// removed: ABC9 is the default
 				continue;
 			}
 			if (args[argidx] == "-nodsp") {
@@ -256,9 +246,6 @@ struct SynthAnalogDevicesPass : public ScriptPass
 
 		if (!design->full_selection())
 			log_cmd_error("This command only operates on fully selected designs!\n");
-
-		if (abc9 && retime)
-			log_cmd_error("-retime option not currently compatible with -abc9!\n");
 
 		log_header(design, "Executing SYNTH_ANALOGDEVICES pass.\n");
 		log_push();
@@ -440,11 +427,9 @@ struct SynthAnalogDevicesPass : public ScriptPass
 
 		if (check_label("map_ffs")) {
 			run("dfflegalize -cell $_DFFE_?P?P_ r -cell $_SDFFE_?P?P_ r");
-			if (abc9 || help_mode) {
-				if (dff || help_mode)
-					run("zinit -all w:* t:$_SDFFE_*", "('-dff' only)");
-				run("techmap -map +/analogdevices/ff_map.v", "('-abc9' only)");
-			}
+			if (dff || help_mode)
+				run("zinit -all w:* t:$_SDFFE_*", "('-dff' only)");
+			run("techmap -map +/analogdevices/ff_map.v");
 		}
 
 		if (check_label("map_luts")) {
@@ -453,39 +438,21 @@ struct SynthAnalogDevicesPass : public ScriptPass
 				run("check");
 				run("flatten");
 			}
-			if (help_mode)
-				run("abc -luts 2:2,3,6:5[,10,20] [-dff] [-D 1]", "(option for '-nowidelut', '-dff', '-retime')");
-			else if (abc9) {
-				run("read_verilog -icells -lib -specify +/analogdevices/abc9_model.v");
-				std::string abc9_opts;
-				std::string k = "synth_analogdevices.abc9.W";
-				if (active_design && active_design->scratchpad.count(k))
-					abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k).c_str());
-				else {
-					abc9_opts += stringf(" -W %s", RTLIL::constpad.at("synth_analogdevices.abc9.W").c_str());
-				}
-				if (nowidelut)
-					abc9_opts += stringf(" -maxlut 6");
-				if (dff)
-					abc9_opts += " -dff";
-				run("abc9" + abc9_opts);
-			}
+			run("read_verilog -icells -lib -specify +/analogdevices/abc9_model.v");
+			std::string abc9_opts;
+			std::string k = "synth_analogdevices.abc9.W";
+			if (active_design && active_design->scratchpad.count(k))
+				abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k).c_str());
 			else {
-				std::string abc_opts;
-				if (nowidelut)
-					abc_opts += " -luts 2:2,3,6:5";
-				else
-					abc_opts += " -luts 2:2,3,6:5,10,20";
-				if (dff)
-					abc_opts += " -dff";
-				if (retime)
-					abc_opts += " -D 1";
-				run("abc -dress" + abc_opts);
+				abc9_opts += stringf(" -W %s", RTLIL::constpad.at("synth_analogdevices.abc9.W").c_str());
 			}
+			if (nowidelut)
+				abc9_opts += stringf(" -maxlut 6");
+			if (dff)
+				abc9_opts += " -dff";
+			run("abc9" + abc9_opts);
 			run("clean");
 
-			if (help_mode || !abc9)
-				run("techmap -map +/analogdevices/ff_map.v", "(only if not '-abc9')");
 			// This shregmap call infers fixed length shift registers after abc
 			//   has performed any necessary retiming
 			if (!nosrl || help_mode)

--- a/techlibs/anlogic/synth_anlogic.cc
+++ b/techlibs/anlogic/synth_anlogic.cc
@@ -57,9 +57,6 @@ struct SynthAnlogicPass : public ScriptPass
 		log("    -noflatten\n");
 		log("        do not flatten design before synthesis\n");
 		log("\n");
-		log("    -retime\n");
-		log("        run 'abc' with '-dff -D 1' options\n");
-		log("\n");
 		log("    -nolutram\n");
 		log("        do not use EG_LOGIC_DRAM16X4 cells in output netlist\n");
 		log("\n");
@@ -81,7 +78,6 @@ struct SynthAnlogicPass : public ScriptPass
 		edif_file = "";
 		json_file = "";
 		flatten = true;
-		retime = false;
 		nolutram = false;
 		nobram = false;
 	}
@@ -124,10 +120,6 @@ struct SynthAnlogicPass : public ScriptPass
 			}
 			if (args[argidx] == "-nobram") {
 				nobram = true;
-				continue;
-			}
-			if (args[argidx] == "-retime") {
-				retime = true;
 				continue;
 			}
 			break;
@@ -193,8 +185,6 @@ struct SynthAnlogicPass : public ScriptPass
 		{
 			run("techmap -map +/techmap.v -map +/anlogic/arith_map.v");
 			run("opt -fast");
-			if (retime || help_mode)
-				run("abc -dff -D 1", "(only if -retime)");
 		}
 
 		if (check_label("map_ffs"))
@@ -207,7 +197,7 @@ struct SynthAnlogicPass : public ScriptPass
 
 		if (check_label("map_luts"))
 		{
-			run("abc -lut 4:6");
+			run("abc9 -lut 4:6");
 			run("clean");
 		}
 

--- a/techlibs/common/synth.cc
+++ b/techlibs/common/synth.cc
@@ -89,9 +89,6 @@ struct SynthPass : public ScriptPass {
 		log("        from label is synonymous to 'begin', and empty to label is\n");
 		log("        synonymous to the end of the command list.\n");
 		log("\n");
-		log("    -abc9\n");
-		log("        use new ABC9 flow (EXPERIMENTAL)\n");
-		log("\n");
 		log("    -no-rw-check\n");
 		log("        marks all recognized read ports as \"return don't-care value on\n");
 		log("        read/write collision\" (same result as setting the no_rw_check\n");
@@ -174,6 +171,7 @@ struct SynthPass : public ScriptPass {
 			}
 			if (args[argidx] == "-lut" && argidx + 1 < args.size()) {
 				lut = atoi(args[++argidx].c_str());
+				abc = "abc9";
 				continue;
 			}
 			if (args[argidx] == "-nofsm") {
@@ -209,7 +207,7 @@ struct SynthPass : public ScriptPass {
 				continue;
 			}
 			if (args[argidx] == "-abc9") {
-				abc = "abc9";
+				// Removed: ABC9 is the default if -lut.
 				continue;
 			}
 			if (args[argidx] == "-no-rw-check") {
@@ -235,9 +233,6 @@ struct SynthPass : public ScriptPass {
 
 		if (!design->full_selection())
 			log_cmd_error("This command only operates on fully selected designs!\n");
-
-		if (abc == "abc9" && !lut)
-			log_cmd_error("ABC9 flow only supported for FPGA synthesis (using '-lut' option)\n");
 
 		log_header(design, "Executing SYNTH pass.\n");
 		log_push();

--- a/techlibs/efinix/synth_efinix.cc
+++ b/techlibs/efinix/synth_efinix.cc
@@ -57,9 +57,6 @@ struct SynthEfinixPass : public ScriptPass
 		log("    -noflatten\n");
 		log("        do not flatten design before synthesis\n");
 		log("\n");
-		log("    -retime\n");
-		log("        run 'abc' with '-dff -D 1' options\n");
-		log("\n");
 		log("    -nobram\n");
 		log("        do not use EFX_RAM_5K cells in output netlist\n");
 		log("\n");
@@ -76,7 +73,7 @@ struct SynthEfinixPass : public ScriptPass
 	}
 
 	string top_opt, edif_file, json_file, latches;
-	bool flatten, retime, nobram;
+	bool flatten, nobram;
 
 	void clear_flags() override
 	{
@@ -84,7 +81,6 @@ struct SynthEfinixPass : public ScriptPass
 		edif_file = "";
 		json_file = "";
 		flatten = true;
-		retime = false;
 		nobram = false;
 		latches = "error";
 	}
@@ -122,7 +118,7 @@ struct SynthEfinixPass : public ScriptPass
 				continue;
 			}
 			if (args[argidx] == "-retime") {
-				retime = true;
+				// Removed: ABC9 does not support retiming.
 				continue;
 			}
 			if (args[argidx] == "-nobram") {
@@ -196,8 +192,6 @@ struct SynthEfinixPass : public ScriptPass
 		{
 			run("techmap -map +/techmap.v -map +/efinix/arith_map.v");
 			run("opt -fast");
-			if (retime || help_mode)
-				run("abc -dff -D 1", "(only if -retime)");
 		}
 
 		if (check_label("map_ffs"))
@@ -212,7 +206,7 @@ struct SynthEfinixPass : public ScriptPass
 
 		if (check_label("map_luts"))
 		{
-			run("abc -lut 4");
+			run("abc9 -lut 4");
 			run("clean");
 		}
 

--- a/techlibs/fabulous/synth_fabulous.cc
+++ b/techlibs/fabulous/synth_fabulous.cc
@@ -417,7 +417,7 @@ struct SynthPass : public ScriptPass {
 		}
 
 		if (check_label("map_luts")) {
-			run(stringf("abc -lut %d -dress", lut));
+			run(stringf("abc9 -lut %d", lut));
 			run("clean");
 		}
 

--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -84,9 +84,6 @@ struct SynthGowinPass : public ScriptPass
 		log("    -noflatten\n");
 		log("        do not flatten design before synthesis\n");
 		log("\n");
-		log("    -retime\n");
-		log("        run 'abc' with '-dff -D 1' options\n");
-		log("\n");
 		log("    -nowidelut\n");
 		log("        do not use muxes to implement LUTs larger than LUT4s\n");
 		log("\n");
@@ -95,9 +92,6 @@ struct SynthGowinPass : public ScriptPass
 		log("\n");
 		log("    -noalu\n");
 		log("        do not use ALU cells\n");
-		log("\n");
-		log("    -noabc9\n");
-		log("        disable use of new ABC9 flow\n");
 		log("\n");
 		log("    -no-rw-check\n");
 		log("        marks all recognized read ports as \"return don't-care value on\n");
@@ -121,7 +115,7 @@ struct SynthGowinPass : public ScriptPass
 	}
 
 	string top_opt, vout_file, json_file, family;
-	bool retime, nobram, nolutram, flatten, nodffe, strict_gw5a_dffs, nowidelut, abc9, noiopads, noalu, no_rw_check, setundef, nodsp;
+	bool nobram, nolutram, flatten, nodffe, strict_gw5a_dffs, nowidelut, noiopads, noalu, no_rw_check, setundef, nodsp;
 
 	void clear_flags() override
 	{
@@ -129,14 +123,12 @@ struct SynthGowinPass : public ScriptPass
 		top_opt = "-auto-top";
 		vout_file = "";
 		json_file = "";
-		retime = false;
 		flatten = true;
 		nobram = false;
 		nodffe = false;
 		strict_gw5a_dffs = false;
 		nolutram = false;
 		nowidelut = false;
-		abc9 = true;
 		noiopads = false;
 		noalu = false;
 		no_rw_check = false;
@@ -177,7 +169,7 @@ struct SynthGowinPass : public ScriptPass
 				continue;
 			}
 			if (args[argidx] == "-retime") {
-				retime = true;
+				// Removed: ABC9 does not support retiming.
 				continue;
 			}
 			if (args[argidx] == "-nobram") {
@@ -209,11 +201,11 @@ struct SynthGowinPass : public ScriptPass
 				continue;
 			}
 			if (args[argidx] == "-abc9") {
-				// removed, ABC9 is on by default.
+				// Removed: ABC9 is on by default.
 				continue;
 			}
 			if (args[argidx] == "-noabc9") {
-				abc9 = false;
+				// Removed: ABC9 can't be disabled.
 				continue;
 			}
 			if (args[argidx] == "-noiopads") {
@@ -330,8 +322,6 @@ struct SynthGowinPass : public ScriptPass
 				run("techmap -map +/techmap.v -map +/gowin/arith_map.v");
 			}
 			run("opt -fast");
-			if (retime || help_mode)
-				run("abc -dff -D 1", "(only if -retime)");
 			if (!noiopads || help_mode)
 				run("iopadmap -bits -inpad IBUF O:I -outpad OBUF I:O "
 					"-toutpad TBUF ~OEN:I:O -tinoutpad IOBUF ~OEN:O:I:IO", "(unless -noiopads)");
@@ -361,16 +351,11 @@ struct SynthGowinPass : public ScriptPass
 		if (check_label("map_luts"))
 		{
 			run("sort");
-			if (nowidelut && abc9) {
-				run("read_verilog -icells -lib -specify +/abc9_model.v");
+			run("read_verilog -icells -lib -specify +/abc9_model.v");
+			if (nowidelut) {
 				run("abc9 -maxlut 4 -W 500");
-			} else if (nowidelut && !abc9) {
-				run("abc -lut 4");
-			} else if (!nowidelut && abc9) {
-				run("read_verilog -icells -lib -specify +/abc9_model.v");
+			} else if (!nowidelut) {
 				run("abc9 -maxlut 8 -W 500");
-			} else if (!nowidelut && !abc9) {
-				run("abc -lut 4:8");
 			}
 			run("clean");
 		}

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -45,8 +45,8 @@ struct SynthIce40Pass : public ScriptPass
 		log("This command runs synthesis for iCE40 FPGAs.\n");
 		log("\n");
 		log("    -device < hx | lp | u >\n");
-		log("        relevant only for '-abc9' flow, optimise timing for the specified\n");
-		log("        device. default: hx\n");
+		log("        optimise timing for the specified device. default: hx\n");
+		log("        (irrelevant if -noabc)\n");
 		log("\n");
 		log("    -top <module>\n");
 		log("        use the specified module as top module\n");
@@ -72,10 +72,7 @@ struct SynthIce40Pass : public ScriptPass
 		log("        do not flatten design before synthesis\n");
 		log("\n");
 		log("    -dff\n");
-		log("        run 'abc'/'abc9' with -dff option\n");
-		log("\n");
-		log("    -retime\n");
-		log("        run 'abc' with '-dff -D 1' options\n");
+		log("        run 'abc9' with -dff option\n");
 		log("\n");
 		log("    -nocarry\n");
 		log("        do not use SB_CARRY cells in output netlist\n");
@@ -97,17 +94,11 @@ struct SynthIce40Pass : public ScriptPass
 		log("        use iCE40 UltraPlus DSP cells for large arithmetic\n");
 		log("\n");
 		log("    -noabc\n");
-		log("        use built-in Yosys LUT techmapping instead of abc\n");
-		log("\n");
-		log("    -abc2\n");
-		log("        run two passes of 'abc' for slightly improved logic density\n");
+		log("        use built-in Yosys LUT techmapping instead of abc9\n");
 		log("\n");
 		log("    -vpr\n");
 		log("        generate an output netlist (and BLIF file) suitable for VPR\n");
 		log("        (this feature is experimental and incomplete)\n");
-		log("\n");
-		log("    -noabc9\n");
-		log("        disable use of new ABC9 flow\n");
 		log("\n");
 		log("    -no-rw-check\n");
 		log("        marks all recognized read ports as \"return don't-care value on\n");
@@ -127,7 +118,7 @@ struct SynthIce40Pass : public ScriptPass
 	}
 
 	string top_opt, blif_file, edif_file, json_file, device_opt, latches;
-	bool nocarry, nodffe, nobram, spram, dsp, flatten, retime, noabc, abc2, vpr, abc9, dff, no_rw_check;
+	bool nocarry, nodffe, nobram, spram, dsp, flatten, noabc, vpr, dff, no_rw_check;
 	int min_ce_use;
 
 	void clear_flags() override
@@ -143,11 +134,8 @@ struct SynthIce40Pass : public ScriptPass
 		spram = false;
 		dsp = false;
 		flatten = true;
-		retime = false;
 		noabc = false;
-		abc2 = false;
 		vpr = false;
-		abc9 = true;
 		device_opt = "hx";
 		no_rw_check = false;
 		latches = "error";
@@ -194,7 +182,7 @@ struct SynthIce40Pass : public ScriptPass
 				continue;
 			}
 			if (args[argidx] == "-retime") {
-				retime = true;
+				// removed, retiming is not supported with ABC9
 				continue;
 			}
 			if (args[argidx] == "-relut") {
@@ -229,20 +217,16 @@ struct SynthIce40Pass : public ScriptPass
 				noabc = true;
 				continue;
 			}
-			if (args[argidx] == "-abc2") {
-				abc2 = true;
-				continue;
-			}
 			if (args[argidx] == "-vpr") {
 				vpr = true;
 				continue;
 			}
 			if (args[argidx] == "-abc9") {
-				// removed, ABC9 is on by default.
+				// removed, ABC9 is used if not -noabc
 				continue;
 			}
 			if (args[argidx] == "-noabc9") {
-				abc9 = false;
+				// removed, ABC9 is used if not -noabc
 				continue;
 			}
 			if (args[argidx] == "-dff") {
@@ -271,11 +255,6 @@ struct SynthIce40Pass : public ScriptPass
 			log_cmd_error("Invalid or no device specified: '%s'\n", device_opt);
 		if (latches != "info" && latches != "warn" && latches != "error")
 			log_cmd_error("Invalid value '%s' for -latches (expected info, warn or error)\n", latches.c_str());
-
-		if (abc9 && retime)
-			log_cmd_error("-retime option not currently compatible with -abc9!\n");
-		if (abc9 && noabc)
-			log_cmd_error("-abc9 is incompatible with -noabc!\n");
 
 		log_header(design, "Executing SYNTH_ICE40 pass.\n");
 		log_push();
@@ -384,8 +363,6 @@ struct SynthIce40Pass : public ScriptPass
 				run("techmap -map +/techmap.v -map +/ice40/arith_map.v");
 			}
 			run("opt -fast");
-			if (retime || help_mode)
-				run("abc -dff -D 1", "(only if -retime)");
 			run("ice40_opt");
 		}
 
@@ -403,10 +380,6 @@ struct SynthIce40Pass : public ScriptPass
 
 		if (check_label("map_luts"))
 		{
-			if (abc2 || help_mode) {
-				run("abc", "      (only if -abc2)");
-				run("ice40_opt", "(only if -abc2)");
-			}
 			if (latches == "error" || help_mode)
 				run("check -latchonly -assert", "(only if -latches error, the default)");
 			run("techmap -map +/ice40/latches_map.v");
@@ -416,22 +389,18 @@ struct SynthIce40Pass : public ScriptPass
 					run("techmap -map +/gate2lut.v -D LUT_WIDTH=4", "(only if -noabc)");
 			}
 			if (!noabc) {
-				if (abc9) {
-					run("read_verilog " + define + " -icells -lib -specify +/ice40/abc9_model.v");
-					std::string abc9_opts;
-					std::string k = "synth_ice40.abc9.W";
-					if (active_design && active_design->scratchpad.count(k))
-						abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k));
-					else {
-						k = stringf("synth_ice40.abc9.%s.W", device_opt);
-						abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k));
-					}
-					if (dff)
-						abc9_opts += " -dff";
-					run("abc9 " + abc9_opts);
+				run("read_verilog " + define + " -icells -lib -specify +/ice40/abc9_model.v");
+				std::string abc9_opts;
+				std::string k = "synth_ice40.abc9.W";
+				if (active_design && active_design->scratchpad.count(k))
+					abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k));
+				else {
+					k = stringf("synth_ice40.abc9.%s.W", device_opt);
+					abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k));
 				}
-				else
-					run(stringf("abc -dress -lut 4 %s", dff ? "-dff" : ""), "(skip if -noabc)");
+				if (dff)
+					abc9_opts += " -dff";
+				run("abc9 " + abc9_opts);
 			}
 			run("ice40_wrapcarry -unwrap");
 			run("techmap -map +/ice40/ff_map.v");

--- a/techlibs/intel/synth_intel.cc
+++ b/techlibs/intel/synth_intel.cc
@@ -79,16 +79,13 @@ struct SynthIntelPass : public ScriptPass {
 		log("    -noflatten\n");
 		log("        do not flatten design before synthesis\n");
 		log("\n");
-		log("    -retime\n");
-		log("        run 'abc' with '-dff -D 1' options\n");
-		log("\n");
 		log("The following commands are executed by this synthesis command:\n");
 		help_script();
 		log("\n");
 	}
 
 	string top_opt, family_opt, vout_file, blif_file;
-	bool retime, flatten, nobram, dff, nodsp, iopads;
+	bool flatten, nobram, dff, nodsp, iopads;
 
 	void clear_flags() override
 	{
@@ -96,7 +93,6 @@ struct SynthIntelPass : public ScriptPass {
 		family_opt = "max10";
 		vout_file = "";
 		blif_file = "";
-		retime = false;
 		flatten = true;
 		nobram = false;
 		dff = false;
@@ -157,7 +153,7 @@ struct SynthIntelPass : public ScriptPass {
 				continue;
 			}
 			if (args[argidx] == "-retime") {
-				retime = true;
+				// Removed: ABC9 does not support retiming.
 				continue;
 			}
 			break;
@@ -259,8 +255,6 @@ struct SynthIntelPass : public ScriptPass {
 			run("opt -full");
 			run("clean -purge");
 			run("setundef -undriven -zero");
-			if (retime || help_mode)
-				run("abc -markgroups -dff -D 1", "(only if -retime)");
 		}
 
 		if (check_label("map_ffs")) {

--- a/techlibs/lattice/synth_lattice.cc
+++ b/techlibs/lattice/synth_lattice.cc
@@ -104,10 +104,7 @@ struct SynthLatticePass : public ScriptPass
 		log("        do not flatten design before synthesis\n");
 		log("\n");
 		log("    -dff\n");
-		log("        run 'abc'/'abc9' with -dff option\n");
-		log("\n");
-		log("    -retime\n");
-		log("        run 'abc' with '-dff -D 1' options\n");
+		log("        run 'abc9' with -dff option\n");
 		log("\n");
 		log("    -noccu2\n");
 		log("        do not use CCU2 cells in output netlist\n");
@@ -130,12 +127,6 @@ struct SynthLatticePass : public ScriptPass
 		log("\n");
 		log("    -asyncprld\n");
 		log("        use async PRLD mode to implement ALDFF (EXPERIMENTAL)\n");
-		log("\n");
-		log("    -abc2\n");
-		log("        run two passes of 'abc' for slightly improved logic density\n");
-		log("\n");
-		log("    -noabc9\n");
-		log("        disable use of new ABC9 flow\n");
 		log("\n");
 		log("    -iopad\n");
 		log("        insert IO buffers\n");
@@ -170,9 +161,9 @@ struct SynthLatticePass : public ScriptPass
 	}
 
 	string top_opt, edif_file, json_file, family, latches;
-	bool noccu2, nodffe, nobram, nolutram, nowidelut, asyncprld, flatten, dff, retime, abc2, abc9, iopad, nodsp, no_rw_check, have_dsp;
+	bool noccu2, nodffe, nobram, nolutram, nowidelut, asyncprld, flatten, dff, iopad, nodsp, no_rw_check, have_dsp;
 	bool cmp2softlogic;
-	string postfix, arith_map, brams_map, dsp_map, cells_map, map_ram_default, widelut_abc;
+	string postfix, arith_map, brams_map, dsp_map, cells_map, map_ram_default;
 	bool is_nexus;
 	std::vector<DSPRule> dsp_rules;
 
@@ -190,9 +181,6 @@ struct SynthLatticePass : public ScriptPass
 		asyncprld = false;
 		flatten = true;
 		dff = false;
-		retime = false;
-		abc2 = false;
-		abc9 = true;
 		iopad = false;
 		nodsp = false;
 		no_rw_check = false;
@@ -206,13 +194,11 @@ struct SynthLatticePass : public ScriptPass
 		is_nexus = false;
 		map_ram_default = "";
 		cells_map = "";
-		widelut_abc = "4:7";
 	}
 
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		string run_from, run_to;
-		bool force_abc9 = false;
 		bool force_widelut = false;
 		bool force_iopad = false;
 		clear_flags();
@@ -257,7 +243,7 @@ struct SynthLatticePass : public ScriptPass
 				continue;
 			}
 			if (args[argidx] == "-retime") {
-				retime = true;
+				// Removed: ABC9 does not support retiming.
 				continue;
 			}
 			if (args[argidx] == "-noccu2") {
@@ -291,17 +277,15 @@ struct SynthLatticePass : public ScriptPass
 				continue;
 			}
 			if (args[argidx] == "-abc2") {
-				abc2 = true;
+				// Removed
 				continue;
 			}
 			if (args[argidx] == "-abc9") {
-				// removed, ABC9 is on by default.
-				force_abc9 = true;
+				// Removed: ABC9 is on by default.
 				continue;
 			}
 			if (args[argidx] == "-noabc9") {
-				force_abc9 = true;
-				abc9 = false;
+				// Removed: ABC9 is on by default.
 				continue;
 			}
 			if (args[argidx] == "-iopad") {
@@ -358,7 +342,6 @@ struct SynthLatticePass : public ScriptPass
 			cells_map = "_trellis";
 			have_dsp = false;
 			if (!force_widelut) nowidelut = true;
-			if (!force_abc9) abc9 = false;
 		} else if (family == "lifcl" ||
 			family == "lfd2nx") {
 			is_nexus = true;
@@ -370,9 +353,7 @@ struct SynthLatticePass : public ScriptPass
 			have_dsp = true;
 			map_ram_default = " -no-auto-huge";
 			cells_map = "_nexus";
-			widelut_abc = "4:5";
 			if (!force_iopad) iopad = true;
-			if (!force_abc9) abc9 = false;
 /*		} else if (family == "xo" ||
 				family == "pm") {
 		} else if (family == "xp" ||
@@ -388,9 +369,6 @@ struct SynthLatticePass : public ScriptPass
 
 		if (!design->full_selection())
 			log_cmd_error("This command only operates on fully selected designs!\n");
-
-		if (abc9 && retime)
-				log_cmd_error("-retime option not currently compatible with -abc9!\n");
 
 		log_header(design, "Executing SYNTH_LATTICE pass.\n");
 		log_push();
@@ -500,8 +478,6 @@ struct SynthLatticePass : public ScriptPass
 				run("attrmvcp -attr src -attr LOC -driven t:IB %x:+[I]");
 			}
 			run("opt -fast");
-			if (retime || help_mode)
-				run("abc -dff -D 1", "(only if -retime)");
 		}
 
 		if (check_label("map_ffs"))
@@ -532,8 +508,8 @@ struct SynthLatticePass : public ScriptPass
 				run("dfflegalize" + dfflegalize_args, "($_*DFFE_* only if not -nodffe)");
 			}
 			run("opt_merge");
-			if ((abc9 && dff) || help_mode)
-				run("zinit -all w:* t:$_DFF_?_ t:$_DFFE_??_ t:$_SDFF*", "(only if -abc9 and -dff)");
+			if (dff || help_mode)
+				run("zinit -all w:* t:$_DFF_?_ t:$_DFFE_??_ t:$_SDFF*", "(only if -dff)");
 			run("techmap -D NO_LUT -map +/lattice/cells_map" + cells_map + ".v");
 			run("opt_expr -undriven -mux_undef");
 			run("simplemap");
@@ -544,38 +520,23 @@ struct SynthLatticePass : public ScriptPass
 
 		if (check_label("map_luts"))
 		{
-			if (abc2 || help_mode)
-				run("abc", "      (only if -abc2)");
 			if (!asyncprld || help_mode) {
 				if (latches == "error" || help_mode)
 					run("check -latchonly -assert", "(skip if -asyncprld; only if -latches error, the default)");
 				run("techmap -map +/lattice/latches_map.v", "(skip if -asyncprld)");
 			}
 
-			if (abc9) {
-				std::string abc9_opts;
-				if (nowidelut)
-					abc9_opts += " -maxlut 4";
-				std::string k = "synth_lattice.abc9.W";
-				if (active_design && active_design->scratchpad.count(k))
-					abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k));
-				else
-					abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k));
-				if (nowidelut)
-					abc9_opts += " -maxlut 4";
-				if (dff)
-					abc9_opts += " -dff";
-				run("abc9" + abc9_opts);
-			} else {
-				std::string abc_args = " -dress";
-				if (nowidelut)
-					abc_args += " -lut 4";
-				else
-					abc_args += " -lut " + widelut_abc;
-				if (dff)
-					abc_args += " -dff";
-				run("abc" + abc_args);
-			}
+			std::string abc9_opts;
+			std::string k = "synth_lattice.abc9.W";
+			if (active_design && active_design->scratchpad.count(k))
+				abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k));
+			else
+				abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k));
+			if (nowidelut)
+				abc9_opts += " -maxlut 4";
+			if (dff)
+				abc9_opts += " -dff";
+			run("abc9" + abc9_opts);
 			run("clean");
 		}
 

--- a/techlibs/microchip/synth_microchip.cc
+++ b/techlibs/microchip/synth_microchip.cc
@@ -81,14 +81,7 @@ struct SynthMicrochipPass : public ScriptPass {
 		log("        do not flatten design before synthesis\n");
 		log("\n");
 		log("    -dff\n");
-		log("        Run 'abc'/'abc9' with -dff option\n");
-		log("\n");
-		log("    -retime\n");
-		log("        Run 'abc' with '-D 1' option to enable flip-flop retiming.\n");
-		log("        implies -dff.\n");
-		log("\n");
-		log("    -noabc9\n");
-		log("        Use classic ABC flow instead of ABC9\n");
+		log("        Run 'abc9' with -dff option\n");
 		log("\n");
 		log("    -discard-ffinit\n");
 		log("        discard FF init value instead of emitting an error\n");
@@ -100,8 +93,8 @@ struct SynthMicrochipPass : public ScriptPass {
 	}
 
 	std::string top_opt, edif_file, blif_file, vlog_file, family;
-	bool flatten, retime, noiopad, noclkbuf, nobram, nocarry, nowidelut, nodsp;
-	bool abc9, dff;
+	bool flatten, noiopad, noclkbuf, nobram, nocarry, nowidelut, nodsp;
+	bool dff;
 	bool discard_ffinit;
 	int lut_size;
 
@@ -116,14 +109,12 @@ struct SynthMicrochipPass : public ScriptPass {
 		vlog_file.clear();
 		family = "polarfire";
 		flatten = true;
-		retime = false;
 		noiopad = false;
 		noclkbuf = false;
 		nocarry = false;
 		nobram = false;
 		nowidelut = false;
 		nodsp = false;
-		abc9 = true;
 		dff = false;
 		lut_size = 4;
 		discard_ffinit = false;
@@ -173,7 +164,7 @@ struct SynthMicrochipPass : public ScriptPass {
 			}
 			if (args[argidx] == "-retime") {
 				dff = true;
-				retime = true;
+				// Removed: ABC9 does not support retiming.
 				continue;
 			}
 			if (args[argidx] == "-nocarry") {
@@ -204,7 +195,7 @@ struct SynthMicrochipPass : public ScriptPass {
 				continue;
 			}
 			if (args[argidx] == "-noabc9") {
-				abc9 = false;
+				// Removed: ABC9 is now the default.
 				continue;
 			}
 			if (args[argidx] == "-nodsp") {
@@ -239,9 +230,6 @@ struct SynthMicrochipPass : public ScriptPass {
 
 		if (!design->full_selection())
 			log_cmd_error("This command only operates on fully selected designs!\n");
-
-		if (abc9 && retime)
-			log_cmd_error("-retime option not currently compatible with -abc9!\n");
 
 		log_header(design, "Executing SYNTH_MICROCHIP pass.\n");
 		log_push();
@@ -480,41 +468,25 @@ struct SynthMicrochipPass : public ScriptPass {
 				run("dfflegalize" + params, "(Converts FFs to supported types)");
 			}
 
-			if (abc9 || help_mode) {
-				if (dff || help_mode)
-					run("zinit -all w:* t:$_SDFFCE_*", "('-dff' only)");
-				run("techmap -D NO_LUT -map +/microchip/cells_map.v", "('-abc9' only)");
-			}
+			if (dff || help_mode)
+				run("zinit -all w:* t:$_SDFFCE_*", "('-dff' only)");
+			run("techmap -D NO_LUT -map +/microchip/cells_map.v");
 		}
 
 		if (check_label("map_luts")) {
 			run("opt_expr -mux_undef -noclkinv");
-			if (help_mode)
-				run("abc -luts 2:2,3,6:5[,10,20] [-dff] [-D 1]", "(option for '-nowidelut', '-dff', '-retime')");
-			else if (abc9) {
-
-				std::string abc9_opts;
-				// for the if command in abc to specify wire delay between adjacent LUTs (default = 0)
-				// NOTE: should not have 0 wire delay between LUTs,
-				//		 otherwise abc might use LUT2+LUT3 instead of single LUT4
-				abc9_opts += " -W 300";
-				if (nowidelut)
-					abc9_opts += stringf(" -maxlut %d", lut_size);
-				if (dff)
-					abc9_opts += " -dff";
-				run("abc9" + abc9_opts);
-			} else {
-				std::string abc_opts = " -lut " + lut_size_s;
-				if (dff)
-					abc_opts += " -dff";
-				if (retime)
-					abc_opts += " -D 1";
-				run("abc" + abc_opts);
-			}
+			std::string abc9_opts;
+			// for the if command in abc to specify wire delay between adjacent LUTs (default = 0)
+			// NOTE: should not have 0 wire delay between LUTs,
+			//		 otherwise abc might use LUT2+LUT3 instead of single LUT4
+			abc9_opts += " -W 300";
+			if (nowidelut)
+				abc9_opts += stringf(" -maxlut %d", lut_size);
+			if (dff)
+				abc9_opts += " -dff";
+			run("abc9" + abc9_opts);
 			run("clean");
 
-			if (help_mode || !abc9)
-				run("techmap -D NO_LUT -map +/microchip/cells_map.v", "(only if not '-abc9')");
 			std::string techmap_args = "-map +/microchip/cells_map.v -D FINAL_MAP";
 			techmap_args += " -D LUT_WIDTH=" + lut_size_s;
 			run("techmap " + techmap_args);

--- a/techlibs/nanoxplore/cells_sim.v
+++ b/techlibs/nanoxplore/cells_sim.v
@@ -1,4 +1,3 @@
-(* abc9_lut=1 *)
 module NX_LUT(input I1, I2, I3, I4, output O);
 
 parameter lut_table = 16'h0000;
@@ -10,7 +9,6 @@ assign O = I1 ? s3[1] : s3[0];
 
 endmodule
 
-(* abc9_box, lib_whitebox *)
 module NX_DFF(input I, CK, L, R, output reg O);
 
 parameter dff_ctxt = 1'bx;
@@ -36,7 +34,6 @@ always @(posedge clock, posedge async_reset)
 
 endmodule
 
-(* abc9_box, lib_whitebox *)
 module NX_DFR(input I, CK, L, R, output O);
 
 parameter data_inv = 1'b0;
@@ -67,8 +64,7 @@ assign O = data_inv ? O_reg : ~O_reg;
 endmodule
 
 
-(* abc9_box, lib_whitebox *)
-module NX_CY(input A1, A2, A3, A4, B1, B2, B3, B4, (* abc9_carry *) input CI, output S1, S2, S3, S4, (* abc9_carry *) output CO);
+module NX_CY(input A1, A2, A3, A4, B1, B2, B3, B4, input CI, output S1, S2, S3, S4, output CO);
 parameter add_carry = 0;
 
 wire CI_1;
@@ -175,14 +171,11 @@ module NX_IOB_O(I, C, T, IO);
 	assign IO = C ? I : 1'bz;
 endmodule
 
-(* abc9_box, lib_whitebox *)
 module NX_CY_1BIT(CI, A, B, S, CO);
-    (* abc9_carry *)
     input CI;
     input A;
     input B;
     output S;
-    (* abc9_carry *)
     output CO;
     parameter first = 1'b0;
 
@@ -217,7 +210,6 @@ module NX_BFR(I, O);
     assign O = data_inv ? ~I : I;
 endmodule
 
-(* abc9_box, lib_whitebox *)
 module NX_RAM(ACK, ACKC, ACKD, ACKR, BCK, BCKC, BCKD, BCKR, AI1, AI2, AI3, AI4, AI5, AI6, AI7, AI8, AI9, AI10, AI11, AI12, AI13
 , AI14, AI15, AI16, AI17, AI18, AI19, AI20, AI21, AI22, AI23, AI24, BI1, BI2, BI3, BI4, BI5, BI6, BI7, BI8, BI9, BI10
 , BI11, BI12, BI13, BI14, BI15, BI16, BI17, BI18, BI19, BI20, BI21, BI22, BI23, BI24, ACOR, AERR, BCOR, BERR, AO1, AO2, AO3

--- a/techlibs/nanoxplore/cells_sim_u.v
+++ b/techlibs/nanoxplore/cells_sim_u.v
@@ -1,4 +1,3 @@
-(* abc9_box, lib_whitebox *)
 module NX_GCK_U(SI1, SI2, CMD, SO);
     input CMD;
     input SI1;
@@ -31,7 +30,6 @@ module NX_GCK_U(SI1, SI2, CMD, SO);
     assign SO = inv_out ? ~SO_int : SO_int;
 endmodule
 
-(* abc9_box, lib_whitebox *)
 module NX_RFB_U(WCK, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, I17, I18, I19, I20
 , I21, I22, I23, I24, I25, I26, I27, I28, I29, I30, I31, I32, I33, I34, I35, I36, O1, O2, O3, O4, O5
 , O6, O7, O8, O9, O10, O11, O12, O13, O14, O15, O16, O17, O18, O19, O20, O21, O22, O23, O24, O25, O26
@@ -205,7 +203,6 @@ module NX_RFB_U(WCK, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14
             mem[WA] <= I[MEM_WIDTH-1:0];
 endmodule
 
-(* abc9_box, lib_whitebox *)
 module NX_WFG_U(R, SI, ZI, SO, ZO);
     input R;
     input SI;

--- a/techlibs/nanoxplore/synth_nanoxplore.cc
+++ b/techlibs/nanoxplore/synth_nanoxplore.cc
@@ -66,9 +66,6 @@ struct SynthNanoXplorePass : public ScriptPass
 		log("    -noflatten\n");
 		log("        do not flatten design before synthesis\n");
 		log("\n");
-		log("    -abc9\n");
-		log("        use new ABC9 flow (EXPERIMENTAL)\n");
-		log("\n");
 		log("    -nocy\n");
 		log("        do not map adders to CY cells\n");
 		log("\n");
@@ -110,7 +107,7 @@ struct SynthNanoXplorePass : public ScriptPass
 	}
 
 	string top_opt, json_file, family, latches;
-	bool flatten, abc9, nocy, nodffe, norfram, nobram, noiopad, no_rw_check;
+	bool flatten, nocy, nodffe, norfram, nobram, noiopad, no_rw_check;
 	std::string postfix;
 	int min_ce_use, min_srst_use;
 
@@ -120,7 +117,6 @@ struct SynthNanoXplorePass : public ScriptPass
 		json_file = "";
 		family = "";
 		flatten = true;
-		abc9 = false;
 		nocy = false;
 		nodffe = false;
 		norfram = false;
@@ -170,7 +166,7 @@ struct SynthNanoXplorePass : public ScriptPass
 				continue;
 			}
 			if (args[argidx] == "-abc9") {
-				abc9 = true;
+				// Removed: ABC9 is the default
 				continue;
 			}
 			if (args[argidx] == "-nocy") {
@@ -349,19 +345,13 @@ struct SynthNanoXplorePass : public ScriptPass
 
 		if (check_label("map_luts"))
 		{
-			if (abc9) {
-				std::string abc9_opts = " -maxlut 4";
-				std::string k = "synth_nanoxplore.abc9.W";
-				if (active_design && active_design->scratchpad.count(k))
-					abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k));
-				else
-					abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k));
-				run("abc9" + abc9_opts);
-			} else {
-				std::string abc_args = " -dress";
-				abc_args += " -lut 4";
-				run("abc" + abc_args);
-			}
+			std::string abc9_opts = " -lut 4";
+			std::string k = "synth_nanoxplore.abc9.W";
+			if (active_design && active_design->scratchpad.count(k))
+				abc9_opts += stringf(" -W %s", active_design->scratchpad_get_string(k));
+			else
+				abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k));
+			run("abc9" + abc9_opts);
 			run("techmap -map +/nanoxplore/cells_map.v t:$lut");
 			run("opt -fast");
 			run("clean");

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -68,10 +68,6 @@ struct SynthQuickLogicPass : public ScriptPass {
 		log("        write the design to the specified verilog file. writing of an output\n");
 		log("        file is omitted if this parameter is not specified.\n");
 		log("\n");
-		log("    -abc\n");
-		log("        use old ABC flow, which has generally worse mapping results but is less\n");
-		log("        likely to have bugs.\n");
-		log("\n");
 		log("    -latches <info|warn|error>\n");
 		log("        select the behaviour for latches that cannot be mapped to a\n");
 		log("        dedicated hardware primitive and are implemented using LUTs\n");
@@ -85,7 +81,7 @@ struct SynthQuickLogicPass : public ScriptPass {
 	}
 
 	string top_opt, blif_file, edif_file, family, currmodule, verilog_file, lib_path, latches;
-	bool abc9, inferAdder, nobram, bramTypes, dsp, ioff, flatten;
+	bool inferAdder, nobram, bramTypes, dsp, ioff, flatten;
 
 	void clear_flags() override
 	{
@@ -95,7 +91,6 @@ struct SynthQuickLogicPass : public ScriptPass {
 		verilog_file = "";
 		currmodule = "";
 		family = "pp3";
-		abc9 = true;
 		inferAdder = true;
 		nobram = false;
 		bramTypes = false;
@@ -149,7 +144,7 @@ struct SynthQuickLogicPass : public ScriptPass {
 				continue;
 			}
 			if (args[argidx] == "-abc") {
-				abc9 = false;
+				// Removed: ABC9 is the default.
 				continue;
 			}
 			if (args[argidx] == "-nocarry" || args[argidx] == "-no_adder") {
@@ -193,7 +188,7 @@ struct SynthQuickLogicPass : public ScriptPass {
 		if (latches != "info" && latches != "warn" && latches != "error")
 			log_cmd_error("Invalid value '%s' for -latches (expected info, warn or error)\n", latches.c_str());
 
-		if (abc9 && design->scratchpad_get_int("abc9.D", 0) == 0) {
+		if (design->scratchpad_get_int("abc9.D", 0) == 0) {
 			log_warning("delay target has not been set via SDC or scratchpad; assuming 12 MHz clock.\n");
 			design->scratchpad_set_int("abc9.D", 41667); // 12MHz = 83.33.. ns; divided by two to allow for interconnect delay.
 		}
@@ -333,23 +328,15 @@ struct SynthQuickLogicPass : public ScriptPass {
 			if (latches == "error" || help_mode)
 				run("check -latchonly -assert", "(only if -latches error, the default)");
 			run("techmap -map " + lib_path + family + "/latches_map.v");
-			if (abc9) {
-				run("read_verilog -lib -specify -icells " + lib_path + family + "/abc9_model.v");
-				run("techmap -map " + lib_path + family + "/abc9_map.v");
-				run("abc9 -maxlut 4 -dff");
-				run("techmap -map " + lib_path + family + "/abc9_unmap.v");
-			} else {
-				run("abc -luts 1,2,2,4 -dress");
-			}
+			run("read_verilog -lib -specify -icells " + lib_path + family + "/abc9_model.v");
+			run("techmap -map " + lib_path + family + "/abc9_map.v");
+			run("abc9 -maxlut 4 -dff");
+			run("techmap -map " + lib_path + family + "/abc9_unmap.v");
 			run("clean");
 		}
 
 		if (check_label("map_luts", "(for qlf_k6n10f)") && (help_mode || family == "qlf_k6n10f")) {
-			if (abc9) {
-				run("abc9 -maxlut 6");
-			} else {
-				run("abc -lut 6 -dress");
-			}
+			run("abc9 -maxlut 6");
 			run("clean");
 			run("opt_lut");
 		}

--- a/techlibs/sf2/synth_sf2.cc
+++ b/techlibs/sf2/synth_sf2.cc
@@ -69,9 +69,6 @@ struct SynthSf2Pass : public ScriptPass
 		log("    -discard-ffinit\n");
 		log("        discard FF init value instead of emitting an error\n");
 		log("\n");
-		log("    -retime\n");
-		log("        run 'abc' with '-dff -D 1' options\n");
-		log("\n");
 		log("\n");
 		log("The following commands are executed by this synthesis command:\n");
 		help_script();
@@ -88,7 +85,6 @@ struct SynthSf2Pass : public ScriptPass
 		vlog_file = "";
 		json_file = "";
 		flatten = true;
-		retime = false;
 		iobs = true;
 		clkbuf = false;
 		discard_ffinit = false;
@@ -131,7 +127,7 @@ struct SynthSf2Pass : public ScriptPass
 				continue;
 			}
 			if (args[argidx] == "-retime") {
-				retime = true;
+				// Removed: ABC9 does not support retiming.
 				continue;
 			}
 			if (args[argidx] == "-noiobs") {
@@ -192,8 +188,6 @@ struct SynthSf2Pass : public ScriptPass
 			run("opt -undriven -fine");
 			run("techmap -map +/techmap.v -map +/sf2/arith_map.v");
 			run("opt -fast");
-			if (retime || help_mode)
-				run("abc -dff -D 1", "(only if -retime)");
 		}
 
 		if (check_label("map_ffs"))
@@ -209,7 +203,7 @@ struct SynthSf2Pass : public ScriptPass
 
 		if (check_label("map_luts"))
 		{
-			run("abc -lut 4");
+			run("abc9 -lut 4");
 			run("clean");
 		}
 

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -127,14 +127,7 @@ struct SynthXilinxPass : public ScriptPass
 		log("        flatten design before synthesis\n");
 		log("\n");
 		log("    -dff\n");
-		log("        run 'abc'/'abc9' with -dff option\n");
-		log("\n");
-		log("    -retime\n");
-		log("        run 'abc' with '-D 1' option to enable flip-flop retiming.\n");
-		log("        implies -dff.\n");
-		log("\n");
-		log("    -abc9\n");
-		log("        use new ABC9 flow (EXPERIMENTAL)\n");
+		log("        run 'abc9' with -dff option\n");
 		log("\n");
 		log("\n");
 		log("The following commands are executed by this synthesis command:\n");
@@ -143,8 +136,8 @@ struct SynthXilinxPass : public ScriptPass
 	}
 
 	std::string top_opt, edif_file, blif_file, json_file, family;
-	bool flatten, retime, ise, noiopad, noclkbuf, nobram, nolutram, nosrl, nocarry, nowidelut, nodsp, uram;
-	bool abc9, dff;
+	bool flatten, ise, noiopad, noclkbuf, nobram, nolutram, nosrl, nocarry, nowidelut, nodsp, uram;
+	bool dff;
 	bool flatten_before_abc;
 	int widemux;
 	int lut_size;
@@ -157,7 +150,6 @@ struct SynthXilinxPass : public ScriptPass
 		blif_file.clear();
 		family = "xc7";
 		flatten = false;
-		retime = false;
 		ise = false;
 		noiopad = false;
 		noclkbuf = false;
@@ -169,7 +161,6 @@ struct SynthXilinxPass : public ScriptPass
 		nowidelut = false;
 		nodsp = false;
 		uram = false;
-		abc9 = false;
 		dff = false;
 		flatten_before_abc = false;
 		widemux = 0;
@@ -218,7 +209,7 @@ struct SynthXilinxPass : public ScriptPass
 			}
 			if (args[argidx] == "-retime") {
 				dff = true;
-				retime = true;
+				// retiming not supported by ABC9
 				continue;
 			}
 			if (args[argidx] == "-nocarry") {
@@ -265,7 +256,7 @@ struct SynthXilinxPass : public ScriptPass
 				continue;
 			}
 			if (args[argidx] == "-abc9") {
-				abc9 = true;
+				// removed: abc9 enabled by default
 				continue;
 			}
 			if (args[argidx] == "-nodsp") {
@@ -325,9 +316,6 @@ struct SynthXilinxPass : public ScriptPass
 
 		if (!design->full_selection())
 			log_cmd_error("This command only operates on fully selected designs!\n");
-
-		if (abc9 && retime)
-			log_cmd_error("-retime option not currently compatible with -abc9!\n");
 
 		log_header(design, "Executing SYNTH_XILINX pass.\n");
 		log_push();
@@ -630,11 +618,9 @@ struct SynthXilinxPass : public ScriptPass
 				run("dfflegalize -cell $_DFFE_?P?P_ 01 -cell $_SDFFE_?P?P_ 01 -cell $_DLATCH_?P?_ 01", "(for xc6v, xc7, xcu, xcup)");
 			else
 				run("dfflegalize -cell $_DFFE_?P?P_ 01 -cell $_DFFSRE_?PPP_ 01 -cell $_SDFFE_?P?P_ 01 -cell $_DLATCH_?P?_ 01 -cell $_DLATCHSR_?PP_ 01", "(for xc5v and older)");
-			if (abc9 || help_mode) {
-				if (dff || help_mode)
-					run("zinit -all w:* t:$_SDFFE_*", "('-dff' only)");
-				run("techmap -map +/xilinx/ff_map.v", "('-abc9' only)");
-			}
+			if (dff || help_mode)
+				run("zinit -all w:* t:$_SDFFE_*", "('-dff' only)");
+			run("techmap -map +/xilinx/ff_map.v");
 		}
 
 		if (check_label("map_luts")) {
@@ -644,13 +630,8 @@ struct SynthXilinxPass : public ScriptPass
 				run("flatten");
 			}
 			if (help_mode)
-				run("abc -luts 2:2,3,6:5[,10,20] [-dff] [-D 1]", "(option for '-nowidelut', '-dff', '-retime')");
-			else if (abc9) {
-				if (lut_size != 6)
-					log_error("'synth_xilinx -abc9' not currently supported for LUT4-based devices.\n");
-				if (family != "xc7")
-					log_warning("'synth_xilinx -abc9' not currently supported for the '%s' family, "
-							"will use timing for 'xc7' instead.\n", family.c_str());
+				run("abc9 -luts 2:2,3,6:5[,10,20] [-dff] [-D 1]", "(option for '-nowidelut', '-dff')");
+			else {
 				run("read_verilog -icells -lib -specify +/xilinx/abc9_model.v");
 				std::string abc9_opts;
 				std::string k = "synth_xilinx.abc9.W";
@@ -660,37 +641,20 @@ struct SynthXilinxPass : public ScriptPass
 					k = stringf("synth_xilinx.abc9.%s.W", family);
 					abc9_opts += stringf(" -W %s", RTLIL::constpad.at(k, RTLIL::constpad.at("synth_xilinx.abc9.xc7.W")));
 				}
-				if (nowidelut)
-					abc9_opts += stringf(" -maxlut %d", lut_size);
+				if (lut_size != 6) {
+					abc9_opts += " -lut " + lut_size_s;
+					if (!nowidelut)
+						abc9_opts += ":" + std::to_string(widelut_size);
+				} else {
+					if (nowidelut)
+						abc9_opts += stringf(" -maxlut %d", lut_size);
+				}
 				if (dff)
 					abc9_opts += " -dff";
 				run("abc9" + abc9_opts);
 			}
-			else {
-				std::string abc_opts;
-				if (lut_size != 6) {
-					if (nowidelut)
-						abc_opts += " -lut " + lut_size_s;
-					else
-						abc_opts += " -lut " + lut_size_s + ":" + std::to_string(widelut_size);
-				} else {
-					if (nowidelut)
-						abc_opts += " -luts 2:2,3,6:5";
-					else if (widelut_size == 8)
-						abc_opts += " -luts 2:2,3,6:5,10,20";
-					else
-						abc_opts += " -luts 2:2,3,6:5,10,20,40";
-				}
-				if (dff)
-					abc_opts += " -dff";
-				if (retime)
-					abc_opts += " -D 1";
-				run("abc" + abc_opts);
-			}
 			run("clean");
 
-			if (help_mode || !abc9)
-				run("techmap -map +/xilinx/ff_map.v", "(only if not '-abc9')");
 			// This shregmap call infers fixed length shift registers after abc
 			//   has performed any necessary retiming
 			if (!nosrl || help_mode)

--- a/tests/arch/anlogic/logic.ys
+++ b/tests/arch/anlogic/logic.ys
@@ -5,7 +5,7 @@ equiv_opt -assert -map +/anlogic/cells_sim.v synth_anlogic # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
 
-select -assert-count 1 t:AL_MAP_LUT1
-select -assert-count 6 t:AL_MAP_LUT2
+select -assert-count 4 t:AL_MAP_LUT1
+select -assert-count 3 t:AL_MAP_LUT2
 select -assert-count 2 t:AL_MAP_LUT4
 select -assert-none t:AL_MAP_LUT1 t:AL_MAP_LUT2 t:AL_MAP_LUT4 %% t:* %D

--- a/tests/arch/anlogic/mux.ys
+++ b/tests/arch/anlogic/mux.ys
@@ -26,12 +26,10 @@ proc
 equiv_opt -assert -map +/anlogic/cells_sim.v synth_anlogic # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux8 # Constrain all select calls below inside the top module
-select -assert-max 3 t:AL_MAP_LUT3
-select -assert-max 3 t:AL_MAP_LUT4
+select -assert-max 4 t:AL_MAP_LUT4
 select -assert-max 1 t:AL_MAP_LUT5
-select -assert-max 1 t:AL_MAP_LUT6
 
-select -assert-none t:AL_MAP_LUT3 t:AL_MAP_LUT4 t:AL_MAP_LUT5 t:AL_MAP_LUT6 %% t:* %D
+select -assert-none t:AL_MAP_LUT4 t:AL_MAP_LUT5 %% t:* %D
 
 design -load read
 hierarchy -top mux16

--- a/tests/arch/efinix/mux.ys
+++ b/tests/arch/efinix/mux.ys
@@ -36,6 +36,6 @@ proc
 equiv_opt -assert -map +/efinix/cells_sim.v synth_efinix # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux16 # Constrain all select calls below inside the top module
-select -assert-max 12 t:EFX_LUT4
+select -assert-max 13 t:EFX_LUT4
 
 select -assert-none t:EFX_LUT4 %% t:* %D

--- a/tests/arch/fabulous/fsm.ys
+++ b/tests/arch/fabulous/fsm.ys
@@ -13,7 +13,6 @@ design -load postopt # load the post-opt design (otherwise equiv_opt loads the p
 cd fsm # Constrain all select calls below inside the top module
 
 select -assert-count 6 t:LUTFF
-select -assert-max 5 t:LUT2
-select -assert-max 4 t:LUT3
-select -assert-max 8 t:LUT4
-select -assert-none t:LUT2 t:LUT3 t:LUT4 t:LUTFF %% t:* %D
+select -assert-max 4 t:LUT2
+select -assert-max 11 t:LUT4
+select -assert-none t:LUT2 t:LUT4 t:LUTFF %% t:* %D

--- a/tests/arch/fabulous/logic.ys
+++ b/tests/arch/fabulous/logic.ys
@@ -4,7 +4,7 @@ proc
 equiv_opt -assert -map prims.v synth_fabulous -noiopad -ff $_DFF_P_ x -ff $_DLATCH_?_ x -extra-plib prims.v -cells-map cells_map.v  -arith-map arith_map.v -extra-map ff_map.v -extra-map latches_map.v # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
-select -assert-max 1 t:LUT1
-select -assert-max 6 t:LUT2
+select -assert-max 4 t:LUT1
+select -assert-max 3 t:LUT2
 select -assert-max 2 t:LUT4
 select -assert-none t:LUT1 t:LUT2 t:LUT4 %% t:* %D

--- a/tests/arch/ice40/bug1598.ys
+++ b/tests/arch/ice40/bug1598.ys
@@ -13,4 +13,4 @@ module led_blink (
 endmodule
 EOT
 proc
-equiv_opt -assert -map +/ice40/cells_sim.v synth_ice40 -abc9
+equiv_opt -assert -map +/ice40/cells_sim.v synth_ice40

--- a/tests/arch/ice40/bug1626.ys
+++ b/tests/arch/ice40/bug1626.ys
@@ -214,4 +214,4 @@ module \ahb_async_sram_halfwidth
 end
 EOT
 
-synth_ice40 -abc2 -abc9
+synth_ice40

--- a/tests/arch/machxo2/lutram.ys
+++ b/tests/arch/machxo2/lutram.ys
@@ -11,7 +11,7 @@ sat -verify -prove-asserts -seq 5 -set-init-zero -show-inputs -show-outputs mite
 
 design -load postopt
 cd lutram_1w1r
-select -assert-count 20 t:LUT4
+select -assert-count 28 t:LUT4
 select -assert-count 8 t:TRELLIS_DPR16X4
 select -assert-count 8 t:TRELLIS_FF
 select -assert-none t:LUT4 t:TRELLIS_DPR16X4 t:TRELLIS_FF %% t:* %D

--- a/tests/arch/machxo2/mux.ys
+++ b/tests/arch/machxo2/mux.ys
@@ -15,7 +15,7 @@ proc
 equiv_opt -assert -map +/lattice/cells_sim_xo2.v synth_lattice -family xo2 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux4 # Constrain all select calls below inside the top module
-select -assert-count 2 t:LUT4
+select -assert-count 3 t:LUT4
 
 select -assert-none t:LUT4 t:TRELLIS_IO %% t:* %D
 
@@ -25,7 +25,7 @@ proc
 equiv_opt -assert -map +/lattice/cells_sim_xo2.v synth_lattice -family xo2 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux8 # Constrain all select calls below inside the top module
-select -assert-count 5 t:LUT4
+select -assert-count 6 t:LUT4
 
 select -assert-none t:LUT4 t:TRELLIS_IO %% t:* %D
 
@@ -35,6 +35,6 @@ proc
 equiv_opt -assert -map +/lattice/cells_sim_xo2.v synth_lattice -family xo2 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux16 # Constrain all select calls below inside the top module
-select -assert-max 12 t:LUT4
+select -assert-max 13 t:LUT4
 
 select -assert-none t:LUT4 t:TRELLIS_IO %% t:* %D

--- a/tests/arch/nexus/add_sub.ys
+++ b/tests/arch/nexus/add_sub.ys
@@ -1,18 +1,8 @@
 read_verilog ../common/add_sub.v
 hierarchy -top top
 proc
-design -save orig
 
 equiv_opt -assert -map +/nexus/cells_sim.v synth_nexus # equivalency check
-design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
-cd top # Constrain all select calls below inside the top module
-stat
-select -assert-count 10 t:LUT4
-select -assert-none t:IB t:OB t:VLO t:LUT4 %% t:* %D
-
-design -load orig
-
-equiv_opt -assert -map +/nexus/cells_sim.v synth_nexus -abc9 # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
 stat

--- a/tests/arch/nexus/counter.ys
+++ b/tests/arch/nexus/counter.ys
@@ -6,6 +6,7 @@ equiv_opt -assert -multiclock -map +/nexus/cells_sim.v synth_nexus # equivalency
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
 stat
+select -assert-count 1 t:INV
 select -assert-count 5 t:CCU2
 select -assert-count 8 t:FD1P3DX
-select -assert-none t:CCU2 t:FD1P3DX t:IB t:OB t:VLO t:VHI %% t:* %D
+select -assert-none t:INV t:CCU2 t:FD1P3DX t:IB t:OB t:VLO t:VHI %% t:* %D

--- a/tests/arch/nexus/logic.ys
+++ b/tests/arch/nexus/logic.ys
@@ -4,5 +4,5 @@ proc
 equiv_opt -assert -map +/nexus/cells_sim.v synth_nexus # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
-select -assert-count 8 t:LUT4
+select -assert-count 5 t:LUT4
 select -assert-none t:LUT4 t:INV t:IB t:OB t:VLO t:VHI %% t:* %D

--- a/tests/arch/xilinx/add_sub.ys
+++ b/tests/arch/xilinx/add_sub.ys
@@ -6,18 +6,18 @@ design -save orig
 equiv_opt -assert -map +/xilinx/cells_sim.v synth_xilinx -noiopad # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
-stat
-select -assert-count 8 t:LUT2
+select -assert-count 1 t:INV
+select -assert-count 7 t:LUT2
 select -assert-count 2 t:CARRY4
-select -assert-none t:LUT2 t:CARRY4 %% t:* %D
+select -assert-none t:INV t:LUT2 t:CARRY4 %% t:* %D
 
 design -load orig
 
 equiv_opt -assert -map +/xilinx/cells_sim.v synth_xilinx -family xc3s -noiopad # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
-stat
-select -assert-count 8 t:LUT2
+select -assert-count 4 t:INV
+select -assert-count 4 t:LUT2
 select -assert-count 6 t:MUXCY
 select -assert-count 8 t:XORCY
-select -assert-none t:LUT2 t:MUXCY t:XORCY %% t:* %D
+select -assert-none t:INV t:LUT2 t:MUXCY t:XORCY %% t:* %D

--- a/tests/arch/xilinx/fsm.ys
+++ b/tests/arch/xilinx/fsm.ys
@@ -30,8 +30,7 @@ cd fsm # Constrain all select calls below inside the top module
 stat
 select -assert-count 1 t:BUFG
 select -assert-count 6 t:FDRE
-select -assert-count 1 t:LUT1
-select -assert-max 1 t:LUT3
-select -assert-max 8 t:LUT4
+select -assert-max 6 t:LUT3
+select -assert-max 6 t:LUT4
 select -assert-count 5 t:MUXF5
-select -assert-none t:BUFG t:FDRE t:LUT1 t:LUT3 t:LUT4 t:MUXF5 %% t:* %D
+select -assert-none t:BUFG t:FDRE t:LUT3 t:LUT4 t:MUXF5 %% t:* %D

--- a/tests/arch/xilinx/logic.ys
+++ b/tests/arch/xilinx/logic.ys
@@ -5,7 +5,7 @@ equiv_opt -assert -map +/xilinx/cells_sim.v synth_xilinx -noiopad # equivalency 
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
 
-select -assert-count 1 t:INV
-select -assert-count 6 t:LUT2
+select -assert-count 4 t:INV
+select -assert-count 3 t:LUT2
 select -assert-count 2 t:LUT4
 select -assert-none t:INV t:LUT2 t:LUT4 %% t:* %D

--- a/tests/arch/xilinx/mux_lut4.ys
+++ b/tests/arch/xilinx/mux_lut4.ys
@@ -20,7 +20,6 @@ cd mux4 # Constrain all select calls below inside the top module
 select -assert-count 4 t:LUT1
 select -assert-count 2 t:MUXF5
 select -assert-count 1 t:MUXF6
-
 select -assert-none t:LUT1 t:MUXF5 t:MUXF6 %% t:* %D
 
 
@@ -30,13 +29,11 @@ proc
 equiv_opt -assert -map +/xilinx/cells_sim.v synth_xilinx -family xc3se -noiopad # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux8 # Constrain all select calls below inside the top module
-select -assert-max 5 t:LUT1
-select -assert-max 3 t:LUT3
-select -assert-max 3 t:LUT4
-select -assert-max 3 t:MUXF5
-select -assert-count 1 t:MUXF6
+select -assert-max 1 t:LUT3
+select -assert-max 5 t:LUT4
+select -assert-max 1 t:MUXF5
 
-select -assert-none t:LUT1 t:LUT3 t:LUT4 t:MUXF5 t:MUXF6 %% t:* %D
+select -assert-none t:LUT3 t:LUT4 t:MUXF5 %% t:* %D
 
 
 design -load read
@@ -45,8 +42,11 @@ proc
 equiv_opt -assert -map +/xilinx/cells_sim.v synth_xilinx -family xc3se -noiopad # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux16 # Constrain all select calls below inside the top module
-select -assert-max 32 t:LUT*
+select -assert-max 14 t:LUT3
+select -assert-max 20 t:LUT4
+select -assert-max 16 t:MUXF5
 select -assert-max 8 t:MUXF6
-select -assert-max 4 t:MUXF7
+select -assert-max 3 t:MUXF7
+select -assert-count 1 t:MUXF8
 
-select -assert-none t:LUT* t:MUXF5 t:MUXF6 t:MUXF7 %% t:* %D
+select -assert-none t:LUT3 t:LUT4 t:MUXF5 t:MUXF6 t:MUXF7 t:MUXF8 %% t:* %D


### PR DESCRIPTION
_If your work is part of a larger effort, please discuss your general plans on [Discourse](https://yosyshq.discourse.group/) first to align your vision with maintainers._
More ABC unification work.

_What are the reasons/motivation for this change?_
I intend to remove `abc -lut`, so all users of it must be moved over to use `abc9 -lut` instead, and options enabling/disabling ABC9 must be removed.

_Explain how this is achieved._
I did my best to break the changes to each synthesis pass into their own commits to make it as easy as possible to review.

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._
I have updated the synth tests where they exist.

cc @mole99 for the changes to `synth_fabulous`
cc @tony-min-1 / @Damon-Ma-MCHP for the changes to `synth_microchip`
cc @gatecat for the changes to `synth_nexus`