### PR TITLE
proc_mux: avoid repeated work in mux tree construction

### DIFF
--- a/kernel/bitpattern.h
+++ b/kernel/bitpattern.h
@@ -97,7 +97,7 @@ struct BitPatternPool
 	 * Convert a constant SigSpec to a pattern. Normalize Yosys many-valued
 	 * to three-valued logic.
 	 */
-	bits_t sig2bits(RTLIL::SigSpec sig)
+	bits_t sig2bits(const RTLIL::SigSpec &sig)
 	{
 		bits_t bits;
 		bits.bitdata = sig.as_const().to_bits();
@@ -111,7 +111,7 @@ struct BitPatternPool
 	 * A literal x/z bit can never match a 2-valued selector, so a pattern containing
 	 * one covers nothing.
 	 */
-	static bool covers_nothing(RTLIL::SigSpec sig)
+	static bool covers_nothing(const RTLIL::SigSpec &sig)
 	{
 		for (auto bit : sig)
 			if (bit.wire == NULL && (bit.data == RTLIL::State::Sx || bit.data == RTLIL::State::Sz))
@@ -122,7 +122,10 @@ struct BitPatternPool
 	/**
 	 * Two cubes match if their intersection is non-empty.
 	 */
-	bool match(bits_t a, bits_t b)
+	// The proc/proc_mux grouping path compares each query against every cube in
+	// the pool. Keep those comparisons reference-based to avoid copying vectors
+	// in the innermost loop.
+	bool match(const bits_t &a, const bits_t &b)
 	{
 		log_assert(int(a.bitdata.size()) == width);
 		log_assert(int(b.bitdata.size()) == width);
@@ -141,7 +144,7 @@ struct BitPatternPool
 	 * pool({01a}).has_any(011) == true
 	 * pool({111}).has_any(01a) == false
 	 */
-	bool has_any(RTLIL::SigSpec sig)
+	bool has_any(const RTLIL::SigSpec &sig)
 	{
 		if (covers_nothing(sig))
 			return false;
@@ -161,7 +164,7 @@ struct BitPatternPool
 	 * pool({011}).has_all(01a) == false
 	 * pool({111}).has_all(01a) == false
 	 */
-	bool has_all(RTLIL::SigSpec sig)
+	bool has_all(const RTLIL::SigSpec &sig)
 	{
 		if (covers_nothing(sig))
 			return true;
@@ -183,7 +186,7 @@ struct BitPatternPool
 	 * Taking 011 out of pool({01a}) -> pool({010}), returns true.
 	 * Taking 011 out of pool({010}) does nothing, returns false.
 	 */
-	bool take(RTLIL::SigSpec sig)
+	bool take(const RTLIL::SigSpec &sig)
 	{
 		bool status = false;
 		if (covers_nothing(sig))

--- a/passes/proc/proc_mux.cc
+++ b/passes/proc/proc_mux.cc
@@ -113,9 +113,10 @@ struct SnippetSwCache
 	const SigSnippets *snippets;
 	int current_snippet;
 
-	bool check(RTLIL::SwitchRule *sw)
+	bool check(RTLIL::SwitchRule *sw) const
 	{
-		return cache[sw].count(current_snippet) != 0;
+		auto it = cache.find(sw);
+		return it != cache.end() && it->second.count(current_snippet) != 0;
 	}
 
 	void insert(const RTLIL::CaseRule *cs, vector<RTLIL::SwitchRule*> &sw_stack)
@@ -326,7 +327,69 @@ bool maybe_touches_sig_wires(const RTLIL::SigSpec &signal, const pool<RTLIL::Wir
 	return false;
 }
 
-RTLIL::SigSpec signal_to_mux_tree_worker(RTLIL::Module *mod, SnippetSwCache &swcache, dict<RTLIL::SwitchRule*, bool> &swpara,
+static bool is_simple_parallel_case(RTLIL::SwitchRule *sw)
+{
+	if (sw->get_bool_attribute(ID::parallel_case))
+		return true;
+
+	pool<Const> case_values;
+	for (auto cs : sw->cases) {
+		for (const auto &pat : cs->compare) {
+			if (!pat.is_fully_def())
+				return false;
+			Const cpat = pat.as_const();
+			if (case_values.count(cpat))
+				return false;
+			case_values.insert(cpat);
+		}
+	}
+
+	return true;
+}
+
+static const std::vector<int> &get_parallel_case_groups(RTLIL::SwitchRule *sw,
+		dict<RTLIL::SwitchRule*, std::vector<int>> &swgroups, bool ifxmode)
+{
+	if (!swgroups.count(sw)) {
+		std::vector<int> pgroups(sw->cases.size());
+
+		// Case grouping only depends on the switch patterns, not on the output
+		// snippet currently being lowered. Cache it once per switch.
+		if (!is_simple_parallel_case(sw)) {
+			BitPatternPool pool(sw->signal.size());
+			bool extra_group_for_next_case = false;
+			for (size_t i = 0; i < sw->cases.size(); i++) {
+				RTLIL::CaseRule *cs = sw->cases[i];
+				if (i != 0) {
+					pgroups[i] = pgroups[i-1];
+					if (extra_group_for_next_case) {
+						pgroups[i] = pgroups[i-1]+1;
+						extra_group_for_next_case = false;
+					}
+					for (const auto &pat : cs->compare)
+						if (!pat.is_fully_const() || !pool.has_all(pat))
+							pgroups[i] = pgroups[i-1]+1;
+					if (cs->compare.empty())
+						pgroups[i] = pgroups[i-1]+1;
+					if (pgroups[i] != pgroups[i-1])
+						pool = BitPatternPool(sw->signal.size());
+				}
+				for (const auto &pat : cs->compare)
+					if (!pat.is_fully_const())
+						extra_group_for_next_case = true;
+					else if (!ifxmode)
+						pool.take(pat);
+			}
+		}
+
+		swgroups[sw] = std::move(pgroups);
+	}
+
+	return swgroups.at(sw);
+}
+
+RTLIL::SigSpec signal_to_mux_tree_worker(RTLIL::Module *mod, SnippetSwCache &swcache,
+		dict<RTLIL::SwitchRule*, std::vector<int>> &swgroups,
 		RTLIL::CaseRule *cs, const RTLIL::SigSpec &sig, const pool<RTLIL::Wire*> &sig_wires,
 		const RTLIL::SigSpec &defval, bool ifxmode, bool wire_prefilter)
 {
@@ -347,59 +410,9 @@ RTLIL::SigSpec signal_to_mux_tree_worker(RTLIL::Module *mod, SnippetSwCache &swc
 		if (!swcache.check(sw))
 			continue;
 
-		// detect groups of parallel cases
-		std::vector<int> pgroups(sw->cases.size());
-		bool is_simple_parallel_case = true;
-
-		if (!sw->get_bool_attribute(ID::parallel_case)) {
-			if (!swpara.count(sw)) {
-				pool<Const> case_values;
-				for (size_t i = 0; i < sw->cases.size(); i++) {
-					RTLIL::CaseRule *cs2 = sw->cases[i];
-					for (auto pat : cs2->compare) {
-						if (!pat.is_fully_def())
-							goto not_simple_parallel_case;
-						Const cpat = pat.as_const();
-						if (case_values.count(cpat))
-							goto not_simple_parallel_case;
-						case_values.insert(cpat);
-					}
-				}
-				if (0)
-			not_simple_parallel_case:
-					is_simple_parallel_case = false;
-				swpara[sw] = is_simple_parallel_case;
-			} else {
-				is_simple_parallel_case = swpara.at(sw);
-			}
-		}
-
-		if (!is_simple_parallel_case) {
-			BitPatternPool pool(sw->signal.size());
-			bool extra_group_for_next_case = false;
-			for (size_t i = 0; i < sw->cases.size(); i++) {
-				RTLIL::CaseRule *cs2 = sw->cases[i];
-				if (i != 0) {
-					pgroups[i] = pgroups[i-1];
-					if (extra_group_for_next_case) {
-						pgroups[i] = pgroups[i-1]+1;
-						extra_group_for_next_case = false;
-					}
-					for (auto pat : cs2->compare)
-						if (!pat.is_fully_const() || !pool.has_all(pat))
-							pgroups[i] = pgroups[i-1]+1;
-					if (cs2->compare.empty())
-						pgroups[i] = pgroups[i-1]+1;
-					if (pgroups[i] != pgroups[i-1])
-						pool = BitPatternPool(sw->signal.size());
-				}
-				for (auto pat : cs2->compare)
-					if (!pat.is_fully_const())
-						extra_group_for_next_case = true;
-					else if (!ifxmode)
-						pool.take(pat);
-			}
-		}
+		// swgroups reserves enough storage before this walk, so recursive cache
+		// insertions cannot invalidate this reference.
+		const auto &pgroups = get_parallel_case_groups(sw, swgroups, ifxmode);
 
 		// mask default bits that are irrelevant because the output is driven by a full case
 		const pool<SigBit> &full_case_bits = get_full_case_bits(swcache, sw);
@@ -413,7 +426,8 @@ RTLIL::SigSpec signal_to_mux_tree_worker(RTLIL::Module *mod, SnippetSwCache &swc
 		for (size_t i = 0; i < sw->cases.size(); i++) {
 			int case_idx = sw->cases.size() - i - 1;
 			RTLIL::CaseRule *cs2 = sw->cases[case_idx];
-			RTLIL::SigSpec value = signal_to_mux_tree_worker(mod, swcache, swpara, cs2, sig, sig_wires, initial_val, ifxmode, wire_prefilter);
+			RTLIL::SigSpec value = signal_to_mux_tree_worker(mod, swcache, swgroups, cs2, sig,
+					sig_wires, initial_val, ifxmode, wire_prefilter);
 			if (last_mux_cell && pgroups[case_idx] == pgroups[case_idx+1])
 				append_pmux(mod, sw->signal, cs2->compare, value, last_mux_cell, sw, cs2, ifxmode);
 			else
@@ -424,15 +438,18 @@ RTLIL::SigSpec signal_to_mux_tree_worker(RTLIL::Module *mod, SnippetSwCache &swc
 	return result;
 }
 
-RTLIL::SigSpec signal_to_mux_tree(RTLIL::Module *mod, SnippetSwCache &swcache, dict<RTLIL::SwitchRule*, bool> &swpara,
-		RTLIL::CaseRule *cs, const RTLIL::SigSpec &sig, const RTLIL::SigSpec &defval, bool ifxmode, bool wire_prefilter)
+RTLIL::SigSpec signal_to_mux_tree(RTLIL::Module *mod, SnippetSwCache &swcache,
+		dict<RTLIL::SwitchRule*, std::vector<int>> &swgroups,
+		RTLIL::CaseRule *cs, const RTLIL::SigSpec &sig, const RTLIL::SigSpec &defval,
+		bool ifxmode, bool wire_prefilter)
 {
 	pool<RTLIL::Wire*> sig_wires;
 	if (wire_prefilter)
 		for (auto &chunk : sig.chunks())
 			if (chunk.wire != NULL)
 				sig_wires.insert(chunk.wire);
-	return signal_to_mux_tree_worker(mod, swcache, swpara, cs, sig, sig_wires, defval, ifxmode, wire_prefilter);
+	return signal_to_mux_tree_worker(mod, swcache, swgroups, cs, sig, sig_wires,
+			defval, ifxmode, wire_prefilter);
 }
 
 void proc_mux(RTLIL::Module *mod, RTLIL::Process *proc, bool ifxmode, bool wire_prefilter)
@@ -446,7 +463,8 @@ void proc_mux(RTLIL::Module *mod, RTLIL::Process *proc, bool ifxmode, bool wire_
 	swcache.snippets = &sigsnip;
 	swcache.insert(&proc->root_case);
 
-	dict<RTLIL::SwitchRule*, bool> swpara;
+	dict<RTLIL::SwitchRule*, std::vector<int>> swgroups;
+	swgroups.reserve(swcache.cache.size());
 
 	int cnt = 0;
 	for (int idx : sigsnip.snippets)
@@ -456,7 +474,8 @@ void proc_mux(RTLIL::Module *mod, RTLIL::Process *proc, bool ifxmode, bool wire_
 
 		log("%6d/%d: %s\n", ++cnt, GetSize(sigsnip.snippets), log_signal(sig));
 
-		RTLIL::SigSpec value = signal_to_mux_tree(mod, swcache, swpara, &proc->root_case, sig, RTLIL::SigSpec(RTLIL::State::Sx, sig.size()), ifxmode, wire_prefilter);
+		RTLIL::SigSpec value = signal_to_mux_tree(mod, swcache, swgroups, &proc->root_case, sig,
+				RTLIL::SigSpec(RTLIL::State::Sx, sig.size()), ifxmode, wire_prefilter);
 		mod->connect(RTLIL::SigSig(sig, value));
 	}
 }

--- a/passes/proc/proc_mux.cc
+++ b/passes/proc/proc_mux.cc
@@ -318,12 +318,26 @@ const pool<SigBit> &get_full_case_bits(SnippetSwCache &swcache, RTLIL::SwitchRul
 	return swcache.full_case_bits_cache.at(sw);
 }
 
-RTLIL::SigSpec signal_to_mux_tree(RTLIL::Module *mod, SnippetSwCache &swcache, dict<RTLIL::SwitchRule*, bool> &swpara,
-		RTLIL::CaseRule *cs, const RTLIL::SigSpec &sig, const RTLIL::SigSpec &defval, bool ifxmode)
+bool maybe_touches_sig_wires(const RTLIL::SigSpec &signal, const pool<RTLIL::Wire*> &sig_wires)
+{
+	for (auto &chunk : signal.chunks())
+		if (chunk.wire != NULL && sig_wires.count(chunk.wire))
+			return true;
+	return false;
+}
+
+RTLIL::SigSpec signal_to_mux_tree_worker(RTLIL::Module *mod, SnippetSwCache &swcache, dict<RTLIL::SwitchRule*, bool> &swpara,
+		RTLIL::CaseRule *cs, const RTLIL::SigSpec &sig, const pool<RTLIL::Wire*> &sig_wires,
+		const RTLIL::SigSpec &defval, bool ifxmode, bool wire_prefilter)
 {
 	RTLIL::SigSpec result = defval;
 
 	for (auto &action : cs->actions) {
+		if (action.first.empty())
+			continue;
+		// Fast prefilter: avoid replace/remove2 when this action can not touch `sig`.
+		if (wire_prefilter && !maybe_touches_sig_wires(action.first, sig_wires))
+			continue;
 		sig.replace(action.first, action.second, &result);
 		action.first.remove2(sig, &action.second);
 	}
@@ -399,7 +413,7 @@ RTLIL::SigSpec signal_to_mux_tree(RTLIL::Module *mod, SnippetSwCache &swcache, d
 		for (size_t i = 0; i < sw->cases.size(); i++) {
 			int case_idx = sw->cases.size() - i - 1;
 			RTLIL::CaseRule *cs2 = sw->cases[case_idx];
-			RTLIL::SigSpec value = signal_to_mux_tree(mod, swcache, swpara, cs2, sig, initial_val, ifxmode);
+			RTLIL::SigSpec value = signal_to_mux_tree_worker(mod, swcache, swpara, cs2, sig, sig_wires, initial_val, ifxmode, wire_prefilter);
 			if (last_mux_cell && pgroups[case_idx] == pgroups[case_idx+1])
 				append_pmux(mod, sw->signal, cs2->compare, value, last_mux_cell, sw, cs2, ifxmode);
 			else
@@ -410,7 +424,18 @@ RTLIL::SigSpec signal_to_mux_tree(RTLIL::Module *mod, SnippetSwCache &swcache, d
 	return result;
 }
 
-void proc_mux(RTLIL::Module *mod, RTLIL::Process *proc, bool ifxmode)
+RTLIL::SigSpec signal_to_mux_tree(RTLIL::Module *mod, SnippetSwCache &swcache, dict<RTLIL::SwitchRule*, bool> &swpara,
+		RTLIL::CaseRule *cs, const RTLIL::SigSpec &sig, const RTLIL::SigSpec &defval, bool ifxmode, bool wire_prefilter)
+{
+	pool<RTLIL::Wire*> sig_wires;
+	if (wire_prefilter)
+		for (auto &chunk : sig.chunks())
+			if (chunk.wire != NULL)
+				sig_wires.insert(chunk.wire);
+	return signal_to_mux_tree_worker(mod, swcache, swpara, cs, sig, sig_wires, defval, ifxmode, wire_prefilter);
+}
+
+void proc_mux(RTLIL::Module *mod, RTLIL::Process *proc, bool ifxmode, bool wire_prefilter)
 {
 	log("Creating decoders for process `%s.%s'.\n", mod->name, proc->name);
 
@@ -431,7 +456,7 @@ void proc_mux(RTLIL::Module *mod, RTLIL::Process *proc, bool ifxmode)
 
 		log("%6d/%d: %s\n", ++cnt, GetSize(sigsnip.snippets), log_signal(sig));
 
-		RTLIL::SigSpec value = signal_to_mux_tree(mod, swcache, swpara, &proc->root_case, sig, RTLIL::SigSpec(RTLIL::State::Sx, sig.size()), ifxmode);
+		RTLIL::SigSpec value = signal_to_mux_tree(mod, swcache, swpara, &proc->root_case, sig, RTLIL::SigSpec(RTLIL::State::Sx, sig.size()), ifxmode, wire_prefilter);
 		mod->connect(RTLIL::SigSig(sig, value));
 	}
 }
@@ -451,10 +476,15 @@ struct ProcMuxPass : public Pass {
 		log("        Use Verilog simulation behavior with respect to undef values in\n");
 		log("        'case' expressions and 'if' conditions.\n");
 		log("\n");
+		log("    -no-wire-prefilter\n");
+		log("        Disable the fast action-wire prefilter. This is useful for\n");
+		log("        debugging and equivalence testing against the legacy behavior.\n");
+		log("\n");
 	}
 	void execute(std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		bool ifxmode = false;
+		bool wire_prefilter = true;
 		log_header(design, "Executing PROC_MUX pass (convert decision trees to multiplexers).\n");
 
 		size_t argidx;
@@ -464,13 +494,17 @@ struct ProcMuxPass : public Pass {
 				ifxmode = true;
 				continue;
 			}
+			if (args[argidx] == "-no-wire-prefilter") {
+				wire_prefilter = false;
+				continue;
+			}
 			break;
 		}
 		extra_args(args, argidx, design);
 
 		for (auto mod : design->all_selected_modules())
 			for (auto proc : mod->selected_processes())
-				proc_mux(mod, proc, ifxmode);
+				proc_mux(mod, proc, ifxmode, wire_prefilter);
 	}
 } ProcMuxPass;
 

--- a/tests/proc/proc_mux_wire_prefilter.ys
+++ b/tests/proc/proc_mux_wire_prefilter.ys
@@ -1,0 +1,33 @@
+read_verilog -sv << EOT
+module gate(
+	input sel,
+	input [7:0] a, b, c, d, e,
+	output reg [7:0] y,
+	output reg [7:0] z
+);
+	always @* begin
+		y = a;
+		z = b;
+		if (sel) begin
+			{y[3:0], z[3:0]} = {c[3:0], d[3:0]};
+			z[7:4] = e[7:4];
+		end
+		y[3:0] = b[3:0];
+	end
+endmodule
+
+module gold(
+	input sel,
+	input [7:0] a, b, c, d, e,
+	output [7:0] y,
+	output [7:0] z
+);
+	assign y = {a[7:4], b[3:0]};
+	assign z = sel ? {e[7:4], d[3:0]} : b;
+endmodule
+EOT
+
+proc gate
+opt gate
+miter -equiv -flatten -make_assert -make_outputs gold gate miter
+sat -verify -set-def-inputs -prove-asserts miter

--- a/tests/proc/proc_mux_wire_prefilter_equiv.ys
+++ b/tests/proc/proc_mux_wire_prefilter_equiv.ys
@@ -1,0 +1,69 @@
+read_verilog -sv << EOT
+module stress(
+	input en0,
+	input en1,
+	input [1:0] sel,
+	input [7:0] a, b, c, d, e,
+	output reg [7:0] y,
+	output reg [7:0] z
+);
+	always @* begin
+		y = a;
+		z = b;
+
+		if (en0) begin
+			{y[7:4], z[3:0]} = {c[7:4], d[3:0]};
+			if (sel[0])
+				y[1:0] = e[1:0];
+		end else begin
+			z[7:4] = e[7:4];
+		end
+
+		case (sel)
+			2'b01: begin
+				y[5:2] = d[5:2];
+				if (en1)
+					z[6:5] = c[6:5];
+			end
+			2'b10, 2'b11: begin
+				{z[2], y[6]} = {a[2], b[6]};
+			end
+		endcase
+
+		y[3:0] = b[3:0];
+	end
+endmodule
+EOT
+
+design -save orig
+
+# Optimized path (wire prefilter enabled).
+design -load orig
+proc_clean
+proc_rmdead
+proc_prune
+proc_init
+proc_arst
+proc_rom
+proc_mux
+proc_clean
+opt_expr -keepdc
+design -stash opt
+
+# Reference path (wire prefilter disabled).
+design -load orig
+proc_clean
+proc_rmdead
+proc_prune
+proc_init
+proc_arst
+proc_rom
+proc_mux -no-wire-prefilter
+proc_clean
+opt_expr -keepdc
+design -stash ref
+
+design -copy-from ref -as gold stress
+design -copy-from opt -as gate stress
+miter -equiv -flatten -make_assert -make_outputs gold gate miter
+sat -verify -set-def-inputs -prove-asserts miter


### PR DESCRIPTION
## Summary

- skip process actions whose left-hand-side wires cannot affect the output snippet currently being lowered
- cache parallel-case grouping once per switch instead of rebuilding it for every output snippet
- avoid `BitPatternPool` argument copies in the grouping hot path
- retain `proc_mux -no-wire-prefilter` as a legacy reference path and add direct and SAT-equivalence regressions

These changes avoid work and cache invariant analysis; they do not change mux-selection policy or output quality.

## Correctness

- release build with bundled libraries passes
- all 17 `tests/proc/*.ys` scripts pass
- `BitpatternTest.*` passes
- optimized and legacy `proc_mux` paths produce byte-identical RTLIL on the differential workloads
- current `main` and this branch produce identical post-`proc_mux` RTLIL, excluding only the generated version header, on Hazard3, OpenSPARC, WF68K, PicoRV32, UDP, and an AXI-lite crossbar
- final Hazard3 synthesis JSON canonicalizes identically after removing creator/build-path metadata

## Complete-flow performance

Paired runs pin both revisions sequentially to the same physical core.

| Workload | Pairs | `main` median | Branch median | Result |
| --- | ---: | ---: | ---: | --- |
| Public Hazard3 Icebreaker | 8 | 32.560 s | 13.826 s | 57.524% less wall time; 2.354x throughput |
| OpenSPARC T2 | 10 | 724.731 s | 721.961 s | +0.633%; 95% CI -1.363% to +2.697% |
| WF68K | 10 | 1537.206 s | 1532.606 s | +0.262%; 95% CI -0.493% to +0.976% |

On public `yosys-bench`, 20 pairs per design produced an equal-weight geomean of +0.272% (95% CI -0.038% to +0.493%). UDP was individually positive at +0.553% (95% CI +0.190% to +0.707%); PicoRV32 and the AXI-lite crossbar were inconclusive.

The large Hazard3 effect is workload-specific: its process tree contains substantially more affected action/case work. On the regular large designs, the isolated pass falls from 2.457 s to 0.300 s on OpenSPARC and from 3.295 s to 0.326 s on WF68K, so the savings are real but diluted inside 12- and 26-minute synthesis flows.

Hazard3 was tested from the public `Wren6991/Hazard3` repository at `c15bffd3e5e80d7b6eb1f98a735f63c8a68da149`.

This is a draft while the change and benchmark presentation receive review.
