### PR TITLE
json: read 'signed' on netnames, matching ports

### DIFF
--- a/frontends/json/jsonparse.cc
+++ b/frontends/json/jsonparse.cc
@@ -452,6 +452,12 @@ void json_import(Design *design, string &modname, JsonNode *node)
 					wire->start_offset = val->data_number;
 			}
 
+			if (net_node->data_dict.count("signed") != 0) {
+				JsonNode *val = net_node->data_dict.at("signed");
+				if (val->type == 'N')
+					wire->is_signed = val->data_number != 0;
+			}
+
 			for (int i = 0; i < GetSize(bits_node->data_array); i++)
 			{
 				JsonNode *bitval_node = bits_node->data_array.at(i);

--- a/tests/various/json_netnames_signed.v
+++ b/tests/various/json_netnames_signed.v
@@ -1,0 +1,5 @@
+module top(input signed [15:0] a, output [31:0] y);
+  wire signed [15:0] t;
+  assign t = a;
+  assign y = t;
+endmodule

--- a/tests/various/json_netnames_signed.ys
+++ b/tests/various/json_netnames_signed.ys
@@ -1,0 +1,8 @@
+! mkdir -p temp
+read_verilog json_netnames_signed.v
+write_json temp/json_netnames_signed_r1.json
+design -reset
+read_json temp/json_netnames_signed_r1.json
+write_json temp/json_netnames_signed_r2.json
+# the internal signed wire t must survive the roundtrip with signedness intact
+! python3 -c "import json; d=json.load(open('temp/json_netnames_signed_r2.json')); assert d['modules']['top']['netnames']['t'].get('signed') == 1, 'signedness lost on internal net t'"


### PR DESCRIPTION
The JSON backend writes `"signed": 1` for any signed wire, including internal nets. The frontend only parsed the attribute for ports (line 351, in the ports loop), so a write-read roundtrip cleared `is_signed` on internal wires without any diagnostic:

```
read_verilog → write_json → read_json → write_json
```

Reproducer:

```verilog
module top(input signed [15:0] a, output [31:0] y);
  wire signed [15:0] t;
  assign t = a;
  assign y = t;
endmodule
```

After one roundtrip, `t` in the re-emitted netnames has no `signed` attribute. Any tool consuming the JSON between the two passes (or using the JSON as an interchange format for a multi-step flow) sees `t` as unsigned.

The fix parses `signed` in the netnames loop, next to the existing `upto`/`offset` handling. Three-line change.

The regression test (`tests/various/json_netnames_signed.ys`, following the `json_param_defaults.ys` pattern) does a full roundtrip and asserts the internal wire still has `signed: 1`. Verified it fails on the unpatched reader and passes with the fix.
