### PR TITLE
synth_gatemate: remove classic ABC mapping for LUTs

### DIFF
--- a/techlibs/gatemate/synth_gatemate.cc
+++ b/techlibs/gatemate/synth_gatemate.cc
@@ -76,13 +76,10 @@ struct SynthGateMatePass : public ScriptPass
 		log("        legacy p_r.\n");
 		log("\n");
 		log("    -dff\n");
-		log("        run 'abc' with -dff option\n");
-		log("\n");
-		log("    -retime\n");
-		log("        run 'abc' with '-dff -D 1' options\n");
+		log("        run 'abc9' with -dff option\n");
 		log("\n");
 		log("    -abc_new\n");
-		log("        use 'abc_new' instead of 'abc' for mapping. (EXPERIMENTAL)\n");
+		log("        use 'abc_new' instead of 'abc -genlib' for mapping. (EXPERIMENTAL)\n");
 		log("\n");
 		log("    -noiopad\n");
 		log("        disable I/O buffer insertion (useful for hierarchical or \n");
@@ -97,7 +94,7 @@ struct SynthGateMatePass : public ScriptPass
 	}
 
 	string top_opt, vlog_file, json_file;
-	bool noflatten, scopename, nobram, noaddf, nomult, nomx4, nomx8, luttree, dff, retime, noiopad, noclkbuf, abc_new;
+	bool noflatten, scopename, nobram, noaddf, nomult, nomx4, nomx8, luttree, dff, noiopad, noclkbuf, abc_new;
 
 	void clear_flags() override
 	{
@@ -113,7 +110,6 @@ struct SynthGateMatePass : public ScriptPass
 		nomx8 = false;
 		luttree = false;
 		dff = false;
-		retime = false;
 		noiopad = false;
 		noclkbuf = false;
 		abc_new = false;
@@ -184,7 +180,7 @@ struct SynthGateMatePass : public ScriptPass
 				continue;
 			}
 			if (args[argidx] == "-retime") {
-				retime = true;
+				// Removed
 				continue;
 			}
 			if (args[argidx] == "-noiopad") {
@@ -283,9 +279,6 @@ struct SynthGateMatePass : public ScriptPass
 			}
 			run("techmap -map +/techmap.v " + techmap_args);
 			run("opt -fast");
-			if (retime) {
-				run("abc -dff -D 1", "(only if -retime)");
-			}
 		}
 
 		if (check_label("map_io", "(skip if '-noiopad')") && !noiopad)
@@ -333,6 +326,7 @@ struct SynthGateMatePass : public ScriptPass
 				}
 				if (abc_new) {
 					run("abc_new " + abc_args, "(with -luttree and -abc_new)");
+					run("scratchpad -unset abc9.script");
 				} else {
 					run("abc " + abc_args, "(with -luttree, without -abc_new)");
 				}
@@ -341,11 +335,11 @@ struct SynthGateMatePass : public ScriptPass
 				run("techmap -map +/gatemate/inv_map.v", "(with -luttree)");
 			}
 			if (!luttree || help_mode) {
-				std::string abc_args = " -dress -lut 4";
+				std::string abc_args = " -lut 4";
 				if (dff) {
 					abc_args += " -dff";
 				}
-				run("abc " + abc_args, "(without -luttree)");
+				run("abc9 " + abc_args, "(without -luttree)");
 			}
 			run("clean");
 		}

--- a/tests/arch/gatemate/fsm.ys
+++ b/tests/arch/gatemate/fsm.ys
@@ -16,10 +16,9 @@ cd fsm # Constrain all select calls below inside the top module
 
 select -assert-count 1 t:CC_BUFG
 select -assert-count 6 t:CC_DFF
-select -assert-max 5 t:CC_LUT2
-select -assert-max 6 t:CC_LUT3
-select -assert-max 9 t:CC_LUT4
-select -assert-none t:CC_BUFG t:CC_DFF t:CC_LUT2 t:CC_LUT3 t:CC_LUT4 %% t:* %D
+select -assert-max 4 t:CC_LUT2
+select -assert-max 11 t:CC_LUT4
+select -assert-none t:CC_BUFG t:CC_DFF t:CC_LUT2 t:CC_LUT4 %% t:* %D
 
 design -load orig
 

--- a/tests/arch/gatemate/logic.ys
+++ b/tests/arch/gatemate/logic.ys
@@ -7,8 +7,8 @@ design -save orig
 equiv_opt -assert -map +/gatemate/cells_sim.v synth_gatemate -noiopad # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd top # Constrain all select calls below inside the top module
-select -assert-max 1 t:CC_LUT1
-select -assert-max 6 t:CC_LUT2
+select -assert-max 4 t:CC_LUT1
+select -assert-max 3 t:CC_LUT2
 select -assert-max 2 t:CC_LUT4
 select -assert-none t:CC_LUT1 t:CC_LUT2 t:CC_LUT4 %% t:* %D
 

--- a/tests/arch/gatemate/mux.ys
+++ b/tests/arch/gatemate/mux.ys
@@ -7,10 +7,8 @@ proc
 equiv_opt -assert -map +/gatemate/cells_sim.v synth_gatemate -noiopad # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux4 # Constrain all select calls below inside the top module
-select -assert-max 1 t:CC_LUT2
-select -assert-max 2 t:CC_LUT4
-select -assert-max 1 t:CC_MX2
-select -assert-none t:CC_LUT2 t:CC_LUT4 t:CC_MX2 %% t:* %D
+select -assert-max 3 t:CC_LUT3
+select -assert-none t:CC_LUT3 %% t:* %D
 
 design -load read
 hierarchy -top mux4
@@ -37,10 +35,9 @@ proc
 equiv_opt -assert -map +/gatemate/cells_sim.v synth_gatemate -noiopad # equivalency check
 design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
 cd mux8 # Constrain all select calls below inside the top module
-select -assert-max 1 t:CC_LUT3
-select -assert-max 5 t:CC_LUT4
-select -assert-max 1 t:CC_MX2
-select -assert-none t:CC_LUT3 t:CC_LUT4 t:CC_MX2 %% t:* %D
+select -assert-max 3 t:CC_LUT3
+select -assert-max 3 t:CC_LUT4
+select -assert-none t:CC_LUT3 t:CC_LUT4 %% t:* %D
 
 design -load read
 hierarchy -top mux8


### PR DESCRIPTION
_If your work is part of a larger effort, please discuss your general plans on [Discourse](https://yosyshq.discourse.group/) first to align your vision with maintainers._
More ABC unification.

_What are the reasons/motivation for this change?_
I forgot about this pass in #6103 because I've always used it with the `-luttree` option for targeting nextpnr, which does not use LUTs.

_Explain how this is achieved._
~~Yeet.~~ Migrate it over too.

_Make sure your change comes with tests. If not possible, share how a reviewer might evaluate it._
Test suite updated.
