### PR TITLE
opt_expr: respect -keepdc for muxes with a fully undef select

### DIFF
--- a/passes/opt/opt_expr.cc
+++ b/passes/opt/opt_expr.cc
@@ -1158,7 +1158,9 @@ skip_fine_alu:
 			if (mux_undef) {
 				if (input.match("*  ")) ACTION_DO(ID::Y, input.extract(1, 1));
 				if (input.match(" * ")) ACTION_DO(ID::Y, input.extract(2, 1));
-				if (input.match("  *")) ACTION_DO(ID::Y, input.extract(2, 1));
+				// An undef select resolves to the A input only when we may pick
+				// values for don't-cares; with -keepdc leave the cell untouched.
+				if (!keepdc && input.match("  *")) ACTION_DO(ID::Y, input.extract(2, 1));
 			}
 		}
 
@@ -1486,9 +1488,19 @@ skip_identity:
 		if (mux_undef && cell->type.in(ID($mux), ID($pmux))) {
 			RTLIL::SigSpec new_a, new_b, new_s;
 			int width = GetSize(cell->getPort(ID::A));
-			if ((cell->getPort(ID::A).is_fully_undef() && cell->getPort(ID::B).is_fully_undef()) ||
-					cell->getPort(ID::S).is_fully_undef()) {
+			// If both data inputs are fully undef the output is undef regardless
+			// of the select, so replacing the mux with A is always valid. This
+			// does not resolve any don't-care and is therefore fine with -keepdc.
+			if (cell->getPort(ID::A).is_fully_undef() && cell->getPort(ID::B).is_fully_undef()) {
 				replace_cell(assign_map, module, cell, "mux_undef", ID::Y, cell->getPort(ID::A));
+				goto next_cell;
+			}
+			// A fully undef select makes the output a don't-care. Resolving it to
+			// the A input is only valid when we are allowed to pick values for
+			// don't-cares; with -keepdc the cell must be left untouched.
+			if (cell->getPort(ID::S).is_fully_undef()) {
+				if (!keepdc)
+					replace_cell(assign_map, module, cell, "mux_undef", ID::Y, cell->getPort(ID::A));
 				goto next_cell;
 			}
 			for (int i = 0; i < cell->getPort(ID::S).size(); i++) {

--- a/tests/opt/opt_expr_mux_undef.ys
+++ b/tests/opt/opt_expr_mux_undef.ys
@@ -287,3 +287,76 @@ select -assert-none t:$_MUX16_
 select -assert-count 1 o:out %ci*
 
 ##########
+# fully undef select, defined data inputs
+# -keepdc: the output is a don't-care that must be preserved,
+#          so the mux is left unchanged
+# no -keepdc: the undef select is resolved to the A input
+# checked for $mux, $pmux and the gate-level $_MUX_
+
+# $mux
+design -reset
+read_rtlil <<EOT2
+module \uut
+  wire output 1 \out
+  wire input 1 \a
+  wire input 2 \b
+  cell $mux \mux
+    parameter \WIDTH 1
+    connect \A \a
+    connect \B \b
+    connect \S 1'x
+    connect \Y \out
+  end
+end
+EOT2
+
+opt_expr -mux_undef -keepdc
+select -assert-count 1 t:$mux
+opt_expr -mux_undef
+select -assert-none t:$mux
+
+# $pmux, multi-bit data and select
+design -reset
+read_rtlil <<EOT2
+module \uut
+  wire width 2 output 1 \out
+  wire width 2 input 2 \a
+  wire width 4 input 3 \b
+  cell $pmux \mux
+    parameter \WIDTH 2
+    parameter \S_WIDTH 2
+    connect \A \a
+    connect \B \b
+    connect \S 2'xx
+    connect \Y \out
+  end
+end
+EOT2
+
+opt_expr -mux_undef -keepdc
+select -assert-count 1 t:$pmux
+opt_expr -mux_undef
+select -assert-none t:$pmux
+
+# gate-level $_MUX_
+design -reset
+read_rtlil <<EOT2
+module \uut
+  wire output 1 \out
+  wire input 1 \a
+  wire input 2 \b
+  cell $_MUX_ \mux
+    connect \A \a
+    connect \B \b
+    connect \S 1'x
+    connect \Y \out
+  end
+end
+EOT2
+
+opt_expr -mux_undef -keepdc
+select -assert-count 1 t:$_MUX_
+opt_expr -mux_undef
+select -assert-none t:$_MUX_
+
+##########


### PR DESCRIPTION
## Summary

Fixes #4988.

`opt_expr -mux_undef` replaced a mux whose select `S` is fully undef with its `A` input **even under `-keepdc`**. `-keepdc` exists to preserve don't-care (`x`) semantics for formal/equivalence flows, so silently resolving the undef select to `A` is a miscompile: the output goes from a don't-care to a concrete value.

This affected three cell paths, all now handled consistently:

* **`$mux`/`$pmux` fast path** (`opt_expr.cc:1489`): the old code OR'd "both data inputs undef" with "select undef" and replaced with `A` unconditionally. These are split — `A&&B` fully undef still replaces with `A` unconditionally (the output is `x` regardless of the select, so no don't-care is resolved and it is fine under `-keepdc`), while a fully undef select resolves to `A` only when `!keepdc`. The trailing `goto next_cell` also stops the per-select-bit loop below from re-collapsing an all-undef select via its `mux_empty` path.
* **Gate-level `$_MUX_`** (`opt_expr.cc:1161`): the undef-select case (`"  *"`) is now gated on `!keepdc` as well, so a post-techmap `$_MUX_` behaves the same as `$mux` under `-keepdc`.

## Before / after (reporter's testcase)

```
$ yosys -p 'read_rtlil uut.il; opt_expr -mux_undef -keepdc; dump'
```

* **Before:** the mux is removed and `\out` is connected to `\a` (don't-care lost).
* **After:** the mux is left unchanged, as expected for `-keepdc`.

`opt_expr -mux_undef` without `-keepdc` still resolves to `\out = \a` as before.

## Testing

* Extended `tests/opt/opt_expr_mux_undef.ys` with fully-undef-select cases for `$mux`, `$pmux` (multi-bit data and select) and `$_MUX_`: under `-keepdc` the mux is asserted still present, without `-keepdc` it is asserted removed. The new assertions fail on the unpatched tree and pass with the fix.
* `tests/opt` (89 scripts) and `tests/various` all pass.

## Scope / notes for reviewers

* The non-`keepdc` behaviour (resolve a fully undef select to `A`) is intentionally left unchanged — picking `A` is a valid don't-care resolution and `-mux_undef` is documented as being allowed to choose values for undef inputs. The issue mentions `1'x` as a possible alternative for the non-keepdc result; happy to make that change separately if preferred, but it would be a behavioural change across existing flows.
* This PR is scoped to a **fully** undef select, matching the issue. Resolution of individual undef select bits / undef data inputs in partially-undef `$pmux` cells (the per-bit loop and the `$_MUX_` undef-data cases) is pre-existing and not guarded by `-keepdc`; that can be addressed as a follow-up if desired.
