### PR TITLE
log rewrite [sc-748]

### DIFF
--- a/examples/cxx-api/demomain.cc
+++ b/examples/cxx-api/demomain.cc
@@ -5,7 +5,7 @@
 
 int main()
 {
-	Yosys::log_streams.push_back(&std::cout);
+	Yosys::log_sinks.push_back(std::make_unique<Yosys::ConsoleLogSink>());
 	Yosys::log_error_stderr = true;
 
 	Yosys::yosys_setup();

--- a/examples/cxx-api/demomain.cc
+++ b/examples/cxx-api/demomain.cc
@@ -5,8 +5,7 @@
 
 int main()
 {
-	Yosys::log_sinks.push_back(std::make_unique<Yosys::ConsoleLogSink>());
-	Yosys::log_error_stderr = true;
+	Yosys::logger().add_sink<Yosys::ConsoleLogSink>();
 
 	Yosys::yosys_setup();
 	Yosys::yosys_banner();

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -321,11 +321,11 @@ AstNode::~AstNode()
 void AstNode::dumpAst(FILE *f, std::string indent) const
 {
 	if (f == NULL) {
-		for (auto &s : log_sinks) {
-			f = s->file_handle();
+		logger().for_each_sink([&](LogSink &sink) {
+			FILE *f = sink.file_handle();
 			if (f)
 				dumpAst(f, indent);
-		}
+		});
 		return;
 	}
 
@@ -428,11 +428,11 @@ void AstNode::dumpVlog(FILE *f, std::string indent) const
 	std::vector<AstNode*> rem_children1, rem_children2;
 
 	if (f == NULL) {
-		for (auto &s : log_sinks) {
-			f = s->file_handle();
+		logger().for_each_sink([&](LogSink &sink) {
+			FILE *f = sink.file_handle();
 			if (f)
 				dumpVlog(f, indent);
-		}
+		});
 		return;
 	}
 
@@ -1944,7 +1944,7 @@ void AstModule::loadconfig() const
 
 void AstNode::formatted_input_error(std::string str) const
 {
-	log_formatted_file_error(*location.begin.filename, location.begin.line, std::move(str));
+	log_file_error(*location.begin.filename, location.begin.line, "%s", std::move(str));
 }
 
 YOSYS_NAMESPACE_END

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -321,8 +321,11 @@ AstNode::~AstNode()
 void AstNode::dumpAst(FILE *f, std::string indent) const
 {
 	if (f == NULL) {
-		for (auto f : log_files)
-			dumpAst(f, indent);
+		for (auto &s : log_sinks) {
+			f = s->file_handle();
+			if (f)
+				dumpAst(f, indent);
+		}
 		return;
 	}
 
@@ -425,8 +428,11 @@ void AstNode::dumpVlog(FILE *f, std::string indent) const
 	std::vector<AstNode*> rem_children1, rem_children2;
 
 	if (f == NULL) {
-		for (auto f : log_files)
-			dumpVlog(f, indent);
+		for (auto &s : log_sinks) {
+			f = s->file_handle();
+			if (f)
+				dumpVlog(f, indent);
+		}
 		return;
 	}
 

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -1944,7 +1944,7 @@ void AstModule::loadconfig() const
 
 void AstNode::formatted_input_error(std::string_view format, std::string str) const
 {
-	logger().log_formatted_file_error(*location.begin.filename, location.begin.line, format, std::move(str));
+	logger().formatted_file_error(*location.begin.filename, location.begin.line, format, std::move(str));
 }
 
 YOSYS_NAMESPACE_END

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -1942,9 +1942,9 @@ void AstModule::loadconfig() const
 	flag_autowire = autowire;
 }
 
-void AstNode::formatted_input_error(std::string str) const
+void AstNode::formatted_input_error(std::string_view format, std::string str) const
 {
-	log_file_error(*location.begin.filename, location.begin.line, "%s", std::move(str));
+	logger().log_formatted_file_error(*location.begin.filename, location.begin.line, format, std::move(str));
 }
 
 YOSYS_NAMESPACE_END

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -379,11 +379,11 @@ namespace AST
 		AstNode *get_struct_member() const;
 
 		// helper to print errors from simplify/genrtlil code
-		[[noreturn]] void formatted_input_error(std::string str) const;
+		[[noreturn]] void formatted_input_error(std::string_view format, std::string str) const;
 		template <typename... Args>
 		[[noreturn]] void input_error(FmtString<TypeIdentity<Args>...> fmt, const Args &... args) const
 		{
-			formatted_input_error(fmt.format(args...));
+			formatted_input_error(fmt.format_string(), fmt.format(args...));
 		}
 	};
 

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -1386,8 +1386,11 @@ void AstNode::detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *foun
 	// everything should have been handled above -> print error if not.
 	default:
 		AstNode *current_scope_ast = current_ast_mod == nullptr ? current_ast : current_ast_mod;
-		for (auto f : log_files)
-			current_scope_ast->dumpAst(f, "verilog-ast> ");
+		for (auto &s : log_sinks) {
+			auto f = s->file_handle();
+			if (f)
+				current_scope_ast->dumpAst(f, "verilog-ast> ");
+		}
 		input_error("Don't know how to detect sign and width for %s node!\n", type2str(type));
 
 	}
@@ -2362,8 +2365,11 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 
 	// everything should have been handled above -> print error if not.
 	default:
-		for (auto f : log_files)
-			current_ast_mod->dumpAst(f, "verilog-ast> ");
+		for (auto &s : log_sinks) {
+			auto f = s->file_handle();
+			if (f)
+				current_ast_mod->dumpAst(f, "verilog-ast> ");
+		}
 		input_error("Don't know how to generate RTLIL code for %s node!\n", type2str(type));
 	}
 

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -1386,11 +1386,11 @@ void AstNode::detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *foun
 	// everything should have been handled above -> print error if not.
 	default:
 		AstNode *current_scope_ast = current_ast_mod == nullptr ? current_ast : current_ast_mod;
-		for (auto &s : log_sinks) {
-			auto f = s->file_handle();
+		logger().for_each_sink([&](LogSink &sink) {
+			FILE *f = sink.file_handle();
 			if (f)
 				current_scope_ast->dumpAst(f, "verilog-ast> ");
-		}
+		});
 		input_error("Don't know how to detect sign and width for %s node!\n", type2str(type));
 
 	}
@@ -2365,11 +2365,11 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 
 	// everything should have been handled above -> print error if not.
 	default:
