### PR TITLE
Retry read operations interrupted by EINTR

### DIFF
--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1194,7 +1194,10 @@ bool read_until_abc_done(abc_output_filter &filt, int fd, DeferredLogs &logs) {
 	bool seen_source_cmd = false;
 	bool seen_yosys_abc_done = false;
 	while (true) {
-		int ret = read(fd, buf, sizeof(buf) - 1);
+		int ret;
+		do {
+			ret = read(fd, buf, sizeof(buf) - 1);
+		} while (ret == -1 && errno == EINTR);
 		if (ret < 0) {
 			logs.log_error("Failed to read from ABC, errno=%d\n", errno);
 			return false;


### PR DESCRIPTION
Interrupted system calls (`EINTR`) during read operations were previously
treated as fatal errors. Add retry logic to continue reading when interrupted.