### PR TITLE
synth*: run check after proc before opt_clean to discover process-ini…

### DIFF
--- a/docs/source/code_examples/macro_commands/prep.ys
+++ b/docs/source/code_examples/macro_commands/prep.ys
@@ -5,11 +5,12 @@ begin:
 
 coarse:
     proc [-ifx]
+    check
     flatten    (if -flatten)
     future
     opt_expr -keepdc
-    opt_clean
     check
+    opt_clean
     opt -noff -keepdc
     wreduce -keepdc [-memx]
     memory_dff    (if -rdff)

--- a/docs/source/code_examples/macro_commands/synth_ice40.ys
+++ b/docs/source/code_examples/macro_commands/synth_ice40.ys
@@ -13,8 +13,8 @@ flatten:
 
 coarse:
     opt_expr
-    opt_clean
     check
+    opt_clean
     opt -nodffe -nosdff
     fsm
     opt

--- a/techlibs/analogdevices/synth_analogdevices.cc
+++ b/techlibs/analogdevices/synth_analogdevices.cc
@@ -275,8 +275,8 @@ struct SynthAnalogDevicesPass : public ScriptPass
 				log_error("Tristate buffers are unsupported without the '-iopad' option.\n");
 			run("deminout");
 			run("opt_expr");
-			run("opt_clean");
 			run("check");
+			run("opt_clean");
 			run("opt -nodffe -nosdff");
 			run("fsm");
 			run("opt");

--- a/techlibs/common/prep.cc
+++ b/techlibs/common/prep.cc
@@ -187,12 +187,14 @@ struct PrepPass : public ScriptPass
 				run("proc [-ifx]");
 			else
 				run(ifxmode ? "proc -ifx" : "proc");
-			if (help_mode || flatten)
+			if (help_mode || flatten) {
+				run("check");
 				run("flatten", "(if -flatten)");
+			}
 			run("future");
 			run(nokeepdc ? "opt_expr" : "opt_expr -keepdc");
-			run("opt_clean");
 			run("check");
