### PR TITLE
abc: module and clock domain parallelism, always

### DIFF
--- a/frontends/blif/blifparse.cc
+++ b/frontends/blif/blifparse.cc
@@ -84,7 +84,12 @@ failed:
 	return std::pair<RTLIL::IdString, int>(RTLIL::IdString(), 0);
 }
 
-void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool run_clean, bool sop_mode, bool wideports)
+static IdString blif_new_id(int autoidx_base, int &local_autoidx)
+{
+	return stringf("$blif$%d$%d", autoidx_base, local_autoidx++);
+}
+
+void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, int autoidx_base, bool run_clean, bool sop_mode, bool wideports)
 {
 	RTLIL::Module *module = nullptr;
 	RTLIL::Const *lutptr = NULL;
@@ -93,6 +98,7 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 	RTLIL::State lut_default_state = RTLIL::State::Sx;
 	std::string err_reason;
 	int blif_maxnum = 0, sopmode = -1;
+	int local_autoidx = 0;
 
 	auto blif_wire = [&](const std::string &wire_name) -> Wire*
 	{
@@ -363,19 +369,19 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 					goto no_latch_clock;
 
 				if (!strcmp(edge, "re"))
-					cell = module->addDffGate(NEW_ID, blif_wire(clock), blif_wire(d), blif_wire(q));
+					cell = module->addDffGate(blif_new_id(autoidx_base, local_autoidx), blif_wire(clock), blif_wire(d), blif_wire(q));
 				else if (!strcmp(edge, "fe"))
-					cell = module->addDffGate(NEW_ID, blif_wire(clock), blif_wire(d), blif_wire(q), false);
+					cell = module->addDffGate(blif_new_id(autoidx_base, local_autoidx), blif_wire(clock), blif_wire(d), blif_wire(q), false);
 				else if (!strcmp(edge, "ah"))
-					cell = module->addDlatchGate(NEW_ID, blif_wire(clock), blif_wire(d), blif_wire(q));
+					cell = module->addDlatchGate(blif_new_id(autoidx_base, local_autoidx), blif_wire(clock), blif_wire(d), blif_wire(q));
 				else if (!strcmp(edge, "al"))
-					cell = module->addDlatchGate(NEW_ID, blif_wire(clock), blif_wire(d), blif_wire(q), false);
+					cell = module->addDlatchGate(blif_new_id(autoidx_base, local_autoidx), blif_wire(clock), blif_wire(d), blif_wire(q), false);
 				else {
 			no_latch_clock:
 					if (dff_name.empty()) {
-						cell = module->addFfGate(NEW_ID, blif_wire(d), blif_wire(q));
+						cell = module->addFfGate(blif_new_id(autoidx_base, local_autoidx), blif_wire(d), blif_wire(q));
 					} else {
-						cell = module->addCell(NEW_ID, dff_name);
+						cell = module->addCell(blif_new_id(autoidx_base, local_autoidx), dff_name);
 						cell->setPort(ID::D, blif_wire(d));
 						cell->setPort(ID::Q, blif_wire(q));
 					}
@@ -394,7 +400,7 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 					goto error;
 
 				IdString celltype = RTLIL::escape_id(p);
-				RTLIL::Cell *cell = module->addCell(NEW_ID, celltype);
+				RTLIL::Cell *cell = module->addCell(blif_new_id(autoidx_base, local_autoidx), celltype);
 				RTLIL::Module *cell_mod = design->module(celltype);
 
 				dict<RTLIL::IdString, dict<int, SigBit>> cell_wideports_cache;
@@ -441,7 +447,7 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 						if (it.second.count(idx))
 							sig.append(it.second.at(idx));
 						else
-							sig.append(module->addWire(NEW_ID));
+							sig.append(module->addWire(blif_new_id(autoidx_base, local_autoidx)));
 					}
 
 					cell->setPort(it.first, sig);
@@ -538,7 +544,7 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 
 				if (sop_mode)
 				{
-					sopcell = module->addCell(NEW_ID, ID($sop));
+					sopcell = module->addCell(blif_new_id(autoidx_base, local_autoidx), ID($sop));
 					sopcell->parameters[ID::WIDTH] = RTLIL::Const(input_sig.size());
 					sopcell->parameters[ID::DEPTH] = 0;
 					sopcell->parameters[ID::TABLE] = RTLIL::Const();
@@ -554,7 +560,7 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 				}
 				else
 				{
-					RTLIL::Cell *cell = module->addCell(NEW_ID, ID($lut));
+					RTLIL::Cell *cell = module->addCell(blif_new_id(autoidx_base, local_autoidx), ID($lut));
 					cell->parameters[ID::WIDTH] = RTLIL::Const(input_sig.size());
 					cell->parameters[ID::LUT] = RTLIL::Const(RTLIL::State::Sx, 1 << input_sig.size());
 					cell->setPort(ID::A, input_sig);
@@ -607,8 +613,8 @@ void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, bool 
 				sopmode = (*output == '1');
 				if (!sopmode) {
 					SigSpec outnet = sopcell->getPort(ID::Y);
-					SigSpec tempnet = module->addWire(NEW_ID);
-					module->addNotGate(NEW_ID, tempnet, outnet);
+					SigSpec tempnet = module->addWire(blif_new_id(autoidx_base, local_autoidx));
+					module->addNotGate(blif_new_id(autoidx_base, local_autoidx), tempnet, outnet);
 					sopcell->setPort(ID::Y, tempnet);
 				}
 			} else
@@ -686,7 +692,7 @@ struct BlifFrontend : public Frontend {
 		}
 		extra_args(f, filename, args, argidx);
 
-		parse_blif(design, *f, "", true, sop_mode, wideports);
+		parse_blif(design, *f, "", autoidx++, true, sop_mode, wideports);
 	}
 } BlifFrontend;
 

--- a/frontends/blif/blifparse.h
+++ b/frontends/blif/blifparse.h
@@ -24,7 +24,7 @@
 
 YOSYS_NAMESPACE_BEGIN
 
-extern void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name,
+extern void parse_blif(RTLIL::Design *design, std::istream &f, IdString dff_name, int autoidx_base,
 		bool run_clean = false, bool sop_mode = false, bool wideports = false);
 
 YOSYS_NAMESPACE_END

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -51,6 +51,7 @@
 #include <climits>
 #include <memory>
 #include <vector>
