### PR TITLE
liberty_cache: per user SCL cache directory [sc-843]

### DIFF
--- a/kernel/io.cc
+++ b/kernel/io.cc
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <string>
 #include <filesystem>
+#include <system_error>
 
 #if !defined(WIN32)
 #include <dirent.h>
@@ -374,6 +375,61 @@ bool create_directory(const std::string& dirname)
 	}
 }
 
+bool make_private_directory(const std::string& dirname)
+{
+#if defined(_WIN32) || defined(__wasi__)
+	if (!create_directory(dirname)) {
+		log_warning("Cannot create the directory %s\n", dirname.c_str());
+		return false;
+	}
+	return true;
+#else
+	if (mkdir(dirname.c_str(), 0700) == 0)
+		return true;
+
+	// Keep the errno of each mkdir(), create_directory() below makes its own calls
+	int err = errno;
+	std::string parent = std::filesystem::path(dirname).parent_path().string();
+
+	if (err == ENOENT && !parent.empty() && create_directory(parent)) {
+		if (mkdir(dirname.c_str(), 0700) == 0)
+			return true;
+		err = errno;
+	}
+
+	if (err != EEXIST) {
+		log_warning("Cannot create the directory %s: %s\n", dirname.c_str(), strerror(err));
+		return false;
+	}
+
+	// Do not use a leftover that isn't ours
+	struct stat st;
+	if (lstat(dirname.c_str(), &st) != 0 || !S_ISDIR(st.st_mode) || st.st_uid != geteuid()) {
+		log_warning("%s is not a directory of this user\n", dirname.c_str());
+		return false;
+	}
+	// Repair the mode if something changed it
+	mode_t mode = st.st_mode & 0777;
+	if (((mode & S_IRWXU) != S_IRWXU || (mode & (S_IWGRP | S_IWOTH)) != 0) && chmod(dirname.c_str(), 0700) != 0) {
+		log_warning("Cannot make the directory %s private: %s\n", dirname.c_str(), strerror(errno));
+		return false;
+	}
+
+	return true;
+#endif
+}
+
+std::string make_user_tmpdir(const std::string& name)
+{
+	log_assert(!name.empty() && name.find('/') == std::string::npos);
+#if defined(_WIN32) || defined(__wasi__)
+	std::string dirname = get_base_tmpdir() + "/" + name;
+#else
+	std::string dirname = stringf("%s/%s-%u", get_base_tmpdir().c_str(), name.c_str(), (unsigned)geteuid());
+#endif
+	return make_private_directory(dirname) ? dirname : "";
+}
+
 std::string escape_filename_spaces(const std::string& filename)
 {
 	std::string out;
@@ -397,6 +453,22 @@ void append_globbed(std::vector<std::string>& paths, std::string pattern)
 
 std::string name_from_file_path(std::string path) {
 	return std::filesystem::path(path).filename().string();
+}
+
+std::string absolute_path(const std::string& path)
+{
+	std::error_code ec;
+	std::filesystem::path result = std::filesystem::absolute(path, ec);
+
+	if (ec)
+		return "";
+
+	result = std::filesystem::weakly_canonical(result, ec);
+
+	if (ec)
+		return "";
+
+	return result.string();
 }
 
 // Includes OS_PATH_SEP at the end if present

--- a/kernel/io.h
+++ b/kernel/io.h
@@ -503,9 +503,12 @@ bool check_directory_exists(const std::string& dirname, bool is_exec = false);
 bool is_absolute_path(std::string filename);
 void remove_directory(std::string dirname);
 bool create_directory(const std::string& dirname);
+bool make_private_directory(const std::string& dirname);
+std::string make_user_tmpdir(const std::string& name);
 std::string escape_filename_spaces(const std::string& filename);
 void append_globbed(std::vector<std::string>& paths, std::string pattern);
 std::string name_from_file_path(std::string path);
+std::string absolute_path(const std::string& path);
 std::string parent_from_file_path(std::string path);
 
 // Exclusive inter-process file lock (flock/LockFileEx, no-op on WASI),

--- a/passes/techmap/libcache.cc
+++ b/passes/techmap/libcache.cc
@@ -23,6 +23,7 @@
  YOSYS_NAMESPACE_BEGIN
  // Read by convert_liberty_files_to_merged_scl() in liberty_cache.h
  bool scl_cache_enabled = true;
+ std::string scl_cache_dir;
  YOSYS_NAMESPACE_END
 
  USING_YOSYS_NAMESPACE
@@ -53,6 +54,11 @@
 		log("Controls the on-disk cache of merged SCL files that the abc and abc9 passes\n");
 		log("generate from liberty files. By default this caching is enabled.\n");
 		log("\n");
+		log("    libcache -scl -dir [path]\n");
+		log("\n");
+		log("Stores the merged SCL files in [path] instead of a directory of this user in\n");
+		log("the temp directory. <empty> means a per user directory in the temp directory.\n");
+		log("\n");
 		log("    libcache -list\n");
 		log("\n");
 		log("Displays the current cache settings and cached paths.\n");
@@ -75,6 +81,8 @@
 		bool list = false;
 		bool verbose = false;
 		bool quiet = false;
+		bool dir = false;
+		std::string dir_path;
 		std::vector<std::string> paths;
 
 		size_t argidx;
@@ -111,21 +119,30 @@
 				quiet = true;
 				continue;
 			}
