### PR TITLE
opt_muxtree: fix replace_known misindexing on constant S bits

### DIFF
--- a/passes/opt/opt_muxtree.cc
+++ b/passes/opt/opt_muxtree.cc
@@ -483,11 +483,14 @@ struct OptMuxtreeWorker
 		bool did_something = false;
 
 		int width_if_b = 0;
-		idict<int> ctrl_bits;
+		// map wire bit -> first S position
+		dict<int, int> ctrl_bits;
 		if (portname == ID::B)
 			width_if_b = GetSize(muxinfo.cell->getPort(ID::A));
-		for (int bit : sig2bits(muxinfo.cell->getPort(ID::S), false))
-			ctrl_bits(bit);
+		vector<int> s_bits = sig2bits(muxinfo.cell->getPort(ID::S), false);
+		for (int j = 0; j < GetSize(s_bits); j++)
+			if (s_bits[j] >= 0)
+				ctrl_bits.insert({s_bits[j], j});
 
 		int slice_idx = 0, slice_off = 0;
 		vector<int> bits = sig2bits(sig, false);

--- a/tests/opt/bug6089.ys
+++ b/tests/opt/bug6089.ys
@@ -1,0 +1,21 @@
+read_verilog -sv <<EOT
+module top (
+	input  logic [1:0] in_2,
+	output logic [1:0] out_1
+);
+	always @* begin
+		out_1 = 2'd0;
+		case ('d1 & in_2)
+			2'd0: out_1 = 2'd0;
+			2'd1: out_1 = in_2;
+			2'd2: out_1 = 2'd1;
+			2'd3: out_1 = 2'd3;
+			default: out_1 = 2'd0;
+		endcase
+	end
+endmodule
+EOT
+
+hierarchy -top top
+proc
+equiv_opt -assert synth


### PR DESCRIPTION
This PR aims to fix #6089 - `sig2bits(S, false)` emits `-1` for constants. The old `idict<int> ctrl_bits` deduplicated them and shifted subsequent indices, so `ctrl_bits.at(bit)` no longer matched the true `S` position and `B` slices got rewritten to the wrong constant - track first `S` position explicitly in a `dict<int,int>`, skipping constants.