### PR TITLE
Support Yosys built as a subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,13 @@ include(UseHomebrew)
 # see https://github.com/YosysHQ/yosys/pull/5936#issuecomment-4637319568
 set(CMAKE_CXX_SCAN_FOR_MODULES NO)
 
+# Cache current yosys cmake root path
+set(YOSYS_CMAKE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}" CACHE INTERNAL "Save source path")
+set(YOSYS_CMAKE_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}" CACHE INTERNAL "Save binary path")
+
 # Build options.
 set(YOSYS_COMPILER_LAUNCHER "" CACHE STRING "Compiler launcher (ccache, sccache)")
+option(YOSYS_ENABLE_UNIT_TESTS "Enable unit tests" ON)
 option(YOSYS_ENABLE_COVERAGE "Enable code coverage" OFF)
 option(YOSYS_ENABLE_PROFILING "Enable instruction profiling" OFF)
 option(YOSYS_ENABLE_FUNCTIONAL_TESTS "Enable running functional tests" OFF)
@@ -376,8 +381,8 @@ target_compile_definitions(yosys_common INTERFACE
 	$<$<CONFIG:Debug,RelWithDebInfo>:DEBUG>
 )
 target_include_directories(yosys_common INTERFACE
-	${CMAKE_SOURCE_DIR}
-	${CMAKE_BINARY_DIR}
+	${YOSYS_CMAKE_SOURCE_DIR}
+	${YOSYS_CMAKE_BINARY_DIR}
 )
 if (SANITIZE)
 	target_compile_options(yosys_common INTERFACE
@@ -433,7 +438,7 @@ if (NOT YOSYS_BUILD_PYTHON_ONLY)
 			IMPORT_SUFFIX ".exe.a"
 		)
 		if (YOSYS_INSTALL_DRIVER)
-			install(FILES ${CMAKE_BINARY_DIR}/yosys.exe.a DESTINATION ${YOSYS_INSTALL_LIBDIR})
+			install(FILES ${YOSYS_CMAKE_BINARY_DIR}/yosys.exe.a DESTINATION ${YOSYS_INSTALL_LIBDIR})
 		endif()
 	endif()
 
