### PR TITLE
Fix resetall not affecting default_nettype

### DIFF
--- a/frontends/verilog/preproc.cc
+++ b/frontends/verilog/preproc.cc
@@ -751,7 +751,6 @@ frontend_verilog_preproc(std::istream                 &f,
                          const define_map_t           &pre_defines,
                          define_map_t                 &global_defines_cache,
                          const std::list<std::string> &include_dirs,
-                         ParseState                   &parse_state,
                          ParseMode                    &parse_mode)
 {
 	define_map_t defines;
@@ -960,7 +959,9 @@ frontend_verilog_preproc(std::istream                 &f,
 		}
 
 		if (tok == "`resetall") {
-			parse_state.default_nettype_wire = true;
+			// `resetall is consumed here and never reaches the lexer, which owns
+			// `default_nettype during parsing.
+			output_code.push_back("\n`default_nettype wire\n");
 			continue;
 		}
 

--- a/frontends/verilog/preproc.h
+++ b/frontends/verilog/preproc.h
@@ -77,7 +77,6 @@ frontend_verilog_preproc(std::istream                 &f,
                          const define_map_t           &pre_defines,
                          define_map_t                 &global_defines_cache,
                          const std::list<std::string> &include_dirs,
-                         VERILOG_FRONTEND::ParseState &parse_state,
                          VERILOG_FRONTEND::ParseMode  &parse_mode);
 
 YOSYS_NAMESPACE_END

--- a/frontends/verilog/verilog_frontend.cc
+++ b/frontends/verilog/verilog_frontend.cc
@@ -509,7 +509,7 @@ struct VerilogFrontend : public Frontend {
 
 		parse_state.lexin = f;
 		if (!flag_nopp) {
-			code_after_preproc = frontend_verilog_preproc(*f, filename, defines_map, *design->verilog_defines, include_dirs, parse_state, parse_mode);
+			code_after_preproc = frontend_verilog_preproc(*f, filename, defines_map, *design->verilog_defines, include_dirs, parse_mode);
 			if (flag_ppdump)
 				log("-- Verilog code after preprocessor --\n%s-- END OF DUMP --\n", code_after_preproc);
 			parse_state.lexin = new std::istringstream(code_after_preproc);

--- a/tests/verilog/default_nettype_resetall.ys
+++ b/tests/verilog/default_nettype_resetall.ys
@@ -1,0 +1,17 @@
+# `resetall must restore `default_nettype to its `wire' default.
+read_verilog <<EOT
+`default_nettype none
+module explicit_nets (input wire i, output wire o);
+    assign o = i;
+endmodule
+`resetall
+module implicit_after_resetall (input i, output o);
+    // `w' is undeclared: legal only if `resetall restored `default_nettype to
+    // `wire'. Under the bug it stayed `none' and read_verilog aborted.
+    assign w = i;
+    assign o = w;
+endmodule
+EOT
+hierarchy -top implicit_after_resetall
+# The implicit net `w' must have been created as a wire.
+select -assert-count 1 implicit_after_resetall/w:w


### PR DESCRIPTION
Hello! Thank you for this tool.

Currently, `` `resetall `` fails to reset `` `default_nettype ``. The preprocessor consumes `` `resetall `` before the lexer ever sees it, so the existing solution (`default_nettype_wire = true`) never reaches the lexer.

Now on `` `resetall ``, the preprocessor emits `` `default_nettype wire `` into its output stream, so the lexer's own directive handler performs the reset. The dead preproc-side assignment and the now-unused `parse_state` parameter are removed.

Thanks!