### PR TITLE
ABCU: fix bufnorm edge cases

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1226,22 +1226,6 @@ RTLIL::Module *RTLIL::Design::top_module() const
 	return module_count == 1 ? module : nullptr;
 }
 
-void RTLIL::Design::add(RTLIL::Module *module)
-{
-	log_assert(modules_.count(module->name) == 0);
-	log_assert(refcount_modules_ == 0);
-	modules_[module->name] = module;
-	module->design = this;
-
-	for (auto mon : monitors)
-		mon->notify_module_add(module);
-
-	if (yosys_xtrace) {
-		log("#X# New Module: %s\n", module);
-		log_backtrace("-X- ", yosys_xtrace-1);
-	}
-}
-
 void RTLIL::Design::add(RTLIL::Binding *binding)
 {
 	log_assert(binding != nullptr);

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -2115,8 +2115,6 @@ public:
 	pool<RTLIL::Wire *> buf_norm_wire_queue;
 	pool<RTLIL::Cell *> pending_deleted_cells;
 	dict<RTLIL::Wire *, pool<RTLIL::Cell *>> buf_norm_connect_index;
-	bool buf_norm_initialized = false;
-	void bufNormalizeInit();
 	void bufNormalize();
 
 	template<typename T> void rewrite_sigspecs(T &functor);

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -2115,6 +2115,8 @@ public:
 	pool<RTLIL::Wire *> buf_norm_wire_queue;
 	pool<RTLIL::Cell *> pending_deleted_cells;
 	dict<RTLIL::Wire *, pool<RTLIL::Cell *>> buf_norm_connect_index;
+	bool buf_norm_initialized = false;
+	void bufNormalizeInit();
 	void bufNormalize();
 
 	template<typename T> void rewrite_sigspecs(T &functor);

--- a/kernel/rtlil_bufnorm.cc
+++ b/kernel/rtlil_bufnorm.cc
@@ -44,38 +44,37 @@ void RTLIL::Design::bufNormalize(bool enable)
 				wire->driverPort_ = IdString();
 			}
 			module->buf_norm_connect_index.clear();
+			module->buf_norm_initialized = false;
 		}
 
 		flagBufferedNormalized = false;
 		return;
 	}
 
-	if (!flagBufferedNormalized)
-	{
-		for (auto module : modules())
-		{
-			// When entering buf normalized mode, we need the first module-level bufNormalize
-			// call to know about all drivers, about all module ports (whether represented by
-			// a cell or not) and about all used but undriven wires (whether represented by a
-			// cell or not). We ensure this by enqueing all cell output ports and all wires.
-
-			for (auto cell : module->cells())
-			for (auto &conn : cell->connections()) {
-				if (GetSize(conn.second) == 0 || (cell->port_dir(conn.first) != RTLIL::PD_OUTPUT && cell->port_dir(conn.first) != RTLIL::PD_INOUT))
-					continue;
-				module->buf_norm_cell_queue.insert(cell);
-				module->buf_norm_cell_port_queue.emplace(cell, conn.first);
-			}
-			for (auto wire : module->wires())
-				module->buf_norm_wire_queue.insert(wire);
-
-		}
-
-		flagBufferedNormalized = true;
-	}
+	flagBufferedNormalized = true;
 
 	for (auto module : modules())
 		module->bufNormalize();
