### PR TITLE
gatemate_foldinv: count module output ports as consumers [sc-737]

### DIFF
--- a/techlibs/gatemate/gatemate_foldinv.cc
+++ b/techlibs/gatemate/gatemate_foldinv.cc
@@ -125,6 +125,10 @@ struct FoldInvWorker {
     void fold_output_inverters()
     {
         pool<SigBit> used_bits;
+        for (auto wire : module->wires())
+            if (wire->port_output)
+                for (auto bit : sigmap(SigSpec(wire)))
+                    used_bits.insert(bit);
         // Find bits that are actually used
         for (auto cell : module->selected_cells()) {
             for (auto conn : cell->connections()) {

--- a/tests/arch/gatemate/logic.ys
+++ b/tests/arch/gatemate/logic.ys
@@ -27,7 +27,7 @@ design -load orig
 equiv_opt -assert -map +/gatemate/cells_sim.v synth_gatemate -noiopad -luttree -abc_new # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
-select -assert-count 4 t:CC_LUT1
-select -assert-count 3 t:CC_LUT2
+select -assert-count 1 t:CC_LUT1
+select -assert-count 6 t:CC_LUT2
 select -assert-count 2 t:CC_L2T4
 select -assert-none t:CC_LUT1 t:CC_LUT2 t:CC_L2T4 %% t:* %D

--- a/tests/arch/gatemate/luttrees.ys
+++ b/tests/arch/gatemate/luttrees.ys
@@ -30,5 +30,5 @@ equiv_opt -async2sync -assert -map +/gatemate/cells_sim.v synth_gatemate -noiopa
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd luttrees # Constrain all select calls below inside the top module
 
-select -assert-count 917 t:CC_LUT1 t:CC_LUT2 t:CC_L2T4 t:CC_L2T5 %%
-select -assert-none t:CC_LUT1 t:CC_LUT2 t:CC_L2T4 t:CC_L2T5 %% t:* %D
+select -assert-count 750 t:CC_LUT2 t:CC_L2T4 t:CC_L2T5 %%
+select -assert-none t:CC_LUT2 t:CC_L2T4 t:CC_L2T5 %% t:* %D


### PR DESCRIPTION
As discussed in https://github.com/YosysHQ/yosys/pull/6077#issuecomment-5238903257, `fold_output_inverters` only counted cell inputs as consumers, so inverters driving module outputs were left unfolded. This showed up as extra `CC_LUT1` cells with `-abc_new`. This PR modifies the fold so that it also these bits as used.