### PR TITLE
abc: Add file lock on liberty scl cache to support parallelism

### DIFF
--- a/passes/techmap/liberty_cache.h
+++ b/passes/techmap/liberty_cache.h
@@ -11,6 +11,8 @@ namespace abc {
 
 #if !defined(_WIN32)
 #include <sys/file.h>
+#include <fcntl.h>
+#include <unistd.h>
 #endif
 
 YOSYS_NAMESPACE_BEGIN

--- a/passes/techmap/liberty_cache.h
+++ b/passes/techmap/liberty_cache.h
@@ -9,7 +9,24 @@ namespace abc {
 }
 #endif
 
+#if !defined(_WIN32)
+#include <sys/file.h>
+#endif
+
 YOSYS_NAMESPACE_BEGIN
+
+#if !defined(_WIN32)
+struct ScopedFlock {
+	int fd;
+	ScopedFlock(const std::string &path) {
+		fd = open(path.c_str(), O_CREAT | O_RDWR, 0666);
+		if (fd >= 0) flock(fd, LOCK_EX);
+	}
+	~ScopedFlock() {
+		if (fd >= 0) { flock(fd, LOCK_UN); close(fd); }
+	}
+};
+#endif
 
 // Controlled by the libcache pass (-scl option), enabled by default
 extern bool scl_cache_enabled;
@@ -81,6 +98,13 @@ inline std::string convert_liberty_files_to_merged_scl(const std::vector<std::st
 	}
 
 	if (need_convert) {
+#if !defined(_WIN32)
+		ScopedFlock flock(merged_scl + ".lock");
+		if (stat(merged_scl.c_str(), &scl_stat) == 0 && scl_stat.st_mtime >= newest_mtime) {
+			log("ABC: using cached merged SCL: %s (%zu files)\n", merged_scl.c_str(), liberty_files.size());
+			return merged_scl;
+		}
+#endif
 		// read_lib -X cell1 -X cell2 file1 ; read_lib -X cell1 -X cell2 -m file2 ; ... ; write_scl merged.scl
 		std::string temp_scl = merged_scl + ".tmp";
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
When launching Yosys with the same liberty libraries in multiple threads/processes in a wrapper application, this file has a race condition upon which multiple threads attempt to build the cache simultaneously. The file then becomes unreadable by abc.

_Explain how this is achieved._
For Linux builds, use flock() to ensure that the first creator of the cache is allowed to finish before other threads can read it. Also verify that none of the liberty files have changed since the cache was last created.

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._
This necessitates a wrapper flow of Yosys to exercise, and it will likely take 50+ concurrent invocations to reliably trigger the issue.