+#include <exception>
 
 #ifdef __linux__
 #  include <fcntl.h>

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -2408,6 +2408,8 @@ struct AbcPass : public Pass {
 		std::vector<std::unique_ptr<AbcModuleState>> work_finished_by_index;
 		int work_finished_count = 0;
 
+		std::exception_ptr error;
+		try {
 		for (auto mod : design->selected_modules())
 		{
 			if (mod->processes.size() > 0) {
@@ -2636,6 +2638,9 @@ struct AbcPass : public Pass {
 				}
 			}
 		}
+		} catch (...) {
+			error = std::current_exception();
+		}
 		work_queue.close();
 		while (work_finished_count < state_index) {
 			std::optional<std::unique_ptr<AbcModuleState>> work =
@@ -2649,6 +2654,8 @@ struct AbcPass : public Pass {
 			work_finished_by_index[next_state_index_to_process] = nullptr;
 			++next_state_index_to_process;
 		}
+		if (error)
+			std::rethrow_exception(error);
 
 		if (config.cleanup) {
 			log("Removing global temp directory.\n");

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -293,8 +293,16 @@ struct RunAbcState {
 	void run(ConcurrentStack<AbcProcess> &process_pool);
 };
 
+struct AbcModuleData {
+	RTLIL::Module *module;
+	AbcSigMap assign_map;
+	FfInitVals initvals;
+};
+
 struct AbcModuleState {
 	RunAbcState run_abc;
+	std::shared_ptr<AbcModuleData> module_data;
+	bool dff_mode = false;
 
 	int state_index;
 	int map_autoidx;
@@ -380,6 +388,8 @@ void AbcModuleState::mark_port(const AbcSigMap &assign_map, RTLIL::SigSpec sig)
 bool AbcModuleState::prepare_cell(const AbcSigMap &assign_map, RTLIL::Cell *cell, bool keepff)
 {
 	if (cell->is_builtin_ff()) {
+		if (!dff_mode)
+			return false;
 		FfData ff(&initvals, cell);
 		gate_type_t type = G(FF);
 		if (!ff.has_clk)
@@ -929,6 +939,7 @@ struct abc_output_filter
 void AbcModuleState::prepare_module(RTLIL::Design *design, RTLIL::Module *module, AbcSigMap &assign_map, const std::vector<RTLIL::Cell*> &cells,
 	bool dff_mode, std::string clk_str)
 {
+	this->dff_mode = dff_mode;
 	if (clk_str != "$")
 	{
 		clk_polarity = true;
@@ -2375,6 +2386,28 @@ struct AbcPass : public Pass {
 
 		emit_global_input_files(config);
 
+		int max_threads = INT_MAX;
+#ifdef YOSYS_LINK_ABC
+		// ABC does't support multithreaded calls so don't call it off the main thread.
+		max_threads = 0;
+#endif
+		int num_worker_threads = ThreadPool::pool_size(1, max_threads);
+		ConcurrentQueue<std::unique_ptr<AbcModuleState>> work_queue(num_worker_threads);
+		ConcurrentQueue<std::unique_ptr<AbcModuleState>> work_finished_queue;
+		ConcurrentStack<AbcProcess> process_pool;
+		ThreadPool worker_threads(num_worker_threads, [&](int){
+				while (std::optional<std::unique_ptr<AbcModuleState>> work =
+						work_queue.pop_front()) {
+					// Only the `run_abc` component is safe to touch here!
+					(*work)->run_abc.run(process_pool);
+					work_finished_queue.push_back(std::move(*work));
+				}
+			});
+		int state_index = 0;
+		int next_state_index_to_process = 0;
+		std::vector<std::unique_ptr<AbcModuleState>> work_finished_by_index;
+		int work_finished_count = 0;
+
 		for (auto mod : design->selected_modules())
 		{
 			if (mod->processes.size() > 0) {
@@ -2382,216 +2415,191 @@ struct AbcPass : public Pass {
 				continue;
 			}
 
-			AbcSigMap assign_map;
+			std::shared_ptr<AbcModuleData> module_data = std::make_shared<AbcModuleData>();
+			module_data->module = mod;
+			AbcSigMap &assign_map = module_data->assign_map;
 			assign_map.set(mod);
 			// Create an FfInitVals and use it for all ABC runs. FfInitVals only cares about
 			// wires with the ID::init attribute and we don't add or remove any such wires
 			// in this pass.
-			FfInitVals initvals;
+			FfInitVals &initvals = module_data->initvals;
 			initvals.set(&assign_map, mod);
 
 			for (auto wire : mod->wires())
 				if (wire->port_id > 0 || wire->get_bool_attribute(ID::keep))
 					assign_map.addVal(SigSpec(wire), AbcSigVal(true));
 
-			if (!dff_mode || !clk_str.empty()) {
-				std::vector<RTLIL::Cell*> cells = mod->selected_cells();
-				assign_cell_connection_ports(mod, {&cells}, assign_map);
-
-				AbcModuleState state(config, initvals, 0, autoidx++);
-				state.prepare_module(design, mod, assign_map, cells, dff_mode, clk_str);
-				ConcurrentStack<AbcProcess> process_pool;
-				state.run_abc.run(process_pool);
-				state.extract(design, mod);
-				continue;
-			}
-
-			NewCellTypes ct(design);
-
-			std::vector<RTLIL::Cell*> all_cells = mod->selected_cells();
-			pool<RTLIL::Cell*> unassigned_cells(all_cells.begin(), all_cells.end());
-
-			pool<RTLIL::Cell*> expand_queue, next_expand_queue;
-			pool<RTLIL::Cell*> expand_queue_up, next_expand_queue_up;
-			pool<RTLIL::Cell*> expand_queue_down, next_expand_queue_down;
-
 			typedef tuple<bool, RTLIL::SigSpec, bool, RTLIL::SigSpec, bool, RTLIL::SigSpec, bool, RTLIL::SigSpec> clkdomain_t;
 			dict<clkdomain_t, std::vector<RTLIL::Cell*>> assigned_cells;
-			dict<RTLIL::Cell*, clkdomain_t> assigned_cells_reverse;
 
-			dict<RTLIL::Cell*, pool<RTLIL::SigBit>> cell_to_bit, cell_to_bit_up, cell_to_bit_down;
-			dict<RTLIL::SigBit, pool<RTLIL::Cell*>> bit_to_cell, bit_to_cell_up, bit_to_cell_down;
+			if (!clk_str.empty()) {
+				std::vector<RTLIL::Cell*> &cells = assigned_cells[clkdomain_t()];
+				cells = mod->selected_cells();
+				assign_cell_connection_ports(mod, {&cells}, assign_map);
+			} else {
+				NewCellTypes ct(design);
 
-			for (auto cell : all_cells)
-			{
-				clkdomain_t key;
+				std::vector<RTLIL::Cell*> all_cells = mod->selected_cells();
+				pool<RTLIL::Cell*> unassigned_cells(all_cells.begin(), all_cells.end());
 
-				for (auto &conn : cell->connections())
-				for (auto bit : conn.second) {
-					bit = assign_map(bit);
-					if (bit.wire != nullptr) {
-						cell_to_bit[cell].insert(bit);
-						bit_to_cell[bit].insert(cell);
-						if (ct.cell_input(cell->type, conn.first)) {
-							cell_to_bit_up[cell].insert(bit);
-							bit_to_cell_down[bit].insert(cell);
+				pool<RTLIL::Cell*> expand_queue, next_expand_queue;
+				pool<RTLIL::Cell*> expand_queue_up, next_expand_queue_up;
+				pool<RTLIL::Cell*> expand_queue_down, next_expand_queue_down;
+
+				dict<RTLIL::Cell*, clkdomain_t> assigned_cells_reverse;
+
+				dict<RTLIL::Cell*, pool<RTLIL::SigBit>> cell_to_bit, cell_to_bit_up, cell_to_bit_down;
+				dict<RTLIL::SigBit, pool<RTLIL::Cell*>> bit_to_cell, bit_to_cell_up, bit_to_cell_down;
+
+				for (auto cell : all_cells)
+				{
+					clkdomain_t key;
+
+					for (auto &conn : cell->connections())
+					for (auto bit : conn.second) {
+						bit = assign_map(bit);
+						if (bit.wire != nullptr) {
+							cell_to_bit[cell].insert(bit);
+							bit_to_cell[bit].insert(cell);
+							if (ct.cell_input(cell->type, conn.first)) {
+								cell_to_bit_up[cell].insert(bit);
+								bit_to_cell_down[bit].insert(cell);
+							}
+							if (ct.cell_output(cell->type, conn.first)) {
+								cell_to_bit_down[cell].insert(bit);
+								bit_to_cell_up[bit].insert(cell);
+							}
 						}
-						if (ct.cell_output(cell->type, conn.first)) {
-							cell_to_bit_down[cell].insert(bit);
-							bit_to_cell_up[bit].insert(cell);
-						}
+					}
+
+					if (!cell->is_builtin_ff())
+						continue;
+
+					FfData ff(&initvals, cell);
+					if (!ff.has_clk)
+						continue;
+					if (ff.has_gclk)
+						continue;
+					if (ff.has_aload)
+						continue;
+					if (ff.has_sr)
+						continue;
+					if (!ff.is_fine)
+						continue;
+					key = clkdomain_t(
+						ff.pol_clk,
+						ff.sig_clk,
+						ff.has_ce ? ff.pol_ce : true,
+						ff.has_ce ? assign_map(ff.sig_ce) : RTLIL::SigSpec(),
+						ff.has_arst ? ff.pol_arst : true,
+						ff.has_arst ? assign_map(ff.sig_arst) : RTLIL::SigSpec(),
+						ff.has_srst ? ff.pol_srst : true,
+						ff.has_srst ? assign_map(ff.sig_srst) : RTLIL::SigSpec()
+					);
+
+					unassigned_cells.erase(cell);
+					expand_queue.insert(cell);
+					expand_queue_up.insert(cell);
+					expand_queue_down.insert(cell);
+
+					assigned_cells[key].push_back(cell);
+					assigned_cells_reverse[cell] = key;
+				}
+
+				while (!expand_queue_up.empty() || !expand_queue_down.empty())
+				{
+					if (!expand_queue_up.empty())
+					{
+						RTLIL::Cell *cell = *expand_queue_up.begin();
+						clkdomain_t key = assigned_cells_reverse.at(cell);
+						expand_queue_up.erase(cell);
+
+						for (auto bit : cell_to_bit_up[cell])
+						for (auto c : bit_to_cell_up[bit])
+							if (unassigned_cells.count(c)) {
+								unassigned_cells.erase(c);
+								next_expand_queue_up.insert(c);
+								assigned_cells[key].push_back(c);
+								assigned_cells_reverse[c] = key;
+								expand_queue.insert(c);
+							}
+					}
+
+					if (!expand_queue_down.empty())
+					{
+						RTLIL::Cell *cell = *expand_queue_down.begin();
+						clkdomain_t key = assigned_cells_reverse.at(cell);
+						expand_queue_down.erase(cell);
+
+						for (auto bit : cell_to_bit_down[cell])
+						for (auto c : bit_to_cell_down[bit])
+							if (unassigned_cells.count(c)) {
+								unassigned_cells.erase(c);
+								next_expand_queue_up.insert(c);
+								assigned_cells[key].push_back(c);
+								assigned_cells_reverse[c] = key;
+								expand_queue.insert(c);
+							}
+					}
+
+					if (expand_queue_up.empty() && expand_queue_down.empty()) {
+						expand_queue_up.swap(next_expand_queue_up);
+						expand_queue_down.swap(next_expand_queue_down);
 					}
 				}
 
-				if (!cell->is_builtin_ff())
-					continue;
-
-				FfData ff(&initvals, cell);
-				if (!ff.has_clk)
-					continue;
-				if (ff.has_gclk)
-					continue;
-				if (ff.has_aload)
-					continue;
-				if (ff.has_sr)
-					continue;
-				if (!ff.is_fine)
-					continue;
-				key = clkdomain_t(
-					ff.pol_clk,
-					ff.sig_clk,
-					ff.has_ce ? ff.pol_ce : true,
-					ff.has_ce ? assign_map(ff.sig_ce) : RTLIL::SigSpec(),
-					ff.has_arst ? ff.pol_arst : true,
-					ff.has_arst ? assign_map(ff.sig_arst) : RTLIL::SigSpec(),
-					ff.has_srst ? ff.pol_srst : true,
-					ff.has_srst ? assign_map(ff.sig_srst) : RTLIL::SigSpec()
-				);
-
-				unassigned_cells.erase(cell);
-				expand_queue.insert(cell);
-				expand_queue_up.insert(cell);
-				expand_queue_down.insert(cell);
-
-				assigned_cells[key].push_back(cell);
-				assigned_cells_reverse[cell] = key;
-			}
-
-			while (!expand_queue_up.empty() || !expand_queue_down.empty())
-			{
-				if (!expand_queue_up.empty())
+				while (!expand_queue.empty())
 				{
-					RTLIL::Cell *cell = *expand_queue_up.begin();
+					RTLIL::Cell *cell = *expand_queue.begin();
 					clkdomain_t key = assigned_cells_reverse.at(cell);
-					expand_queue_up.erase(cell);
+					expand_queue.erase(cell);
 
-					for (auto bit : cell_to_bit_up[cell])
-					for (auto c : bit_to_cell_up[bit])
-						if (unassigned_cells.count(c)) {
-							unassigned_cells.erase(c);
-							next_expand_queue_up.insert(c);
-							assigned_cells[key].push_back(c);
-							assigned_cells_reverse[c] = key;
-							expand_queue.insert(c);
-						}
+					for (auto bit : cell_to_bit.at(cell)) {
+						for (auto c : bit_to_cell[bit])
+							if (unassigned_cells.count(c)) {
+								unassigned_cells.erase(c);
+								next_expand_queue.insert(c);
+								assigned_cells[key].push_back(c);
+								assigned_cells_reverse[c] = key;
+							}
+						bit_to_cell[bit].clear();
+					}
+
+					if (expand_queue.empty())
+						expand_queue.swap(next_expand_queue);
 				}
 
-				if (!expand_queue_down.empty())
+				clkdomain_t key(true, RTLIL::SigSpec(), true, RTLIL::SigSpec(), true, RTLIL::SigSpec(), true, RTLIL::SigSpec());
+				for (auto cell : unassigned_cells) {
+					assigned_cells[key].push_back(cell);
+					assigned_cells_reverse[cell] = key;
+				}
+
+				for (auto &it : assigned_cells)
+					it.second.clear();
+				for (auto cell : all_cells)
+					assigned_cells.at(assigned_cells_reverse.at(cell)).push_back(cell);
+
+				log_header(design, "Summary of detected clock domains:\n");
 				{
-					RTLIL::Cell *cell = *expand_queue_down.begin();
-					clkdomain_t key = assigned_cells_reverse.at(cell);
-					expand_queue_down.erase(cell);
-
-					for (auto bit : cell_to_bit_down[cell])
-					for (auto c : bit_to_cell_down[bit])
-						if (unassigned_cells.count(c)) {
-							unassigned_cells.erase(c);
-							next_expand_queue_up.insert(c);
-							assigned_cells[key].push_back(c);
-							assigned_cells_reverse[c] = key;
-							expand_queue.insert(c);
-						}
+					std::vector<std::vector<RTLIL::Cell*>*> cell_sets;
+					for (auto &it : assigned_cells) {
+						log("  %d cells in clk=%s%s, en=%s%s, arst=%s%s, srst=%s%s\n", GetSize(it.second),
+								std::get<0>(it.first) ? "" : "!", log_signal(std::get<1>(it.first)),
+								std::get<2>(it.first) ? "" : "!", log_signal(std::get<3>(it.first)),
+								std::get<4>(it.first) ? "" : "!", log_signal(std::get<5>(it.first)),
+								std::get<6>(it.first) ? "" : "!", log_signal(std::get<7>(it.first)));
+						cell_sets.push_back(&it.second);
+					}
+					assign_cell_connection_ports(mod, cell_sets, assign_map);
 				}
-
-				if (expand_queue_up.empty() && expand_queue_down.empty()) {
-					expand_queue_up.swap(next_expand_queue_up);
-					expand_queue_down.swap(next_expand_queue_down);
-				}
-			}
-
-			while (!expand_queue.empty())
-			{
-				RTLIL::Cell *cell = *expand_queue.begin();
-				clkdomain_t key = assigned_cells_reverse.at(cell);
-				expand_queue.erase(cell);
-
-				for (auto bit : cell_to_bit.at(cell)) {
-					for (auto c : bit_to_cell[bit])
-						if (unassigned_cells.count(c)) {
-							unassigned_cells.erase(c);
-							next_expand_queue.insert(c);
-							assigned_cells[key].push_back(c);
-							assigned_cells_reverse[c] = key;
-						}
-					bit_to_cell[bit].clear();
-				}
-
-				if (expand_queue.empty())
-					expand_queue.swap(next_expand_queue);
-			}
-
-			clkdomain_t key(true, RTLIL::SigSpec(), true, RTLIL::SigSpec(), true, RTLIL::SigSpec(), true, RTLIL::SigSpec());
-			for (auto cell : unassigned_cells) {
-				assigned_cells[key].push_back(cell);
-				assigned_cells_reverse[cell] = key;
-			}
-
-			log_header(design, "Summary of detected clock domains:\n");
-			{
-				std::vector<std::vector<RTLIL::Cell*>*> cell_sets;
-				for (auto &it : assigned_cells) {
-					log("  %d cells in clk=%s%s, en=%s%s, arst=%s%s, srst=%s%s\n", GetSize(it.second),
-							std::get<0>(it.first) ? "" : "!", log_signal(std::get<1>(it.first)),
-							std::get<2>(it.first) ? "" : "!", log_signal(std::get<3>(it.first)),
-							std::get<4>(it.first) ? "" : "!", log_signal(std::get<5>(it.first)),
-							std::get<6>(it.first) ? "" : "!", log_signal(std::get<7>(it.first)));
-					cell_sets.push_back(&it.second);
-				}
-				assign_cell_connection_ports(mod, cell_sets, assign_map);
 			}
 
 			// Advance autoidx by the clock domain count for multi-threaded determinism
 			int autoidx_base = autoidx;
 			autoidx.ensure_at_least(autoidx_base + GetSize(assigned_cells));
 
-			// Reserve one core for our main thread, and don't create more worker threads
-			// than ABC runs.
-			int max_threads = assigned_cells.size();
-			if (max_threads <= 1) {
-				// Just do everything on the main thread.
-				max_threads = 0;
-			}
-#ifdef YOSYS_LINK_ABC
-			// ABC does't support multithreaded calls so don't call it off the main thread.
-			max_threads = 0;
-#endif
-			int num_worker_threads = ThreadPool::pool_size(1, max_threads);
-			ConcurrentQueue<std::unique_ptr<AbcModuleState>> work_queue(num_worker_threads);
-			ConcurrentQueue<std::unique_ptr<AbcModuleState>> work_finished_queue;
-			ConcurrentStack<AbcProcess> process_pool;
-			ThreadPool worker_threads(num_worker_threads, [&](int){
-					while (std::optional<std::unique_ptr<AbcModuleState>> work =
-							work_queue.pop_front()) {
-						// Only the `run_abc` component is safe to touch here!
-						(*work)->run_abc.run(process_pool);
-						work_finished_queue.push_back(std::move(*work));
-					}
-				});
-			int state_index = 0;
-			int next_state_index_to_process = 0;
-			std::vector<std::unique_ptr<AbcModuleState>> work_finished_by_index;
-			work_finished_by_index.resize(assigned_cells.size());
-			int work_finished_count = 0;
+			int domain_index = 0;
 			for (auto &it : assigned_cells) {
 				// Make sure we process the results in the order we expect. When we can
 				// process results before the next ABC run, do so, to keep memory usage low(er).
@@ -2600,22 +2608,30 @@ struct AbcPass : public Pass {
 					work_finished_by_index[(*work)->state_index] = std::move(*work);
 					++work_finished_count;
 				}
-				while (work_finished_by_index[next_state_index_to_process] != nullptr) {
-					work_finished_by_index[next_state_index_to_process]->extract(design, mod);
+				while (next_state_index_to_process < GetSize(work_finished_by_index) &&
+						work_finished_by_index[next_state_index_to_process] != nullptr) {
+					AbcModuleState &finished = *work_finished_by_index[next_state_index_to_process];
+					finished.extract(design, finished.module_data->module);
 					work_finished_by_index[next_state_index_to_process] = nullptr;
 					++next_state_index_to_process;
 				}
 				std::unique_ptr<AbcModuleState> state = std::make_unique<AbcModuleState>(
-						config, initvals, state_index, autoidx_base + state_index);
-				state->clk_polarity = std::get<0>(it.first);
-				state->clk_sig = assign_map(std::get<1>(it.first));
-				state->en_polarity = std::get<2>(it.first);
-				state->en_sig = assign_map(std::get<3>(it.first));
-				state->arst_polarity = std::get<4>(it.first);
-				state->arst_sig = assign_map(std::get<5>(it.first));
-				state->srst_polarity = std::get<6>(it.first);
-				state->srst_sig = assign_map(std::get<7>(it.first));
-				state->prepare_module(design, mod, assign_map, it.second, !state->clk_sig.empty(), "$");
+						config, initvals, state_index++, autoidx_base + domain_index++);
+				state->module_data = module_data;
+				if (!clk_str.empty()) {
+					state->prepare_module(design, mod, assign_map, it.second, dff_mode, clk_str);
+				} else {
+					state->clk_polarity = std::get<0>(it.first);
+					state->clk_sig = assign_map(std::get<1>(it.first));
+					state->en_polarity = std::get<2>(it.first);
+					state->en_sig = assign_map(std::get<3>(it.first));
+					state->arst_polarity = std::get<4>(it.first);
+					state->arst_sig = assign_map(std::get<5>(it.first));
+					state->srst_polarity = std::get<6>(it.first);
+					state->srst_sig = assign_map(std::get<7>(it.first));
+					state->prepare_module(design, mod, assign_map, it.second, dff_mode && !state->clk_sig.empty(), "$");
+				}
+				work_finished_by_index.emplace_back();
 				if (num_worker_threads > 0) {
 					work_queue.push_back(std::move(state));
 				} else {
@@ -2623,20 +2639,20 @@ struct AbcPass : public Pass {
 					state->run_abc.run(process_pool);
 					work_finished_queue.push_back(std::move(state));
 				}
-				state_index++;
 			}
-			work_queue.close();
-			while (work_finished_count < GetSize(assigned_cells)) {
-				std::optional<std::unique_ptr<AbcModuleState>> work =
-					work_finished_queue.pop_front();
-				work_finished_by_index[(*work)->state_index] = std::move(*work);
-				++work_finished_count;
-			}
-			while (next_state_index_to_process < GetSize(work_finished_by_index)) {
-				work_finished_by_index[next_state_index_to_process]->extract(design, mod);
-				work_finished_by_index[next_state_index_to_process] = nullptr;
-				++next_state_index_to_process;
-			}
+		}
+		work_queue.close();
+		while (work_finished_count < state_index) {
+			std::optional<std::unique_ptr<AbcModuleState>> work =
+				work_finished_queue.pop_front();
+			work_finished_by_index[(*work)->state_index] = std::move(*work);
+			++work_finished_count;
+		}
+		while (next_state_index_to_process < GetSize(work_finished_by_index)) {
+			AbcModuleState &finished = *work_finished_by_index[next_state_index_to_process];
+			finished.extract(design, finished.module_data->module);
+			work_finished_by_index[next_state_index_to_process] = nullptr;
+			++next_state_index_to_process;
 		}
 
 		if (config.cleanup) {

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -1536,7 +1536,7 @@ void AbcModuleState::extract(RTLIL::Design *design, RTLIL::Module *module)
 
 	bool builtin_lib = run_abc.config.liberty_files.empty() && run_abc.config.genlib_files.empty();
 	RTLIL::Design *mapped_design = new RTLIL::Design;
-	parse_blif(mapped_design, ifs, builtin_lib ? ID(DFF) : ID(_dff_));
+	parse_blif(mapped_design, ifs, builtin_lib ? ID(DFF) : ID(_dff_), map_autoidx);
 
 	ifs.close();
 
@@ -2574,11 +2574,6 @@ struct AbcPass : public Pass {
 					assigned_cells[key].push_back(cell);
 					assigned_cells_reverse[cell] = key;
 				}
-
-				for (auto &it : assigned_cells)
-					it.second.clear();
-				for (auto cell : all_cells)
-					assigned_cells.at(assigned_cells_reverse.at(cell)).push_back(cell);
 
 				log_header(design, "Summary of detected clock domains:\n");
 				{

--- a/tests/arch/gatemate/fsm.ys
+++ b/tests/arch/gatemate/fsm.ys
@@ -33,11 +33,11 @@ cd fsm # Constrain all select calls below inside the top module
 
 select -assert-count 1 t:CC_BUFG
 select -assert-count 6 t:CC_DFF
-select -assert-max 2 t:CC_LUT1
+select -assert-max 4 t:CC_LUT1
 select -assert-count 1 t:CC_LUT2
 select -assert-max 14 t:CC_L2T4
-select -assert-max 5 t:CC_L2T5
-select -assert-max 1 t:CC_MX2
+select -assert-max 6 t:CC_L2T5
+select -assert-max 3 t:CC_MX2
 select -assert-none t:CC_BUFG t:CC_DFF t:CC_LUT1 t:CC_LUT2 t:CC_L2T4 t:CC_L2T5 t:CC_MX2 %% t:* %D
 
 design -load orig

--- a/tests/blif/gatesi.blif.ok
+++ b/tests/blif/gatesi.blif.ok
@@ -7,8 +7,8 @@
 1
 .names $undef
 .subckt ORNOT A=:1.test_1[0] B=in_a_var[0] Y=$abc$2385$new_n57
-.subckt NOT A=$abc$2385$new_n65 Y=$abc$2385$new_n66
-.subckt XNOR A=$abc$2385$new_n62 B=$abc$2385$new_n88 Y=$abc$2385$auto$maccmap.cc:240:synth$253.P[1]
+.subckt ORNOT A=in_a_var[0] B=:1.test_1[0] Y=$abc$2385$new_n58
+.subckt AND A=:1.test_1[2] B=$abc$2385$new_n64 Y=$abc$2385$new_n67
 .subckt NAND A=:1.test_1[0] B=:1.test_2[0] Y=$abc$2385$new_n157
 .subckt ANDNOT A=:1.test_2[0] B=$abc$2385$new_n91 Y=$abc$2385$new_n158
 .subckt ANDNOT A=:1.test_2[1] B=$abc$2385$new_n64 Y=$abc$2385$new_n159
@@ -18,8 +18,8 @@
 .subckt ANDNOT A=:1.test_1[1] B=:1.test_1[0] Y=$abc$2385$new_n163
 .subckt ANDNOT A=:1.test_2[2] B=:1.test_1[0] Y=$abc$2385$new_n164
 .subckt XNOR A=$abc$2385$new_n160 B=$abc$2385$new_n164 Y=$abc$2385$new_n165
-.subckt AND A=:1.test_1[2] B=$abc$2385$new_n64 Y=$abc$2385$new_n67
 .subckt MUX A=$abc$2385$new_n160 B=$abc$2385$new_n165 S=:1.test_2[2] Y=$abc$2385$new_n166
+.subckt AND A=:1.test_1[3] B=$abc$2385$new_n67 Y=$abc$2385$new_n68
 .subckt ORNOT A=:1.test_2[0] B=:1.test_1[0] Y=$abc$2385$new_n167
 .subckt AND A=$abc$2385$new_n159 B=$abc$2385$new_n167 Y=$abc$2385$new_n168
 .subckt AND A=$abc$2385$new_n166 B=$abc$2385$new_n168 Y=$abc$2385$new_n169
@@ -29,8 +29,8 @@
 .subckt ANDNOT A=:1.test_2[1] B=$abc$2385$new_n91 Y=$abc$2385$new_n173
 .subckt ANDNOT A=:1.test_2[1] B=$abc$2385$new_n103 Y=$abc$2385$new_n174
 .subckt AND A=$abc$2385$new_n158 B=$abc$2385$new_n174 Y=$abc$2385$new_n175
-.subckt AND A=:1.test_1[3] B=$abc$2385$new_n67 Y=$abc$2385$new_n68
 .subckt XOR A=$abc$2385$new_n172 B=$abc$2385$new_n173 Y=$abc$2385$new_n176
+.subckt AND A=:1.test_1[4] B=$abc$2385$new_n68 Y=$abc$2385$new_n69
 .subckt NAND A=:1.test_2[2] B=$abc$2385$new_n65 Y=$abc$2385$new_n177
 .subckt AND A=:1.test_1[0] B=:1.test_2[3] Y=$abc$2385$new_n178
 .subckt NAND A=:1.test_1[0] B=$abc$2385$new_n177 Y=$abc$2385$new_n179
@@ -40,8 +40,8 @@
 .subckt NAND A=$abc$2385$new_n176 B=$abc$2385$new_n182 Y=$abc$2385$new_n183
 .subckt XOR A=$abc$2385$new_n176 B=$abc$2385$new_n182 Y=$abc$2385$new_n184
 .subckt NAND A=$abc$2385$new_n171 B=$abc$2385$new_n184 Y=$abc$2385$new_n185
-.subckt AND A=:1.test_1[4] B=$abc$2385$new_n68 Y=$abc$2385$new_n69
 .subckt XOR A=$abc$2385$new_n171 B=$abc$2385$new_n184 Y=$abc$2385$new_n186
+.subckt AND A=:1.test_1[5] B=$abc$2385$new_n69 Y=$abc$2385$new_n70
 .subckt NAND A=$abc$2385$new_n169 B=$abc$2385$new_n186 Y=$abc$2385$new_n187
 .subckt NAND A=$abc$2385$new_n185 B=$abc$2385$new_n187 Y=$abc$2385$new_n188
 .subckt ANDNOT A=:1.test_2[0] B=$abc$2385$new_n115 Y=$abc$2385$new_n189
@@ -51,8 +51,8 @@
 .subckt ANDNOT A=:1.test_2[2] B=$abc$2385$new_n91 Y=$abc$2385$new_n193
 .subckt NAND A=$abc$2385$new_n192 B=$abc$2385$new_n193 Y=$abc$2385$new_n194
 .subckt XOR A=$abc$2385$new_n192 B=$abc$2385$new_n193 Y=$abc$2385$new_n195
-.subckt AND A=:1.test_1[5] B=$abc$2385$new_n69 Y=$abc$2385$new_n70
 .subckt AND A=:1.test_2[3] B=$abc$2385$new_n179 Y=$abc$2385$new_n196
+.subckt AND A=:1.test_1[6] B=$abc$2385$new_n70 Y=$abc$2385$new_n71
 .subckt NAND A=:1.test_2[3] B=$abc$2385$new_n65 Y=$abc$2385$new_n197
 .subckt NAND A=:1.test_1[0] B=$abc$2385$new_n197 Y=$abc$2385$new_n198
 .subckt AND A=:1.test_2[4] B=$abc$2385$new_n198 Y=$abc$2385$new_n199
@@ -62,8 +62,8 @@
 .subckt AND A=$abc$2385$new_n201 B=$abc$2385$new_n202 Y=$abc$2385$new_n203
 .subckt NAND A=$abc$2385$new_n175 B=$abc$2385$new_n203 Y=$abc$2385$new_n204
 .subckt XOR A=$abc$2385$new_n175 B=$abc$2385$new_n203 Y=$abc$2385$new_n205
-.subckt AND A=:1.test_1[6] B=$abc$2385$new_n70 Y=$abc$2385$new_n71
 .subckt NAND A=$abc$2385$new_n196 B=$abc$2385$new_n205 Y=$abc$2385$new_n206
+.subckt XNOR A=:1.test_1[6] B=$abc$2385$new_n70 Y=$abc$2385$new_n72
 .subckt XOR A=$abc$2385$new_n196 B=$abc$2385$new_n205 Y=$abc$2385$new_n207
 .subckt AND A=$abc$2385$new_n195 B=$abc$2385$new_n207 Y=$abc$2385$new_n208
 .subckt XOR A=$abc$2385$new_n195 B=$abc$2385$new_n207 Y=$abc$2385$new_n209
@@ -73,8 +73,8 @@
 .subckt AND A=$abc$2385$new_n188 B=$abc$2385$new_n212 Y=$abc$2385$new_n213
 .subckt ANDNOT A=:1.test_2[0] B=$abc$2385$new_n77 Y=$abc$2385$new_n214
 .subckt ANDNOT A=:1.test_2[3] B=$abc$2385$new_n91 Y=$abc$2385$new_n215
-.subckt XNOR A=:1.test_1[6] B=$abc$2385$new_n70 Y=$abc$2385$new_n72
 .subckt ANDNOT A=:1.test_2[2] B=$abc$2385$new_n103 Y=$abc$2385$new_n216
+.subckt NOT A=$abc$2385$new_n72 Y=$abc$2385$new_n73
 .subckt ANDNOT A=:1.test_2[2] B=$abc$2385$new_n115 Y=$abc$2385$new_n217
 .subckt NAND A=$abc$2385$new_n174 B=$abc$2385$new_n217 Y=$abc$2385$new_n218
 .subckt XOR A=$abc$2385$new_n190 B=$abc$2385$new_n216 Y=$abc$2385$new_n219
@@ -84,8 +84,8 @@
 .subckt XOR A=$abc$2385$new_n214 B=$abc$2385$new_n221 Y=$abc$2385$new_n223
 .subckt NAND A=:1.test_2[4] B=$abc$2385$new_n65 Y=$abc$2385$new_n224
 .subckt NAND A=:1.test_1[0] B=$abc$2385$new_n224 Y=$abc$2385$new_n225
-.subckt NOT A=$abc$2385$new_n72 Y=$abc$2385$new_n73
 .subckt AND A=:1.test_2[5] B=$abc$2385$new_n225 Y=$abc$2385$new_n226
+.subckt AND A=:1.test_1[7] B=$abc$2385$new_n71 Y=$abc$2385$new_n74
 .subckt NAND A=:1.test_2[4] B=$abc$2385$new_n163 Y=$abc$2385$new_n227
 .subckt NAND A=$abc$2385$new_n226 B=$abc$2385$new_n227 Y=$abc$2385$new_n228
 .subckt ORNOT A=:1.test_2[5] B=$abc$2385$new_n224 Y=$abc$2385$new_n229
@@ -95,8 +95,8 @@
 .subckt XOR A=$abc$2385$new_n230 B=$abc$2385$new_n231 Y=$abc$2385$new_n233
 .subckt NAND A=$abc$2385$new_n199 B=$abc$2385$new_n233 Y=$abc$2385$new_n234
 .subckt XOR A=$abc$2385$new_n199 B=$abc$2385$new_n233 Y=$abc$2385$new_n235
-.subckt AND A=:1.test_1[7] B=$abc$2385$new_n71 Y=$abc$2385$new_n74
 .subckt AND A=$abc$2385$new_n223 B=$abc$2385$new_n235 Y=$abc$2385$new_n236
+.subckt XNOR A=:1.test_1[7] B=$abc$2385$new_n71 Y=$abc$2385$new_n75
 .subckt XOR A=$abc$2385$new_n223 B=$abc$2385$new_n235 Y=$abc$2385$new_n237
 .subckt NAND A=$abc$2385$new_n208 B=$abc$2385$new_n237 Y=$abc$2385$new_n238
 .subckt XOR A=$abc$2385$new_n208 B=$abc$2385$new_n237 Y=$abc$2385$new_n239
@@ -106,8 +106,8 @@
 .subckt AND A=$abc$2385$new_n211 B=$abc$2385$new_n242 Y=$abc$2385$new_n243
 .subckt XOR A=$abc$2385$new_n211 B=$abc$2385$new_n242 Y=$abc$2385$new_n244
 .subckt NAND A=$abc$2385$new_n213 B=$abc$2385$new_n244 Y=$abc$2385$new_n245
-.subckt XNOR A=:1.test_1[7] B=$abc$2385$new_n71 Y=$abc$2385$new_n75
 .subckt AND A=:1.test_2[0] B=$abc$2385$new_n163 Y=$abc$2385$new_n246
+.subckt ANDNOT A=:1.test_1[5] B=$abc$2385$new_n69 Y=$abc$2385$new_n76
 .subckt NAND A=:1.test_2[0] B=$abc$2385$new_n163 Y=$abc$2385$new_n247
 .subckt XOR A=$abc$2385$new_n158 B=$abc$2385$new_n170 Y=$abc$2385$new_n248
 .subckt AND A=$abc$2385$new_n246 B=$abc$2385$new_n248 Y=$abc$2385$new_n249
@@ -117,9 +117,9 @@
 .subckt AND A=$abc$2385$new_n251 B=$abc$2385$new_n252 Y=$abc$2385$new_n253
 .subckt NAND A=$abc$2385$new_n244 B=$abc$2385$new_n253 Y=$abc$2385$new_n254
 .subckt XNOR A=$abc$2385$new_n213 B=$abc$2385$new_n244 Y=$abc$2385$new_n255
-.subckt ORNOT A=in_a_var[0] B=:1.test_1[0] Y=$abc$2385$new_n58
-.subckt ANDNOT A=:1.test_1[5] B=$abc$2385$new_n69 Y=$abc$2385$new_n76
 .subckt NAND A=$abc$2385$new_n245 B=$abc$2385$new_n254 Y=$abc$2385$new_n256
+.subckt XNOR A=:1.test_1[0] B=in_a_var[0] Y=$abc$2385$new_n59
+.subckt XNOR A=:1.test_1[5] B=$abc$2385$new_n69 Y=$abc$2385$new_n77
 .subckt NAND A=$abc$2385$new_n238 B=$abc$2385$new_n241 Y=$abc$2385$new_n257
 .subckt ANDNOT A=:1.test_2[0] B=$abc$2385$new_n72 Y=$abc$2385$new_n258
 .subckt ORNOT A=$abc$2385$new_n77 B=:1.test_2[1] Y=$abc$2385$new_n259
@@ -129,8 +129,8 @@
 .subckt ANDNOT A=:1.test_2[4] B=$abc$2385$new_n91 Y=$abc$2385$new_n263
 .subckt ANDNOT A=:1.test_2[3] B=$abc$2385$new_n103 Y=$abc$2385$new_n264
 .subckt ANDNOT A=:1.test_2[3] B=$abc$2385$new_n115 Y=$abc$2385$new_n265
-.subckt XNOR A=:1.test_1[5] B=$abc$2385$new_n69 Y=$abc$2385$new_n77
 .subckt NAND A=$abc$2385$new_n216 B=$abc$2385$new_n265 Y=$abc$2385$new_n266
+.subckt NOR A=:1.test_1[3] B=:1.test_1[4] Y=$abc$2385$new_n78
 .subckt XOR A=$abc$2385$new_n217 B=$abc$2385$new_n264 Y=$abc$2385$new_n267
 .subckt NAND A=$abc$2385$new_n263 B=$abc$2385$new_n267 Y=$abc$2385$new_n268
 .subckt XOR A=$abc$2385$new_n263 B=$abc$2385$new_n267 Y=$abc$2385$new_n269
@@ -140,8 +140,8 @@
 .subckt XOR A=$abc$2385$new_n222 B=$abc$2385$new_n271 Y=$abc$2385$new_n273
 .subckt NAND A=:1.test_2[5] B=$abc$2385$new_n65 Y=$abc$2385$new_n274
 .subckt NAND A=:1.test_1[0] B=$abc$2385$new_n274 Y=$abc$2385$new_n275
-.subckt NOR A=:1.test_1[3] B=:1.test_1[4] Y=$abc$2385$new_n78
 .subckt AND A=:1.test_2[6] B=$abc$2385$new_n275 Y=$abc$2385$new_n276
+.subckt AND A=$abc$2385$new_n63 B=$abc$2385$new_n78 Y=$abc$2385$new_n79
 .subckt NAND A=:1.test_2[5] B=$abc$2385$new_n163 Y=$abc$2385$new_n277
 .subckt NAND A=:1.test_2[6] B=$abc$2385$new_n65 Y=$abc$2385$new_n278
 .subckt NAND A=$abc$2385$new_n276 B=$abc$2385$new_n277 Y=$abc$2385$new_n279
@@ -151,8 +151,8 @@
 .subckt NAND A=$abc$2385$new_n281 B=$abc$2385$new_n282 Y=$abc$2385$new_n283
 .subckt XOR A=$abc$2385$new_n281 B=$abc$2385$new_n282 Y=$abc$2385$new_n284
 .subckt NAND A=$abc$2385$new_n226 B=$abc$2385$new_n284 Y=$abc$2385$new_n285
-.subckt AND A=$abc$2385$new_n63 B=$abc$2385$new_n78 Y=$abc$2385$new_n79
 .subckt XOR A=$abc$2385$new_n226 B=$abc$2385$new_n284 Y=$abc$2385$new_n286
+.subckt ANDNOT A=$abc$2385$new_n79 B=:1.test_1[2] Y=$abc$2385$new_n80
 .subckt NAND A=$abc$2385$new_n273 B=$abc$2385$new_n286 Y=$abc$2385$new_n287
 .subckt XOR A=$abc$2385$new_n273 B=$abc$2385$new_n286 Y=$abc$2385$new_n288
 .subckt NAND A=$abc$2385$new_n236 B=$abc$2385$new_n288 Y=$abc$2385$new_n289
@@ -162,8 +162,8 @@
 .subckt XOR A=$abc$2385$new_n290 B=$abc$2385$new_n291 Y=$abc$2385$new_n293
 .subckt NAND A=$abc$2385$new_n257 B=$abc$2385$new_n293 Y=$abc$2385$new_n294
 .subckt XOR A=$abc$2385$new_n257 B=$abc$2385$new_n293 Y=$abc$2385$new_n295
-.subckt ANDNOT A=$abc$2385$new_n79 B=:1.test_1[2] Y=$abc$2385$new_n80
 .subckt NAND A=$abc$2385$new_n243 B=$abc$2385$new_n295 Y=$abc$2385$new_n296
+.subckt AND A=$abc$2385$new_n77 B=$abc$2385$new_n80 Y=$abc$2385$new_n81
 .subckt XOR A=$abc$2385$new_n243 B=$abc$2385$new_n295 Y=$abc$2385$new_n297
 .subckt NAND A=$abc$2385$new_n256 B=$abc$2385$new_n297 Y=$abc$2385$new_n298
 .subckt XNOR A=$abc$2385$new_n256 B=$abc$2385$new_n297 Y=$abc$2385$new_n299
@@ -173,8 +173,8 @@
 .subckt XNOR A=$abc$2385$new_n251 B=$abc$2385$new_n252 Y=$abc$2385$new_n303
 .subckt XOR A=$abc$2385$new_n249 B=$abc$2385$new_n250 Y=$abc$2385$new_n304
 .subckt XNOR A=$abc$2385$new_n249 B=$abc$2385$new_n250 Y=$abc$2385$new_n305
-.subckt AND A=$abc$2385$new_n77 B=$abc$2385$new_n80 Y=$abc$2385$new_n81
 .subckt NAND A=$abc$2385$new_n103 B=$abc$2385$new_n304 Y=$abc$2385$new_n306
+.subckt NAND A=$abc$2385$new_n75 B=$abc$2385$new_n81 Y=$abc$2385$new_n82
 .subckt OR A=$abc$2385$new_n103 B=$abc$2385$new_n304 Y=$abc$2385$new_n307
 .subckt XNOR A=$abc$2385$new_n247 B=$abc$2385$new_n248 Y=$abc$2385$new_n308
 .subckt NAND A=:1.test_1[0] B=:1.test_2[1] Y=$abc$2385$new_n309
@@ -184,8 +184,8 @@
 .subckt OR A=:1.test_2[1] B=$abc$2385$new_n157 Y=$abc$2385$new_n313
 .subckt NAND A=$abc$2385$new_n312 B=$abc$2385$new_n313 Y=$abc$2385$new_n314
 .subckt OR A=$abc$2385$new_n308 B=$abc$2385$new_n314 Y=$abc$2385$new_n315
-.subckt NAND A=$abc$2385$new_n75 B=$abc$2385$new_n81 Y=$abc$2385$new_n82
 .subckt NAND A=$abc$2385$new_n91 B=$abc$2385$new_n315 Y=$abc$2385$new_n316
+.subckt OR A=$abc$2385$new_n73 B=$abc$2385$new_n82 Y=$abc$2385$new_n83
 .subckt NAND A=$abc$2385$new_n308 B=$abc$2385$new_n314 Y=$abc$2385$new_n317
 .subckt NAND A=$abc$2385$new_n316 B=$abc$2385$new_n317 Y=$abc$2385$new_n318
 .subckt NAND A=$abc$2385$new_n307 B=$abc$2385$new_n318 Y=$abc$2385$new_n319
@@ -195,8 +195,8 @@
 .subckt ORNOT A=$abc$2385$new_n303 B=$abc$2385$new_n115 Y=$abc$2385$new_n323
 .subckt NAND A=$abc$2385$new_n321 B=$abc$2385$new_n322 Y=$abc$2385$new_n324
 .subckt NAND A=$abc$2385$new_n323 B=$abc$2385$new_n324 Y=$abc$2385$new_n325
-.subckt OR A=$abc$2385$new_n73 B=$abc$2385$new_n82 Y=$abc$2385$new_n83
 .subckt NAND A=$abc$2385$new_n77 B=$abc$2385$new_n325 Y=$abc$2385$new_n326
+.subckt AND A=$abc$2385$new_n66 B=$abc$2385$new_n83 Y=$abc$2385$new_n84
 .subckt NAND A=$abc$2385$new_n302 B=$abc$2385$new_n326 Y=$abc$2385$new_n327
 .subckt OR A=$abc$2385$new_n77 B=$abc$2385$new_n325 Y=$abc$2385$new_n328
 .subckt AND A=$abc$2385$new_n327 B=$abc$2385$new_n328 Y=$abc$2385$new_n329
@@ -206,8 +206,8 @@
 .subckt OR A=in_b_var[5] B=$abc$2385$new_n302 Y=$abc$2385$new_n333
 .subckt NAND A=in_b_var[4] B=$abc$2385$new_n303 Y=$abc$2385$new_n334
 .subckt OR A=in_b_var[4] B=$abc$2385$new_n303 Y=$abc$2385$new_n335
-.subckt AND A=$abc$2385$new_n66 B=$abc$2385$new_n83 Y=$abc$2385$new_n84
 .subckt AND A=in_b_var[1] B=$abc$2385$new_n320 Y=$abc$2385$new_n336
+.subckt ORNOT A=$abc$2385$new_n84 B=in_a_var[1] Y=$abc$2385$new_n85
 .subckt OR A=in_b_var[3] B=$abc$2385$new_n305 Y=$abc$2385$new_n337
 .subckt ANDNOT A=in_b_var[2] B=$abc$2385$new_n308 Y=$abc$2385$new_n338
 .subckt XNOR A=in_b_var[2] B=$abc$2385$new_n308 Y=$abc$2385$new_n339
@@ -217,8 +217,8 @@
 .subckt NAND A=$abc$2385$new_n336 B=$abc$2385$new_n342 Y=$abc$2385$new_n343
 .subckt NAND A=$abc$2385$new_n337 B=$abc$2385$new_n338 Y=$abc$2385$new_n344
 .subckt AND A=$abc$2385$new_n340 B=$abc$2385$new_n344 Y=$abc$2385$new_n345
-.subckt ORNOT A=$abc$2385$new_n84 B=in_a_var[1] Y=$abc$2385$new_n85
 .subckt AND A=$abc$2385$new_n343 B=$abc$2385$new_n345 Y=$abc$2385$new_n346
+.subckt XNOR A=in_a_var[1] B=$abc$2385$new_n84 Y=$abc$2385$new_n86
 .subckt AND A=in_b_var[0] B=$abc$2385$new_n157 Y=$abc$2385$new_n347
 .subckt XOR A=in_b_var[1] B=$abc$2385$new_n320 Y=$abc$2385$new_n348
 .subckt AND A=$abc$2385$new_n342 B=$abc$2385$new_n348 Y=$abc$2385$new_n349
@@ -228,9 +228,9 @@
 .subckt NAND A=$abc$2385$new_n334 B=$abc$2385$new_n352 Y=$abc$2385$new_n353
 .subckt NAND A=$abc$2385$new_n333 B=$abc$2385$new_n353 Y=$abc$2385$new_n354
 .subckt NAND A=in_b_var[6] B=$abc$2385$new_n299 Y=$abc$2385$new_n355
-.subckt XNOR A=:1.test_1[0] B=in_a_var[0] Y=$abc$2385$new_n59
-.subckt XNOR A=in_a_var[1] B=$abc$2385$new_n84 Y=$abc$2385$new_n86
 .subckt NAND A=in_b_var[5] B=$abc$2385$new_n302 Y=$abc$2385$new_n356
+.subckt NAND A=in_b_var[0] B=$abc$2385$new_n59 Y=$abc$2385$new_n60
+.subckt NAND A=in_b_var[1] B=$abc$2385$new_n86 Y=$abc$2385$new_n87
 .subckt AND A=$abc$2385$new_n355 B=$abc$2385$new_n356 Y=$abc$2385$new_n357
 .subckt NAND A=$abc$2385$new_n354 B=$abc$2385$new_n357 Y=$abc$2385$new_n358
 .subckt AND A=$abc$2385$new_n157 B=$abc$2385$new_n320 Y=$abc$2385$new_n359
@@ -240,8 +240,8 @@
 .subckt AND A=$abc$2385$new_n302 B=$abc$2385$new_n362 Y=$abc$2385$new_n363
 .subckt NAND A=$abc$2385$new_n299 B=$abc$2385$new_n363 Y=$abc$2385$new_n364
 .subckt AND A=$abc$2385$new_n296 B=$abc$2385$new_n298 Y=$abc$2385$new_n365
-.subckt NAND A=in_b_var[1] B=$abc$2385$new_n86 Y=$abc$2385$new_n87
 .subckt AND A=$abc$2385$new_n289 B=$abc$2385$new_n292 Y=$abc$2385$new_n366
+.subckt XNOR A=in_b_var[1] B=$abc$2385$new_n86 Y=$abc$2385$new_n88
 .subckt OR A=:1.test_2[0] B=$abc$2385$new_n75 Y=$abc$2385$new_n367
 .subckt AND A=$abc$2385$new_n261 B=$abc$2385$new_n367 Y=$abc$2385$new_n368
 .subckt XNOR A=$abc$2385$new_n270 B=$abc$2385$new_n368 Y=$abc$2385$new_n369
@@ -251,8 +251,8 @@
 .subckt ANDNOT A=:1.test_2[4] B=$abc$2385$new_n103 Y=$abc$2385$new_n373
 .subckt XNOR A=$abc$2385$new_n372 B=$abc$2385$new_n373 Y=$abc$2385$new_n374
 .subckt XNOR A=$abc$2385$new_n371 B=$abc$2385$new_n374 Y=$abc$2385$new_n375
-.subckt XNOR A=in_b_var[1] B=$abc$2385$new_n86 Y=$abc$2385$new_n88
 .subckt XOR A=$abc$2385$new_n260 B=$abc$2385$new_n265 Y=$abc$2385$new_n376
+.subckt ANDNOT A=$abc$2385$new_n62 B=$abc$2385$new_n88 Y=$abc$2385$new_n89
 .subckt XNOR A=$abc$2385$new_n375 B=$abc$2385$new_n376 Y=$abc$2385$new_n377
 .subckt NAND A=$abc$2385$new_n266 B=$abc$2385$new_n268 Y=$abc$2385$new_n378
 .subckt ANDNOT A=:1.test_2[7] B=:1.test_1[0] Y=$abc$2385$new_n379
@@ -262,8 +262,8 @@
 .subckt XNOR A=$abc$2385$new_n377 B=$abc$2385$new_n382 Y=$abc$2385$new_n383
 .subckt XNOR A=$abc$2385$new_n370 B=$abc$2385$new_n383 Y=$abc$2385$new_n384
 .subckt NAND A=$abc$2385$new_n283 B=$abc$2385$new_n285 Y=$abc$2385$new_n385
-.subckt ANDNOT A=$abc$2385$new_n62 B=$abc$2385$new_n88 Y=$abc$2385$new_n89
 .subckt AND A=$abc$2385$new_n272 B=$abc$2385$new_n287 Y=$abc$2385$new_n386
+.subckt AND A=$abc$2385$new_n85 B=$abc$2385$new_n87 Y=$abc$2385$new_n90
 .subckt XNOR A=$abc$2385$new_n385 B=$abc$2385$new_n386 Y=$abc$2385$new_n387
 .subckt XNOR A=$abc$2385$new_n384 B=$abc$2385$new_n387 Y=$abc$2385$new_n388
 .subckt XNOR A=$abc$2385$new_n366 B=$abc$2385$new_n388 Y=$abc$2385$new_n389
@@ -273,8 +273,8 @@
 .subckt OR A=in_b_var[6] B=$abc$2385$new_n299 Y=$abc$2385$new_n393
 .subckt ORNOT A=in_b_var[6] B=in_a_var[6] Y=$abc$2385$new_n394
 .subckt ORNOT A=in_a_var[5] B=in_b_var[5] Y=$abc$2385$new_n395
-.subckt AND A=$abc$2385$new_n85 B=$abc$2385$new_n87 Y=$abc$2385$new_n90
 .subckt ORNOT A=in_b_var[5] B=in_a_var[5] Y=$abc$2385$new_n396
+.subckt XNOR A=:1.test_1[2] B=$abc$2385$new_n64 Y=$abc$2385$new_n91
 .subckt ORNOT A=in_b_var[4] B=in_a_var[4] Y=$abc$2385$new_n397
 .subckt AND A=$abc$2385$new_n396 B=$abc$2385$new_n397 Y=$abc$2385$new_n398
 .subckt ORNOT A=in_b_var[2] B=in_a_var[2] Y=$abc$2385$new_n399
@@ -284,8 +284,8 @@
 .subckt NAND A=$abc$2385$new_n401 B=$abc$2385$new_n402 Y=$abc$2385$new_n403
 .subckt ORNOT A=in_a_var[2] B=in_b_var[2] Y=$abc$2385$new_n404
 .subckt NAND A=$abc$2385$new_n402 B=$abc$2385$new_n404 Y=$abc$2385$new_n405
-.subckt XNOR A=:1.test_1[2] B=$abc$2385$new_n64 Y=$abc$2385$new_n91
 .subckt NOR A=$abc$2385$new_n401 B=$abc$2385$new_n405 Y=$abc$2385$new_n406
+.subckt AND A=$abc$2385$new_n83 B=$abc$2385$new_n91 Y=$abc$2385$new_n92
 .subckt ORNOT A=in_a_var[0] B=in_b_var[0] Y=$abc$2385$new_n407
 .subckt ORNOT A=in_a_var[1] B=in_b_var[1] Y=$abc$2385$new_n408
 .subckt NAND A=$abc$2385$new_n407 B=$abc$2385$new_n408 Y=$abc$2385$new_n409
@@ -295,8 +295,8 @@
 .subckt NAND A=$abc$2385$new_n403 B=$abc$2385$new_n412 Y=$abc$2385$new_n413
 .subckt ORNOT A=in_a_var[4] B=in_b_var[4] Y=$abc$2385$new_n414
 .subckt NAND A=$abc$2385$new_n413 B=$abc$2385$new_n414 Y=$abc$2385$new_n415
-.subckt AND A=$abc$2385$new_n83 B=$abc$2385$new_n91 Y=$abc$2385$new_n92
 .subckt NAND A=$abc$2385$new_n398 B=$abc$2385$new_n415 Y=$abc$2385$new_n416
+.subckt ORNOT A=$abc$2385$new_n92 B=in_a_var[2] Y=$abc$2385$new_n93
 .subckt NAND A=$abc$2385$new_n395 B=$abc$2385$new_n416 Y=$abc$2385$new_n417
 .subckt NAND A=$abc$2385$new_n394 B=$abc$2385$new_n417 Y=$abc$2385$new_n418
 .subckt NAND A=$abc$2385$new_n394 B=$abc$2385$new_n395 Y=$abc$2385$new_n419
@@ -306,8 +306,8 @@
 .subckt AND A=$abc$2385$new_n410 B=$abc$2385$new_n414 Y=$abc$2385$new_n423
 .subckt AND A=$abc$2385$new_n422 B=$abc$2385$new_n423 Y=$abc$2385$new_n424
 .subckt AND A=$abc$2385$new_n406 B=$abc$2385$new_n424 Y=$abc$2385$new_n425
-.subckt ORNOT A=$abc$2385$new_n92 B=in_a_var[2] Y=$abc$2385$new_n93
 .subckt NAND A=$abc$2385$new_n421 B=$abc$2385$new_n425 Y=$abc$2385$new_n426
+.subckt XNOR A=in_a_var[2] B=$abc$2385$new_n92 Y=$abc$2385$new_n94
 .subckt ORNOT A=in_a_var[6] B=in_b_var[6] Y=$abc$2385$new_n427
 .subckt AND A=$abc$2385$new_n151 B=$abc$2385$new_n427 Y=$abc$2385$new_n428
 .subckt AND A=$abc$2385$new_n426 B=$abc$2385$new_n428 Y=$abc$2385$new_n429
@@ -317,8 +317,8 @@
 .subckt AND A=$abc$2385$new_n364 B=$abc$2385$new_n432 Y=$abc$2385$new_n433
 .subckt AND A=$abc$2385$new_n358 B=$abc$2385$new_n433 Y=$abc$2385$new_n434
 .subckt AND A=$abc$2385$new_n332 B=$abc$2385$new_n434 Y=$abc$2385$new_n435
-.subckt XNOR A=in_a_var[2] B=$abc$2385$new_n92 Y=$abc$2385$new_n94
 .subckt AND A=$abc$2385$new_n157 B=$abc$2385$new_n435 Y=$abc$2385$new_n436
+.subckt NAND A=in_b_var[2] B=$abc$2385$new_n94 Y=$abc$2385$new_n95
 .subckt XNOR A=$abc$2385$new_n157 B=$abc$2385$new_n435 Y=$abc$2385$new_n437
 .subckt ORNOT A=$abc$2385$new_n74 B=:1.test_1[0] Y=$abc$2385$new_n438
 .subckt MUX A=:1.test_1[0] B=$abc$2385$new_n437 S=$abc$2385$new_n74 Y=$abc$1802$auto$ghdl.cc:825:import_module$22[0]
@@ -328,8 +328,8 @@
 .subckt ORNOT A=:1.test_1[2] B=$abc$2385$new_n83 Y=$abc$2385$new_n443
 .subckt ANDNOT A=$abc$2385$new_n308 B=$abc$2385$new_n359 Y=$abc$2385$new_n444
 .subckt XNOR A=$abc$2385$new_n308 B=$abc$2385$new_n359 Y=$abc$2385$new_n445
-.subckt NAND A=in_b_var[2] B=$abc$2385$new_n94 Y=$abc$2385$new_n95
 .subckt NAND A=$abc$2385$new_n435 B=$abc$2385$new_n445 Y=$abc$2385$new_n446
+.subckt XNOR A=in_b_var[2] B=$abc$2385$new_n94 Y=$abc$2385$new_n96
 .subckt ORNOT A=$abc$2385$new_n435 B=$abc$2385$new_n308 Y=$abc$2385$new_n447
 .subckt AND A=$abc$2385$new_n74 B=$abc$2385$new_n446 Y=$abc$2385$new_n448
 .subckt NAND A=$abc$2385$new_n447 B=$abc$2385$new_n448 Y=$abc$2385$new_n449
@@ -339,9 +339,9 @@
 .subckt AND A=$abc$2385$new_n304 B=$abc$2385$new_n452 Y=$abc$2385$new_n453
 .subckt XNOR A=$abc$2385$new_n305 B=$abc$2385$new_n452 Y=$abc$2385$new_n454
 .subckt MUX A=$abc$2385$new_n451 B=$abc$2385$new_n454 S=$abc$2385$new_n74 Y=$abc$1802$auto$ghdl.cc:825:import_module$22[3]
-.subckt NAND A=in_b_var[0] B=$abc$2385$new_n59 Y=$abc$2385$new_n60
-.subckt XNOR A=in_b_var[2] B=$abc$2385$new_n94 Y=$abc$2385$new_n96
 .subckt ORNOT A=:1.test_1[4] B=$abc$2385$new_n83 Y=$abc$2385$new_n456
+.subckt XOR A=in_b_var[0] B=$abc$2385$new_n59 Y=$abc$2385$auto$maccmap.cc:114:fulladd$252.Y[0]
+.subckt OR A=$abc$2385$new_n90 B=$abc$2385$new_n96 Y=$abc$2385$new_n97
 .subckt ORNOT A=$abc$2385$new_n303 B=$abc$2385$new_n453 Y=$abc$2385$new_n457
 .subckt XNOR A=$abc$2385$new_n303 B=$abc$2385$new_n453 Y=$abc$2385$new_n458
 .subckt MUX A=$abc$2385$new_n456 B=$abc$2385$new_n458 S=$abc$2385$new_n74 Y=$abc$1802$auto$ghdl.cc:825:import_module$22[4]
@@ -351,8 +351,8 @@
 .subckt NAND A=$abc$2385$new_n74 B=$abc$2385$new_n462 Y=$abc$2385$new_n463
 .subckt NAND A=$abc$2385$new_n460 B=$abc$2385$new_n463 Y=$abc$1802$auto$ghdl.cc:825:import_module$22[5]
 .subckt NAND A=$abc$2385$new_n299 B=$abc$2385$new_n461 Y=$abc$2385$new_n465
-.subckt OR A=$abc$2385$new_n90 B=$abc$2385$new_n96 Y=$abc$2385$new_n97
 .subckt OR A=$abc$2385$new_n299 B=$abc$2385$new_n461 Y=$abc$2385$new_n466
+.subckt XOR A=$abc$2385$new_n90 B=$abc$2385$new_n96 Y=$abc$2385$new_n98
 .subckt AND A=$abc$2385$new_n74 B=$abc$2385$new_n466 Y=$abc$2385$new_n467
 .subckt NAND A=$abc$2385$new_n465 B=$abc$2385$new_n467 Y=$abc$2385$new_n468
 .subckt MUX A=$abc$2385$new_n73 B=$abc$2385$new_n137 S=$abc$2385$new_n76 Y=$abc$2385$new_n469
@@ -362,8 +362,8 @@
 .subckt ANDNOT A=$abc$2385$new_n137 B=$abc$2385$new_n76 Y=$abc$2385$new_n473
 .subckt XNOR A=$abc$2385$new_n150 B=$abc$2385$new_n473 Y=$abc$2385$new_n474
 .subckt AND A=$abc$2385$new_n472 B=$abc$2385$new_n474 Y=$abc$1802$auto$ghdl.cc:825:import_module$22[7]
-.subckt XOR A=$abc$2385$new_n90 B=$abc$2385$new_n96 Y=$abc$2385$new_n98
 .subckt AND A=$abc$2385$new_n58 B=$abc$2385$new_n438 Y=:38.Y[0]
+.subckt NAND A=$abc$2385$new_n89 B=$abc$2385$new_n98 Y=$abc$2385$new_n99
 .subckt NAND A=in_a_var[1] B=$abc$2385$new_n74 Y=$abc$2385$new_n477
 .subckt NAND A=$abc$2385$new_n84 B=$abc$2385$new_n477 Y=:38.Y[1]
 .subckt NAND A=in_a_var[2] B=$abc$2385$new_n74 Y=$abc$2385$new_n479
@@ -373,8 +373,8 @@
 .subckt NAND A=in_a_var[4] B=$abc$2385$new_n74 Y=$abc$2385$new_n483
 .subckt NAND A=$abc$2385$new_n116 B=$abc$2385$new_n483 Y=:38.Y[4]
 .subckt NAND A=in_a_var[5] B=$abc$2385$new_n74 Y=$abc$2385$new_n485
-.subckt NAND A=$abc$2385$new_n89 B=$abc$2385$new_n98 Y=$abc$2385$new_n99
 .subckt NAND A=$abc$2385$new_n127 B=$abc$2385$new_n485 Y=:38.Y[5]
+.subckt XOR A=$abc$2385$new_n89 B=$abc$2385$new_n98 Y=$abc$2385$auto$maccmap.cc:240:synth$253.Y[2]
 .subckt NAND A=in_a_var[6] B=$abc$2385$new_n74 Y=$abc$2385$new_n487
 .subckt NAND A=$abc$2385$new_n137 B=$abc$2385$new_n487 Y=:38.Y[6]
 .subckt NAND A=in_a_var[7] B=$abc$2385$new_n74 Y=$abc$2385$new_n489
@@ -384,8 +384,8 @@
 .subckt DFF C=clk D=$abc$2385$auto$maccmap.cc:240:synth$253.Y[2] Q=out_var[2]
 .subckt DFF C=clk D=$abc$2385$auto$maccmap.cc:240:synth$253.Y[3] Q=out_var[3]
 .subckt DFF C=clk D=$abc$2385$auto$maccmap.cc:240:synth$253.Y[4] Q=out_var[4]
-.subckt XOR A=$abc$2385$new_n89 B=$abc$2385$new_n98 Y=$abc$2385$auto$maccmap.cc:240:synth$253.Y[2]
 .subckt DFF C=clk D=$abc$2385$auto$maccmap.cc:240:synth$253.Y[5] Q=out_var[5]
+.subckt NAND A=$abc$2385$new_n97 B=$abc$2385$new_n99 Y=$abc$2385$new_n101
 .subckt DFF C=clk D=$abc$2385$auto$maccmap.cc:240:synth$253.Y[6] Q=out_var[6]
 .subckt DFF C=clk D=$abc$2385$auto$maccmap.cc:240:synth$253.Y[7] Q=out_var[7]
 .subckt DFF C=clk D=:38.Y[0] Q=:1.test_1[0]
@@ -395,8 +395,8 @@
 .subckt DFF C=clk D=:38.Y[4] Q=:1.test_1[4]
 .subckt DFF C=clk D=:38.Y[5] Q=:1.test_1[5]
 .subckt DFF C=clk D=:38.Y[6] Q=:1.test_1[6]
-.subckt NAND A=$abc$2385$new_n97 B=$abc$2385$new_n99 Y=$abc$2385$new_n101
 .subckt DFF C=clk D=:38.Y[7] Q=:1.test_1[7]
+.subckt AND A=$abc$2385$new_n93 B=$abc$2385$new_n95 Y=$abc$2385$new_n102
 .subckt DFF C=clk D=$abc$1802$auto$ghdl.cc:825:import_module$22[0] Q=:1.test_2[0]
 .subckt DFF C=clk D=$abc$1802$auto$ghdl.cc:825:import_module$22[1] Q=:1.test_2[1]
 .subckt DFF C=clk D=$abc$1802$auto$ghdl.cc:825:import_module$22[2] Q=:1.test_2[2]
@@ -405,12 +405,11 @@
 .subckt DFF C=clk D=$abc$1802$auto$ghdl.cc:825:import_module$22[5] Q=:1.test_2[5]
 .subckt DFF C=clk D=$abc$1802$auto$ghdl.cc:825:import_module$22[6] Q=:1.test_2[6]
 .subckt DFF C=clk D=$abc$1802$auto$ghdl.cc:825:import_module$22[7] Q=:1.test_2[7]
-.subckt AND A=$abc$2385$new_n93 B=$abc$2385$new_n95 Y=$abc$2385$new_n102
 .subckt XNOR A=:1.test_1[3] B=$abc$2385$new_n67 Y=$abc$2385$new_n103
 .subckt AND A=$abc$2385$new_n83 B=$abc$2385$new_n103 Y=$abc$2385$new_n104
 .subckt ORNOT A=$abc$2385$new_n104 B=in_a_var[3] Y=$abc$2385$new_n105
-.subckt XOR A=in_b_var[0] B=$abc$2385$new_n59 Y=$abc$2385$auto$maccmap.cc:114:fulladd$252.Y[0]
 .subckt XNOR A=in_a_var[3] B=$abc$2385$new_n104 Y=$abc$2385$new_n106
+.subckt NAND A=$abc$2385$new_n57 B=$abc$2385$new_n60 Y=$abc$2385$new_n62
 .subckt NAND A=in_b_var[3] B=$abc$2385$new_n106 Y=$abc$2385$new_n107
 .subckt XNOR A=in_b_var[3] B=$abc$2385$new_n106 Y=$abc$2385$new_n108
 .subckt OR A=$abc$2385$new_n102 B=$abc$2385$new_n108 Y=$abc$2385$new_n109
@@ -420,8 +419,8 @@
 .subckt NAND A=$abc$2385$new_n109 B=$abc$2385$new_n111 Y=$abc$2385$new_n113
 .subckt AND A=$abc$2385$new_n105 B=$abc$2385$new_n107 Y=$abc$2385$new_n114
 .subckt XNOR A=:1.test_1[4] B=$abc$2385$new_n68 Y=$abc$2385$new_n115
-.subckt NAND A=$abc$2385$new_n57 B=$abc$2385$new_n60 Y=$abc$2385$new_n62
 .subckt AND A=$abc$2385$new_n83 B=$abc$2385$new_n115 Y=$abc$2385$new_n116
+.subckt NOR A=:1.test_1[0] B=:1.test_1[1] Y=$abc$2385$new_n63
 .subckt ORNOT A=$abc$2385$new_n116 B=in_a_var[4] Y=$abc$2385$new_n117
 .subckt XNOR A=in_a_var[4] B=$abc$2385$new_n116 Y=$abc$2385$new_n118
 .subckt NAND A=in_b_var[4] B=$abc$2385$new_n118 Y=$abc$2385$new_n119
@@ -431,8 +430,8 @@
 .subckt NAND A=$abc$2385$new_n113 B=$abc$2385$new_n122 Y=$abc$2385$new_n123
 .subckt XOR A=$abc$2385$new_n113 B=$abc$2385$new_n122 Y=$abc$2385$auto$maccmap.cc:240:synth$253.Y[4]
 .subckt AND A=$abc$2385$new_n121 B=$abc$2385$new_n123 Y=$abc$2385$new_n125
-.subckt NOR A=:1.test_1[0] B=:1.test_1[1] Y=$abc$2385$new_n63
 .subckt AND A=$abc$2385$new_n117 B=$abc$2385$new_n119 Y=$abc$2385$new_n126
+.subckt AND A=:1.test_1[0] B=:1.test_1[1] Y=$abc$2385$new_n64
 .subckt AND A=$abc$2385$new_n77 B=$abc$2385$new_n83 Y=$abc$2385$new_n127
 .subckt ORNOT A=$abc$2385$new_n127 B=in_a_var[5] Y=$abc$2385$new_n128
 .subckt XNOR A=in_a_var[5] B=$abc$2385$new_n127 Y=$abc$2385$new_n129
@@ -442,8 +441,8 @@
 .subckt NAND A=$abc$2385$new_n126 B=$abc$2385$new_n131 Y=$abc$2385$new_n133
 .subckt XOR A=$abc$2385$new_n126 B=$abc$2385$new_n131 Y=$abc$2385$new_n134
 .subckt XNOR A=$abc$2385$new_n125 B=$abc$2385$new_n134 Y=$abc$2385$auto$maccmap.cc:240:synth$253.Y[5]
-.subckt AND A=:1.test_1[0] B=:1.test_1[1] Y=$abc$2385$new_n64
 .subckt AND A=$abc$2385$new_n128 B=$abc$2385$new_n130 Y=$abc$2385$new_n136
+.subckt XOR A=:1.test_1[0] B=:1.test_1[1] Y=$abc$2385$new_n65
 .subckt AND A=$abc$2385$new_n72 B=$abc$2385$new_n82 Y=$abc$2385$new_n137
 .subckt ORNOT A=$abc$2385$new_n137 B=in_a_var[6] Y=$abc$2385$new_n138
 .subckt XNOR A=in_a_var[6] B=$abc$2385$new_n137 Y=$abc$2385$new_n139
@@ -453,8 +452,8 @@
 .subckt XOR A=$abc$2385$new_n136 B=$abc$2385$new_n141 Y=$abc$2385$new_n143
 .subckt NAND A=$abc$2385$new_n125 B=$abc$2385$new_n132 Y=$abc$2385$new_n144
 .subckt AND A=$abc$2385$new_n133 B=$abc$2385$new_n144 Y=$abc$2385$new_n145
-.subckt XOR A=:1.test_1[0] B=:1.test_1[1] Y=$abc$2385$new_n65
 .subckt NAND A=$abc$2385$new_n143 B=$abc$2385$new_n145 Y=$abc$2385$new_n146
+.subckt NOT A=$abc$2385$new_n65 Y=$abc$2385$new_n66
 .subckt XOR A=$abc$2385$new_n143 B=$abc$2385$new_n145 Y=$abc$2385$auto$maccmap.cc:240:synth$253.Y[6]
 .subckt AND A=$abc$2385$new_n142 B=$abc$2385$new_n146 Y=$abc$2385$new_n148
 .subckt AND A=$abc$2385$new_n138 B=$abc$2385$new_n140 Y=$abc$2385$new_n149
@@ -464,6 +463,7 @@
 .subckt XNOR A=$abc$2385$new_n150 B=$abc$2385$new_n152 Y=$abc$2385$new_n153
 .subckt XNOR A=$abc$2385$new_n149 B=$abc$2385$new_n153 Y=$abc$2385$new_n154
 .subckt XNOR A=$abc$2385$new_n148 B=$abc$2385$new_n154 Y=$abc$2385$auto$maccmap.cc:240:synth$253.Y[7]
+.subckt XNOR A=$abc$2385$new_n62 B=$abc$2385$new_n88 Y=$abc$2385$auto$maccmap.cc:240:synth$253.P[1]
 .gateinit :1.test_2[7]=0
 .gateinit :1.test_2[6]=0
 .gateinit :1.test_2[5]=0


### PR DESCRIPTION
On main, `abc` is parallelized across clock domains, but only when `-dff` is used, which seems like an arbitrary limitation. It's also parallelized within each module for simplicity, rather than across all modules.

This PR implements parallelism across clock domains across all modules. This happens both with and without `-dff`. This differs from #6166 and #5653 where non-`-dff` doesn't benefit from clock domain parallelism at all. The code damage is very limited as there's minimal conceptual changes, I'm only hoisting and what we have and removing a conditional, with simple code damage as a result (similar to #6177, and reblessing ordering-sensitive tests).

I don't think I can easily include a test because thread sensitive testing isn't appropriate for our CI-oriented test suite. Some more "offline" test could be added.

@jmichalski-ant @QuantamHD let me know what gains you see with this