### PR TITLE
verilog: fix `**` associativity to right per IEEE 1364-2005 / 1800-2017

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -575,7 +575,7 @@
 %left OP_SHL OP_SHR OP_SSHL OP_SSHR
 %left TOK_PLUS TOK_MINUS
 %left TOK_ASTER TOK_SLASH TOK_PERC
-%left OP_POW
+%right OP_POW
 %precedence OP_CAST
 %precedence UNARY_OPS
 

--- a/tests/opt/pow_assoc.ys
+++ b/tests/opt/pow_assoc.ys
@@ -1,6 +1,4 @@
-# The power operator `**` is right-associative per IEEE 1364-2005 sec 5.1 /
-# 1800-2017 sec 11.4.1: `2**3**2` is `2**(3**2)` = 512. A `%left` declaration
-# in the grammar parsed it as `(2**3)**2` = 64.
+# `**` is right-associative: 2**3**2 is 2**(3**2) = 512.
 
 read_verilog << EOT
 module top(output [15:0] unparen, output [15:0] right, output [15:0] left);

--- a/tests/opt/pow_assoc.ys
+++ b/tests/opt/pow_assoc.ys
@@ -1,0 +1,35 @@
+# The power operator `**` is right-associative per IEEE 1364-2005 sec 5.1 /
+# 1800-2017 sec 11.4.1: `2**3**2` is `2**(3**2)` = 512. A `%left` declaration
+# in the grammar parsed it as `(2**3)**2` = 64.
+
+read_verilog << EOT
+module top(output [15:0] unparen, output [15:0] right, output [15:0] left);
+    assign unparen = 2**3**2;
+    assign right   = 2**(3**2);
+    assign left    = (2**3)**2;
+endmodule
+EOT
+
+prep -top top
+opt -full
+design -stash gate
+
+read_verilog << EOT
+module top(output [15:0] unparen, output [15:0] right, output [15:0] left);
+    assign unparen = 16'd512;
+    assign right   = 16'd512;
+    assign left    = 16'd64;
+endmodule
+EOT
+
+prep -top top
+opt -full
+design -stash gold
+
+design -copy-from gold -as gold top
+design -copy-from gate -as gate top
+equiv_make gold gate equiv
+hierarchy -top equiv
+equiv_simple
+equiv_induct
+equiv_status -assert


### PR DESCRIPTION
The power operator `**` is right-associative per IEEE 1364-2005 section 5.1 and IEEE 1800-2017 section 11.4.1. The grammar declared it `%left`, so unparenthesized chains were parsed left-associatively and silently produced wrong values:

```verilog
module m(output [15:0] y);
    assign y = 2**3**2;
endmodule
```

Parsed as `(2**3)**2` = 64. Should be `2**(3**2)` = 512 per the LRM. No warning, no error; the wrong constant propagates through ordinary optimization.

The fix is the declaration change (`%left` to `%right` in `frontends/verilog/verilog_parser.y`). The rest of the precedence table matches the standard; this was the only operator with the wrong associativity (every other binary operator is left-associative, and the ternary is handled structurally).

The regression test (`tests/opt/pow_assoc.ys`) uses `equiv_opt`-style checking against hardcoded expected constants: the unparenthesized form and the explicit right-associative form must both fold to 512, and the explicit left-associative form to 64. Verified it fails on the unpatched grammar and passes with the fix.
