### PR TITLE
arith_tree: do not flatten a chain link narrower than its consumer

### DIFF
--- a/passes/techmap/arith_tree.cc
+++ b/passes/techmap/arith_tree.cc
@@ -134,6 +134,13 @@ struct ArithTreeWorker {
 			else if (consumer != c)
 				return nullptr;
 		}
+		// A link truncates its own result at its own Y width. That truncation
+		// is invisible only if the consumer truncates at least as hard, since
+		// (x % 2**link) % 2**parent == x % 2**parent only when parent <= link.
+		// A link narrower than its consumer discards a carry that the wider
+		// consumer would otherwise see, so it must not be flattened away.
+		if (consumer != nullptr && GetSize(sig) < GetSize(consumer->getPort(ID::Y)))
+			return nullptr;
 		return consumer;
 	}
 

--- a/tests/arith_tree/arith_tree_equiv.ys
+++ b/tests/arith_tree/arith_tree_equiv.ys
@@ -163,7 +163,7 @@ design -reset
 read_verilog <<EOT
 module equiv_double_neg(
 	input [3:0] a, b, c,
-	output [3:0] y
+	output [4:0] y
 );
 	wire [3:0] ab = a - b;
 	assign y = c - ab;
@@ -172,7 +172,21 @@ EOT
 hierarchy -auto-top
 proc
 equiv_opt -assert arith_tree
-design -load postopt
-select -assert-count 2 t:$fa
-select -assert-count 1 t:$add
+design -reset
+
+# A chain link that is narrower than the cell consuming it truncates its own
+# result, and that truncation is observable in the wider consumer. Flattening
+# the chain must not recover the carry the narrower link discarded.
+read_verilog <<EOT
+module equiv_narrow_intermediate(
+	input [7:0] a, b, c,
+	output [8:0] y
+);
+	wire [7:0] t = a + b;
+	assign y = t + c;
+endmodule
+EOT
+hierarchy -auto-top
+proc
+equiv_opt -assert arith_tree
 design -reset


### PR DESCRIPTION
## arith_tree: do not flatten a chain link that is narrower than its consumer

`arith_tree` changes the boolean function of the circuit when a link in an
`$add`/`$sub`/`$alu` chain is narrower than the cell that consumes it.

### The counterexample

```verilog
module top(input [7:0] a, b, c, output [8:0] o);
  wire [7:0] t = a + b;   // 8 bit intermediate, truncates
  assign o = t + c;       // 9 bit result
endmodule
```

Mitering `synth -noabc` against `synth -noabc -arith_tree` and calling
`sat -verify -prove-asserts` returns a model:

```
  Signal Name             Dec       Hex           Bin
  --------------- ----------- --------- -------------
  \in_a                   169        a9      10101001
  \in_b                   135        87      10000111
  \in_c                     7         7      00000111
  \trigger                  1         1             1
```

The two implementations compute different functions:

* before the pass: `((a + b) mod 256) + c`
* after the pass: `a + b + c`

They differ exactly when `a + b` overflows 8 bits, and they differ by 256, the
carry that the 8 bit intermediate discards and the 9 bit result does not.

| inputs | before | after |
|---|---|---|
| a=169, b=135, c=7 | `9'000110111` | `9'100110111` |
| a=255, b=1, c=0 | `9'000000000` | `9'100000000` |
| a=200, b=100, c=3 | `9'000101111` | `9'100101111` |
| a=255, b=255, c=255 | `9'111111101` | `9'011111101` |

Under the idiom this test directory already uses, `equiv_opt -assert arith_tree`
reports `Found a total of 1 unproven $equiv cells` and exits non zero, naming
the top bit:

```
  Unproven $equiv $auto$equiv_make.cc:258:find_same_wires$15: \y_gold [8] \y_gate [8]
```

### Root cause

`sole_chainable_consumer` (`passes/techmap/arith_tree.cc` lines 119 to 137)
decides whether a cell may be folded into its consumer. It checks fanout, and
that every bit of the link's `Y` reaches one and the same candidate cell, but it
never compares any width.

A link truncates its own result at its own `Y` width. That truncation is
invisible only when the consumer truncates at least as hard, since

```
(x mod 2**link) mod 2**parent  ==  x mod 2**parent    only when parent <= link
```

When the consumer is wider, the link's discarded carry becomes observable, and
flattening the chain silently recovers it.

The same missing width notion shows up from the other side in
`extract_chain_operands`. `overlaps()` (line 189) is an any bit test, and the
two operand guards at lines 256 and 261 use it to drop a whole operand as soon
as a single one of its bits comes from the chain. That also discards the bits of
that operand which did not come from the chain, for example the constant zero
extension bits in `\B = { 1'0 $sub_Y }`.

### The sister pass already guards this exact case

`alumacc` performs the structurally identical merge, folding a child `$macc`
model into its parent, and it does check this. `passes/techmap/alumacc.cc` line
283:

```cpp
if (GetSize(other_n->y) != GetSize(n->y) && macc_may_overflow(other_n->macc, GetSize(other_n->y), port.is_signed))
        continue;
```

`macc_may_overflow` (same file, line 222) bounds the sum of the child's terms
and answers whether the child can exceed its own width. When the child is a
different width than the parent and can overflow, `alumacc` declines the merge.

`arith_tree` has no equivalent. That asymmetry is why this reads as an
oversight rather than a deliberate tradeoff: the same hazard was already
identified and handled one file over, and the newer pass simply does not carry
the guard across.

One honest note on the patch below. `alumacc` is the more precise of the two:
it still merges when the narrower child provably cannot overflow, so it keeps
QoR that a blunt width comparison gives up. The patch here takes the
conservative form, refusing whenever the link is narrower, because that is the
smallest change that is obviously sound. Reusing the `macc_may_overflow` style
of analysis in `arith_tree` would recover the cases this gives up, and that
seems worth doing, but it is a larger change than a correctness fix should
carry on its own.

### Scope

`arith_tree` is not part of the default `synth` script, so a default flow is
unaffected. It is however wired into the standard entry point as an opt in
flag, `synth -arith_tree` (`techlibs/common/synth.cc`, where it runs directly
after `alumacc`), and it is reachable by calling the pass on its own. A user who
turns that flag on gets silently wrong logic from an ordinary RTL pattern, with
no error and no warning.

### Why the existing tests do not catch this

`tests/arith_tree/` holds 13 `.ys` files and they are the only tests that invoke
the pass. Seven call `equiv_opt`, the other six assert cell counts only.

Several already build an intermediate wire: `wire [7:0] ab = a + b;` in
`arith_tree_negative.ys` and `arith_tree_edge_cases.ys`, `wire [7:0] ab = a - b;`
in `arith_tree_sub_chains.ys`, `wire [3:0] ab = a - b;` in `arith_tree_equiv.ys`.
In every one of them the intermediate has exactly the same width as the result,
so nothing truncates and the chain flattens correctly. Not one existing case has
an intermediate narrower than the result.

That is the whole size of the gap: widening the output of the existing
`equiv_double_neg` case from `[3:0]` to `[4:0]`, a one character change, turns it
from green to red.

### The change

`sole_chainable_consumer` refuses the fold when the link is narrower than its
consumer. Two cases are added to `tests/arith_tree/arith_tree_equiv.ys`: the
widened `equiv_double_neg`, and a dedicated `equiv_narrow_intermediate` that
names the condition directly.


cc @hexratcc as the author of the pass. The refactor that introduced the chain
folding was a sound piece of work and the tests it shipped with are thorough on
structure; this particular shape, an intermediate narrower than the result, just
was not among them, so nothing in review had a reason to flag it.
