### PR TITLE
rmports: remove output ports unused by all instances [sc-799]

### DIFF
--- a/passes/opt/rmports.cc
+++ b/passes/opt/rmports.cc
@@ -33,7 +33,10 @@ struct RmportsPassPass : public Pass {
 		log("    rmports [selection]\n");
 		log("\n");
 		log("This pass identifies ports in the selected modules which are not used or\n");
-		log("driven and removes them.\n");
+		log("driven and removes them. Output ports which are driven inside the module\n");
+		log("are also removed if their connections on all instances of the module lead\n");
+		log("nowhere. This does not apply to the top module and to modules which are\n");
+		log("never instantiated.\n");
 		log("\n");
 	}
 
@@ -47,14 +50,61 @@ struct RmportsPassPass : public Pass {
 		// The set of ports we removed
 		dict<IdString, pool<IdString>> removed_ports;
 
+		// Find the ports which are used by some instance in the design
+		dict<IdString, pool<IdString>> used_instance_ports;
+		pool<IdString> instantiated;
+		ScanInstances(design, used_instance_ports, instantiated);
+
 		// Find all of the unused ports, and remove them from that module
 		auto modules = design->selected_modules();
 		for(auto mod : modules)
-			ScanModule(mod, removed_ports);
+			ScanModule(mod, removed_ports, used_instance_ports[mod->name], instantiated.count(mod->name));
 
 		// Remove the unused ports from all instances of those modules
 		for(auto mod : modules)
 			CleanupModule(mod, removed_ports);
+	}
+
+	// A port is used by an instance if some bit of its connection goes anywhere
+	// else in the parent module: a public, port or kept wire, a second reference
+	// to the same bit, or any wire at all if the parent still contains processes
+	void ScanInstances(Design *design, dict<IdString, pool<IdString>> &used_instance_ports, pool<IdString> &instantiated)
+	{
+		// Count how often each wire bit is referenced anywhere in the design
+		dict<SigBit, int> bit_refs;
+		for(auto mod : design->modules())
+		{
+			for(auto &conn : mod->connections())
+				for(auto bit : SigSpec{conn.first, conn.second})
+					if(bit.wire != NULL)
+						bit_refs[bit]++;
+			for(auto cell : mod->cells())
+			{
+				instantiated.insert(cell->type);
+				for(auto &conn : cell->connections())
+					for(auto bit : conn.second)
+						if(bit.wire != NULL)
+							bit_refs[bit]++;
+			}
+		}
+
+		for(auto mod : design->modules())
+		{
+			bool has_procs = !mod->processes.empty();
+			for(auto cell : mod->cells())
+				for(auto &conn : cell->connections())
+					for(auto bit : conn.second)
+					{
+						if(bit.wire == NULL)
+							continue;
+						if(has_procs || bit.wire->name.isPublic() || bit.wire->port_input || bit.wire->port_output ||
+								bit.wire->get_bool_attribute(ID::keep) || bit_refs.at(bit) > 1)
+						{
+							used_instance_ports[cell->type].insert(conn.first);
+							break;
+						}
+					}
+		}
 	}
 
 	void CleanupModule(Module *module, dict<IdString, pool<IdString>> &removed_ports)
@@ -81,7 +131,8 @@ struct RmportsPassPass : public Pass {
 		}
 	}
 
