### PR TITLE
xilinx_dsp: do not absorb nonzero sync-load constants into RSTM/RSTP

### DIFF
--- a/techlibs/microchip/microchip_dsp.pmg
+++ b/techlibs/microchip/microchip_dsp.pmg
@@ -408,6 +408,11 @@ match ff
 	// does not support clock inversion
 	select param(ff, \CLK_POLARITY).as_bool()
 
+	// Check that reset value, if present, is fully 0 (the DSP's output
+	// register resets to zero; absorbing a nonzero sync-load constant
+	// would corrupt it)
+	filter ff->type.in($dff, $dffe) || param(ff, \SRST_VALUE).is_fully_zero()
+
 	slice offset GetSize(port(ff, \D))
 	index <SigBit> port(ff, \D)[offset] === argD[0]
 

--- a/techlibs/xilinx/xilinx_dsp.pmg
+++ b/techlibs/xilinx/xilinx_dsp.pmg
@@ -488,6 +488,10 @@ match ff
 	// DSP48E1 does not support clock inversion
 	select param(ff, \CLK_POLARITY).as_bool()
 
+	// Check that reset value, if present, is fully 0 (RSTM/RSTP reset to
+	// zero; absorbing a nonzero sync-load constant would corrupt it)
+	filter ff->type.in($dff, $dffe) || param(ff, \SRST_VALUE).is_fully_zero()
+
 	slice offset GetSize(port(ff, \D))
 	index <SigBit> port(ff, \D)[offset] === argD[0]
 

--- a/techlibs/xilinx/xilinx_dsp48a.pmg
+++ b/techlibs/xilinx/xilinx_dsp48a.pmg
@@ -397,6 +397,11 @@ match ff
 	// DSP48E1 does not support clock inversion
 	select param(ff, \CLK_POLARITY).as_bool()
 
+	// Check that reset value, if present, is fully 0 (the DSP's output
+	// registers reset to zero; absorbing a nonzero sync-load constant
+	// would corrupt it)
+	filter ff->type.in($dff, $dffe) || param(ff, \SRST_VALUE).is_fully_zero()
+
 	slice offset GetSize(port(ff, \D))
 	index <SigBit> port(ff, \D)[offset] === argD[0]
 

--- a/tests/arch/microchip/dsp_nonzero_srst.ys
+++ b/tests/arch/microchip/dsp_nonzero_srst.ys
@@ -1,0 +1,34 @@
+# The MACC_PA output register resets to zero, so a register with a
+# synchronous load of a nonzero constant must not be absorbed into the DSP.
+# (No equivalence check here: cells_sim.v has no behavioural MACC_PA model.)
+# https://github.com/YosysHQ/yosys/pull/6138
+
+read_verilog <<EOT
+module top(input clk, cond, input signed [8:0] a, b, output reg signed [17:0] q);
+always @(posedge clk)
+	if (cond)
+		q <= a * b;
+	else
+		q <= 50;
+endmodule
+EOT
+synth_microchip -top top -family polarfire -noiopad
+select -assert-count 1 t:MACC_PA
+# the register must stay in fabric
+select -assert-min 1 t:SLE
+
+# control: a synchronous load of zero is a plain sync reset and is still
+# absorbed into the DSP output register (no fabric registers left)
+design -reset
+read_verilog <<EOT
+module top(input clk, cond, input signed [8:0] a, b, output reg signed [17:0] q);
+always @(posedge clk)
+	if (cond)
+		q <= a * b;
+	else
+		q <= 0;
+endmodule
+EOT
+synth_microchip -top top -family polarfire -noiopad
+select -assert-count 1 t:MACC_PA
+select -assert-none t:SLE

