### PR TITLE
arith_tree: add regression tests for links narrower than their consumer (follow-up to #6130)

### DIFF
--- a/tests/arith_tree/arith_tree_edge_cases.ys
+++ b/tests/arith_tree/arith_tree_edge_cases.ys
@@ -443,3 +443,41 @@ opt_clean
 select -assert-none t:$fa
 select -assert-min 1 t:$macc t:$macc_v2 %u
 design -reset
+
+# A link narrower than its consumer truncates its partial sum; folding it into
+# the wider tree would resurrect the discarded carry. Such a link must be left
+# out of the chain, both from raw $add cells and from alumacc $alu cells.
+read_verilog <<EOT
+module trunc_narrow_no_fold(
+	input [7:0] a, b, c,
+	output [8:0] y
+);
+	wire [7:0] t = a + b;
+	assign y = t + c;
+endmodule
+EOT
+hierarchy -auto-top
+proc
+arith_tree
+select -assert-none t:$fa
+select -assert-count 2 t:$add
+design -reset
+
+read_verilog <<EOT
+module trunc_narrow_no_fold_alu(
+	input [7:0] a, b, c,
+	output [8:0] y
+);
+	wire [7:0] t = a + b;
+	assign y = t + c;
+endmodule
+EOT
+hierarchy -auto-top
+proc
+alumacc
+opt_clean
+arith_tree
+opt_clean
+select -assert-none t:$fa
+select -assert-count 2 t:$alu
+design -reset

--- a/tests/arith_tree/arith_tree_equiv.ys
+++ b/tests/arith_tree/arith_tree_equiv.ys
@@ -190,3 +190,22 @@ hierarchy -auto-top
 proc
 equiv_opt -assert arith_tree
 design -reset
+
+# Only the truncating link must be excluded: with a truncated t entering the
+# wider (t+c+d) chain as a leaf, the wide part still folds into a tree and the
+# whole result stays equivalent.
+read_verilog <<EOT
+module equiv_trunc_mixed(
+	input [7:0] a, b, c, d,
+	output [9:0] y
+);
+	wire [7:0] t = a + b;
+	assign y = t + c + d;
+endmodule
+EOT
+hierarchy -auto-top
+proc
+equiv_opt -assert arith_tree
+design -load postopt
+select -assert-min 1 t:$fa
+design -reset


### PR DESCRIPTION
**What are the reasons/motivation for this change?**

Follow-up to #6130 (merged as 59a3826), which stops `arith_tree` from folding a chain link that is narrower than the cell consuming it. This PR adds tests only, there is no source change. #6130 shipped with one equivalence test; the three blocks below pin down the structure the pass must now produce, and check that it excludes nothing more than the truncating link.

**Explain how this is achieved.**

`tests/arith_tree/arith_tree_edge_cases.ys`, two new blocks:

1. `trunc_narrow_no_fold`: `wire [7:0] t = a + b; assign y = t + c;` with `y` 9 bits wide, built from raw `$add` cells. After `arith_tree`, no `$fa` cell may exist and both `$add` cells must remain (`select -assert-count 2 t:$add`).
2. `trunc_narrow_no_fold_alu`: the same module after `alumacc`, so the chain is made of `$alu` cells, with the same expectations on `$alu`.

`tests/arith_tree/arith_tree_equiv.ys`, one new block:

3. `equiv_trunc_mixed`: the truncated `t` enters the wider chain `y = t + c + d` as a leaf. `equiv_opt -assert arith_tree` must hold, and the wide part must still be folded (`select -assert-min 1 t:$fa` on the post-opt design). Only the truncating link is left out, the rest of the chain keeps its tree.

**If applicable, please suggest to reviewers how they can test the change.**

`yosys -q tests/arith_tree/arith_tree_edge_cases.ys` and `yosys -q tests/arith_tree/arith_tree_equiv.ys`.