### PR TITLE
check: detect process-driver conflicts

### DIFF
--- a/passes/cmds/check.cc
+++ b/passes/cmds/check.cc
@@ -160,13 +160,17 @@ struct CheckPass : public Pass {
 			TopoSort<std::pair<RTLIL::IdString, int>> topo;
 			for (auto &proc_it : module->processes)
 			{
+				pool<SigBit> proc_driven_bits;
 				std::vector<RTLIL::CaseRule*> all_cases = {&proc_it.second->root_case};
 				for (size_t i = 0; i < all_cases.size(); i++) {
 					for (auto action : all_cases[i]->actions) {
-						for (auto bit : sigmap(action.first))
+						for (auto bit : sigmap(action.first)) {
 							wire_drivers[bit].push_back(
 								stringf("action %s <= %s (case rule) in process %s",
 										log_signal(action.first), log_signal(action.second), proc_it.first.unescape()));
+							if (bit.wire)
+								proc_driven_bits.insert(bit);
+						}
 
 						for (auto bit : sigmap(action.second))
 							if (bit.wire) used_wires.insert(bit);
@@ -184,10 +188,13 @@ struct CheckPass : public Pass {
 					for (auto bit : sigmap(sync->signal))
 						if (bit.wire) used_wires.insert(bit);
 					for (auto action : sync->actions) {
-						for (auto bit : sigmap(action.first))
+						for (auto bit : sigmap(action.first)) {
 							wire_drivers[bit].push_back(
 								stringf("action %s <= %s (sync rule) in process %s",
 										log_signal(action.first), log_signal(action.second), proc_it.first.unescape()));
+							if (bit.wire && sync->type != RTLIL::SyncType::STi)
+								proc_driven_bits.insert(bit);
+						}
 						for (auto bit : sigmap(action.second))
 							if (bit.wire) used_wires.insert(bit);
 					}
@@ -200,6 +207,8 @@ struct CheckPass : public Pass {
 							if (bit.wire) used_wires.insert(bit);
 					}
 				}
+				for (auto bit : proc_driven_bits)
+					wire_drivers_count[bit]++;
 			}
 
 			struct CircuitEdgesDatabase : AbstractCellEdgesDatabase {

--- a/tests/various/check_proc_driver_conflict.ys
+++ b/tests/various/check_proc_driver_conflict.ys
@@ -1,0 +1,40 @@
+# This is invalid or at least not supported by Yosys so we error out
+# https://www.edaboard.com/threads/verilog-or-systemverilog-signal-initialization-rule-mentor-multiply-driven.342388/
+read_verilog -sv <<EOT
+module ff1 (input logic clk, input logic d, output logic q);
+	always_ff @(posedge clk) q <= d;
+endmodule
+
+module top (input logic clk, input logic d);
+	logic q_inst = 0;
+	ff1 u0 (clk, d, q_inst);
+endmodule
+EOT
+
+# before `hierarchy` the port directions are unknown, so nothing is reported yet
+logger -expect log "Found and reported 0 problems." 1
+check
+logger -check-expected
+
+hierarchy -top top -check
+
+logger -expect warning "multiple conflicting drivers for top" 1
+logger -expect log "Found and reported 1 problems." 1
+check
+logger -check-expected
+
+# This is what was meant in the previous example, but it is supported and gives no warnings
+design -reset
+read_verilog -sv <<EOT
+module top (input logic clk, input logic d, output logic q);
+	logic q_inst = 0;
+	always_ff @(posedge clk) q_inst <= d;
+	assign q = q_inst;
+endmodule
+EOT
+
+hierarchy -top top -check
+
+logger -expect log "Found and reported 0 problems." 1
+check
+logger -check-expected


### PR DESCRIPTION
Fixes the necessity to sequence `check` after `proc` to avoid #6165. In other words: `check` now reports an error in that scenario (see included test) even before `proc`. The way it works is that outside of initial blocks we track all bits written to by a process and count each such process to be a driver of those bits. We skip initial blocks to avoid warnings in the second case in the test which we already supported. In the first case, the initial value assignment isn't in an initial block, but as an unconditional assignment in a process like this:

```
process $proc$...
  assign $0\q_inst[0:0] 1'0
  sync always
    update \q_inst $0\q_inst[0:0]
end
```