-	void ScanModule(Module* module, dict<IdString, pool<IdString>> &removed_ports)
+	void ScanModule(Module* module, dict<IdString, pool<IdString>> &removed_ports,
+			const pool<IdString> &used_instance_ports, bool is_instantiated)
 	{
 		log("Finding unconnected ports in module %s\n", module->name);
 
@@ -139,12 +190,27 @@ struct RmportsPassPass : public Pass {
 		}
 
 		// Now that we know what IS used, get rid of anything that isn't in that list
+		bool keep_outputs = !is_instantiated || module->get_bool_attribute(ID::top);
 		pool<IdString> unused_ports;
 		for(auto port : module->ports)
 		{
-			if(used_ports.find(port) != used_ports.end())
+			if(used_ports.find(port) == used_ports.end())
+			{
+				unused_ports.insert(port);
 				continue;
-			unused_ports.insert(port);
+			}
+
+			// An output which no instance of this module uses can be removed
+			// even if it is driven internally
+			auto wire = module->wire(port);
+			if(
+				wire->port_output &&
+				!wire->port_input &&
+				!keep_outputs &&
+				used_instance_ports.find(port) == used_instance_ports.end() &&
+				!wire->get_bool_attribute(ID::keep)
+			)
+				unused_ports.insert(port);
 		}
 
 		// Print the ports out as we go through them

--- a/passes/opt/rmports.cc
+++ b/passes/opt/rmports.cc
@@ -30,13 +30,20 @@ struct RmportsPassPass : public Pass {
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
-		log("    rmports [selection]\n");
+		log("    rmports [options] [selection]\n");
 		log("\n");
 		log("This pass identifies ports in the selected modules which are not used or\n");
-		log("driven and removes them. Output ports which are driven inside the module\n");
-		log("are also removed if their connections on all instances of the module lead\n");
-		log("nowhere. This does not apply to the top module and to modules which are\n");
-		log("never instantiated.\n");
+		log("driven and removes them.\n");
+		log("\n");
+		log("An output which is driven inside the module is also removed, if no\n");
+		log("instance of the module uses it. The top module, a module which nothing\n");
+		log("instantiates, and a port with the keep attribute stay. This needs a clear\n");
+		log("top module: one with the top attribute, or the only module which nothing\n");
+		log("instantiates. Without one, a parent design which is not loaded can still\n");
+		log("use these ports.\n");
+		log("\n");
+		log("    -purge\n");
+		log("        remove driven outputs also when there is no clear top module\n");
 		log("\n");
 	}
 
@@ -44,7 +51,18 @@ struct RmportsPassPass : public Pass {
 	{
 		log_header(design, "Executing RMPORTS pass (remove ports with no connections).\n");
 
-		size_t argidx = 1;
+		bool purge_mode = false;
+
+		size_t argidx;
+		for(argidx = 1; argidx < args.size(); argidx++)
+		{
+			if(args[argidx] == "-purge")
+			{
+				purge_mode = true;
+				continue;
+			}
+			break;
+		}
 		extra_args(args, argidx, design);
 
 		// The set of ports we removed
@@ -53,22 +71,58 @@ struct RmportsPassPass : public Pass {
 		// Find the ports which are used by some instance in the design
 		dict<IdString, pool<IdString>> used_instance_ports;
 		pool<IdString> instantiated;
-		ScanInstances(design, used_instance_ports, instantiated);
+		pool<IdString> positional;
+		CollectInstantiated(design, instantiated);
+		bool scan_outputs = purge_mode || HasTopModule(design) || HasUniqueRoot(design, instantiated);
+		if(scan_outputs)
+			ScanInstances(design, used_instance_ports, positional);
+		else
+			log("The design has no clear top module. Outputs which are driven inside their module stay.\n");
 
 		// Find all of the unused ports, and remove them from that module
-		auto modules = design->selected_modules();
-		for(auto mod : modules)
-			ScanModule(mod, removed_ports, used_instance_ports[mod->name], instantiated.count(mod->name));
+		for(auto mod : design->selected_modules())
+		{
+			bool keep_outputs = !scan_outputs || !instantiated.count(mod->name) ||
+					positional.count(mod->name) || mod->get_bool_attribute(ID::top);
+			ScanModule(mod, removed_ports, used_instance_ports[mod->name], keep_outputs);
+		}
 
 		// Remove the unused ports from all instances of those modules
-		for(auto mod : modules)
+		for(auto mod : design->modules())
 			CleanupModule(mod, removed_ports);
+	}
+
+	// The cell types which some cell in the design instantiates
+	void CollectInstantiated(Design *design, pool<IdString> &instantiated)
+	{
+		for(auto mod : design->modules())
+			for(auto cell : mod->cells())
+				instantiated.insert(cell->type);
+	}
+
+	bool HasTopModule(Design *design)
+	{
+		for(auto mod : design->modules())
+			if(mod->get_bool_attribute(ID::top))
+				return true;
+		return false;
+	}
+
+	// A design where only one module is not instantiated has a clear top even
+	// when no module has the attribute
+	bool HasUniqueRoot(Design *design, const pool<IdString> &instantiated)
+	{
+		int roots = 0;
+		for(auto mod : design->modules())
+			if(!instantiated.count(mod->name))
+				roots++;
+		return roots == 1;
 	}
 
 	// A port is used by an instance if some bit of its connection goes anywhere
 	// else in the parent module: a public, port or kept wire, a second reference
 	// to the same bit, or any wire at all if the parent still contains processes
-	void ScanInstances(Design *design, dict<IdString, pool<IdString>> &used_instance_ports, pool<IdString> &instantiated)
+	void ScanInstances(Design *design, dict<IdString, pool<IdString>> &used_instance_ports, pool<IdString> &positional)
 	{
 		// Count how often each wire bit is referenced anywhere in the design
 		dict<SigBit, int> bit_refs;
@@ -79,13 +133,10 @@ struct RmportsPassPass : public Pass {
 					if(bit.wire != NULL)
 						bit_refs[bit]++;
 			for(auto cell : mod->cells())
-			{
-				instantiated.insert(cell->type);
 				for(auto &conn : cell->connections())
 					for(auto bit : conn.second)
 						if(bit.wire != NULL)
 							bit_refs[bit]++;
-			}
 		}
 
 		for(auto mod : design->modules())
@@ -93,6 +144,10 @@ struct RmportsPassPass : public Pass {
 			bool has_procs = !mod->processes.empty();
 			for(auto cell : mod->cells())
 				for(auto &conn : cell->connections())
+				{
+					if(!conn.first.isPublic())
+						positional.insert(cell->type);
+
 					for(auto bit : conn.second)
 					{
 						if(bit.wire == NULL)
@@ -104,6 +159,7 @@ struct RmportsPassPass : public Pass {
 							break;
 						}
 					}
+				}
 		}
 	}
 
@@ -132,7 +188,7 @@ struct RmportsPassPass : public Pass {
 	}
 
 	void ScanModule(Module* module, dict<IdString, pool<IdString>> &removed_ports,
-			const pool<IdString> &used_instance_ports, bool is_instantiated)
+			const pool<IdString> &used_instance_ports, bool keep_outputs)
 	{
 		log("Finding unconnected ports in module %s\n", module->name);
 
@@ -190,7 +246,6 @@ struct RmportsPassPass : public Pass {
 		}
 
 		// Now that we know what IS used, get rid of anything that isn't in that list
-		bool keep_outputs = !is_instantiated || module->get_bool_attribute(ID::top);
 		pool<IdString> unused_ports;
 		for(auto port : module->ports)
 		{

--- a/tests/opt/bug1793.ys
+++ b/tests/opt/bug1793.ys
@@ -1,27 +1,131 @@
 # rmports: remove output ports which are driven internally but unused by all instances
+# https://github.com/YosysHQ/yosys/issues/1793
 
 read_verilog <<EOT
-module sub(input a, output x, output y);
-assign x = a;
-assign y = ~a;
+module sub(input a, input z, output x, output y);
+  assign x = a;
+  assign y = ~a;
 endmodule
+
 module top(input a, output o);
-sub s(.a(a), .x(o), .y());
+  sub s(.a(a), .z(), .x(o), .y());
 endmodule
 EOT
 hierarchy -top top
-proc
+design -save simple
 
 select -assert-count 2 sub/o:*
+select -assert-count 2 sub/i:*
 rmports
-select -assert-count 1 sub/o:x
+hierarchy -check
+select -assert-count 0 sub/o:y
+select -assert-count 1 sub/w:y
 select -assert-count 1 sub/o:*
+select -assert-count 1 sub/i:a
 select -assert-count 1 sub/i:*
-# ports of the top module are kept
 select -assert-count 1 top/o:*
 select -assert-count 1 top/i:*
 
-# repro #1793
+# a parent outside the selection is cleaned up as well
+design -load simple
+rmports sub
+select -assert-count 1 sub/o:*
+hierarchy -check
+
+# an output is kept when any instance uses it
+design -reset
+read_verilog <<EOT
+module sub(input a, output x, output y);
+  assign x = a;
+  assign y = ~a;
+endmodule
+
+module top(input a, output o, output p);
+  sub s1(.a(a), .x(o), .y());
+  sub s2(.a(a), .x(), .y(p));
+endmodule
+EOT
+hierarchy -top top
+rmports
+hierarchy -check
+select -assert-count 2 sub/o:*
+
+# a cell which is not derived yet names its ports $1, $2, etc
+design -reset
+read_verilog <<EOT
+module sub(input as, output xs, input bs, output ys, input cs);
+  assign xs = as & bs;
+  assign ys = as ^ cs;
+endmodule
+
+(* top *)
+module top(input a, input b, output o);
+  wire t;
+  sub s(a, t, b);
+  assign o = t ^ a;
+endmodule
+EOT
+rmports
+hierarchy -check -top top
+select -assert-count 2 sub/o:*
+
+# a box parent is never selected, but should also be cleaned up
+design -reset
+read_verilog <<EOT
+module sub(input a, output x, output y);
+  assign x = a;
+  assign y = ~a;
+endmodule
+
+module mid(input a, output x);
+  wire dead;
+  sub s(.a(a), .x(x), .y(dead));
+endmodule
+
+module top(input a, output o);
+  mid m(.a(a), .x(o));
+endmodule
+EOT
+hierarchy -top top
+# a public wire counts as a use
+rename -hide mid/w:dead
+setattr -mod -set whitebox 1 mid
+select -clear
+rmports
+select -assert-count 1 sub/o:*
+hierarchy -check
+
+# two modules are a root here, so there is no clear top
+design -reset
+read_verilog <<EOT
+module sub(input a, output x, output y);
+  assign x = a;
+  assign y = ~a;
+endmodule
+
+module use1(input a, output o);
+  sub s(.a(a), .x(o), .y());
+endmodule
+
+module use2(input a, output o);
+  sub s(.a(a), .x(o), .y());
+endmodule
+EOT
+design -save roots
+
+rmports
+select -assert-count 2 sub/o:*
+rmports -purge
+hierarchy -check
+select -assert-count 1 sub/o:x
+
+design -load roots
+delete use2
+rmports
+hierarchy -check
+select -assert-count 1 sub/o:x
+
+# repro
 design -reset
 read_verilog <<EOT
 module TOP(a, b, y);
@@ -39,16 +143,12 @@ module sub(as, bs, ys);
   assign ys = as & bs;
 endmodule
 EOT
-prep
-splitnets
-rmports
+hierarchy
 delete w:NC
-clean -purge
-rmports
 splitnets -ports
 rmports
+hierarchy -check
 clean -purge
-opt_clean -purge
 
 select -assert-count 3 sub/o:*
 select -assert-count 8 sub/i:*

--- a/tests/opt/bug1793.ys
+++ b/tests/opt/bug1793.ys
@@ -1,0 +1,56 @@
+# rmports: remove output ports which are driven internally but unused by all instances
+
+read_verilog <<EOT
+module sub(input a, output x, output y);
+assign x = a;
+assign y = ~a;
+endmodule
+module top(input a, output o);
+sub s(.a(a), .x(o), .y());
+endmodule
+EOT
+hierarchy -top top
+proc
+
+select -assert-count 2 sub/o:*
+rmports
+select -assert-count 1 sub/o:x
+select -assert-count 1 sub/o:*
+select -assert-count 1 sub/i:*
+# ports of the top module are kept
+select -assert-count 1 top/o:*
+select -assert-count 1 top/i:*
+
+# repro #1793
+design -reset
+read_verilog <<EOT
+module TOP(a, b, y);
+  input [3:0] a, b;
+  output [2:0] y;
+  reg [2:0] tmp;
+  wire NC;
+  sub p(a, b, {NC, tmp});
+  assign y = tmp;
+endmodule
+
+module sub(as, bs, ys);
+  input [3:0] as, bs;
+  output [3:0] ys;
+  assign ys = as & bs;
+endmodule
+EOT
+prep
+splitnets
+rmports
+delete w:NC
+clean -purge
+rmports
+splitnets -ports
+rmports
+clean -purge
+opt_clean -purge
+
+select -assert-count 3 sub/o:*
+select -assert-count 8 sub/i:*
+select -assert-count 3 TOP/o:*
+select -assert-count 8 TOP/i:*


### PR DESCRIPTION
This PR aims to fix #1793 - `rmports` only examined connections inside a module, so an internally driven output was never removed even when no instance used it. This adds a design-wide scan so that an output port is now also removed when its connections on all instances lead nowhere (public wires, parent ports, keep wires and modules with processes count as uses). Top modules and never-instantiated modules are untouched.