### PR TITLE
cmake: fix wheels build

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -65,7 +65,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p bison
-          curl -L https://ftpmirror.gnu.org/gnu/bison/bison-3.8.2.tar.gz | tar --strip-components=1 -xzC bison
+          curl -L https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz | tar --strip-components=1 -xzC bison
       ## Software installed by default in GitHub Action Runner VMs:
       ##  https://github.com/actions/runner-images
       - if: ${{ matrix.os.family == 'macos' }}

--- a/cmake/GetPyosysVersion.cmake
+++ b/cmake/GetPyosysVersion.cmake
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.27)
 set(CMAKE_MESSAGE_LOG_LEVEL ERROR)
-set(CMAKE_MODULE_PATH "${YOSYS_CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+set(YOSYS_CMAKE_SOURCE_DIR "${CMAKE_SOURCE_DIR}" CACHE INTERNAL "Save source path")
 include(YosysVersion)
 
 yosys_extract_version()


### PR DESCRIPTION
Fix wheels build.
- old bison URL is unavailable for some time
- GetPyosysVersion.cmake is used as main cmake file directly by wheels build so it needs this variable properly set.