### PR TITLE
verilog: support '{default: ...} assignment patterns for unpacked arrays

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -702,6 +702,8 @@ void AstNode::dumpVlog(FILE *f, std::string indent) const
 		for (int i = 0; i < GetSize(children); i++) {
 			if (i != 0)
 				fprintf(f, ", ");
+			if (integer != 0)
+				fprintf(f, "default: ");
 			children[i]->dumpVlog(f, "");
 		}
 		fprintf(f, "}");

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -3372,9 +3372,30 @@ skip_dynamic_range_lvalue_expansion:;
 				return add_indices_to_id(std::move(id), array_indices_from_position(mem, position));
 			};
 
+			// Return the value of a `'{default: <value>}` pattern, or nullptr for positional patterns.
+			auto pattern_default_value = [](AstNode *pattern) -> AstNode* {
+				if (pattern->type == AST_ASSIGN_PATTERN && pattern->integer != 0)
+					return pattern->children[0].get();
+				return nullptr;
+			};
+
 			// Validate nested assignment pattern shape against unpacked dimensions.
 			std::function<void(AstNode*, int)> validate_pattern_shape = [&](AstNode *pattern, int dim) {
 				log_assert(pattern->type == AST_ASSIGN_PATTERN);
+
+				if (AstNode *def = pattern_default_value(pattern)) {
+					// A default applies to every element of this dimension. If the value is
+					// itself an assignment pattern, it maps onto the next unpacked dimension;
+					// otherwise it applies recursively down to the leaf elements.
+					if (dim + 1 < num_dims) {
+						if (def->type == AST_ASSIGN_PATTERN)
+							validate_pattern_shape(def, dim + 1);
+						else if (is_unexpanded_array_ref(def) &&
+								!arrays_have_compatible_dims_from(lhs_mem, dim + 1, def->id2ast))
+							input_error("Array dimension mismatch in 'default:' assignment pattern value\n");
+					}
+					return;
+				}
 
 				int expected = lhs_mem->dimensions[dim].range_width;
 				if (GetSize(pattern->children) != expected)
@@ -3404,16 +3425,21 @@ skip_dynamic_range_lvalue_expansion:;
 				AstNode *pattern = rhs;
 				for (int d = 0; d < num_dims; d++) {
 					log_assert(pattern->type == AST_ASSIGN_PATTERN);
-					AstNode *element = pattern->children[position[d]].get();
+					AstNode *def = pattern_default_value(pattern);
+					AstNode *element = def ? def : pattern->children[position[d]].get();
 
 					if (d + 1 == num_dims)
 						return element->clone();
 
 					if (element->type == AST_ASSIGN_PATTERN) {
 						pattern = element;
-					} else {
+					} else if (is_unexpanded_array_ref(element)) {
 						std::vector<int> subposition(position.begin() + d + 1, position.end());
 						return add_position_to_id(element->clone(), element->id2ast, subposition);
+					} else {
+						// A non-aggregate default value applies recursively to the leaf elements.
+						log_assert(def != nullptr);
+						return def->clone();
 					}
 				}
 				log_abort();
@@ -3431,7 +3457,9 @@ skip_dynamic_range_lvalue_expansion:;
 				    !arrays_have_compatible_dims(lhs_mem, false_mem))
 					input_error("Array dimension mismatch in ternary expression\n");
 			} else {
-				if (num_dims > 1 && GetSize(rhs->children) == lhs_mem->dimensions[0].range_width) {
+				if (pattern_default_value(rhs)) {
+					validate_pattern_shape(rhs, 0);
+				} else if (num_dims > 1 && GetSize(rhs->children) == lhs_mem->dimensions[0].range_width) {
 					validate_pattern_shape(rhs, 0);
 				} else if (num_dims == 1 && GetSize(rhs->children) == total_elements) {
 					pattern_is_flat = true;

--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -3590,7 +3590,16 @@ assignment_pattern_list:
 		$$ = std::make_unique<AstNode>(@$, AST_ASSIGN_PATTERN);
 		$$->children.push_back(std::move($1));
 	} |
+	TOK_DEFAULT TOK_COL expr {
+		// A default pattern is marked by a non-zero 'integer' field and carries
+		// the default value as its only child.
+		$$ = std::make_unique<AstNode>(@$, AST_ASSIGN_PATTERN);
+		$$->integer = 1;
+		$$->children.push_back(std::move($3));
+	} |
 	assignment_pattern_list TOK_COMMA expr {
+		if ($1->integer != 0)
+			err_at_loc(@3, "Assignment patterns with 'default:' cannot have further elements.");
 		$$ = std::move($1);
 		$$->children.push_back(std::move($3));
 	};

--- a/tests/svtypes/array_assign.sv
+++ b/tests/svtypes/array_assign.sv
@@ -165,4 +165,93 @@ module top;
     always_comb begin
         assert(ap_nested_width_ctx[0][0] == 5'h10);
     end
+
+    // Test 17: Default assignment pattern on a whole unpacked array.
+    logic [7:0] ap_def [0:3];
+    assign ap_def = '{default: 8'h5a};
+    always_comb begin
+        assert(ap_def[0] == 8'h5a);
+        assert(ap_def[1] == 8'h5a);
+        assert(ap_def[2] == 8'h5a);
+        assert(ap_def[3] == 8'h5a);
+    end
+
+    // Test 18: Default assignment pattern with a runtime expression value.
+    wire [7:0] ap_def_in = 8'h3d;
+    logic [7:0] ap_def_rt [0:1];
+    assign ap_def_rt = '{default: ap_identity(ap_def_in[0]) ? ap_def_in ^ 8'hff : 8'h00};
+    always_comb begin
+        assert(ap_def_rt[0] == 8'hc2);
+        assert(ap_def_rt[1] == 8'hc2);
+    end
+
+    // Test 19: Non-aggregate default value applies recursively to all leaf elements.
+    logic [3:0] ap_def_2d [2][3];
+    assign ap_def_2d = '{default: 4'h7};
+    always_comb begin
+        assert(ap_def_2d[0][0] == 4'h7);
+        assert(ap_def_2d[0][2] == 4'h7);
+        assert(ap_def_2d[1][1] == 4'h7);
+        assert(ap_def_2d[1][2] == 4'h7);
+    end
+
+    // Test 20: Nested default assignment patterns map onto successive dimensions.
+    logic [3:0] ap_def_nested [2][2];
+    assign ap_def_nested = '{default: '{default: 4'h3}};
+    always_comb begin
+        assert(ap_def_nested[0][0] == 4'h3);
+        assert(ap_def_nested[0][1] == 4'h3);
+        assert(ap_def_nested[1][0] == 4'h3);
+        assert(ap_def_nested[1][1] == 4'h3);
+    end
+
+    // Test 21: Default value that is itself a positional pattern for the next dimension.
+    logic ap_def_pos [2][2];
+    assign ap_def_pos = '{default: '{1'b1, 1'b0}};
+    always_comb begin
+        assert(ap_def_pos[0][0] == 1'b1);
+        assert(ap_def_pos[0][1] == 1'b0);
+        assert(ap_def_pos[1][0] == 1'b1);
+        assert(ap_def_pos[1][1] == 1'b0);
+    end
+
+    // Test 22: Default pattern nested inside a positional pattern.
+    logic ap_pos_def [2][2];
+    assign ap_pos_def = '{'{1'b0, 1'b1}, '{default: 1'b1}};
+    always_comb begin
+        assert(ap_pos_def[0][0] == 1'b0);
+        assert(ap_pos_def[0][1] == 1'b1);
+        assert(ap_pos_def[1][0] == 1'b1);
+        assert(ap_pos_def[1][1] == 1'b1);
+    end
+
+    // Test 23: Procedural blocking assignment with a default pattern.
+    logic [1:0] ap_def_proc [0:2];
+    always_comb begin
+        ap_def_proc = '{default: 2'h2};
+
+        assert(ap_def_proc[0] == 2'h2);
+        assert(ap_def_proc[1] == 2'h2);
+        assert(ap_def_proc[2] == 2'h2);
+    end
+
+    // Test 24: Default pattern value uses the target element width context.
+    logic [4:0] ap_def_width_ctx [0:1];
+    assign ap_def_width_ctx = '{default: 4'hf + 4'h1};
+    always_comb begin
+        assert(ap_def_width_ctx[0] == 5'h10);
+        assert(ap_def_width_ctx[1] == 5'h10);
+    end
+
+    // Test 25: Default value that is a compatible unpacked array expression.
+    wire ap_def_row [2];
+    wire ap_def_rows [2][2];
+    assign ap_def_row = '{1'b1, 1'b0};
+    assign ap_def_rows = '{default: ap_def_row};
+    always_comb begin
+        assert(ap_def_rows[0][0] == 1'b1);
+        assert(ap_def_rows[0][1] == 1'b0);
+        assert(ap_def_rows[1][0] == 1'b1);
+        assert(ap_def_rows[1][1] == 1'b0);
+    end
 endmodule

--- a/tests/svtypes/array_assign_default_pattern.ys
+++ b/tests/svtypes/array_assign_default_pattern.ys
@@ -1,0 +1,18 @@
+read_verilog -sv <<EOT
+module t (input logic [31:0] d, output logic [31:0] q);
+  logic [31:0] m [0:3];
+  assign m = '{default: 32'h0};
+  assign q = m[0] ^ d;
+endmodule
+EOT
+
+hierarchy -top t
+design -reset
+
+logger -expect error "Assignment patterns with 'default:' cannot have further elements." 1
+read_verilog -sv <<EOT
+module top;
+    wire a [2];
+    assign a = '{default: 1'b0, 1'b1};
+endmodule
+EOT


### PR DESCRIPTION
Fixes #6120.

`'{default: <expr>}` (IEEE 1800-2017 §10.9.2) was rejected with a syntax error; only positional assignment patterns were accepted since #5827. This adds the `default:` form for whole unpacked array assignments, with the same scope as the positional support:

- `'{default: v}` broadcasts `v` to every element; if `v` is not itself an assignment pattern it applies recursively down to the leaf elements of multi-dimensional arrays.
- A nested pattern value (`'{default: '{...}}` / `'{default: '{default: ...}}`) maps onto the next unpacked dimension, and default patterns can appear inside positional ones.
- A default value that is a whole-array reference is indexed per element, with a dimension compatibility check.
- Mixing `default:` with positional elements is rejected in the parser.

Implementation notes:

- The parser marks a default pattern by setting the (otherwise unused) `integer` field on the `AST_ASSIGN_PATTERN` node and stores the value as its only child, so the value sits in the same child position as a positional element and gets identical width-context handling — `'{default: 4'hf + 4'h1}` on 5-bit elements yields `5'h10`, matching the positional behavior (test 15 vs. new test 24).
- The whole-array assignment expansion in `simplify.cc` selects the default value for every element position, recursing per dimension for nested patterns.
- Packed targets keep the existing "Assignment pattern is only supported for whole unpacked array assignments" error (patterns on packed targets were never supported, positionally either); previously the `default:` form died earlier with `syntax error, unexpected TOK_DEFAULT`.

Tests: nine new proven cases in `tests/svtypes/array_assign.sv` (broadcast, runtime function-call/ternary value, multi-dim recursion, nested default/positional mixes, procedural blocking assignment, element width context, array-valued default) plus `tests/svtypes/array_assign_default_pattern.ys` with the issue's repro and the mixing-error check. The `svtypes`, `verilog`, `simple`, `various`, `sat`, and `proc` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
