### PR TITLE
opt_ffinv: only treat single-bit $not/$_NOT_ as inverters

### DIFF
--- a/passes/opt/opt_ffinv.cc
+++ b/passes/opt/opt_ffinv.cc
@@ -26,6 +26,13 @@
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
+static bool is_single_bit_inverter(RTLIL::Cell *cell)
+{
+	return cell->type.in(ID($not), ID($_NOT_)) &&
+			cell->getPort(ID::A).size() == 1 &&
+			cell->getPort(ID::Y).size() == 1;
+}
+
 struct OptFfInvWorker
 {
 	int count = 0;
@@ -52,8 +59,10 @@ struct OptFfInvWorker
 				continue;
 			if (port.port != ID::Y)
 				return false;
-			if (port.cell->type.in(ID($not), ID($_NOT_))) {
+			if (is_single_bit_inverter(port.cell)) {
 				// OK
+			} else if (port.cell->type.in(ID($not), ID($_NOT_))) {
+				return false;
 			} else if (port.cell->type.in(ID($lut))) {
 				if (port.cell->getParam(ID::WIDTH) != 1)
 					return false;
@@ -78,8 +87,12 @@ struct OptFfInvWorker
 				return false;
 			if (port.port != ID::A)
 				return false;
-			if (!port.cell->type.in(ID($not), ID($_NOT_), ID($lut)))
+			if (port.cell->type.in(ID($not), ID($_NOT_))) {
+				if (!is_single_bit_inverter(port.cell))
+					return false;
+			} else if (!port.cell->type.in(ID($lut))) {
 				return false;
+			}
 			q_luts.insert(port.cell);
 		}
 
@@ -137,8 +150,12 @@ struct OptFfInvWorker
 				continue;
 			if (port.port != ID::Y)
 				return false;
-			if (!port.cell->type.in(ID($not), ID($_NOT_), ID($lut)))
+			if (port.cell->type.in(ID($not), ID($_NOT_))) {
+				if (!is_single_bit_inverter(port.cell))
+					return false;
+			} else if (!port.cell->type.in(ID($lut))) {
 				return false;
+			}
 			log_assert(d_lut == nullptr);
 			d_lut = port.cell;
 		}
@@ -157,8 +174,10 @@ struct OptFfInvWorker
 				return false;
 			if (port.port != ID::A)
 				return false;
-			if (port.cell->type.in(ID($not), ID($_NOT_))) {
+			if (is_single_bit_inverter(port.cell)) {
 				// OK
+			} else if (port.cell->type.in(ID($not), ID($_NOT_))) {
+				return false;
 			} else if (port.cell->type.in(ID($lut))) {
 				if (port.cell->getParam(ID::WIDTH) != 1)
 					return false;

--- a/tests/opt/bug6189.ys
+++ b/tests/opt/bug6189.ys
@@ -1,0 +1,12 @@
+read_verilog <<EOF
+module bug(input clk, d, input [7:0] x, output [8:0] y);
+  reg q;
+  always @(posedge clk) q <= ~d;
+  assign y = ~{x, q};
+endmodule
+EOF
+
+hierarchy -top bug
+proc
+opt_ffinv
+check -assert


### PR DESCRIPTION
`opt_ffinv` crashes with `std::out_of_range` (`SigSpec::operator[]`) when a multi-bit `$not` cell is connected to a 1-bit FF. Found while synthesizing OpenTitan `top_englishbreakfast` / `top_earlgrey` / `top_darjeeling`.

Minimal testcase:

```verilog
module bug(input clk, d, input [7:0] x, output [8:0] y);
  reg q;
  always @(posedge clk) q <= ~d;
  assign y = ~{x, q};
endmodule
```

Reproduce with:

```
yosys -p 'read_verilog case.v; hierarchy -top bug; proc; opt_ffinv'
```

On current `main` (01dc90937):

```
4. Executing OPT_FFINV pass (push inverters through FFs).
terminate called after throwing an instance of 'std::out_of_range'
  what():  SigSpec::operator[]
Aborted (core dumped)
```

**Root cause:** the FF-LUT discovery treats any `$not`/`$_NOT_` cell connected to the FF as a single-bit inverter, without checking its width. With the testcase above the candidate is a 9-bit `$not`, so `module->connect(lut->Y, ff.sig_q)` constructs a 9-bit-to-1-bit connection, and the subsequent `ModIndex` notification runs past the end of the 1-bit sig_q.

**Fix:** only treat `$not`/`$_NOT_` cells as inverters when both their `A` and `Y` ports are 1 bit wide (new `is_single_bit_inverter()` helper used at all four places where these cell types are checked). Wider `$not` cells are left untouched, so the optimization is simply skipped for them.

Regression test in `tests/opt/bug6189.ys` (crashed before the fix, passes with `check -assert` after). Also verified on the full OpenTitan `top_englishbreakfast` design: the pass completes with the fix.

Fixes #6189