+}
+
+void RTLIL::Module::bufNormalizeInit()
+{
+	// When entering buf normalized mode, we need the first module-level bufNormalize
+	// call to know about all drivers, about all module ports (whether represented by
+	// a cell or not) and about all used but undriven wires (whether represented by a
+	// cell or not). We ensure this by enqueing all cell output ports and all wires.
+
+	for (auto cell : cells())
+	for (auto &conn : cell->connections()) {
+		if (GetSize(conn.second) == 0 || (cell->port_dir(conn.first) != RTLIL::PD_OUTPUT && cell->port_dir(conn.first) != RTLIL::PD_INOUT))
+			continue;
+		buf_norm_cell_queue.insert(cell);
+		buf_norm_cell_port_queue.emplace(cell, conn.first);
+	}
+	for (auto wire : wires())
+		buf_norm_wire_queue.insert(wire);
+
+	buf_norm_initialized = true;
 }
 
 struct bit_drive_data_t {
@@ -95,11 +94,16 @@ void RTLIL::Module::bufNormalize()
 	if (!design->flagBufferedNormalized)
 		return;
 
+	// A module added after the design entered buf normalized mode has to be
+	// enqueued before its first pass
+	if (!buf_norm_initialized)
+		bufNormalizeInit();
+
 	if (!buf_norm_cell_queue.empty() || !buf_norm_wire_queue.empty() || !connections_.empty())
 	{
 		// Ensure that every enqueued input port is represented by a cell
 		for (auto wire : buf_norm_wire_queue) {
-			if (wire->port_input && !wire->port_output) {
+			if (wire->port_input && !wire->port_output && GetSize(wire) != 0) {
 				if (wire->driverCell_ != nullptr && wire->driverCell_->type != ID($input_port)) {
 					wire->driverCell_ = nullptr;
 					wire->driverPort_.clear();
@@ -425,6 +429,10 @@ void RTLIL::Module::bufNormalize()
 		// connected via `$connect` cells but every wire of the net has the
 		// corresponding bit still driven by a buffered `Sz`.
 		for (auto wire : wire_queue_entries) {
+			// A zero-width wire carries no bits and needs no driver
+			if (GetSize(wire) == 0)
+				continue;
+
 			SigSpec wire_drivers;
 			for (int i = 0; i < GetSize(wire); ++i) {
 				SigBit bit(wire, i);

--- a/kernel/rtlil_bufnorm.cc
+++ b/kernel/rtlil_bufnorm.cc
@@ -28,6 +28,19 @@
 YOSYS_NAMESPACE_BEGIN
 
 
+static void buf_norm_seed_queues(RTLIL::Module *module)
+{
+	for (auto cell : module->cells())
+	for (auto &conn : cell->connections()) {
+		if (GetSize(conn.second) == 0 || (cell->port_dir(conn.first) != RTLIL::PD_OUTPUT && cell->port_dir(conn.first) != RTLIL::PD_INOUT))
+			continue;
+		module->buf_norm_cell_queue.insert(cell);
+		module->buf_norm_cell_port_queue.emplace(cell, conn.first);
+	}
+	for (auto wire : module->wires())
+		module->buf_norm_wire_queue.insert(wire);
+}
+
 void RTLIL::Design::bufNormalize(bool enable)
 {
 	if (!enable)
@@ -44,37 +57,22 @@ void RTLIL::Design::bufNormalize(bool enable)
 				wire->driverPort_ = IdString();
 			}
 			module->buf_norm_connect_index.clear();
-			module->buf_norm_initialized = false;
 		}
 
 		flagBufferedNormalized = false;
 		return;
 	}
 
-	flagBufferedNormalized = true;
+	if (!flagBufferedNormalized)
+	{
+		for (auto module : modules())
+			buf_norm_seed_queues(module);
+
+		flagBufferedNormalized = true;
+	}
 
 	for (auto module : modules())
 		module->bufNormalize();
-}
-
-void RTLIL::Module::bufNormalizeInit()
-{
-	// When entering buf normalized mode, we need the first module-level bufNormalize
-	// call to know about all drivers, about all module ports (whether represented by
-	// a cell or not) and about all used but undriven wires (whether represented by a
-	// cell or not). We ensure this by enqueing all cell output ports and all wires.
-
-	for (auto cell : cells())
-	for (auto &conn : cell->connections()) {
-		if (GetSize(conn.second) == 0 || (cell->port_dir(conn.first) != RTLIL::PD_OUTPUT && cell->port_dir(conn.first) != RTLIL::PD_INOUT))
-			continue;
-		buf_norm_cell_queue.insert(cell);
-		buf_norm_cell_port_queue.emplace(cell, conn.first);
-	}
-	for (auto wire : wires())
-		buf_norm_wire_queue.insert(wire);
-
-	buf_norm_initialized = true;
 }
 
 struct bit_drive_data_t {
@@ -93,11 +91,6 @@ void RTLIL::Module::bufNormalize()
 
 	if (!design->flagBufferedNormalized)
 		return;
-
-	// A module added after the design entered buf normalized mode has to be
-	// enqueued before its first pass
-	if (!buf_norm_initialized)
-		bufNormalizeInit();
 
 	if (!buf_norm_cell_queue.empty() || !buf_norm_wire_queue.empty() || !connections_.empty())
 	{
@@ -676,6 +669,27 @@ void RTLIL::Cell::setPort(RTLIL::IdString portname, RTLIL::SigSpec signal)
 	}
 	conn_it->second = std::move(signal);
 
+}
+
+void RTLIL::Design::add(RTLIL::Module *module)
+{
+	log_assert(modules_.count(module->name) == 0);
+	log_assert(refcount_modules_ == 0);
+	modules_[module->name] = module;
+	module->design = this;
+
+	for (auto mon : monitors)
+		mon->notify_module_add(module);
+
+	if (yosys_xtrace) {
+		log("#X# New Module: %s\n", module);
+		log_backtrace("-X- ", yosys_xtrace-1);
+	}
+
+	if (flagBufferedNormalized) {
+		buf_norm_seed_queues(module);
+		module->bufNormalize();
+	}
 }
 
 YOSYS_NAMESPACE_END

--- a/kernel/rtlil_bufnorm.cc
+++ b/kernel/rtlil_bufnorm.cc
@@ -30,6 +30,11 @@ YOSYS_NAMESPACE_BEGIN
 
 static void buf_norm_seed_queues(RTLIL::Module *module)
 {
+	// When entering buf normalized mode, we need the first module-level bufNormalize
+	// call to know about all drivers, about all module ports (whether represented by
+	// a cell or not) and about all used but undriven wires (whether represented by a
+	// cell or not). We ensure this by enqueing all cell output ports and all wires.
+
 	for (auto cell : module->cells())
 	for (auto &conn : cell->connections()) {
 		if (GetSize(conn.second) == 0 || (cell->port_dir(conn.first) != RTLIL::PD_OUTPUT && cell->port_dir(conn.first) != RTLIL::PD_INOUT))


### PR DESCRIPTION
While working on write_xaiger2 for ABCU I discovered some minor edge cases, list of my fixes is below. 
- Move the enqueue seeding from into `Module::bufNormalizeInit()`, guarded by a per-module flag. A module created after the design entered bufnorm mode was never seeded, so its cells and wires never got queued.
- Skip zero-width input ports when forcing an `$input_port` driver cell.
- Skip zero-width wires in the undriven scan, since they carry no bits and need no driver.