-		for (auto &s : log_sinks) {
-			auto f = s->file_handle();
+		logger().for_each_sink([&](LogSink &sink) {
+			FILE *f = sink.file_handle();
 			if (f)
 				current_ast_mod->dumpAst(f, "verilog-ast> ");
-		}
+		});
 		input_error("Don't know how to generate RTLIL code for %s node!\n", type2str(type));
 	}
 

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -2791,8 +2791,10 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 		auto buf = children[0]->clone();
 		while (buf->simplify(true, stage, width_hint, sign_hint)) { }
 		if (buf->type != AST_CONSTANT) {
-			// for (auto f : log_files)
-			// 	dumpAst(f, "verilog-ast> ");
+			// for (auto &s : log_sinks) {
+			//   auto f = s->file_handle();
+			//   if (f)
+			// 	  dumpAst(f, "verilog-ast> ");
 			input_error("Condition for generate if is not constant!\n");
 		}
 		if (buf->asBool() != 0) {
@@ -2828,8 +2830,10 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 		auto buf = children[0]->clone();
 		while (buf->simplify(true, stage, width_hint, sign_hint)) { }
 		if (buf->type != AST_CONSTANT) {
-			// for (auto f : log_files)
-			// 	dumpAst(f, "verilog-ast> ");
+			// for (auto &s : log_sinks) {
+			//   auto f = s->file_handle();
+			//   if (f)
+			//     dumpAst(f, "verilog-ast> ");
 			input_error("Condition for generate case is not constant!\n");
 		}
 
@@ -2862,8 +2866,10 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 				buf->set_in_param_flag(true);
 				while (buf->simplify(true, stage, width_hint, sign_hint)) { }
 				if (buf->type != AST_CONSTANT) {
-					// for (auto f : log_files)
-					// 	dumpAst(f, "verilog-ast> ");
+					// for (auto &s : log_sinks) {
+					//   auto f = s->file_handle();
+					//   if (f)
+					//     dumpAst(f, "verilog-ast> ");
 					input_error("Expression in generate case is not constant!\n");
 				}
 

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -2791,10 +2791,11 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 		auto buf = children[0]->clone();
 		while (buf->simplify(true, stage, width_hint, sign_hint)) { }
 		if (buf->type != AST_CONSTANT) {
-			// for (auto &s : log_sinks) {
-			//   auto f = s->file_handle();
-			//   if (f)
-			// 	  dumpAst(f, "verilog-ast> ");
+			//logger().for_each_sink([&](LogSink &sink) {
+			//	FILE *f = sink.file_handle();
+			//	if (f)
+			//		dumpAst(f, "verilog-ast> ");
+			//});
 			input_error("Condition for generate if is not constant!\n");
 		}
 		if (buf->asBool() != 0) {
@@ -2830,10 +2831,11 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 		auto buf = children[0]->clone();
 		while (buf->simplify(true, stage, width_hint, sign_hint)) { }
 		if (buf->type != AST_CONSTANT) {
-			// for (auto &s : log_sinks) {
-			//   auto f = s->file_handle();
-			//   if (f)
-			//     dumpAst(f, "verilog-ast> ");
+			//logger().for_each_sink([&](LogSink &sink) {
+			//	FILE *f = sink.file_handle();
+			//	if (f)
+			//		dumpAst(f, "verilog-ast> ");
+			//});
 			input_error("Condition for generate case is not constant!\n");
 		}
 
@@ -2866,10 +2868,11 @@ bool AstNode::simplify(bool const_fold, int stage, int width_hint, bool sign_hin
 				buf->set_in_param_flag(true);
 				while (buf->simplify(true, stage, width_hint, sign_hint)) { }
 				if (buf->type != AST_CONSTANT) {
-					// for (auto &s : log_sinks) {
-					//   auto f = s->file_handle();
-					//   if (f)
-					//     dumpAst(f, "verilog-ast> ");
+					//logger().for_each_sink([&](LogSink &sink) {
+					//	FILE *f = sink.file_handle();
+					//	if (f)
+					//		dumpAst(f, "verilog-ast> ");
+					//});
 					input_error("Expression in generate case is not constant!\n");
 				}
 

--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -608,9 +608,14 @@ int main(int argc, char **argv)
 		if (logger().get_warnings_total())
 			log("Warnings: %d unique messages, %d total\n", logger().get_warnings_unique(), logger().get_warnings_total());
 
-		if (logger().get_experimentals_num() != 0)
-			log("Warnings: %d experimental features used (not excluded with -x).\n", logger().get_experimentals_num());
+		if (GetSize(logger().get_experimental()) != 0)
+			log("Warnings: %d experimental features used (not excluded with -x).\n", GetSize(logger().get_experimental()));
 
+		if (GetSize(logger().get_deprecated()) != 0) {
+			log("Deprecated features used:\n");
+			for(auto &feature : logger().get_deprecated())
+				log("    %s\n", feature);
+		}
 #ifdef _WIN32
 		log("End of script. Logfile hash: %s\n", hash);
 		(void)wall_clock_start;

--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -604,7 +604,12 @@ int main(int argc, char **argv)
 		yosys_xtrace = 0;
 		log_spacer();
 
-		logger().report_warning_stats(mode_v && !mode_q);
+		logger().set_log_forced(mode_v && !mode_q);
+		if (logger().get_warnings_total())
+			log("Warnings: %d unique messages, %d total\n", logger().get_warnings_unique(), logger().get_warnings_total());
+
+		if (logger().get_experimentals_num() != 0)
+			log("Warnings: %d experimental features used (not excluded with -x).\n", logger().get_experimentals_num());
 
 #ifdef _WIN32
 		log("End of script. Logfile hash: %s\n", hash);

--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -161,6 +161,7 @@ int main(int argc, char **argv)
 	bool run_tcl_shell = false;
 	bool mode_v = false;
 	bool mode_q = false;
+	FILE *log_errfile = NULL;
 
 	cxxopts::Options options(argv[0], "Yosys Open SYnthesis Suite");
 	options.set_width(SIZE_MAX);
@@ -314,12 +315,11 @@ int main(int argc, char **argv)
 		for (const auto& key : {"l", "L"}) {
 			if (result.count(key)) {
 				for (const auto& filename : result[key].as<std::vector<std::string>>()) {
-					if (FILE* f = fopen(filename.c_str(), "wt")) {
-						log_files.push_back(f);
-						if (key[0] == 'L') setvbuf(f, NULL, _IOLBF, 0);
-					} else {
-						std::cerr << "Can't open log file `" << filename << "' for writing!\n";
-						exit(1);
+					try {
+						log_sinks.push_back(std::make_unique<FileLogSink>(filename, key[0] == 'L', false));
+					} catch (const std::runtime_error &e) {
+ 					   std::cerr << e.what();
+					   exit(1);
 					}
 				}
 			}
@@ -405,8 +405,9 @@ int main(int argc, char **argv)
 		}
 
 		if (log_errfile == NULL) {
-			log_files.push_back(stdout);
-			log_error_stderr = true;
+			log_sinks.push_back(std::make_unique<ConsoleLogSink>());
+		} else {
+			log_sinks.push_back(std::make_unique<StderrLogSink>());
 		}
 
 		if (print_banner)
@@ -609,7 +610,7 @@ int main(int argc, char **argv)
 		log_spacer();
 
 		if (mode_v && !mode_q)
-			log_files.push_back(stderr);
+			log_stderr_force = true;
 
 		if (log_warnings_count)
 			log("Warnings: %d unique messages, %d total\n", GetSize(log_warnings), log_warnings_count);

--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -161,7 +161,7 @@ int main(int argc, char **argv)
 	bool mode_v = false;
 	bool mode_q = false;
 	bool quiet_warnings = false;
-	FILE *log_errfile = NULL;
+	bool log_stderr = false;
 
 	cxxopts::Options options(argv[0], "Yosys Open SYnthesis Suite");
 	options.set_width(SIZE_MAX);
@@ -326,12 +326,12 @@ int main(int argc, char **argv)
 		}
 		if (result.count("q")) {
 			mode_q = true;
-			if (log_errfile == stderr) quiet_warnings = true;
-			log_errfile = stderr;
+			if (log_stderr) quiet_warnings = true;
+			log_stderr = true;
 		}
 		if (result.count("v")) {
 			mode_v = true;
-			log_errfile = stderr;
+			log_stderr = true;
 			logger().set_verbose_level(result["v"].as<int>());
 		}
 		if (result.count("t")) logger().set_log_time(true);
@@ -404,7 +404,7 @@ int main(int argc, char **argv)
 			Hasher::set_fudge((Hasher::hash_t)seed);
 		}
 
-		if (log_errfile == NULL) {
+		if (!log_stderr) {
 			logger().add_sink<ConsoleLogSink>();
 		} else {
 			logger().add_sink<StderrLogSink>(quiet_warnings);

--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -112,6 +112,10 @@ namespace Yosys {
 };
 #endif
 
+namespace Yosys {
+	extern bool log_stderr_sink_forced;
+};
+
 #ifdef _WIN32
 int wmain(int argc, wchar_t **wargv)
 {
@@ -604,7 +608,7 @@ int main(int argc, char **argv)
 		yosys_xtrace = 0;
 		log_spacer();
 
-		logger().set_log_forced(mode_v && !mode_q);
+		log_stderr_sink_forced = mode_v && !mode_q;
 		if (logger().get_warnings_total())
 			log("Warnings: %d unique messages, %d total\n", logger().get_warnings_unique(), logger().get_warnings_total());
 

--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -160,6 +160,7 @@ int main(int argc, char **argv)
 	bool run_tcl_shell = false;
 	bool mode_v = false;
 	bool mode_q = false;
+	bool quiet_warnings = false;
 	FILE *log_errfile = NULL;
 
 	cxxopts::Options options(argv[0], "Yosys Open SYnthesis Suite");
@@ -325,7 +326,7 @@ int main(int argc, char **argv)
 		}
 		if (result.count("q")) {
 			mode_q = true;
-			if (log_errfile == stderr) logger().set_quiet_warnings(true);
+			if (log_errfile == stderr) quiet_warnings = true;
 			log_errfile = stderr;
 		}
 		if (result.count("v")) {
@@ -405,9 +406,8 @@ int main(int argc, char **argv)
 
 		if (log_errfile == NULL) {
 			logger().add_sink<ConsoleLogSink>();
-			logger().set_error_stderr(true);
 		} else {
-			logger().add_sink<StderrLogSink>();
+			logger().add_sink<StderrLogSink>(quiet_warnings);
 		}
 
 		if (print_banner)
@@ -604,10 +604,7 @@ int main(int argc, char **argv)
 		yosys_xtrace = 0;
 		log_spacer();
 
-		if (mode_v && !mode_q)
-			logger().set_stderr_force(true);
-
-		logger().report_warning_stats();
+		logger().report_warning_stats(mode_v && !mode_q);
 
 #ifdef _WIN32
 		log("End of script. Logfile hash: %s\n", hash);

--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -19,7 +19,6 @@
 
 #include "kernel/yosys.h"
 #include "kernel/hashlib.h"
-#include "libs/sha1/sha1.h"
 #define CXXOPTS_VECTOR_DELIMITER '\0'
 #include "libs/cxxopts/include/cxxopts.hpp"
 #include <iostream>
@@ -287,7 +286,7 @@ int main(int argc, char **argv)
 			run_shell = false;
 		}
 		if (result.count("C")) run_tcl_shell = true;
-		if (result.count("g")) log_force_debug++;
+		if (result.count("g")) logger().force_debug_on();
 		if (result.count("m")) plugin_filenames = result["m"].as<std::vector<std::string>>();
 		if (result.count("f")) frontend_command = result["f"].as<std::string>();
 		if (result.count("H")) {
@@ -316,7 +315,7 @@ int main(int argc, char **argv)
 			if (result.count(key)) {
 				for (const auto& filename : result[key].as<std::vector<std::string>>()) {
 					try {
-						log_sinks.push_back(std::make_unique<FileLogSink>(filename, key[0] == 'L', false));
+						logger().add_sink<FileLogSink>(filename, key[0] == 'L', false);
 					} catch (const std::runtime_error &e) {
  					   std::cerr << e.what();
 					   exit(1);
@@ -326,15 +325,15 @@ int main(int argc, char **argv)
 		}
 		if (result.count("q")) {
 			mode_q = true;
-			if (log_errfile == stderr) log_quiet_warnings = true;
+			if (log_errfile == stderr) logger().set_quiet_warnings(true);
 			log_errfile = stderr;
 		}
 		if (result.count("v")) {
 			mode_v = true;
 			log_errfile = stderr;
-			log_verbose_level = result["v"].as<int>();
+			logger().set_verbose_level(result["v"].as<int>());
 		}
-		if (result.count("t")) log_time = true;
+		if (result.count("t")) logger().set_log_time(true);
 		if (result.count("d")) timing_details = true;
 		for (const auto& key : {"s", "c"}) {
 			if (result.count(key)) {
@@ -353,11 +352,11 @@ int main(int argc, char **argv)
 				auto regexes = result[key].as<std::vector<std::string>>();
 				for (const auto& regex : regexes) {
 					if (std::string(key) == "W")
-						log_warn_regexes.push_back(std::regex(regex));
+						logger().add_warn(regex);
 					if (std::string(key) == "w")
-						log_nowarn_regexes.push_back(std::regex(regex));
+						logger().add_nowarn(regex);
 					if (std::string(key) == "e")
-						log_werror_regexes.push_back(std::regex(regex));
+						logger().add_werror(regex);
 				}
 			}
 		}
@@ -372,7 +371,7 @@ int main(int argc, char **argv)
 						std::cerr << "Invalid number of tokens in -P ALL." << std::endl;
 						exit(1);
 					}
-					log_hdump_all = true;
+					logger().set_hdump_all(true);
 				} else {
 					if (!tokens.empty() && !tokens[0].empty() && tokens[0].back() == '.')
 						tokens[0].pop_back();
@@ -382,14 +381,14 @@ int main(int argc, char **argv)
 						std::cerr << "Invalid number of tokens in -P." << std::endl;
 						exit(1);
 					}
-					log_hdump[tokens[0]].insert(tokens[1]);
+					logger().add_hdump(tokens[0],tokens[1]);
 				}
 			}
 		}
 		if (result.count("E")) depsfile = result["E"].as<std::string>();
 		if (result.count("x")) {
-			auto ignores = result["x"].as<std::vector<std::string>>();
-			log_experimentals_ignored.insert(ignores.begin(), ignores.end());
+			for (const auto &ignore : result["x"].as<std::vector<std::string>>())
+    			logger().add_experimental_ignore(ignore);
 		}
 		if (result.count("perffile")) perffile = result["perffile"].as<std::string>();
 		if (result.count("infile")) {
@@ -405,10 +404,10 @@ int main(int argc, char **argv)
 		}
 
 		if (log_errfile == NULL) {
-			log_sinks.push_back(std::make_unique<ConsoleLogSink>());
-			log_error_stderr = true;
+			logger().add_sink<ConsoleLogSink>();
+			logger().set_error_stderr(true);
 		} else {
-			log_sinks.push_back(std::make_unique<StderrLogSink>());
+			logger().add_sink<StderrLogSink>();
 		}
 
 		if (print_banner)
@@ -452,7 +451,7 @@ int main(int argc, char **argv)
 #endif
 
 	if (print_stats)
-		log_hasher = new SHA1;
+		logger().start_hasher();
 
 #if defined(__OpenBSD__)
 	// save the executable origin for proc_self_dirname()
@@ -596,28 +595,19 @@ int main(int argc, char **argv)
 		fprintf(f, "\n");
 	}
 
-	if (log_expect_no_warnings && log_warnings_count_noexpect)
-		log_error("Unexpected warnings found: %d unique messages, %d total, %d expected\n", GetSize(log_warnings),
-					log_warnings_count, log_warnings_count - log_warnings_count_noexpect);
+	logger().report_unexpected_error();
 
 	if (print_stats)
 	{
-		std::string hash = log_hasher->final().substr(0, 10);
-		delete log_hasher;
-		log_hasher = nullptr;
-
-		log_time = false;
+		std::string hash = logger().finish_hasher();
+		logger().set_log_time(false);
 		yosys_xtrace = 0;
 		log_spacer();
 
 		if (mode_v && !mode_q)
-			log_stderr_force = true;
+			logger().set_stderr_force(true);
 
-		if (log_warnings_count)
-			log("Warnings: %d unique messages, %d total\n", GetSize(log_warnings), log_warnings_count);
-
-		if (!log_experimentals.empty())
-			log("Warnings: %d experimental features used (not excluded with -x).\n", GetSize(log_experimentals));
+		logger().report_warning_stats();
 
 #ifdef _WIN32
 		log("End of script. Logfile hash: %s\n", hash);
@@ -719,7 +709,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	log_check_expected();
+	logger().check_expected();
 
 	yosys_atexit();
 

--- a/kernel/driver.cc
+++ b/kernel/driver.cc
@@ -406,6 +406,7 @@ int main(int argc, char **argv)
 
 		if (log_errfile == NULL) {
 			log_sinks.push_back(std::make_unique<ConsoleLogSink>());
+			log_error_stderr = true;
 		} else {
 			log_sinks.push_back(std::make_unique<StderrLogSink>());
 		}

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -39,7 +39,7 @@
 YOSYS_NAMESPACE_BEGIN
 
 std::vector<FILE*> log_files;
-std::vector<std::ostream*> log_streams;
+std::vector<std::ostream*> log_streams, log_warning_streams;
 std::vector<std::string> log_scratchpads;
 std::map<std::string, std::set<std::string>> log_hdump;
 std::vector<std::regex> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
@@ -100,7 +100,7 @@ int gettimeofday(struct timeval *tv, struct timezone *tz)
 }
 #endif
 
-static void logv_string(std::string_view format, std::string str) {
+static void logv_string(std::string_view format, std::string str, LogSeverity severity = LogSeverity::LOG_INFO) {
 	size_t remove_leading = 0;
 	while (format.size() > 1 && format[0] == '\n') {
 		logv_string("\n", "\n");
@@ -156,6 +156,10 @@ static void logv_string(std::string_view format, std::string str) {
 
 		for (auto f : log_streams)
 			*f << time_str;
+
+		if (severity >= LogSeverity::LOG_WARNING)
+			for (auto f : log_warning_streams)
+				*f << time_str;
 	}
 
 	for (auto f : log_files)
@@ -163,6 +167,12 @@ static void logv_string(std::string_view format, std::string str) {
 
 	for (auto f : log_streams)
 		*f << str;
+
+	if (severity >= LogSeverity::LOG_WARNING)
+		for (auto f : log_warning_streams) {
+			*f << str;
+			f->flush();
+		}
 
 	RTLIL::Design *design = yosys_get_design();
 	if (design != nullptr)
@@ -201,13 +211,13 @@ static void logv_string(std::string_view format, std::string str) {
 	}
 }
 
-void log_formatted_string(std::string_view format, std::string str)
+void log_formatted_string(std::string_view format, std::string str, LogSeverity severity)
 {
 	log_assert(!Multithreading::active());
 
 	if (log_make_debug && !ys_debug(1))
 		return;
-	logv_string(format, std::move(str));
+	logv_string(format, std::move(str), severity);
 }
 
 void log_formatted_header(RTLIL::Design *design, std::string_view format, std::string str)
@@ -297,7 +307,7 @@ void log_formatted_warning(std::string_view prefix, std::string message)
 			if (log_errfile != NULL && !log_quiet_warnings)
 				log_files.push_back(log_errfile);
 
-			log("%s%s", prefix, message);
+			log_formatted_string("%s", stringf("%s%s", prefix, message), LogSeverity::LOG_WARNING);
 			log_flush();
 
 			if (log_errfile != NULL && !log_quiet_warnings)
@@ -352,7 +362,7 @@ static void log_error_with_prefix(std::string_view prefix, std::string str)
 	log_last_error = std::move(str);
 	std::string message(prefix);
 	message += log_last_error;
-	logv_string("%s%s", message);
+	log_formatted_string("%s", message, LogSeverity::LOG_ERROR);
 	log_flush();
 
 	log_make_debug = bak_log_make_debug;
@@ -429,7 +439,7 @@ void log_formatted_cmd_error(std::string str)
 			pop_errfile = true;
 		}
 
-		log("ERROR: %s", log_last_error);
+		log_formatted_string("ERROR: %s", log_last_error, LogSeverity::LOG_ERROR);
 		log_flush();
 
 		if (pop_errfile)

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -439,7 +439,7 @@ void log_formatted_cmd_error(std::string str)
 			pop_errfile = true;
 		}
 
-		log_formatted_string("ERROR: %s", log_last_error, LogSeverity::LOG_ERROR);
+		log_formatted_string("%s", stringf("ERROR: %s", log_last_error), LogSeverity::LOG_ERROR);
 		log_flush();
 
 		if (pop_errfile)

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -38,6 +38,8 @@
 
 YOSYS_NAMESPACE_BEGIN
 
+bool log_stderr_sink_forced = false;
+
 LogManager &logger()
 {
 	static LogManager instance;
@@ -101,7 +103,7 @@ bool StderrLogSink::should_log(const LogMessage &msg) const
 {
 	return msg.severity == LogSeverity::Error ||
 			(msg.severity == LogSeverity::Warning && !quiet_warnings) ||
-			logger().get_log_forced();
+			log_stderr_sink_forced;
 }
 
 void StderrLogSink::log(const LogMessage &msg)
@@ -248,7 +250,7 @@ void LogManager::log_formatted_header(RTLIL::Design *design, std::string_view fo
 		header_count.back()++;
 
 	if (int(header_count.size()) <= log_verbose_level) {
-		log_forced = true;
+		log_stderr_sink_forced = true;
 	}
 
 	std::string header_id;
@@ -271,7 +273,7 @@ void LogManager::log_formatted_header(RTLIL::Design *design, std::string_view fo
 			if (yosys_xtrace)
 				log("#X# -- end of dump --\n");
 		}
-	log_forced = false;
+	log_stderr_sink_forced = false;
 }
 
 void LogManager::log_formatted_warning(std::string_view prefix, std::string_view format, std::string message)

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -44,6 +44,12 @@ LogManager &logger()
     return instance;
 }
 
+std::chrono::steady_clock::time_point LogManager::get_initial_time() const
+{
+    static const auto initial_time = std::chrono::steady_clock::now();
+    return initial_time;
+}
+
 void (*log_error_atexit)() = NULL;
 void (*log_verific_callback)(int msg_type, const char *message_id, const char* file_path, unsigned int left_line, unsigned int left_col, unsigned int right_line, unsigned int right_col, const char *msg) = NULL;
 
@@ -184,7 +190,11 @@ void LogManager::logv_string(std::string_view prefix, std::string_view format, s
 		log_hasher->update(str);
 
 	auto msg = LogMessage(severity, prefix, format, str_in);
-	log(msg);
+	for (auto &sink : log_sinks) {
+		if (sink->should_log(msg))
+			sink->log(msg);
+	}
+
 
 	static std::string linebuffer;
 	static bool log_warn_regex_recusion_guard = false;
@@ -253,12 +263,12 @@ void LogManager::log_formatted_header(RTLIL::Design *design, std::string_view fo
 
 	if (log_hdump.count(header_id) && design != nullptr)
 		for (auto &filename : log_hdump.at(header_id)) {
-			YOSYS_NAMESPACE_PREFIX log("Dumping current design to '%s'.\n", filename);
+			log("Dumping current design to '%s'.\n", filename);
 			if (yosys_xtrace)
 				IdString::xtrace_db_dump();
 			Pass::call(design, {"dump", "-o", filename});
 			if (yosys_xtrace)
-				YOSYS_NAMESPACE_PREFIX log("#X# -- end of dump --\n");
+				log("#X# -- end of dump --\n");
 		}
 	log_stderr_force = false;
 }
@@ -275,7 +285,7 @@ void LogManager::log_formatted_warning(std::string_view prefix, std::string mess
 
 	if (suppressed)
 	{
-		YOSYS_NAMESPACE_PREFIX log("Suppressed %s%s", prefix, message);
+		log("Suppressed %s%s", prefix, message);
 	}
 	else
 	{
@@ -326,7 +336,7 @@ void LogManager::log_formatted_file_warning(std::string_view filename, int linen
 
 void LogManager::log_formatted_file_info(std::string_view filename, int lineno, std::string str)
 {
-	YOSYS_NAMESPACE_PREFIX log("%s:%d: Info: %s", filename, lineno, str);
+	log("%s:%d: Info: %s", filename, lineno, str);
 }
 
 void LogManager::log_suppressed() {
@@ -422,8 +432,8 @@ void LogManager::log_formatted_cmd_error(std::string message)
 
 void LogManager::log_spacer()
 {
-	if (log_newline_count < 2) YOSYS_NAMESPACE_PREFIX log("\n");
-	if (log_newline_count < 2) YOSYS_NAMESPACE_PREFIX log("\n");
+	if (log_newline_count < 2) log("\n");
+	if (log_newline_count < 2) log("\n");
 }
 
 void LogManager::log_push()
@@ -635,7 +645,7 @@ void LogManager::check_expected()
 	auto check_err = [&](const std::string kind, std::string pattern, LogExpectedItem item) {
 		if (item.current_count == item.expected_count) {
 			log_warn_regexes.clear();
-			YOSYS_NAMESPACE_PREFIX log("Expected %s pattern '%s' found !!!\n", kind, pattern);
+			log("Expected %s pattern '%s' found !!!\n", kind, pattern);
 			yosys_shutdown();
 			#if defined(_MSC_VER)
 				_exit(0);
@@ -664,10 +674,10 @@ void LogManager::report_unexpected_error()
 void LogManager::report_warning_stats()
 {
 	if (log_warnings_count)
-		YOSYS_NAMESPACE_PREFIX log("Warnings: %d unique messages, %d total\n", GetSize(log_warnings), log_warnings_count);
+		log("Warnings: %d unique messages, %d total\n", GetSize(log_warnings), log_warnings_count);
 
 	if (!log_experimentals.empty())
-		YOSYS_NAMESPACE_PREFIX log("Warnings: %d experimental features used (not excluded with -x).\n", GetSize(log_experimentals));
+		log("Warnings: %d experimental features used (not excluded with -x).\n", GetSize(log_experimentals));
 }
 
 void LogManager::add_expect(std::string type, std::string pattern, int count)

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -195,6 +195,8 @@ void LogManager::logv_string(std::string_view prefix, std::string_view format, s
 			sink->log(msg);
 	}
 
+	if (severity == LogSeverity::LOG_HEADER)
+		str = str_in;
 
 	static std::string linebuffer;
 	static bool log_warn_regex_recusion_guard = false;
@@ -254,8 +256,7 @@ void LogManager::log_formatted_header(RTLIL::Design *design, std::string_view fo
 	for (int c : header_count)
 		header_id += stringf("%s%d", header_id.empty() ? "" : ".", c);
 
-	log_formatted_string(stringf("%s. ", header_id), {}, {}, LogSeverity::LOG_HEADER);
-	log_formatted_string({}, format, std::move(str), LogSeverity::LOG_HEADER);
+	log_formatted_string(stringf("%s. ", header_id), format, std::move(str), LogSeverity::LOG_HEADER);
 	flush();
 
 	if (log_hdump_all)

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -396,10 +396,16 @@ void LogManager::log_formatted_file_error(std::string_view filename, int lineno,
 
 void LogManager::log_experimental(const std::string &str)
 {
-	if (log_experimentals_ignored.count(str) == 0 && log_experimentals.count(str) == 0) {
+	if (experimental_ignored.count(str) == 0 && experimental.count(str) == 0) {
 		log_warning("Feature '%s' is experimental.\n", str);
-		log_experimentals.insert(str);
+		experimental.insert(str);
 	}
+}
+
+void LogManager::log_deprecated(const std::string &str)
+{
+	log_warning("Feature '%s' is deprecated.\n", str);
+	deprecated.insert(str);
 }
 
 void LogManager::log_formatted_error(std::string_view format, std::string str)

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -118,6 +118,8 @@ static void log_default_callback(LogMessage msg)
 			design->scratchpad[scratchpad].append(str);
 }
 
+void (*log_callback)(LogMessage msg) = log_default_callback;
+
 static void logv_string(std::string_view prefix, std::string_view format, std::string str_in, LogSeverity severity) {
 	size_t remove_leading = 0;
 	while (format.size() > 1 && format[0] == '\n') {
@@ -143,7 +145,7 @@ static void logv_string(std::string_view prefix, std::string_view format, std::s
 	if (log_hasher)
 		log_hasher->update(str);
 
-	log_default_callback(LogMessage(severity, prefix, format, str_in));
+	log_callback(LogMessage(severity, prefix, format, str_in));
 
 	static std::string linebuffer;
 	static bool log_warn_regex_recusion_guard = false;

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -56,7 +56,7 @@ void (*log_verific_callback)(int msg_type, const char *message_id, const char* f
 // TODO: remove when log_id is removed
 vector<char*> log_id_cache;
 
-static bool next_print_log = false;
+static bool next_print_log = true;
 
 FileLogSink::FileLogSink(const std::string &filename, bool line_buffered, bool append)
 	: file(fopen(filename.c_str(), append ? "at" : "wt"))

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -184,15 +184,15 @@ void LogManager::logv_string(LogSeverity severity, std::string_view prefix, std:
 
 	size_t nnl_pos = str.find_last_not_of('\n');
 	if (nnl_pos == std::string::npos)
-		log_newline_count += GetSize(str);
+		newline_count += GetSize(str);
 	else
-		log_newline_count = GetSize(str) - nnl_pos - 1;
+		newline_count = GetSize(str) - nnl_pos - 1;
 
-	if (log_hasher)
-		log_hasher->update(str);
+	if (hasher)
+		hasher->update(str);
 
 	auto msg = LogMessage(severity, prefix, format, str_in);
-	for (auto &sink : log_sinks) {
+	for (auto &sink : sinks) {
 		if (sink->should_log(msg))
 			sink->log(msg);
 	}
@@ -201,13 +201,13 @@ void LogManager::logv_string(LogSeverity severity, std::string_view prefix, std:
 		str = str_in;
 
 	static std::string linebuffer;
-	static bool log_warn_regex_recusion_guard = false;
+	static bool warn_regex_recusion_guard = false;
 
-	if (!log_warn_regex_recusion_guard)
+	if (!warn_regex_recusion_guard)
 	{
-		log_warn_regex_recusion_guard = true;
+		warn_regex_recusion_guard = true;
 
-		if (log_warn_regexes.empty() && log_expect_log.empty() && log_expect_prefix_log.empty())
+		if (warn_regexes.empty() && expect_log.empty() && expect_prefix_log.empty())
 		{
 			linebuffer.clear();
 		}
@@ -216,11 +216,11 @@ void LogManager::logv_string(LogSeverity severity, std::string_view prefix, std:
 			linebuffer += str;
 
 			if (!linebuffer.empty() && linebuffer.back() == '\n') {
-				for (auto &re : log_warn_regexes)
+				for (auto &re : warn_regexes)
 					if (std::regex_search(linebuffer, re))
 						log_warning("Found log message matching -W regex:\n%s", str);
 
-				for (auto &[_, item] : log_expect_log)
+				for (auto &[_, item] : expect_log)
 					if (std::regex_search(linebuffer, item.pattern))
 						item.current_count++;
 
@@ -228,28 +228,28 @@ void LogManager::logv_string(LogSeverity severity, std::string_view prefix, std:
 			}
 		}
 
-		log_warn_regex_recusion_guard = false;
+		warn_regex_recusion_guard = false;
 	}
 }
 
-void LogManager::log_formatted_string(LogSeverity severity, std::string_view prefix, std::string_view format, std::string str)
+void LogManager::formatted_string(LogSeverity severity, std::string_view prefix, std::string_view format, std::string str)
 {
 	log_assert(!Multithreading::active());
 
-	if (log_make_debug && !is_debug(1))
+	if (make_debug && !is_debug(1))
 		return;
 	logv_string(severity, prefix, format, std::move(str));
 }
 
-void LogManager::log_formatted_header(RTLIL::Design *design, std::string_view format, std::string str)
+void LogManager::formatted_header(RTLIL::Design *design, std::string_view format, std::string str)
 {
 	log_assert(!Multithreading::active());
 
-	log_spacer();
+	spacer();
 	if (header_count.size() > 0)
 		header_count.back()++;
 
-	if (int(header_count.size()) <= log_verbose_level) {
+	if (int(header_count.size()) <= verbose_level) {
 		log_stderr_sink_forced = true;
 	}
 
@@ -258,14 +258,14 @@ void LogManager::log_formatted_header(RTLIL::Design *design, std::string_view fo
 	for (int c : header_count)
 		header_id += stringf("%s%d", header_id.empty() ? "" : ".", c);
 
-	log_formatted_string(LogSeverity::Header, stringf("%s. ", header_id), format, std::move(str));
+	formatted_string(LogSeverity::Header, stringf("%s. ", header_id), format, std::move(str));
 	flush();
 
-	if (log_hdump_all)
-		log_hdump[header_id].insert("yosys_dump_" + header_id + ".il");
+	if (hdump_all)
+		hdump[header_id].insert("yosys_dump_" + header_id + ".il");
 
-	if (log_hdump.count(header_id) && design != nullptr)
-		for (auto &filename : log_hdump.at(header_id)) {
+	if (hdump.count(header_id) && design != nullptr)
+		for (auto &filename : hdump.at(header_id)) {
 			log("Dumping current design to '%s'.\n", filename);
 			if (yosys_xtrace)
 				IdString::xtrace_db_dump();
@@ -276,13 +276,13 @@ void LogManager::log_formatted_header(RTLIL::Design *design, std::string_view fo
 	log_stderr_sink_forced = false;
 }
 
-void LogManager::log_formatted_warning(std::string_view prefix, std::string_view format, std::string message)
+void LogManager::formatted_warning(std::string_view prefix, std::string_view format, std::string message)
 {
 	log_assert(!Multithreading::active());
 
 	bool suppressed = false;
 
-	for (auto &re : log_nowarn_regexes)
+	for (auto &re : nowarn_regexes)
 		if (std::regex_search(message, re))
 			suppressed = true;
 
@@ -292,86 +292,86 @@ void LogManager::log_formatted_warning(std::string_view prefix, std::string_view
 	}
 	else
 	{
-		int bak_log_make_debug = log_make_debug;
-		log_make_debug = 0;
+		int bak_make_debug = make_debug;
+		make_debug = 0;
 
-		for (auto &re : log_werror_regexes)
+		for (auto &re : werror_regexes)
 			if (std::regex_search(message, re))
-				log_formatted_error(format, message);
+				formatted_error(format, message);
 
 		bool warning_match = false;
-		for (auto &[_, item] : log_expect_warning)
+		for (auto &[_, item] : expect_warning)
 			if (std::regex_search(message, item.pattern)) {
 				item.current_count++;
 				warning_match = true;
 			}
 
-		for (auto &[_, item] : log_expect_prefix_warning)
+		for (auto &[_, item] : expect_prefix_warning)
 			if (std::regex_search(string(prefix) + message, item.pattern)) {
 				item.current_count++;
 				warning_match = true;
 			}
 
-		if (log_warnings.count(message))
+		if (warnings.count(message))
 		{
-			log_formatted_string(LogSeverity::Info, prefix, format, message);
+			formatted_string(LogSeverity::Info, prefix, format, message);
 			flush();
 		}
 		else
 		{
-			log_formatted_string(LogSeverity::Warning, prefix, format, message);
+			formatted_string(LogSeverity::Warning, prefix, format, message);
 			flush();
-			log_warnings.insert(message);
+			warnings.insert(message);
 		}
 
 		if (!warning_match)
-			log_warnings_count_noexpect++;
-		log_warnings_count++;
-		log_make_debug = bak_log_make_debug;
+			warnings_count_noexpect++;
+		warnings_count++;
+		make_debug = bak_make_debug;
 	}
 }
 
-void LogManager::log_formatted_file_warning(std::string_view filename, int lineno, std::string_view format, std::string str)
+void LogManager::formatted_file_warning(std::string_view filename, int lineno, std::string_view format, std::string str)
 {
 	std::string prefix = stringf("%s:%d: Warning: ", filename, lineno);
-	log_formatted_warning(prefix, format, std::move(str));
+	formatted_warning(prefix, format, std::move(str));
 }
 
-void LogManager::log_formatted_file_info(std::string_view filename, int lineno, std::string_view format, std::string str)
+void LogManager::formatted_file_info(std::string_view filename, int lineno, std::string_view format, std::string str)
 {
 	std::string prefix = stringf("%s:%d: Info: ", filename, lineno);
-	log_formatted_string(LogSeverity::Info, prefix, format, std::move(str));
+	formatted_string(LogSeverity::Info, prefix, format, std::move(str));
 }
 
-void LogManager::log_suppressed() {
-	if (log_debug_suppressed && !log_make_debug) {
+void LogManager::suppressed() {
+	if (debug_suppressed && !make_debug) {
 		constexpr const char* format = "<suppressed ~%d debug messages>\n";
-		logv_string(LogSeverity::Info, {}, format, stringf(format, log_debug_suppressed));
-		log_debug_suppressed = 0;
+		logv_string(LogSeverity::Info, {}, format, stringf(format, debug_suppressed));
+		debug_suppressed = 0;
 	}
 }
 
 [[noreturn]]
-void LogManager::log_error_with_prefix(std::string_view prefix, std::string_view format, std::string message)
+void LogManager::error_with_prefix(std::string_view prefix, std::string_view format, std::string message)
 {
-	int bak_log_make_debug = log_make_debug;
-	log_make_debug = 0;
-	log_suppressed();
+	int bak_make_debug = make_debug;
+	make_debug = 0;
+	suppressed();
 
-	log_formatted_string(LogSeverity::Error, prefix, format, message);
+	formatted_string(LogSeverity::Error, prefix, format, message);
 	flush();
 
-	log_make_debug = bak_log_make_debug;
+	make_debug = bak_make_debug;
 
-	for (auto &[_, item] : log_expect_error)
+	for (auto &[_, item] : expect_error)
 		if (std::regex_search(message, item.pattern))
 			item.current_count++;
 
-	for (auto &[_, item] : log_expect_prefix_error)
+	for (auto &[_, item] : expect_prefix_error)
 		if (std::regex_search(string(prefix) + message, item.pattern))
 			item.current_count++;
 
-	log_errors_count++;
+	errors_count++;
 
 	check_expected();
 
@@ -390,13 +390,13 @@ void LogManager::log_error_with_prefix(std::string_view prefix, std::string_view
 #endif
 }
 
-void LogManager::log_formatted_file_error(std::string_view filename, int lineno, std::string_view format, std::string str)
+void LogManager::formatted_file_error(std::string_view filename, int lineno, std::string_view format, std::string str)
 {
 	std::string prefix = stringf("%s:%d: ERROR: ", filename, lineno);
-	log_error_with_prefix(prefix, format, str);
+	error_with_prefix(prefix, format, str);
 }
 
-void LogManager::log_experimental(const std::string &str)
+void LogManager::add_experimental(const std::string &str)
 {
 	if (experimental_ignored.count(str) == 0 && experimental.count(str) == 0) {
 		log_warning("Feature '%s' is experimental.\n", str);
@@ -404,7 +404,7 @@ void LogManager::log_experimental(const std::string &str)
 	}
 }
 
-void LogManager::log_deprecated(const std::string &str)
+void LogManager::add_deprecated(const std::string &str)
 {
 	if (deprecated.count(str) == 0) {
 		log_warning("Feature '%s' is deprecated.\n", str);
@@ -412,9 +412,9 @@ void LogManager::log_deprecated(const std::string &str)
 	}
 }
 
-void LogManager::log_formatted_error(std::string_view format, std::string str)
+void LogManager::formatted_error(std::string_view format, std::string str)
 {
-	log_error_with_prefix("ERROR: ", format, std::move(str));
+	error_with_prefix("ERROR: ", format, std::move(str));
 }
 
 void log_assert_failure(const char *expr, const char *file, int line)
@@ -432,30 +432,30 @@ void log_yosys_abort_message(std::string_view file, int line, std::string_view f
 	log_error("Abort in %s:%d (%s): %s\n", file, line, func, message);
 }
 
-void LogManager::log_formatted_cmd_error(std::string_view format, std::string message)
+void LogManager::formatted_cmd_error(std::string_view format, std::string message)
 {
-	if (log_cmd_error_throw) {
-		log_formatted_string(LogSeverity::Error, "ERROR: ", format, message);
+	if (cmd_error_throw) {
+		formatted_string(LogSeverity::Error, "ERROR: ", format, message);
 		flush();
 
 		throw log_cmd_error_exception();
 	}
 
-	log_formatted_error(format, message);
+	formatted_error(format, message);
 }
 
-void LogManager::log_spacer()
+void LogManager::spacer()
 {
-	if (log_newline_count < 2) log("\n");
-	if (log_newline_count < 2) log("\n");
+	if (newline_count < 2) log("\n");
+	if (newline_count < 2) log("\n");
 }
 
-void LogManager::log_push()
+void LogManager::push()
 {
 	header_count.push_back(0);
 }
 
-void LogManager::log_pop()
+void LogManager::pop()
 {
 	header_count.pop_back();
 	log_id_cache_clear();
@@ -559,7 +559,7 @@ void log_backtrace(const char *prefix, int levels)
 void log_backtrace(const char*, int) { }
 #endif
 
-void LogManager::log_reset_stack()
+void LogManager::reset_stack()
 {
 	while (header_count.size() > 1)
 		header_count.pop_back();
@@ -626,39 +626,39 @@ void LogManager::check_expected()
 {
 	// copy out all of the expected logs so that they cannot be re-checked
 	// or match against themselves
-	dict<std::string, LogExpectedItem> expect_log, expect_warning, expect_error;
-	dict<std::string, LogExpectedItem> expect_prefix_log, expect_prefix_warning, expect_prefix_error;
-	std::swap(expect_warning, log_expect_warning);
-	std::swap(expect_log, log_expect_log);
-	std::swap(expect_error, log_expect_error);
-	std::swap(expect_prefix_warning, log_expect_prefix_warning);
-	std::swap(expect_prefix_log, log_expect_prefix_log);
-	std::swap(expect_prefix_error, log_expect_prefix_error);
+	dict<std::string, LogExpectedItem> expect_log_copy, expect_warning_copy, expect_error_copy;
+	dict<std::string, LogExpectedItem> expect_prefix_log_copy, expect_prefix_warning_copy, expect_prefix_error_copy;
+	std::swap(expect_warning_copy, expect_warning);
+	std::swap(expect_log_copy, expect_log);
+	std::swap(expect_error_copy, expect_error);
+	std::swap(expect_prefix_warning_copy, expect_prefix_warning);
+	std::swap(expect_prefix_log_copy, expect_prefix_log);
+	std::swap(expect_prefix_error_copy, expect_prefix_error);
 
 	auto check = [&](const std::string kind, std::string pattern, LogExpectedItem item) {
 		if (item.current_count == 0) {
-			log_warn_regexes.clear();
+			warn_regexes.clear();
 			log_error("Expected %s pattern '%s' not found !\n", kind, pattern);
 		}
 		if (item.current_count != item.expected_count) {
-			log_warn_regexes.clear();
+			warn_regexes.clear();
 			log_error("Expected %s pattern '%s' found %d time(s), instead of %d time(s) !\n",
 				kind.c_str(), pattern.c_str(), item.current_count, item.expected_count);
 		}
 	};
 
-	for (auto &[pattern, item] : expect_warning)
+	for (auto &[pattern, item] : expect_warning_copy)
 		check("warning", pattern, item);
-	for (auto &[pattern, item] : expect_prefix_warning)
+	for (auto &[pattern, item] : expect_prefix_warning_copy)
 		check("prefixed warning", pattern, item);
-	for (auto &[pattern, item] : expect_log)
+	for (auto &[pattern, item] : expect_log_copy)
 		check("log", pattern, item);
-	for (auto &[pattern, item] : expect_prefix_log)
+	for (auto &[pattern, item] : expect_prefix_log_copy)
 		check("prefixed log", pattern, item);
 
 	auto check_err = [&](const std::string kind, std::string pattern, LogExpectedItem item) {
 		if (item.current_count == item.expected_count) {
-			log_warn_regexes.clear();
+			warn_regexes.clear();
 			log("Expected %s pattern '%s' found !!!\n", kind, pattern);
 			yosys_shutdown();
 			#if defined(_MSC_VER)
@@ -667,52 +667,52 @@ void LogManager::check_expected()
 				_Exit(0);
 			#endif
 		} else {
-			log_warn_regexes.clear();
+			warn_regexes.clear();
 			log_error("Expected %s pattern '%s' not found !\n", kind, pattern);
 		}
 	};
-	for (auto &[pattern, item] : expect_error)
+	for (auto &[pattern, item] : expect_error_copy)
 		check_err("error", pattern, item);
-	for (auto &[pattern, item] : expect_prefix_error)
+	for (auto &[pattern, item] : expect_prefix_error_copy)
 		check_err("prefixed error", pattern, item);
 }
 
 void LogManager::report_unexpected_error()
 {
-	if (log_expect_no_warnings && log_warnings_count_noexpect)
-		log_error("Unexpected warnings found: %d unique messages, %d total, %d expected\n", GetSize(log_warnings),
-					log_warnings_count, log_warnings_count - log_warnings_count_noexpect);
+	if (expect_no_warnings && warnings_count_noexpect)
+		log_error("Unexpected warnings found: %d unique messages, %d total, %d expected\n", GetSize(warnings),
+					warnings_count, warnings_count - warnings_count_noexpect);
 }
 
 void LogManager::add_expect(std::string type, std::string pattern, int count)
 {
 	if (type == "error")
-		log_expect_error[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
+		expect_error[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
 	else if (type == "prefix-error")
-		log_expect_prefix_error[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
+		expect_prefix_error[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
 	else if (type == "warning")
-		log_expect_warning[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
+		expect_warning[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
 	else if (type == "prefix-warning")
-		log_expect_prefix_warning[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
+		expect_prefix_warning[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
 	else if (type == "log")
-		log_expect_log[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
+		expect_log[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
 	else if (type == "prefix-log")
-		log_expect_prefix_log[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
+		expect_prefix_log[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
 	else log_abort();
 }
 
 void LogManager::start_hasher()
 {
-	log_hasher = std::make_unique<SHA1>();
+	hasher = std::make_unique<SHA1>();
 }
 
 std::string LogManager::finish_hasher()
 {
-	if (!log_hasher)
+	if (!hasher)
 		return {};
 
-	std::string hash = log_hasher->final().substr(0, 10);
-	log_hasher.reset();
+	std::string hash = hasher->final().substr(0, 10);
+	hasher.reset();
 	return hash;
 }
 

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -40,14 +40,14 @@ YOSYS_NAMESPACE_BEGIN
 
 LogManager &logger()
 {
-    static LogManager instance;
-    return instance;
+	static LogManager instance;
+	return instance;
 }
 
 std::chrono::steady_clock::time_point LogManager::get_initial_time() const
 {
-    static const auto initial_time = std::chrono::steady_clock::now();
-    return initial_time;
+	static const auto initial_time = std::chrono::steady_clock::now();
+	return initial_time;
 }
 
 void (*log_error_atexit)() = NULL;
@@ -87,7 +87,7 @@ void FileLogSink::flush()
 
 void ConsoleLogSink::log(const LogMessage &msg)
 {
-	FILE *file = (msg.severity == LogSeverity::LOG_ERROR) ? stderr : stdout;
+	FILE *file = (msg.severity == LogSeverity::Error) ? stderr : stdout;
 	fputs(msg.cached_msg.c_str(), file);
 }
 
@@ -99,8 +99,8 @@ void ConsoleLogSink::flush()
 
 bool StderrLogSink::should_log(const LogMessage &msg) const
 {
-	return msg.severity == LogSeverity::LOG_ERROR ||
-			(msg.severity == LogSeverity::LOG_WARNING && !quiet_warnings) ||
+	return msg.severity == LogSeverity::Error ||
+			(msg.severity == LogSeverity::Warning && !quiet_warnings) ||
 			logger().get_log_forced();
 }
 
@@ -151,7 +151,7 @@ LogMessage::LogMessage(LogSeverity severity, std::string_view prefix, std::strin
 		// Special case to detect newlines in Python log output, since
 		// the binding always calls `log("%s", payload)` and the newline
 		// is then in the first formatted argument
-		if (format == "%s" && message.back() == '\n')
+		if (format == "%s" && !message.empty() && message.back() == '\n')
 			next_print_log = true;
 	}
 	cached_msg = stringf("%s%s%s", time_str, prefix, message);
@@ -195,7 +195,7 @@ void LogManager::logv_string(std::string_view prefix, std::string_view format, s
 			sink->log(msg);
 	}
 
-	if (severity == LogSeverity::LOG_HEADER)
+	if (severity == LogSeverity::Header)
 		str = str_in;
 
 	static std::string linebuffer;
@@ -256,7 +256,7 @@ void LogManager::log_formatted_header(RTLIL::Design *design, std::string_view fo
 	for (int c : header_count)
 		header_id += stringf("%s%d", header_id.empty() ? "" : ".", c);
 
-	log_formatted_string(stringf("%s. ", header_id), format, std::move(str), LogSeverity::LOG_HEADER);
+	log_formatted_string(stringf("%s. ", header_id), format, std::move(str), LogSeverity::Header);
 	flush();
 
 	if (log_hdump_all)
@@ -312,12 +312,12 @@ void LogManager::log_formatted_warning(std::string_view prefix, std::string_view
 
 		if (log_warnings.count(message))
 		{
-			log_formatted_string(prefix, format, message, LogSeverity::LOG_INFO);
+			log_formatted_string(prefix, format, message, LogSeverity::Info);
 			flush();
 		}
 		else
 		{
-			log_formatted_string(prefix, format, message, LogSeverity::LOG_WARNING);
+			log_formatted_string(prefix, format, message, LogSeverity::Warning);
 			flush();
 			log_warnings.insert(message);
 		}
@@ -338,13 +338,13 @@ void LogManager::log_formatted_file_warning(std::string_view filename, int linen
 void LogManager::log_formatted_file_info(std::string_view filename, int lineno, std::string_view format, std::string str)
 {
 	std::string prefix = stringf("%s:%d: Info: ", filename, lineno);
-	log_formatted_string(prefix, format, std::move(str), LogSeverity::LOG_INFO);
+	log_formatted_string(prefix, format, std::move(str), LogSeverity::Info);
 }
 
 void LogManager::log_suppressed() {
 	if (log_debug_suppressed && !log_make_debug) {
 		constexpr const char* format = "<suppressed ~%d debug messages>\n";
-		logv_string({}, format, stringf(format, log_debug_suppressed),LogSeverity::LOG_INFO);
+		logv_string({}, format, stringf(format, log_debug_suppressed),LogSeverity::Info);
 		log_debug_suppressed = 0;
 	}
 }
@@ -356,7 +356,7 @@ void LogManager::log_error_with_prefix(std::string_view prefix, std::string_view
 	log_make_debug = 0;
 	log_suppressed();
 
-	log_formatted_string(prefix, format, message, LogSeverity::LOG_ERROR);
+	log_formatted_string(prefix, format, message, LogSeverity::Error);
 	flush();
 
 	log_make_debug = bak_log_make_debug;
@@ -425,7 +425,7 @@ void log_yosys_abort_message(std::string_view file, int line, std::string_view f
 void LogManager::log_formatted_cmd_error(std::string_view format, std::string message)
 {
 	if (log_cmd_error_throw) {
-		log_formatted_string("ERROR: ", format, message, LogSeverity::LOG_ERROR);
+		log_formatted_string("ERROR: ", format, message, LogSeverity::Error);
 		flush();
 
 		throw log_cmd_error_exception();
@@ -690,6 +690,7 @@ void LogManager::add_expect(std::string type, std::string pattern, int count)
 		log_expect_prefix_log[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
 	else log_abort();
 }
+
 void LogManager::start_hasher()
 {
 	log_hasher = std::make_unique<SHA1>();
@@ -704,4 +705,5 @@ std::string LogManager::finish_hasher()
 	log_hasher.reset();
 	return hash;
 }
+
 YOSYS_NAMESPACE_END

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -273,7 +273,7 @@ void LogManager::log_formatted_header(RTLIL::Design *design, std::string_view fo
 	log_stderr_force = false;
 }
 
-void LogManager::log_formatted_warning(std::string_view prefix, std::string message)
+void LogManager::log_formatted_warning(std::string_view prefix, std::string_view format, std::string message)
 {
 	log_assert(!Multithreading::active());
 
@@ -294,7 +294,7 @@ void LogManager::log_formatted_warning(std::string_view prefix, std::string mess
 
 		for (auto &re : log_werror_regexes)
 			if (std::regex_search(message, re))
-				log_formatted_error(message);
+				log_formatted_error(format, message);
 
 		bool warning_match = false;
 		for (auto &[_, item] : log_expect_warning)
@@ -311,12 +311,12 @@ void LogManager::log_formatted_warning(std::string_view prefix, std::string mess
 
 		if (log_warnings.count(message))
 		{
-			log_formatted_string(prefix, "%s", message, LogSeverity::LOG_INFO);
+			log_formatted_string(prefix, format, message, LogSeverity::LOG_INFO);
 			flush();
 		}
 		else
 		{
-			log_formatted_string(prefix, "%s", message, LogSeverity::LOG_WARNING);
+			log_formatted_string(prefix, format, message, LogSeverity::LOG_WARNING);
 			flush();
 			log_warnings.insert(message);
 		}
@@ -328,15 +328,16 @@ void LogManager::log_formatted_warning(std::string_view prefix, std::string mess
 	}
 }
 
-void LogManager::log_formatted_file_warning(std::string_view filename, int lineno, std::string str)
+void LogManager::log_formatted_file_warning(std::string_view filename, int lineno, std::string_view format, std::string str)
 {
 	std::string prefix = stringf("%s:%d: Warning: ", filename, lineno);
-	log_formatted_warning(prefix, std::move(str));
+	log_formatted_warning(prefix, format, std::move(str));
 }
 
-void LogManager::log_formatted_file_info(std::string_view filename, int lineno, std::string str)
+void LogManager::log_formatted_file_info(std::string_view filename, int lineno, std::string_view format, std::string str)
 {
-	log("%s:%d: Info: %s", filename, lineno, str);
+	std::string prefix = stringf("%s:%d: Info: ", filename, lineno);
+	log_formatted_string(prefix, format, std::move(str), LogSeverity::LOG_INFO);
 }
 
 void LogManager::log_suppressed() {
@@ -348,13 +349,13 @@ void LogManager::log_suppressed() {
 }
 
 [[noreturn]]
-void LogManager::log_error_with_prefix(std::string_view prefix, std::string message)
+void LogManager::log_error_with_prefix(std::string_view prefix, std::string_view format, std::string message)
 {
 	int bak_log_make_debug = log_make_debug;
 	log_make_debug = 0;
 	log_suppressed();
 
-	log_formatted_string(prefix, "%s", message, LogSeverity::LOG_ERROR);
+	log_formatted_string(prefix, format, message, LogSeverity::LOG_ERROR);
 	flush();
 
 	log_make_debug = bak_log_make_debug;
@@ -384,10 +385,10 @@ void LogManager::log_error_with_prefix(std::string_view prefix, std::string mess
 #endif
 }
 
-void LogManager::log_formatted_file_error(std::string_view filename, int lineno, std::string str)
+void LogManager::log_formatted_file_error(std::string_view filename, int lineno, std::string_view format, std::string str)
 {
 	std::string prefix = stringf("%s:%d: ERROR: ", filename, lineno);
-	log_error_with_prefix(prefix, str);
+	log_error_with_prefix(prefix, format, str);
 }
 
 void LogManager::log_experimental(const std::string &str)
@@ -398,9 +399,9 @@ void LogManager::log_experimental(const std::string &str)
 	}
 }
 
-void LogManager::log_formatted_error(std::string str)
+void LogManager::log_formatted_error(std::string_view format, std::string str)
 {
-	log_error_with_prefix("ERROR: ", std::move(str));
+	log_error_with_prefix("ERROR: ", format, std::move(str));
 }
 
 void log_assert_failure(const char *expr, const char *file, int line)
@@ -418,16 +419,16 @@ void log_yosys_abort_message(std::string_view file, int line, std::string_view f
 	log_error("Abort in %s:%d (%s): %s\n", file, line, func, message);
 }
 
-void LogManager::log_formatted_cmd_error(std::string message)
+void LogManager::log_formatted_cmd_error(std::string_view format, std::string message)
 {
 	if (log_cmd_error_throw) {
-		log_formatted_string("ERROR: ", "%s", message, LogSeverity::LOG_ERROR);
+		log_formatted_string("ERROR: ", format, message, LogSeverity::LOG_ERROR);
 		flush();
 
 		throw log_cmd_error_exception();
 	}
 
-	log_formatted_error(message);
+	log_formatted_error(format, message);
 }
 
 void LogManager::log_spacer()

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -38,9 +38,8 @@
 
 YOSYS_NAMESPACE_BEGIN
 
-std::vector<FILE*> log_files;
-std::vector<std::ostream*> log_streams;
-std::vector<std::string> log_scratchpads;
+std::vector<std::unique_ptr<LogSink>> log_sinks;
+
 std::map<std::string, std::set<std::string>> log_hdump;
 std::vector<std::regex> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
 dict<std::string, LogExpectedItem> log_expect_log, log_expect_warning, log_expect_error;
@@ -50,7 +49,6 @@ int log_warnings_count = 0;
 int log_warnings_count_noexpect = 0;
 bool log_expect_no_warnings = false;
 bool log_hdump_all = false;
-FILE *log_errfile = NULL;
 SHA1 *log_hasher = NULL;
 
 bool log_time = false;
@@ -58,13 +56,15 @@ bool log_error_stderr = false;
 bool log_cmd_error_throw = false;
 bool log_quiet_warnings = false;
 int log_verbose_level;
-string log_last_error;
+
 void (*log_error_atexit)() = NULL;
 void (*log_verific_callback)(int msg_type, const char *message_id, const char* file_path, unsigned int left_line, unsigned int left_col, unsigned int right_line, unsigned int right_col, const char *msg) = NULL;
 
 int log_make_debug = 0;
 int log_force_debug = 0;
 int log_debug_suppressed = 0;
+
+bool log_stderr_force = false;
 
 vector<int> header_count;
 vector<char*> log_id_cache;
@@ -73,14 +73,83 @@ static std::optional<std::chrono::steady_clock::time_point> initial_time;
 static bool next_print_log = false;
 static int log_newline_count = 0;
 
-static void log_id_cache_clear()
+FileLogSink::FileLogSink(const std::string &filename, bool line_buffered, bool append)
+	: file(fopen(filename.c_str(), append ? "at" : "wt"))
 {
-	for (auto p : log_id_cache)
-		free(p);
-	log_id_cache.clear();
+	if (!file)
+		throw std::runtime_error("Can't open log file `" + filename + "' for writing!\n");
+
+	if (line_buffered)
+		setvbuf(file, nullptr, _IOLBF, 0);
 }
 
-static void log_default_callback(LogMessage msg)
+FileLogSink::~FileLogSink()
+{
+	flush();
+	if (file)
+		fclose(file);
+}
+
+void FileLogSink::log(const LogMessage &msg)
+{
+	fputs(msg.legacy_msg.c_str(), file);
+}
+
+void FileLogSink::flush()
+{
+	fflush(file);
+}
+
+void ConsoleLogSink::log(const LogMessage &msg)
+{
+	FILE *file = msg.severity == LogSeverity::LOG_ERROR ? stderr : stdout;
+	fputs(msg.legacy_msg.c_str(), file);
+}
+
+void ConsoleLogSink::flush()
+{
+	fflush(stdout);
+	fflush(stderr);
+}
+
+bool StderrLogSink::should_log(const LogMessage &msg) const
+{
+	return msg.severity == LogSeverity::LOG_ERROR ||
+			(msg.severity == LogSeverity::LOG_WARNING && !log_quiet_warnings) ||
+			/* (msg.severity == LogSeverity::LOG_HEADER && int(header_count.size()) <= log_verbose_level) || */
+			log_stderr_force;
+}
+
+void StderrLogSink::log(const LogMessage &msg)
+{
+	fputs(msg.legacy_msg.c_str(), stderr);
+}
+
+void StderrLogSink::flush()
+{
+	fflush(stderr);
+}
+
+ScratchPadLogSink::ScratchPadLogSink(std::string scratchpad)
+    : scratchpad(std::move(scratchpad))
+{
+}
+
+void ScratchPadLogSink::log(const LogMessage &msg)
+{
+	RTLIL::Design *design = yosys_get_design();
+	if (!design)
+		return;
+
+	design->scratchpad[scratchpad].append(msg.legacy_msg);
+}
+
+LogMessage::LogMessage(LogSeverity severity, std::string_view prefix, std::string_view format, std::string_view message) :
+	severity(severity),
+	prefix(prefix),
+	format(format),
+	message(message),
+	timestamp(std::chrono::steady_clock::now())
 {
 	std::string time_str;
 	if (log_time)
@@ -94,31 +163,24 @@ static void log_default_callback(LogMessage msg)
 			time_str += stringf("[%05d.%06d] ", int(us.count() / 1'000'000),int(us.count() % 1'000'000));
 		}
 
-		if (!msg.format.empty() && msg.format.back() == '\n')
+		if (!format.empty() && format.back() == '\n')
 			next_print_log = true;
 
 		// Special case to detect newlines in Python log output, since
 		// the binding always calls `log("%s", payload)` and the newline
 		// is then in the first formatted argument
-		if (msg.format == "%s" && msg.message.back() == '\n')
+		if (format == "%s" && message.back() == '\n')
 			next_print_log = true;
 	}
-
-	std::string str = stringf("%s%s%s", time_str, msg.prefix, msg.message);
-	for (auto f : log_files) {
-		fputs(str.c_str(), f);
-	}
-
-	for (auto f : log_streams)
-		*f << str;
-
-	RTLIL::Design *design = yosys_get_design();
-	if (design != nullptr)
-		for (auto &scratchpad : log_scratchpads)
-			design->scratchpad[scratchpad].append(str);
+	legacy_msg = stringf("%s%s%s", time_str, prefix, message);
 }
 
-void (*log_callback)(LogMessage msg) = log_default_callback;
+static void log_id_cache_clear()
+{
+	for (auto p : log_id_cache)
+		free(p);
+	log_id_cache.clear();
+}
 
 static void logv_string(std::string_view prefix, std::string_view format, std::string str_in, LogSeverity severity) {
 	size_t remove_leading = 0;
@@ -145,7 +207,11 @@ static void logv_string(std::string_view prefix, std::string_view format, std::s
 	if (log_hasher)
 		log_hasher->update(str);
 
-	log_callback(LogMessage(severity, prefix, format, str_in));
+	auto msg = LogMessage(severity, prefix, format, str_in);
+	for (auto &sink : log_sinks) {
+		if (sink->should_log(msg))
+			sink->log(msg);
+	}
 
 	static std::string linebuffer;
 	static bool log_warn_regex_recusion_guard = false;
@@ -192,15 +258,12 @@ void log_formatted_header(RTLIL::Design *design, std::string_view format, std::s
 {
 	log_assert(!Multithreading::active());
 
-	bool pop_errfile = false;
-
 	log_spacer();
 	if (header_count.size() > 0)
 		header_count.back()++;
 
-	if (int(header_count.size()) <= log_verbose_level && log_errfile != NULL) {
-		log_files.push_back(log_errfile);
-		pop_errfile = true;
+	if (int(header_count.size()) <= log_verbose_level) {
+		log_stderr_force = true;
 	}
 
 	std::string header_id;
@@ -224,9 +287,7 @@ void log_formatted_header(RTLIL::Design *design, std::string_view format, std::s
 			if (yosys_xtrace)
 				log("#X# -- end of dump --\n");
 		}
-
-	if (pop_errfile)
-		log_files.pop_back();
+	log_stderr_force = false;
 }
 
 void log_formatted_warning(std::string_view prefix, std::string message)
@@ -267,20 +328,13 @@ void log_formatted_warning(std::string_view prefix, std::string message)
 
 		if (log_warnings.count(message))
 		{
-			log_formatted_string(prefix, "%s", message, LogSeverity::LOG_WARNING);
+			log_formatted_string(prefix, "%s", message, LogSeverity::LOG_INFO);
 			log_flush();
 		}
 		else
 		{
-			if (log_errfile != NULL && !log_quiet_warnings)
-				log_files.push_back(log_errfile);
-
 			log_formatted_string(prefix, "%s", message, LogSeverity::LOG_WARNING);
 			log_flush();
-
-			if (log_errfile != NULL && !log_quiet_warnings)
-				log_files.pop_back();
-
 			log_warnings.insert(message);
 		}
 
@@ -311,36 +365,23 @@ void log_suppressed() {
 }
 
 [[noreturn]]
-static void log_error_with_prefix(std::string_view prefix, std::string str)
+static void log_error_with_prefix(std::string_view prefix, std::string message)
 {
 	int bak_log_make_debug = log_make_debug;
 	log_make_debug = 0;
 	log_suppressed();
 
-	if (log_errfile != NULL)
-		log_files.push_back(log_errfile);
-
-	if (log_error_stderr) {
-		log_flush(); // Make sure we flush stdout before replacing it with stderr
-		for (auto &f : log_files)
-			if (f == stdout)
-				f = stderr;
-	}
-
-	log_last_error = std::move(str);
-	std::string message(prefix);
-	message += log_last_error;
-	log_formatted_string(prefix, "%s", log_last_error, LogSeverity::LOG_ERROR);
+	log_formatted_string(prefix, "%s", message, LogSeverity::LOG_ERROR);
 	log_flush();
 
 	log_make_debug = bak_log_make_debug;
 
 	for (auto &[_, item] : log_expect_error)
-		if (std::regex_search(log_last_error, item.pattern))
+		if (std::regex_search(message, item.pattern))
 			item.current_count++;
 
 	for (auto &[_, item] : log_expect_prefix_error)
-		if (std::regex_search(message, item.pattern))
+		if (std::regex_search(string(prefix) + message, item.pattern))
 			item.current_count++;
 
 	log_check_expected();
@@ -394,29 +435,16 @@ void log_yosys_abort_message(std::string_view file, int line, std::string_view f
 	log_error("Abort in %s:%d (%s): %s\n", file, line, func, message);
 }
 
-void log_formatted_cmd_error(std::string str)
+void log_formatted_cmd_error(std::string message)
 {
 	if (log_cmd_error_throw) {
-		log_last_error = str;
-
-		// Make sure the error message gets through any selective silencing
-		// of log output
-		bool pop_errfile = false;
-		if (log_errfile != NULL) {
-			log_files.push_back(log_errfile);
-			pop_errfile = true;
-		}
-
-		log_formatted_string("ERROR: ", "%s", log_last_error, LogSeverity::LOG_ERROR);
+		log_formatted_string("ERROR: ", "%s", message, LogSeverity::LOG_ERROR);
 		log_flush();
-
-		if (pop_errfile)
-			log_files.pop_back();
 
 		throw log_cmd_error_exception();
 	}
 
-	log_formatted_error(str);
+	log_formatted_error(message);
 }
 
 void log_spacer()
@@ -544,11 +572,8 @@ void log_reset_stack()
 
 void log_flush()
 {
-	for (auto f : log_files)
-		fflush(f);
-
-	for (auto f : log_streams)
-		f->flush();
+	for (auto &sink : log_sinks)
+		sink->flush();
 }
 
 void log_dump_val_worker(RTLIL::IdString v) {

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -87,7 +87,7 @@ void FileLogSink::flush()
 
 void ConsoleLogSink::log(const LogMessage &msg)
 {
-	FILE *file = (msg.severity == LogSeverity::LOG_ERROR && logger().get_error_stderr()) ? stderr : stdout;
+	FILE *file = (msg.severity == LogSeverity::LOG_ERROR) ? stderr : stdout;
 	fputs(msg.cached_msg.c_str(), file);
 }
 
@@ -100,7 +100,7 @@ void ConsoleLogSink::flush()
 bool StderrLogSink::should_log(const LogMessage &msg) const
 {
 	return msg.severity == LogSeverity::LOG_ERROR ||
-			(msg.severity == LogSeverity::LOG_WARNING && !logger().get_quiet_warnings()) ||
+			(msg.severity == LogSeverity::LOG_WARNING && !quiet_warnings) ||
 			logger().get_stderr_force();
 }
 
@@ -671,8 +671,9 @@ void LogManager::report_unexpected_error()
 }
 
 
-void LogManager::report_warning_stats()
+void LogManager::report_warning_stats(bool stderr_force)
 {
+	log_stderr_force = stderr_force;
 	if (log_warnings_count)
 		log("Warnings: %d unique messages, %d total\n", GetSize(log_warnings), log_warnings_count);
 

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -164,10 +164,10 @@ static void log_id_cache_clear()
 	log_id_cache.clear();
 }
 
-void LogManager::logv_string(std::string_view prefix, std::string_view format, std::string str_in, LogSeverity severity) {
+void LogManager::logv_string(LogSeverity severity, std::string_view prefix, std::string_view format, std::string str_in) {
 	size_t remove_leading = 0;
 	while (format.size() > 1 && format[0] == '\n') {
-		logv_string(prefix, "\n", "\n", severity);
+		logv_string(severity, prefix, "\n", "\n");
 		format = format.substr(1);
 		++remove_leading;
 	}
@@ -230,13 +230,13 @@ void LogManager::logv_string(std::string_view prefix, std::string_view format, s
 	}
 }
 
-void LogManager::log_formatted_string(std::string_view prefix, std::string_view format, std::string str, LogSeverity severity)
+void LogManager::log_formatted_string(LogSeverity severity, std::string_view prefix, std::string_view format, std::string str)
 {
 	log_assert(!Multithreading::active());
 
 	if (log_make_debug && !is_debug(1))
 		return;
-	logv_string(prefix, format, std::move(str), severity);
+	logv_string(severity, prefix, format, std::move(str));
 }
 
 void LogManager::log_formatted_header(RTLIL::Design *design, std::string_view format, std::string str)
@@ -256,7 +256,7 @@ void LogManager::log_formatted_header(RTLIL::Design *design, std::string_view fo
 	for (int c : header_count)
 		header_id += stringf("%s%d", header_id.empty() ? "" : ".", c);
 
-	log_formatted_string(stringf("%s. ", header_id), format, std::move(str), LogSeverity::Header);
+	log_formatted_string(LogSeverity::Header, stringf("%s. ", header_id), format, std::move(str));
 	flush();
 
 	if (log_hdump_all)
@@ -312,12 +312,12 @@ void LogManager::log_formatted_warning(std::string_view prefix, std::string_view
 
 		if (log_warnings.count(message))
 		{
-			log_formatted_string(prefix, format, message, LogSeverity::Info);
+			log_formatted_string(LogSeverity::Info, prefix, format, message);
 			flush();
 		}
 		else
 		{
-			log_formatted_string(prefix, format, message, LogSeverity::Warning);
+			log_formatted_string(LogSeverity::Warning, prefix, format, message);
 			flush();
 			log_warnings.insert(message);
 		}
@@ -338,13 +338,13 @@ void LogManager::log_formatted_file_warning(std::string_view filename, int linen
 void LogManager::log_formatted_file_info(std::string_view filename, int lineno, std::string_view format, std::string str)
 {
 	std::string prefix = stringf("%s:%d: Info: ", filename, lineno);
-	log_formatted_string(prefix, format, std::move(str), LogSeverity::Info);
+	log_formatted_string(LogSeverity::Info, prefix, format, std::move(str));
 }
 
 void LogManager::log_suppressed() {
 	if (log_debug_suppressed && !log_make_debug) {
 		constexpr const char* format = "<suppressed ~%d debug messages>\n";
-		logv_string({}, format, stringf(format, log_debug_suppressed),LogSeverity::Info);
+		logv_string(LogSeverity::Info, {}, format, stringf(format, log_debug_suppressed));
 		log_debug_suppressed = 0;
 	}
 }
@@ -356,7 +356,7 @@ void LogManager::log_error_with_prefix(std::string_view prefix, std::string_view
 	log_make_debug = 0;
 	log_suppressed();
 
-	log_formatted_string(prefix, format, message, LogSeverity::Error);
+	log_formatted_string(LogSeverity::Error, prefix, format, message);
 	flush();
 
 	log_make_debug = bak_log_make_debug;
@@ -433,7 +433,7 @@ void log_yosys_abort_message(std::string_view file, int line, std::string_view f
 void LogManager::log_formatted_cmd_error(std::string_view format, std::string message)
 {
 	if (log_cmd_error_throw) {
-		log_formatted_string("ERROR: ", format, message, LogSeverity::Error);
+		log_formatted_string(LogSeverity::Error, "ERROR: ", format, message);
 		flush();
 
 		throw log_cmd_error_exception();

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -40,7 +40,6 @@ YOSYS_NAMESPACE_BEGIN
 
 std::vector<FILE*> log_files;
 std::vector<std::ostream*> log_streams;
-std::vector<LogSink*> log_sinks;
 std::vector<std::string> log_scratchpads;
 std::map<std::string, std::set<std::string>> log_hdump;
 std::vector<std::regex> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
@@ -70,7 +69,7 @@ int log_debug_suppressed = 0;
 vector<int> header_count;
 vector<char*> log_id_cache;
 
-static struct timeval initial_tv = { 0, 0 };
+static std::optional<std::chrono::steady_clock::time_point> initial_time;
 static bool next_print_log = false;
 static int log_newline_count = 0;
 
@@ -81,36 +80,56 @@ static void log_id_cache_clear()
 	log_id_cache.clear();
 }
 
-#if defined(_WIN32) && !defined(__MINGW32__)
-// this will get time information and return it in timeval, simulating gettimeofday()
-int gettimeofday(struct timeval *tv, struct timezone *tz)
+static void log_default_callback(LogMessage msg)
 {
-	LARGE_INTEGER counter;
-	LARGE_INTEGER freq;
+	std::string time_str;
+	if (log_time)
+	{
+		if (next_print_log || !initial_time) {
+			next_print_log = false;
+			if (!initial_time)
+    			initial_time = std::chrono::steady_clock::now();
+			auto elapsed = std::chrono::steady_clock::now() - *initial_time;
+			auto us = std::chrono::duration_cast<std::chrono::microseconds>(elapsed);
+			time_str += stringf("[%05d.%06d] ", int(us.count() / 1'000'000),int(us.count() % 1'000'000));
+		}
 
-	QueryPerformanceFrequency(&freq);
-	QueryPerformanceCounter(&counter);
+		if (!msg.format.empty() && msg.format.back() == '\n')
+			next_print_log = true;
 
-	counter.QuadPart *= 1'000'000;
-	counter.QuadPart /= freq.QuadPart;
+		// Special case to detect newlines in Python log output, since
+		// the binding always calls `log("%s", payload)` and the newline
+		// is then in the first formatted argument
+		if (msg.format == "%s" && msg.message.back() == '\n')
+			next_print_log = true;
+	}
 
-	tv->tv_sec = long(counter.QuadPart / 1000000);
-	tv->tv_usec = counter.QuadPart % 1'000'000;
+	std::string str = stringf("%s%s%s", time_str, msg.prefix, msg.message);
+	for (auto f : log_files) {
+		fputs(str.c_str(), f);
+	}
 
-	return 0;
+	for (auto f : log_streams)
+		*f << str;
+
+	RTLIL::Design *design = yosys_get_design();
+	if (design != nullptr)
+		for (auto &scratchpad : log_scratchpads)
+			design->scratchpad[scratchpad].append(str);
 }
-#endif
 
-static void logv_string(std::string_view format, std::string str, LogSeverity severity = LogSeverity::LOG_INFO) {
+static void logv_string(std::string_view prefix, std::string_view format, std::string str_in, LogSeverity severity) {
 	size_t remove_leading = 0;
 	while (format.size() > 1 && format[0] == '\n') {
-		logv_string("\n", "\n");
+		logv_string(prefix, "\n", "\n", severity);
 		format = format.substr(1);
 		++remove_leading;
 	}
 	if (remove_leading > 0) {
-		str = str.substr(remove_leading);
+		str_in = str_in.substr(remove_leading);
 	}
+
+	std::string str = stringf("%s%s",prefix,str_in);
 
 	if (str.empty())
 		return;
@@ -124,55 +143,7 @@ static void logv_string(std::string_view format, std::string str, LogSeverity se
 	if (log_hasher)
 		log_hasher->update(str);
 
-	if (log_time)
-	{
-		std::string time_str;
-
-		if (next_print_log || initial_tv.tv_sec == 0) {
-			next_print_log = false;
-			struct timeval tv;
-			gettimeofday(&tv, NULL);
-			if (initial_tv.tv_sec == 0)
-				initial_tv = tv;
-			if (tv.tv_usec < initial_tv.tv_usec) {
-				tv.tv_sec--;
-				tv.tv_usec += 1'000'000;
-			}
-			tv.tv_sec -= initial_tv.tv_sec;
-			tv.tv_usec -= initial_tv.tv_usec;
-			time_str += stringf("[%05d.%06d] ", int(tv.tv_sec), int(tv.tv_usec));
-		}
-
-		if (!format.empty() && format[format.size() - 1] == '\n')
-			next_print_log = true;
-
-		// Special case to detect newlines in Python log output, since
-		// the binding always calls `log("%s", payload)` and the newline
-		// is then in the first formatted argument
-		if (format == "%s" && str.back() == '\n')
-			next_print_log = true;
-
-		for (auto f : log_files)
-			fputs(time_str.c_str(), f);
-
-		for (auto f : log_streams)
-			*f << time_str;
-	}
-
-	for (auto f : log_files)
-		fputs(str.c_str(), f);
-
-	for (auto f : log_streams)
-		*f << str;
-
-	LogMessage log_msg(severity, str);
-	for (LogSink* sink : log_sinks)
-		sink->log(log_msg);
-
-	RTLIL::Design *design = yosys_get_design();
-	if (design != nullptr)
-		for (auto &scratchpad : log_scratchpads)
-			design->scratchpad[scratchpad].append(str);
+	log_default_callback(LogMessage(severity, prefix, format, str_in));
 
 	static std::string linebuffer;
 	static bool log_warn_regex_recusion_guard = false;
@@ -206,13 +177,13 @@ static void logv_string(std::string_view format, std::string str, LogSeverity se
 	}
 }
 
-void log_formatted_string(std::string_view format, std::string str, LogSeverity severity)
+void log_formatted_string(std::string_view prefix, std::string_view format, std::string str, LogSeverity severity)
 {
 	log_assert(!Multithreading::active());
 
 	if (log_make_debug && !ys_debug(1))
 		return;
-	logv_string(format, std::move(str), severity);
+	logv_string(prefix, format, std::move(str), severity);
 }
 
 void log_formatted_header(RTLIL::Design *design, std::string_view format, std::string str)
@@ -235,8 +206,8 @@ void log_formatted_header(RTLIL::Design *design, std::string_view format, std::s
 	for (int c : header_count)
 		header_id += stringf("%s%d", header_id.empty() ? "" : ".", c);
 
-	log("%s. ", header_id);
-	log_formatted_string(format, std::move(str));
+	log_formatted_string(stringf("%s. ", header_id), {}, {}, LogSeverity::LOG_HEADER);
+	log_formatted_string({}, format, std::move(str), LogSeverity::LOG_HEADER);
 	log_flush();
 
 	if (log_hdump_all)
@@ -277,7 +248,7 @@ void log_formatted_warning(std::string_view prefix, std::string message)
 
 		for (auto &re : log_werror_regexes)
 			if (std::regex_search(message, re))
-				log_error("%s", message);
+				log_formatted_error(message);
 
 		bool warning_match = false;
 		for (auto &[_, item] : log_expect_warning)
@@ -294,7 +265,7 @@ void log_formatted_warning(std::string_view prefix, std::string message)
 
 		if (log_warnings.count(message))
 		{
-			log("%s%s", prefix, message);
+			log_formatted_string(prefix, "%s", message, LogSeverity::LOG_WARNING);
 			log_flush();
 		}
 		else
@@ -302,7 +273,7 @@ void log_formatted_warning(std::string_view prefix, std::string message)
 			if (log_errfile != NULL && !log_quiet_warnings)
 				log_files.push_back(log_errfile);
 
-			log_formatted_string("%s", stringf("%s%s", prefix, message), LogSeverity::LOG_WARNING);
+			log_formatted_string(prefix, "%s", message, LogSeverity::LOG_WARNING);
 			log_flush();
 
 			if (log_errfile != NULL && !log_quiet_warnings)
@@ -332,7 +303,7 @@ void log_formatted_file_info(std::string_view filename, int lineno, std::string 
 void log_suppressed() {
 	if (log_debug_suppressed && !log_make_debug) {
 		constexpr const char* format = "<suppressed ~%d debug messages>\n";
-		logv_string(format, stringf(format, log_debug_suppressed));
+		logv_string({}, format, stringf(format, log_debug_suppressed),LogSeverity::LOG_INFO);
 		log_debug_suppressed = 0;
 	}
 }
@@ -357,7 +328,7 @@ static void log_error_with_prefix(std::string_view prefix, std::string str)
 	log_last_error = std::move(str);
 	std::string message(prefix);
 	message += log_last_error;
-	log_formatted_string("%s", message, LogSeverity::LOG_ERROR);
+	log_formatted_string(prefix, "%s", log_last_error, LogSeverity::LOG_ERROR);
 	log_flush();
 
 	log_make_debug = bak_log_make_debug;
@@ -434,7 +405,7 @@ void log_formatted_cmd_error(std::string str)
 			pop_errfile = true;
 		}
 
-		log_formatted_string("%s", stringf("ERROR: %s", log_last_error), LogSeverity::LOG_ERROR);
+		log_formatted_string("ERROR: ", "%s", log_last_error, LogSeverity::LOG_ERROR);
 		log_flush();
 
 		if (pop_errfile)

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -101,7 +101,7 @@ bool StderrLogSink::should_log(const LogMessage &msg) const
 {
 	return msg.severity == LogSeverity::LOG_ERROR ||
 			(msg.severity == LogSeverity::LOG_WARNING && !quiet_warnings) ||
-			logger().get_stderr_force();
+			logger().get_log_forced();
 }
 
 void StderrLogSink::log(const LogMessage &msg)
@@ -248,7 +248,7 @@ void LogManager::log_formatted_header(RTLIL::Design *design, std::string_view fo
 		header_count.back()++;
 
 	if (int(header_count.size()) <= log_verbose_level) {
-		log_stderr_force = true;
+		log_forced = true;
 	}
 
 	std::string header_id;
@@ -271,7 +271,7 @@ void LogManager::log_formatted_header(RTLIL::Design *design, std::string_view fo
 			if (yosys_xtrace)
 				log("#X# -- end of dump --\n");
 		}
-	log_stderr_force = false;
+	log_forced = false;
 }
 
 void LogManager::log_formatted_warning(std::string_view prefix, std::string_view format, std::string message)
@@ -368,6 +368,8 @@ void LogManager::log_error_with_prefix(std::string_view prefix, std::string_view
 	for (auto &[_, item] : log_expect_prefix_error)
 		if (std::regex_search(string(prefix) + message, item.pattern))
 			item.current_count++;
+
+	log_errors_count++;
 
 	check_expected();
 
@@ -670,17 +672,6 @@ void LogManager::report_unexpected_error()
 	if (log_expect_no_warnings && log_warnings_count_noexpect)
 		log_error("Unexpected warnings found: %d unique messages, %d total, %d expected\n", GetSize(log_warnings),
 					log_warnings_count, log_warnings_count - log_warnings_count_noexpect);
-}
-
-
-void LogManager::report_warning_stats(bool stderr_force)
-{
-	log_stderr_force = stderr_force;
-	if (log_warnings_count)
-		log("Warnings: %d unique messages, %d total\n", GetSize(log_warnings), log_warnings_count);
-
-	if (!log_experimentals.empty())
-		log("Warnings: %d experimental features used (not excluded with -x).\n", GetSize(log_experimentals));
 }
 
 void LogManager::add_expect(std::string type, std::string pattern, int count)

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -38,40 +38,19 @@
 
 YOSYS_NAMESPACE_BEGIN
 
-std::vector<std::unique_ptr<LogSink>> log_sinks;
-
-std::map<std::string, std::set<std::string>> log_hdump;
-std::vector<std::regex> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
-dict<std::string, LogExpectedItem> log_expect_log, log_expect_warning, log_expect_error;
-dict<std::string, LogExpectedItem> log_expect_prefix_log, log_expect_prefix_warning, log_expect_prefix_error;
-std::set<std::string> log_warnings, log_experimentals, log_experimentals_ignored;
-int log_warnings_count = 0;
-int log_warnings_count_noexpect = 0;
-bool log_expect_no_warnings = false;
-bool log_hdump_all = false;
-SHA1 *log_hasher = NULL;
-
-bool log_time = false;
-bool log_error_stderr = false;
-bool log_cmd_error_throw = false;
-bool log_quiet_warnings = false;
-int log_verbose_level;
+LogManager &logger()
+{
+    static LogManager instance;
+    return instance;
+}
 
 void (*log_error_atexit)() = NULL;
 void (*log_verific_callback)(int msg_type, const char *message_id, const char* file_path, unsigned int left_line, unsigned int left_col, unsigned int right_line, unsigned int right_col, const char *msg) = NULL;
 
-int log_make_debug = 0;
-int log_force_debug = 0;
-int log_debug_suppressed = 0;
-
-bool log_stderr_force = false;
-
-vector<int> header_count;
+// TODO: remove when log_id is removed
 vector<char*> log_id_cache;
 
-static std::optional<std::chrono::steady_clock::time_point> initial_time;
 static bool next_print_log = false;
-static int log_newline_count = 0;
 
 FileLogSink::FileLogSink(const std::string &filename, bool line_buffered, bool append)
 	: file(fopen(filename.c_str(), append ? "at" : "wt"))
@@ -92,7 +71,7 @@ FileLogSink::~FileLogSink()
 
 void FileLogSink::log(const LogMessage &msg)
 {
-	fputs(msg.legacy_msg.c_str(), file);
+	fputs(msg.cached_msg.c_str(), file);
 }
 
 void FileLogSink::flush()
@@ -102,8 +81,8 @@ void FileLogSink::flush()
 
 void ConsoleLogSink::log(const LogMessage &msg)
 {
-	FILE *file = (msg.severity == LogSeverity::LOG_ERROR && log_error_stderr) ? stderr : stdout;
-	fputs(msg.legacy_msg.c_str(), file);
+	FILE *file = (msg.severity == LogSeverity::LOG_ERROR && logger().get_error_stderr()) ? stderr : stdout;
+	fputs(msg.cached_msg.c_str(), file);
 }
 
 void ConsoleLogSink::flush()
@@ -115,14 +94,13 @@ void ConsoleLogSink::flush()
 bool StderrLogSink::should_log(const LogMessage &msg) const
 {
 	return msg.severity == LogSeverity::LOG_ERROR ||
-			(msg.severity == LogSeverity::LOG_WARNING && !log_quiet_warnings) ||
-			/* (msg.severity == LogSeverity::LOG_HEADER && int(header_count.size()) <= log_verbose_level) || */
-			log_stderr_force;
+			(msg.severity == LogSeverity::LOG_WARNING && !logger().get_quiet_warnings()) ||
+			logger().get_stderr_force();
 }
 
 void StderrLogSink::log(const LogMessage &msg)
 {
-	fputs(msg.legacy_msg.c_str(), stderr);
+	fputs(msg.cached_msg.c_str(), stderr);
 }
 
 void StderrLogSink::flush()
@@ -131,7 +109,7 @@ void StderrLogSink::flush()
 }
 
 ScratchPadLogSink::ScratchPadLogSink(std::string scratchpad)
-    : scratchpad(std::move(scratchpad))
+	: scratchpad(std::move(scratchpad))
 {
 }
 
@@ -141,7 +119,7 @@ void ScratchPadLogSink::log(const LogMessage &msg)
 	if (!design)
 		return;
 
-	design->scratchpad[scratchpad].append(msg.legacy_msg);
+	design->scratchpad[scratchpad].append(msg.cached_msg);
 }
 
 LogMessage::LogMessage(LogSeverity severity, std::string_view prefix, std::string_view format, std::string_view message) :
@@ -152,13 +130,11 @@ LogMessage::LogMessage(LogSeverity severity, std::string_view prefix, std::strin
 	timestamp(std::chrono::steady_clock::now())
 {
 	std::string time_str;
-	if (log_time)
+	if (logger().get_log_time())
 	{
-		if (next_print_log || !initial_time) {
+		if (next_print_log) {
 			next_print_log = false;
-			if (!initial_time)
-    			initial_time = std::chrono::steady_clock::now();
-			auto elapsed = std::chrono::steady_clock::now() - *initial_time;
+			auto elapsed = std::chrono::steady_clock::now() - logger().get_initial_time();
 			auto us = std::chrono::duration_cast<std::chrono::microseconds>(elapsed);
 			time_str += stringf("[%05d.%06d] ", int(us.count() / 1'000'000),int(us.count() % 1'000'000));
 		}
@@ -172,7 +148,7 @@ LogMessage::LogMessage(LogSeverity severity, std::string_view prefix, std::strin
 		if (format == "%s" && message.back() == '\n')
 			next_print_log = true;
 	}
-	legacy_msg = stringf("%s%s%s", time_str, prefix, message);
+	cached_msg = stringf("%s%s%s", time_str, prefix, message);
 }
 
 static void log_id_cache_clear()
@@ -182,7 +158,7 @@ static void log_id_cache_clear()
 	log_id_cache.clear();
 }
 
-static void logv_string(std::string_view prefix, std::string_view format, std::string str_in, LogSeverity severity) {
+void LogManager::logv_string(std::string_view prefix, std::string_view format, std::string str_in, LogSeverity severity) {
 	size_t remove_leading = 0;
 	while (format.size() > 1 && format[0] == '\n') {
 		logv_string(prefix, "\n", "\n", severity);
@@ -208,10 +184,7 @@ static void logv_string(std::string_view prefix, std::string_view format, std::s
 		log_hasher->update(str);
 
 	auto msg = LogMessage(severity, prefix, format, str_in);
-	for (auto &sink : log_sinks) {
-		if (sink->should_log(msg))
-			sink->log(msg);
-	}
+	log(msg);
 
 	static std::string linebuffer;
 	static bool log_warn_regex_recusion_guard = false;
@@ -245,16 +218,16 @@ static void logv_string(std::string_view prefix, std::string_view format, std::s
 	}
 }
 
-void log_formatted_string(std::string_view prefix, std::string_view format, std::string str, LogSeverity severity)
+void LogManager::log_formatted_string(std::string_view prefix, std::string_view format, std::string str, LogSeverity severity)
 {
 	log_assert(!Multithreading::active());
 
-	if (log_make_debug && !ys_debug(1))
+	if (log_make_debug && !is_debug(1))
 		return;
 	logv_string(prefix, format, std::move(str), severity);
 }
 
-void log_formatted_header(RTLIL::Design *design, std::string_view format, std::string str)
+void LogManager::log_formatted_header(RTLIL::Design *design, std::string_view format, std::string str)
 {
 	log_assert(!Multithreading::active());
 
@@ -273,24 +246,24 @@ void log_formatted_header(RTLIL::Design *design, std::string_view format, std::s
 
 	log_formatted_string(stringf("%s. ", header_id), {}, {}, LogSeverity::LOG_HEADER);
 	log_formatted_string({}, format, std::move(str), LogSeverity::LOG_HEADER);
-	log_flush();
+	flush();
 
 	if (log_hdump_all)
 		log_hdump[header_id].insert("yosys_dump_" + header_id + ".il");
 
 	if (log_hdump.count(header_id) && design != nullptr)
 		for (auto &filename : log_hdump.at(header_id)) {
-			log("Dumping current design to '%s'.\n", filename);
+			YOSYS_NAMESPACE_PREFIX log("Dumping current design to '%s'.\n", filename);
 			if (yosys_xtrace)
 				IdString::xtrace_db_dump();
 			Pass::call(design, {"dump", "-o", filename});
 			if (yosys_xtrace)
-				log("#X# -- end of dump --\n");
+				YOSYS_NAMESPACE_PREFIX log("#X# -- end of dump --\n");
 		}
 	log_stderr_force = false;
 }
 
-void log_formatted_warning(std::string_view prefix, std::string message)
+void LogManager::log_formatted_warning(std::string_view prefix, std::string message)
 {
 	log_assert(!Multithreading::active());
 
@@ -302,7 +275,7 @@ void log_formatted_warning(std::string_view prefix, std::string message)
 
 	if (suppressed)
 	{
-		log("Suppressed %s%s", prefix, message);
+		YOSYS_NAMESPACE_PREFIX log("Suppressed %s%s", prefix, message);
 	}
 	else
 	{
@@ -329,12 +302,12 @@ void log_formatted_warning(std::string_view prefix, std::string message)
 		if (log_warnings.count(message))
 		{
 			log_formatted_string(prefix, "%s", message, LogSeverity::LOG_INFO);
-			log_flush();
+			flush();
 		}
 		else
 		{
 			log_formatted_string(prefix, "%s", message, LogSeverity::LOG_WARNING);
-			log_flush();
+			flush();
 			log_warnings.insert(message);
 		}
 
@@ -345,18 +318,18 @@ void log_formatted_warning(std::string_view prefix, std::string message)
 	}
 }
 
-void log_formatted_file_warning(std::string_view filename, int lineno, std::string str)
+void LogManager::log_formatted_file_warning(std::string_view filename, int lineno, std::string str)
 {
 	std::string prefix = stringf("%s:%d: Warning: ", filename, lineno);
 	log_formatted_warning(prefix, std::move(str));
 }
 
-void log_formatted_file_info(std::string_view filename, int lineno, std::string str)
+void LogManager::log_formatted_file_info(std::string_view filename, int lineno, std::string str)
 {
-	log("%s:%d: Info: %s", filename, lineno, str);
+	YOSYS_NAMESPACE_PREFIX log("%s:%d: Info: %s", filename, lineno, str);
 }
 
-void log_suppressed() {
+void LogManager::log_suppressed() {
 	if (log_debug_suppressed && !log_make_debug) {
 		constexpr const char* format = "<suppressed ~%d debug messages>\n";
 		logv_string({}, format, stringf(format, log_debug_suppressed),LogSeverity::LOG_INFO);
@@ -365,14 +338,14 @@ void log_suppressed() {
 }
 
 [[noreturn]]
-static void log_error_with_prefix(std::string_view prefix, std::string message)
+void LogManager::log_error_with_prefix(std::string_view prefix, std::string message)
 {
 	int bak_log_make_debug = log_make_debug;
 	log_make_debug = 0;
 	log_suppressed();
 
 	log_formatted_string(prefix, "%s", message, LogSeverity::LOG_ERROR);
-	log_flush();
+	flush();
 
 	log_make_debug = bak_log_make_debug;
 
@@ -384,7 +357,7 @@ static void log_error_with_prefix(std::string_view prefix, std::string message)
 		if (std::regex_search(string(prefix) + message, item.pattern))
 			item.current_count++;
 
-	log_check_expected();
+	check_expected();
 
 	if (log_error_atexit)
 		log_error_atexit();
@@ -401,13 +374,13 @@ static void log_error_with_prefix(std::string_view prefix, std::string message)
 #endif
 }
 
-void log_formatted_file_error(std::string_view filename, int lineno, std::string str)
+void LogManager::log_formatted_file_error(std::string_view filename, int lineno, std::string str)
 {
 	std::string prefix = stringf("%s:%d: ERROR: ", filename, lineno);
 	log_error_with_prefix(prefix, str);
 }
 
-void log_experimental(const std::string &str)
+void LogManager::log_experimental(const std::string &str)
 {
 	if (log_experimentals_ignored.count(str) == 0 && log_experimentals.count(str) == 0) {
 		log_warning("Feature '%s' is experimental.\n", str);
@@ -415,7 +388,7 @@ void log_experimental(const std::string &str)
 	}
 }
 
-void log_formatted_error(std::string str)
+void LogManager::log_formatted_error(std::string str)
 {
 	log_error_with_prefix("ERROR: ", std::move(str));
 }
@@ -435,11 +408,11 @@ void log_yosys_abort_message(std::string_view file, int line, std::string_view f
 	log_error("Abort in %s:%d (%s): %s\n", file, line, func, message);
 }
 
-void log_formatted_cmd_error(std::string message)
+void LogManager::log_formatted_cmd_error(std::string message)
 {
 	if (log_cmd_error_throw) {
 		log_formatted_string("ERROR: ", "%s", message, LogSeverity::LOG_ERROR);
-		log_flush();
+		flush();
 
 		throw log_cmd_error_exception();
 	}
@@ -447,22 +420,22 @@ void log_formatted_cmd_error(std::string message)
 	log_formatted_error(message);
 }
 
-void log_spacer()
+void LogManager::log_spacer()
 {
-	if (log_newline_count < 2) log("\n");
-	if (log_newline_count < 2) log("\n");
+	if (log_newline_count < 2) YOSYS_NAMESPACE_PREFIX log("\n");
+	if (log_newline_count < 2) YOSYS_NAMESPACE_PREFIX log("\n");
 }
 
-void log_push()
+void LogManager::log_push()
 {
 	header_count.push_back(0);
 }
 
-void log_pop()
+void LogManager::log_pop()
 {
 	header_count.pop_back();
 	log_id_cache_clear();
-	log_flush();
+	flush();
 }
 
 #if defined(YOSYS_ENABLE_DLOPEN)
@@ -562,18 +535,12 @@ void log_backtrace(const char *prefix, int levels)
 void log_backtrace(const char*, int) { }
 #endif
 
-void log_reset_stack()
+void LogManager::log_reset_stack()
 {
 	while (header_count.size() > 1)
 		header_count.pop_back();
 	log_id_cache_clear();
-	log_flush();
-}
-
-void log_flush()
-{
-	for (auto &sink : log_sinks)
-		sink->flush();
+	flush();
 }
 
 void log_dump_val_worker(RTLIL::IdString v) {
@@ -631,7 +598,7 @@ void log_wire(RTLIL::Wire *wire, std::string indent)
 	log("%s", buf.str());
 }
 
-void log_check_expected()
+void LogManager::check_expected()
 {
 	// copy out all of the expected logs so that they cannot be re-checked
 	// or match against themselves
@@ -668,7 +635,7 @@ void log_check_expected()
 	auto check_err = [&](const std::string kind, std::string pattern, LogExpectedItem item) {
 		if (item.current_count == item.expected_count) {
 			log_warn_regexes.clear();
-			log("Expected %s pattern '%s' found !!!\n", kind, pattern);
+			YOSYS_NAMESPACE_PREFIX log("Expected %s pattern '%s' found !!!\n", kind, pattern);
 			yosys_shutdown();
 			#if defined(_MSC_VER)
 				_exit(0);
@@ -686,4 +653,51 @@ void log_check_expected()
 		check_err("prefixed error", pattern, item);
 }
 
+void LogManager::report_unexpected_error()
+{
+	if (log_expect_no_warnings && log_warnings_count_noexpect)
+		log_error("Unexpected warnings found: %d unique messages, %d total, %d expected\n", GetSize(log_warnings),
+					log_warnings_count, log_warnings_count - log_warnings_count_noexpect);
+}
+
+
+void LogManager::report_warning_stats()
+{
+	if (log_warnings_count)
+		YOSYS_NAMESPACE_PREFIX log("Warnings: %d unique messages, %d total\n", GetSize(log_warnings), log_warnings_count);
+
+	if (!log_experimentals.empty())
+		YOSYS_NAMESPACE_PREFIX log("Warnings: %d experimental features used (not excluded with -x).\n", GetSize(log_experimentals));
+}
+
+void LogManager::add_expect(std::string type, std::string pattern, int count)
+{
+	if (type == "error")
+		log_expect_error[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
+	else if (type == "prefix-error")
+		log_expect_prefix_error[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
+	else if (type == "warning")
+		log_expect_warning[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
+	else if (type == "prefix-warning")
+		log_expect_prefix_warning[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
+	else if (type == "log")
+		log_expect_log[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
+	else if (type == "prefix-log")
+		log_expect_prefix_log[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
+	else log_abort();
+}
+void LogManager::start_hasher()
+{
+	log_hasher = std::make_unique<SHA1>();
+}
+
+std::string LogManager::finish_hasher()
+{
+	if (!log_hasher)
+		return {};
+
+	std::string hash = log_hasher->final().substr(0, 10);
+	log_hasher.reset();
+	return hash;
+}
 YOSYS_NAMESPACE_END

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -404,8 +404,10 @@ void LogManager::log_experimental(const std::string &str)
 
 void LogManager::log_deprecated(const std::string &str)
 {
-	log_warning("Feature '%s' is deprecated.\n", str);
-	deprecated.insert(str);
+	if (deprecated.count(str) == 0) {
+		log_warning("Feature '%s' is deprecated.\n", str);
+		deprecated.insert(str);
+	}
 }
 
 void LogManager::log_formatted_error(std::string_view format, std::string str)

--- a/kernel/log.cc
+++ b/kernel/log.cc
@@ -102,7 +102,7 @@ void FileLogSink::flush()
 
 void ConsoleLogSink::log(const LogMessage &msg)
 {
-	FILE *file = msg.severity == LogSeverity::LOG_ERROR ? stderr : stdout;
+	FILE *file = (msg.severity == LogSeverity::LOG_ERROR && log_error_stderr) ? stderr : stdout;
 	fputs(msg.legacy_msg.c_str(), file);
 }
 

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -91,9 +91,22 @@ enum LogSeverity {
 	LOG_ERROR
 };
 
+struct LogMessage {
+	LogMessage(LogSeverity severity, std::string_view message) :
+		severity(severity), timestamp(std::time(nullptr)), message(message) {}
+	LogSeverity severity;
+	std::time_t timestamp;
+	std::string message;
+};
+
+class LogSink {
+ public:
+	virtual void log(const LogMessage& message) = 0;
+};
+
 extern std::vector<FILE*> log_files;
 extern std::vector<std::ostream*> log_streams;
-extern std::vector<std::ostream*> log_warning_streams;
+extern std::vector<LogSink*> log_sinks;
 extern std::vector<std::string> log_scratchpads;
 extern std::map<std::string, std::set<std::string>> log_hdump;
 extern std::vector<std::regex> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -85,8 +85,15 @@ YOSYS_NAMESPACE_BEGIN
 
 struct log_cmd_error_exception { };
 
+enum LogSeverity {
+	LOG_INFO,
+	LOG_WARNING,
+	LOG_ERROR
+};
+
 extern std::vector<FILE*> log_files;
 extern std::vector<std::ostream*> log_streams;
+extern std::vector<std::ostream*> log_warning_streams;
 extern std::vector<std::string> log_scratchpads;
 extern std::map<std::string, std::set<std::string>> log_hdump;
 extern std::vector<std::regex> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
@@ -120,12 +127,10 @@ static inline bool ys_debug(int = 0) { return false; }
 #endif
 #  define log_debug(...) do { if (ys_debug(1)) log(__VA_ARGS__); } while (0)
 
-void log_formatted_string(std::string_view format, std::string str);
+void log_formatted_string(std::string_view format, std::string str, LogSeverity severity = LogSeverity::LOG_INFO);
 template <typename... Args>
 inline void log(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	if (log_make_debug && !ys_debug(1))
-		return;
 	log_formatted_string(fmt.format_string(), fmt.format(args...));
 }
 

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -22,6 +22,7 @@
 
 #include "kernel/yosys_common.h"
 
+#include <chrono>
 #include <time.h>
 
 #include <regex>
@@ -86,27 +87,30 @@ YOSYS_NAMESPACE_BEGIN
 struct log_cmd_error_exception { };
 
 enum LogSeverity {
+	LOG_DEBUG,
+	LOG_COMMENT,
 	LOG_INFO,
+	LOG_HEADER,
 	LOG_WARNING,
 	LOG_ERROR
 };
 
 struct LogMessage {
-	LogMessage(LogSeverity severity, std::string_view message) :
-		severity(severity), timestamp(std::time(nullptr)), message(message) {}
+	LogMessage(LogSeverity severity, std::string_view prefix, std::string_view format, std::string_view message) :
+		severity(severity),
+		prefix(prefix),
+		format(format),
+		message(message),
+		timestamp(std::chrono::steady_clock::now()) {}
 	LogSeverity severity;
-	std::time_t timestamp;
+	std::string prefix;
+	std::string format;
 	std::string message;
-};
-
-class LogSink {
- public:
-	virtual void log(const LogMessage& message) = 0;
+	std::chrono::steady_clock::time_point timestamp;
 };
 
 extern std::vector<FILE*> log_files;
 extern std::vector<std::ostream*> log_streams;
-extern std::vector<LogSink*> log_sinks;
 extern std::vector<std::string> log_scratchpads;
 extern std::map<std::string, std::set<std::string>> log_hdump;
 extern std::vector<std::regex> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
@@ -138,13 +142,26 @@ static inline bool ys_debug(int n = 0) { if (log_force_debug) return true; log_d
 #else
 static inline bool ys_debug(int = 0) { return false; }
 #endif
-#  define log_debug(...) do { if (ys_debug(1)) log(__VA_ARGS__); } while (0)
 
-void log_formatted_string(std::string_view format, std::string str, LogSeverity severity = LogSeverity::LOG_INFO);
+void log_formatted_string(std::string_view prefix, std::string_view format, std::string str, LogSeverity severity);
 template <typename... Args>
 inline void log(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	log_formatted_string(fmt.format_string(), fmt.format(args...));
+	log_formatted_string({}, fmt.format_string(), fmt.format(args...), LogSeverity::LOG_INFO);
+}
+
+template <typename... Args>
+inline void log_comment(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
+{
+	log_formatted_string({}, fmt.format_string(), fmt.format(args...), LogSeverity::LOG_COMMENT);
+}
+
+template <typename... Args>
+inline void log_debug(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
+{
+    if (!ys_debug(1))
+        return;
+    log_formatted_string({}, fmt.format_string(), fmt.format(args...), LogSeverity::LOG_DEBUG);
 }
 
 void log_formatted_header(RTLIL::Design *design, std::string_view format, std::string str);
@@ -163,12 +180,12 @@ inline void log_warning(FmtString<TypeIdentity<Args>...> fmt, const Args &... ar
 
 inline void log_formatted_warning_noprefix(std::string str)
 {
-	log_formatted_warning("", str);
+	log_formatted_warning({}, str);
 }
 template <typename... Args>
 inline void log_warning_noprefix(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	log_formatted_warning("", fmt.format(args...));
+	log_formatted_warning({}, fmt.format(args...));
 }
 
 void log_experimental(const std::string &str);
@@ -185,8 +202,6 @@ void log_formatted_file_info(std::string_view filename, int lineno, std::string 
 template <typename... Args>
 void log_file_info(std::string_view filename, int lineno, FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	if (log_make_debug && !ys_debug(1))
-		return;
 	log_formatted_file_info(filename, lineno, fmt.format(args...));
 }
 

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -388,10 +388,8 @@ public:
 	void set_log_time(bool value) { log_time = value; }
 	void set_cmd_error_throw(bool value) { log_cmd_error_throw = value; }
 	void set_hdump_all(bool value) { log_hdump_all = value; }
-	void set_log_forced(bool value) { log_forced = value; }
 	int get_verbose_level() const { return log_verbose_level; }
 	bool get_log_time() const { return log_time; }
-	bool get_log_forced() const { return log_forced; }
 	int get_warnings_unique() const { return GetSize(log_warnings); }
 	int get_warnings_total() const { return log_warnings_count; }
 	int get_errors_total() const { return log_errors_count; }
@@ -447,7 +445,6 @@ private:
 	bool log_expect_no_warnings = false;
 	bool log_time = false;
 	bool log_cmd_error_throw = false;
-	bool log_forced = false;
 	std::map<std::string, std::set<std::string>> log_hdump;
 	bool log_hdump_all = false;
 

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -219,14 +219,6 @@ public:
 			func(*sink);
 	}
 
-	void log(const LogMessage &msg)
-	{
-		for (auto &sink : log_sinks) {
-			if (sink->should_log(msg))
-				sink->log(msg);
-		}
-	}
-
 	bool empty() { return log_sinks.empty(); }
 	void clear() { log_sinks.clear(); }
 	void flush() { for (auto &sink : log_sinks) sink->flush(); }
@@ -404,7 +396,7 @@ public:
 	bool get_error_stderr() const { return log_error_stderr; }
 	bool get_quiet_warnings() const { return log_quiet_warnings; }
 	bool get_stderr_force() const { return log_stderr_force; }
-	std::chrono::steady_clock::time_point get_initial_time() const { return initial_time; }
+	std::chrono::steady_clock::time_point get_initial_time() const;
 
 	void add_hdump(std::string name, std::string value) { log_hdump[name].insert(value); }
 
@@ -438,7 +430,6 @@ private:
 	void logv_string(std::string_view prefix, std::string_view format, std::string str_in, LogSeverity severity);
 	[[noreturn]] void log_error_with_prefix(std::string_view prefix, std::string message);
 
-	std::chrono::steady_clock::time_point initial_time = std::chrono::steady_clock::now();
 	std::vector<std::unique_ptr<LogSink>> log_sinks;
 	int log_verbose_level = 0;
 	int log_newline_count = 0;

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -394,14 +394,14 @@ public:
 
 	void log_formatted_string(std::string_view prefix, std::string_view format, std::string str, LogSeverity severity);
 	void log_formatted_header(RTLIL::Design *design, std::string_view format, std::string str);
-	void log_formatted_warning(std::string_view prefix, std::string message);
-	void log_formatted_file_warning(std::string_view filename, int lineno, std::string str);
-	void log_formatted_file_info(std::string_view filename, int lineno, std::string str);
+	void log_formatted_warning(std::string_view prefix, std::string_view format, std::string message);
+	void log_formatted_file_warning(std::string_view filename, int lineno, std::string_view format, std::string str);
+	void log_formatted_file_info(std::string_view filename, int lineno, std::string_view format, std::string str);
 	void log_suppressed();
-	[[noreturn]] void log_formatted_file_error(std::string_view filename, int lineno, std::string str);
+	[[noreturn]] void log_formatted_file_error(std::string_view filename, int lineno, std::string_view format, std::string str);
 	void log_experimental(const std::string &str);
-	[[noreturn]] void log_formatted_error(std::string str);
-	[[noreturn]] void log_formatted_cmd_error(std::string message);
+	[[noreturn]] void log_formatted_error(std::string_view format, std::string str);
+	[[noreturn]] void log_formatted_cmd_error(std::string_view format, std::string message);
 	void log_spacer();
 	void log_push();
 	void log_pop();
@@ -420,7 +420,7 @@ public:
 
 private:
 	void logv_string(std::string_view prefix, std::string_view format, std::string str_in, LogSeverity severity);
-	[[noreturn]] void log_error_with_prefix(std::string_view prefix, std::string message);
+	[[noreturn]] void log_error_with_prefix(std::string_view prefix, std::string_view format, std::string message);
 
 	std::vector<std::unique_ptr<LogSink>> log_sinks;
 	int log_verbose_level = 0;
@@ -488,13 +488,13 @@ inline void log_header(RTLIL::Design *design, FmtString<TypeIdentity<Args>...> f
 template <typename... Args>
 inline void log_warning(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_warning("Warning: ", fmt.format(args...));
+	logger().log_formatted_warning("Warning: ", fmt.format_string(), fmt.format(args...));
 }
 
 template <typename... Args>
 inline void log_warning_noprefix(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_warning({}, fmt.format(args...));
+	logger().log_formatted_warning({}, fmt.format_string(), fmt.format(args...));
 }
 
 inline void log_experimental(const std::string &str)
@@ -506,31 +506,31 @@ inline void log_experimental(const std::string &str)
 template <typename... Args>
 void log_file_warning(std::string_view filename, int lineno, FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_file_warning(filename, lineno, fmt.format(args...));
+	logger().log_formatted_file_warning(filename, lineno, fmt.format_string(), fmt.format(args...));
 }
 
 template <typename... Args>
 void log_file_info(std::string_view filename, int lineno, FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_file_info(filename, lineno, fmt.format(args...));
+	logger().log_formatted_file_info(filename, lineno, fmt.format_string(), fmt.format(args...));
 }
 
 template <typename... Args>
 [[noreturn]] void log_error(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_error(fmt.format(args...));
+	logger().log_formatted_error(fmt.format_string(), fmt.format(args...));
 }
 
 template <typename... Args>
 [[noreturn]] void log_file_error(std::string_view filename, int lineno, FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_file_error(filename, lineno, fmt.format(args...));
+	logger().log_formatted_file_error(filename, lineno, fmt.format_string(), fmt.format(args...));
 }
 
 template <typename... Args>
 [[noreturn]] void log_cmd_error(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_cmd_error(fmt.format(args...));
+	logger().log_formatted_cmd_error(fmt.format_string(), fmt.format(args...));
 }
 
 inline void log_suppressed()

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -166,7 +166,7 @@ class StreamLogSink : public LogSink
 {
 public:
 	explicit StreamLogSink(std::ostream &stream) : stream(stream) {}
-	void log(const LogMessage &msg) override { stream << msg.message; }
+	void log(const LogMessage &msg) override { stream << msg.cached_msg; }
 	void flush() override { stream.flush(); }
 
 private:

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -371,7 +371,6 @@ public:
 	void set_force_debug(bool enabled) { log_force_debug = enabled ? 1 : 0;	}
 
 	void report_unexpected_error();
-	void report_warning_stats(bool stderr_force);
 
 	void add_experimental_ignore(std::string name) { log_experimentals_ignored.insert(name); }
 	void add_warn(std::string pattern) { log_warn_regexes.push_back(YS_REGEX_COMPILE(pattern)); }
@@ -385,9 +384,14 @@ public:
 	void set_log_time(bool value) { log_time = value; }
 	void set_cmd_error_throw(bool value) { log_cmd_error_throw = value; }
 	void set_hdump_all(bool value) { log_hdump_all = value; }
+	void set_log_forced(bool value) { log_forced = value; }
 	int get_verbose_level() const { return log_verbose_level; }
 	bool get_log_time() const { return log_time; }
-	bool get_stderr_force() const { return log_stderr_force; }
+	bool get_log_forced() const { return log_forced; }
+	int get_warnings_unique() const { return GetSize(log_warnings); }
+	int get_warnings_total() const { return log_warnings_count; }
+	int get_errors_total() const { return log_errors_count; }
+	int get_experimentals_num() const { return GetSize(log_experimentals); }
 	std::chrono::steady_clock::time_point get_initial_time() const;
 
 	void add_hdump(std::string name, std::string value) { log_hdump[name].insert(value); }
@@ -426,6 +430,7 @@ private:
 	int log_verbose_level = 0;
 	int log_newline_count = 0;
 	vector<int> header_count;
+	int log_errors_count = 0;
 	int log_warnings_count = 0;
 	int log_warnings_count_noexpect = 0;
 	std::set<std::string> log_warnings, log_experimentals, log_experimentals_ignored;
@@ -436,7 +441,7 @@ private:
 	bool log_expect_no_warnings = false;
 	bool log_time = false;
 	bool log_cmd_error_throw = false;
-	bool log_stderr_force = false;
+	bool log_forced = false;
 	std::map<std::string, std::set<std::string>> log_hdump;
 	bool log_hdump_all = false;
 

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -197,12 +197,6 @@ private:
 public:
 	LogManager() = default;
 
-	LogManager(const LogManager &) = delete;
-	LogManager &operator=(const LogManager &) = delete;
-
-	LogManager(LogManager &&) = default;
-	LogManager &operator=(LogManager &&) = default;
-
 	template<typename T, typename... Args>
 	T &add_sink(Args&&... args)
 	{

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -86,13 +86,13 @@ YOSYS_NAMESPACE_BEGIN
 
 struct log_cmd_error_exception { };
 
-enum LogSeverity {
-	LOG_DEBUG,
-	LOG_COMMENT,
-	LOG_INFO,
-	LOG_HEADER,
-	LOG_WARNING,
-	LOG_ERROR
+enum class LogSeverity {
+	Debug,
+	Comment,
+	Info,
+	Header,
+	Warning,
+	Error
 };
 
 struct LogMessage {
@@ -148,7 +148,7 @@ class ConsoleLogSink : public LogSink
 public:
 	void log(const LogMessage &msg) override;
 	void flush() override;
-	FILE *file_handle() override { return stdout; };
+	FILE *file_handle() override { return stdout; }
 };
 
 class StderrLogSink : public LogSink
@@ -218,6 +218,10 @@ public:
 
 	bool empty() { return log_sinks.empty(); }
 	void clear() { log_sinks.clear(); }
+	void clear_original()
+	{
+		std::erase_if(log_sinks, [](const auto &sink) { return dynamic_cast<LogSinkRef *>(sink.get()) != nullptr; });
+	}
 	void flush() { for (auto &sink : log_sinks) sink->flush(); }
 
 	class Scoped
@@ -467,13 +471,13 @@ static inline bool ys_debug(int = 0) { return false; }
 template <typename... Args>
 inline void log(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_string({}, fmt.format_string(), fmt.format(args...), LogSeverity::LOG_INFO);
+	logger().log_formatted_string({}, fmt.format_string(), fmt.format(args...), LogSeverity::Info);
 }
 
 template <typename... Args>
 inline void log_comment(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_string({}, fmt.format_string(), fmt.format(args...), LogSeverity::LOG_COMMENT);
+	logger().log_formatted_string({}, fmt.format_string(), fmt.format(args...), LogSeverity::Comment);
 }
 
 template <typename... Args>
@@ -481,7 +485,7 @@ inline void log_debug(FmtString<TypeIdentity<Args>...> fmt, const Args &... args
 {
 	if (!ys_debug(1))
 		return;
-	logger().log_formatted_string({}, fmt.format_string(), fmt.format(args...), LogSeverity::LOG_DEBUG);
+	logger().log_formatted_string({}, fmt.format_string(), fmt.format(args...), LogSeverity::Debug);
 }
 
 template <typename... Args>

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -205,44 +205,44 @@ public:
 	{
 		auto sink = std::make_unique<T>(std::forward<Args>(args)...);
 		T &ref = *sink;
-		log_sinks.push_back(std::move(sink));
+		sinks.push_back(std::move(sink));
 		return ref;
 	}
 
 	template<typename F>
 	void for_each_sink(F &&func)
 	{
-		for (auto &sink : log_sinks)
+		for (auto &sink : sinks)
 			func(*sink);
 	}
 
-	bool empty() { return log_sinks.empty(); }
-	void clear() { log_sinks.clear(); }
+	bool empty() { return sinks.empty(); }
+	void clear() { sinks.clear(); }
 	void clear_original()
 	{
-		std::erase_if(log_sinks, [](const auto &sink) { return dynamic_cast<LogSinkRef *>(sink.get()) != nullptr; });
+		std::erase_if(sinks, [](const auto &sink) { return dynamic_cast<LogSinkRef *>(sink.get()) != nullptr; });
 	}
-	void flush() { for (auto &sink : log_sinks) sink->flush(); }
+	void flush() { for (auto &sink : sinks) sink->flush(); }
 
 	class Scoped
 	{
 	public:
 		explicit Scoped(LogManager &manager) :
 			manager(manager),
-			backup_log_sinks(std::move(manager.log_sinks)),
-			backup_log_verbose_level(manager.log_verbose_level)
+			backup_sinks(std::move(manager.sinks)),
+			backup_verbose_level(manager.verbose_level)
 		{
-			manager.log_sinks.reserve(backup_log_sinks.size());
+			manager.sinks.reserve(backup_sinks.size());
 
-			for (const auto &sink : backup_log_sinks)
-				manager.log_sinks.push_back(std::make_unique<LogSinkRef>(sink.get()));
+			for (const auto &sink : backup_sinks)
+				manager.sinks.push_back(std::make_unique<LogSinkRef>(sink.get()));
 		}
 
 		~Scoped()
 		{
-			manager.log_sinks.clear();
-			manager.log_sinks = std::move(backup_log_sinks);
-			manager.log_verbose_level = backup_log_verbose_level;
+			manager.sinks.clear();
+			manager.sinks = std::move(backup_sinks);
+			manager.verbose_level = backup_verbose_level;
 		}
 
 		Scoped(const Scoped &) = delete;
@@ -250,11 +250,11 @@ public:
 
 	private:
 		LogManager &manager;
-		std::vector<std::unique_ptr<LogSink>> backup_log_sinks;
-		int backup_log_verbose_level;
+		std::vector<std::unique_ptr<LogSink>> backup_sinks;
+		int backup_verbose_level;
 	};
 
-	Scoped scoped()
+	Scoped sink_scope()
 	{
 		return Scoped(*this);
 	}
@@ -263,14 +263,14 @@ public:
 	{
 	public:
 		explicit ScopedCmdErrorThrow(LogManager &manager)
-			: manager(manager), previous(manager.log_cmd_error_throw)
+			: manager(manager), previous(manager.cmd_error_throw)
 		{
-			manager.log_cmd_error_throw = true;
+			manager.cmd_error_throw = true;
 		}
 
 		~ScopedCmdErrorThrow()
 		{
-			manager.log_cmd_error_throw = previous;
+			manager.cmd_error_throw = previous;
 		}
 
 	private:
@@ -278,7 +278,7 @@ public:
 		bool previous;
 	};
 
-	ScopedCmdErrorThrow scoped_cmd_error_throw()
+	ScopedCmdErrorThrow error_throw_scope()
 	{
 		return ScopedCmdErrorThrow(*this);
 	}
@@ -303,7 +303,7 @@ public:
 			if (status)
 				return;
 			status = true;
-			manager.log_make_debug++;
+			manager.make_debug++;
 		}
 
 		void off_silent()
@@ -311,7 +311,7 @@ public:
 			if (!status)
 				return;
 			status = false;
-			manager.log_make_debug--;
+			manager.make_debug--;
 		}
 
 		void off()
@@ -323,7 +323,7 @@ public:
 		bool status = false;
 	};
 
-	LogMakeDebugHdl make_debug(bool start_on = false)
+	LogMakeDebugHdl make_debug_scope(bool start_on = false)
 	{
 		return LogMakeDebugHdl(*this, start_on);
 	}
@@ -349,7 +349,7 @@ public:
 				return;
 
 			active = true;
-			manager.log_force_debug++;
+			manager.force_debug++;
 		}
 
 		void off()
@@ -358,68 +358,68 @@ public:
 				return;
 
 			active = false;
-			manager.log_force_debug--;
+			manager.force_debug--;
 		}
 	private:
 		LogManager &manager;
 		bool active = false;
 	};
 
-	ForceDebug force_debug(bool start_on = false)
+	ForceDebug force_debug_scope(bool start_on = false)
 	{
 		return ForceDebug(*this, start_on);
 	}
 
-	void force_debug_on() { log_force_debug++; }
-	void force_debug_off() { if (log_force_debug > 0) log_force_debug--; }
-	void set_force_debug(bool enabled) { log_force_debug = enabled ? 1 : 0;	}
+	void force_debug_on() { force_debug++; }
+	void force_debug_off() { if (force_debug > 0) force_debug--; }
+	void set_force_debug(bool enabled) { force_debug = enabled ? 1 : 0;	}
 
 	void report_unexpected_error();
 
 	void add_experimental_ignore(std::string name) { experimental_ignored.insert(name); }
-	void add_warn(std::string pattern) { log_warn_regexes.push_back(YS_REGEX_COMPILE(pattern)); }
-	void add_nowarn(std::string pattern) { log_nowarn_regexes.push_back(YS_REGEX_COMPILE(pattern)); }
-	void add_werror(std::string pattern) { log_werror_regexes.push_back(YS_REGEX_COMPILE(pattern)); }
+	void add_warn(std::string pattern) { warn_regexes.push_back(YS_REGEX_COMPILE(pattern)); }
+	void add_nowarn(std::string pattern) { nowarn_regexes.push_back(YS_REGEX_COMPILE(pattern)); }
+	void add_werror(std::string pattern) { werror_regexes.push_back(YS_REGEX_COMPILE(pattern)); }
 	void add_expect(std::string type, std::string pattern, int count);
 
-	void set_verbose_level(int level) { log_verbose_level = level; }
-	void add_verbose_level(int level) { log_verbose_level += level; }
-	void set_expect_no_warnings(bool value) { log_expect_no_warnings = value; }
+	void set_verbose_level(int level) { verbose_level = level; }
+	void add_verbose_level(int level) { verbose_level += level; }
+	void set_expect_no_warnings(bool value) { expect_no_warnings = value; }
 	void set_log_time(bool value) { log_time = value; }
-	void set_cmd_error_throw(bool value) { log_cmd_error_throw = value; }
-	void set_hdump_all(bool value) { log_hdump_all = value; }
-	int get_verbose_level() const { return log_verbose_level; }
+	void set_cmd_error_throw(bool value) { cmd_error_throw = value; }
+	void set_hdump_all(bool value) { hdump_all = value; }
+	int get_verbose_level() const { return verbose_level; }
 	bool get_log_time() const { return log_time; }
-	int get_warnings_unique() const { return GetSize(log_warnings); }
-	int get_warnings_total() const { return log_warnings_count; }
-	int get_errors_total() const { return log_errors_count; }
+	int get_warnings_unique() const { return GetSize(warnings); }
+	int get_warnings_total() const { return warnings_count; }
+	int get_errors_total() const { return errors_count; }
 	const std::set<std::string> &get_experimental() const { return experimental; }
 	const std::set<std::string> &get_deprecated() const { return deprecated; }
 	std::chrono::steady_clock::time_point get_initial_time() const;
 
-	void add_hdump(std::string name, std::string value) { log_hdump[name].insert(value); }
+	void add_hdump(std::string name, std::string value) { hdump[name].insert(value); }
 
-	void log_formatted_string(LogSeverity severity, std::string_view prefix, std::string_view format, std::string str);
-	void log_formatted_header(RTLIL::Design *design, std::string_view format, std::string str);
-	void log_formatted_warning(std::string_view prefix, std::string_view format, std::string message);
-	void log_formatted_file_warning(std::string_view filename, int lineno, std::string_view format, std::string str);
-	void log_formatted_file_info(std::string_view filename, int lineno, std::string_view format, std::string str);
-	void log_suppressed();
-	[[noreturn]] void log_formatted_file_error(std::string_view filename, int lineno, std::string_view format, std::string str);
-	void log_experimental(const std::string &str);
-	void log_deprecated(const std::string &str);
-	[[noreturn]] void log_formatted_error(std::string_view format, std::string str);
-	[[noreturn]] void log_formatted_cmd_error(std::string_view format, std::string message);
-	void log_spacer();
-	void log_push();
-	void log_pop();
+	void formatted_string(LogSeverity severity, std::string_view prefix, std::string_view format, std::string str);
+	void formatted_header(RTLIL::Design *design, std::string_view format, std::string str);
+	void formatted_warning(std::string_view prefix, std::string_view format, std::string message);
+	void formatted_file_warning(std::string_view filename, int lineno, std::string_view format, std::string str);
+	void formatted_file_info(std::string_view filename, int lineno, std::string_view format, std::string str);
+	[[noreturn]] void formatted_file_error(std::string_view filename, int lineno, std::string_view format, std::string str);
+	[[noreturn]] void formatted_error(std::string_view format, std::string str);
+	[[noreturn]] void formatted_cmd_error(std::string_view format, std::string message);
+	void suppressed();
+	void add_experimental(const std::string &str);
+	void add_deprecated(const std::string &str);
+	void spacer();
+	void push();
+	void pop();
 
-	void log_reset_stack();
+	void reset_stack();
 
 	void check_expected();
-	bool expects_error() { return (log_expect_error.size() + log_expect_prefix_error.size())>0; }
+	bool expects_error() { return (expect_error.size() + expect_prefix_error.size())>0; }
 #ifndef NDEBUG
-	bool is_debug(int n = 0) { if (log_force_debug) return true; log_debug_suppressed += n; return false; }
+	bool is_debug(int n = 0) { if (force_debug) return true; debug_suppressed += n; return false; }
 #else
 	bool is_debug(int = 0) { return false; }
 #endif
@@ -428,30 +428,30 @@ public:
 
 private:
 	void logv_string(LogSeverity severity, std::string_view prefix, std::string_view format, std::string str_in);
-	[[noreturn]] void log_error_with_prefix(std::string_view prefix, std::string_view format, std::string message);
+	[[noreturn]] void error_with_prefix(std::string_view prefix, std::string_view format, std::string message);
 
-	std::vector<std::unique_ptr<LogSink>> log_sinks;
-	int log_verbose_level = 0;
-	int log_newline_count = 0;
+	std::vector<std::unique_ptr<LogSink>> sinks;
+	int verbose_level = 0;
+	int newline_count = 0;
 	vector<int> header_count;
-	int log_errors_count = 0;
-	int log_warnings_count = 0;
-	int log_warnings_count_noexpect = 0;
-	std::set<std::string> log_warnings, experimental, experimental_ignored, deprecated;
+	int errors_count = 0;
+	int warnings_count = 0;
+	int warnings_count_noexpect = 0;
+	std::set<std::string> warnings, experimental, experimental_ignored, deprecated;
 
-	std::vector<std::regex> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
-	dict<std::string, LogExpectedItem> log_expect_log, log_expect_warning, log_expect_error;
-	dict<std::string, LogExpectedItem> log_expect_prefix_log, log_expect_prefix_warning, log_expect_prefix_error;
-	bool log_expect_no_warnings = false;
+	std::vector<std::regex> warn_regexes, nowarn_regexes, werror_regexes;
+	dict<std::string, LogExpectedItem> expect_log, expect_warning, expect_error;
+	dict<std::string, LogExpectedItem> expect_prefix_log, expect_prefix_warning, expect_prefix_error;
+	bool expect_no_warnings = false;
 	bool log_time = false;
-	bool log_cmd_error_throw = false;
-	std::map<std::string, std::set<std::string>> log_hdump;
-	bool log_hdump_all = false;
+	bool cmd_error_throw = false;
+	std::map<std::string, std::set<std::string>> hdump;
+	bool hdump_all = false;
 
-	int log_debug_suppressed = 0;
-	int log_make_debug = 0;
-	int log_force_debug = 0;
-	std::unique_ptr<SHA1> log_hasher;
+	int debug_suppressed = 0;
+	int make_debug = 0;
+	int force_debug = 0;
+	std::unique_ptr<SHA1> hasher;
 };
 
 LogManager &logger();
@@ -470,20 +470,20 @@ static inline bool ys_debug(int = 0) { return false; }
 template <typename... Args>
 inline void log(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_string(LogSeverity::Info, {}, fmt.format_string(), fmt.format(args...));
+	logger().formatted_string(LogSeverity::Info, {}, fmt.format_string(), fmt.format(args...));
 }
 
 template <typename... Args>
 inline void log_comment(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_string(LogSeverity::Comment, {}, fmt.format_string(), fmt.format(args...));
+	logger().formatted_string(LogSeverity::Comment, {}, fmt.format_string(), fmt.format(args...));
 }
 
 template <typename... Args>
 inline void log_formatted_string(LogSeverity severity, std::string_view prefix,
 		FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_string(severity, prefix, fmt.format_string(), fmt.format(args...));
+	logger().formatted_string(severity, prefix, fmt.format_string(), fmt.format(args...));
 }
 
 #define log_debug(...) do { if (ys_debug(1)) YOSYS_NAMESPACE_PREFIX log_formatted_string(YOSYS_NAMESPACE_PREFIX LogSeverity::Debug, {}, __VA_ARGS__); } while (0)
@@ -491,72 +491,72 @@ inline void log_formatted_string(LogSeverity severity, std::string_view prefix,
 template <typename... Args>
 inline void log_header(RTLIL::Design *design, FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_header(design, fmt.format_string(), fmt.format(args...));
+	logger().formatted_header(design, fmt.format_string(), fmt.format(args...));
 }
 
 template <typename... Args>
 inline void log_warning(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_warning("Warning: ", fmt.format_string(), fmt.format(args...));
+	logger().formatted_warning("Warning: ", fmt.format_string(), fmt.format(args...));
 }
 
 template <typename... Args>
 inline void log_warning_noprefix(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_warning({}, fmt.format_string(), fmt.format(args...));
+	logger().formatted_warning({}, fmt.format_string(), fmt.format(args...));
 }
 
 inline void log_experimental(const std::string &str)
 {
-	logger().log_experimental(str);
+	logger().add_experimental(str);
 }
 
 inline void log_deprecated(const std::string &str)
 {
-	logger().log_deprecated(str);
+	logger().add_deprecated(str);
 }
 
 // Log with filename to report a problem in a source file.
 template <typename... Args>
 void log_file_warning(std::string_view filename, int lineno, FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_file_warning(filename, lineno, fmt.format_string(), fmt.format(args...));
+	logger().formatted_file_warning(filename, lineno, fmt.format_string(), fmt.format(args...));
 }
 
 template <typename... Args>
 void log_file_info(std::string_view filename, int lineno, FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_file_info(filename, lineno, fmt.format_string(), fmt.format(args...));
+	logger().formatted_file_info(filename, lineno, fmt.format_string(), fmt.format(args...));
 }
 
 template <typename... Args>
 [[noreturn]] void log_error(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_error(fmt.format_string(), fmt.format(args...));
+	logger().formatted_error(fmt.format_string(), fmt.format(args...));
 }
 
 template <typename... Args>
 [[noreturn]] void log_file_error(std::string_view filename, int lineno, FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_file_error(filename, lineno, fmt.format_string(), fmt.format(args...));
+	logger().formatted_file_error(filename, lineno, fmt.format_string(), fmt.format(args...));
 }
 
 template <typename... Args>
 [[noreturn]] void log_cmd_error(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_cmd_error(fmt.format_string(), fmt.format(args...));
+	logger().formatted_cmd_error(fmt.format_string(), fmt.format(args...));
 }
 
 inline void log_suppressed()
 {
-	logger().log_suppressed();
+	logger().suppressed();
 }
 
-inline void log_spacer() { logger().log_spacer(); }
-inline void log_push() { logger().log_push(); }
-inline void log_pop() { logger().log_pop(); }
+inline void log_spacer() { logger().spacer(); }
+inline void log_push() { logger().push(); }
+inline void log_pop() { logger().pop(); }
 
-inline void log_reset_stack() { logger().log_reset_stack(); }
+inline void log_reset_stack() { logger().reset_stack(); }
 inline void log_flush() { logger().flush(); }
 
 void log_backtrace(const char *prefix, int levels);

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -154,9 +154,12 @@ public:
 class StderrLogSink : public LogSink
 {
 public:
+	explicit StderrLogSink(bool quiet) : quiet_warnings(quiet) {}
 	bool should_log(const LogMessage &msg) const override;
 	void log(const LogMessage &msg) override;
 	void flush() override;
+private:
+	bool quiet_warnings;
 };
 
 class StreamLogSink : public LogSink
@@ -368,7 +371,7 @@ public:
 	void set_force_debug(bool enabled) { log_force_debug = enabled ? 1 : 0;	}
 
 	void report_unexpected_error();
-	void report_warning_stats();
+	void report_warning_stats(bool stderr_force);
 
 	void add_experimental_ignore(std::string name) { log_experimentals_ignored.insert(name); }
 	void add_warn(std::string pattern) { log_warn_regexes.push_back(YS_REGEX_COMPILE(pattern)); }
@@ -380,15 +383,10 @@ public:
 	void add_verbose_level(int level) { log_verbose_level += level; }
 	void set_expect_no_warnings(bool value) { log_expect_no_warnings = value; }
 	void set_log_time(bool value) { log_time = value; }
-	void set_error_stderr(bool value) { log_error_stderr = value; }
 	void set_cmd_error_throw(bool value) { log_cmd_error_throw = value; }
-	void set_quiet_warnings(bool value) { log_quiet_warnings = value; }
-	void set_stderr_force(bool value) { log_stderr_force = value; }
 	void set_hdump_all(bool value) { log_hdump_all = value; }
 	int get_verbose_level() const { return log_verbose_level; }
 	bool get_log_time() const { return log_time; }
-	bool get_error_stderr() const { return log_error_stderr; }
-	bool get_quiet_warnings() const { return log_quiet_warnings; }
 	bool get_stderr_force() const { return log_stderr_force; }
 	std::chrono::steady_clock::time_point get_initial_time() const;
 
@@ -437,9 +435,7 @@ private:
 	dict<std::string, LogExpectedItem> log_expect_prefix_log, log_expect_prefix_warning, log_expect_prefix_error;
 	bool log_expect_no_warnings = false;
 	bool log_time = false;
-	bool log_error_stderr = false;
 	bool log_cmd_error_throw = false;
-	bool log_quiet_warnings = false;
 	bool log_stderr_force = false;
 	std::map<std::string, std::set<std::string>> log_hdump;
 	bool log_hdump_all = false;

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -376,7 +376,7 @@ public:
 
 	void report_unexpected_error();
 
-	void add_experimental_ignore(std::string name) { log_experimentals_ignored.insert(name); }
+	void add_experimental_ignore(std::string name) { experimental_ignored.insert(name); }
 	void add_warn(std::string pattern) { log_warn_regexes.push_back(YS_REGEX_COMPILE(pattern)); }
 	void add_nowarn(std::string pattern) { log_nowarn_regexes.push_back(YS_REGEX_COMPILE(pattern)); }
 	void add_werror(std::string pattern) { log_werror_regexes.push_back(YS_REGEX_COMPILE(pattern)); }
@@ -395,7 +395,8 @@ public:
 	int get_warnings_unique() const { return GetSize(log_warnings); }
 	int get_warnings_total() const { return log_warnings_count; }
 	int get_errors_total() const { return log_errors_count; }
-	int get_experimentals_num() const { return GetSize(log_experimentals); }
+	const std::set<std::string> &get_experimental() const { return experimental; }
+	const std::set<std::string> &get_deprecated() const { return deprecated; }
 	std::chrono::steady_clock::time_point get_initial_time() const;
 
 	void add_hdump(std::string name, std::string value) { log_hdump[name].insert(value); }
@@ -408,6 +409,7 @@ public:
 	void log_suppressed();
 	[[noreturn]] void log_formatted_file_error(std::string_view filename, int lineno, std::string_view format, std::string str);
 	void log_experimental(const std::string &str);
+	void log_deprecated(const std::string &str);
 	[[noreturn]] void log_formatted_error(std::string_view format, std::string str);
 	[[noreturn]] void log_formatted_cmd_error(std::string_view format, std::string message);
 	void log_spacer();
@@ -437,7 +439,7 @@ private:
 	int log_errors_count = 0;
 	int log_warnings_count = 0;
 	int log_warnings_count_noexpect = 0;
-	std::set<std::string> log_warnings, log_experimentals, log_experimentals_ignored;
+	std::set<std::string> log_warnings, experimental, experimental_ignored, deprecated;
 
 	std::vector<std::regex> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
 	dict<std::string, LogExpectedItem> log_expect_log, log_expect_warning, log_expect_error;
@@ -509,6 +511,11 @@ inline void log_warning_noprefix(FmtString<TypeIdentity<Args>...> fmt, const Arg
 inline void log_experimental(const std::string &str)
 {
 	logger().log_experimental(str);
+}
+
+inline void log_deprecated(const std::string &str)
+{
+	logger().log_deprecated(str);
 }
 
 // Log with filename to report a problem in a source file.

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -102,237 +102,470 @@ struct LogMessage {
 	std::string format;
 	std::string message;
 	std::chrono::steady_clock::time_point timestamp;
-	//TODO: remove
-	std::string legacy_msg;
+
+	std::string cached_msg;
 };
 
 class LogSink
 {
 public:
-    virtual ~LogSink() = default;
+	virtual ~LogSink() = default;
 
-    virtual bool should_log(const LogMessage &) const { return true; }
-    virtual void log(const LogMessage &msg) = 0;
+	virtual bool should_log(const LogMessage &) const { return true; }
+	virtual void log(const LogMessage &msg) = 0;
 	virtual void flush() {}
 	// TODO: Remove when AST/read_verilog removed
 	virtual FILE *file_handle() { return nullptr; }
 };
 
-extern std::vector<std::unique_ptr<LogSink>> log_sinks;
-
 class LogSinkRef : public LogSink
 {
 public:
-    explicit LogSinkRef(LogSink *sink) : sink(sink) {}
-    bool should_log(const LogMessage &msg) const override { return sink->should_log(msg); }
-    void log(const LogMessage &msg) override { sink->log(msg); }
-    void flush() override { sink->flush(); }
+	explicit LogSinkRef(LogSink *sink) : sink(sink) {}
+	bool should_log(const LogMessage &msg) const override { return sink->should_log(msg); }
+	void log(const LogMessage &msg) override { sink->log(msg); }
+	void flush() override { sink->flush(); }
 	FILE *file_handle() override { return sink->file_handle(); }
 private:
-    LogSink *sink;
+	LogSink *sink;
 };
 
 class FileLogSink : public LogSink
 {
 public:
-    explicit FileLogSink(const std::string &filename, bool line_buffered, bool append);
-    ~FileLogSink() override;
-    void log(const LogMessage &msg) override;
+	explicit FileLogSink(const std::string &filename, bool line_buffered, bool append);
+	~FileLogSink() override;
+	void log(const LogMessage &msg) override;
 	void flush() override;
 	FILE *file_handle() override { return file; }
 
 private:
-    FILE *file;
+	FILE *file;
 };
 
 class ConsoleLogSink : public LogSink
 {
 public:
-    void log(const LogMessage &msg) override;
-    void flush() override;
+	void log(const LogMessage &msg) override;
+	void flush() override;
 	FILE *file_handle() override { return stdout; };
 };
 
 class StderrLogSink : public LogSink
 {
 public:
-    bool should_log(const LogMessage &msg) const override;
-    void log(const LogMessage &msg) override;
-    void flush() override;
+	bool should_log(const LogMessage &msg) const override;
+	void log(const LogMessage &msg) override;
+	void flush() override;
+};
+
+class StreamLogSink : public LogSink
+{
+public:
+	explicit StreamLogSink(std::ostream &stream) : stream(stream) {}
+	void log(const LogMessage &msg) override { stream << msg.message; }
+	void flush() override { stream.flush(); }
+
+private:
+	std::ostream &stream;
 };
 
 class ScratchPadLogSink : public LogSink
 {
 public:
-    explicit ScratchPadLogSink(std::string scratchpad);
-    void log(const LogMessage &msg) override;
+	explicit ScratchPadLogSink(std::string scratchpad);
+	void log(const LogMessage &msg) override;
 
-	private:
-    std::string scratchpad;
+private:
+	std::string scratchpad;
 };
 
-extern bool log_stderr_force;
+class LogManager
+{
+private:
+	struct LogExpectedItem
+	{
+		LogExpectedItem(const std::regex &pat, int expected) :
+				pattern(pat), expected_count(expected), current_count(0) {}
+		LogExpectedItem() : expected_count(0), current_count(0) {}
 
-extern std::map<std::string, std::set<std::string>> log_hdump;
-extern std::vector<std::regex> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
-extern std::set<std::string> log_warnings, log_experimentals, log_experimentals_ignored;
-extern int log_warnings_count;
-extern int log_warnings_count_noexpect;
-extern bool log_expect_no_warnings;
-extern bool log_hdump_all;
-extern SHA1 *log_hasher;
+		std::regex pattern;
+		int expected_count;
+		int current_count;
+	};
 
-extern bool log_time;
-extern bool log_error_stderr;
-extern bool log_cmd_error_throw;
-extern bool log_quiet_warnings;
-extern int log_verbose_level;
+public:
+	LogManager() = default;
+
+	LogManager(const LogManager &) = delete;
+	LogManager &operator=(const LogManager &) = delete;
+
+	LogManager(LogManager &&) = default;
+	LogManager &operator=(LogManager &&) = default;
+
+	template<typename T, typename... Args>
+	T &add_sink(Args&&... args)
+	{
+		auto sink = std::make_unique<T>(std::forward<Args>(args)...);
+		T &ref = *sink;
+		log_sinks.push_back(std::move(sink));
+		return ref;
+	}
+
+	template<typename F>
+	void for_each_sink(F &&func)
+	{
+		for (auto &sink : log_sinks)
+			func(*sink);
+	}
+
+	void log(const LogMessage &msg)
+	{
+		for (auto &sink : log_sinks) {
+			if (sink->should_log(msg))
+				sink->log(msg);
+		}
+	}
+
+	bool empty() { return log_sinks.empty(); }
+	void clear() { log_sinks.clear(); }
+	void flush() { for (auto &sink : log_sinks) sink->flush(); }
+
+	class Scoped
+	{
+	public:
+		explicit Scoped(LogManager &manager) :
+			manager(manager),
+			backup_log_sinks(std::move(manager.log_sinks)),
+			backup_log_verbose_level(manager.log_verbose_level)
+		{
+			manager.log_sinks.reserve(backup_log_sinks.size());
+
+			for (const auto &sink : backup_log_sinks)
+				manager.log_sinks.push_back(std::make_unique<LogSinkRef>(sink.get()));
+		}
+
+		~Scoped()
+		{
+			manager.log_sinks.clear();
+			manager.log_sinks = std::move(backup_log_sinks);
+			manager.log_verbose_level = backup_log_verbose_level;
+		}
+
+		Scoped(const Scoped &) = delete;
+		Scoped &operator=(const Scoped &) = delete;
+
+	private:
+		LogManager &manager;
+		std::vector<std::unique_ptr<LogSink>> backup_log_sinks;
+		int backup_log_verbose_level;
+	};
+
+	Scoped scoped()
+	{
+		return Scoped(*this);
+	}
+
+	class ScopedCmdErrorThrow
+	{
+	public:
+		explicit ScopedCmdErrorThrow(LogManager &manager)
+			: manager(manager), previous(manager.log_cmd_error_throw)
+		{
+			manager.log_cmd_error_throw = true;
+		}
+
+		~ScopedCmdErrorThrow()
+		{
+			manager.log_cmd_error_throw = previous;
+		}
+
+	private:
+		LogManager &manager;
+		bool previous;
+	};
+
+	ScopedCmdErrorThrow scoped_cmd_error_throw()
+	{
+		return ScopedCmdErrorThrow(*this);
+	}
+
+	class LogMakeDebugHdl
+	{
+	public:
+		explicit LogMakeDebugHdl(LogManager &manager, bool start_on = false)
+			: manager(manager)
+		{
+			if (start_on)
+				on();
+		}
+
+		~LogMakeDebugHdl()
+		{
+			off();
+		}
+
+		void on()
+		{
+			if (status)
+				return;
+			status = true;
+			manager.log_make_debug++;
+		}
+
+		void off_silent()
+		{
+			if (!status)
+				return;
+			status = false;
+			manager.log_make_debug--;
+		}
+
+		void off()
+		{
+			off_silent();
+		}
+	private:
+		LogManager &manager;
+		bool status = false;
+	};
+
+	LogMakeDebugHdl make_debug(bool start_on = false)
+	{
+		return LogMakeDebugHdl(*this, start_on);
+	}
+
+	class ForceDebug
+	{
+	public:
+		explicit ForceDebug(LogManager &manager, bool start_on = false)
+			: manager(manager)
+		{
+			if (start_on)
+				on();
+		}
+
+		~ForceDebug()
+		{
+			off();
+		}
+
+		void on()
+		{
+			if (active)
+				return;
+
+			active = true;
+			manager.log_force_debug++;
+		}
+
+		void off()
+		{
+			if (!active)
+				return;
+
+			active = false;
+			manager.log_force_debug--;
+		}
+	private:
+		LogManager &manager;
+		bool active = false;
+	};
+
+	ForceDebug force_debug(bool start_on = false)
+	{
+		return ForceDebug(*this, start_on);
+	}
+
+	void force_debug_on() { log_force_debug++; }
+	void force_debug_off() { if (log_force_debug > 0) log_force_debug--; }
+	void set_force_debug(bool enabled) { log_force_debug = enabled ? 1 : 0;	}
+
+	void report_unexpected_error();
+	void report_warning_stats();
+
+	void add_experimental_ignore(std::string name) { log_experimentals_ignored.insert(name); }
+	void add_warn(std::string pattern) { log_warn_regexes.push_back(YS_REGEX_COMPILE(pattern)); }
+	void add_nowarn(std::string pattern) { log_nowarn_regexes.push_back(YS_REGEX_COMPILE(pattern)); }
+	void add_werror(std::string pattern) { log_werror_regexes.push_back(YS_REGEX_COMPILE(pattern)); }
+	void add_expect(std::string type, std::string pattern, int count);
+
+	void set_verbose_level(int level) { log_verbose_level = level; }
+	void add_verbose_level(int level) { log_verbose_level += level; }
+	void set_expect_no_warnings(bool value) { log_expect_no_warnings = value; }
+	void set_log_time(bool value) { log_time = value; }
+	void set_error_stderr(bool value) { log_error_stderr = value; }
+	void set_cmd_error_throw(bool value) { log_cmd_error_throw = value; }
+	void set_quiet_warnings(bool value) { log_quiet_warnings = value; }
+	void set_stderr_force(bool value) { log_stderr_force = value; }
+	void set_hdump_all(bool value) { log_hdump_all = value; }
+	int get_verbose_level() const { return log_verbose_level; }
+	bool get_log_time() const { return log_time; }
+	bool get_error_stderr() const { return log_error_stderr; }
+	bool get_quiet_warnings() const { return log_quiet_warnings; }
+	bool get_stderr_force() const { return log_stderr_force; }
+	std::chrono::steady_clock::time_point get_initial_time() const { return initial_time; }
+
+	void add_hdump(std::string name, std::string value) { log_hdump[name].insert(value); }
+
+	void log_formatted_string(std::string_view prefix, std::string_view format, std::string str, LogSeverity severity);
+	void log_formatted_header(RTLIL::Design *design, std::string_view format, std::string str);
+	void log_formatted_warning(std::string_view prefix, std::string message);
+	void log_formatted_file_warning(std::string_view filename, int lineno, std::string str);
+	void log_formatted_file_info(std::string_view filename, int lineno, std::string str);
+	void log_suppressed();
+	[[noreturn]] void log_formatted_file_error(std::string_view filename, int lineno, std::string str);
+	void log_experimental(const std::string &str);
+	[[noreturn]] void log_formatted_error(std::string str);
+	[[noreturn]] void log_formatted_cmd_error(std::string message);
+	void log_spacer();
+	void log_push();
+	void log_pop();
+
+	void log_reset_stack();
+
+	void check_expected();
+	bool expects_error() { return (log_expect_error.size() + log_expect_prefix_error.size())>0; }
+#ifndef NDEBUG
+	bool is_debug(int n = 0) { if (log_force_debug) return true; log_debug_suppressed += n; return false; }
+#else
+	bool is_debug(int = 0) { return false; }
+#endif
+	void start_hasher();
+	std::string finish_hasher();
+
+private:
+	void logv_string(std::string_view prefix, std::string_view format, std::string str_in, LogSeverity severity);
+	[[noreturn]] void log_error_with_prefix(std::string_view prefix, std::string message);
+
+	std::chrono::steady_clock::time_point initial_time = std::chrono::steady_clock::now();
+	std::vector<std::unique_ptr<LogSink>> log_sinks;
+	int log_verbose_level = 0;
+	int log_newline_count = 0;
+	vector<int> header_count;
+	int log_warnings_count = 0;
+	int log_warnings_count_noexpect = 0;
+	std::set<std::string> log_warnings, log_experimentals, log_experimentals_ignored;
+
+	std::vector<std::regex> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
+	dict<std::string, LogExpectedItem> log_expect_log, log_expect_warning, log_expect_error;
+	dict<std::string, LogExpectedItem> log_expect_prefix_log, log_expect_prefix_warning, log_expect_prefix_error;
+	bool log_expect_no_warnings = false;
+	bool log_time = false;
+	bool log_error_stderr = false;
+	bool log_cmd_error_throw = false;
+	bool log_quiet_warnings = false;
+	bool log_stderr_force = false;
+	std::map<std::string, std::set<std::string>> log_hdump;
+	bool log_hdump_all = false;
+
+	int log_debug_suppressed = 0;
+	int log_make_debug = 0;
+	int log_force_debug = 0;
+	std::unique_ptr<SHA1> log_hasher;
+};
+
+LogManager &logger();
+
 extern void (*log_error_atexit)();
-
-extern int log_make_debug;
-extern int log_force_debug;
-extern int log_debug_suppressed;
 
 void set_verific_logging(void (*cb)(int msg_type, const char *message_id, const char* file_path, unsigned int left_line, unsigned int left_col, unsigned int right_line, unsigned int right_col, const char *msg));
 extern void (*log_verific_callback)(int msg_type, const char *message_id, const char* file_path, unsigned int left_line, unsigned int left_col, unsigned int right_line, unsigned int right_col, const char *msg);
 
 #ifndef NDEBUG
-static inline bool ys_debug(int n = 0) { if (log_force_debug) return true; log_debug_suppressed += n; return false; }
+static inline bool ys_debug(int n = 0) { return logger().is_debug(n); }
 #else
 static inline bool ys_debug(int = 0) { return false; }
 #endif
 
-void log_formatted_string(std::string_view prefix, std::string_view format, std::string str, LogSeverity severity);
 template <typename... Args>
 inline void log(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	log_formatted_string({}, fmt.format_string(), fmt.format(args...), LogSeverity::LOG_INFO);
+	logger().log_formatted_string({}, fmt.format_string(), fmt.format(args...), LogSeverity::LOG_INFO);
 }
 
 template <typename... Args>
 inline void log_comment(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	log_formatted_string({}, fmt.format_string(), fmt.format(args...), LogSeverity::LOG_COMMENT);
+	logger().log_formatted_string({}, fmt.format_string(), fmt.format(args...), LogSeverity::LOG_COMMENT);
 }
 
 template <typename... Args>
 inline void log_debug(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-    if (!ys_debug(1))
-        return;
-    log_formatted_string({}, fmt.format_string(), fmt.format(args...), LogSeverity::LOG_DEBUG);
+	if (!ys_debug(1))
+		return;
+	logger().log_formatted_string({}, fmt.format_string(), fmt.format(args...), LogSeverity::LOG_DEBUG);
 }
 
-void log_formatted_header(RTLIL::Design *design, std::string_view format, std::string str);
 template <typename... Args>
 inline void log_header(RTLIL::Design *design, FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	log_formatted_header(design, fmt.format_string(), fmt.format(args...));
+	logger().log_formatted_header(design, fmt.format_string(), fmt.format(args...));
 }
 
-void log_formatted_warning(std::string_view prefix, std::string str);
 template <typename... Args>
 inline void log_warning(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	log_formatted_warning("Warning: ", fmt.format(args...));
+	logger().log_formatted_warning("Warning: ", fmt.format(args...));
 }
 
-inline void log_formatted_warning_noprefix(std::string str)
-{
-	log_formatted_warning({}, str);
-}
 template <typename... Args>
 inline void log_warning_noprefix(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	log_formatted_warning({}, fmt.format(args...));
+	logger().log_formatted_warning({}, fmt.format(args...));
 }
 
-void log_experimental(const std::string &str);
+inline void log_experimental(const std::string &str)
+{
+	logger().log_experimental(str);
+}
 
 // Log with filename to report a problem in a source file.
-void log_formatted_file_warning(std::string_view filename, int lineno, std::string str);
 template <typename... Args>
 void log_file_warning(std::string_view filename, int lineno, FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	log_formatted_file_warning(filename, lineno, fmt.format(args...));
+	logger().log_formatted_file_warning(filename, lineno, fmt.format(args...));
 }
 
-void log_formatted_file_info(std::string_view filename, int lineno, std::string str);
 template <typename... Args>
 void log_file_info(std::string_view filename, int lineno, FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	log_formatted_file_info(filename, lineno, fmt.format(args...));
+	logger().log_formatted_file_info(filename, lineno, fmt.format(args...));
 }
 
-[[noreturn]] void log_formatted_error(std::string str);
 template <typename... Args>
 [[noreturn]] void log_error(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	log_formatted_error(fmt.format(args...));
+	logger().log_formatted_error(fmt.format(args...));
 }
 
-[[noreturn]] void log_formatted_file_error(std::string_view filename, int lineno, std::string str);
 template <typename... Args>
 [[noreturn]] void log_file_error(std::string_view filename, int lineno, FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	log_formatted_file_error(filename, lineno, fmt.format(args...));
+	logger().log_formatted_file_error(filename, lineno, fmt.format(args...));
 }
 
-[[noreturn]] void log_formatted_cmd_error(std::string str);
 template <typename... Args>
 [[noreturn]] void log_cmd_error(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	log_formatted_cmd_error(fmt.format(args...));
+	logger().log_formatted_cmd_error(fmt.format(args...));
 }
 
-void log_suppressed();
+inline void log_suppressed()
+{
+	logger().log_suppressed();
+}
 
-struct LogMakeDebugHdl {
-	bool status = false;
-	LogMakeDebugHdl(bool start_on = false) {
-		if (start_on)
-			on();
-	}
-	~LogMakeDebugHdl() {
-		off();
-	}
-	void on() {
-		if (status) return;
-		status=true;
-		log_make_debug++;
-	}
-	void off_silent() {
-		if (!status) return;
-		status=false;
-		log_make_debug--;
-	}
-	void off() {
-		off_silent();
-	}
-};
+inline void log_spacer() { logger().log_spacer(); }
+inline void log_push() { logger().log_push(); }
+inline void log_pop() { logger().log_pop(); }
 
-void log_spacer();
-void log_push();
-void log_pop();
+inline void log_reset_stack() { logger().log_reset_stack(); }
+inline void log_flush() { logger().flush(); }
 
 void log_backtrace(const char *prefix, int levels);
-void log_reset_stack();
-void log_flush();
 
-struct LogExpectedItem
-{
-	LogExpectedItem(const std::regex &pat, int expected) :
-			pattern(pat), expected_count(expected), current_count(0) {}
-	LogExpectedItem() : expected_count(0), current_count(0) {}
-
-	std::regex pattern;
-	int expected_count;
-	int current_count;
-};
-
-extern dict<std::string, LogExpectedItem> log_expect_log, log_expect_warning, log_expect_error;
-extern dict<std::string, LogExpectedItem> log_expect_prefix_log, log_expect_prefix_warning, log_expect_prefix_error;
-void log_check_expected();
 
 std::string log_signal(const RTLIL::SigSpec &sig, bool autoint = true);
 std::string log_const(const RTLIL::Const &value, bool autoint = true);

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -96,22 +96,83 @@ enum LogSeverity {
 };
 
 struct LogMessage {
-	LogMessage(LogSeverity severity, std::string_view prefix, std::string_view format, std::string_view message) :
-		severity(severity),
-		prefix(prefix),
-		format(format),
-		message(message),
-		timestamp(std::chrono::steady_clock::now()) {}
+	LogMessage(LogSeverity severity, std::string_view prefix, std::string_view format, std::string_view message);
 	LogSeverity severity;
 	std::string prefix;
 	std::string format;
 	std::string message;
 	std::chrono::steady_clock::time_point timestamp;
+	//TODO: remove
+	std::string legacy_msg;
 };
 
-extern std::vector<FILE*> log_files;
-extern std::vector<std::ostream*> log_streams;
-extern std::vector<std::string> log_scratchpads;
+class LogSink
+{
+public:
+    virtual ~LogSink() = default;
+
+    virtual bool should_log(const LogMessage &) const { return true; }
+    virtual void log(const LogMessage &msg) = 0;
+	virtual void flush() {}
+	// TODO: Remove when AST/read_verilog removed
+	virtual FILE *file_handle() { return nullptr; }
+};
+
+extern std::vector<std::unique_ptr<LogSink>> log_sinks;
+
+class LogSinkRef : public LogSink
+{
+public:
+    explicit LogSinkRef(LogSink *sink) : sink(sink) {}
+    bool should_log(const LogMessage &msg) const override { return sink->should_log(msg); }
+    void log(const LogMessage &msg) override { sink->log(msg); }
+    void flush() override { sink->flush(); }
+	FILE *file_handle() override { return sink->file_handle(); }
+private:
+    LogSink *sink;
+};
+
+class FileLogSink : public LogSink
+{
+public:
+    explicit FileLogSink(const std::string &filename, bool line_buffered, bool append);
+    ~FileLogSink() override;
+    void log(const LogMessage &msg) override;
+	void flush() override;
+	FILE *file_handle() override { return file; }
+
+private:
+    FILE *file;
+};
+
+class ConsoleLogSink : public LogSink
+{
+public:
+    void log(const LogMessage &msg) override;
+    void flush() override;
+	FILE *file_handle() override { return stdout; };
+};
+
+class StderrLogSink : public LogSink
+{
+public:
+    bool should_log(const LogMessage &msg) const override;
+    void log(const LogMessage &msg) override;
+    void flush() override;
+};
+
+class ScratchPadLogSink : public LogSink
+{
+public:
+    explicit ScratchPadLogSink(std::string scratchpad);
+    void log(const LogMessage &msg) override;
+
+	private:
+    std::string scratchpad;
+};
+
+extern bool log_stderr_force;
+
 extern std::map<std::string, std::set<std::string>> log_hdump;
 extern std::vector<std::regex> log_warn_regexes, log_nowarn_regexes, log_werror_regexes;
 extern std::set<std::string> log_warnings, log_experimentals, log_experimentals_ignored;
@@ -119,7 +180,6 @@ extern int log_warnings_count;
 extern int log_warnings_count_noexpect;
 extern bool log_expect_no_warnings;
 extern bool log_hdump_all;
-extern FILE *log_errfile;
 extern SHA1 *log_hasher;
 
 extern bool log_time;
@@ -127,7 +187,6 @@ extern bool log_error_stderr;
 extern bool log_cmd_error_throw;
 extern bool log_quiet_warnings;
 extern int log_verbose_level;
-extern string log_last_error;
 extern void (*log_error_atexit)();
 
 extern int log_make_debug;

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -401,7 +401,7 @@ public:
 
 	void add_hdump(std::string name, std::string value) { log_hdump[name].insert(value); }
 
-	void log_formatted_string(std::string_view prefix, std::string_view format, std::string str, LogSeverity severity);
+	void log_formatted_string(LogSeverity severity, std::string_view prefix, std::string_view format, std::string str);
 	void log_formatted_header(RTLIL::Design *design, std::string_view format, std::string str);
 	void log_formatted_warning(std::string_view prefix, std::string_view format, std::string message);
 	void log_formatted_file_warning(std::string_view filename, int lineno, std::string_view format, std::string str);
@@ -429,7 +429,7 @@ public:
 	std::string finish_hasher();
 
 private:
-	void logv_string(std::string_view prefix, std::string_view format, std::string str_in, LogSeverity severity);
+	void logv_string(LogSeverity severity, std::string_view prefix, std::string_view format, std::string str_in);
 	[[noreturn]] void log_error_with_prefix(std::string_view prefix, std::string_view format, std::string message);
 
 	std::vector<std::unique_ptr<LogSink>> log_sinks;
@@ -473,22 +473,23 @@ static inline bool ys_debug(int = 0) { return false; }
 template <typename... Args>
 inline void log(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_string({}, fmt.format_string(), fmt.format(args...), LogSeverity::Info);
+	logger().log_formatted_string(LogSeverity::Info, {}, fmt.format_string(), fmt.format(args...));
 }
 
 template <typename... Args>
 inline void log_comment(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	logger().log_formatted_string({}, fmt.format_string(), fmt.format(args...), LogSeverity::Comment);
+	logger().log_formatted_string(LogSeverity::Comment, {}, fmt.format_string(), fmt.format(args...));
 }
 
 template <typename... Args>
-inline void log_debug(FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
+inline void log_formatted_string(LogSeverity severity, std::string_view prefix,
+		FmtString<TypeIdentity<Args>...> fmt, const Args &... args)
 {
-	if (!ys_debug(1))
-		return;
-	logger().log_formatted_string({}, fmt.format_string(), fmt.format(args...), LogSeverity::Debug);
+	logger().log_formatted_string(severity, prefix, fmt.format_string(), fmt.format(args...));
 }
+
+#define log_debug(...) do { if (ys_debug(1)) YOSYS_NAMESPACE_PREFIX log_formatted_string(YOSYS_NAMESPACE_PREFIX LogSeverity::Debug, {}, __VA_ARGS__); } while (0)
 
 template <typename... Args>
 inline void log_header(RTLIL::Design *design, FmtString<TypeIdentity<Args>...> fmt, const Args &... args)

--- a/kernel/log_compat.cc
+++ b/kernel/log_compat.cc
@@ -37,7 +37,7 @@ void log_cmd_error(const char *format, ...)
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-    log_formatted_cmd_error(formatted);
+    logger().log_formatted_cmd_error(formatted);
 }
 
 void log_warning(const char *format, ...)
@@ -46,7 +46,7 @@ void log_warning(const char *format, ...)
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-    log_formatted_warning("Warning: ", formatted);
+    logger().log_formatted_warning("Warning: ", formatted);
 }
 
 void log_warning_noprefix(const char *format, ...)
@@ -55,7 +55,7 @@ void log_warning_noprefix(const char *format, ...)
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-    log_formatted_warning("", formatted);
+    logger().log_formatted_warning("", formatted);
 }
 
 void log_error(const char *format, ...)
@@ -64,7 +64,7 @@ void log_error(const char *format, ...)
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-    log_formatted_error(formatted);
+    logger().log_formatted_error(formatted);
 }
 
 static inline void log_formatted(std::string const &str)

--- a/kernel/log_compat.cc
+++ b/kernel/log_compat.cc
@@ -73,7 +73,7 @@ void log(const char *format, ...)
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-	logger().log_formatted_string({}, format, formatted, LogSeverity::Info);
+	logger().log_formatted_string(LogSeverity::Info, {}, format, formatted);
 }
 
 void log_compat(const char *format, ...)
@@ -82,7 +82,7 @@ void log_compat(const char *format, ...)
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-	logger().log_formatted_string({}, format, formatted, LogSeverity::Info);
+	logger().log_formatted_string(LogSeverity::Info, {}, format, formatted);
 }
 
 YOSYS_NAMESPACE_END

--- a/kernel/log_compat.cc
+++ b/kernel/log_compat.cc
@@ -33,56 +33,56 @@ YOSYS_NAMESPACE_BEGIN
 
 void log_cmd_error(const char *format, ...)
 {
-    va_list ap;
+	va_list ap;
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-    logger().log_formatted_cmd_error(format, formatted);
+	logger().log_formatted_cmd_error(format, formatted);
 }
 
 void log_warning(const char *format, ...)
 {
-    va_list ap;
+	va_list ap;
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-    logger().log_formatted_warning("Warning: ", format, formatted);
+	logger().log_formatted_warning("Warning: ", format, formatted);
 }
 
 void log_warning_noprefix(const char *format, ...)
 {
-    va_list ap;
+	va_list ap;
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-    logger().log_formatted_warning({}, format, formatted);
+	logger().log_formatted_warning({}, format, formatted);
 }
 
 void log_error(const char *format, ...)
 {
-    va_list ap;
+	va_list ap;
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-    logger().log_formatted_error(format, formatted);
+	logger().log_formatted_error(format, formatted);
 }
 
 void log(const char *format, ...)
 {
-    va_list ap;
+	va_list ap;
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-    logger().log_formatted_string({}, format, formatted, LogSeverity::LOG_INFO);
+	logger().log_formatted_string({}, format, formatted, LogSeverity::Info);
 }
 
 void log_compat(const char *format, ...)
 {
-    va_list ap;
-    va_start(ap, format);
-    std::string formatted = vstringf(format, ap);
-    va_end(ap);
-    logger().log_formatted_string({}, format, formatted, LogSeverity::LOG_INFO);
+	va_list ap;
+	va_start(ap, format);
+	std::string formatted = vstringf(format, ap);
+	va_end(ap);
+	logger().log_formatted_string({}, format, formatted, LogSeverity::Info);
 }
 
 YOSYS_NAMESPACE_END

--- a/kernel/log_compat.cc
+++ b/kernel/log_compat.cc
@@ -37,7 +37,7 @@ void log_cmd_error(const char *format, ...)
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-    logger().log_formatted_cmd_error(formatted);
+    logger().log_formatted_cmd_error(format, formatted);
 }
 
 void log_warning(const char *format, ...)
@@ -46,7 +46,7 @@ void log_warning(const char *format, ...)
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-    logger().log_formatted_warning("Warning: ", formatted);
+    logger().log_formatted_warning("Warning: ", format, formatted);
 }
 
 void log_warning_noprefix(const char *format, ...)
@@ -55,7 +55,7 @@ void log_warning_noprefix(const char *format, ...)
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-    logger().log_formatted_warning("", formatted);
+    logger().log_formatted_warning({}, format, formatted);
 }
 
 void log_error(const char *format, ...)
@@ -64,14 +64,7 @@ void log_error(const char *format, ...)
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-    logger().log_formatted_error(formatted);
-}
-
-static inline void log_formatted(std::string const &str)
-{
-    // We use this inline wrapper as the following becomes ambiguous as soon as
-    // the `log` function below is declared.
-    return log("%s", str);
+    logger().log_formatted_error(format, formatted);
 }
 
 void log(const char *format, ...)
@@ -80,7 +73,7 @@ void log(const char *format, ...)
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-    log_formatted(formatted);
+    logger().log_formatted_string({}, format, formatted, LogSeverity::LOG_INFO);
 }
 
 void log_compat(const char *format, ...)
@@ -89,7 +82,7 @@ void log_compat(const char *format, ...)
     va_start(ap, format);
     std::string formatted = vstringf(format, ap);
     va_end(ap);
-    log_formatted(formatted);
+    logger().log_formatted_string({}, format, formatted, LogSeverity::LOG_INFO);
 }
 
 YOSYS_NAMESPACE_END

--- a/kernel/log_compat.cc
+++ b/kernel/log_compat.cc
@@ -37,7 +37,7 @@ void log_cmd_error(const char *format, ...)
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-	logger().log_formatted_cmd_error(format, formatted);
+	logger().formatted_cmd_error(format, formatted);
 }
 
 void log_warning(const char *format, ...)
@@ -46,7 +46,7 @@ void log_warning(const char *format, ...)
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-	logger().log_formatted_warning("Warning: ", format, formatted);
+	logger().formatted_warning("Warning: ", format, formatted);
 }
 
 void log_warning_noprefix(const char *format, ...)
@@ -55,7 +55,7 @@ void log_warning_noprefix(const char *format, ...)
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-	logger().log_formatted_warning({}, format, formatted);
+	logger().formatted_warning({}, format, formatted);
 }
 
 void log_error(const char *format, ...)
@@ -64,7 +64,7 @@ void log_error(const char *format, ...)
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-	logger().log_formatted_error(format, formatted);
+	logger().formatted_error(format, formatted);
 }
 
 void log(const char *format, ...)
@@ -73,7 +73,7 @@ void log(const char *format, ...)
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-	logger().log_formatted_string(LogSeverity::Info, {}, format, formatted);
+	logger().formatted_string(LogSeverity::Info, {}, format, formatted);
 }
 
 void log_compat(const char *format, ...)
@@ -82,7 +82,7 @@ void log_compat(const char *format, ...)
 	va_start(ap, format);
 	std::string formatted = vstringf(format, ap);
 	va_end(ap);
-	logger().log_formatted_string(LogSeverity::Info, {}, format, formatted);
+	logger().formatted_string(LogSeverity::Info, {}, format, formatted);
 }
 
 YOSYS_NAMESPACE_END

--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -753,16 +753,6 @@ static struct CellHelpMessages {
 	SimHelper get(string name) { return cell_help[get_cell_name(name)]; }
 } cell_help_messages;
 
-class HelpMsgLogSink : public LogSink
-{
-public:
-    explicit HelpMsgLogSink(std::ostream *buf) : buf(buf) {}
-    void log(const LogMessage &msg) override { *buf << msg.message; }
-    void flush() override { buf->flush(); }
-private:
-    std::ostream *buf;
-};
-
 struct HelpPass : public Pass {
 	HelpPass() : Pass("help", "display help messages") { }
 	void help() override
@@ -815,9 +805,11 @@ struct HelpPass : public Pass {
 
 				// dump command help
 				std::ostringstream buf;
-				log_sinks.push_back(std::make_unique<HelpMsgLogSink>(&buf));
-				pass->help();
-				log_sinks.pop_back();
+				{
+					auto log_scope = logger().scoped();
+					logger().add_sink<StreamLogSink>(buf);
+					pass->help();
+				}
 				std::stringstream ss;
 				ss << buf.str();
 

--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -753,6 +753,16 @@ static struct CellHelpMessages {
 	SimHelper get(string name) { return cell_help[get_cell_name(name)]; }
 } cell_help_messages;
 
+class HelpMsgLogSink : public LogSink
+{
+public:
+    explicit HelpMsgLogSink(std::ostream *buf) : buf(buf) {}
+    void log(const LogMessage &msg) override { *buf << msg.message; }
+    void flush() override { buf->flush(); }
+private:
+    std::ostream *buf;
+};
+
 struct HelpPass : public Pass {
 	HelpPass() : Pass("help", "display help messages") { }
 	void help() override
@@ -805,9 +815,9 @@ struct HelpPass : public Pass {
 
 				// dump command help
 				std::ostringstream buf;
-				log_streams.push_back(&buf);
+				log_sinks.push_back(std::make_unique<HelpMsgLogSink>(&buf));
 				pass->help();
-				log_streams.pop_back();
+				log_sinks.pop_back();
 				std::stringstream ss;
 				ss << buf.str();
 

--- a/kernel/register.cc
+++ b/kernel/register.cc
@@ -806,7 +806,7 @@ struct HelpPass : public Pass {
 				// dump command help
 				std::ostringstream buf;
 				{
-					auto log_scope = logger().scoped();
+					auto log_scope = logger().sink_scope();
 					logger().add_sink<StreamLogSink>(buf);
 					pass->help();
 				}

--- a/kernel/satgen.cc
+++ b/kernel/satgen.cc
@@ -1400,9 +1400,9 @@ void report_missing_model(bool warn_only, RTLIL::Cell* cell)
 		s = stringf("No SAT model available for cell %s (%s).\n", cell, cell->type.unescape());
 
 	if (warn_only) {
-		log_formatted_warning_noprefix(s);
+		log_warning_noprefix("%s", s);
 	} else {
-		log_formatted_error(s);
+		log_error("%s", s);
 	}
 }
 

--- a/kernel/tclapi.cc
+++ b/kernel/tclapi.cc
@@ -100,7 +100,7 @@ static int tcl_yosys_cmd(ClientData, Tcl_Interp *interp, int argc, const char *a
 	yosys_get_design()->scratchpad_unset("result.string");
 
 	bool in_repl = yosys_tcl_repl_active;
-	auto guard = logger().scoped_cmd_error_throw();
+	auto guard = logger().error_throw_scope();
 	try {
 		if (args.size() == 1) {
 			Pass::call(yosys_get_design(), args[0]);

--- a/kernel/tclapi.cc
+++ b/kernel/tclapi.cc
@@ -100,10 +100,7 @@ static int tcl_yosys_cmd(ClientData, Tcl_Interp *interp, int argc, const char *a
 	yosys_get_design()->scratchpad_unset("result.string");
 
 	bool in_repl = yosys_tcl_repl_active;
-	bool restore_log_cmd_error_throw = log_cmd_error_throw;
-
-	log_cmd_error_throw = true;
-
+	auto guard = logger().scoped_cmd_error_throw();
 	try {
 		if (args.size() == 1) {
 			Pass::call(yosys_get_design(), args[0]);
@@ -120,14 +117,12 @@ static int tcl_yosys_cmd(ClientData, Tcl_Interp *interp, int argc, const char *a
 		Tcl_SetResult(interp, (char *)"Yosys command produced an error", TCL_STATIC);
 
 		yosys_tcl_repl_active = in_repl;
-		log_cmd_error_throw = restore_log_cmd_error_throw;
 		return TCL_ERROR;
 	} catch (...) {
 		log_error("uncaught exception during Yosys command invoked from TCL\n");
 	}
 
 	yosys_tcl_repl_active = in_repl;
-	log_cmd_error_throw = restore_log_cmd_error_throw;
 
 	auto &scratchpad = yosys_get_design()->scratchpad;
 	auto result = scratchpad.find("result.json");

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -286,7 +286,7 @@ void yosys_shutdown()
 	yosys_design = NULL;
 	RTLIL::OwningIdString::collect_garbage();
 
-	log_sinks.clear();
+	logger().clear();
 
 #ifdef YOSYS_ENABLE_TCL
 	if (yosys_tcl_interp != NULL) {
@@ -995,7 +995,7 @@ void shell(RTLIL::Design *design)
 	static int recursion_counter = 0;
 
 	recursion_counter++;
-	log_cmd_error_throw = true;
+	auto guard = logger().scoped_cmd_error_throw();
 
 #if defined(YOSYS_ENABLE_READLINE) || defined(YOSYS_ENABLE_EDITLINE)
 	rl_readline_name = (char*)"yosys";
@@ -1055,7 +1055,6 @@ void shell(RTLIL::Design *design)
 		free(command);
 #endif
 	recursion_counter--;
-	log_cmd_error_throw = false;
 }
 
 struct ShellPass : public Pass {

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -286,11 +286,7 @@ void yosys_shutdown()
 	yosys_design = NULL;
 	RTLIL::OwningIdString::collect_garbage();
 
-	for (auto f : log_files)
-		if (f != stderr)
-			fclose(f);
-	log_errfile = NULL;
-	log_files.clear();
+	log_sinks.clear();
 
 #ifdef YOSYS_ENABLE_TCL
 	if (yosys_tcl_interp != NULL) {

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -995,7 +995,7 @@ void shell(RTLIL::Design *design)
 	static int recursion_counter = 0;
 
 	recursion_counter++;
-	auto guard = logger().scoped_cmd_error_throw();
+	auto guard = logger().error_throw_scope();
 
 #if defined(YOSYS_ENABLE_READLINE) || defined(YOSYS_ENABLE_EDITLINE)
 	rl_readline_name = (char*)"yosys";

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -777,7 +777,7 @@ bool run_frontend(std::string filename, std::string command, RTLIL::Design *desi
 			from_to_active = run_from.empty();
 		}
 
-		log("\n-- Executing script file `%s' --\n", filename);
+		log_comment("\n-- Executing script file `%s' --\n", filename);
 
 		FILE *f = stdin;
 
@@ -847,9 +847,9 @@ bool run_frontend(std::string filename, std::string command, RTLIL::Design *desi
 	}
 
 	if (filename == "-") {
-		log("\n-- Parsing stdin using frontend `%s' --\n", command);
+		log_comment("\n-- Parsing stdin using frontend `%s' --\n", command);
 	} else {
-		log("\n-- Parsing `%s' using frontend `%s' --\n", filename, command);
+		log_comment("\n-- Parsing `%s' using frontend `%s' --\n", filename, command);
 	}
 
 	if (command[0] == ' ') {
@@ -868,7 +868,7 @@ void run_pass(std::string command, RTLIL::Design *design)
 	if (design == nullptr)
 		design = yosys_design;
 
-	log("\n-- Running command `%s' --\n", command);
+	log_comment("\n-- Running command `%s' --\n", command);
 
 	Pass::call(design, command);
 }
@@ -907,9 +907,9 @@ void run_backend(std::string filename, std::string command, RTLIL::Design *desig
 		filename = "-";
 
 	if (filename == "-") {
-		log("\n-- Writing to stdout using backend `%s' --\n", command);
+		log_comment("\n-- Writing to stdout using backend `%s' --\n", command);
 	} else {
-		log("\n-- Writing to `%s' using backend `%s' --\n", filename, command);
+		log_comment("\n-- Writing to `%s' using backend `%s' --\n", filename, command);
 	}
 
 	Backend::backend_call(design, NULL, filename, command);

--- a/passes/cmds/logger.cc
+++ b/passes/cmds/logger.cc
@@ -85,22 +85,22 @@ struct LoggerPass : public Pass {
 		{
 
 			if (args[argidx] == "-time") {
-				log_time = true;
+				logger().set_log_time(true);
 				log("Enabled timestamp in logs.\n");
 				continue;
 			}
 			if (args[argidx] == "-notime") {
-				log_time = false;
+				logger().set_log_time(false);
 				log("Disabled timestamp in logs.\n");
 				continue;
 			}
 			if (args[argidx] == "-stderr") {
-				log_error_stderr = true;
+				logger().set_error_stderr(true);
 				log("Enabled loggint errors to stderr.\n");
 				continue;
 			}
 			if (args[argidx] == "-nostderr") {
-				log_error_stderr = false;
+				logger().set_error_stderr(false);
 				log("Disabled loggint errors to stderr.\n");
 				continue;
 			}
@@ -109,7 +109,7 @@ struct LoggerPass : public Pass {
 				if (pattern.front() == '\"' && pattern.back() == '\"') pattern = pattern.substr(1, pattern.size() - 2);
 				try {
 					log("Added regex '%s' for warnings to warn list.\n", pattern);
-					log_warn_regexes.push_back(YS_REGEX_COMPILE(pattern));
+					logger().add_warn(pattern);
 				}
 				catch (const std::regex_error& e) {
 					log_cmd_error("Error in regex expression '%s' !\n", pattern);
@@ -121,7 +121,7 @@ struct LoggerPass : public Pass {
 				if (pattern.front() == '\"' && pattern.back() == '\"') pattern = pattern.substr(1, pattern.size() - 2);
 				try {
 					log("Added regex '%s' for warnings to nowarn list.\n", pattern);
-					log_nowarn_regexes.push_back(YS_REGEX_COMPILE(pattern));
+					logger().add_nowarn(pattern);
 				}
 				catch (const std::regex_error& e) {
 					log_cmd_error("Error in regex expression '%s' !\n", pattern);
@@ -133,7 +133,7 @@ struct LoggerPass : public Pass {
 				if (pattern.front() == '\"' && pattern.back() == '\"') pattern = pattern.substr(1, pattern.size() - 2);
 				try {
 					log("Added regex '%s' for warnings to werror list.\n", pattern);
-					log_werror_regexes.push_back(YS_REGEX_COMPILE(pattern));
+					logger().add_werror(pattern);
 				}
 				catch (const std::regex_error& e) {
 					log_cmd_error("Error in regex expression '%s' !\n", pattern);
@@ -141,19 +141,19 @@ struct LoggerPass : public Pass {
 				continue;
 			}
 			if (args[argidx] == "-debug") {
-				log_force_debug = 1;
+				logger().set_force_debug(true);
 				log("Enabled debug log messages.\n");
 				continue;
 			}
 			if (args[argidx] == "-nodebug") {
-				log_force_debug = 0;
+				logger().set_force_debug(false);
 				log("Disabled debug log messages.\n");
 				continue;
 			}
 			if (args[argidx] == "-experimental" && argidx+1 < args.size()) {
 				std::string value = args[++argidx];
 				log("Added '%s' experimental ignore list.\n", value);
-				log_experimentals_ignored.insert(value);
+				logger().add_experimental_ignore(value);
 				continue;
 			}
 			if (args[argidx] == "-expect" && argidx+3 < args.size()) {
@@ -161,7 +161,7 @@ struct LoggerPass : public Pass {
 				if (type!="error" && type!="warning" && type!="log"
 						&& type!="prefix-error" && type!="prefix-warning" && type!="prefix-log")
 					log_cmd_error("Expect command require type to be 'log', 'warning' or 'error' !\n");
-				if ((type=="error" || type=="prefix-error") && log_expect_error.size()>0)
+				if ((type=="error" || type=="prefix-error") && logger().expects_error())
 					log_cmd_error("Only single error message can be expected !\n");
 				std::string pattern = args[++argidx];
 				if (pattern.front() == '\"' && pattern.back() == '\"') pattern = pattern.substr(1, pattern.size() - 2);
@@ -173,19 +173,7 @@ struct LoggerPass : public Pass {
 				log("Added regex '%s' to expected %s messages list.\n",
 					pattern.c_str(), type.c_str());
 				try {
-					if (type == "error")
-						log_expect_error[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
-					else if (type == "prefix-error")
-						log_expect_prefix_error[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
-					else if (type == "warning")
-						log_expect_warning[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
-					else if (type == "prefix-warning")
-						log_expect_prefix_warning[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
-					else if (type == "log")
-						log_expect_log[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
-					else if (type == "prefix-log")
-						log_expect_prefix_log[pattern] = LogExpectedItem(YS_REGEX_COMPILE(pattern), count);
-					else log_abort();
+					logger().add_expect(type, pattern, count);
 				}
 				catch (const std::regex_error& e) {
 					log_cmd_error("Error in regex expression '%s' !\n", pattern);
@@ -193,11 +181,11 @@ struct LoggerPass : public Pass {
 				continue;
 			}
 			if (args[argidx] == "-expect-no-warnings") {
-				log_expect_no_warnings = true;
+				logger().set_expect_no_warnings(true);
 				continue;
 			}
 			if (args[argidx] == "-check-expected") {
-				log_check_expected();
+				logger().check_expected();
 				continue;
 			}
 			break;

--- a/passes/cmds/logger.cc
+++ b/passes/cmds/logger.cc
@@ -42,9 +42,6 @@ struct LoggerPass : public Pass {
 		log("    -[no]time\n");
 		log("        enable/disable display of timestamp in log output.\n");
 		log("\n");
-		log("    -[no]stderr\n");
-		log("        enable/disable logging errors to stderr.\n");
-		log("\n");
 		log("    -warn regex\n");
 		log("        print a warning for all log messages matching the regex.\n");
 		log("\n");
@@ -92,16 +89,6 @@ struct LoggerPass : public Pass {
 			if (args[argidx] == "-notime") {
 				logger().set_log_time(false);
 				log("Disabled timestamp in logs.\n");
-				continue;
-			}
-			if (args[argidx] == "-stderr") {
-				logger().set_error_stderr(true);
-				log("Enabled loggint errors to stderr.\n");
-				continue;
-			}
-			if (args[argidx] == "-nostderr") {
-				logger().set_error_stderr(false);
-				log("Disabled loggint errors to stderr.\n");
 				continue;
 			}
 			if (args[argidx] == "-warn" && argidx+1 < args.size()) {

--- a/passes/cmds/tee.cc
+++ b/passes/cmds/tee.cc
@@ -64,7 +64,7 @@ struct TeePass : public Pass {
 		for (argidx = 1; argidx < args.size(); argidx++)
 		{
 			if (args[argidx] == "-q") {
-				logger().clear();
+				logger().clear_original();
 				continue;
 			}
 			if ((args[argidx] == "-o" || args[argidx] == "-a") && argidx+1 < args.size()) {
@@ -73,9 +73,8 @@ struct TeePass : public Pass {
 				rewrite_filename(path);
 				try {
 					logger().add_sink<FileLogSink>(path.c_str(), false, is_append);
-				} catch (const std::runtime_error &e) {
-					std::cerr << e.what();
-					exit(1);
+				} catch (const std::runtime_error &) {
+					log_cmd_error("Can't create file %s.\n", args[argidx]);
 				}
 				continue;
 			}

--- a/passes/cmds/tee.cc
+++ b/passes/cmds/tee.cc
@@ -58,17 +58,13 @@ struct TeePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
-		int backup_log_verbose_level = log_verbose_level;
-		auto backup_log_sinks = std::move(log_sinks);
-	    log_sinks.reserve(backup_log_sinks.size());
-	    for (const auto &sink : backup_log_sinks)
-    	    log_sinks.push_back(std::make_unique<LogSinkRef>(sink.get()));
+		auto log_scope = logger().scoped();
 
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
 		{
 			if (args[argidx] == "-q") {
-				log_sinks.clear();
+				logger().clear();
 				continue;
 			}
 			if ((args[argidx] == "-o" || args[argidx] == "-a") && argidx+1 < args.size()) {
@@ -76,7 +72,7 @@ struct TeePass : public Pass {
 				auto path = args[++argidx];
 				rewrite_filename(path);
 				try {
-					log_sinks.push_back(std::make_unique<FileLogSink>(path.c_str(), false, is_append));
+					logger().add_sink<FileLogSink>(path.c_str(), false, is_append);
 				} catch (const std::runtime_error &e) {
 					std::cerr << e.what();
 					exit(1);
@@ -86,28 +82,18 @@ struct TeePass : public Pass {
 			if (args[argidx] == "-s" && argidx+1 < args.size()) {
 				auto name = args[++argidx];
 				design->scratchpad[name] = "";
-				log_sinks.push_back(std::make_unique<ScratchPadLogSink>(name));
+				logger().add_sink<ScratchPadLogSink>(name);
 				continue;
 			}
 			if (GetSize(args[argidx]) >= 2 && (args[argidx][0] == '-' || args[argidx][0] == '+') && args[argidx][1] >= '0' && args[argidx][1] <= '9') {
-				log_verbose_level += atoi(args[argidx].c_str());
+				logger().add_verbose_level(atoi(args[argidx].c_str()));
 				continue;
 			}
 			break;
 		}
 
-		try {
-			std::vector<std::string> new_args(args.begin() + argidx, args.end());
-			Pass::call(design, new_args);
-		} catch (...) {
-			log_sinks.clear();
-			log_sinks = std::move(backup_log_sinks);
-			throw;
-		}
-
-		log_verbose_level = backup_log_verbose_level;
-		log_sinks.clear();
-		log_sinks = std::move(backup_log_sinks);
+		std::vector<std::string> new_args(args.begin() + argidx, args.end());
+		Pass::call(design, new_args);
 	}
 } TeePass;
 

--- a/passes/cmds/tee.cc
+++ b/passes/cmds/tee.cc
@@ -58,41 +58,35 @@ struct TeePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
-		std::vector<FILE*> backup_log_files, files_to_close;
-		std::vector<std::ostream*> backup_log_streams;
-		std::vector<std::string> backup_log_scratchpads;
 		int backup_log_verbose_level = log_verbose_level;
-		backup_log_streams = log_streams;
-		backup_log_files = log_files;
-		backup_log_scratchpads = log_scratchpads;
+		auto backup_log_sinks = std::move(log_sinks);
+	    log_sinks.reserve(backup_log_sinks.size());
+	    for (const auto &sink : backup_log_sinks)
+    	    log_sinks.push_back(std::make_unique<LogSinkRef>(sink.get()));
 
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)
 		{
-			if (args[argidx] == "-q" && files_to_close.empty()) {
-				log_files.clear();
-				log_streams.clear();
+			if (args[argidx] == "-q") {
+				log_sinks.clear();
 				continue;
 			}
 			if ((args[argidx] == "-o" || args[argidx] == "-a") && argidx+1 < args.size()) {
-				const char *open_mode = args[argidx] == "-o" ? "w" : "a+";
+				bool is_append = args[argidx] == "-a";
 				auto path = args[++argidx];
 				rewrite_filename(path);
-				FILE *f = fopen(path.c_str(), open_mode);
-				yosys_input_files.insert(args[argidx]);
-				if (f == NULL) {
-					for (auto cf : files_to_close)
-						fclose(cf);
-					log_cmd_error("Can't create file %s.\n", args[argidx]);
+				try {
+					log_sinks.push_back(std::make_unique<FileLogSink>(path.c_str(), false, is_append));
+				} catch (const std::runtime_error &e) {
+					std::cerr << e.what();
+					exit(1);
 				}
-				log_files.push_back(f);
-				files_to_close.push_back(f);
 				continue;
 			}
 			if (args[argidx] == "-s" && argidx+1 < args.size()) {
 				auto name = args[++argidx];
 				design->scratchpad[name] = "";
-				log_scratchpads.push_back(name);
+				log_sinks.push_back(std::make_unique<ScratchPadLogSink>(name));
 				continue;
 			}
 			if (GetSize(args[argidx]) >= 2 && (args[argidx][0] == '-' || args[argidx][0] == '+') && args[argidx][1] >= '0' && args[argidx][1] <= '9') {
@@ -106,21 +100,14 @@ struct TeePass : public Pass {
 			std::vector<std::string> new_args(args.begin() + argidx, args.end());
 			Pass::call(design, new_args);
 		} catch (...) {
-			for (auto cf : files_to_close)
-				fclose(cf);
-			log_files = backup_log_files;
-			log_streams = backup_log_streams;
-			log_scratchpads = backup_log_scratchpads;
+			log_sinks.clear();
+			log_sinks = std::move(backup_log_sinks);
 			throw;
 		}
 
-		for (auto cf : files_to_close)
-			fclose(cf);
-
 		log_verbose_level = backup_log_verbose_level;
-		log_files = backup_log_files;
-		log_streams = backup_log_streams;
-		log_scratchpads = backup_log_scratchpads;
+		log_sinks.clear();
+		log_sinks = std::move(backup_log_sinks);
 	}
 } TeePass;
 

--- a/passes/cmds/tee.cc
+++ b/passes/cmds/tee.cc
@@ -58,7 +58,7 @@ struct TeePass : public Pass {
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
-		auto log_scope = logger().scoped();
+		auto log_scope = logger().sink_scope();
 
 		size_t argidx;
 		for (argidx = 1; argidx < args.size(); argidx++)

--- a/passes/cmds/trace.cc
+++ b/passes/cmds/trace.cc
@@ -153,7 +153,7 @@ struct DebugPass : public Pass {
 			return;
 		}
 
-		auto force_debug = logger().force_debug(true);
+		auto force_debug = logger().force_debug_scope(true);
 
 		std::vector<std::string> new_args(args.begin() + argidx, args.end());
 		Pass::call(design, new_args);

--- a/passes/cmds/trace.cc
+++ b/passes/cmds/trace.cc
@@ -144,27 +144,19 @@ struct DebugPass : public Pass {
 			log_cmd_error("Cannot specify both -on and -off\n");
 
 		if (mode_on) {
-			log_force_debug++;
+			logger().force_debug_on();
 			return;
 		}
 
 		if (mode_off) {
-			if (log_force_debug > 0)
-				log_force_debug--;
+			logger().force_debug_off();
 			return;
 		}
 
-		log_force_debug++;
+		auto force_debug = logger().force_debug(true);
 
-		try {
-			std::vector<std::string> new_args(args.begin() + argidx, args.end());
-			Pass::call(design, new_args);
-		} catch (...) {
-			log_force_debug--;
-			throw;
-		}
-
-		log_force_debug--;
+		std::vector<std::string> new_args(args.begin() + argidx, args.end());
+		Pass::call(design, new_args);
 	}
 } DebugPass;
 

--- a/passes/opt/opt_demorgan.cc
+++ b/passes/opt/opt_demorgan.cc
@@ -186,6 +186,7 @@ struct OptDemorganPass : public Pass {
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing OPT_DEMORGAN pass (push inverters through $reduce_* cells).\n");
+		log_deprecated("opt_demorgan");
 
 		int argidx = 1;
 		extra_args(args, argidx, design);

--- a/passes/techmap/libparse.cc
+++ b/passes/techmap/libparse.cc
@@ -39,7 +39,7 @@ void warn(std::string str) {
 #else
 #include "kernel/log.h"
 void warn(std::string str) {
-	Yosys::log_formatted_warning("", str);
+	Yosys::log_warning_noprefix("%s", str);
 }
 #endif
 

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -419,7 +419,7 @@ struct TechmapWorker
 
 		bool log_continue = false;
 		bool did_something = false;
-		auto mkdebug = logger().make_debug();
+		auto mkdebug = logger().make_debug_scope();
 
 		SigMap sigmap(module);
 		FfInitVals initvals(&sigmap, module);

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -419,7 +419,7 @@ struct TechmapWorker
 
 		bool log_continue = false;
 		bool did_something = false;
-		LogMakeDebugHdl mkdebug;
+		auto mkdebug = logger().make_debug();
 
 		SigMap sigmap(module);
 		FfInitVals initvals(&sigmap, module);

--- a/pyosys/generator.py
+++ b/pyosys/generator.py
@@ -119,21 +119,15 @@ global_denylist = frozenset(
     {
         # deprecated
         "builtin_ff_cell_types",
-        "logv_file_error",
         # no implementation
         "set_verific_logging",
-        # can't bridge to python cleanly
-        ## std::regex
-        "log_warn_regexes",
-        "log_nowarn_regexes",
-        "log_werror_regexes",
         ## function pointers
         "log_error_atexit",
         "log_verific_callback",
         # incomplete type
         "yosys_get_tcl_interp",
-        # unique ptr vector
-        "log_sinks",
+        # manually added later
+        "logger",
     }
 )
 pyosys_headers = [

--- a/pyosys/generator.py
+++ b/pyosys/generator.py
@@ -126,8 +126,6 @@ global_denylist = frozenset(
         "log_verific_callback",
         # incomplete type
         "yosys_get_tcl_interp",
-        # manually added later
-        "logger",
     }
 )
 pyosys_headers = [

--- a/pyosys/generator.py
+++ b/pyosys/generator.py
@@ -132,6 +132,8 @@ global_denylist = frozenset(
         "log_verific_callback",
         # incomplete type
         "yosys_get_tcl_interp",
+        # unique ptr vector
+        "log_sinks",
     }
 )
 pyosys_headers = [

--- a/pyosys/wrappers_tpl.cc
+++ b/pyosys/wrappers_tpl.cc
@@ -180,12 +180,12 @@ namespace pyosys {
 		// Logging Methods
 		m.def("log_header", [](Design *d, std::string s) { logger().log_formatted_header(d, "%s", s); });
 		m.def("log", [](std::string s) { logger().log_formatted_string({}, "%s", s, LogSeverity::LOG_INFO); });
-		m.def("log_file_info", [](std::string_view file, int line, std::string s) { logger().log_formatted_file_info(file, line, s); });
-		m.def("log_warning", [](std::string s) { logger().log_formatted_warning("Warning: ", s); });
-		m.def("log_warning_noprefix", [](std::string s) { logger().log_formatted_warning("", s); });
-		m.def("log_file_warning", [](std::string_view file, int line, std::string s) { logger().log_formatted_file_warning(file, line, s); });
-		m.def("log_error", [](std::string s) { logger().log_formatted_error(s); });
-		m.def("log_file_error", [](std::string_view file, int line, std::string s) { logger().log_formatted_file_error(file, line, s); });
+		m.def("log_file_info", [](std::string_view file, int line, std::string s) { logger().log_formatted_file_info(file, line, "%s", s); });
+		m.def("log_warning", [](std::string s) { logger().log_formatted_warning("Warning: ", "%s", s); });
+		m.def("log_warning_noprefix", [](std::string s) { logger().log_formatted_warning("", "%s", s); });
+		m.def("log_file_warning", [](std::string_view file, int line, std::string s) { logger().log_formatted_file_warning(file, line, "%s", s); });
+		m.def("log_error", [](std::string s) { logger().log_formatted_error("%s", s); });
+		m.def("log_file_error", [](std::string_view file, int line, std::string s) { logger().log_formatted_file_error(file, line, "%s", s); });
 
 		// Namespace to host global objects
 		auto global_variables = py::class_<Globals>(m, "Globals");

--- a/pyosys/wrappers_tpl.cc
+++ b/pyosys/wrappers_tpl.cc
@@ -168,8 +168,8 @@ namespace pyosys {
 		m.doc() = "python access to libyosys";
 
 		if (!yosys_already_setup()) {
-			log_sinks.push_back(std::make_unique<ConsoleLogSink>());
-			log_error_stderr = true;
+			logger().add_sink<ConsoleLogSink>();
+			logger().set_error_stderr(true);
 			yosys_setup();
 
 			// Cleanup
@@ -179,17 +179,24 @@ namespace pyosys {
 		}
 
 		// Logging Methods
-		m.def("log_header", [](Design *d, std::string s) { log_formatted_header(d, "%s", s); });
-		m.def("log", [](std::string s) { log_formatted_string({}, "%s", s, LogSeverity::LOG_INFO); });
-		m.def("log_file_info", [](std::string_view file, int line, std::string s) { log_formatted_file_info(file, line, s); });
-		m.def("log_warning", [](std::string s) { log_formatted_warning("Warning: ", s); });
-		m.def("log_warning_noprefix", [](std::string s) { log_formatted_warning("", s); });
-		m.def("log_file_warning", [](std::string_view file, int line, std::string s) { log_formatted_file_warning(file, line, s); });
-		m.def("log_error", [](std::string s) { log_formatted_error(s); });
-		m.def("log_file_error", [](std::string_view file, int line, std::string s) { log_formatted_file_error(file, line, s); });
+		m.def("log_header", [](Design *d, std::string s) { logger().log_formatted_header(d, "%s", s); });
+		m.def("log", [](std::string s) { logger().log_formatted_string({}, "%s", s, LogSeverity::LOG_INFO); });
+		m.def("log_file_info", [](std::string_view file, int line, std::string s) { logger().log_formatted_file_info(file, line, s); });
+		m.def("log_warning", [](std::string s) { logger().log_formatted_warning("Warning: ", s); });
+		m.def("log_warning_noprefix", [](std::string s) { logger().log_formatted_warning("", s); });
+		m.def("log_file_warning", [](std::string_view file, int line, std::string s) { logger().log_formatted_file_warning(file, line, s); });
+		m.def("log_error", [](std::string s) { logger().log_formatted_error(s); });
+		m.def("log_file_error", [](std::string_view file, int line, std::string s) { logger().log_formatted_file_error(file, line, s); });
 
 		// Namespace to host global objects
 		auto global_variables = py::class_<Globals>(m, "Globals");
+		global_variables.def_property_readonly_static(
+			"logger",
+			[](const pyosys::Globals &) -> Yosys::LogManager & {
+				return logger();
+			},
+			pybind11::return_value_policy::reference
+		);
 
 		// Trampoline Classes
 		py::class_<Pass, pyosys::PassTrampoline, std::unique_ptr<Pass, py::nodelete>>(m, "Pass")

--- a/pyosys/wrappers_tpl.cc
+++ b/pyosys/wrappers_tpl.cc
@@ -180,7 +180,7 @@ namespace pyosys {
 
 		// Logging Methods
 		m.def("log_header", [](Design *d, std::string s) { log_formatted_header(d, "%s", s); });
-		m.def("log", [](std::string s) { log_formatted_string("%s", s); });
+		m.def("log", [](std::string s) { log_formatted_string({}, "%s", s, LogSeverity::LOG_INFO); });
 		m.def("log_file_info", [](std::string_view file, int line, std::string s) { log_formatted_file_info(file, line, s); });
 		m.def("log_warning", [](std::string s) { log_formatted_warning("Warning: ", s); });
 		m.def("log_warning_noprefix", [](std::string s) { log_formatted_warning("", s); });

--- a/pyosys/wrappers_tpl.cc
+++ b/pyosys/wrappers_tpl.cc
@@ -168,7 +168,7 @@ namespace pyosys {
 		m.doc() = "python access to libyosys";
 
 		if (!yosys_already_setup()) {
-			log_streams.push_back(&std::cout);
+			log_sinks.push_back(std::make_unique<ConsoleLogSink>());
 			log_error_stderr = true;
 			yosys_setup();
 

--- a/pyosys/wrappers_tpl.cc
+++ b/pyosys/wrappers_tpl.cc
@@ -179,7 +179,7 @@ namespace pyosys {
 
 		// Logging Methods
 		m.def("log_header", [](Design *d, std::string s) { logger().log_formatted_header(d, "%s", s); });
-		m.def("log", [](std::string s) { logger().log_formatted_string({}, "%s", s, LogSeverity::LOG_INFO); });
+		m.def("log", [](std::string s) { logger().log_formatted_string({}, "%s", s, LogSeverity::Info); });
 		m.def("log_file_info", [](std::string_view file, int line, std::string s) { logger().log_formatted_file_info(file, line, "%s", s); });
 		m.def("log_warning", [](std::string s) { logger().log_formatted_warning("Warning: ", "%s", s); });
 		m.def("log_warning_noprefix", [](std::string s) { logger().log_formatted_warning("", "%s", s); });

--- a/pyosys/wrappers_tpl.cc
+++ b/pyosys/wrappers_tpl.cc
@@ -169,7 +169,6 @@ namespace pyosys {
 
 		if (!yosys_already_setup()) {
 			logger().add_sink<ConsoleLogSink>();
-			logger().set_error_stderr(true);
 			yosys_setup();
 
 			// Cleanup

--- a/pyosys/wrappers_tpl.cc
+++ b/pyosys/wrappers_tpl.cc
@@ -178,14 +178,14 @@ namespace pyosys {
 		}
 
 		// Logging Methods
-		m.def("log_header", [](Design *d, std::string s) { logger().log_formatted_header(d, "%s", s); });
-		m.def("log", [](std::string s) { logger().log_formatted_string({}, "%s", s, LogSeverity::Info); });
-		m.def("log_file_info", [](std::string_view file, int line, std::string s) { logger().log_formatted_file_info(file, line, "%s", s); });
-		m.def("log_warning", [](std::string s) { logger().log_formatted_warning("Warning: ", "%s", s); });
-		m.def("log_warning_noprefix", [](std::string s) { logger().log_formatted_warning("", "%s", s); });
-		m.def("log_file_warning", [](std::string_view file, int line, std::string s) { logger().log_formatted_file_warning(file, line, "%s", s); });
-		m.def("log_error", [](std::string s) { logger().log_formatted_error("%s", s); });
-		m.def("log_file_error", [](std::string_view file, int line, std::string s) { logger().log_formatted_file_error(file, line, "%s", s); });
+		m.def("log_header", [](Design *d, std::string s) { logger().formatted_header(d, "%s", s); });
+		m.def("log", [](std::string s) { logger().formatted_string(LogSeverity::Info, {}, "%s", s); });
+		m.def("log_file_info", [](std::string_view file, int line, std::string s) { logger().formatted_file_info(file, line, "%s", s); });
+		m.def("log_warning", [](std::string s) { logger().formatted_warning("Warning: ", "%s", s); });
+		m.def("log_warning_noprefix", [](std::string s) { logger().formatted_warning("", "%s", s); });
+		m.def("log_file_warning", [](std::string_view file, int line, std::string s) { logger().formatted_file_warning(file, line, "%s", s); });
+		m.def("log_error", [](std::string s) { logger().formatted_error("%s", s); });
+		m.def("log_file_error", [](std::string_view file, int line, std::string s) { logger().formatted_file_error(file, line, "%s", s); });
 
 		// Namespace to host global objects
 		auto global_variables = py::class_<Globals>(m, "Globals");

--- a/pyosys/wrappers_tpl.cc
+++ b/pyosys/wrappers_tpl.cc
@@ -190,13 +190,6 @@ namespace pyosys {
 
 		// Namespace to host global objects
 		auto global_variables = py::class_<Globals>(m, "Globals");
-		global_variables.def_property_readonly_static(
-			"logger",
-			[](const pyosys::Globals &) -> Yosys::LogManager & {
-				return logger();
-			},
-			pybind11::return_value_policy::reference
-		);
 
 		// Trampoline Classes
 		py::class_<Pass, pyosys::PassTrampoline, std::unique_ptr<Pass, py::nodelete>>(m, "Pass")

--- a/tests/unit/kernel/cellTypesTest.cc
+++ b/tests/unit/kernel/cellTypesTest.cc
@@ -11,7 +11,7 @@ YOSYS_NAMESPACE_BEGIN
 TEST(CellTypesTest, basic)
 {
 	yosys_setup();
-	log_files.push_back(stdout);
+	if (log_sinks.empty()) log_sinks.push_back(std::make_unique<ConsoleLogSink>());
 	CellTypes older;
 	NewCellTypes newer;
 	older.setup(nullptr);

--- a/tests/unit/kernel/cellTypesTest.cc
+++ b/tests/unit/kernel/cellTypesTest.cc
@@ -11,7 +11,7 @@ YOSYS_NAMESPACE_BEGIN
 TEST(CellTypesTest, basic)
 {
 	yosys_setup();
-	if (log_sinks.empty()) log_sinks.push_back(std::make_unique<ConsoleLogSink>());
+	if (logger().empty()) logger().add_sink<ConsoleLogSink>();
 	CellTypes older;
 	NewCellTypes newer;
 	older.setup(nullptr);

--- a/tests/unit/kernel/logTest.cc
+++ b/tests/unit/kernel/logTest.cc
@@ -1,3 +1,4 @@
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "kernel/yosys.h"
@@ -9,6 +10,40 @@ TEST(KernelLogTest, logvValidValues)
 {
 	//TODO: Implement log test
 	EXPECT_EQ(7, 7);
+}
+
+class TestSink : public LogSink {
+ public:
+	void log(const LogMessage& message) override {
+		messages_.push_back(message);
+	}
+	std::vector<LogMessage> messages_;
+};
+
+TEST(KernelLogTest, logToSink)
+{
+	TestSink sink;
+	log_sinks.push_back(&sink);
+	log("test info log");
+	log_warning("test warning log");
+
+	std::vector<LogMessage> expected{
+		LogMessage(LogSeverity::LOG_INFO, "test info log"),
+		LogMessage(LogSeverity::LOG_WARNING, "test warning log"),
+	};
+	// Certain calls to the log.h interface may prepend a string to
+	// the provided string. We should ensure that the expected string
+	// is a subset of the actual string. Additionally, we don't want to
+	// compare timestamps. So, we use a custom comparator.
+	for (const LogMessage& expected_msg : expected) {
+		EXPECT_THAT(sink.messages_, ::testing::Contains(::testing::Truly(
+			[&](const LogMessage& actual) {
+				return actual.severity == expected_msg.severity &&
+					actual.message.find(expected_msg.message) != std::string::npos;
+			}
+		)));
+	}
+	EXPECT_NE(sink.messages_[0].timestamp, 0);
 }
 
 YOSYS_NAMESPACE_END

--- a/tests/unit/kernel/logTest.cc
+++ b/tests/unit/kernel/logTest.cc
@@ -1,4 +1,3 @@
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "kernel/yosys.h"
@@ -10,40 +9,6 @@ TEST(KernelLogTest, logvValidValues)
 {
 	//TODO: Implement log test
 	EXPECT_EQ(7, 7);
-}
-
-class TestSink : public LogSink {
- public:
-	void log(const LogMessage& message) override {
-		messages_.push_back(message);
-	}
-	std::vector<LogMessage> messages_;
-};
-
-TEST(KernelLogTest, logToSink)
-{
-	TestSink sink;
-	log_sinks.push_back(&sink);
-	log("test info log");
-	log_warning("test warning log");
-
-	std::vector<LogMessage> expected{
-		LogMessage(LogSeverity::LOG_INFO, "test info log"),
-		LogMessage(LogSeverity::LOG_WARNING, "test warning log"),
-	};
-	// Certain calls to the log.h interface may prepend a string to
-	// the provided string. We should ensure that the expected string
-	// is a subset of the actual string. Additionally, we don't want to
-	// compare timestamps. So, we use a custom comparator.
-	for (const LogMessage& expected_msg : expected) {
-		EXPECT_THAT(sink.messages_, ::testing::Contains(::testing::Truly(
-			[&](const LogMessage& actual) {
-				return actual.severity == expected_msg.severity &&
-					actual.message.find(expected_msg.message) != std::string::npos;
-			}
-		)));
-	}
-	EXPECT_NE(sink.messages_[0].timestamp, 0);
 }
 
 YOSYS_NAMESPACE_END

--- a/tests/unit/kernel/modindexTest.cc
+++ b/tests/unit/kernel/modindexTest.cc
@@ -28,7 +28,7 @@ TEST(ModIndexSwapTest, has)
 
 TEST(ModIndexDeleteTest, has)
 {
-    if (log_sinks.empty()) log_sinks.push_back(std::make_unique<ConsoleLogSink>());
+    if (logger().empty()) logger().add_sink<ConsoleLogSink>();
     Design* d = new Design;
     Module* m = d->addModule("$m");
     Wire* w = m->addWire("$w");

--- a/tests/unit/kernel/modindexTest.cc
+++ b/tests/unit/kernel/modindexTest.cc
@@ -28,7 +28,7 @@ TEST(ModIndexSwapTest, has)
 
 TEST(ModIndexDeleteTest, has)
 {
-    if (log_files.empty()) log_files.emplace_back(stdout);
+    if (log_sinks.empty()) log_sinks.push_back(std::make_unique<ConsoleLogSink>());
     Design* d = new Design;
     Module* m = d->addModule("$m");
     Wire* w = m->addWire("$w");

--- a/tests/unit/kernel/rtlilTest.cc
+++ b/tests/unit/kernel/rtlilTest.cc
@@ -19,7 +19,7 @@ namespace RTLIL {
 	class KernelRtlilTest : public testing::Test {
 	protected:
 		KernelRtlilTest() {
-			if (log_files.empty()) log_files.emplace_back(stdout);
+			if (log_sinks.empty()) log_sinks.push_back(std::make_unique<ConsoleLogSink>());
 		}
 		virtual void SetUp() override {
 			IdString::ensure_prepopulated();

--- a/tests/unit/kernel/rtlilTest.cc
+++ b/tests/unit/kernel/rtlilTest.cc
@@ -19,7 +19,7 @@ namespace RTLIL {
 	class KernelRtlilTest : public testing::Test {
 	protected:
 		KernelRtlilTest() {
-			if (log_sinks.empty()) log_sinks.push_back(std::make_unique<ConsoleLogSink>());
+			if (logger().empty()) logger().add_sink<ConsoleLogSink>();
 		}
 		virtual void SetUp() override {
 			IdString::ensure_prepopulated();

--- a/tests/unit/kernel/threadingTest.cc
+++ b/tests/unit/kernel/threadingTest.cc
@@ -7,7 +7,7 @@ YOSYS_NAMESPACE_BEGIN
 class ThreadingTest : public testing::Test {
 protected:
 	ThreadingTest() {
-		if (log_sinks.empty()) log_sinks.push_back(std::make_unique<ConsoleLogSink>());
+		if (logger().empty()) logger().add_sink<ConsoleLogSink>();
 	}
 };
 

--- a/tests/unit/kernel/threadingTest.cc
+++ b/tests/unit/kernel/threadingTest.cc
@@ -7,8 +7,7 @@ YOSYS_NAMESPACE_BEGIN
 class ThreadingTest : public testing::Test {
 protected:
 	ThreadingTest() {
-		if (log_files.empty())
-			log_files.emplace_back(stdout);
+		if (log_sinks.empty()) log_sinks.push_back(std::make_unique<ConsoleLogSink>());
 	}
 };
 

--- a/tests/unit/techmap/libparseTest.cc
+++ b/tests/unit/techmap/libparseTest.cc
@@ -8,7 +8,7 @@ namespace RTLIL {
 	class TechmapLibparseTest : public testing::Test {
 	protected:
 		TechmapLibparseTest() {
-			if (log_sinks.empty()) log_sinks.push_back(std::make_unique<ConsoleLogSink>());
+			if (logger().empty()) logger().add_sink<ConsoleLogSink>();
 		}
 		void checkAll(std::initializer_list<std::string> expressions, std::string expected) {
 			for (const auto& e : expressions) {

--- a/tests/unit/techmap/libparseTest.cc
+++ b/tests/unit/techmap/libparseTest.cc
@@ -8,7 +8,7 @@ namespace RTLIL {
 	class TechmapLibparseTest : public testing::Test {
 	protected:
 		TechmapLibparseTest() {
-			if (log_files.empty()) log_files.emplace_back(stdout);
+			if (log_sinks.empty()) log_sinks.push_back(std::make_unique<ConsoleLogSink>());
 		}
 		void checkAll(std::initializer_list<std::string> expressions, std::string expected) {
 			for (const auto& e : expressions) {


### PR DESCRIPTION
This one is based on old PR https://github.com/YosysHQ/yosys/pull/5311 and continues work on that

- LogSeverity includes more options
- LogMessage preserves format and timestamp as well
- timestamp is now using chrono
- ~~code is using callback till sinks are added and existing code use them~~
- logs are matching previously generated

Task list:
- [x] remove log_last_error (this was added for YosysJS)
- [x] add LogSink
- [x] create ConsoleLogSink and StdErrorLogSink
- [x] create FileLogSink and use it in driver
- [x] create ScratchPadSink
- [x] create HelpMsgSink and use it in register.cc
- [x] make AST dump not using log_files
- [x] remove log_files, log_streams, log_scratchpads, log_errfile, log_error_stderr, log_quiet_warnings, log_verbose_level, log_time
- [x] get rid of static variables

Potential future updates improvements:
- [ ] add filtering to LogSink based on LogMessage
- [ ] differentiate fatal error and regular error
- [ ] get rid of macros
