### PR TITLE
CXXRTL: workaround LLVM regression in LoopRotatePass (fixes #4419)

### DIFF
--- a/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
+++ b/backends/cxxrtl/runtime/cxxrtl/cxxrtl.h
@@ -198,9 +198,14 @@ struct value : public expr_base<value<Bits>> {
 	value<NewBits> trunc() const {
 		static_assert(NewBits <= Bits, "trunc() may not increase width");
 		value<NewBits> result;
-		for (size_t n = 0; n < result.chunks; n++)
-			result.data[n] = data[n];
-		result.data[result.chunks - 1] &= result.msb_mask;
+		if (chunks == 1 && result.chunks == 1) {
+			// DCE loop as early as possible in common case
+			result.data[0] = data[0] & result.msb_mask;
+		} else {
+			for (size_t n = 0; n < result.chunks; n++)
+				result.data[n] = data[n];
+			result.data[result.chunks - 1] &= result.msb_mask;
+		}
 		return result;
 	}
 
@@ -209,8 +214,13 @@ struct value : public expr_base<value<Bits>> {
 	value<NewBits> zext() const {
 		static_assert(NewBits >= Bits, "zext() may not decrease width");
 		value<NewBits> result;
-		for (size_t n = 0; n < chunks; n++)
-			result.data[n] = data[n];
+		if (chunks == 1 && result.chunks == 1) {
+			// DCE loop as early as possible in common case
+			result.data[0] = data[0];
+		} else {
+			for (size_t n = 0; n < chunks; n++)
+				result.data[n] = data[n];
+		}
 		return result;
 	}
 
@@ -219,8 +229,13 @@ struct value : public expr_base<value<Bits>> {
 	value<NewBits> sext() const {
 		static_assert(NewBits >= Bits, "sext() may not decrease width");
 		value<NewBits> result;
-		for (size_t n = 0; n < chunks; n++)
-			result.data[n] = data[n];
+		if (chunks == 1 && result.chunks == 1) {
+			// DCE loop as early as possible in common case
+			result.data[0] = data[0];
+		} else {
+			for (size_t n = 0; n < chunks; n++)
+				result.data[n] = data[n];
+		}
 		if (is_neg()) {
 			result.data[chunks - 1] |= ~msb_mask;
 			for (size_t n = chunks; n < result.chunks; n++)
@@ -237,15 +252,20 @@ struct value : public expr_base<value<Bits>> {
 		value<NewBits> result;
 		constexpr size_t shift_chunks = (Bits - NewBits) / chunk::bits;
 		constexpr size_t shift_bits   = (Bits - NewBits) % chunk::bits;
-		chunk::type carry = 0;
-		if (shift_chunks + result.chunks < chunks) {
-			carry = (shift_bits == 0) ? 0
-				: data[shift_chunks + result.chunks] << (chunk::bits - shift_bits);
-		}
-		for (size_t n = result.chunks; n > 0; n--) {
-			result.data[n - 1] = carry | (data[shift_chunks + n - 1] >> shift_bits);
-			carry = (shift_bits == 0) ? 0
-				: data[shift_chunks + n - 1] << (chunk::bits - shift_bits);
+		if (chunks == 1 && result.chunks == 1) {
+			// DCE loop as early as possible in common case
+			result.data[0] = data[0] >> shift_bits;
+		} else {
+			chunk::type carry = 0;
+			if (shift_chunks + result.chunks < chunks) {
+				carry = (shift_bits == 0) ? 0
+					: data[shift_chunks + result.chunks] << (chunk::bits - shift_bits);
+			}
+			for (size_t n = result.chunks; n > 0; n--) {
+				result.data[n - 1] = carry | (data[shift_chunks + n - 1] >> shift_bits);
+				carry = (shift_bits == 0) ? 0
+					: data[shift_chunks + n - 1] << (chunk::bits - shift_bits);
+			}
 		}
 		return result;
 	}
@@ -257,14 +277,19 @@ struct value : public expr_base<value<Bits>> {
 		value<NewBits> result;
 		constexpr size_t shift_chunks = (NewBits - Bits) / chunk::bits;
 		constexpr size_t shift_bits   = (NewBits - Bits) % chunk::bits;
-		chunk::type carry = 0;
-		for (size_t n = 0; n < chunks; n++) {
-			result.data[shift_chunks + n] = (data[n] << shift_bits) | carry;
-			carry = (shift_bits == 0) ? 0
-				: data[n] >> (chunk::bits - shift_bits);
+		if (chunks == 1 && result.chunks == 1) {
+			// DCE loop as early as possible in common case
+			result.data[0] = data[0] << shift_bits;
+		} else {
+			chunk::type carry = 0;
+			for (size_t n = 0; n < chunks; n++) {
+				result.data[shift_chunks + n] = (data[n] << shift_bits) | carry;
+				carry = (shift_bits == 0) ? 0
+					: data[n] >> (chunk::bits - shift_bits);
+			}
+			if (shift_chunks + chunks < result.chunks)
+				result.data[shift_chunks + chunks] = carry;
 		}
-		if (shift_chunks + chunks < result.chunks)
-			result.data[shift_chunks + chunks] = carry;
 		return result;
 	}
 


### PR DESCRIPTION
Problem: LoopRotatePass applies a transformation to each loop which has O(function size) cost due to invalidating some bookkeeping. CXXRTL output is one huge function with thousands of loops. Most of these loops are 1-trip but that doesn't help because loop elimination is after loop rotation.

Fix is to add an `if` (with constexpr condition) for the common 1-word case, to cause the loop to be DCE'd long before LoopRotatePass. This does not seem to affect performance (at -O2) but reduces compile time for Hazard by around 7.5x. Do this for the worst offenders: trunc, zext, sext, rtrunc, rzext, which are used everywhere in slice and concat.

Arguably an upstream LLVM bug but it has been present since v18 at least, so affects a lot of users.

---

Repro is attached to the original issue, #4419.

Compiling Hazard3 without this change (just `clang++ -O2` with `Apple clang version 21.0.0`):

```
===-------------------------------------------------------------------------===
                          Pass execution timing report
===-------------------------------------------------------------------------===
  Total Execution Time: 526.6140 seconds (527.1429 wall clock)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  ---Instr---  --- Name ---
  414.8552 ( 79.3%)   1.4400 ( 45.3%)  416.2952 ( 79.1%)  416.7155 ( 79.1%)  3595722383522  LoopRotatePass
  32.6263 (  6.2%)   0.1393 (  4.4%)  32.7656 (  6.2%)  32.8000 (  6.2%)  316273723046  GVNPass
  26.2275 (  5.0%)   0.2120 (  6.7%)  26.4395 (  5.0%)  26.4632 (  5.0%)  313686967708  SROAPass
  26.2332 (  5.0%)   0.0905 (  2.8%)  26.3237 (  5.0%)  26.3527 (  5.0%)  265943248108  SCCPPass
   5.1670 (  1.0%)   0.0371 (  1.2%)   5.2041 (  1.0%)   5.2094 (  1.0%)  46569044959  JumpThreadingPass
```

With this change:

```
===-------------------------------------------------------------------------===
                          Pass execution timing report
===-------------------------------------------------------------------------===
  Total Execution Time: 70.9259 seconds (71.0016 wall clock)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  ---Instr---  --- Name ---
  22.9708 ( 33.1%)   0.1660 ( 11.6%)  23.1369 ( 32.6%)  23.1675 ( 32.6%)  232799099284  GVNPass
  18.8346 ( 27.1%)   0.0628 (  4.4%)  18.8974 ( 26.6%)  18.9174 ( 26.6%)  202757822043  SCCPPass
   8.9867 ( 12.9%)   0.0201 (  1.4%)   9.0068 ( 12.7%)   9.0147 ( 12.7%)  86333868732  LoopRotatePass
   3.7400 (  5.4%)   0.2253 ( 15.7%)   3.9653 (  5.6%)   3.9686 (  5.6%)  59099967452  InstCombinePass
   3.4979 (  5.0%)   0.0804 (  5.6%)   3.5782 (  5.0%)   3.5814 (  5.0%)  50242252582  SROAPass
```

Testing: I just ran CoreMark and my `sw_testcases` suite on Hazard3. All passes and simulates at same speed before/after (190 kHz realtime). This was not a functional correctness bug, so I didn't add any regression tests with these changes.