@@ -511,14 +516,14 @@ endif()
 # (The use of `${makefile_vars}` in `add_custom_{target,command}()` adds dependencies for
 # all of the targets specified via `$<TARGET_FILE:tgt>`.)
 set(makefile_vars
-	BUILD_DIR=${CMAKE_BINARY_DIR}
+	BUILD_DIR=${YOSYS_CMAKE_BINARY_DIR}
 	PROGRAM_PREFIX=${YOSYS_PROGRAM_PREFIX}
 	ABC=$<IF:$<TARGET_EXISTS:yosys-abc>,$<TARGET_FILE:yosys-abc>,${YOSYS_ABC_EXECUTABLE}>
 	YOSYS=$<TARGET_FILE:yosys>
-	YOSYS_CONFIG=${CMAKE_BINARY_DIR}/${YOSYS_PROGRAM_PREFIX}yosys-config
+	YOSYS_CONFIG=${YOSYS_CMAKE_BINARY_DIR}/${YOSYS_PROGRAM_PREFIX}yosys-config
 	YOSYS_FILTERLIB=$<$<TARGET_EXISTS:yosys-filterlib>:$<TARGET_FILE:yosys-filterlib>>
-	YOSYS_SMTBMC=${CMAKE_BINARY_DIR}/${YOSYS_PROGRAM_PREFIX}yosys-smtbmc
-	YOSYS_WITNESS=${CMAKE_BINARY_DIR}/${YOSYS_PROGRAM_PREFIX}yosys-witness
+	YOSYS_SMTBMC=${YOSYS_CMAKE_BINARY_DIR}/${YOSYS_PROGRAM_PREFIX}yosys-smtbmc
+	YOSYS_WITNESS=${YOSYS_CMAKE_BINARY_DIR}/${YOSYS_PROGRAM_PREFIX}yosys-witness
 )
 set(makefile_depends
 	# abc is implied via $<TARGET_FILE>
@@ -528,20 +533,20 @@ set(makefile_depends
 	$<$<TARGET_EXISTS:yosys-witness>:yosys-witness>
 )
 
-if (NOT YOSYS_BUILD_PYTHON_ONLY)
+if (NOT YOSYS_BUILD_PYTHON_ONLY AND YOSYS_ENABLE_UNIT_TESTS)
 	# Tests.
 	add_subdirectory(tests/unit)
 
 	add_custom_target(test-unit
 		COMMAND ${CMAKE_CTEST_COMMAND} --test-dir tests/unit --output-on-failure
-		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+		WORKING_DIRECTORY ${YOSYS_CMAKE_BINARY_DIR}
 		DEPENDS $<$<TARGET_EXISTS:yosys-gtest-all>:yosys-gtest-all>
 	)
 
 	add_custom_target(test-vanilla
 		COMMAND make vanilla-test ${makefile_vars}
 			ENABLE_FUNCTIONAL_TESTS=$<IF:$<BOOL:${YOSYS_ENABLE_FUNCTIONAL_TESTS}>,1,0>
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests
+		WORKING_DIRECTORY ${YOSYS_CMAKE_SOURCE_DIR}/tests
 		DEPENDS ${makefile_depends}
 		USES_TERMINAL
 		JOB_SERVER_AWARE TRUE
@@ -550,7 +555,7 @@ if (NOT YOSYS_BUILD_PYTHON_ONLY)
 	add_custom_target(test-functional
 		COMMAND make functional ${makefile_vars}
 			ENABLE_FUNCTIONAL_TESTS=$<IF:$<BOOL:${YOSYS_ENABLE_FUNCTIONAL_TESTS}>,1,0>
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests
+		WORKING_DIRECTORY ${YOSYS_CMAKE_SOURCE_DIR}/tests
 		DEPENDS ${makefile_depends}
 		USES_TERMINAL
 		JOB_SERVER_AWARE TRUE
@@ -563,20 +568,20 @@ if (NOT YOSYS_BUILD_PYTHON_ONLY)
 	# Docs.
 	add_custom_target(docs-prepare
 		COMMAND make gen ${makefile_vars}
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docs
+		WORKING_DIRECTORY ${YOSYS_CMAKE_SOURCE_DIR}/docs
 		DEPENDS ${makefile_depends}
 		JOB_SERVER_AWARE TRUE
 	)
 	foreach (format html latexpdf)
 		add_custom_target(docs-${format}
 			COMMAND make ${format}
-			WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docs
+			WORKING_DIRECTORY ${YOSYS_CMAKE_SOURCE_DIR}/docs
 			DEPENDS docs-prepare
 		)
 	endforeach()
 	add_custom_target(test-docs
 		COMMAND make test ${makefile_vars}
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docs
+		WORKING_DIRECTORY ${YOSYS_CMAKE_SOURCE_DIR}/docs
 		DEPENDS ${makefile_depends}
 		JOB_SERVER_AWARE TRUE
 	)
@@ -599,9 +604,9 @@ math(EXPR YOSYS_VERSION_MINOR_next "${YOSYS_VERSION_MINOR} + 1")
 add_custom_target(increment-minor-version
 	COMMAND ${CMAKE_COMMAND} -E echo
 		"set(YOSYS_VERSION_MAJOR ${YOSYS_VERSION_MAJOR})"
-		> ${CMAKE_SOURCE_DIR}/cmake/YosysVersionData.cmake
+		> ${YOSYS_CMAKE_SOURCE_DIR}/cmake/YosysVersionData.cmake
 	COMMAND ${CMAKE_COMMAND} -E echo
 		"set(YOSYS_VERSION_MINOR ${YOSYS_VERSION_MINOR_next})"
-		>> ${CMAKE_SOURCE_DIR}/cmake/YosysVersionData.cmake
+		>> ${YOSYS_CMAKE_SOURCE_DIR}/cmake/YosysVersionData.cmake
 	VERBATIM
 )

--- a/cmake/FindPyosysEnv.cmake
+++ b/cmake/FindPyosysEnv.cmake
@@ -28,7 +28,7 @@ foreach (strategy virtualenv host uv fail)
 		list(FILTER pybind11_INCLUDE_DIR INCLUDE REGEX "/pybind11/")
 
 		execute_process(
-			COMMAND ${PyosysEnv_PYTHON} ${CMAKE_SOURCE_DIR}/pyosys/generator.py --help
+			COMMAND ${PyosysEnv_PYTHON} ${YOSYS_CMAKE_SOURCE_DIR}/pyosys/generator.py --help
 			RESULT_VARIABLE result
 			OUTPUT_QUIET
 			ERROR_QUIET

--- a/cmake/GetPyosysVersion.cmake
+++ b/cmake/GetPyosysVersion.cmake
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.27)
 set(CMAKE_MESSAGE_LOG_LEVEL ERROR)
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH "${YOSYS_CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 include(YosysVersion)
 
 yosys_extract_version()

--- a/cmake/PmgenCommand.cmake
+++ b/cmake/PmgenCommand.cmake
@@ -36,9 +36,9 @@ function(pmgen_command arg_NAME)
 	cmake_parse_arguments(PARSE_ARGV 1 arg "DEBUG" "PREFIX" "")
 	set(arg_INPUTS ${arg_UNPARSED_ARGUMENTS})
 
-	set(pmgen_script ${CMAKE_SOURCE_DIR}/passes/pmgen/pmgen.py)
+	set(pmgen_script ${YOSYS_CMAKE_SOURCE_DIR}/passes/pmgen/pmgen.py)
 	set(pmgen_output ${CMAKE_CURRENT_BINARY_DIR}/${arg_NAME}_pm.h)
-	cmake_path(RELATIVE_PATH pmgen_output BASE_DIRECTORY ${CMAKE_BINARY_DIR} OUTPUT_VARIABLE pmgen_output_rel)
+	cmake_path(RELATIVE_PATH pmgen_output BASE_DIRECTORY ${YOSYS_CMAKE_BINARY_DIR} OUTPUT_VARIABLE pmgen_output_rel)
 	add_custom_command(
 		DEPENDS ${pmgen_script} ${arg_INPUTS}
 		OUTPUT ${pmgen_output}

--- a/cmake/UseHomebrew.cmake
+++ b/cmake/UseHomebrew.cmake
@@ -10,7 +10,7 @@ function(use_homebrew)
 	if (NOT arg_ROOT)
 		execute_process(
 			COMMAND brew --prefix
-			WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+			WORKING_DIRECTORY ${YOSYS_CMAKE_SOURCE_DIR}
 			RESULT_VARIABLE brew_prefix_result
 			OUTPUT_VARIABLE brew_prefix_out
 			OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/cmake/YosysAbc.cmake
+++ b/cmake/YosysAbc.cmake
@@ -32,11 +32,11 @@ function(yosys_abc_target arg_LIBNAME arg_EXENAME)
 	# This way, no assumptions about the environment are made, and Yosys can be compiled
 	# on Windows without MSYS as a result (while benefitting other platforms as well).
 	set(all_sources)
-	_yosys_abc_extract_makefile(module_files "MODULES :=" ${CMAKE_SOURCE_DIR}/abc/Makefile)
-	_yosys_abc_extract_makefile(module_files_cudd "MODULES \\+=" ${CMAKE_SOURCE_DIR}/abc/Makefile)
+	_yosys_abc_extract_makefile(module_files "MODULES :=" ${YOSYS_CMAKE_SOURCE_DIR}/abc/Makefile)
+	_yosys_abc_extract_makefile(module_files_cudd "MODULES \\+=" ${YOSYS_CMAKE_SOURCE_DIR}/abc/Makefile)
 	list(REMOVE_ITEM module_files "$(wildcard" "src/ext*)")
 	foreach (module_file ${module_files} ${module_files_cudd})
-		_yosys_abc_extract_makefile(module_sources "SRC \\+=" ${CMAKE_SOURCE_DIR}/abc/${module_file}/module.make)
+		_yosys_abc_extract_makefile(module_sources "SRC \\+=" ${YOSYS_CMAKE_SOURCE_DIR}/abc/${module_file}/module.make)
 		list(APPEND all_sources ${module_sources})
 	endforeach()
 	list(TRANSFORM all_sources PREPEND abc/)
@@ -90,13 +90,13 @@ function(yosys_abc_target arg_LIBNAME arg_EXENAME)
 		$<${YOSYS_ENABLE_THREADS}:Threads::Threads>
 		$<${YOSYS_ENABLE_READLINE}:PkgConfig::readline>
 		$<$<BOOL:${WIN32}>:-lshlwapi>
-		$<$<CXX_COMPILER_ID:MSVC>:${CMAKE_SOURCE_DIR}/abc/lib/x64/pthreadVC2.lib>
+		$<$<CXX_COMPILER_ID:MSVC>:${YOSYS_CMAKE_SOURCE_DIR}/abc/lib/x64/pthreadVC2.lib>
 	)
 	set_target_properties(${arg_LIBNAME} PROPERTIES
 		YOSYS_IS_ABC ON
 	)
 	if(MSVC)
-    	install(FILES "${CMAKE_SOURCE_DIR}/abc/lib/x64/pthreadVC2.dll" DESTINATION bin)
+    	install(FILES "${YOSYS_CMAKE_SOURCE_DIR}/abc/lib/x64/pthreadVC2.dll" DESTINATION bin)
 	endif()
 
 	yosys_cxx_executable(${arg_EXENAME}

--- a/cmake/YosysAbcSubmodule.cmake
+++ b/cmake/YosysAbcSubmodule.cmake
@@ -9,8 +9,8 @@ function(yosys_check_abc_submodule)
 
 	yosys_call_git(submodule status abc)
 	set(git_commit)
-	if (EXISTS "${CMAKE_SOURCE_DIR}/abc/.gitcommit")
-		file(READ "${CMAKE_SOURCE_DIR}/abc/.gitcommit" git_commit)
+	if (EXISTS "${YOSYS_CMAKE_SOURCE_DIR}/abc/.gitcommit")
+		file(READ "${YOSYS_CMAKE_SOURCE_DIR}/abc/.gitcommit" git_commit)
 		string(STRIP "${git_commit}" git_commit)
 	endif()
 	set(abc_status "none")
@@ -55,7 +55,7 @@ function(yosys_check_abc_submodule)
 		)
 	else() #
 		message(FATAL_ERROR
-			"${CMAKE_SOURCE_DIR} is not configured as a git repository, and 'abc' folder is missing.\n"
+			"${YOSYS_CMAKE_SOURCE_DIR} is not configured as a git repository, and 'abc' folder is missing.\n"
 			"If you already have ABC, set 'YOSYS_ABC_EXECUTABLE' CMake variable to point to ABC executable.\n"
 			"Otherwise, download release archive 'yosys.tar.gz' from https://github.com/YosysHQ/yosys/releases.\n"
 			"    ('Source code' archive does not contain submodules.)\n"

--- a/cmake/YosysComponent.cmake
+++ b/cmake/YosysComponent.cmake
@@ -110,7 +110,7 @@ function(yosys_component arg_PREFIX arg_NAME)
 	list(APPEND share_file_pairs ${arg_DATA_EXPLICIT})
 	if (share_file_pairs)
 		set(data_depends)
-		set(share_root ${CMAKE_BINARY_DIR}/share)
+		set(share_root ${YOSYS_CMAKE_BINARY_DIR}/share)
 		while (share_file_pairs)
 			list(LENGTH share_file_pairs share_file_unpaired)
 			if (share_file_unpaired EQUAL 1)
@@ -123,6 +123,7 @@ function(yosys_component arg_PREFIX arg_NAME)
 			cmake_path(APPEND out_dir ${dst_parent})
 			cmake_path(GET dst_file FILENAME dst_filename)
 			cmake_path(APPEND out_dir ${dst_filename} OUTPUT_VARIABLE out_file)
+            message(STATUS "Create directory ${share_root}/${out_dir}")
 			file(MAKE_DIRECTORY ${share_root}/${out_dir})
 			add_custom_command(
 				DEPENDS ${src_file}
@@ -302,7 +303,7 @@ endfunction()
 # 	yosys_install_component_data(<component>... DESTINATION <directory>)
 #
 # Install data files for every `<component>` into `<directory>`.
-# Equivalent to copying `${CMAKE_BINARY_DIR}/share/.` to `<directory>/.` after a clean rebuild.
+# Equivalent to copying `${YOSYS_CMAKE_BINARY_DIR}/share/.` to `<directory>/.` after a clean rebuild.
 #
 function(yosys_install_component_data)
 	cmake_parse_arguments(PARSE_ARGV 0 arg "" "DESTINATION" "")
@@ -315,7 +316,7 @@ function(yosys_install_component_data)
 		get_target_property(data_files ${namespace}_${component} YOSYS_DATA_FILES)
 		foreach (data_file ${data_files})
 			cmake_path(GET data_file PARENT_PATH data_dir)
-			install(FILES ${CMAKE_BINARY_DIR}/share/${data_file} DESTINATION ${arg_DESTINATION}/${data_dir})
+			install(FILES ${YOSYS_CMAKE_BINARY_DIR}/share/${data_file} DESTINATION ${arg_DESTINATION}/${data_dir})
 		endforeach()
 	endforeach()
 endfunction()

--- a/cmake/YosysConfigScript.cmake
+++ b/cmake/YosysConfigScript.cmake
@@ -6,9 +6,9 @@
 #
 function(yosys_config_script scope)
 	if (scope STREQUAL BUILD)
-		set(BINDIR ${CMAKE_BINARY_DIR})
-		set(LIBDIR ${CMAKE_BINARY_DIR})
-		set(DATDIR ${CMAKE_BINARY_DIR}/share)
+		set(BINDIR ${YOSYS_CMAKE_BINARY_DIR})
+		set(LIBDIR ${YOSYS_CMAKE_BINARY_DIR})
+		set(DATDIR ${YOSYS_CMAKE_BINARY_DIR}/share)
 		set(suffix "")
 	elseif (scope STREQUAL INSTALL)
 		set(BINDIR ${YOSYS_INSTALL_FULL_BINDIR})
@@ -56,13 +56,13 @@ function(yosys_config_script scope)
 	string(JOIN " " LIBS
 		${platform_libs}
 	)
-	configure_file(${CMAKE_SOURCE_DIR}/misc/yosys-config.in
+	configure_file(${YOSYS_CMAKE_SOURCE_DIR}/misc/yosys-config.in
 		${YOSYS_PROGRAM_PREFIX}yosys-config${suffix}
 		USE_SOURCE_PERMISSIONS
 		@ONLY
 	)
 	if (scope STREQUAL INSTALL)
-		install(PROGRAMS ${CMAKE_BINARY_DIR}/${YOSYS_PROGRAM_PREFIX}yosys-config.install
+		install(PROGRAMS ${YOSYS_CMAKE_BINARY_DIR}/${YOSYS_PROGRAM_PREFIX}yosys-config.install
 			RENAME yosys-config
 			DESTINATION ${YOSYS_INSTALL_BINDIR}
 		)

--- a/cmake/YosysLinkTarget.cmake
+++ b/cmake/YosysLinkTarget.cmake
@@ -19,7 +19,7 @@ function(yosys_cxx_library arg_TARGET arg_SCOPE)
 	set_target_properties(${arg_TARGET} PROPERTIES
 		PREFIX "${YOSYS_PROGRAM_PREFIX}"
 		OUTPUT_NAME "${arg_OUTPUT_NAME}"
-		RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+		RUNTIME_OUTPUT_DIRECTORY ${YOSYS_CMAKE_BINARY_DIR}
 	)
 	if (${arg_INSTALL_IF})
 		install(TARGETS ${arg_TARGET} DESTINATION ${YOSYS_INSTALL_LIBDIR})
@@ -49,7 +49,7 @@ function(yosys_cxx_executable arg_TARGET)
 	set_target_properties(${arg_TARGET} PROPERTIES
 		PREFIX "${YOSYS_PROGRAM_PREFIX}"
 		OUTPUT_NAME "${arg_OUTPUT_NAME}"
-		RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+		RUNTIME_OUTPUT_DIRECTORY ${YOSYS_CMAKE_BINARY_DIR}
 	)
 	if (${arg_INSTALL_IF})
 		install(TARGETS ${arg_TARGET} DESTINATION ${YOSYS_INSTALL_BINDIR})
@@ -82,9 +82,9 @@ function(yosys_python_executable basename source)
 			COMMAND_ERROR_IS_FATAL ANY
 		)
 
-		add_executable(${basename} ${CMAKE_SOURCE_DIR}/misc/launcher.c)
+		add_executable(${basename} ${YOSYS_CMAKE_SOURCE_DIR}/misc/launcher.c)
 		target_compile_definitions(${basename} GUI=0)
-		set(scriptname ${CMAKE_BINARY_DIR}/${YOSYS_PROGRAM_PREFIX}${basename}-script.py)
+		set(scriptname ${YOSYS_CMAKE_BINARY_DIR}/${YOSYS_PROGRAM_PREFIX}${basename}-script.py)
 		configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${source} ${scriptname} @ONLY)
 		if (${arg_INSTALL_IF})
 			install(TARGETS ${basename} DESTINATION ${YOSYS_INSTALL_BINDIR})
@@ -92,7 +92,7 @@ function(yosys_python_executable basename source)
 		endif()
 	else()
 		set(PYTHON_SHEBANG "/usr/bin/env python3")
-		set(scriptname ${CMAKE_BINARY_DIR}/${YOSYS_PROGRAM_PREFIX}${basename}${CMAKE_EXECUTABLE_SUFFIX})
+		set(scriptname ${YOSYS_CMAKE_BINARY_DIR}/${YOSYS_PROGRAM_PREFIX}${basename}${CMAKE_EXECUTABLE_SUFFIX})
 		configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${source} ${scriptname} USE_SOURCE_PERMISSIONS @ONLY)
 		if (${arg_INSTALL_IF})
 			install(PROGRAMS ${scriptname} DESTINATION ${YOSYS_INSTALL_BINDIR})

--- a/cmake/YosysVersion.cmake
+++ b/cmake/YosysVersion.cmake
@@ -11,7 +11,7 @@
 function(yosys_call_git)
 	execute_process(
 		COMMAND ${GIT_EXECUTABLE} ${ARGV}
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+		WORKING_DIRECTORY ${YOSYS_CMAKE_SOURCE_DIR}
 		RESULT_VARIABLE git_result
 		OUTPUT_VARIABLE git_output
 		OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -87,8 +87,8 @@ function(yosys_extract_version)
 		# Build YOSYS_CHECKOUT_INFO (git sha1 and dirty status).
 		if (git_abbrev STREQUAL "")
 			# No git checkout, see if the tarball was created with `git archive`.
-			file(READ ${CMAKE_SOURCE_DIR}/.gitcommit git_abbrev)
-			set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/.gitcommit)
+			file(READ ${YOSYS_CMAKE_SOURCE_DIR}/.gitcommit git_abbrev)
+			set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${YOSYS_CMAKE_SOURCE_DIR}/.gitcommit)
 			string(STRIP "${git_abbrev}" git_abbrev)
 			if (git_abbrev MATCHES "Format:")
 				# No substitutions, we're out of options.

--- a/frontends/verilog/CMakeLists.txt
+++ b/frontends/verilog/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT FLEX_INCLUDE_DIRS)
-	set(FLEX_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/libs/flex)
+	set(FLEX_INCLUDE_DIRS ${YOSYS_CMAKE_SOURCE_DIR}/libs/flex)
 endif()
 
 flex_target(verilog_lexer

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -4,10 +4,10 @@ configure_file(yosys_config.h.in yosys_config.h @ONLY)
 set(cellhelp_sources)
 foreach (library simlib simcells)
 	add_custom_command(
-		DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/cellhelp.py ${CMAKE_SOURCE_DIR}/techlibs/common/${library}.v
+		DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/cellhelp.py ${YOSYS_CMAKE_SOURCE_DIR}/techlibs/common/${library}.v
 		OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${library}_help.inc
 		COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/cellhelp.py
-			${CMAKE_SOURCE_DIR}/techlibs/common/${library}.v
+			${YOSYS_CMAKE_SOURCE_DIR}/techlibs/common/${library}.v
 			> ${CMAKE_CURRENT_BINARY_DIR}/${library}_help.inc
 		VERBATIM
 	)

--- a/pyosys/CMakeLists.txt
+++ b/pyosys/CMakeLists.txt
@@ -15,7 +15,7 @@ add_custom_command(
 		-- ${PyosysEnv_PYTHON}
 			${CMAKE_CURRENT_SOURCE_DIR}/generator.py
 			${CMAKE_CURRENT_BINARY_DIR}/wrappers.cc
-			--build-dir ${CMAKE_BINARY_DIR}
+			--build-dir ${YOSYS_CMAKE_BINARY_DIR}
 	VERBATIM
 	COMMENT "Generating Python wrappers"
 )


### PR DESCRIPTION
# Motivation

Yosys is widely used by many projects as an essential component. 
Yosys's CMake build compatibility opens the door to tight integration to other tools:

- Yosys can be called through APIs without a systemcall
- Yosys internal data structure can be read and query for further optimization in downstream tools
- Easy to manage Yosys dependency in installer

Therefore, Yosys should be built a subdirectory in CMake build system

# Proposed solution

Modified Cmake scripts so that Yosys can be built in a parent CMake project.

Tested in the OpenFPGA project (latest master) without issues. 

https://github.com/lnis-uofu/OpenFPGA