+			run("opt_clean");
 			run(nokeepdc ? "opt -noff" : "opt -noff -keepdc");
 			if (!ifxmode) {
 				if (help_mode)

--- a/techlibs/common/synth.cc
+++ b/techlibs/common/synth.cc
@@ -275,8 +275,8 @@ struct SynthPass : public ScriptPass {
 				run("flatten", "  (if -flatten)");
 			}
 			run("opt_expr");
-			run("opt_clean");
 			run("check");
+			run("opt_clean");
 			run("opt -nodffe -nosdff");
 			if (!nofsm || help_mode)
 				run("fsm" + fsm_opts, "      (unless -nofsm)");

--- a/techlibs/fabulous/synth_fabulous.cc
+++ b/techlibs/fabulous/synth_fabulous.cc
@@ -307,8 +307,8 @@ struct SynthPass : public ScriptPass {
 
 			// synth pass
 			run("opt_expr");
-			run("opt_clean");
 			run("check");
+			run("opt_clean");
 			run("opt -nodffe -nosdff");
 			if (!nofsm)
 				run("fsm" + fsm_opts, "      (unless -nofsm)");

--- a/techlibs/gatemate/synth_gatemate.cc
+++ b/techlibs/gatemate/synth_gatemate.cc
@@ -230,8 +230,8 @@ struct SynthGateMatePass : public ScriptPass
 			run("tribuf -logic");
 			run("deminout");
 			run("opt_expr");
-			run("opt_clean");
 			run("check");
+			run("opt_clean");
 			run("opt -nodffe -nosdff");
 			run("fsm");
 			run("opt");

--- a/techlibs/gowin/synth_gowin.cc
+++ b/techlibs/gowin/synth_gowin.cc
@@ -264,8 +264,8 @@ struct SynthGowinPass : public ScriptPass
 			run("tribuf -logic");
 			run("deminout");
 			run("opt_expr");
-			run("opt_clean");
 			run("check");
+			run("opt_clean");
 			run("opt -nodffe -nosdff");
 			run("fsm");
 			run("opt");

--- a/techlibs/ice40/synth_ice40.cc
+++ b/techlibs/ice40/synth_ice40.cc
@@ -299,8 +299,8 @@ struct SynthIce40Pass : public ScriptPass
 		if (check_label("coarse"))
 		{
 			run("opt_expr");
-			run("opt_clean");
 			run("check");
+			run("opt_clean");
 			run("opt -nodffe -nosdff");
 			run("fsm");
 			run("opt");

--- a/techlibs/intel/synth_intel.cc
+++ b/techlibs/intel/synth_intel.cc
@@ -204,8 +204,8 @@ struct SynthIntelPass : public ScriptPass {
 			run("tribuf -logic");
 			run("deminout");
 			run("opt_expr");
-			run("opt_clean");
 			run("check");
+			run("opt_clean");
 			run("opt -nodffe -nosdff");
 			run("fsm");
 			run("opt");

--- a/techlibs/intel_alm/synth_intel_alm.cc
+++ b/techlibs/intel_alm/synth_intel_alm.cc
@@ -191,8 +191,8 @@ struct SynthIntelALMPass : public ScriptPass {
 			run("tribuf -logic");
 			run("deminout");
 			run("opt_expr");
-			run("opt_clean");
 			run("check");
+			run("opt_clean");
 			run("opt -nodffe -nosdff");
 			run("fsm");
 			run("opt");

--- a/techlibs/lattice/synth_lattice.cc
+++ b/techlibs/lattice/synth_lattice.cc
@@ -402,8 +402,8 @@ struct SynthLatticePass : public ScriptPass
 			run("tribuf -logic");
 			run("deminout");
 			run("opt_expr");
-			run("opt_clean");
 			run("check");
+			run("opt_clean");
 			run("opt -nodffe -nosdff");
 			run("fsm");
 			run("opt");

--- a/techlibs/microchip/synth_microchip.cc
+++ b/techlibs/microchip/synth_microchip.cc
@@ -266,8 +266,8 @@ struct SynthMicrochipPass : public ScriptPass {
 				log_error("Tristate buffers are unsupported without the '-iopad' option.\n");
 			run("deminout");
 			run("opt_expr");
-			run("opt_clean");
 			run("check");
+			run("opt_clean");
 			run("opt -nodffe -nosdff");
 			run("fsm");
 			run("opt");

--- a/techlibs/nanoxplore/synth_nanoxplore.cc
+++ b/techlibs/nanoxplore/synth_nanoxplore.cc
@@ -267,8 +267,8 @@ struct SynthNanoXplorePass : public ScriptPass
 			run("tribuf -logic");
 			run("deminout");
 			run("opt_expr");
-			run("opt_clean");
 			run("check");
+			run("opt_clean");
 			run("opt -nodffe -nosdff");
 			run("fsm");
 			run("opt");

--- a/techlibs/quicklogic/synth_quicklogic.cc
+++ b/techlibs/quicklogic/synth_quicklogic.cc
@@ -231,8 +231,8 @@ struct SynthQuickLogicPass : public ScriptPass {
 			}
 			run("deminout");
 			run("opt_expr");
-			run("opt_clean");
 			run("check");
+			run("opt_clean");
 			run("opt -nodffe -nosdff");
 			run("fsm");
 			run("opt");

--- a/techlibs/xilinx/synth_xilinx.cc
+++ b/techlibs/xilinx/synth_xilinx.cc
@@ -354,8 +354,8 @@ struct SynthXilinxPass : public ScriptPass
 				log_error("Tristate buffers are unsupported without the '-iopad' option.\n");
 			run("deminout");
 			run("opt_expr");
-			run("opt_clean");
 			run("check");
+			run("opt_clean");
 			run("opt -nodffe -nosdff");
 			run("fsm");
 			run("opt");


### PR DESCRIPTION
…tial driver conflicts

Ensures synthesis passes report [this conflict shape](https://www.edaboard.com/threads/verilog-or-systemverilog-signal-initialization-rule-mentor-multiply-driven.342388/) as a warning, since opt_clean hides it