### PR TITLE
cmake: replace -Werror=unused with more specific options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 	endif()
 	set(no_abc_options
 		"$<$<AND:$<NOT:$<BOOL:$<TARGET_PROPERTY:YOSYS_IS_ABC>>>,$<CONFIG:Sanitize>>:-fsanitize=${SANITIZE}>"
-		"$<$<NOT:$<BOOL:$<TARGET_PROPERTY:YOSYS_IS_ABC>>>:-Wall;-Wextra;-Werror=unused>"
+		"$<$<NOT:$<BOOL:$<TARGET_PROPERTY:YOSYS_IS_ABC>>>:-Wall;-Wextra;-Werror=unused-variable;-Werror=unused-parameter;-Werror=unused-function>"
 	)
 	add_compile_options("${no_abc_options}")
 	add_link_options("${no_abc_options}")

--- a/kernel/fstdata.cc
+++ b/kernel/fstdata.cc
@@ -22,10 +22,12 @@
 USING_YOSYS_NAMESPACE
 
 
+#if defined(YOSYS_ENABLE_SPAWN)
 static std::string file_base_name(std::string const & path)
 {
 	return path.substr(path.find_last_of("/\\") + 1);
 }
+#endif
 
 FstData::FstData(std::string filename) : ctx(nullptr)
 {

--- a/kernel/threading.cc
+++ b/kernel/threading.cc
@@ -102,6 +102,9 @@ ParallelDispatchThreadPool::ParallelDispatchThreadPool(int pool_size)
 		: num_worker_threads_(0)
 #endif
 {
+#ifndef YOSYS_ENABLE_THREADS
+	(void)pool_size;
+#endif
 	main_to_workers_signal.resize(num_worker_threads_, 0);
 	// Don't start the threads until we've constructed all our data members.
 	thread_pool = std::make_unique<ThreadPool>(num_worker_threads_, [this](int thread_num){
@@ -148,6 +151,7 @@ void ParallelDispatchThreadPool::run_worker(int thread_num)
 	}
 	signal_worker_done();
 #else
+	(void)thread_num;
 	(void)current_work;
 #endif
 }

--- a/libs/ezsat/ezcmdline.cc
+++ b/libs/ezsat/ezcmdline.cc
@@ -87,6 +87,9 @@ bool ezCmdlineSAT::solver(const std::vector<int> &modelExpressions, std::vector<
 	}
 	return true;
 #else
+	(void)modelExpressions;
+	(void)modelValues;
+	(void)assumptions;
 	Yosys::log_error("SAT solver command not available in this build!\n");
 #endif
 }


### PR DESCRIPTION
Promoting "unused" to error is not same in gcc and clang, also different between compiler version. Right now it is breaking on unused templates after llvm brew is updated