### PR TITLE
dfflibmap: rank cells on an explicit tuple [sc-906]

### DIFF
--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -264,12 +264,21 @@ struct FfSpec {
 	bool dff_has_enable = false, dff_enapol = false;
 };
 
+// how good a candidate cell is, in decreasing order of importance
+struct CellRank {
+	// smaller is better -> we can compare lexicographically with std::tuple comparison operators
+	bool inv = false; // the cell only drives the inverted output, so it needs an output inverter
+	int pins = 0;
+	double area = 0;
+
+	std::tuple<bool, int, double> key() const { return std::make_tuple(inv, pins, area); }
+	bool operator<(const CellRank &other) const { return key() < other.key(); }
+};
+
 struct BestCell {
 	const LibertyAst *cell = nullptr;
 	std::map<std::string, char> ports;
-	int pins = 0;
-	bool noninv = false;
-	double area = 0;
+	CellRank rank;
 };
 
 static bool is_dont_use(const LibertyAst *cell, std::vector<std::string> &dont_use_cells)
@@ -330,16 +339,20 @@ static void find_better_cell(BestCell &best, const LibertyAst *cell, const Liber
 			this_cell_ports[pin->args[0]] = 0;
 	}
 
-	if (!found_output || (best.cell != nullptr && (num_pins > best.pins || (best.noninv && !found_noninv_output))))
+	if (!found_output)
 		return;
 
-	if (best.cell != nullptr && num_pins == best.pins && area >= best.area)
+	CellRank rank;
+	rank.inv = !found_noninv_output;
+	rank.pins = num_pins;
+	rank.area = area;
+
+	// on a tie keep the cell we found first, so the result does not depend on the cell order
+	if (best.cell != nullptr && !(rank < best.rank))
 		return;
 
 	best.cell = cell;
-	best.pins = num_pins;
-	best.area = area;
-	best.noninv = found_noninv_output;
+	best.rank = rank;
 	best.ports.swap(this_cell_ports);
 }
 
@@ -411,7 +424,7 @@ static void find_cell(std::vector<const LibertyAst *> cells, IdString cell_type,
 
 	if (best.cell != nullptr) {
 		log("  cell %s (%sinv, pins=%d, area=%.2f) is a direct match for cell type %s.\n",
-				best.cell->args[0].c_str(), best.noninv ? "non" : "", best.pins, best.area, cell_type.c_str());
+				best.cell->args[0].c_str(), best.rank.inv ? "" : "non", best.rank.pins, best.rank.area, cell_type.c_str());
 		cell_mappings[cell_type].cell_name = RTLIL::escape_id(best.cell->args[0]);
 		cell_mappings[cell_type].ports = best.ports;
 	}

--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -266,13 +266,13 @@ struct FfSpec {
 
 // how good a candidate cell is, in decreasing order of importance
 struct CellRank {
-	// smaller is better -> we can compare lexicographically with std::tuple comparison operators
 	bool inv = false; // the cell only drives the inverted output, so it needs an output inverter
 	int pins = 0;
 	double area = 0;
 
-	std::tuple<bool, int, double> key() const { return std::make_tuple(inv, pins, area); }
-	bool operator<(const CellRank &other) const { return key() < other.key(); }
+	auto operator<=>(const CellRank &other) const = default;
+
+	std::string description() const { return stringf("%sinv, pins=%d, area=%.2f", inv ? "" : "non", pins, area); }
 };
 
 struct BestCell {
@@ -423,8 +423,7 @@ static void find_cell(std::vector<const LibertyAst *> cells, IdString cell_type,
 	}
 
 	if (best.cell != nullptr) {
-		log("  cell %s (%sinv, pins=%d, area=%.2f) is a direct match for cell type %s.\n",
-				best.cell->args[0].c_str(), best.rank.inv ? "" : "non", best.rank.pins, best.rank.area, cell_type.c_str());
+		log("  cell %s (%s) is a direct match for cell type %s.\n", best.cell->args[0], best.rank.description(), cell_type);
 		cell_mappings[cell_type].cell_name = RTLIL::escape_id(best.cell->args[0]);
 		cell_mappings[cell_type].ports = best.ports;
 	}

--- a/tests/techmap/dfflibmap_noninv.lib
+++ b/tests/techmap/dfflibmap_noninv.lib
@@ -1,0 +1,55 @@
+library(test) {
+  // both cells have the same area and pin count, but only DFF_Q has a non-inverted output
+  cell (DFF_QN) {
+    area : 1;
+    ff("IQ", "IQN") {
+      next_state : "D";
+      clocked_on : "CLK";
+    }
+    pin(D) {
+      direction : input;
+    }
+    pin(CLK) {
+      direction : input;
+    }
+    pin(QN) {
+      direction: output;
+      function : "IQN";
+    }
+  }
+  cell (DFF_Q) {
+    area : 1;
+    ff("IQ", "IQN") {
+      next_state : "D";
+      clocked_on : "CLK";
+    }
+    pin(D) {
+      direction : input;
+    }
+    pin(CLK) {
+      direction : input;
+    }
+    pin(Q) {
+      direction: output;
+      function : "IQ";
+    }
+  }
+  // identical to DFF_Q, so the first of the two must win
+  cell (DFF_Q_ALT) {
+    area : 1;
+    ff("IQ", "IQN") {
+      next_state : "D";
+      clocked_on : "CLK";
+    }
+    pin(D) {
+      direction : input;
+    }
+    pin(CLK) {
+      direction : input;
+    }
+    pin(Q) {
+      direction: output;
+      function : "IQ";
+    }
+  }
+}

--- a/tests/techmap/dfflibmap_noninv.ys
+++ b/tests/techmap/dfflibmap_noninv.ys
@@ -1,0 +1,12 @@
+read_verilog -icells <<EOT
+module top(input C, D, output Q);
+  $_DFF_P_ ff (.C(C), .D(D), .Q(Q));
+endmodule
+EOT
+
+dfflibmap -liberty dfflibmap_noninv.lib
+clean
+
+select -assert-count 1 t:DFF_Q
+select -assert-none t:DFF_QN t:DFF_Q_ALT
+select -assert-none t:$_NOT_


### PR DESCRIPTION
Fixes #6172 - the previous method of comparing best cells  was a bit flaky, this PR aims to improve the situation by instead using the spaceship operator (thx for the tip @widlarizer).