+			if (args[argidx] == "-dir") {
+				if (argidx+1 >= args.size())
+					log_cmd_error("The -dir option needs a path.\n");
+				dir = true;
+				dir_path = args[++argidx];
+				continue;
+			}
 			append_globbed(paths, args[argidx]);
 			break;
 		}
-		int modes = enable + disable + purge + list + verbose + quiet;
+		int modes = enable + disable + purge + list + verbose + quiet + dir;
 		if (modes == 0)
-			log_cmd_error("At least one of -enable, -disable, -purge, -list,\n-verbose, or -quiet is required.\n");
+			log_cmd_error("At least one of -enable, -disable, -purge, -list,\n-verbose, -quiet, or -dir is required.\n");
 		if (modes > 1)
-			log_cmd_error("Only one of -enable, -disable, -purge, -list,\n-verbose, or -quiet may be present.\n");
+			log_cmd_error("Only one of -enable, -disable, -purge, -list,\n-verbose, -quiet, or -dir may be present.\n");
 
 		if (all && !paths.empty())
 			log_cmd_error("The -all option cannot be combined with a list of paths.\n");
 		if (list && (all || !paths.empty()))
 			log_cmd_error("The -list mode takes no further options.\n");
-		if (scl && !(enable || disable))
-			log_cmd_error("The -scl option can only be combined with -enable or -disable.\n");
+		if (scl && !(enable || disable || dir))
+			log_cmd_error("The -scl option can only be combined with -enable, -disable, or -dir.\n");
+		if (dir && !scl)
+			log_cmd_error("The -dir option requires -scl.\n");
 		if (scl && (all || !paths.empty()))
 			log_cmd_error("The -scl option cannot be combined with -all or a list of paths.\n");
 		if (!list && !all && !scl && paths.empty())
@@ -134,6 +151,10 @@
 		if (list) {
 			log("Caching is %s by default.\n", LibertyAstCache::instance.cache_by_default ? "enabled" : "disabled");
 			log("SCL caching is %s.\n", scl_cache_enabled ? "enabled" : "disabled");
+			if (scl_cache_dir.empty())
+				log("SCL files are cached in a directory of this user in the temp directory.\n");
+			else
+				log("SCL files are cached in `%s'.\n", scl_cache_dir);
 			for (auto const &entry : LibertyAstCache::instance.cache_path)
 				log("Caching is %s for `%s'.\n", entry.second ? "enabled" : "disabled", entry.first);
 			for (auto const &entry : LibertyAstCache::instance.cached)
@@ -157,6 +178,16 @@
 					LibertyAstCache::instance.cached.erase(path);
 					LibertyAstCache::instance.cache_path.erase(path);
 				}
+			}
+		} else if (dir) {
+			rewrite_filename(dir_path);
+
+			if (dir_path.empty()) {
+				scl_cache_dir.clear();
+			} else {
+				scl_cache_dir = absolute_path(dir_path);
+				if (scl_cache_dir.empty())
+					log_cmd_error("Cannot make `%s' an absolute path.\n", dir_path);
 			}
 		} else if (verbose) {
 			LibertyAstCache::instance.verbose = true;

--- a/passes/techmap/liberty_cache.h
+++ b/passes/techmap/liberty_cache.h
@@ -17,6 +17,9 @@ YOSYS_NAMESPACE_BEGIN
 // Controlled by the libcache pass (-scl option), enabled by default
 extern bool scl_cache_enabled;
 
+// Controlled by the libcache pass (-scl -dir option), user temp dir by default
+extern std::string scl_cache_dir;
+
 /*
  * convert_liberty_files_to_merged_scl() - Convert multiple Liberty files to a single merged SCL cache file.
  * @liberty_files: Vector of liberty file paths to merge
@@ -31,12 +34,15 @@ inline std::string convert_liberty_files_to_merged_scl(const std::vector<std::st
 	if (liberty_files.empty() || !scl_cache_enabled)
 		return "";
 
-	std::string cache_dir = get_base_tmpdir() + "/yosys-liberty-scl-cache";
+	std::string cache_dir;
 
-	if (!create_directory(cache_dir)) {
-		log_warning("ABC: cannot create cache directory %s, falling back to liberty format\n", cache_dir.c_str());
+	if (scl_cache_dir.empty())
+		cache_dir = make_user_tmpdir("yosys-liberty-scl-cache");
+	else if (make_private_directory(scl_cache_dir))
+		cache_dir = scl_cache_dir;
+
+	if (cache_dir.empty())
 		return "";
-	}
 
 	// Sort to ensure consistent hash regardless of order
 	std::vector<std::string> sorted_files = liberty_files;


### PR DESCRIPTION
This PR aims to fix #6157. The scl cache moves from a shared `$TMPDIR/yosys-liberty-scl-cache` to a per user `...-<uid>` directory at mode `0700`, so the first user to run yosys no longer locks everybody else out. Also adds `libcache -scl -dir <path>` to put the cache elsewhere, `TMPDIR` still works and moves everything as before.