--- a/tests/arch/xilinx/dsp_nonzero_srst.ys
+++ b/tests/arch/xilinx/dsp_nonzero_srst.ys
@@ -1,0 +1,60 @@
+# The DSP48E1/DSP48A1 output registers reset to zero, so a register with a
+# synchronous load of a nonzero constant must not be absorbed into the DSP.
+# https://github.com/YosysHQ/yosys/pull/6138
+
+read_verilog <<EOT
+module top(input clk, cond, input signed [8:0] a, b, output reg signed [17:0] q);
+always @(posedge clk)
+	if (cond)
+		q <= a * b;
+	else
+		q <= 50;
+endmodule
+EOT
+design -save read
+
+proc
+equiv_opt -assert -map +/xilinx/cells_sim.v synth_xilinx -noiopad # equivalency check
+design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
+cd top # Constrain all select calls below inside the top module
+select -assert-count 1 t:DSP48E1
+# the register must stay in fabric
+select -assert-min 1 t:FDRE t:FDSE %u
+
+design -load read
+proc
+equiv_opt -assert -map +/xilinx/cells_sim.v synth_xilinx -family xc6s -noiopad # equivalency check
+design -load postopt # load the post-opt design (otherwise equiv_opt loads the pre-opt design)
+cd top # Constrain all select calls below inside the top module
+select -assert-count 1 t:DSP48A1
+# the register must stay in fabric
+select -assert-min 1 t:FDRE t:FDSE %u
+
+# control: a synchronous load of zero is a plain sync reset and is still
+# absorbed into PREG (no fabric registers left)
+design -reset
+read_verilog <<EOT
+module top(input clk, cond, input signed [8:0] a, b, output reg signed [17:0] q);
+always @(posedge clk)
+	if (cond)
+		q <= a * b;
+	else
+		q <= 0;
+endmodule
+EOT
+design -save read_zero
+
+proc
+equiv_opt -assert -map +/xilinx/cells_sim.v synth_xilinx -noiopad # equivalency check
+design -load postopt
+cd top
+select -assert-count 1 t:DSP48E1
+select -assert-none t:FDRE t:FDSE %u
+
+design -load read_zero
+proc
+equiv_opt -assert -map +/xilinx/cells_sim.v synth_xilinx -family xc6s -noiopad # equivalency check
+design -load postopt
+cd top
+select -assert-count 1 t:DSP48A1
+select -assert-none t:FDRE t:FDSE %u


### PR DESCRIPTION
*Authorship notice: investigation and patch developed with substantial AI assistance (Claude), reviewed and hardware-verified by me.*

**Symptom.** `synth_xilinx` silently miscompiles a register with synchronous-load-of-a-nonzero-constant semantics feeding from a multiply, e.g. `if (cond) q <= a*b; else q <= 50;`. The netlist reads 0 instead of 50 whenever the load branch is active. RTL sim is correct, gate-level sim and hardware are wrong. Found on real hardware: a MEGA65 core port (xc7a100t) where a terminal renderer's row-advance constant vanished, visibly shifting all on-screen text by one row.

**Root cause.** `opt_dff` turns the load-of-constant into an `$sdff` with `SRST_VALUE=50`. In `techlibs/xilinx/xilinx_dsp.pmg`, the `in_dffe` subpattern guards against this (`filter ff->type.in($dff, $dffe) || param(ff, \SRST_VALUE).is_fully_zero()`), but the `out_dffe` subpattern — MREG/PREG absorption, whose own header comment says the reset mux's "other input is fully zero" — matches `$sdff`/`$sdffe` with no `SRST_VALUE` check. The register is absorbed into MREG and its srst line wired to RSTM, which resets to zero; the nonzero constant is dropped from the design. `xilinx_dsp48a.pmg` has the same omission in its `out_dffe`; `microchip_dsp.pmg` checks `srstZero` correctly. abc9 is not involved (reproduces with and without).

**Fix.** Add the same `is_fully_zero()` filter to both `out_dffe` subpatterns (`xilinx_dsp.pmg`, `xilinx_dsp48a.pmg`). The multiply is still packed into the DSP; the register simply stays in fabric when its reset value is nonzero.
